### PR TITLE
Bugfix #76 - Make RocksDB integration more, if not completely, sound.

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -64,7 +64,7 @@ url = "2.2.2"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 
 [dev-dependencies]
-tokio = { version = "1.20.1", features = ["macros"] }
+tokio = { version = "1.20.1", features = ["macros", "rt"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 surf = { version = "2.3.2", optional = true, default-features = false, features = ["encoding", "wasm-client"] }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The current rocksdb integration is unsound, in the sense that non-`unsafe` code can trigger undefined behavior (e.g. use-after-free)

## What does this change do?

`Pin`s the rocksdb datastore in an `Arc` that gets dropped after any underlying transactions.

The public API is unaffected, so the fix can be freely improved/replaced in the future.

## What is your testing strategy?

I added a test.

I will rely on the CI system to point out any formatting issues that need to be fixed before potential merging, as my local `cargo fmt` misbehaves and tries to rewrite most of the files in the repo.

## Is this related to any issues?

Fixes #76

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
