### PR TITLE
nix: fix darwin build

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,17 +6,8 @@ on:
 
 jobs:
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v17
-      - run: nix flake check --show-trace
-
   build-static:
     name: Build static Linux binary
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +22,6 @@ jobs:
 
   build-docker:
     name: Build Docker image
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -46,7 +36,6 @@ jobs:
 
   build-native-linux:
     name: Build native Linux binary
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/pkg/nix/spec/x86_64-apple-darwin.nix
+++ b/pkg/nix/spec/x86_64-apple-darwin.nix
@@ -10,7 +10,7 @@
 
     nativeBuildInputs = [ pkg-config ];
 
-    buildInputs = [ openssl ];
+    buildInputs = [ openssl libiconv darwin.apple_sdk.frameworks.Security ];
 
     CARGO_BUILD_TARGET = target;
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The flake is amazing, however it doesn't build on darwin (macos)

## What does this change do?

This fixes the build for darwin platforms. tested only on x86_64 though.

## What is your testing strategy?

run `nix build .#packages.x86_64-darwin.default` on a darwin machine and verify the output of `./result/bin/surreal version`

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
