### PR TITLE
Add a note about the `nightly` binary to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,13 @@ brew install surrealdb/tap/surreal
 The easiest and preferred way to get going with SurrealDB on Unix operating systems is to install and use the SurrealDB command-line tool. Run the following command in your terminal and follow the on-screen instructions.
 
 ```bash
-curl -sSf https://install.surrealdb.com | sh
+curl --proto '=https' --tlsv1.2 -sSf https://install.surrealdb.com | sh
+```
+
+If you want a binary newer than what's currently released, you can install the nightly one.
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://install.surrealdb.com | sh -s -- --nightly
 ```
 
 <h4><a href="https://surrealdb.com/install#gh-dark-mode-only"><img width="20" src="/img/white/windows.svg"></a><a href="https://surrealdb.com/install#gh-light-mode-only"><img width="20" src="/img/black/windows.svg"></a>


### PR DESCRIPTION
## What is the motivation?

We now build nightly binaries but they are not yet documented.

## What does this change do?

It adds a note to the README with an instruction on how to install on Linux.

## What is your testing strategy?

Ran the command locally to make sure it works.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
