### PR TITLE
Feature #1509 - Option #1: Add unary `NOT` operator

### DIFF
--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -13,6 +13,7 @@ pub mod http;
 pub mod is;
 pub mod math;
 pub mod meta;
+pub mod not;
 pub mod operate;
 pub mod parse;
 pub mod rand;

--- a/lib/src/fnc/not.rs
+++ b/lib/src/fnc/not.rs
@@ -1,0 +1,8 @@
+use crate::ctx::Context;
+use crate::sql::Value;
+use crate::Error;
+
+/// Returns a boolean that is false if the input is truthy and true otherwise.
+pub fn run(_: &Context, val: Value) -> Result<Value, Error> {
+	Ok((!val.is_truthy()).into())
+}

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -886,6 +886,7 @@ impl Value {
 				Function::Script(_, _) => "fn::script".to_string().into(),
 				Function::Normal(f, _) => f.to_string().into(),
 				Function::Cast(_, v) => v.to_idiom(),
+				Function::Not(v) => v.to_idiom(),
 			},
 			_ => self.to_string().into(),
 		}

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -299,3 +299,50 @@ async fn function_string_slice() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn function_not() -> Result<(), Error> {
+	let sql = r#"
+		RETURN NOT true;
+		RETURN NOT NOT true;
+		RETURN NOT false;
+		RETURN NOT NOT false;
+		RETURN NOT 0;
+		RETURN NOT 1;
+		RETURN NOT "hello";
+	"#;
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	assert_eq!(res.len(), 7);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::False;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::True;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::True;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::False;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::True;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::False;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::False;
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

See #1509 - There is a lack of ergonomic boolean negation.

## What does this change do?

Adds a new unary `NOT` operator, with a syntax and semantics similar to regular  SQL:
- `NOT true` is `false`
- `NOT false` is `true`

It is based on the *truthiness* of the input:
- `NOT 0` is `true`
- `NOT 42` is `false`

## Implementation strategy

The implementation defines a new type of function, `Function::Not`. This means that, for better or for worse, parsing precedence should be similar to `Function::Cast` (`<int>`).

While it might make more sense for `NOT` to be an _operator_ in a unary (one operand) expression, it seems that only binary (two operand) expressions are supported. However, this is an implementation detail that can be fixed later.

## What is your testing strategy?

Added a parsing test and a correctness test.

## Is this related to any issues?

Fixes #1509

Alternative to #1542

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
