### PR TITLE
Feature gate more http functions

### DIFF
--- a/lib/src/fnc/http.rs
+++ b/lib/src/fnc/http.rs
@@ -32,6 +32,7 @@ pub async fn delete((_, _): (Value, Option<Value>)) -> Result<Value, Error> {
 	Err(Error::HttpDisabled)
 }
 
+#[cfg(feature = "http")]
 fn try_as_uri(fn_name: &str, value: Value) -> Result<Strand, Error> {
 	match value {
 		// Avoid surf crate panic by pre-checking URI.
@@ -44,6 +45,7 @@ fn try_as_uri(fn_name: &str, value: Value) -> Result<Strand, Error> {
 	}
 }
 
+#[cfg(feature = "http")]
 fn try_as_opts(
 	fn_name: &str,
 	error_message: &str,


### PR DESCRIPTION
## What is the motivation?

Some `http` functions are not feature-gated, causing the build to break when the `http` feature is not enabled.

## What does this change do?

It feature-gates them.

## What is your testing strategy?

Made sure tests still pass, with and without the `http` feature.

## Is this related to any issues?

Extracted from https://github.com/surrealdb/surrealdb/pull/100.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
