### PR TITLE
type::table(type::thing(...)) should work as expected.

### DIFF
--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -93,7 +93,10 @@ pub fn string(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 }
 
 pub fn table(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
-	Ok(Value::Table(Table(args.remove(0).as_string())))
+	Ok(Value::Table(Table(match args.remove(0) {
+		Value::Thing(t) => t.tb.clone(),
+		v => v.as_string()
+	})))
 }
 
 pub fn thing(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {

--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -95,7 +95,7 @@ pub fn string(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 pub fn table(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 	Ok(Value::Table(Table(match args.remove(0) {
 		Value::Thing(t) => t.tb.clone(),
-		v => v.as_string()
+		v => v.as_string(),
 	})))
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Wanted to fix #68 - `type::table(type::thing(1, 2))` should return 1.

## What does this change do?

Fixes #68 by making `type::table` extract the table from `Value::Thing`

## What is your testing strategy?

The tests still pass, but don't necessarily exercise the new behavior (or the old behavior). Didn't see a good place to add a test.

I tried `cargo fmt` (`cargo 1.65.0-nightly (efd4ca3dc 2022-08-12)`) but it touched over 10 files that I didn't edit.

## Is this related to any issues?

#68

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
