### PR TITLE
bugfix - string::words handles extra spaces better

### DIFF
--- a/lib/src/fnc/string.rs
+++ b/lib/src/fnc/string.rs
@@ -81,5 +81,5 @@ pub fn uppercase(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 }
 
 pub fn words(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
-	Ok(args.remove(0).as_string().split(' ').collect::<Vec<&str>>().into())
+	Ok(args.remove(0).as_string().split_whitespace().collect::<Vec<&str>>().into())
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The current `string::words` method emits extra empty strings when the input has spaces before, in the middle, or after.
```sql
> select * from string::words("  foo   bar  ");
[{"time":"85.534µs","status":"OK","result":["","","foo","","","bar","",""]}]
```
For reference, the docs say the following, which seems contrary to the behavior:
![image](https://user-images.githubusercontent.com/20015102/187100134-c7f514f8-c336-4b37-87b0-f5ca8c9f9dab.png)

## What does this change do?

Replace `.split(' ')` with `.split_whitespace()`, which is Unicode-aware and more aligned with what I assume the purpose of this function is:
```rust
pub fn main() {
    println!("{:?}", "  foo  bar  ".split(' ').collect::<Vec<&str>>());
    // ["", "", "foo", "", "bar", "", ""]

    println!("{:?}", "  foo  bar  ".split_whitespace().collect::<Vec<&str>>());
    // ["foo", "bar"]
}
```

## What is your testing strategy?

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=14a852673c097e8e607f424f3b58a173

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
