### PR TITLE
Disable unstable rustfmt options

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,12 +1,17 @@
-blank_lines_lower_bound = 1
 edition = "2021"
 hard_tabs = true
-indent_style = "Block"
-match_arm_blocks = true
 merge_derives = true
-reorder_impl_items = true
 reorder_imports = true
 reorder_modules = true
 use_field_init_shorthand = true
 use_small_heuristics = "Off"
-wrap_comments = true
+
+# -----------------------------------
+# Unstable options we would like to use in future
+# -----------------------------------
+
+#blank_lines_lower_bound = 1
+#indent_style = "Block"
+#match_arm_blocks = true
+#reorder_impl_items = true
+#wrap_comments = true


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Remove confusing warnings from `cargo fmt` output.

## What does this change do?

It comments out all currently unstable options.

## What is your testing strategy?

I ran `cargo fmt`.

## Is this related to any issues?

It fixes https://github.com/surrealdb/surrealdb/issues/85.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
