### PR TITLE
Fix RPC method return types

### DIFF
--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -571,6 +571,10 @@ impl Value {
 		matches!(self, Value::Object(_))
 	}
 
+	pub fn is_number(&self) -> bool {
+		matches!(self, Value::Number(_))
+	}
+
 	pub fn is_int(&self) -> bool {
 		matches!(self, Value::Number(Number::Int(_)))
 	}

--- a/src/iam/signup.rs
+++ b/src/iam/signup.rs
@@ -11,7 +11,7 @@ use surrealdb::sql::Value;
 use surrealdb::Auth;
 use surrealdb::Session;
 
-pub async fn signup(session: &mut Session, vars: Object) -> Result<String, Error> {
+pub async fn signup(session: &mut Session, vars: Object) -> Result<Value, Error> {
 	// Parse the specified variables
 	let ns = vars.get("NS").or_else(|| vars.get("ns"));
 	let db = vars.get("DB").or_else(|| vars.get("db"));
@@ -24,9 +24,7 @@ pub async fn signup(session: &mut Session, vars: Object) -> Result<String, Error
 			let db = db.to_strand().as_string();
 			let sc = sc.to_strand().as_string();
 			// Attempt to signin to specified scope
-			let res = super::signup::sc(session, ns, db, sc, vars).await?;
-			// Return the result to the client
-			Ok(res)
+			super::signup::sc(session, ns, db, sc, vars).await
 		}
 		_ => Err(Error::InvalidAuth),
 	}
@@ -38,7 +36,7 @@ pub async fn sc(
 	db: String,
 	sc: String,
 	vars: Object,
-) -> Result<String, Error> {
+) -> Result<Value, Error> {
 	// Get a database reference
 	let kvs = DB.get().unwrap();
 	// Get local copy of options
@@ -95,7 +93,7 @@ pub async fn sc(
 								// Create the authentication token
 								match enc {
 									// The auth token was created successfully
-									Ok(tk) => Ok(tk),
+									Ok(tk) => Ok(tk.into()),
 									// There was an error creating the token
 									_ => Err(Error::InvalidAuth),
 								}

--- a/src/net/signin.rs
+++ b/src/net/signin.rs
@@ -57,11 +57,11 @@ async fn handler(
 		Ok(Value::Object(vars)) => match crate::iam::signin::signin(&mut session, vars).await {
 			// Authentication was successful
 			Ok(v) => match output.as_deref() {
-				Some("application/json") => Ok(output::json(&Success::new(v))),
-				Some("application/cbor") => Ok(output::cbor(&Success::new(v))),
-				Some("application/msgpack") => Ok(output::pack(&Success::new(v))),
-				Some("text/plain") => Ok(output::text(v)),
-				None => Ok(output::text(v)),
+				Some("application/json") => Ok(output::json(&Success::new(v.as_string()))),
+				Some("application/cbor") => Ok(output::cbor(&Success::new(v.as_string()))),
+				Some("application/msgpack") => Ok(output::pack(&Success::new(v.as_string()))),
+				Some("text/plain") => Ok(output::text(v.as_string())),
+				None => Ok(output::text(v.as_string())),
 				// An incorrect content-type was requested
 				_ => Err(warp::reject::custom(Error::InvalidType)),
 			},

--- a/src/net/signup.rs
+++ b/src/net/signup.rs
@@ -57,11 +57,11 @@ async fn handler(
 		Ok(Value::Object(vars)) => match crate::iam::signup::signup(&mut session, vars).await {
 			// Authentication was successful
 			Ok(v) => match output.as_deref() {
-				Some("application/json") => Ok(output::json(&Success::new(v))),
-				Some("application/cbor") => Ok(output::cbor(&Success::new(v))),
-				Some("application/msgpack") => Ok(output::pack(&Success::new(v))),
-				Some("text/plain") => Ok(output::text(v)),
-				None => Ok(output::text(v)),
+				Some("application/json") => Ok(output::json(&Success::new(v.as_string()))),
+				Some("application/cbor") => Ok(output::cbor(&Success::new(v.as_string()))),
+				Some("application/msgpack") => Ok(output::pack(&Success::new(v.as_string()))),
+				Some("text/plain") => Ok(output::text(v.as_string())),
+				None => Ok(output::text(v.as_string())),
 				// An incorrect content-type was requested
 				_ => Err(warp::reject::custom(Error::InvalidType)),
 			},


### PR DESCRIPTION
## What is the motivation?

These types should technically deserialize into `()`.

## What does this change do?

Updates return types for root signup, root signin and ping to return `Value::None` which deserializes into `()`.

## What is your testing strategy?

Ran the binary manually and made sure tests still pass in CI.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
