### PR TITLE
#34: Make --ns and --db arguments optional in command-line REPL

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -414,7 +414,7 @@ pub fn init() {
 			.arg(
 				Arg::new("ns")
 					.long("ns")
-					.required(true)
+					.required(false)
 					.takes_value(true)
 					.forbid_empty_values(true)
 					.help("The namespace to export the data from"),
@@ -422,7 +422,7 @@ pub fn init() {
 			.arg(
 				Arg::new("db")
 					.long("db")
-					.required(true)
+					.required(false)
 					.takes_value(true)
 					.forbid_empty_values(true)
 					.help("The database to export the data from"),

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -13,8 +13,16 @@ pub fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 	let user = matches.value_of("user").unwrap();
 	let pass = matches.value_of("pass").unwrap();
 	let conn = matches.value_of("conn").unwrap();
-	let ns = matches.value_of("ns").unwrap();
-	let db = matches.value_of("db").unwrap();
+
+	let ns = match matches.value_of("ns") {
+		Some(val) => val,
+		None => "",
+	};
+	let db = match matches.value_of("db") {
+		Some(val) => val,
+		None => "",
+	};
+
 	// If we should pretty-print responses
 	let pretty = matches.is_present("pretty");
 	// Set the correct import URL


### PR DESCRIPTION
## What is the motivation?

Making `--ns` and `--db` arguments optional for the `sql` subcomman, allowing them to be specified at a later time.

## What does this change do?

Makes `--ns` and `--db` arguments optional for the `sql` subcommand in the CLI.

## What is your testing strategy?

I've run the CLI with the `sql` command against the SurrealDB database serve (started using `cargo run -- start memory --bind 0.0.0.0:9000 --user root --pass root`, and verified that the CLI is able to start and that I can specify both the `db` and `ns` variables. After doing so I am also able to insert data.

## Is this related to any issues?

It is related to issue #34.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

[x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
