### PR TITLE
Make FoundationDB version configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,12 @@ version = "1.0.0-beta.7"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 
 [features]
-default = []
+default = ["storage-rocksdb", "scripting", "http"]
+storage-rocksdb = ["surrealdb/kv-rocksdb"]
 storage-tikv = ["surrealdb/kv-tikv"]
-storage-fdb = ["surrealdb/kv-fdb"]
+storage-fdb = ["surrealdb/kv-fdb-6_3"]
+scripting = ["surrealdb/scripting"]
+http = ["surrealdb/http"]
 
 [workspace]
 members = ["lib"]
@@ -40,7 +43,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.85"
 serde_pack = { version = "1.1.0", package = "rmp-serde" }
-surrealdb = { path = "lib" }
+surrealdb = { path = "lib", default-features = false, features = ["kv-mem", "parallel"] }
 thiserror = "1.0.36"
 tokio = { version = "1.21.1", features = ["macros", "signal"] }
 warp = { version = "0.3.2", features = ["compression", "tls", "websocket"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,12 +17,23 @@ license = "Apache-2.0"
 default = ["parallel", "kv-mem", "kv-rocksdb", "scripting", "http"]
 parallel = ["dep:executor"]
 kv-tikv = ["dep:tikv"]
-kv-fdb = ["dep:foundationdb"]
+kv-fdb-5_1 = ["foundationdb/fdb-5_1", "kv-fdb"]
+kv-fdb-5_2 = ["foundationdb/fdb-5_2", "kv-fdb"]
+kv-fdb-6_0 = ["foundationdb/fdb-6_0", "kv-fdb"]
+kv-fdb-6_1 = ["foundationdb/fdb-6_1", "kv-fdb"]
+kv-fdb-6_2 = ["foundationdb/fdb-6_2", "kv-fdb"]
+kv-fdb-6_3 = ["foundationdb/fdb-6_3", "kv-fdb"]
+kv-fdb-7_0 = ["foundationdb/fdb-7_0", "kv-fdb"]
+kv-fdb-7_1 = ["foundationdb/fdb-7_1", "kv-fdb"]
 kv-mem = ["dep:echodb"]
 kv-indxdb = ["dep:indxdb"]
 kv-rocksdb = ["dep:rocksdb"]
 scripting = ["dep:js", "dep:executor"]
 http = ["dep:surf"]
+
+# This is an internal feature. It shouldn't be activated directly.
+# One of the `kv-fdb-*` features that specify the version to use must be used instead.
+kv-fdb = ["foundationdb"]
 
 [dependencies]
 addr = { version = "0.15.6", default-features = false, features = ["std"] }
@@ -37,7 +48,7 @@ dmp = "0.1.1"
 echodb = { version = "0.3.0", optional = true }
 executor = { version = "1.4.1", package = "async-executor", optional = true }
 futures = "0.3.24"
-foundationdb = { version = "0.7.0", default-features = false, features = ["fdb-6_3", "embedded-fdb-include"], optional = true }
+foundationdb = { version = "0.7.0", default-features = false, features = ["embedded-fdb-include"], optional = true }
 fuzzy-matcher = "0.3.7"
 geo = { version = "0.23.0", features = ["use-serde"] }
 indxdb = { version = "0.2.0", optional = true }


### PR DESCRIPTION
## What is the motivation?

The FoundationDB version of the library that SurrealDB links to needs to match the version of the FoundationDB server.

## What does this change do?

It makes the FDB library version that we link to configurable  so we don't lock in our users to a particular version 

## What is your testing strategy?

Made sure tests still pass and tested that linking to different versions works (in a separate PR).

## Is this related to any issues?

It was extracted from https://github.com/surrealdb/surrealdb/pull/100. Though it's needed by that PR, it's useful outside it.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
