### PR TITLE
Add minimal WASM Nix target

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,19 +6,20 @@
         "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1664412889,
-        "narHash": "sha256-gyVtTQf3CiXLe1cwNRFxqUqYl9BCmIDvK7hIpzR/oQU=",
+        "lastModified": 1669943300,
+        "narHash": "sha256-1adQsyh7MvtlR19cJvL0VWemVTWwVbWSKrmrfX60ztU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "755acd231a7de182fdc772bee1b2a1f21d4ec9ed",
+        "rev": "fb80a689c5c517bc40d9cc1828c384c38de90dda",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
-        "ref": "v0.7.0",
+        "ref": "v0.10.0",
         "repo": "crane",
         "type": "github"
       }
@@ -31,11 +32,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1664865507,
-        "narHash": "sha256-KUonhQPn7SigY+4mfI/UydMQv4nIhBKIqgeU3JAaowI=",
+        "lastModified": 1670480689,
+        "narHash": "sha256-DADoR6R7DpnQaZjuUr6Z5EeNxr9ClP6u3Oqf7PpS9yA=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "93c65e24793653fdc45339022218a9ceca6219dd",
+        "rev": "e7941faba7f6cd0a6058330ad8c40d8dc52d741c",
         "type": "github"
       },
       "original": {
@@ -63,11 +64,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -78,11 +79,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -109,16 +110,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664790708,
-        "narHash": "sha256-fzxmpOPjzOVIt9KeDN4EDPI13xJn+u0uMxheKCWken8=",
+        "lastModified": 1670461440,
+        "narHash": "sha256-jy1LB8HOMKGJEGXgzFRLDU1CBGL0/LlkolgnqIsF0D8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "81a3237b64e67b66901c735654017e75f0c50943",
+        "rev": "04a75b2eecc0acf6239acf9dd04485ff8d14f425",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05-small",
+        "ref": "nixos-22.11-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -135,17 +136,42 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1664652573,
-        "narHash": "sha256-mVf9fjQbtYbrVvQSaJOCwArWIvXHrXqVVUhP0x9ZcVY=",
+        "lastModified": 1670426523,
+        "narHash": "sha256-Zh+pAuj4PmBmISXCz+54yVSwSXZwbn+ZELgM85xVUE0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "5c28ad193238635189f849c94ffc178f00008b12",
+        "rev": "6e8a54d0f68702cf7981c8299357838eb0f4d5b2",
         "type": "github"
       },
       "original": {
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1667487142,
+        "narHash": "sha256-bVuzLs1ZVggJAbJmEDVO9G6p8BH3HRaolK70KXvnWnU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "cf668f737ac986c0a89e83b6b2e3c5ddbd8cf33b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,10 @@
     "A scalable, distributed, collaborative, document-graph database, for the realtime web";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05-small";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11-small";
     flake-utils.url = "github:numtide/flake-utils/v1.0.0";
     crane = {
-      url = "github:ipetkov/crane/v0.7.0";
+      url = "github:ipetkov/crane/v0.10.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     fenix = {
@@ -76,6 +76,9 @@
           # nix build .#static-binary
           static-binary = packages.x86_64-unknown-linux-musl;
 
+          # nix build .#wasm
+          wasm = packages.wasm32-unknown-unknown;
+
           # nix build .#windows-binary
           windows-binary = packages.x86_64-pc-windows-gnu;
         } // (pkgs.lib.attrsets.mapAttrs (target: _:
@@ -95,6 +98,9 @@
           # nix develop .#static-binary
           static-binary = devShells.x86_64-unknown-linux-musl;
 
+          # nix develop .#wasm
+          wasm = devShells.wasm32-unknown-unknown;
+
           # nix develop .#windows-binary
           windows-binary = devShells.x86_64-pc-windows-gnu;
         } // (pkgs.lib.attrsets.mapAttrs (target: _:
@@ -108,7 +114,7 @@
             hardeningDisable = [ "fortify" ];
 
             depsBuildBuild = buildSpec.depsBuildBuild or [ ]
-              ++ [ rustToolchain ] ++ (with pkgs; [ nixfmt cargo-watch ]);
+              ++ [ rustToolchain ] ++ (with pkgs; [ nixfmt cargo-watch wasm-pack ]);
 
             inherit (util) SURREAL_BUILD_METADATA;
           })) util.platforms);

--- a/pkg/nix/README.md
+++ b/pkg/nix/README.md
@@ -9,11 +9,11 @@ SurrealDB has support for the Nix package manager. It makes it easier to build t
 ## Table of Contents
 
 - [Running Nix from Docker](#running-nix-from-docker)
-  * [Building a Docker image (recommended)](#building-a-docker-image--recommended-)
+  * [Building a Docker image (recommended)](#building-a-docker-image-recommended)
   * [Building a static binary](#building-a-static-binary)
 - [Installing Nix](#installing-nix)
-  * [Activating support for Nix Flakes (recommended)](#activating-support-for-nix-flakes--recommended-)
-  * [Setting up a binary cache (optional)](#setting-up-a-binary-cache--optional-)
+  * [Activating support for Nix Flakes (recommended)](#activating-support-for-nix-flakes-recommended)
+  * [Setting up a binary cache (optional)](#setting-up-a-binary-cache-optional)
 - [Installing SurrealDB](#installing-surrealdb)
 - [Setting up a development environment](#setting-up-a-development-environment)
   * [Setting dependencies up automatically](#setting-dependencies-up-automatically)

--- a/pkg/nix/spec/wasm32-unknown-unknown.nix
+++ b/pkg/nix/spec/wasm32-unknown-unknown.nix
@@ -1,0 +1,13 @@
+{ pkgs, target, util }:
+
+{
+  inherit target;
+
+  buildSpec = with pkgs; {
+      nativeBuildInputs = [ pkg-config ];
+
+      buildInputs = [ openssl ];
+
+      CARGO_BUILD_TARGET = target;
+    };
+}


### PR DESCRIPTION
## What is the motivation?

WASM is one of the main targets officially supported by SurrealDB. The Nix flake does not currently have this target.

## What does this change do?

It adds a minimal WASM target to the flake. For now, this only works with `nix develop .#wasm`.

## What is your testing strategy?

Made sure `nix build` still works fine.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
