### PR TITLE
Bugfix integer range

### DIFF
--- a/lib/src/sql/ending.rs
+++ b/lib/src/sql/ending.rs
@@ -23,6 +23,13 @@ pub fn number(i: &str) -> IResult<&str, ()> {
 	)))(i)
 }
 
+pub fn integer(i: &str) -> IResult<&str, ()> {
+	peek(alt((
+		map(number, |_| ()),
+		map(char('.'), |_| ()),
+	)))(i)
+}
+
 pub fn ident(i: &str) -> IResult<&str, ()> {
 	peek(alt((
 		map(multispace1, |_| ()),

--- a/lib/src/sql/ending.rs
+++ b/lib/src/sql/ending.rs
@@ -2,12 +2,12 @@ use crate::sql::comment::comment;
 use crate::sql::error::IResult;
 use crate::sql::operator::{assigner, operator};
 use nom::branch::alt;
+use nom::bytes::complete::tag;
 use nom::character::complete::char;
 use nom::character::complete::multispace1;
 use nom::combinator::eof;
 use nom::combinator::map;
 use nom::combinator::peek;
-use nom::bytes::complete::tag;
 
 pub fn number(i: &str) -> IResult<&str, ()> {
 	peek(alt((

--- a/lib/src/sql/ending.rs
+++ b/lib/src/sql/ending.rs
@@ -7,6 +7,7 @@ use nom::character::complete::multispace1;
 use nom::combinator::eof;
 use nom::combinator::map;
 use nom::combinator::peek;
+use nom::bytes::complete::tag;
 
 pub fn number(i: &str) -> IResult<&str, ()> {
 	peek(alt((
@@ -19,14 +20,8 @@ pub fn number(i: &str) -> IResult<&str, ()> {
 		map(char('}'), |_| ()),
 		map(char(';'), |_| ()),
 		map(char(','), |_| ()),
+		map(tag(".."), |_| ()),
 		map(eof, |_| ()),
-	)))(i)
-}
-
-pub fn integer(i: &str) -> IResult<&str, ()> {
-	peek(alt((
-		map(number, |_| ()),
-		map(char('.'), |_| ()),
 	)))(i)
 }
 

--- a/lib/src/sql/number.rs
+++ b/lib/src/sql/number.rs
@@ -1,5 +1,4 @@
-use crate::sql::ending::integer as integer_ending;
-use crate::sql::ending::number as number_ending;
+use crate::sql::ending::number as ending;
 use crate::sql::error::IResult;
 use crate::sql::serde::is_internal_serialization;
 use bigdecimal::BigDecimal;
@@ -505,13 +504,13 @@ pub fn number(i: &str) -> IResult<&str, Number> {
 
 pub fn integer(i: &str) -> IResult<&str, i64> {
 	let (i, v) = i64(i)?;
-	let (i, _) = integer_ending(i)?;
+	let (i, _) = ending(i)?;
 	Ok((i, v))
 }
 
 pub fn decimal(i: &str) -> IResult<&str, &str> {
 	let (i, v) = recognize_float(i)?;
-	let (i, _) = number_ending(i)?;
+	let (i, _) = ending(i)?;
 	Ok((i, v))
 }
 

--- a/lib/src/sql/number.rs
+++ b/lib/src/sql/number.rs
@@ -1,4 +1,5 @@
-use crate::sql::ending::number as ending;
+use crate::sql::ending::integer as integer_ending;
+use crate::sql::ending::number as number_ending;
 use crate::sql::error::IResult;
 use crate::sql::serde::is_internal_serialization;
 use bigdecimal::BigDecimal;
@@ -504,13 +505,13 @@ pub fn number(i: &str) -> IResult<&str, Number> {
 
 pub fn integer(i: &str) -> IResult<&str, i64> {
 	let (i, v) = i64(i)?;
-	let (i, _) = ending(i)?;
+	let (i, _) = integer_ending(i)?;
 	Ok((i, v))
 }
 
 pub fn decimal(i: &str) -> IResult<&str, &str> {
 	let (i, v) = recognize_float(i)?;
-	let (i, _) = ending(i)?;
+	let (i, _) = number_ending(i)?;
 	Ok((i, v))
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Right now, `SELECT * FROM person:1..1000;` will not select the result of `CREATE person:5`.

That's because `1..1000` is parsed as `Id::String("1")..Id::Number(1000)`, which comes down to the first `.` in `..` signaling the parser to stop parsing an integer.

## What does this change do?

This change adds `..` as an ending pattern for number parsing, including integers.

## What is your testing strategy?

I tested the query above, and it went from broken to working.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)