### PR TITLE
Fix bug in time::month()

### DIFF
--- a/lib/src/fnc/time.rs
+++ b/lib/src/fnc/time.rs
@@ -89,9 +89,9 @@ pub fn mins(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 
 pub fn month(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 	match args.len() {
-		0 => Ok(Utc::now().day().into()),
+		0 => Ok(Utc::now().month().into()),
 		_ => match args.remove(0) {
-			Value::Datetime(v) => Ok(v.day().into()),
+			Value::Datetime(v) => Ok(v.month().into()),
 			_ => Ok(Value::None),
 		},
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Fix a bug in the time::month() function.

## What does this change do?

Make time::month() return the month of a provided timestamp instead of the day.

## What is your testing strategy?

Tested locally against the current main branch and the branch containing the fix.

## Is this related to any issues?

Fixed #214.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
