### PR TITLE
Disable Nix Action on PRs.

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,7 +1,6 @@
 name: Nix
 
 on:
-  - pull_request
   - push
 
 jobs:


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The Nix packages are built on every commit to every PR. This seems unnecessary and wasteful from a time and energy perspective, as AFAIK Nix is for end-users.

## What does this change do?

No longer run Nix action on pull request trigger.

## What is your testing strategy?

Nix actions were not run on *this* PR, so it seems to be working.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/master/CONTRIBUTING.md)
