### PR TITLE
Endpoint to return internal AST structure for a supplied query

### DIFF
--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -40,7 +40,7 @@ pub(crate) mod query;
 pub(crate) mod range;
 pub(crate) mod regex;
 pub(crate) mod script;
-pub(crate) mod serde;
+pub mod serde;
 pub(crate) mod split;
 pub(crate) mod start;
 pub(crate) mod statement;

--- a/lib/src/sql/serde.rs
+++ b/lib/src/sql/serde.rs
@@ -9,10 +9,10 @@ pub(crate) fn is_internal_serialization() -> bool {
 	INTERNAL_SERIALIZATION.with(|v| v.load(Ordering::Relaxed))
 }
 
-pub(crate) fn beg_internal_serialization() {
+pub fn beg_internal_serialization() {
 	INTERNAL_SERIALIZATION.with(|v| v.store(true, Ordering::Relaxed))
 }
 
-pub(crate) fn end_internal_serialization() {
+pub fn end_internal_serialization() {
 	INTERNAL_SERIALIZATION.with(|v| v.store(false, Ordering::Relaxed))
 }

--- a/src/net/ast.rs
+++ b/src/net/ast.rs
@@ -1,5 +1,7 @@
+use std::str;
+
 use bytes::Bytes;
-use warp::Filter;
+use warp::{path, Filter};
 
 use surrealdb::sql::serde::{beg_internal_serialization, end_internal_serialization};
 use surrealdb::Session;

--- a/src/net/ast.rs
+++ b/src/net/ast.rs
@@ -1,7 +1,5 @@
-use std::str;
-
 use bytes::Bytes;
-use warp::{path, Filter};
+use warp::Filter;
 
 use surrealdb::sql::serde::{beg_internal_serialization, end_internal_serialization};
 use surrealdb::Session;

--- a/src/net/ast.rs
+++ b/src/net/ast.rs
@@ -1,8 +1,8 @@
 use bytes::Bytes;
 use warp::Filter;
 
-use surrealdb::Session;
 use surrealdb::sql::serde::{beg_internal_serialization, end_internal_serialization};
+use surrealdb::Session;
 
 use crate::err::Error;
 use crate::net::output;
@@ -10,7 +10,7 @@ use crate::net::session;
 
 const MAX: u64 = 1024 * 1024; // 1 MiB
 
-pub fn config() -> impl Filter<Extract=impl warp::Reply, Error=warp::Rejection> + Clone {
+pub fn config() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
 	// Set base path
 	let base = warp::path("ast").and(warp::path::end());
 	// Set opts method
@@ -69,4 +69,3 @@ async fn handler(
 		_ => Err(warp::reject::custom(Error::InvalidAuth)),
 	}
 }
-

--- a/src/net/ast.rs
+++ b/src/net/ast.rs
@@ -1,0 +1,55 @@
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use warp::Filter;
+use warp::ws::{Message, WebSocket, Ws};
+
+use surrealdb::Session;
+use surrealdb::sql::Query;
+
+use crate::cli::CF;
+use crate::dbs::DB;
+use crate::err::Error;
+use crate::net::output;
+use crate::net::session;
+
+const MAX: u64 = 1024 * 1024; // 1 MiB
+
+pub fn config() -> impl Filter<Extract=impl warp::Reply, Error=warp::Rejection> + Clone {
+	// Set base path
+	let base = warp::path("ast").and(warp::path::end());
+	// Set opts method
+	let opts = base.and(warp::options()).map(warp::reply);
+	// Set post method
+	let post = base
+		.and(warp::post())
+		.and(session::build())
+		.and(warp::header::<String>(http::header::ACCEPT.as_str()))
+		.and(warp::body::content_length_limit(MAX))
+		.and(warp::body::bytes())
+		.and_then(handler);
+	// Specify route
+	opts.or(post)
+}
+
+async fn handler(session: Session, sql: Bytes) -> Result<impl warp::Reply, warp::Rejection> {
+	// Check the permissions
+	match session.au.is_kv() {
+		true => {
+			// Convert the received sql query
+			let sql = std::str::from_utf8(&sql).unwrap();
+			// Get the AST of the query
+			let ast = surrealdb::sql::parse(&sql);
+			// Unwrap and send the json response back
+			match ast {
+				Ok(parsed_query) => {
+					debug!(target: "DEBUG", "Executing AST: {}", serde_json::to_string_pretty(&parsed_query).unwrap());
+					Ok(output::json(&parsed_query))
+				}
+				Err(err) => Err(warp::reject::custom(Error::from(err))),
+			}
+		}
+		// There was an error with permissions
+		_ => Err(warp::reject::custom(Error::InvalidAuth)),
+	}
+}
+

--- a/src/net/asttosql.rs
+++ b/src/net/asttosql.rs
@@ -1,17 +1,11 @@
-use std::fmt::Display;
 use std::str;
 
 use bytes::Bytes;
-use serde_json::Value;
-use warp::{path, Filter};
+use warp::Filter;
 
-use surrealdb::sql::serde::{beg_internal_serialization, end_internal_serialization};
-use surrealdb::sql::{parse, Query};
-use surrealdb::Datastore;
+use surrealdb::sql::Query;
 use surrealdb::Session;
 
-use crate::cli::CF;
-use crate::dbs::DB;
 use crate::err::Error;
 use crate::net::output;
 use crate::net::session;
@@ -37,25 +31,22 @@ pub fn config() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejecti
 
 async fn handler(
 	session: Session,
-	output: String,
+	_output: String,
 	sql: Bytes,
 ) -> Result<impl warp::Reply, warp::Rejection> {
 	// Check the permissions
 	if !session.au.is_kv() {
-		return Err(warp::reject::custom(Error::Permission));
+		return Err(warp::reject::custom(Error::InvalidAuth));
 	}
 
-	match str::from_utf8(&sql) {
-		// Convert our JSON AST to a Query object
-		Ok(json_ast) => match serde_json::from_str::<Query>(json_ast) {
-			// Run format over it, and out put the query
-			Ok(query) => {
-				debug!(target: "DEBUG", "Executing: {}", query);
-				Ok(output::text(format!("{}", query)))
-			}
-			Err(err) => Err(warp::reject::custom(Error::from(err))),
-		},
-		// There was an issue serialising the Query
+	let json_ast = str::from_utf8(&sql).unwrap();
+
+	match serde_json::from_str::<Query>(json_ast) {
+		// Run format over it, and out put the query
+		Ok(query) => {
+			debug!(target: "DEBUG", "Executing: {}", query);
+			Ok(output::text(format!("{}", query)))
+		}
 		Err(err) => Err(warp::reject::custom(Error::from(err))),
 	}
 }

--- a/src/net/asttosql.rs
+++ b/src/net/asttosql.rs
@@ -1,0 +1,61 @@
+use std::fmt::Display;
+use std::str;
+
+use bytes::Bytes;
+use serde_json::Value;
+use warp::{path, Filter};
+
+use surrealdb::sql::serde::{beg_internal_serialization, end_internal_serialization};
+use surrealdb::sql::{parse, Query};
+use surrealdb::Datastore;
+use surrealdb::Session;
+
+use crate::cli::CF;
+use crate::dbs::DB;
+use crate::err::Error;
+use crate::net::output;
+use crate::net::session;
+
+const MAX: u64 = 1024 * 1024; // 1 MiB
+
+pub fn config() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+	// Set base path
+	let base = warp::path!("ast" / "sql").and(warp::path::end());
+	// Set opts method
+	let opts = base.and(warp::options()).map(warp::reply);
+	// Set post method
+	let post = base
+		.and(warp::post())
+		.and(session::build())
+		.and(warp::header::<String>(http::header::ACCEPT.as_str()))
+		.and(warp::body::content_length_limit(MAX))
+		.and(warp::body::bytes())
+		.and_then(handler);
+
+	opts.or(post)
+}
+
+async fn handler(
+	session: Session,
+	output: String,
+	sql: Bytes,
+) -> Result<impl warp::Reply, warp::Rejection> {
+	// Check the permissions
+	if !session.au.is_kv() {
+		return Err(warp::reject::custom(Error::Permission));
+	}
+
+	match str::from_utf8(&sql) {
+		// Convert our JSON AST to a Query object
+		Ok(json_ast) => match serde_json::from_str::<Query>(json_ast) {
+			// Run format over it, and out put the query
+			Ok(query) => {
+				debug!(target: "DEBUG", "Executing: {}", query);
+				Ok(output::text(format!("{}", query)))
+			}
+			Err(err) => Err(warp::reject::custom(Error::from(err))),
+		},
+		// There was an issue serialising the Query
+		Err(err) => Err(warp::reject::custom(Error::from(err))),
+	}
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,3 +1,4 @@
+mod ast;
 mod export;
 mod fail;
 mod head;
@@ -15,7 +16,6 @@ mod sql;
 mod status;
 mod sync;
 mod version;
-mod ast;
 use crate::cli::CF;
 use crate::err::Error;
 use warp::Filter;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -20,6 +20,7 @@ mod signin;
 mod signup;
 mod sql;
 mod status;
+mod structure;
 mod sync;
 mod version;
 
@@ -50,7 +51,10 @@ pub async fn init() -> Result<(), Error> {
 		.or(sql::config())
 		// SQL AST endpoint
 		.or(ast::config())
+		// AST to SQL endpoint
 		.or(asttosql::config())
+		// Json array of table name => fields array for usage in type generation code
+		.or(structure::config())
 		// API query endpoint
 		.or(key::config())
 		// Catch all errors

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -15,7 +15,7 @@ mod sql;
 mod status;
 mod sync;
 mod version;
-
+mod ast;
 use crate::cli::CF;
 use crate::err::Error;
 use warp::Filter;
@@ -45,6 +45,8 @@ pub async fn init() -> Result<(), Error> {
 		.or(rpc::config())
 		// SQL query endpoint
 		.or(sql::config())
+		// SQL AST endpoint
+		.or(ast::config())
 		// API query endpoint
 		.or(key::config())
 		// Catch all errors

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,4 +1,10 @@
+use warp::Filter;
+
+use crate::cli::CF;
+use crate::err::Error;
+
 mod ast;
+mod asttosql;
 mod export;
 mod fail;
 mod head;
@@ -16,9 +22,6 @@ mod sql;
 mod status;
 mod sync;
 mod version;
-use crate::cli::CF;
-use crate::err::Error;
-use warp::Filter;
 
 const LOG: &str = "surrealdb::net";
 
@@ -47,12 +50,13 @@ pub async fn init() -> Result<(), Error> {
 		.or(sql::config())
 		// SQL AST endpoint
 		.or(ast::config())
+		.or(asttosql::config())
 		// API query endpoint
 		.or(key::config())
 		// Catch all errors
 		.recover(fail::recover)
 		// End routes setup
-	;
+		;
 	// Specify a generic version header
 	let net = net.with(head::version());
 	// Specify a generic server header

--- a/src/net/structure.rs
+++ b/src/net/structure.rs
@@ -1,0 +1,83 @@
+use std::collections::BTreeMap;
+
+use warp::Filter;
+
+use surrealdb::sql::{Kind, Object, Value};
+use surrealdb::Session;
+
+use crate::dbs::DB;
+use crate::err::Error;
+use crate::net::output;
+use crate::net::session;
+
+pub fn config() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+	// Set base path
+	let base = warp::path("structure").and(warp::path::end());
+	// Set opts method
+	let opts = base.and(warp::options()).map(warp::reply);
+	// Set post method
+	let post = base.and(warp::post()).and(session::build()).and_then(handler);
+	// Specify route
+	opts.or(post)
+}
+
+async fn handler(session: Session) -> Result<impl warp::Reply, warp::Rejection> {
+	// Check the permissions
+	if !session.au.is_kv() {
+		return Err(warp::reject::custom(Error::InvalidAuth));
+	}
+	// Get a database reference
+	let db = DB.get().unwrap();
+	// Extract the Namespace header value
+	let nsv = match session.ns {
+		Some(ns) => ns,
+		None => return Err(warp::reject::custom(Error::NoNsHeader)),
+	};
+	// Extract the DB header value
+	let dbv = match session.db {
+		Some(db) => db,
+		None => return Err(warp::reject::custom(Error::NoDbHeader)),
+	};
+	// Create a transaction
+	let mut txn = match db.transaction(false, false).await {
+		Ok(txn) => txn,
+		Err(e) => return Err(warp::reject::custom(Error::Db(e))),
+	};
+	// Get all table definitions
+	let tables = match txn.all_tb(&nsv, &dbv).await {
+		Ok(tables) => tables,
+		Err(e) => return Err(warp::reject::custom(Error::Db(e))),
+	};
+	// Temp storage for structures that will be output
+	let mut table_definitions = BTreeMap::new();
+	for table in tables.iter() {
+		// Get all fields of this table
+		let fields = txn.all_fd(&nsv, &dbv, &table.name).await;
+		if fields.is_err() {
+			continue;
+		}
+		let fields = fields.unwrap();
+
+		// Create a temp array for storing all field objects of this table
+		let mut fields_collect: Vec<Object> = Vec::new();
+		fields.iter().for_each(|field| {
+			let field_type = field.kind.clone().unwrap();
+			// Add an object of {"name":"x", "type":"string"} or {"name":"x", "type":{"type": "record", "name": "table_name"}}
+			fields_collect.push(Object::from(map! {
+				"name".to_string() => Value::from(field.name.clone().to_string()),
+				"type".to_string() => match field_type {
+					Kind::Record(record) => Value::from(map!{
+						"type".to_string() => Value::from("record"),
+						"table".to_string() => Value::from(record.iter().map(|ref v| v.to_string()).collect::<Vec<_>>().join(", "))
+					}),
+					_ => Value::from(field_type.to_string())
+				}
+			}));
+		});
+		// Insert the table name => fields array into the table_definitions map
+		table_definitions.insert(table.name.to_string(), fields_collect);
+	}
+
+	// Send response
+	Ok(output::json(&table_definitions))
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

It's useful to have a way to get this information so we can build libraries/lsp etc.

## What does this change do?

Exposes an /ast endpoint, which takes a query and returns the internal AST structure for this.

## What is your testing strategy?

I manually tested a few different queries, made bad queries to break the code etc. It uses a lot of the same logic from existing endpoints

## Is this related to any issues?
- #248 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [ X ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)


**Sidenote**:

I don't really know rust, I'm able to roughly understand it from my past experience with a bunch of languages. If I got anything here really wrong, I apologise(mainly worried about making the lib/src/sql/serde.rs public)

... but hopefully it's 90%+ of the way there with no issues