### PR TITLE
Replace a permanent redirect with a temporary one

### DIFF
--- a/src/net/index.rs
+++ b/src/net/index.rs
@@ -3,5 +3,7 @@ use warp::http::Uri;
 use warp::Filter;
 
 pub fn config() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-	warp::path::end().and(warp::get()).map(|| warp::redirect(Uri::from_static(cnf::APP_ENDPOINT)))
+	warp::path::end()
+		.and(warp::get())
+		.map(|| warp::redirect::temporary(Uri::from_static(cnf::APP_ENDPOINT)))
 }


### PR DESCRIPTION
## What is the motivation?

A permanent redirect makes the browser redirect the user to https://surrealdb.com/app from localhost:8000 even after shutting down SurrealDB, which is not a pleasant experience. Using a temporary redirect would fix this behavior.

## What does this change do?

Replaces 301 redirect with 307

## What is your testing strategy?

1. Start SurrealDB
2. Navigate to http://0.0.0.0:8000
3. Browser should redirect to https://surrealdb.com/app
4. Shut down SurrealDB
5. Navigate to http://0.0.0.0:8000
6. Browser should **not** redirect to https://surrealdb.com/app

## Is this related to any issues?

It resolves this: https://discord.com/channels/902568124350599239/1049776752324526200

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
