### PR TITLE
Support additional build metadata

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,56 @@
+use std::process::Command;
+use std::{env, str};
+
+const BUILD_METADATA: &str = "SURREAL_BUILD_METADATA";
+
+fn main() {
+	println!("cargo:rerun-if-env-changed={BUILD_METADATA}");
+	println!("cargo:rerun-if-changed=lib");
+	println!("cargo:rerun-if-changed=src");
+	println!("cargo:rerun-if-changed=Cargo.toml");
+	println!("cargo:rerun-if-changed=Cargo.lock");
+	if let Some(metadata) = build_metadata() {
+		println!("cargo:rustc-env={BUILD_METADATA}={metadata}");
+	}
+}
+
+fn build_metadata() -> Option<String> {
+	if let Ok(metadata) = env::var(BUILD_METADATA) {
+		return Some(metadata);
+	}
+	let date = git()
+		.args(["show", "--no-patch", "--format=%ad", "--date=format:%Y%m%d"])
+		.output_string()?;
+	let rev = git().args(["rev-parse", "--short", "HEAD"]).output_string()?;
+	let repo_clean = git()
+		.args(["diff", "--quiet"])
+		.output()
+		.map(|output| output.status.success())
+		.unwrap_or_default();
+	let metadata = if repo_clean {
+		format!("{date}.{rev}")
+	} else {
+		format!("{date}.{rev}.dirty")
+	};
+	Some(metadata)
+}
+
+fn git() -> Command {
+	Command::new("git")
+}
+
+trait CommandExt {
+	fn output_string(&mut self) -> Option<String>;
+}
+
+impl CommandExt for Command {
+	fn output_string(&mut self) -> Option<String> {
+		self.output()
+			.ok()
+			.filter(|output| output.status.success())
+			.and_then(|output| {
+				str::from_utf8(&output.stdout).ok().map(|output| output.trim().to_string())
+			})
+			.filter(|output| !output.is_empty())
+	}
+}

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -5,6 +5,6 @@ use crate::err::Error;
 pub fn init(_: &clap::ArgMatches) -> Result<(), Error> {
 	get_cfg!(target_os: "windows", "macos", "ios", "linux", "android", "freebsd", "openbsd", "netbsd");
 	get_cfg!(target_arch: "x86", "x86_64", "mips", "powerpc", "powerpc64", "arm", "aarch64");
-	println!("{} {} for {} on {}", PKG_NAME, PKG_VERS, target_os(), target_arch());
+	println!("{} {} for {} on {}", PKG_NAME, *PKG_VERS, target_os(), target_arch());
 	Ok(())
 }

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -1,3 +1,5 @@
+use once_cell::sync::Lazy;
+
 pub const LOGO: &str = "
  .d8888b.                                             888 8888888b.  888888b.
 d88P  Y88b                                            888 888  'Y88b 888  '88b
@@ -12,7 +14,13 @@ Y88b  d88P Y88b 888 888     888     Y8b.     888  888 888 888  .d88P 888   d88P
 
 // The name and version of this build
 pub const PKG_NAME: &str = env!("CARGO_PKG_NAME");
-pub const PKG_VERS: &str = env!("CARGO_PKG_VERSION");
+pub static PKG_VERS: Lazy<String> = Lazy::new(|| match option_env!("SURREAL_BUILD_METADATA") {
+	Some(metadata) if !metadata.trim().is_empty() => {
+		let version = env!("CARGO_PKG_VERSION");
+		format!("{version}+{metadata}")
+	}
+	_ => env!("CARGO_PKG_VERSION").to_owned(),
+});
 
 // The publicly visible name of the server
 pub const SERVER_NAME: &str = "SurrealDB";

--- a/src/net/head.rs
+++ b/src/net/head.rs
@@ -9,7 +9,7 @@ const SERVER: &str = "Server";
 const VERSION: &str = "Version";
 
 pub fn version() -> warp::filters::reply::WithHeader {
-	let val = format!("{}-{}", PKG_NAME, PKG_VERS);
+	let val = format!("{}-{}", PKG_NAME, *PKG_VERS);
 	warp::reply::with::header(VERSION, val)
 }
 

--- a/src/net/version.rs
+++ b/src/net/version.rs
@@ -8,6 +8,6 @@ pub fn config() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejecti
 }
 
 pub async fn handler() -> Result<impl warp::Reply, warp::Rejection> {
-	let val = format!("{}-{}", PKG_NAME, PKG_VERS);
+	let val = format!("{}-{}", PKG_NAME, *PKG_VERS);
 	Ok(warp::reply::with_status(val, http::StatusCode::OK))
 }


### PR DESCRIPTION
## What is the motivation?

The current version reported, for example `1.0.0-beta.7` does not carry enough information to pinpoint the exact commit built when building from source. SemVer allows for adding additional build metadata by adding it after the `+` sign. This can be very helpful for debugging.

## What does this change do?

It makes it possible to specify optional build metadata using the `SURREAL_BUILD_METADATA` environment variable. Build tools like `Nix` can set this variable to something like `20220926.a72052a`. The first part is the date on which the commit being built was made. The second part is the short form of the commit. In this case the version reported by `surreal version` will be `1.0.0-beta.7+20220926.a72052a`.

## What is your testing strategy?

Made sure tests still pass and tested the functionality in a separate PR.

## Is this related to any issues?

Extracted from https://github.com/surrealdb/surrealdb/pull/100.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
