### PR TITLE
Don't panic on invalid UTF-8 in request.

### DIFF
--- a/src/net/import.rs
+++ b/src/net/import.rs
@@ -1,6 +1,7 @@
 use crate::cli::CF;
 use crate::dbs::DB;
 use crate::err::Error;
+use crate::net::input::bytes_to_utf8;
 use crate::net::output;
 use crate::net::session;
 use bytes::Bytes;
@@ -34,7 +35,7 @@ async fn handler(
 			// Get local copy of options
 			let opt = CF.get().unwrap();
 			// Convert the body to a byte slice
-			let sql = std::str::from_utf8(&sql).unwrap();
+			let sql = bytes_to_utf8(&sql)?;
 			// Execute the sql query in the database
 			match db.execute(sql, &session, None, opt.strict).await {
 				Ok(res) => match output.as_ref() {

--- a/src/net/input.rs
+++ b/src/net/input.rs
@@ -1,0 +1,6 @@
+use crate::err::Error;
+use bytes::Bytes;
+
+pub(crate) fn bytes_to_utf8(bytes: &Bytes) -> Result<&str, warp::Rejection> {
+	std::str::from_utf8(bytes).map_err(|_| warp::reject::custom(Error::Request))
+}

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -1,6 +1,7 @@
 use crate::cli::CF;
 use crate::dbs::DB;
 use crate::err::Error;
+use crate::net::input::bytes_to_utf8;
 use crate::net::output;
 use crate::net::params::Params;
 use crate::net::session;
@@ -172,7 +173,7 @@ async fn create_all(
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 	// Convert the HTTP request body
-	let data = str::from_utf8(&body).unwrap();
+	let data = bytes_to_utf8(&body)?;
 	// Parse the request body as JSON
 	match surrealdb::sql::json(data) {
 		Ok(data) => {
@@ -285,7 +286,7 @@ async fn create_one(
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 	// Convert the HTTP request body
-	let data = str::from_utf8(&body).unwrap();
+	let data = bytes_to_utf8(&body)?;
 	// Parse the Record ID as a SurrealQL value
 	let rid = match surrealdb::sql::json(&id) {
 		Ok(id) => id,
@@ -333,7 +334,7 @@ async fn update_one(
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 	// Convert the HTTP request body
-	let data = str::from_utf8(&body).unwrap();
+	let data = bytes_to_utf8(&body)?;
 	// Parse the Record ID as a SurrealQL value
 	let rid = match surrealdb::sql::json(&id) {
 		Ok(id) => id,
@@ -381,7 +382,7 @@ async fn modify_one(
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 	// Convert the HTTP request body
-	let data = str::from_utf8(&body).unwrap();
+	let data = bytes_to_utf8(&body)?;
 	// Parse the Record ID as a SurrealQL value
 	let rid = match surrealdb::sql::json(&id) {
 		Ok(id) => id,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -4,6 +4,7 @@ mod head;
 mod health;
 mod import;
 mod index;
+mod input;
 mod key;
 mod log;
 mod output;

--- a/src/net/signin.rs
+++ b/src/net/signin.rs
@@ -1,9 +1,9 @@
 use crate::err::Error;
+use crate::net::input::bytes_to_utf8;
 use crate::net::output;
 use crate::net::session;
 use bytes::Bytes;
 use serde::Serialize;
-use std::str;
 use surrealdb::sql::Value;
 use surrealdb::Session;
 use warp::Filter;
@@ -50,7 +50,7 @@ async fn handler(
 	mut session: Session,
 ) -> Result<impl warp::Reply, warp::Rejection> {
 	// Convert the HTTP body into text
-	let data = str::from_utf8(&body).unwrap();
+	let data = bytes_to_utf8(&body)?;
 	// Parse the provided data as JSON
 	match surrealdb::sql::json(data) {
 		// The provided value was an object

--- a/src/net/signup.rs
+++ b/src/net/signup.rs
@@ -1,9 +1,9 @@
 use crate::err::Error;
+use crate::net::input::bytes_to_utf8;
 use crate::net::output;
 use crate::net::session;
 use bytes::Bytes;
 use serde::Serialize;
-use std::str;
 use surrealdb::sql::Value;
 use surrealdb::Session;
 use warp::Filter;
@@ -50,7 +50,7 @@ async fn handler(
 	mut session: Session,
 ) -> Result<impl warp::Reply, warp::Rejection> {
 	// Convert the HTTP body into text
-	let data = str::from_utf8(&body).unwrap();
+	let data = bytes_to_utf8(&body)?;
 	// Parse the provided data as JSON
 	match surrealdb::sql::json(data) {
 		// The provided value was an object

--- a/src/net/sql.rs
+++ b/src/net/sql.rs
@@ -1,6 +1,7 @@
 use crate::cli::CF;
 use crate::dbs::DB;
 use crate::err::Error;
+use crate::net::input::bytes_to_utf8;
 use crate::net::output;
 use crate::net::params::Params;
 use crate::net::session;
@@ -46,7 +47,7 @@ async fn handler(
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 	// Convert the received sql query
-	let sql = std::str::from_utf8(&sql).unwrap();
+	let sql = bytes_to_utf8(&sql)?;
 	// Execute the received sql query
 	match db.execute(sql, &session, params.parse().into(), opt.strict).await {
 		// Convert the response to JSON


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `net` components of the SurrealDB server `unwrap()` the result of `str::from_utf8` on request bodies, leading to a suboptimal error message if that assumption is violated.

```console
finnb:~$ head /dev/urandom > bad.bin
finnb:~$ curl --request POST --header "Accept: application/json" --header "NS: test" --header "DB: test" --user "root:root" --data-binary @bad.bin http://localhost:8000/sql
curl: (52) Empty reply from server
```

## What does this change do?

Handles the error, returning `Error::Request` to indicate invalid data was passed.

```console
finnb:~$ head /dev/urandom > bad.bin
finnb:~$ curl --request POST --header "Accept: application/json" --header "NS: test" --header "DB: test" --user "root:root" --data-binary @bad.bin http://localhost:8000/sql
{"code":400,"details":"Request problems detected","description":"There is a problem with your request. Refer to the documentation for further information.","information":"The request body contains invalid data"}
```

## What is your testing strategy?

Tried the above curl commands. Also tried a normal query to make sure it worked.

## Is this related to any issues?

Not that I know of.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
