### PR TITLE
Bugfix #1533 : compare last should pull lasts

### DIFF
--- a/lib/src/sql/value/compare.rs
+++ b/lib/src/sql/value/compare.rs
@@ -46,7 +46,7 @@ impl Value {
 						(None, Some(_)) => Some(Ordering::Less),
 						(_, _) => Some(Ordering::Equal),
 					},
-					Part::Last => match (a.first(), b.first()) {
+					Part::Last => match (a.last(), b.last()) {
 						(Some(a), Some(b)) => a.compare(b, path.next(), collate, numeric),
 						(Some(_), None) => Some(Ordering::Greater),
 						(None, Some(_)) => Some(Ordering::Less),
@@ -191,5 +191,14 @@ mod tests {
 		let two = Value::parse("{ test: { other: null, something: [1, null, 3] } }");
 		let res = one.compare(&two, &idi, false, false);
 		assert_eq!(res, Some(Ordering::Greater));
+	}
+
+	#[test]
+	fn compare_last() {
+		let idi = Idiom::parse("test[$]");
+		let one = Value::parse("{ test: [1,5] }");
+		let two = Value::parse("{ test: [2,4] }");
+		let res = one.compare(&two, &idi, false, false);
+		assert_eq!(res, Some(Ordering::Greater))
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

fixes bug in compare arrays code

## What does this change do?

compare of last items now references last item

## What is your testing strategy?

created regression test for bug 

## Is this related to any issues?

#1533

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
