### PR TITLE
Add bcrypt capabilities to `crypto`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2b2456fd614d856680dcd9fcc660a51a820fa09daef2e49772b56a193c8474"
 
 [[package]]
+name = "bcrypt"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e7c93a3fb23b2fdde989b2c9ec4dd153063ec81f408507f84c090cd91c6641"
+dependencies = [
+ "base64",
+ "blowfish",
+ "getrandom 0.2.7",
+ "zeroize",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +476,16 @@ dependencies = [
  "fastrand",
  "futures-lite",
  "once_cell",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher 0.4.3",
 ]
 
 [[package]]
@@ -3674,6 +3696,7 @@ dependencies = [
  "async-channel",
  "async-executor",
  "async-recursion",
+ "bcrypt",
  "bigdecimal",
  "chrono",
  "deunicode",
@@ -4585,6 +4608,12 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zstd-sys"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -64,6 +64,7 @@ tikv = { version = "0.1.0", package = "tikv-client", optional = true }
 trice = "0.1.0"
 url = "2.3.1"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
+bcrypt = "0.13.0"
 
 [dev-dependencies]
 tokio = { version = "1.21.1", features = ["macros", "rt"] }

--- a/lib/src/fnc/crypto.rs
+++ b/lib/src/fnc/crypto.rs
@@ -191,3 +191,23 @@ pub mod scrypt {
 		Ok(hash.into())
 	}
 }
+
+pub mod bcrypt {
+
+	use crate::ctx::Context;
+	use crate::err::Error;
+	use crate::sql::value::Value;
+	use bcrypt;
+
+	pub fn cmp(_: &Context, args: Vec<Value>) -> Result<Value, Error> {
+		let args: [Value; 2] = args.try_into().unwrap();
+		let [hash, pass] = args.map(Value::as_string);
+		Ok(bcrypt::verify(pass, &hash).unwrap_or(false).into())
+	}
+
+	pub fn gen(_: &Context, mut args: Vec<Value>) -> Result<Value, Error> {
+		let pass = args.remove(0).as_string();
+		let hash = bcrypt::hash(pass, bcrypt::DEFAULT_COST).unwrap();
+		Ok(hash.into())
+	}
+}

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -64,6 +64,8 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"crypto::pbkdf2::generate" => args::check(ctx, name, args, Args::One, crypto::pbkdf2::gen),
 		"crypto::scrypt::compare" => args::check(ctx, name, args, Args::Two, crypto::scrypt::cmp),
 		"crypto::scrypt::generate" => args::check(ctx, name, args, Args::One, crypto::scrypt::gen),
+		"crypto::bcrypt::compare" => args::check(ctx, name, args, Args::Two, crypto::bcrypt::cmp),
+		"crypto::bcrypt::generate" => args::check(ctx, name, args, Args::One, crypto::bcrypt::gen),
 		//
 		"geo::area" => args::check(ctx, name, args, Args::One, geo::area),
 		"geo::bearing" => args::check(ctx, name, args, Args::Two, geo::bearing),

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -276,7 +276,7 @@ fn function_crypto(i: &str) -> IResult<&str, &str> {
 		tag("crypto::argon2::compare"),
 		tag("crypto::argon2::generate"),
 		tag("crypto::bcrypt::compare"),
-		tag("crypto::bcrypt::generate"),		
+		tag("crypto::bcrypt::generate"),
 		tag("crypto::md5"),
 		tag("crypto::pbkdf2::compare"),
 		tag("crypto::pbkdf2::generate"),

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -275,6 +275,8 @@ fn function_crypto(i: &str) -> IResult<&str, &str> {
 	alt((
 		tag("crypto::argon2::compare"),
 		tag("crypto::argon2::generate"),
+		tag("crypto::bcrypt::compare"),
+		tag("crypto::bcrypt::generate"),		
 		tag("crypto::md5"),
 		tag("crypto::pbkdf2::compare"),
 		tag("crypto::pbkdf2::generate"),
@@ -283,8 +285,6 @@ fn function_crypto(i: &str) -> IResult<&str, &str> {
 		tag("crypto::sha1"),
 		tag("crypto::sha256"),
 		tag("crypto::sha512"),
-		tag("crypto::bcrypt::compare"),
-		tag("crypto::bcrypt::generate"),
 	))(i)
 }
 

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -283,6 +283,8 @@ fn function_crypto(i: &str) -> IResult<&str, &str> {
 		tag("crypto::sha1"),
 		tag("crypto::sha256"),
 		tag("crypto::sha512"),
+		tag("crypto::bcrypt::compare"),
+		tag("crypto::bcrypt::generate"),
 	))(i)
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Many companies, projects and solutions use bcrypt for their password hashing as it is one of the most popular. People should be able to migrate their existing data and still be able to take advantage of the `crypto` lib, or choose bcrypt over other options in new projects should they wish.

## What does this change do?

This change adds the functions `crypto::bcrypt::generate` and `crypto::bcrypt::compare` for use in SQL queries.

## What is your testing strategy?

- Compile with changes
- Test changes match expected behaviour

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
