### PR TITLE
Fix building surrealdb with no default features and cut down dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,13 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Run cargo check
+      - name: Run cargo check --package surrealdb
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --package surrealdb
+
+      - name: Run cargo check --workspace
         uses: actions-rs/cargo@v1
         with:
           command: check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4287,6 +4287,7 @@ dependencies = [
  "atomic",
  "getrandom 0.2.7",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1664865507,
-        "narHash": "sha256-KUonhQPn7SigY+4mfI/UydMQv4nIhBKIqgeU3JAaowI=",
+        "lastModified": 1665815894,
+        "narHash": "sha256-Vboo1L4NMGLKZKVLnOPi9OHlae7uoNyfgvyIUm+SVXE=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "93c65e24793653fdc45339022218a9ceca6219dd",
+        "rev": "2348450241a5f945f0ba07e44ecbfac2f541d7f4",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664790708,
-        "narHash": "sha256-fzxmpOPjzOVIt9KeDN4EDPI13xJn+u0uMxheKCWken8=",
+        "lastModified": 1665798813,
+        "narHash": "sha256-krXd6Y3NoOt0ewuESohyAle9hcWxRN8oPXNmWEMIMmc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "81a3237b64e67b66901c735654017e75f0c50943",
+        "rev": "d3974c99a5bde46166bf9c02b7a6580a4eee59df",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1664652573,
-        "narHash": "sha256-mVf9fjQbtYbrVvQSaJOCwArWIvXHrXqVVUhP0x9ZcVY=",
+        "lastModified": 1665765556,
+        "narHash": "sha256-w9L5j0TIB5ay4aRwzGCp8mgvGsu5dVJQvbEFutwr6xE=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "5c28ad193238635189f849c94ffc178f00008b12",
+        "rev": "018b8429cf3fa9d8aed916704e41dfedeb0f4f78",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,9 @@
           # nix build .#static-binary
           static-binary = packages.x86_64-unknown-linux-musl;
 
+          # nix build .#wasm
+          wasm = packages.wasm32-unknown-unknown;
+
           # nix build .#windows-binary
           windows-binary = packages.x86_64-pc-windows-gnu;
         } // (pkgs.lib.attrsets.mapAttrs (target: _:
@@ -95,6 +98,9 @@
           # nix develop .#static-binary
           static-binary = devShells.x86_64-unknown-linux-musl;
 
+          # nix develop .#wasm
+          wasm = devShells.wasm32-unknown-unknown;
+
           # nix develop .#windows-binary
           windows-binary = devShells.x86_64-pc-windows-gnu;
         } // (pkgs.lib.attrsets.mapAttrs (target: _:
@@ -108,7 +114,7 @@
             hardeningDisable = [ "fortify" ];
 
             depsBuildBuild = buildSpec.depsBuildBuild or [ ]
-              ++ [ rustToolchain ] ++ (with pkgs; [ nixfmt cargo-watch ]);
+              ++ [ rustToolchain ] ++ (with pkgs; [ nixfmt cargo-watch wasm-pack ]);
 
             inherit (util) SURREAL_BUILD_METADATA;
           })) util.platforms);

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0"
 [features]
 default = ["parallel", "kv-mem", "kv-rocksdb", "scripting", "http"]
 parallel = ["dep:executor"]
-kv-tikv = ["dep:tikv"]
+kv-tikv = ["dep:tikv", "compute"]
 kv-fdb-5_1 = ["foundationdb/fdb-5_1", "kv-fdb"]
 kv-fdb-5_2 = ["foundationdb/fdb-5_2", "kv-fdb"]
 kv-fdb-6_0 = ["foundationdb/fdb-6_0", "kv-fdb"]
@@ -25,29 +25,42 @@ kv-fdb-6_2 = ["foundationdb/fdb-6_2", "kv-fdb"]
 kv-fdb-6_3 = ["foundationdb/fdb-6_3", "kv-fdb"]
 kv-fdb-7_0 = ["foundationdb/fdb-7_0", "kv-fdb"]
 kv-fdb-7_1 = ["foundationdb/fdb-7_1", "kv-fdb"]
-kv-mem = ["dep:echodb"]
-kv-indxdb = ["dep:indxdb"]
-kv-rocksdb = ["dep:rocksdb"]
+kv-mem = ["dep:echodb", "compute"]
+kv-indxdb = ["dep:indxdb", "compute"]
+kv-rocksdb = ["dep:rocksdb", "compute"]
 scripting = ["dep:js", "dep:executor"]
 http = ["dep:surf"]
 
-# This is an internal feature. It shouldn't be activated directly.
+# -----------------------------------
+# Internal features
+# -----------------------------------
+
+# These are internal features. They shouldn't be activated directly.
+
 # One of the `kv-fdb-*` features that specify the version to use must be used instead.
-kv-fdb = ["foundationdb"]
+kv-fdb = ["foundationdb", "compute"]
+
+# Used to activate features that require any KV store
+compute = [
+    "dep:addr", "dep:async-recursion", "dep:bcrypt", "dep:channel", "dep:deunicode",
+    "dep:futures", "dep:md-5", "dep:pbkdf2", "dep:scrypt", "dep:semver",
+    "dep:sha-1", "dep:sha2", "dep:trice", "dep:url"
+]
 
 [dependencies]
-addr = { version = "0.15.6", default-features = false, features = ["std"] }
+addr = { version = "0.15.6", default-features = false, features = ["std"], optional = true }
 argon2 = "0.4.1"
-async-recursion = "1.0.0"
+async-recursion = { version = "1.0.0", optional = true }
+bcrypt = { version = "0.13.0", optional = true }
 bigdecimal = { version = "0.3.0", features = ["serde", "string-only"] }
-channel = { version = "1.7.1", package = "async-channel" }
+channel = { version = "1.7.1", package = "async-channel", optional = true }
 chrono = { version = "0.4.22", features = ["serde"] }
 derive = { version = "0.5.0", package = "surrealdb-derive" }
-deunicode = "1.3.2"
+deunicode = { version = "1.3.2", optional = true }
 dmp = "0.1.1"
 echodb = { version = "0.3.0", optional = true }
 executor = { version = "1.4.1", package = "async-executor", optional = true }
-futures = "0.3.24"
+futures = { version = "0.3.24", optional = true }
 foundationdb = { version = "0.7.0", default-features = false, features = ["embedded-fdb-include"], optional = true }
 fuzzy-matcher = "0.3.7"
 geo = { version = "0.23.0", features = ["use-serde"] }
@@ -55,33 +68,33 @@ indxdb = { version = "0.2.0", optional = true }
 js = { version = "0.1.7", package = "rquickjs", features = ["bindgen", "classes", "futures", "loader", "macro", "properties", "parallel"], optional = true }
 lexical-sort = "0.3.1"
 log = "0.4.17"
-md-5 = "0.10.5"
+md-5 = { version = "0.10.5", optional = true }
 msgpack = { version = "1.1.1", package = "rmp-serde" }
 nanoid = "0.4.0"
 nom = { version = "7.1.1", features = ["alloc"] }
 once_cell = "1.15.0"
-pbkdf2 = "0.11.0"
+pbkdf2 = { version = "0.11.0", optional = true }
 rand = "0.8.5"
 regex = "1.6.0"
 rocksdb = { version = "0.19.0", optional = true }
-scrypt = "0.10.0"
-semver = { version = "1.0.14", default-features = false }
+scrypt = { version = "0.10.0", optional = true }
+semver = { version = "1.0.14", default-features = false, optional = true }
 serde = { version = "1.0.145", features = ["derive"] }
-sha-1 = "0.10.0"
-sha2 = "0.10.6"
+sha-1 = { version = "0.10.0", optional = true }
+sha2 = { version = "0.10.6", optional = true }
 storekey = "0.3.0"
 thiserror = "1.0.37"
 tikv = { version = "0.1.0", package = "tikv-client", optional = true }
-trice = "0.1.0"
-url = "2.3.1"
-uuid = { version = "1.2.1", features = ["serde", "v4", "v7"] }
-bcrypt = "0.13.0"
+trice = { version = "0.1.0", optional = true }
+url = { version = "2.3.1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.21.2", features = ["macros", "rt"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 surf = { version = "2.3.2", optional = true, default-features = false, features = ["encoding", "wasm-client"] }
+uuid = { version = "1.2.1", features = ["serde", "js", "v4", "v7"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 surf = { version = "2.3.2", optional = true, default-features = false, features = ["encoding", "curl-client"] }
+uuid = { version = "1.2.1", features = ["serde", "v4", "v7"] }

--- a/lib/src/cnf/mod.rs
+++ b/lib/src/cnf/mod.rs
@@ -1,11 +1,13 @@
-#[cfg(feature = "parallel")]
 /// Specifies how many concurrent jobs can be buffered in the worker channel.
+#[cfg(all(feature = "compute", feature = "parallel"))]
 pub const MAX_CONCURRENT_TASKS: usize = 64;
 
 /// Specifies how deep various forms of computation will go before the query fails.
+#[cfg(feature = "compute")]
 pub const MAX_COMPUTATION_DEPTH: u8 = 30;
 
 /// Specifies the names of parameters which can not be specified in a query.
+#[cfg(feature = "compute")]
 pub const PROTECTED_PARAM_NAMES: &[&str] = &["auth", "scope", "token", "session"];
 
 /// The characters which are supported in server record IDs.

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -336,12 +336,14 @@ impl From<rocksdb::Error> for Error {
 	}
 }
 
+#[cfg(feature = "compute")]
 impl From<channel::RecvError> for Error {
 	fn from(e: channel::RecvError) -> Error {
 		Error::Channel(e.to_string())
 	}
 }
 
+#[cfg(feature = "compute")]
 impl<T> From<channel::SendError<T>> for Error {
 	fn from(e: channel::SendError<T>) -> Error {
 		Error::Channel(e.to_string())

--- a/lib/src/exe/mod.rs
+++ b/lib/src/exe/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "parallel")]
-
 use executor::{Executor, Task};
 use once_cell::sync::Lazy;
 use std::future::Future;

--- a/lib/src/fnc/http.rs
+++ b/lib/src/fnc/http.rs
@@ -1,5 +1,6 @@
 use crate::err::Error;
 use crate::sql::value::Value;
+#[cfg(feature = "http")]
 use crate::sql::{Object, Strand};
 
 #[cfg(not(feature = "http"))]

--- a/lib/src/fnc/script/modules/surrealdb.rs
+++ b/lib/src/fnc/script/modules/surrealdb.rs
@@ -2,5 +2,5 @@
 #[quickjs(bare)]
 #[allow(non_upper_case_globals)]
 pub mod package {
-	pub const version: &str = env!("CARGO_PKG_VERSION");
+	pub const version: &str = crate::VERSION;
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,6 +7,7 @@
 //! persisted to disk, a browser-based embedded datastore backed by IndexedDB, or for connecting
 //! to a distributed [TiKV](https://tikv.org) key-value store.
 
+#[cfg(feature = "compute")]
 #[macro_use]
 extern crate log;
 
@@ -14,30 +15,36 @@ extern crate log;
 mod mac;
 
 mod cnf;
+#[cfg(feature = "compute")]
 mod ctx;
+#[cfg(feature = "compute")]
 mod dbs;
+#[cfg(feature = "compute")]
 mod doc;
-mod env;
 mod err;
+#[cfg(all(feature = "compute", feature = "parallel"))]
 mod exe;
+#[cfg(feature = "compute")]
 mod fnc;
+#[cfg(feature = "compute")]
 mod key;
+#[cfg(feature = "compute")]
 mod kvs;
 
+#[cfg(feature = "compute")]
+pub mod env;
 // SQL
 pub mod sql;
 
 // Exports
-pub use dbs::Auth;
-pub use dbs::Response;
-pub use dbs::Session;
+#[cfg(feature = "compute")]
+pub use dbs::{Auth, Response, Session};
 pub use err::Error;
-pub use kvs::Datastore;
-pub use kvs::Key;
-pub use kvs::Transaction;
-pub use kvs::Val;
+#[cfg(feature = "compute")]
+pub use kvs::{Datastore, Key, Transaction, Val};
 
 // Re-exports
+#[cfg(feature = "compute")]
 pub mod channel {
 	pub use channel::bounded as new;
 	pub use channel::Receiver;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -50,3 +50,5 @@ pub mod channel {
 	pub use channel::Receiver;
 	pub use channel::Sender;
 }
+
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/lib/src/mac/mod.rs
+++ b/lib/src/mac/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "compute")]
 macro_rules! bytes {
 	($expression:expr) => {
 		format!("{}\n", $expression).into_bytes()
@@ -12,6 +13,7 @@ macro_rules! map {
     }};
 }
 
+#[cfg(feature = "compute")]
 macro_rules! get_cfg {
 	($i:ident : $($s:expr),+) => (
 		let $i = || { $( if cfg!($i=$s) { return $s; } );+ "unknown"};

--- a/lib/src/sql/array.rs
+++ b/lib/src/sql/array.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::mightbespace;
 use crate::sql::common::commas;
@@ -122,6 +124,7 @@ impl Array {
 }
 
 impl Array {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/constant.rs
+++ b/lib/src/sql/constant.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::error::IResult;
 use crate::sql::serde::is_internal_serialization;
+#[cfg(feature = "compute")]
 use crate::sql::value::Value;
 use derive::Store;
 use nom::branch::alt;
@@ -36,6 +39,7 @@ pub enum Constant {
 }
 
 impl Constant {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,

--- a/lib/src/sql/data.rs
+++ b/lib/src/sql/data.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::mightbespace;
 use crate::sql::comment::shouldbespace;
@@ -9,7 +11,9 @@ use crate::sql::error::IResult;
 use crate::sql::fmt::Fmt;
 use crate::sql::idiom::{idiom, Idiom};
 use crate::sql::operator::{assigner, Operator};
+#[cfg(feature = "compute")]
 use crate::sql::table::Table;
+#[cfg(feature = "compute")]
 use crate::sql::thing::Thing;
 use crate::sql::value::{value, Value};
 use nom::branch::alt;
@@ -39,6 +43,7 @@ impl Default for Data {
 
 impl Data {
 	/// Fetch the 'id' field if one has been specified
+	#[cfg(feature = "compute")]
 	pub(crate) async fn rid(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/expression.rs
+++ b/lib/src/sql/expression.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
+#[cfg(feature = "compute")]
 use crate::fnc;
 use crate::sql::error::IResult;
 use crate::sql::operator::{operator, Operator};
@@ -57,6 +60,7 @@ impl Expression {
 }
 
 impl Expression {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/field.rs
+++ b/lib/src/sql/field.rs
@@ -1,12 +1,15 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::common::commas;
 use crate::sql::error::IResult;
 use crate::sql::fmt::Fmt;
 use crate::sql::idiom::{idiom, Idiom};
+#[cfg(feature = "compute")]
 use crate::sql::part::Part;
 use crate::sql::value::{value, Value};
 use nom::branch::alt;
@@ -61,6 +64,7 @@ impl Display for Fields {
 }
 
 impl Fields {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
+#[cfg(feature = "compute")]
 use crate::fnc;
 use crate::sql::comment::mightbespace;
 use crate::sql::common::commas;
@@ -104,6 +107,7 @@ impl Function {
 }
 
 impl Function {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/future.rs
+++ b/lib/src/sql/future.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
+#[cfg(feature = "compute")]
 use crate::dbs::Options;
+#[cfg(feature = "compute")]
 use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::mightbespace;
 use crate::sql::error::IResult;
@@ -14,6 +18,7 @@ use std::fmt;
 pub struct Future(pub Value);
 
 impl Future {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/id.rs
+++ b/lib/src/sql/id.rs
@@ -1,7 +1,11 @@
 use crate::cnf::ID_CHARS;
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
+#[cfg(feature = "compute")]
 use crate::dbs::Options;
+#[cfg(feature = "compute")]
 use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::array::{array, Array};
 use crate::sql::error::IResult;
@@ -121,6 +125,7 @@ impl Display for Id {
 }
 
 impl Id {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/ident.rs
+++ b/lib/src/sql/ident.rs
@@ -49,6 +49,7 @@ impl Ident {
 		self.0.to_string()
 	}
 	/// Returns a yield if an alias is specified
+	#[cfg(feature = "compute")]
 	pub(crate) fn is_id(&self) -> bool {
 		self.0.as_str() == "id"
 	}

--- a/lib/src/sql/idiom.rs
+++ b/lib/src/sql/idiom.rs
@@ -1,16 +1,21 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::common::commas;
 use crate::sql::error::IResult;
 use crate::sql::fmt::Fmt;
+#[cfg(feature = "compute")]
 use crate::sql::part::Next;
 use crate::sql::part::{all, field, first, graph, index, last, part, thing, Part};
+#[cfg(feature = "compute")]
 use crate::sql::paths::{ID, IN, OUT};
+#[cfg(feature = "compute")]
 use crate::sql::value::Value;
-use md5::Digest;
-use md5::Md5;
+#[cfg(feature = "compute")]
+use md5::{Digest, Md5};
 use nom::branch::alt;
 use nom::multi::separated_list1;
 use nom::multi::{many0, many1};
@@ -69,6 +74,7 @@ impl Idiom {
 		self
 	}
 	/// Convert this Idiom to a unique hash
+	#[cfg(feature = "compute")]
 	pub(crate) fn to_hash(&self) -> String {
 		let mut hasher = Md5::new();
 		hasher.update(self.to_string().as_str());
@@ -88,28 +94,34 @@ impl Idiom {
 			.into()
 	}
 	/// Check if this expression is an 'id' field
+	#[cfg(feature = "compute")]
 	pub(crate) fn is_id(&self) -> bool {
 		self.0.len() == 1 && self.0[0].eq(&ID[0])
 	}
 	/// Check if this expression is an 'in' field
+	#[cfg(feature = "compute")]
 	pub(crate) fn is_in(&self) -> bool {
 		self.0.len() == 1 && self.0[0].eq(&IN[0])
 	}
 	/// Check if this expression is an 'out' field
+	#[cfg(feature = "compute")]
 	pub(crate) fn is_out(&self) -> bool {
 		self.0.len() == 1 && self.0[0].eq(&OUT[0])
 	}
 	/// Check if this is an expression with multiple yields
+	#[cfg(feature = "compute")]
 	pub(crate) fn is_multi_yield(&self) -> bool {
 		self.iter().any(Self::split_multi_yield)
 	}
 	/// Check if the path part is a yield in a multi-yield expression
+	#[cfg(feature = "compute")]
 	pub(crate) fn split_multi_yield(v: &Part) -> bool {
 		matches!(v, Part::Graph(g) if g.alias.is_some())
 	}
 }
 
 impl Idiom {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/limit.rs
+++ b/lib/src/sql/limit.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::error::IResult;
@@ -15,6 +17,7 @@ use std::fmt;
 pub struct Limit(pub Value);
 
 impl Limit {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn process(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod output;
 pub(crate) mod param;
 pub(crate) mod parser;
 pub(crate) mod part;
+#[cfg(feature = "compute")]
 pub(crate) mod paths;
 pub(crate) mod permission;
 pub(crate) mod query;

--- a/lib/src/sql/object.rs
+++ b/lib/src/sql/object.rs
@@ -1,6 +1,7 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
 use crate::err::Error;
 use crate::sql::comment::mightbespace;
 use crate::sql::common::{commas, val_char};
@@ -116,6 +117,7 @@ impl Object {
 }
 
 impl Object {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/param.rs
+++ b/lib/src/sql/param.rs
@@ -1,12 +1,15 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::error::IResult;
 use crate::sql::idiom;
 use crate::sql::idiom::Idiom;
-use crate::sql::part::Next;
-use crate::sql::part::Part;
+#[cfg(feature = "compute")]
+use crate::sql::part::{Next, Part};
+#[cfg(feature = "compute")]
 use crate::sql::value::Value;
 use nom::character::complete::char;
 use serde::{Deserialize, Serialize};
@@ -31,6 +34,7 @@ impl Deref for Param {
 }
 
 impl Param {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/part.rs
+++ b/lib/src/sql/part.rs
@@ -3,6 +3,7 @@ use crate::sql::ending::ident as ending;
 use crate::sql::error::IResult;
 use crate::sql::graph::{graph as graph_raw, Graph};
 use crate::sql::ident::{ident, Ident};
+#[cfg(feature = "compute")]
 use crate::sql::idiom::Idiom;
 use crate::sql::number::{number, Number};
 use crate::sql::thing::{thing as thing_raw, Thing};
@@ -92,6 +93,7 @@ impl From<&str> for Part {
 
 impl Part {
 	/// Returns a yield if an alias is specified
+	#[cfg(feature = "compute")]
 	pub(crate) fn alias(&self) -> Option<&Idiom> {
 		match self {
 			Part::Graph(v) => v.alias.as_ref(),

--- a/lib/src/sql/range.rs
+++ b/lib/src/sql/range.rs
@@ -1,10 +1,15 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
+#[cfg(feature = "compute")]
 use crate::dbs::Options;
+#[cfg(feature = "compute")]
 use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::error::IResult;
 use crate::sql::id::{id, Id};
 use crate::sql::ident::ident_raw;
+#[cfg(feature = "compute")]
 use crate::sql::value::Value;
 use nom::branch::alt;
 use nom::character::complete::char;
@@ -25,6 +30,7 @@ pub struct Range {
 }
 
 impl Range {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/start.rs
+++ b/lib/src/sql/start.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::error::IResult;
@@ -15,6 +17,7 @@ use std::fmt;
 pub struct Start(pub Value);
 
 impl Start {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn process(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statement.rs
+++ b/lib/src/sql/statement.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::{comment, mightbespace};
 use crate::sql::common::colons;
@@ -24,6 +26,7 @@ use crate::sql::statements::select::{select, SelectStatement};
 use crate::sql::statements::set::{set, SetStatement};
 use crate::sql::statements::update::{update, UpdateStatement};
 use crate::sql::statements::yuse::{yuse, UseStatement};
+#[cfg(feature = "compute")]
 use crate::sql::value::Value;
 use nom::branch::alt;
 use nom::combinator::map;
@@ -96,6 +99,7 @@ impl Statement {
 		}
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		match self {
 			Self::Use(_) => false,
@@ -118,6 +122,7 @@ impl Statement {
 		}
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/create.rs
+++ b/lib/src/sql/statements/create.rs
@@ -1,17 +1,17 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Iterable;
-use crate::dbs::Iterator;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Statement;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Iterable, Iterator, Level, Options, Statement, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::data::{data, Data};
 use crate::sql::error::IResult;
 use crate::sql::output::{output, Output};
 use crate::sql::timeout::{timeout, Timeout};
-use crate::sql::value::{whats, Value, Values};
+#[cfg(feature = "compute")]
+use crate::sql::value::Value;
+use crate::sql::value::{whats, Values};
 use derive::Store;
 use nom::bytes::complete::tag_no_case;
 use nom::combinator::opt;
@@ -29,10 +29,12 @@ pub struct CreateStatement {
 }
 
 impl CreateStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		true
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/define.rs
+++ b/lib/src/sql/statements/define.rs
@@ -1,7 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Level, Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::algorithm::{algorithm, Algorithm};
 use crate::sql::base::{base, base_or_scope, Base};
@@ -14,6 +15,7 @@ use crate::sql::idiom;
 use crate::sql::idiom::{Idiom, Idioms};
 use crate::sql::kind::{kind, Kind};
 use crate::sql::permission::{permissions, Permissions};
+#[cfg(feature = "compute")]
 use crate::sql::statements::UpdateStatement;
 use crate::sql::strand::strand_raw;
 use crate::sql::value::{value, values, Value, Values};
@@ -47,6 +49,7 @@ pub enum DefineStatement {
 }
 
 impl DefineStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,
@@ -108,6 +111,7 @@ pub struct DefineNamespaceStatement {
 }
 
 impl DefineNamespaceStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -157,6 +161,7 @@ pub struct DefineDatabaseStatement {
 }
 
 impl DefineDatabaseStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -214,6 +219,7 @@ pub struct DefineLoginStatement {
 }
 
 impl DefineLoginStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -337,6 +343,7 @@ pub struct DefineTokenStatement {
 }
 
 impl DefineTokenStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -457,6 +464,7 @@ pub struct DefineScopeStatement {
 }
 
 impl DefineScopeStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -579,6 +587,7 @@ pub struct DefineTableStatement {
 }
 
 impl DefineTableStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,
@@ -754,6 +763,7 @@ pub struct DefineEventStatement {
 }
 
 impl DefineEventStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -835,6 +845,7 @@ pub struct DefineFieldStatement {
 }
 
 impl DefineFieldStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -975,6 +986,7 @@ pub struct DefineIndexStatement {
 }
 
 impl DefineIndexStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/delete.rs
+++ b/lib/src/sql/statements/delete.rs
@@ -1,17 +1,17 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Iterable;
-use crate::dbs::Iterator;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Statement;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Iterable, Iterator, Level, Options, Statement, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::cond::{cond, Cond};
 use crate::sql::error::IResult;
 use crate::sql::output::{output, Output};
 use crate::sql::timeout::{timeout, Timeout};
-use crate::sql::value::{whats, Value, Values};
+#[cfg(feature = "compute")]
+use crate::sql::value::Value;
+use crate::sql::value::{whats, Values};
 use derive::Store;
 use nom::bytes::complete::tag_no_case;
 use nom::combinator::opt;
@@ -30,10 +30,12 @@ pub struct DeleteStatement {
 }
 
 impl DeleteStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		true
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/ifelse.rs
+++ b/lib/src/sql/statements/ifelse.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::error::IResult;
@@ -19,6 +21,7 @@ pub struct IfelseStatement {
 }
 
 impl IfelseStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		for (cond, then) in self.exprs.iter() {
 			if cond.writeable() || then.writeable() {
@@ -28,6 +31,7 @@ impl IfelseStatement {
 		self.close.as_ref().map_or(false, |v| v.writeable())
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/info.rs
+++ b/lib/src/sql/statements/info.rs
@@ -1,12 +1,15 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Level, Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::error::IResult;
 use crate::sql::ident::{ident, Ident};
+#[cfg(feature = "compute")]
 use crate::sql::object::Object;
+#[cfg(feature = "compute")]
 use crate::sql::value::Value;
 use derive::Store;
 use nom::branch::alt;
@@ -24,6 +27,7 @@ pub enum InfoStatement {
 }
 
 impl InfoStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,

--- a/lib/src/sql/statements/insert.rs
+++ b/lib/src/sql/statements/insert.rs
@@ -1,10 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Iterable;
-use crate::dbs::Iterator;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Statement;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Iterable, Iterator, Level, Options, Statement, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::data::{single, update, values, Data};
@@ -12,6 +10,7 @@ use crate::sql::error::IResult;
 use crate::sql::output::{output, Output};
 use crate::sql::table::{table, Table};
 use crate::sql::timeout::{timeout, Timeout};
+#[cfg(feature = "compute")]
 use crate::sql::value::Value;
 use derive::Store;
 use nom::branch::alt;
@@ -33,10 +32,12 @@ pub struct InsertStatement {
 }
 
 impl InsertStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		true
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/kill.rs
+++ b/lib/src/sql/statements/kill.rs
@@ -1,11 +1,13 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Level, Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::error::IResult;
 use crate::sql::uuid::{uuid, Uuid};
+#[cfg(feature = "compute")]
 use crate::sql::value::Value;
 use derive::Store;
 use nom::bytes::complete::tag_no_case;
@@ -18,6 +20,7 @@ pub struct KillStatement {
 }
 
 impl KillStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,

--- a/lib/src/sql/statements/live.rs
+++ b/lib/src/sql/statements/live.rs
@@ -1,7 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Level, Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::cond::{cond, Cond};
@@ -31,6 +32,7 @@ pub struct LiveStatement {
 }
 
 impl LiveStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/output.rs
+++ b/lib/src/sql/statements/output.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::error::IResult;
@@ -20,10 +22,12 @@ pub struct OutputStatement {
 }
 
 impl OutputStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		self.what.writeable()
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/relate.rs
+++ b/lib/src/sql/statements/relate.rs
@@ -1,10 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Iterable;
-use crate::dbs::Iterator;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Statement;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Iterable, Iterator, Level, Options, Statement, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::array::array;
 use crate::sql::comment::mightbespace;
@@ -41,10 +39,12 @@ pub struct RelateStatement {
 }
 
 impl RelateStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		true
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/remove.rs
+++ b/lib/src/sql/statements/remove.rs
@@ -1,7 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Level, Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::base::{base, base_or_scope, Base};
 use crate::sql::comment::shouldbespace;
@@ -9,6 +10,7 @@ use crate::sql::error::IResult;
 use crate::sql::ident::{ident, Ident};
 use crate::sql::idiom;
 use crate::sql::idiom::Idiom;
+#[cfg(feature = "compute")]
 use crate::sql::value::Value;
 use derive::Store;
 use nom::branch::alt;
@@ -32,6 +34,7 @@ pub enum RemoveStatement {
 }
 
 impl RemoveStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,
@@ -93,6 +96,7 @@ pub struct RemoveNamespaceStatement {
 }
 
 impl RemoveNamespaceStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -149,6 +153,7 @@ pub struct RemoveDatabaseStatement {
 }
 
 impl RemoveDatabaseStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -206,6 +211,7 @@ pub struct RemoveLoginStatement {
 }
 
 impl RemoveLoginStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -285,6 +291,7 @@ pub struct RemoveTokenStatement {
 }
 
 impl RemoveTokenStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -378,6 +385,7 @@ pub struct RemoveScopeStatement {
 }
 
 impl RemoveScopeStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -434,6 +442,7 @@ pub struct RemoveTableStatement {
 }
 
 impl RemoveTableStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -491,6 +500,7 @@ pub struct RemoveEventStatement {
 }
 
 impl RemoveEventStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -551,6 +561,7 @@ pub struct RemoveFieldStatement {
 }
 
 impl RemoveFieldStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,
@@ -611,6 +622,7 @@ pub struct RemoveIndexStatement {
 }
 
 impl RemoveIndexStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -1,23 +1,25 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Iterable;
-use crate::dbs::Iterator;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Statement;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Iterable, Iterator, Level, Options, Statement, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::cond::{cond, Cond};
 use crate::sql::error::IResult;
 use crate::sql::fetch::{fetch, Fetchs};
-use crate::sql::field::{fields, Field, Fields};
+#[cfg(feature = "compute")]
+use crate::sql::field::Field;
+use crate::sql::field::{fields, Fields};
 use crate::sql::group::{group, Groups};
 use crate::sql::limit::{limit, Limit};
 use crate::sql::order::{order, Orders};
 use crate::sql::split::{split, Splits};
 use crate::sql::start::{start, Start};
 use crate::sql::timeout::{timeout, Timeout};
-use crate::sql::value::{selects, Value, Values};
+#[cfg(feature = "compute")]
+use crate::sql::value::Value;
+use crate::sql::value::{selects, Values};
 use crate::sql::version::{version, Version};
 use derive::Store;
 use nom::bytes::complete::tag_no_case;
@@ -43,6 +45,7 @@ pub struct SelectStatement {
 }
 
 impl SelectStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn limit(
 		&self,
 		ctx: &Context<'_>,
@@ -56,6 +59,7 @@ impl SelectStatement {
 		}
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		if self.expr.iter().any(|v| match v {
 			Field::All => false,
@@ -70,6 +74,7 @@ impl SelectStatement {
 		self.cond.as_ref().map_or(false, |v| v.writeable())
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/set.rs
+++ b/lib/src/sql/statements/set.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::mightbespace;
 use crate::sql::comment::shouldbespace;
@@ -21,10 +23,12 @@ pub struct SetStatement {
 }
 
 impl SetStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		self.what.writeable()
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/statements/update.rs
+++ b/lib/src/sql/statements/update.rs
@@ -1,10 +1,8 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Iterable;
-use crate::dbs::Iterator;
-use crate::dbs::Level;
-use crate::dbs::Options;
-use crate::dbs::Statement;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Iterable, Iterator, Level, Options, Statement, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::cond::{cond, Cond};
@@ -12,7 +10,9 @@ use crate::sql::data::{data, Data};
 use crate::sql::error::IResult;
 use crate::sql::output::{output, Output};
 use crate::sql::timeout::{timeout, Timeout};
-use crate::sql::value::{whats, Value, Values};
+#[cfg(feature = "compute")]
+use crate::sql::value::Value;
+use crate::sql::value::{whats, Values};
 use derive::Store;
 use nom::bytes::complete::tag_no_case;
 use nom::combinator::opt;
@@ -31,10 +31,12 @@ pub struct UpdateStatement {
 }
 
 impl UpdateStatement {
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		true
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/subquery.rs
+++ b/lib/src/sql/subquery.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::comment::mightbespace;
 use crate::sql::error::IResult;
+#[cfg(feature = "compute")]
 use crate::sql::paths::ID;
 use crate::sql::statements::create::{create, CreateStatement};
 use crate::sql::statements::delete::{delete, DeleteStatement};
@@ -40,6 +43,7 @@ impl PartialOrd for Subquery {
 }
 
 impl Subquery {
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		match self {
 			Self::Value(v) => v.writeable(),
@@ -53,6 +57,7 @@ impl Subquery {
 		}
 	}
 
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/thing.rs
+++ b/lib/src/sql/thing.rs
@@ -1,12 +1,15 @@
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
+#[cfg(feature = "compute")]
 use crate::err::Error;
 use crate::sql::error::IResult;
 use crate::sql::escape::escape_rid;
 use crate::sql::id::{id, Id};
 use crate::sql::ident::ident_raw;
 use crate::sql::serde::is_internal_serialization;
+#[cfg(feature = "compute")]
 use crate::sql::value::Value;
 use derive::Store;
 use nom::branch::alt;
@@ -57,6 +60,7 @@ impl fmt::Display for Thing {
 }
 
 impl Thing {
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/lib/src/sql/value/mod.rs
+++ b/lib/src/sql/value/mod.rs
@@ -4,29 +4,43 @@ pub use self::value::*;
 mod value;
 
 mod all;
+#[cfg(feature = "compute")]
 mod array;
+#[cfg(feature = "compute")]
 mod clear;
 mod compare;
+#[cfg(feature = "compute")]
 mod decrement;
+#[cfg(feature = "compute")]
 mod def;
+#[cfg(feature = "compute")]
 mod del;
 mod diff;
 mod each;
 mod every;
+#[cfg(feature = "compute")]
 mod fetch;
 mod first;
 mod flatten;
 mod generate;
+#[cfg(feature = "compute")]
 mod get;
+#[cfg(feature = "compute")]
 mod increment;
 mod last;
+#[cfg(feature = "compute")]
 mod merge;
+#[cfg(feature = "compute")]
 mod object;
+#[cfg(feature = "compute")]
 mod patch;
 mod pick;
 mod put;
+#[cfg(feature = "compute")]
 mod replace;
+#[cfg(feature = "compute")]
 mod rid;
+#[cfg(feature = "compute")]
 mod set;
 mod single;
 mod walk;

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -1,8 +1,9 @@
 #![allow(clippy::derive_ord_xor_partial_ord)]
 
+#[cfg(feature = "compute")]
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Transaction;
+#[cfg(feature = "compute")]
+use crate::dbs::{Options, Transaction};
 use crate::err::Error;
 use crate::sql::array::{array, Array};
 use crate::sql::common::commas;
@@ -33,6 +34,7 @@ use crate::sql::subquery::{subquery, Subquery};
 use crate::sql::table::{table, Table};
 use crate::sql::thing::{thing, Thing};
 use crate::sql::uuid::{uuid as unique, Uuid};
+#[cfg(feature = "compute")]
 use async_recursion::async_recursion;
 use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
@@ -1252,6 +1254,7 @@ impl fmt::Display for Value {
 }
 
 impl Value {
+	#[cfg(feature = "compute")]
 	pub(crate) fn writeable(&self) -> bool {
 		match self {
 			Value::Array(v) => v.iter().any(|v| v.writeable()),
@@ -1265,6 +1268,7 @@ impl Value {
 
 	#[cfg_attr(feature = "parallel", async_recursion)]
 	#[cfg_attr(not(feature = "parallel"), async_recursion(?Send))]
+	#[cfg(feature = "compute")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,

--- a/pkg/nix/README.md
+++ b/pkg/nix/README.md
@@ -9,11 +9,11 @@ SurrealDB has support for the Nix package manager. It makes it easier to build t
 ## Table of Contents
 
 - [Running Nix from Docker](#running-nix-from-docker)
-  * [Building a Docker image (recommended)](#building-a-docker-image--recommended-)
+  * [Building a Docker image (recommended)](#building-a-docker-image-recommended)
   * [Building a static binary](#building-a-static-binary)
 - [Installing Nix](#installing-nix)
-  * [Activating support for Nix Flakes (recommended)](#activating-support-for-nix-flakes--recommended-)
-  * [Setting up a binary cache (optional)](#setting-up-a-binary-cache--optional-)
+  * [Activating support for Nix Flakes (recommended)](#activating-support-for-nix-flakes-recommended)
+  * [Setting up a binary cache (optional)](#setting-up-a-binary-cache-optional)
 - [Installing SurrealDB](#installing-surrealdb)
 - [Setting up a development environment](#setting-up-a-development-environment)
   * [Setting dependencies up automatically](#setting-dependencies-up-automatically)

--- a/pkg/nix/spec/wasm32-unknown-unknown.nix
+++ b/pkg/nix/spec/wasm32-unknown-unknown.nix
@@ -1,0 +1,13 @@
+{ pkgs, target, util }:
+
+{
+  inherit target;
+
+  buildSpec = with pkgs; {
+      nativeBuildInputs = [ pkg-config ];
+
+      buildInputs = [ openssl ];
+
+      CARGO_BUILD_TARGET = target;
+    };
+}

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,5 +1,6 @@
 use crate::cnf::PKG_VERSION;
 use crate::err::Error;
+use surrealdb::env;
 
 const LOG: &str = "surrealdb::env";
 
@@ -10,17 +11,7 @@ pub async fn init() -> Result<(), Error> {
 	Ok(())
 }
 
-/// Get the target operating system
-pub fn os() -> &'static str {
-	get_cfg!(target_os: "windows", "macos", "ios", "linux", "android", "freebsd", "openbsd", "netbsd");
-	target_os()
-}
-/// Get the target system architecture
-pub fn arch() -> &'static str {
-	get_cfg!(target_arch: "x86", "x86_64", "mips", "powerpc", "powerpc64", "arm", "aarch64");
-	target_arch()
-}
 /// Get the current release identifier
 pub fn release() -> String {
-	format!("{} for {} on {}", *PKG_VERSION, os(), arch())
+	format!("{} for {} on {}", *PKG_VERSION, env::os(), env::arch())
 }

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -13,9 +13,3 @@ macro_rules! mrg {
         $($m)+
     }};
 }
-
-macro_rules! get_cfg {
-	($i:ident : $($s:expr),+) => (
-		let $i = || { $( if cfg!($i=$s) { return $s; } );+ "unknown"};
-	)
-}


### PR DESCRIPTION
## What is the motivation?

Currently building the `surrealdb` crate with no default features is broken.

## What does this change do?

It fixes building `surrealdb` with `--no-default-features` and marks optional any dependencies not used afterwards.

## What is your testing strategy?

I ran `cargo check --no-default-features --package surrealdb` and made sure it builds fine. Also made the CI run it to make sure it won't break again in future.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
