### PR TITLE
Add .idea/ and history.txt to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,11 @@ Temporary Items
 
 /target/
 /lib/target/
+.idea/
 
 # -----------------------------------
 # Specific
 # -----------------------------------
 
 surreal
+history.txt


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I use IntelliJ IDEA, which is common for developing Rust, and it creates a `.idea` directory. The SurrealDB server creates a `history.txt` file. Neither should be checked in to GitHub.

## What does this change do?

Adds the above to the `.gitignore` file.

## What is your testing strategy?

`git add .` didn't add those files.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
