### PR TITLE
Test the library with `--no-default-features`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,13 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Run cargo check
+      - name: Run cargo check --package surrealdb
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --package surrealdb
+
+      - name: Run cargo check --workspace
         uses: actions-rs/cargo@v1
         with:
           command: check


### PR DESCRIPTION
## What is the motivation?

Until recently it wasn't possible to build `surrealdb` with `--no-default-features`.

## What does this change do?

Adds a test to check building `surrealdb` with `--no-default-features`.

## What is your testing strategy?

This changeset is just a new test.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
