### PR TITLE
Fix typo on synchronous for math::roun to math::round

### DIFF
--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -119,7 +119,7 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"math::nearestrank" => math::nearestrank,
 		"math::percentile" => math::percentile,
 		"math::product" => math::product,
-		"math::roun" => math::round,
+		"math::round" => math::round,
 		"math::spread" => math::spread,
 		"math::sqrt" => math::sqrt,
 		"math::stddev" => math::stddev,


### PR DESCRIPTION
## What is the motivation?

Small fix for typo on code

## What does this change do?

Simple typo on functions for math::round

## What is your testing strategy?

n/a

## Is this related to any issues?

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
