### PR TITLE
Add DB_PATH environment variable

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -122,6 +122,7 @@ pub fn init() {
 			.arg(
 				Arg::new("path")
 					.index(1)
+					.env("DB_PATH")
 					.required(false)
 					.validator(path_valid)
 					.default_value("memory")


### PR DESCRIPTION
## What is the motivation?

To specify the on disk database path through an environment variable.

## What does this change do?

Makes the CLI recognize a new DB_PATH environment variable.

## What is your testing strategy?

````
> DB_PATH=/data/database.db
> cargo run -- start
> cargo test
````

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

[x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
