### PR TITLE
Feature gate scripting tests

### DIFF
--- a/lib/tests/script.rs
+++ b/lib/tests/script.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "scripting")]
+
 mod parse;
 use parse::Parse;
 use surrealdb::sql::Value;


### PR DESCRIPTION
## What is the motivation?

Currently running tests without the activating the `scripting` feature is broken because those scripting tests run even when the scripting feature is not enabled.

## What does this change do?

It feature-gates scripting tests.

## What is your testing strategy?

Made sure tests still pass.

## Is this related to any issues?

It was extracted from https://github.com/surrealdb/surrealdb/pull/100, where this issue was identified.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
