### PR TITLE
Bugfix #1267 - Limit time and memory available to Javascript functions.

### DIFF
--- a/lib/src/ctx/cancellation.rs
+++ b/lib/src/ctx/cancellation.rs
@@ -1,0 +1,24 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+/// A 'static view into the cancellation status of a Context.
+#[derive(Clone, Debug, Default)]
+pub struct Cancellation {
+	deadline: Option<Instant>,
+	cancellations: Vec<Arc<AtomicBool>>,
+}
+
+impl Cancellation {
+	pub fn new(deadline: Option<Instant>, cancellations: Vec<Arc<AtomicBool>>) -> Cancellation {
+		Self {
+			deadline,
+			cancellations,
+		}
+	}
+
+	pub fn is_done(&self) -> bool {
+		self.deadline.map(|d| d <= Instant::now()).unwrap_or(false)
+			|| self.cancellations.iter().any(|c| c.load(Ordering::Relaxed))
+	}
+}

--- a/lib/src/ctx/canceller.rs
+++ b/lib/src/ctx/canceller.rs
@@ -16,6 +16,6 @@ impl Canceller {
 	}
 	// Cancel the context.
 	pub fn cancel(&self) {
-		self.cancelled.store(true, Ordering::SeqCst);
+		self.cancelled.store(true, Ordering::Relaxed);
 	}
 }

--- a/lib/src/ctx/mod.rs
+++ b/lib/src/ctx/mod.rs
@@ -11,6 +11,7 @@ pub use self::canceller::*;
 pub use self::context::*;
 pub use self::reason::*;
 
+pub mod cancellation;
 pub mod canceller;
 pub mod context;
 pub mod reason;

--- a/lib/src/fnc/script/main.rs
+++ b/lib/src/fnc/script/main.rs
@@ -25,9 +25,11 @@ pub async fn run(
 	let exe = Executor::default();
 	// Create an JavaScript context
 	let run = js::Runtime::new().unwrap();
-	// Note: the default max_stack_size of rquickjs can be left as-is, but there is no default
-	// memory limit.
+	// Explicitly set max stack size to 256 KiB
+	run.set_max_stack_size(262_144);
+	// Explicitly set max memory size to 2 MB
 	run.set_memory_limit(2_000_000);
+	// Ensure scripts are cancelled with context
 	let cancellation = ctx.cancellation();
 	run.set_interrupt_handler(Some(Box::new(move || cancellation.is_done())));
 	// Create an execution context

--- a/lib/src/fnc/script/main.rs
+++ b/lib/src/fnc/script/main.rs
@@ -25,6 +25,11 @@ pub async fn run(
 	let exe = Executor::default();
 	// Create an JavaScript context
 	let run = js::Runtime::new().unwrap();
+	// Note: the default max_stack_size of rquickjs can be left as-is, but there is no default
+	// memory limit.
+	run.set_memory_limit(2_000_000);
+	let cancellation = ctx.cancellation();
+	run.set_interrupt_handler(Some(Box::new(move || cancellation.is_done())));
 	// Create an execution context
 	let ctx = js::Context::full(&run).unwrap();
 	// Set the module resolver and loader


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Javascript could consume arbitrary time and memory, causing issues.

## What does this change do?

- Forces Javascript to conform to the `TIMEOUT` of the associated query **(note: the timeout may not exist, but that's a separate issue about picking a good default timeout value)**
- Cancels Javascript if the `Context` is cancelled
- Imposes a 2MB memory limit on Javascript

Also, see notes on the diff :)

## What is your testing strategy?

Tested infinite loop with `TIMEOUT` clause, and infinite loop that allocates memory.

## Is this related to any issues?

Fixes #1267

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
