### PR TITLE
add flag to disable banner

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -238,6 +238,14 @@ pub fn init() {
 					.forbid_empty_values(true)
 					.help("The logging level for the database server")
 					.value_parser(["warn", "info", "debug", "trace", "full"]),
+			)
+			.arg(
+				Arg::new("no-banner")
+					.env("NO_BANNER")
+					.long("no-banner")
+					.required(false)
+					.takes_value(false)
+					.help("Whether a banner should be outputted"),
 			),
 	);
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -245,7 +245,7 @@ pub fn init() {
 					.long("no-banner")
 					.required(false)
 					.takes_value(false)
-					.help("Whether a banner should be outputted"),
+					.help("Whether to hide the startup banner"),
 			),
 	);
 

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -18,8 +18,14 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 		Some("full") => log::init(4),
 		_ => unreachable!(),
 	};
-	// Output SurrealDB logo
-	println!("{LOGO}");
+
+	// Check if a banner should be outputted
+	let no_banner = matches.is_present("no-banner");
+	if !no_banner {
+		// Output SurrealDB logo
+		println!("{LOGO}");
+	}
+
 	// Setup the cli options
 	config::init(matches);
 	// Initiate environment

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -20,8 +20,7 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 	};
 
 	// Check if a banner should be outputted
-	let no_banner = matches.is_present("no-banner");
-	if !no_banner {
+	if !matches.is_present("no-banner") {
 		// Output SurrealDB logo
 		println!("{LOGO}");
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?
Make the output more readable when the `start` command is used.

## What does this change do?

Add a flag to disable the ASCII (logo) banner when the `start` command is used. 

Example
`cargo run -- start --log trace --user root --pass root memory --no-banner`

## What is your testing strategy?

Only manual testing was done. I have tested the flags and environmental variables locally on my machine. 

## Is this related to any issues?

https://github.com/surrealdb/surrealdb/issues/1536

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
