### PR TITLE
Feature - Add duration functions

### DIFF
--- a/lib/src/fnc/duration.rs
+++ b/lib/src/fnc/duration.rs
@@ -1,62 +1,55 @@
 use crate::err::Error;
-use crate::sql::duration::Duration;
 use crate::sql::value::Value;
 
-pub fn secs((duration,): (Option<Value>,)) -> Result<Value, Error> {
+pub fn secs((duration,): (Value,)) -> Result<Value, Error> {
 	let duration = match duration {
-		Some(Value::Duration(d)) => d,
-		None => Duration::default(),
-		Some(_) => return Ok(Value::None),
+		Value::Duration(d) => d,
+		_ => return Ok(Value::None),
 	};
 
 	Ok(duration.secs())
 }
 
-pub fn mins((duration,): (Option<Value>,)) -> Result<Value, Error> {
+pub fn mins((duration,): (Value,)) -> Result<Value, Error> {
 	let duration = match duration {
-		Some(Value::Duration(d)) => d,
-		None => Duration::default(),
-		Some(_) => return Ok(Value::None),
+		Value::Duration(d) => d,
+		_ => return Ok(Value::None),
 	};
 
 	Ok(duration.mins())
 }
 
-pub fn hours((duration,): (Option<Value>,)) -> Result<Value, Error> {
+pub fn hours((duration,): (Value,)) -> Result<Value, Error> {
 	let duration = match duration {
-		Some(Value::Duration(d)) => d,
-		None => Duration::default(),
-		Some(_) => return Ok(Value::None),
+		Value::Duration(d) => d,
+		_ => return Ok(Value::None),
 	};
 
 	Ok(duration.hours())
 }
 
-pub fn days((duration,): (Option<Value>,)) -> Result<Value, Error> {
+pub fn days((duration,): (Value,)) -> Result<Value, Error> {
 	let duration = match duration {
-		Some(Value::Duration(d)) => d,
-		None => Duration::default(),
-		Some(_) => return Ok(Value::None),
+		Value::Duration(d) => d,
+		_ => return Ok(Value::None),
 	};
 
 	Ok(duration.days())
 }
 
-pub fn weeks((duration,): (Option<Value>,)) -> Result<Value, Error> {
+pub fn weeks((duration,): (Value,)) -> Result<Value, Error> {
 	let duration = match duration {
-		Some(Value::Duration(d)) => d,
-		None => Duration::default(),
-		Some(_) => return Ok(Value::None),
+		Value::Duration(d) => d,
+		_ => return Ok(Value::None),
 	};
 
 	Ok(duration.weeks())
 }
 
-pub fn years((duration,): (Option<Value>,)) -> Result<Value, Error> {
+pub fn years((duration,): (Value,)) -> Result<Value, Error> {
 	let duration = match duration {
-		Some(Value::Duration(d)) => d,
-		None => Duration::default(),
-		Some(_) => return Ok(Value::None),
+		Value::Duration(d) => d,
+		_ => return Ok(Value::None),
 	};
 
 	Ok(duration.years())

--- a/lib/src/fnc/duration.rs
+++ b/lib/src/fnc/duration.rs
@@ -1,56 +1,44 @@
 use crate::err::Error;
 use crate::sql::value::Value;
 
-pub fn secs((duration,): (Value,)) -> Result<Value, Error> {
-	let duration = match duration {
-		Value::Duration(d) => d,
-		_ => return Ok(Value::None),
-	};
-
-	Ok(duration.secs())
-}
-
-pub fn mins((duration,): (Value,)) -> Result<Value, Error> {
-	let duration = match duration {
-		Value::Duration(d) => d,
-		_ => return Ok(Value::None),
-	};
-
-	Ok(duration.mins())
+pub fn days((duration,): (Value,)) -> Result<Value, Error> {
+	Ok(match duration {
+		Value::Duration(d) => d.days(),
+		_ => Value::None,
+	})
 }
 
 pub fn hours((duration,): (Value,)) -> Result<Value, Error> {
-	let duration = match duration {
-		Value::Duration(d) => d,
-		_ => return Ok(Value::None),
-	};
-
-	Ok(duration.hours())
+	Ok(match duration {
+		Value::Duration(d) => d.hours(),
+		_ => Value::None,
+	})
 }
 
-pub fn days((duration,): (Value,)) -> Result<Value, Error> {
-	let duration = match duration {
-		Value::Duration(d) => d,
-		_ => return Ok(Value::None),
-	};
+pub fn mins((duration,): (Value,)) -> Result<Value, Error> {
+	Ok(match duration {
+		Value::Duration(d) => d.mins(),
+		_ => Value::None,
+	})
+}
 
-	Ok(duration.days())
+pub fn secs((duration,): (Value,)) -> Result<Value, Error> {
+	Ok(match duration {
+		Value::Duration(d) => d.secs(),
+		_ => Value::None,
+	})
 }
 
 pub fn weeks((duration,): (Value,)) -> Result<Value, Error> {
-	let duration = match duration {
-		Value::Duration(d) => d,
-		_ => return Ok(Value::None),
-	};
-
-	Ok(duration.weeks())
+	Ok(match duration {
+		Value::Duration(d) => d.weeks(),
+		_ => Value::None,
+	})
 }
 
 pub fn years((duration,): (Value,)) -> Result<Value, Error> {
-	let duration = match duration {
-		Value::Duration(d) => d,
-		_ => return Ok(Value::None),
-	};
-
-	Ok(duration.years())
+	Ok(match duration {
+		Value::Duration(d) => d.years(),
+		_ => Value::None,
+	})
 }

--- a/lib/src/fnc/duration.rs
+++ b/lib/src/fnc/duration.rs
@@ -1,0 +1,63 @@
+use crate::err::Error;
+use crate::sql::duration::Duration;
+use crate::sql::value::Value;
+
+pub fn secs((duration,): (Option<Value>,)) -> Result<Value, Error> {
+	let duration = match duration {
+		Some(Value::Duration(d)) => d,
+		None => Duration::default(),
+		Some(_) => return Ok(Value::None),
+	};
+
+	Ok(duration.secs())
+}
+
+pub fn mins((duration,): (Option<Value>,)) -> Result<Value, Error> {
+	let duration = match duration {
+		Some(Value::Duration(d)) => d,
+		None => Duration::default(),
+		Some(_) => return Ok(Value::None),
+	};
+
+	Ok(duration.mins())
+}
+
+pub fn hours((duration,): (Option<Value>,)) -> Result<Value, Error> {
+	let duration = match duration {
+		Some(Value::Duration(d)) => d,
+		None => Duration::default(),
+		Some(_) => return Ok(Value::None),
+	};
+
+	Ok(duration.hours())
+}
+
+pub fn days((duration,): (Option<Value>,)) -> Result<Value, Error> {
+	let duration = match duration {
+		Some(Value::Duration(d)) => d,
+		None => Duration::default(),
+		Some(_) => return Ok(Value::None),
+	};
+
+	Ok(duration.days())
+}
+
+pub fn weeks((duration,): (Option<Value>,)) -> Result<Value, Error> {
+	let duration = match duration {
+		Some(Value::Duration(d)) => d,
+		None => Duration::default(),
+		Some(_) => return Ok(Value::None),
+	};
+
+	Ok(duration.weeks())
+}
+
+pub fn years((duration,): (Option<Value>,)) -> Result<Value, Error> {
+	let duration = match duration {
+		Some(Value::Duration(d)) => d,
+		None => Duration::default(),
+		Some(_) => return Ok(Value::None),
+	};
+
+	Ok(duration.years())
+}

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -78,10 +78,10 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"crypto::sha256" => crypto::sha256,
 		"crypto::sha512" => crypto::sha512,
 		//
-		"duration::secs" => duration::secs,
-		"duration::mins" => duration::mins,
-		"duration::hours" => duration::hours,
 		"duration::days" => duration::days,
+		"duration::hours" => duration::hours,
+		"duration::mins" => duration::mins,
+		"duration::secs" => duration::secs,
 		"duration::weeks" => duration::weeks,
 		"duration::years" => duration::years,
 		//

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -7,6 +7,7 @@ pub mod array;
 pub mod cast;
 pub mod count;
 pub mod crypto;
+pub mod duration;
 pub mod future;
 pub mod geo;
 pub mod http;
@@ -76,6 +77,13 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"crypto::sha1" => crypto::sha1,
 		"crypto::sha256" => crypto::sha256,
 		"crypto::sha512" => crypto::sha512,
+		//
+		"duration::secs" => duration::secs,
+		"duration::mins" => duration::mins,
+		"duration::hours" => duration::hours,
+		"duration::days" => duration::days,
+		"duration::weeks" => duration::weeks,
+		"duration::years" => duration::years,
 		//
 		"geo::area" => geo::area,
 		"geo::bearing" => geo::bearing,

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -1,4 +1,5 @@
 use crate::sql::common::{take_digits, take_digits_range, take_u32_len};
+use crate::sql::duration::Duration;
 use crate::sql::error::IResult;
 use crate::sql::serde::is_internal_serialization;
 use chrono::{DateTime, FixedOffset, TimeZone, Utc};
@@ -7,9 +8,9 @@ use nom::character::complete::char;
 use nom::combinator::map;
 use nom::sequence::delimited;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::ops::Deref;
 use std::str;
+use std::{fmt, ops};
 
 const SINGLE: char = '\'';
 const DOUBLE: char = '"';
@@ -66,6 +67,16 @@ impl Serialize for Datetime {
 			serializer.serialize_newtype_struct("Datetime", &self.0)
 		} else {
 			serializer.serialize_some(&self.0)
+		}
+	}
+}
+
+impl ops::Sub<Datetime> for Datetime {
+	type Output = Duration;
+	fn sub(self, other: Datetime) -> Duration {
+		match (self.0 - other.0).to_std() {
+			Ok(d) => Duration::from(d),
+			Err(_) => Duration::default(),
 		}
 	}
 }

--- a/lib/src/sql/duration.rs
+++ b/lib/src/sql/duration.rs
@@ -63,35 +63,30 @@ impl Duration {
 	pub fn mins(&self) -> Value {
 		let secs = self.0.as_secs();
 		let mins = secs / SECONDS_PER_MINUTE;
-
 		mins.into()
 	}
 
 	pub fn hours(&self) -> Value {
 		let secs = self.0.as_secs();
 		let hours = secs / SECONDS_PER_HOUR;
-
 		hours.into()
 	}
 
 	pub fn days(&self) -> Value {
 		let secs = self.0.as_secs();
 		let days = secs / SECONDS_PER_DAY;
-
 		days.into()
 	}
 
 	pub fn weeks(&self) -> Value {
 		let secs = self.0.as_secs();
 		let weeks = secs / SECONDS_PER_WEEK;
-
 		weeks.into()
 	}
 
 	pub fn years(&self) -> Value {
 		let secs = self.0.as_secs();
 		let years = secs / SECONDS_PER_YEAR;
-
 		years.into()
 	}
 }

--- a/lib/src/sql/duration.rs
+++ b/lib/src/sql/duration.rs
@@ -2,6 +2,7 @@ use crate::sql::common::take_u64;
 use crate::sql::datetime::Datetime;
 use crate::sql::error::IResult;
 use crate::sql::serde::is_internal_serialization;
+use crate::sql::value::Value;
 use chrono::DurationRound;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
@@ -53,6 +54,45 @@ impl Deref for Duration {
 impl Duration {
 	pub fn to_raw(&self) -> String {
 		self.to_string()
+	}
+
+	pub fn secs(&self) -> Value {
+		self.0.as_secs().into()
+	}
+
+	pub fn mins(&self) -> Value {
+		let secs = self.0.as_secs();
+		let mins = secs / SECONDS_PER_MINUTE;
+
+		mins.into()
+	}
+
+	pub fn hours(&self) -> Value {
+		let secs = self.0.as_secs();
+		let hours = secs / SECONDS_PER_HOUR;
+
+		hours.into()
+	}
+
+	pub fn days(&self) -> Value {
+		let secs = self.0.as_secs();
+		let days = secs / SECONDS_PER_DAY;
+
+		days.into()
+	}
+
+	pub fn weeks(&self) -> Value {
+		let secs = self.0.as_secs();
+		let weeks = secs / SECONDS_PER_WEEK;
+
+		weeks.into()
+	}
+
+	pub fn years(&self) -> Value {
+		let secs = self.0.as_secs();
+		let years = secs / SECONDS_PER_YEAR;
+
+		years.into()
 	}
 }
 

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -239,6 +239,7 @@ fn function_names(i: &str) -> IResult<&str, &str> {
 		function_array,
 		function_count,
 		function_crypto,
+		function_duration,
 		function_geo,
 		function_http,
 		function_is,
@@ -286,6 +287,17 @@ fn function_crypto(i: &str) -> IResult<&str, &str> {
 		tag("crypto::sha1"),
 		tag("crypto::sha256"),
 		tag("crypto::sha512"),
+	))(i)
+}
+
+fn function_duration(i: &str) -> IResult<&str, &str> {
+	alt((
+		tag("duration::secs"),
+		tag("duration::mins"),
+		tag("duration::hours"),
+		tag("duration::days"),
+		tag("duration::weeks"),
+		tag("duration::years"),
 	))(i)
 }
 

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -292,10 +292,10 @@ fn function_crypto(i: &str) -> IResult<&str, &str> {
 
 fn function_duration(i: &str) -> IResult<&str, &str> {
 	alt((
-		tag("duration::secs"),
-		tag("duration::mins"),
-		tag("duration::hours"),
 		tag("duration::days"),
+		tag("duration::hours"),
+		tag("duration::mins"),
+		tag("duration::secs"),
 		tag("duration::weeks"),
 		tag("duration::years"),
 	))(i)

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -1199,6 +1199,7 @@ impl ops::Sub for Value {
 	fn sub(self, other: Self) -> Self {
 		match (self, other) {
 			(Value::Number(v), Value::Number(w)) => Value::Number(v - w),
+			(Value::Datetime(v), Value::Datetime(w)) => Value::Duration(v - w),
 			(Value::Datetime(v), Value::Duration(w)) => Value::Datetime(w - v),
 			(Value::Duration(v), Value::Datetime(w)) => Value::Datetime(v - w),
 			(Value::Duration(v), Value::Duration(w)) => Value::Duration(v - w),


### PR DESCRIPTION
## What is the motivation?

Provide a richer set of operations to manipulate `Datetime` and `Duration` values.

For context, my original use-case was basically allowing something like this:
```
CREATE person:punie SET
    name = "Punie",
    birthday = "1989-04-17",
    age = <future> { duration::years(time::now() - birthday) }
;
```
which, as of today, I would expect to return something like this:
```
[
  {
    "result": [
      {
        "age": 33,
        "birthday": "1989-04-17T00:00:00Z",
        "id": "person:punie",
        "name": "Punie"
      }
    ],
    "status": "OK",
    "time": "1.788416ms"
  }
]
```

This is my first contribution here, and it might be a bit presumptuous of me to come and add such functionality 😅 
But it is a testament to how clean and easy to understand the codebase is. Truly amazing work here.

Anyway, I'm more than willing to take any feedback on this feature should you think it is of value. Specially regarding function naming and/or adding a `duration::` function namespace (I hesitated to add those under `time::duration::`).

## What does this change do?

The changes in this PR:
- allow subtracting a `Datetime` from another `Datetime`, returning a `Duration`
- provide a set of `duration::[fn]` functions to extract as number some part of a `Duration`

## What is your testing strategy?

I have tested the added operations running SurrealDB in-memory.
I did not see any pre-existing tests for `time::` functions or `ops::Sub` implementations so I didn't add any for the additions I made but I'm happy to write some if requested.

## Is this related to any issues?

This PR is not related to any open issue.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
