### PR TITLE
Fix anomalies in `math` functions

### DIFF
--- a/lib/src/fnc/math.rs
+++ b/lib/src/fnc/math.rs
@@ -68,7 +68,10 @@ pub fn max(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 
 pub fn mean(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 	match args.remove(0) {
-		Value::Array(v) => Ok(v.as_numbers().mean().into()),
+		Value::Array(v) => match v.is_empty() {
+			true => Ok(Value::None),
+			false => Ok(v.as_numbers().mean().into()),
+		},
 		_ => Ok(Value::None),
 	}
 }

--- a/lib/src/fnc/math.rs
+++ b/lib/src/fnc/math.rs
@@ -143,12 +143,8 @@ pub fn spread(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 }
 
 pub fn sqrt(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
-	let v = args.remove(0);
-	let v_number = v.as_number();
-	let v_float = v_number.clone().as_float();
-
-	match v_float {
-		num if num >= 0.0 => Ok(v_number.sqrt().into()),
+	match args.remove(0).as_number() {
+		v if v >= Number::Int(0) => Ok(v.sqrt().into()),
 		_ => Err(Error::InvalidArguments {
 			name: String::from("math::sqrt"),
 			message: String::from("The argument must be a positive number."),

--- a/lib/src/fnc/math.rs
+++ b/lib/src/fnc/math.rs
@@ -143,7 +143,17 @@ pub fn spread(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 }
 
 pub fn sqrt(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
-	Ok(args.remove(0).as_number().sqrt().into())
+	let v = args.remove(0);
+	let v_number = v.as_number();
+	let v_float = v_number.clone().as_float();
+
+	match v_float {
+		num if num > 0.0 => Ok(v_number.sqrt().into()),
+		_ => Err(Error::InvalidArguments {
+			name: String::from("math::sqrt"),
+			message: String::from("The argument must be a number greater than 0."),
+		}),
+	}
 }
 
 pub fn stddev(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {

--- a/lib/src/fnc/math.rs
+++ b/lib/src/fnc/math.rs
@@ -148,10 +148,10 @@ pub fn sqrt(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 	let v_float = v_number.clone().as_float();
 
 	match v_float {
-		num if num > 0.0 => Ok(v_number.sqrt().into()),
+		num if num >= 0.0 => Ok(v_number.sqrt().into()),
 		_ => Err(Error::InvalidArguments {
 			name: String::from("math::sqrt"),
-			message: String::from("The argument must be a number greater than 0."),
+			message: String::from("The argument must be a positive number."),
 		}),
 	}
 }

--- a/lib/src/fnc/math.rs
+++ b/lib/src/fnc/math.rs
@@ -78,7 +78,10 @@ pub fn mean(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 
 pub fn median(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 	match args.remove(0) {
-		Value::Array(v) => Ok(v.as_numbers().median().into()),
+		Value::Array(v) => match v.is_empty() {
+			true => Ok(Value::None),
+			false => Ok(v.as_numbers().median().into()),
+		},
 		_ => Ok(Value::None),
 	}
 }

--- a/lib/src/fnc/math.rs
+++ b/lib/src/fnc/math.rs
@@ -145,10 +145,7 @@ pub fn spread(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 pub fn sqrt(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
 	match args.remove(0).as_number() {
 		v if v >= Number::Int(0) => Ok(v.sqrt().into()),
-		_ => Err(Error::InvalidArguments {
-			name: String::from("math::sqrt"),
-			message: String::from("The argument must be a positive number."),
-		}),
+		_ => Ok(Value::None),
 	}
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Make the math functions more consistent.

## What does this change do?

This change will:

- Return `Value::None` when inputting a negative value into `math::sqrt`
- Fix `math::median` panicking on an empty array (it now returns None)
- Fix `math::mean` panicking on an empty array (it now returns None)

## What is your testing strategy?

- Compile with changes
- Test changes match expected behaviour

## Is this related to any issues?

Resolves https://github.com/surrealdb/surrealdb/issues/218

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)