### PR TITLE
Feature: Limit number of concurrent futures when fetching remote records

### DIFF
--- a/lib/src/sql/value/del.rs
+++ b/lib/src/sql/value/del.rs
@@ -47,7 +47,7 @@ impl Value {
 						_ => {
 							let path = path.next();
 							let futs = v.iter_mut().map(|v| v.del(ctx, opt, txn, path));
-							stream::iter(futs).buffered(10).await?;
+							stream::iter(futs).buffered(10).collect().await?;
 							Ok(())
 						}
 					},
@@ -114,7 +114,7 @@ impl Value {
 					},
 					_ => {
 						let futs = v.iter_mut().map(|v| v.del(ctx, opt, txn, path));
-						stream::iter(futs).buffered(10).await?;
+						stream::iter(futs).buffered(10).collect().await?;
 						Ok(())
 					}
 				},

--- a/lib/src/sql/value/del.rs
+++ b/lib/src/sql/value/del.rs
@@ -47,7 +47,7 @@ impl Value {
 						_ => {
 							let path = path.next();
 							let futs = v.iter_mut().map(|v| v.del(ctx, opt, txn, path));
-							stream::iter(futs).buffered(10).collect().await?;
+							stream::iter(futs).buffered(10);
 							Ok(())
 						}
 					},
@@ -114,7 +114,7 @@ impl Value {
 					},
 					_ => {
 						let futs = v.iter_mut().map(|v| v.del(ctx, opt, txn, path));
-						stream::iter(futs).buffered(10).collect().await?;
+						stream::iter(futs).buffered(10);
 						Ok(())
 					}
 				},

--- a/lib/src/sql/value/del.rs
+++ b/lib/src/sql/value/del.rs
@@ -7,7 +7,7 @@ use crate::sql::part::Next;
 use crate::sql::part::Part;
 use crate::sql::value::Value;
 use async_recursion::async_recursion;
-use futures::future::try_join_all;
+use futures::stream::{self, StreamExt};
 use std::collections::HashSet;
 
 impl Value {
@@ -47,7 +47,7 @@ impl Value {
 						_ => {
 							let path = path.next();
 							let futs = v.iter_mut().map(|v| v.del(ctx, opt, txn, path));
-							futures::stream::iter(futs).buffered(10).await?;
+							stream::iter(futs).buffered(10).await?;
 							Ok(())
 						}
 					},
@@ -114,7 +114,7 @@ impl Value {
 					},
 					_ => {
 						let futs = v.iter_mut().map(|v| v.del(ctx, opt, txn, path));
-						futures::stream::iter(futs).buffered(10).await?;
+						stream::iter(futs).buffered(10).await?;
 						Ok(())
 					}
 				},

--- a/lib/src/sql/value/del.rs
+++ b/lib/src/sql/value/del.rs
@@ -47,7 +47,7 @@ impl Value {
 						_ => {
 							let path = path.next();
 							let futs = v.iter_mut().map(|v| v.del(ctx, opt, txn, path));
-							try_join_all(futs).await?;
+							futures::stream::iter(futs).buffered(10).await?;
 							Ok(())
 						}
 					},
@@ -114,7 +114,7 @@ impl Value {
 					},
 					_ => {
 						let futs = v.iter_mut().map(|v| v.del(ctx, opt, txn, path));
-						try_join_all(futs).await?;
+						futures::stream::iter(futs).buffered(10).await?;
 						Ok(())
 					}
 				},

--- a/lib/src/sql/value/get.rs
+++ b/lib/src/sql/value/get.rs
@@ -43,7 +43,7 @@ impl Value {
 					Part::All => {
 						let path = path.next();
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						futures::stream::iter(futs).buffered(10).collect().await.map(Into::into)
+						futures::stream::iter(futs).buffered(10)
 					}
 					Part::First => match v.first() {
 						Some(v) => v.get(ctx, opt, txn, path.next()).await,
@@ -69,7 +69,7 @@ impl Value {
 					}
 					_ => {
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						stream::iter(futs).buffered(10).collect().await.map(Into::into)
+						stream::iter(futs).buffered(10)
 					}
 				},
 				// Current path part is a thing

--- a/lib/src/sql/value/get.rs
+++ b/lib/src/sql/value/get.rs
@@ -10,7 +10,7 @@ use crate::sql::paths::ID;
 use crate::sql::statements::select::SelectStatement;
 use crate::sql::value::{Value, Values};
 use async_recursion::async_recursion;
-use futures::future::try_join_all;
+use futures::stream::{StreamExt};
 
 impl Value {
 	#[cfg_attr(feature = "parallel", async_recursion)]

--- a/lib/src/sql/value/get.rs
+++ b/lib/src/sql/value/get.rs
@@ -43,7 +43,7 @@ impl Value {
 					Part::All => {
 						let path = path.next();
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						try_join_all(futs).await.map(Into::into)
+						futures::stream::iter(futs).buffered(10).await.map(Into::into)
 					}
 					Part::First => match v.first() {
 						Some(v) => v.get(ctx, opt, txn, path.next()).await,
@@ -69,7 +69,7 @@ impl Value {
 					}
 					_ => {
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						try_join_all(futs).await.map(Into::into)
+						futures::stream::iter(futs).buffered(10).await.map(Into::into)
 					}
 				},
 				// Current path part is a thing

--- a/lib/src/sql/value/get.rs
+++ b/lib/src/sql/value/get.rs
@@ -43,7 +43,7 @@ impl Value {
 					Part::All => {
 						let path = path.next();
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						futures::stream::iter(futs).buffered(10).await.map(Into::into)
+						futures::stream::iter(futs).buffered(10).collect().await.map(Into::into)
 					}
 					Part::First => match v.first() {
 						Some(v) => v.get(ctx, opt, txn, path.next()).await,
@@ -69,7 +69,7 @@ impl Value {
 					}
 					_ => {
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						stream::iter(futs).buffered(10).await.map(Into::into)
+						stream::iter(futs).buffered(10).collect().await.map(Into::into)
 					}
 				},
 				// Current path part is a thing

--- a/lib/src/sql/value/get.rs
+++ b/lib/src/sql/value/get.rs
@@ -10,7 +10,7 @@ use crate::sql::paths::ID;
 use crate::sql::statements::select::SelectStatement;
 use crate::sql::value::{Value, Values};
 use async_recursion::async_recursion;
-use futures::stream::{StreamExt};
+use futures::stream::{self, StreamExt};
 
 impl Value {
 	#[cfg_attr(feature = "parallel", async_recursion)]
@@ -69,7 +69,7 @@ impl Value {
 					}
 					_ => {
 						let futs = v.iter().map(|v| v.get(ctx, opt, txn, path));
-						futures::stream::iter(futs).buffered(10).await.map(Into::into)
+						stream::iter(futs).buffered(10).await.map(Into::into)
 					}
 				},
 				// Current path part is a thing

--- a/lib/src/sql/value/set.rs
+++ b/lib/src/sql/value/set.rs
@@ -58,7 +58,7 @@ impl Value {
 					Part::All => {
 						let path = path.next();
 						let futs = v.iter_mut().map(|v| v.set(ctx, opt, txn, path, val.clone()));
-						stream::iter(futs).buffered(10).await?;
+						stream::iter(futs).buffered(10).collect().await?;
 						Ok(())
 					}
 					Part::First => match v.first_mut() {
@@ -84,7 +84,7 @@ impl Value {
 					}
 					_ => {
 						let futs = v.iter_mut().map(|v| v.set(ctx, opt, txn, path, val.clone()));
-						stream::iter(futs).buffered(10).await?;
+						stream::iter(futs).buffered(10).collect().await?;
 						Ok(())
 					}
 				},

--- a/lib/src/sql/value/set.rs
+++ b/lib/src/sql/value/set.rs
@@ -6,7 +6,7 @@ use crate::sql::part::Next;
 use crate::sql::part::Part;
 use crate::sql::value::Value;
 use async_recursion::async_recursion;
-use futures::future::try_join_all;
+use futures::stream::{self, StreamExt};
 
 impl Value {
 	#[cfg_attr(feature = "parallel", async_recursion)]
@@ -58,7 +58,7 @@ impl Value {
 					Part::All => {
 						let path = path.next();
 						let futs = v.iter_mut().map(|v| v.set(ctx, opt, txn, path, val.clone()));
-						futures::stream::iter(futs).buffered(10).await?;
+						stream::iter(futs).buffered(10).await?;
 						Ok(())
 					}
 					Part::First => match v.first_mut() {
@@ -84,7 +84,7 @@ impl Value {
 					}
 					_ => {
 						let futs = v.iter_mut().map(|v| v.set(ctx, opt, txn, path, val.clone()));
-						futures::stream::iter(futs).buffered(10).await?;
+						stream::iter(futs).buffered(10).await?;
 						Ok(())
 					}
 				},

--- a/lib/src/sql/value/set.rs
+++ b/lib/src/sql/value/set.rs
@@ -58,7 +58,7 @@ impl Value {
 					Part::All => {
 						let path = path.next();
 						let futs = v.iter_mut().map(|v| v.set(ctx, opt, txn, path, val.clone()));
-						try_join_all(futs).await?;
+						futures::stream::iter(futs).buffered(10).await?;
 						Ok(())
 					}
 					Part::First => match v.first_mut() {
@@ -84,7 +84,7 @@ impl Value {
 					}
 					_ => {
 						let futs = v.iter_mut().map(|v| v.set(ctx, opt, txn, path, val.clone()));
-						try_join_all(futs).await?;
+						futures::stream::iter(futs).buffered(10).await?;
 						Ok(())
 					}
 				},

--- a/lib/src/sql/value/set.rs
+++ b/lib/src/sql/value/set.rs
@@ -58,7 +58,7 @@ impl Value {
 					Part::All => {
 						let path = path.next();
 						let futs = v.iter_mut().map(|v| v.set(ctx, opt, txn, path, val.clone()));
-						stream::iter(futs).buffered(10).collect().await?;
+						stream::iter(futs).buffered(10);
 						Ok(())
 					}
 					Part::First => match v.first_mut() {
@@ -84,7 +84,7 @@ impl Value {
 					}
 					_ => {
 						let futs = v.iter_mut().map(|v| v.set(ctx, opt, txn, path, val.clone()));
-						stream::iter(futs).buffered(10).collect().await?;
+						stream::iter(futs).buffered(10);
 						Ok(())
 					}
 				},


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

Replaced try_join_all to buffered

## Is this related to any issues?

#22 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
