### PR TITLE
Feature: array::flatten(array) -> array #1306

### DIFF
--- a/lib/src/fnc/array.rs
+++ b/lib/src/fnc/array.rs
@@ -3,6 +3,7 @@ use crate::sql::array::Combine;
 use crate::sql::array::Complement;
 use crate::sql::array::Concat;
 use crate::sql::array::Difference;
+use crate::sql::array::Flatten;
 use crate::sql::array::Intersect;
 use crate::sql::array::Union;
 use crate::sql::array::Uniq;
@@ -41,6 +42,13 @@ pub fn distinct((arg,): (Value,)) -> Result<Value, Error> {
 		Value::Array(v) => Ok(v.uniq().into()),
 		_ => Ok(Value::None),
 	}
+}
+
+pub fn flatten((arg,): (Value,)) -> Result<Value, Error> {
+	Ok(match arg {
+		Value::Array(v) => v.flatten().into(),
+		_ => Value::None,
+	})
 }
 
 pub fn intersect(arrays: (Value, Value)) -> Result<Value, Error> {

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -64,6 +64,7 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"array::concat" => array::concat,
 		"array::difference" => array::difference,
 		"array::distinct" => array::distinct,
+		"array::flatten" => array::flatten,
 		"array::intersect" => array::intersect,
 		"array::len" => array::len,
 		"array::sort" => array::sort,

--- a/lib/src/sql/array.rs
+++ b/lib/src/sql/array.rs
@@ -303,6 +303,25 @@ impl Difference<Array> for Array {
 
 // ------------------------------
 
+pub trait Flatten<T> {
+	fn flatten(self) -> T;
+}
+
+impl Flatten<Array> for Array {
+	fn flatten(self) -> Array {
+		let mut out = Array::new();
+		for v in self.into_iter() {
+			match v {
+				Value::Array(a) => out.append(&mut a.clone()),
+				_ => out.push(v),
+			}
+		}
+		out
+	}
+}
+
+// ------------------------------
+
 pub trait Intersect<T> {
 	fn intersect(self, other: T) -> T;
 }

--- a/lib/src/sql/array.rs
+++ b/lib/src/sql/array.rs
@@ -312,7 +312,7 @@ impl Flatten<Array> for Array {
 		let mut out = Array::new();
 		for v in self.into_iter() {
 			match v {
-				Value::Array(a) => out.append(&mut a.clone()),
+				Value::Array(mut a) => out.append(&mut a),
 				_ => out.push(v),
 			}
 		}

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -234,6 +234,7 @@ fn function_array(i: &str) -> IResult<&str, &str> {
 		tag("array::complement"),
 		tag("array::concat"),
 		tag("array::difference"),
+		tag("array::flatten"),
 		tag("array::distinct"),
 		tag("array::intersect"),
 		tag("array::len"),

--- a/lib/tests/array.rs
+++ b/lib/tests/array.rs
@@ -1,0 +1,39 @@
+mod parse;
+use parse::Parse;
+use surrealdb::sql;
+use surrealdb::sql::Value;
+use surrealdb::Datastore;
+use surrealdb::Error;
+use surrealdb::Session;
+
+#[tokio::test]
+async fn flatten() -> Result<(), Error> {
+	let sql = "
+    SELECT * FROM array::flatten([[1, 2], [3, 4]]);
+    SELECT * FROM array::flatten([]);
+    SELECT * FROM array::flatten([[1,2], [3, 4], 'SurrealDB', [5, 6, [7, 8]]]);
+    SELECT * FROM [array::flatten(1)];
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	assert_eq!(res.len(), 4);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[1, 2, 3, 4]");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[]");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[1, 2, 3, 4, 'SurrealDB', 5, 6, [7, 8]]");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::Array(sql::Array(vec![Value::None]));
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Motivation is in issue #1306 

## What does this change do?

Adds a new function to `array` to flatten an array 1 level.

`array::flatten(array) -> array`

## What is your testing strategy?

I've created a new test file for arrays at `lib/tests/array.rs` and it is passing.

Tested using the following queries
```sql
SELECT * FROM array::flatten([[1, 2], [3, 4]]);
SELECT * FROM array::flatten([]);
SELECT * FROM array::flatten([[1,2], [3, 4], 'SurrealDB', [5, 6, [7, 8]]]);
SELECT * FROM [array::flatten(1)];
```
respective expected output
```js
[1, 2, 3, 4]
[]
[1, 2, 3, 4, 'SurrealDB', 5, 6, [7, 8]]
[None]
```
The last one is wrapped in an array to verify that `array:flatten(1)` itself doesn't return an array in the case of the input not being an array.

## Is this related to any issues?

Fixes #1306

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
