### PR TITLE
Update tikv-client to use git upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "any_ascii"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +224,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
 dependencies = [
  "event-listener",
+]
+
+[[package]]
+name = "async-recursion"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -350,33 +370,14 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.57.0"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
 dependencies = [
  "bitflags",
- "cexpr 0.4.0",
+ "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex 0.1.1",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.60.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
-dependencies = [
- "bitflags",
- "cexpr 0.6.0",
- "clang-sys",
- "clap",
+ "clap 2.34.0",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -386,7 +387,30 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex 1.1.0",
+ "shlex",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap 3.2.17",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
  "which",
 ]
 
@@ -459,15 +483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boringssl-src"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0511b9f0b739706e05b7279ece5dfc1932a42839cf005cb0f00420a3fea27c96"
-dependencies = [
- "cmake",
-]
-
-[[package]]
 name = "brotli"
 version = "3.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,20 +551,11 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cexpr"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
-dependencies = [
- "nom 5.1.2",
-]
-
-[[package]]
-name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.1",
+ "nom",
 ]
 
 [[package]]
@@ -606,6 +612,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
@@ -614,9 +635,9 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "indexmap",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
- "textwrap",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
@@ -865,7 +886,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -1180,7 +1201,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69adb701525370e5f8958454b46e8459b276d81ce6391edbf84eae32eeddff75"
 dependencies = [
- "async-recursion",
+ "async-recursion 1.0.0",
  "async-trait",
  "foundationdb-gen",
  "foundationdb-macros",
@@ -1447,17 +1468,18 @@ dependencies = [
 
 [[package]]
 name = "grpcio"
-version = "0.8.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cf790272c5fb75a2fd7f2e8282e910d0fe0ed1d954cb29b07b74228694302a"
+checksum = "f9bcdd3694fa08158334501af37bdf5b4f00b1865b602d917e3cd74ecf80cd0a"
 dependencies = [
  "bytes 1.2.1",
- "futures 0.3.23",
+ "futures-executor",
+ "futures-util",
  "grpcio-sys",
  "libc",
  "log",
  "parking_lot",
- "prost 0.7.0",
+ "prost 0.9.0",
 ]
 
 [[package]]
@@ -1475,12 +1497,11 @@ dependencies = [
 
 [[package]]
 name = "grpcio-sys"
-version = "0.8.1"
+version = "0.10.3+1.44.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f89a56d830be4dddc939c377c95e3b77e30c86a8df99c20095c34cf9038447b"
+checksum = "f23adc509a3c4dea990e0ab8d2add4a65389ee69c288b7851d75dd1df7a6d6c6"
 dependencies = [
- "bindgen 0.57.0",
- "boringssl-src",
+ "bindgen 0.59.2",
  "cc",
  "cmake",
  "libc",
@@ -2169,16 +2190,6 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -3077,6 +3088,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "rustyline"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,12 +3364,6 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
-
-[[package]]
-name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
@@ -3386,6 +3397,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+
+[[package]]
+name = "slog-term"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
+dependencies = [
+ "atty",
+ "slog",
+ "term",
+ "thread_local",
+ "time 0.3.13",
 ]
 
 [[package]]
@@ -3528,6 +3558,12 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -3569,7 +3605,7 @@ dependencies = [
  "base64",
  "bytes 1.2.1",
  "chrono",
- "clap",
+ "clap 3.2.17",
  "fern",
  "futures 0.3.23",
  "http",
@@ -3597,7 +3633,7 @@ dependencies = [
  "argon2",
  "async-channel",
  "async-executor",
- "async-recursion",
+ "async-recursion 1.0.0",
  "bigdecimal",
  "chrono",
  "deunicode",
@@ -3612,7 +3648,7 @@ dependencies = [
  "log",
  "md-5",
  "nanoid",
- "nom 7.1.1",
+ "nom",
  "once_cell",
  "pbkdf2",
  "rand 0.8.5",
@@ -3670,12 +3706,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -3716,11 +3772,12 @@ dependencies = [
 [[package]]
 name = "tikv-client"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26904b386ca52ce25b3a620b397e6e4e93c4fd06d13c2c5936d9ac597f897263"
+source = "git+https://github.com/tikv/client-rust?rev=68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b#68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b"
 dependencies = [
+ "async-recursion 0.3.2",
  "async-trait",
  "derive-new",
+ "either",
  "fail",
  "futures 0.3.23",
  "futures-timer",
@@ -3730,8 +3787,11 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "regex",
+ "semver 1.0.13",
  "serde",
  "serde_derive",
+ "slog",
+ "slog-term",
  "thiserror",
  "tikv-client-common",
  "tikv-client-pd",
@@ -3743,23 +3803,23 @@ dependencies = [
 [[package]]
 name = "tikv-client-common"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72fc3bb3fbec1f2a3354d4bbe48501b23ea47b79da2ffaedeadcc8a6183188e4"
+source = "git+https://github.com/tikv/client-rust?rev=68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b#68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b"
 dependencies = [
  "futures 0.3.23",
  "grpcio",
  "lazy_static",
  "log",
  "regex",
+ "semver 1.0.13",
  "thiserror",
  "tikv-client-proto",
+ "tokio",
 ]
 
 [[package]]
 name = "tikv-client-pd"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cadef1633d4e7952d9a3a88211f03f71e9f90769a5b50c40b5eccc06408977"
+source = "git+https://github.com/tikv/client-rust?rev=68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b#68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b"
 dependencies = [
  "async-trait",
  "futures 0.3.23",
@@ -3772,14 +3832,13 @@ dependencies = [
 [[package]]
 name = "tikv-client-proto"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9707c63c11c19b87b6eb3df40c6103d0f1e2f06b53445bad91a8c9e06407d9b"
+source = "git+https://github.com/tikv/client-rust?rev=68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b#68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b"
 dependencies = [
  "futures 0.3.23",
  "grpcio",
  "lazy_static",
- "prost 0.7.0",
- "prost-derive 0.7.0",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
  "protobuf",
  "protobuf-build",
 ]
@@ -3787,8 +3846,7 @@ dependencies = [
 [[package]]
 name = "tikv-client-store"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab348b60ef0a384985c488e25bf35721956b3b45332945f0841f9ac8a693586"
+source = "git+https://github.com/tikv/client-rust?rev=68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b#68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b"
 dependencies = [
  "async-trait",
  "derive-new",
@@ -4213,6 +4271,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -57,7 +57,7 @@ sha-1 = "0.10.0"
 sha2 = "0.10.2"
 storekey = "0.3.0"
 thiserror = "1.0.32"
-tikv = { version = "0.1.0", package = "tikv-client", optional = true }
+tikv = { version = "0.1.0", package = "tikv-client", git = "https://github.com/tikv/client-rust", optional = true, rev = "68b7f1e1ab0e059cbee1a3200d559ef4b03d4c8b" }
 trice = "0.1.0"
 url = "2.2.2"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }

--- a/lib/src/kvs/tikv/mod.rs
+++ b/lib/src/kvs/tikv/mod.rs
@@ -23,7 +23,7 @@ pub struct Transaction {
 impl Datastore {
 	// Open a new database
 	pub async fn new(path: &str) -> Result<Datastore, Error> {
-		match tikv::TransactionClient::new(vec![path]).await {
+		match tikv::TransactionClient::new(vec![path], None).await {
 			Ok(db) => Ok(Datastore {
 				db,
 			}),


### PR DESCRIPTION
## What is the motivation?

We are unable to build SurrealDB on Linux because of `grpcio-sys-0.8.1` crate being pulled for `tikv-client` in version `0.1.0` specifically in crates.io repo.
We can fix this right now instead of waiting for the next release of `tikv-client`

## What does this change do?

We set `tikv-client` to use github upstream on the specific commit that fixes our issue.
A little API change was necessary for `tikv_client::TransactionClient::new`.

## What is your testing strategy?

It finally builds because eliminates `grpcio-sys-0.8.1`

## Is this related to any issues?

#52

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

[y] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
