### PR TITLE
Updated error message to be QueryPermissions

### DIFF
--- a/lib/src/doc/document.rs
+++ b/lib/src/doc/document.rs
@@ -70,7 +70,7 @@ impl<'a> Document<'a> {
 					run.add_and_cache_tb(opt.ns(), opt.db(), &rid.tb, opt.strict).await
 				}
 				// We can't create the table so error
-				false => Err(Error::TbNotFound),
+				false => Err(Error::QueryPermissions),
 			},
 			// There was an error
 			Err(err) => Err(err),


### PR DESCRIPTION
## What is the motivation?

When executing a create statement when unauthorized the error message returned is "The table does not exist"

## What does this change do?

Changes the error type so the message is now "You don't have permission to perform this query type"

## What is your testing strategy?

Send a `create` RPC message to the database without signing in first.

## Is this related to any issues?

#177 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)

<img width="790" alt="Screen Shot 2022-09-16 at 3 56 24 PM" src="https://user-images.githubusercontent.com/827735/190743149-ba35effd-d6fd-4ca5-a556-f045ead59c64.png">
