### PR TITLE
Add Building Instructions for Windows OS [#217]

### DIFF
--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -314,3 +314,48 @@ docker run --pull --rm -v $PWD:/volume -t clux/muslrust:stable cargo build --rel
 ```
 
 </details>
+
+
+## Building on Windows-amd64 (Windows OS)
+
+<details><summary>Click to show details</summary>
+
+###  ✅ Compile for `windows-amd64`
+
+> Compiling SurrealDB with windows OS requires **Administrator** priveledge!
+
+⚠**Tested on Windows 10 build 22H2(19044.2006)**
+
+1. Install LLVM with Clang 👉 [Download Here](https://github.com/llvm/llvm-project/releases) *look for something end with `amd64.exe`*
+2. Install `MYSYS2` 👉 Follow instructions on [their website](https://www.msys2.org/)
+3. Add Symlinks for llvm
+
+   ```powershell
+   New-Item -Path "C:\Program Files\LLVM\x86_64-w64-mingw32" -ItemType SymbolicLink -Value "C:\msys64\mingw64\x86_64-w64-mingw32"
+   New-Item -Path "C:\Program Files\LLVM\i686-w64-mingw32" -ItemType SymbolicLink -Value "C:\msys64\mingw64\i686-w64-mingw32"
+    ```
+
+4. Add GCC binary path to environment
+
+    ```powershell
+    $PATH += "C:\msys64\mingw64\bin"
+    $PATH += "C:\msys64\mingw32\bin"
+    $CC_x86_64_pc_windows_gnu = "x86_64-w64-mingw32-gcc"
+    $CC_i686_pc_windows_gnu = "i686-w64-mingw32-gcc"
+    $HOST_CC = "x86_64-w64-mingw32-gcc"
+    ```
+
+5. Install `patch` GNU Util
+    Go to GNUWin32 page for [*patch*](http://gnuwin32.sourceforge.net/packages/patch.htm) and
+    install the [*patch*](http://gnuwin32.sourceforge.net/downlinks/patch-bin-zip.php)
+    binaries.
+
+	> For some bizzare reasons, **patch.exe needs elevated priviledge** to be invoked during
+	> compilation
+
+    Add directory containing the `patch.exe` to your PATH
+
+6. Run cargo in an **elevated ⚠** shell
+
+    Running `cargo build` in an **elevated shell** will now build the `SurrealDB` in Windows OS.
+</details>


### PR DESCRIPTION
Instructions to building Surreal DB using Windows OS has been added

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I was playing around with Surreal DB and wanted to embed in a project, so I tried building on Windows
and compilation failed. Despite my obsession with Surreal DB, I dug deeper and finally somehow got it to
compile and then build

## What does this change do?

Adds Instruction to doc/BUILDING.md to build Surreal DB on Windows OS (build number:19044.2006)

## What is your testing strategy?

I built the crate and tried issuing `CREATE`, `SELECT`, `UPDATE` and `INFO` commands to an in-memory
and also, file-backed dbs(using surreal::DataStore) and checks returned results.

Also tried connecting cli ([the one from canonical location](https://windows.surrealdb.com) (using `sql` command)) to aforementioned file-based db and validated records were created by issuing commands via cli.

Then created a file based db with cli and tried doing same as before with crate I built, and all worked fine 😁

## Is this related to any issues?

Builds fail because rquickjs crate (used to provide embedded js-engine functionality by the database to run arbitrary js-funcs in queries) required `patch`(A GNU Utility) to patch upstream quickjs source-code. Since, `patch` doesn't come pre-installed with Windows OS, builds were failing

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [ ✅] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
