### PR TITLE
Bugfix #99 - Spawn a scoped thread to handle CPU intensive hashing

### DIFF
--- a/lib/src/exe/mod.rs
+++ b/lib/src/exe/mod.rs
@@ -1,0 +1,9 @@
+pub async fn spawn_blocking_non_static<T: Send>(work: impl FnOnce() -> T + Send) -> T {
+	let (sender, receiver) = futures::channel::oneshot::channel();
+	std::thread::scope(|s| {
+		s.spawn(|| {
+			sender.send(work()).unwrap_or_else(|_| unreachable!("receiver dropped too early"));
+		});
+	});
+	receiver.await.unwrap_or_else(|_| unreachable!("sender dropped too early"))
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -18,7 +18,6 @@ mod ctx;
 mod dbs;
 mod doc;
 mod err;
-#[cfg(feature = "parallel")]
 mod exe;
 mod fnc;
 mod key;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -18,6 +18,8 @@ mod ctx;
 mod dbs;
 mod doc;
 mod err;
+#[cfg(feature = "parallel")]
+mod exe;
 mod fnc;
 mod key;
 mod kvs;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Right now, extremely CPU intensive password-hash functions block threads used by the async executor as described in #99 

## What does this change do?

Spawns a scoped thread for every hashing task. This diverges from the plan described [here](https://github.com/surrealdb/surrealdb/issues/99#issuecomment-1235912670), because lifetimes were a concern (in particular, `&Context` and `&str` arguments). Without scoped threads, it is difficult to spawn a non-`'static` task into another thread/`Executor` and, without [this](https://github.com/Kimundi/scoped-threadpool-rs), it is difficult to spawn non-`'static` tasks into a threadpool.

Only does the above if the `parallel` feature is present.

## What does this change *not* do?

- Does not make the hashing functions `async` as suggested [here](https://github.com/surrealdb/surrealdb/issues/99#issuecomment-1235912670) because I think it would add code/complexity without solving a problem
- Does not attempt to consolidate argument validation as suggested [here](https://github.com/surrealdb/surrealdb/issues/99#issuecomment-1235923990) because of the above, so this can just as easily go in a separate PR once I figure it out.
- Does not limit number of threads spawned (could fix with a dependency on https://github.com/Kimundi/scoped-threadpool-rs, which relies on `unsafe` code). I still think this change is worth doing either way, but let me know if this additional dependency is acceptable and I'll update the PR.

## MSRV Warning

Scoped threads are new, having been stabilized last month (https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html). I didn't see a MSRV for SurrealDB listed, though.

## What is your testing strategy?

Tried a few hashing and non-hashing queries.

## Is this related to any issues?

Fixes #99 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
