### PR TITLE
Optimize the map builder macros

### DIFF
--- a/lib/src/mac/mod.rs
+++ b/lib/src/mac/mod.rs
@@ -6,9 +6,9 @@ macro_rules! bytes {
 
 macro_rules! map {
     ($($k:expr => $v:expr),* $(,)?) => {{
-        let mut m = ::std::collections::BTreeMap::new();
-        $(m.insert($k, $v);)+
-        m
+        ::std::collections::BTreeMap::from([
+            $(($k, $v),)+
+        ])
     }};
 }
 


### PR DESCRIPTION
## What is the motivation?

Performance improvement

## What does this change do?

Use build BTreeMap from array instead of many insert operations.

## What is your testing strategy?

No new tests required.

## Is this related to any issues?

No. Just simple improvement.
