### PR TITLE
Make `nbf` field optional

### DIFF
--- a/src/iam/signin.rs
+++ b/src/iam/signin.rs
@@ -132,7 +132,7 @@ pub async fn sc(
 								let val = Claims {
 									iss: SERVER_NAME.to_owned(),
 									iat: Utc::now().timestamp(),
-									nbf: Utc::now().timestamp(),
+									nbf: Some(Utc::now().timestamp()),
 									exp: match sv.session {
 										Some(v) => Utc::now() + Duration::from_std(v.0).unwrap(),
 										_ => Utc::now() + Duration::hours(1),
@@ -202,7 +202,7 @@ pub async fn db(
 					let val = Claims {
 						iss: SERVER_NAME.to_owned(),
 						iat: Utc::now().timestamp(),
-						nbf: Utc::now().timestamp(),
+						nbf: Some(Utc::now().timestamp()),
 						exp: (Utc::now() + Duration::hours(1)).timestamp(),
 						ns: Some(ns.to_owned()),
 						db: Some(db.to_owned()),
@@ -257,7 +257,7 @@ pub async fn ns(
 					let val = Claims {
 						iss: SERVER_NAME.to_owned(),
 						iat: Utc::now().timestamp(),
-						nbf: Utc::now().timestamp(),
+						nbf: Some(Utc::now().timestamp()),
 						exp: (Utc::now() + Duration::hours(1)).timestamp(),
 						ns: Some(ns.to_owned()),
 						id: Some(user),

--- a/src/iam/signup.rs
+++ b/src/iam/signup.rs
@@ -67,7 +67,7 @@ pub async fn sc(
 								let val = Claims {
 									iss: SERVER_NAME.to_owned(),
 									iat: Utc::now().timestamp(),
-									nbf: Utc::now().timestamp(),
+									nbf: Some(Utc::now().timestamp()),
 									exp: match sv.session {
 										Some(v) => Utc::now() + Duration::from_std(v.0).unwrap(),
 										_ => Utc::now() + Duration::hours(1),

--- a/src/iam/token.rs
+++ b/src/iam/token.rs
@@ -9,9 +9,10 @@ pub static HEADER: Lazy<Header> = Lazy::new(|| Header::new(Algorithm::HS512));
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Claims {
 	pub iat: i64,
-	pub nbf: i64,
 	pub exp: i64,
 	pub iss: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub nbf: Option<i64>,
 	#[serde(alias = "ns")]
 	#[serde(alias = "NS")]
 	#[serde(rename = "NS")]
@@ -45,9 +46,12 @@ impl From<Claims> for Value {
 		let mut out = Object::default();
 		// Add default fields
 		out.insert("iat".to_string(), v.iat.into());
-		out.insert("nbf".to_string(), v.nbf.into());
 		out.insert("exp".to_string(), v.exp.into());
 		out.insert("iss".to_string(), v.iss.into());
+		// Add nbf field if set
+		if let Some(nbf) = v.nbf {
+			out.insert("nbf".to_string(), nbf.into());
+		}
 		// Add NS field if set
 		if let Some(ns) = v.ns {
 			out.insert("NS".to_string(), ns.into());


### PR DESCRIPTION
<!-- Thank you for submitting this pull request! We appreciate you spending the time to work on these changes. -->

## What is the motivation?

It's all in the issue I made #1244.

**In short:**
- Using Auth0
- They do not generate `nbf` by default.
- They do not allow any means to enable `nbf`.
- But I want to use Auth0 as full-blown auth provider.

## What does this change do?

Makes the `nbf` field optional for token based auth.

Allowing for scenarios:
1. If `nbf` is defined, then checking for it's compliance against the time of authentication.
2. If `nbf` is not defined, then doing nothing about it and only relying on `iss` and `exp` keys.

## What is your testing strategy?

1. `DEFINE TOKEN ... ON SCOPE ...`
2. Signed a JWT without the `nbf` key and tried to auth.
3. The auth was successful, **as expected**.
4. Signed a JWT with the `nbf` key and value way into future but before `exp` and tried to auth.
5. The auth was unsuccessful, **as expected**.
6. Signed a JWT with the `nbf` key and value after `iss`, but before `exp` and before `now()`.
7. The auth was successful, **as expected**.

## Is this related to any issues?
https://github.com/surrealdb/surrealdb/issues/1244

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
