### PR TITLE
Initial work towards not cloning values by default on get

### DIFF
--- a/lib/src/dbs/iterator.rs
+++ b/lib/src/dbs/iterator.rs
@@ -186,10 +186,11 @@ impl Iterator {
 						if let Field::Alone(v) = field {
 							match v {
 								Value::Function(f) if f.is_aggregate() => {
-									let x = vals
-										.all()
+									let x = vals.all();
+									let x = x
 										.get(ctx, opt, txn, v.to_idiom().as_ref())
-										.await?;
+										.await?
+										.into_owned();
 									let x = f.aggregate(x).compute(ctx, opt, txn, None).await?;
 									obj.set(ctx, opt, txn, v.to_idiom().as_ref(), x).await?;
 								}
@@ -207,7 +208,8 @@ impl Iterator {
 									let x = vals
 										.all()
 										.get(ctx, opt, txn, v.to_idiom().as_ref())
-										.await?;
+										.await?
+										.into_owned();
 									let x = f.aggregate(x).compute(ctx, opt, txn, None).await?;
 									obj.set(ctx, opt, txn, i, x).await?;
 								}
@@ -307,18 +309,20 @@ impl Iterator {
 				// Loop over each value
 				for obj in &mut self.results {
 					// Get the value at the path
-					let val = obj.get(ctx, opt, txn, fetch).await?;
+					let val = obj.get(ctx, opt, txn, fetch).await?.into_owned();
 					// Set the value at the path
 					match val {
 						Value::Array(v) => {
 							// Fetch all remote records
-							let val = Value::Array(v).get(ctx, opt, txn, &[Part::Any]).await?;
+							let val = Value::Array(v);
+							let val = val.get(ctx, opt, txn, &[Part::Any]).await?.into_owned();
 							// Set the value at the path
 							obj.set(ctx, opt, txn, fetch, val).await?;
 						}
 						Value::Thing(v) => {
 							// Fetch all remote records
-							let val = Value::Thing(v).get(ctx, opt, txn, &[Part::All]).await?;
+							let val = Value::Thing(v);
+							let val = val.get(ctx, opt, txn, &[Part::All]).await?.into_owned();
 							// Set the value at the path
 							obj.set(ctx, opt, txn, fetch, val).await?;
 						}

--- a/lib/src/sql/param.rs
+++ b/lib/src/sql/param.rs
@@ -50,7 +50,8 @@ impl Param {
 						// Process the parameter value
 						let res = v.compute(ctx, opt, txn, doc).await?;
 						// Return the desired field
-						res.get(ctx, opt, txn, pth.next()).await
+						let x = res.get(ctx, opt, txn, pth.next()).await;
+						x.map(|x| x.into_owned())
 					}
 					// The base document does not exist
 					None => Ok(Value::None),
@@ -63,7 +64,8 @@ impl Param {
 						// Process the parameter value
 						let res = v.compute(ctx, opt, txn, doc).await?;
 						// Return the desired field
-						res.get(ctx, opt, txn, pth.next()).await
+						let x = res.get(ctx, opt, txn, pth.next()).await;
+						x.map(|x| x.into_owned())
 					}
 					// The base variable does not exist
 					None => Ok(Value::None),

--- a/lib/src/sql/subquery.rs
+++ b/lib/src/sql/subquery.rs
@@ -76,11 +76,15 @@ impl Subquery {
 				// Process result
 				match v.limit() {
 					1 => match v.expr.single() {
-						Some(v) => res.first().get(&ctx, &opt, txn, &v).await,
+						Some(v) => {
+							let x = res.first();
+							let x = x.get(&ctx, &opt, txn, &v).await;
+							x.map(|x| x.into_owned())
+						}
 						None => res.first().ok(),
 					},
 					_ => match v.expr.single() {
-						Some(v) => res.get(&ctx, &opt, txn, &v).await,
+						Some(v) => res.get(&ctx, &opt, txn, &v).await.map(|x| x.into_owned()),
 						None => res.ok(),
 					},
 				}

--- a/lib/src/sql/value/decrement.rs
+++ b/lib/src/sql/value/decrement.rs
@@ -15,7 +15,7 @@ impl Value {
 		path: &[Part],
 		val: Value,
 	) -> Result<(), Error> {
-		match self.get(ctx, opt, txn, path).await? {
+		match self.get(ctx, opt, txn, path).await?.into_owned() {
 			Value::Number(v) => match val {
 				Value::Number(x) => self.set(ctx, opt, txn, path, Value::from(v - x)).await,
 				_ => Ok(()),

--- a/lib/src/sql/value/get.rs
+++ b/lib/src/sql/value/get.rs
@@ -11,70 +11,93 @@ use crate::sql::statements::select::SelectStatement;
 use crate::sql::value::{Value, Values};
 use async_recursion::async_recursion;
 use futures::future::try_join_all;
+use std::borrow::Cow;
 
 impl Value {
 	#[cfg_attr(feature = "parallel", async_recursion)]
 	#[cfg_attr(not(feature = "parallel"), async_recursion(?Send))]
-	pub async fn get(
-		&self,
+	pub async fn get<'a>(
+		&'a self,
 		ctx: &Context<'_>,
 		opt: &Options,
 		txn: &Transaction,
 		path: &[Part],
-	) -> Result<Self, Error> {
+	) -> Result<Cow<'a, Self>, Error> {
 		match path.first() {
 			// Get the current path part
 			Some(p) => match self {
 				// Current path part is an object
 				Value::Object(v) => match p {
 					Part::Graph(_) => match v.rid() {
-						Some(v) => Value::Thing(v).get(ctx, opt, txn, path).await,
-						None => Ok(Value::None),
+						Some(v) => {
+							let x = Value::Thing(v);
+							let x = x.get(ctx, opt, txn, path).await;
+							// Without this manual cloning, it ends up with "cannot return value referencing temporary value"
+							x.map(|x| Cow::from(x.into_owned()))
+						}
+						None => Ok(Cow::from(&Value::None)),
 					},
 					Part::Field(f) => match v.get(f as &str) {
 						Some(v) => v.get(ctx, opt, txn, path.next()).await,
-						None => Ok(Value::None),
+						None => Ok(Cow::from(&Value::None)),
 					},
 					Part::All => self.get(ctx, opt, txn, path.next()).await,
 					Part::Any => self.get(ctx, opt, txn, path.next()).await,
-					_ => Ok(Value::None),
+					_ => Ok(Cow::from(&Value::None)),
 				},
 				// Current path part is an array
 				Value::Array(v) => match p {
 					Part::All => {
 						let path = path.next();
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						try_join_all(futs).await.map(Into::into)
+						let x: Result<Vec<Value>, Error> = try_join_all(futs).await.map(|x| {
+							let z = x.into_iter();
+							let z = z.map(|y| y.into_owned());
+							z.collect()
+						});
+						let x: Result<Value, Error> = x.map(Into::into);
+						x.map(Cow::from)
 					}
 					Part::Any => {
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						try_join_all(futs).await.map(Into::into)
+						let x: Result<Vec<Value>, Error> = try_join_all(futs).await.map(|x| {
+							let z = x.into_iter().map(|y| y.into_owned());
+							z.collect()
+						});
+						let x: Result<Value, Error> = x.map(Into::into);
+						x.map(Cow::from)
 					}
 					Part::First => match v.first() {
 						Some(v) => v.get(ctx, opt, txn, path.next()).await,
-						None => Ok(Value::None),
+						None => Ok(Cow::from(&Value::None)),
 					},
 					Part::Last => match v.last() {
 						Some(v) => v.get(ctx, opt, txn, path.next()).await,
-						None => Ok(Value::None),
+						None => Ok(Cow::from(&Value::None)),
 					},
 					Part::Index(i) => match v.get(i.to_usize()) {
 						Some(v) => v.get(ctx, opt, txn, path.next()).await,
-						None => Ok(Value::None),
+						None => Ok(Cow::from(&Value::None)),
 					},
 					Part::Where(w) => {
 						let path = path.next();
 						let mut a = Vec::new();
 						for v in v.iter() {
 							if w.compute(ctx, opt, txn, Some(v)).await?.is_truthy() {
-								a.push(v.get(ctx, opt, txn, path).await?)
+								a.push(v.get(ctx, opt, txn, path).await?.into_owned())
 							}
 						}
-						Ok(a.into())
+						Ok(Cow::Owned(a.into()))
 					}
 					_ => {
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						try_join_all(futs).await.map(Into::into)
+						let x = try_join_all(futs).await;
+						let x: Result<Vec<Value>, Error> = x.map(|x| {
+							let x = x.into_iter().map(|y| y.into_owned()).collect();
+							x
+						});
+						let x: Result<Value, Error> = x.map(Into::into);
+						x.map(Cow::from)
 					}
 				},
 				// Current path part is a thing
@@ -84,7 +107,7 @@ impl Value {
 					// Check how many path parts are remaining
 					match path.len() {
 						// No remote embedded fields, so just return this
-						0 => Ok(Value::Thing(val)),
+						0 => Ok(Cow::from(Value::Thing(val))),
 						// Remote embedded field, so fetch the thing
 						_ => match p {
 							// This is a graph traversal expression
@@ -100,22 +123,25 @@ impl Value {
 									..SelectStatement::default()
 								};
 								match path.len() {
-									1 => stm
-										.compute(ctx, opt, txn, None)
-										.await?
-										.all()
-										.get(ctx, opt, txn, ID.as_ref())
-										.await?
-										.flatten()
-										.ok(),
-									_ => stm
-										.compute(ctx, opt, txn, None)
-										.await?
-										.all()
-										.get(ctx, opt, txn, path.next())
-										.await?
-										.flatten()
-										.ok(),
+									1 => {
+										let x = stm.compute(ctx, opt, txn, None).await?.all();
+										let x = x.get(ctx, opt, txn, ID.as_ref()).await?;
+										let x = x
+											// without .into_owned() it end up with
+											//  move occurs because value has type `sql::value::value::Value`, which does not implement the `Copy` trait
+											.into_owned()
+											.flatten()
+											.ok()
+											.map(Cow::from);
+										x
+									}
+									_ => {
+										let x = stm.compute(ctx, opt, txn, None).await?.all();
+										let x = x.get(ctx, opt, txn, path.next()).await?;
+										let x = x.into_owned().flatten().ok().map(Cow::from);
+										// We can't use x.clone() as Error doesn't derive Clone(and it can't due to various underlying serde-related errors don't derive Clone)
+										x.map(|x| Cow::from(x.into_owned()))
+									}
 								}
 							}
 							// This is a remote field expression
@@ -125,11 +151,14 @@ impl Value {
 									what: Values(vec![Value::from(val)]),
 									..SelectStatement::default()
 								};
-								stm.compute(ctx, opt, txn, None)
-									.await?
-									.first()
-									.get(ctx, opt, txn, path)
-									.await
+								let x = stm.compute(ctx, opt, txn, None).await?;
+								let x = x.first();
+								let x = x.get(ctx, opt, txn, path).await;
+								let x = match x {
+									Ok(x) => Ok(Cow::from(x.into_owned())),
+									Err(x) => Err(x),
+								};
+								x
 							}
 						},
 					}
@@ -137,14 +166,14 @@ impl Value {
 				// Ignore everything else
 				_ => match p {
 					Part::Any => match path.len() {
-						1 => Ok(self.clone()),
-						_ => Ok(Value::None),
+						1 => Ok(Cow::from(self)),
+						_ => Ok(Cow::from(&Value::None)),
 					},
-					_ => Ok(Value::None),
+					_ => Ok(Cow::from(&Value::None)),
 				},
 			},
 			// No more parts so get the value
-			None => Ok(self.clone()),
+			None => Ok(Cow::from(self)),
 		}
 	}
 }
@@ -165,7 +194,7 @@ mod tests {
 		let idi = Idiom::default();
 		let val = Value::parse("{ test: { other: null, something: 123 } }");
 		let res = val.get(&ctx, &opt, &txn, &idi).await.unwrap();
-		assert_eq!(res, val);
+		assert_eq!(res.into_owned(), val);
 	}
 
 	#[tokio::test]
@@ -174,7 +203,7 @@ mod tests {
 		let idi = Idiom::parse("test.something");
 		let val = Value::parse("{ test: { other: null, something: 123 } }");
 		let res = val.get(&ctx, &opt, &txn, &idi).await.unwrap();
-		assert_eq!(res, Value::from(123));
+		assert_eq!(res.into_owned(), Value::from(123));
 	}
 
 	#[tokio::test]
@@ -184,7 +213,7 @@ mod tests {
 		let val = Value::parse("{ test: { other: test:tobie, something: 123 } }");
 		let res = val.get(&ctx, &opt, &txn, &idi).await.unwrap();
 		assert_eq!(
-			res,
+			res.into_owned(),
 			Value::from(Thing {
 				tb: String::from("test"),
 				id: Id::from("tobie")
@@ -198,7 +227,7 @@ mod tests {
 		let idi = Idiom::parse("test.something[1]");
 		let val = Value::parse("{ test: { something: [123, 456, 789] } }");
 		let res = val.get(&ctx, &opt, &txn, &idi).await.unwrap();
-		assert_eq!(res, Value::from(456));
+		assert_eq!(res.into_owned(), Value::from(456));
 	}
 
 	#[tokio::test]
@@ -208,7 +237,7 @@ mod tests {
 		let val = Value::parse("{ test: { something: [test:tobie, test:jaime] } }");
 		let res = val.get(&ctx, &opt, &txn, &idi).await.unwrap();
 		assert_eq!(
-			res,
+			res.into_owned(),
 			Value::from(Thing {
 				tb: String::from("test"),
 				id: Id::from("jaime")
@@ -222,7 +251,7 @@ mod tests {
 		let idi = Idiom::parse("test.something[1].age");
 		let val = Value::parse("{ test: { something: [{ age: 34 }, { age: 36 }] } }");
 		let res = val.get(&ctx, &opt, &txn, &idi).await.unwrap();
-		assert_eq!(res, Value::from(36));
+		assert_eq!(res.into_owned(), Value::from(36));
 	}
 
 	#[tokio::test]
@@ -231,7 +260,7 @@ mod tests {
 		let idi = Idiom::parse("test.something[*].age");
 		let val = Value::parse("{ test: { something: [{ age: 34 }, { age: 36 }] } }");
 		let res = val.get(&ctx, &opt, &txn, &idi).await.unwrap();
-		assert_eq!(res, Value::from(vec![34, 36]));
+		assert_eq!(res.into_owned(), Value::from(vec![34, 36]));
 	}
 
 	#[tokio::test]
@@ -240,7 +269,7 @@ mod tests {
 		let idi = Idiom::parse("test.something.age");
 		let val = Value::parse("{ test: { something: [{ age: 34 }, { age: 36 }] } }");
 		let res = val.get(&ctx, &opt, &txn, &idi).await.unwrap();
-		assert_eq!(res, Value::from(vec![34, 36]));
+		assert_eq!(res.into_owned(), Value::from(vec![34, 36]));
 	}
 
 	#[tokio::test]
@@ -249,7 +278,7 @@ mod tests {
 		let idi = Idiom::parse("test.something[WHERE age > 35].age");
 		let val = Value::parse("{ test: { something: [{ age: 34 }, { age: 36 }] } }");
 		let res = val.get(&ctx, &opt, &txn, &idi).await.unwrap();
-		assert_eq!(res, Value::from(vec![36]));
+		assert_eq!(res.into_owned(), Value::from(vec![36]));
 	}
 
 	#[tokio::test]
@@ -259,7 +288,7 @@ mod tests {
 		let val = Value::parse("{ test: { something: [{ age: 34 }, { age: 36 }] } }");
 		let res = val.get(&ctx, &opt, &txn, &idi).await.unwrap();
 		assert_eq!(
-			res,
+			res.into_owned(),
 			Value::from(vec![Value::from(map! {
 				"age".to_string() => Value::from(36),
 			})])

--- a/lib/src/sql/value/increment.rs
+++ b/lib/src/sql/value/increment.rs
@@ -15,7 +15,7 @@ impl Value {
 		path: &[Part],
 		val: Value,
 	) -> Result<(), Error> {
-		match self.get(ctx, opt, txn, path).await? {
+		match self.get(ctx, opt, txn, path).await?.into_owned() {
 			Value::Number(v) => match val {
 				Value::Number(x) => self.set(ctx, opt, txn, path, Value::from(v + x)).await,
 				_ => Ok(()),

--- a/lib/src/sql/value/patch.rs
+++ b/lib/src/sql/value/patch.rs
@@ -15,7 +15,7 @@ impl Value {
 	) -> Result<(), Error> {
 		for o in val.to_operations()?.into_iter() {
 			match o.op {
-				Op::Add => match self.get(ctx, opt, txn, &o.path).await? {
+				Op::Add => match self.get(ctx, opt, txn, &o.path).await?.into_owned() {
 					Value::Array(_) => self.increment(ctx, opt, txn, &o.path, o.value).await?,
 					_ => self.set(ctx, opt, txn, &o.path, o.value).await?,
 				},
@@ -23,7 +23,9 @@ impl Value {
 				Op::Replace => self.set(ctx, opt, txn, &o.path, o.value).await?,
 				Op::Change => {
 					if let Value::Strand(p) = o.value {
-						if let Value::Strand(v) = self.get(ctx, opt, txn, &o.path).await? {
+						if let Value::Strand(v) =
+							self.get(ctx, opt, txn, &o.path).await?.into_owned()
+						{
 							let mut dmp = dmp::new();
 							let mut pch = dmp.patch_from_text(p.as_string());
 							let (txt, _) = dmp.patch_apply(&mut pch, v.as_str());


### PR DESCRIPTION
## What is the motivation?

This is the initial work towards quit cloning values by default on `get`.

## What does this change do?

Modifies the `get` function to return a `Cow` without cloning the source value whenever possible.

The consumers of `get` are modified as well to `clone` the value on their end, to reduce the scope of this pull request.

In upcoming pull request(s), I'd like to further defer clones, so that we can actually reduce the amounts of `clone`. The next candidate would obviously be `compute` which is mentioned in the original issue, followed by other structs/impls touched in this pull request(like iterator, params, subquery, and so on).

My ultimate goal is to reduce the number of calls to `into_owned()` and `clone` across SurrealDB's code-base so that it's fully COW. I'm not yet very sure if it's entirely possible though!

## What is your testing strategy?

I'll manually run a few queries against SurrealKV + in-memory for verification and update this section with the result.

## Is this related to any issues?

Yes. See #26.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

[x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
