### PR TITLE
Feature: Limit number of concurrent futures when fetching remote records

### DIFF
--- a/lib/src/sql/value/del.rs
+++ b/lib/src/sql/value/del.rs
@@ -47,7 +47,7 @@ impl Value {
 						_ => {
 							let path = path.next();
 							let futs = v.iter_mut().map(|v| v.del(ctx, opt, txn, path));
-							try_join_all(futs).await?;
+							futures::stream::iter(futs).buffered(10).await?;
 							Ok(())
 						}
 					},
@@ -114,7 +114,7 @@ impl Value {
 					},
 					_ => {
 						let futs = v.iter_mut().map(|v| v.del(ctx, opt, txn, path));
-						try_join_all(futs).await?;
+						futures::stream::iter(futs).buffered(10).await?;
 						Ok(())
 					}
 				},

--- a/lib/src/sql/value/get.rs
+++ b/lib/src/sql/value/get.rs
@@ -44,11 +44,11 @@ impl Value {
 					Part::All => {
 						let path = path.next();
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						try_join_all(futs).await.map(Into::into)
+						futures::stream::iter(futs).buffered(10).await.map(Into::into);
 					}
 					Part::Any => {
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						try_join_all(futs).await.map(Into::into)
+						futures::stream::iter(futs).buffered(10).await.map(Into::into);
 					}
 					Part::First => match v.first() {
 						Some(v) => v.get(ctx, opt, txn, path.next()).await,

--- a/lib/src/sql/value/set.rs
+++ b/lib/src/sql/value/set.rs
@@ -58,7 +58,7 @@ impl Value {
 					Part::All => {
 						let path = path.next();
 						let futs = v.iter_mut().map(|v| v.set(ctx, opt, txn, path, val.clone()));
-						try_join_all(futs).await?;
+						futures::stream::iter(futs).buffered(10).await?;
 						Ok(())
 					}
 					Part::First => match v.first_mut() {
@@ -84,7 +84,7 @@ impl Value {
 					}
 					_ => {
 						let futs = v.iter_mut().map(|v| v.set(ctx, opt, txn, path, val.clone()));
-						try_join_all(futs).await?;
+						futures::stream::iter(futs).buffered(10).await?;
 						Ok(())
 					}
 				},


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

Replaced try_join_all with buffered

## Is this related to any issues?

#22 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
