### PR TITLE
Feature #1509 - Option #2: Add `not` function

### DIFF
--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -13,6 +13,7 @@ pub mod http;
 pub mod is;
 pub mod math;
 pub mod meta;
+pub mod not;
 pub mod operate;
 pub mod parse;
 pub mod rand;
@@ -135,6 +136,8 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"meta::id" => meta::id,
 		"meta::table" => meta::tb,
 		"meta::tb" => meta::tb,
+		//
+		"not" => not::not,
 		//
 		"parse::email::host" => parse::email::host,
 		"parse::email::user" => parse::email::user,

--- a/lib/src/fnc/not.rs
+++ b/lib/src/fnc/not.rs
@@ -1,0 +1,7 @@
+use crate::sql::Value;
+use crate::Error;
+
+/// Returns a boolean that is false if the input is truthy and true otherwise.
+pub fn not((val,): (Value,)) -> Result<Value, Error> {
+	Ok((!val.is_truthy()).into())
+}

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -223,6 +223,7 @@ fn function_names(i: &str) -> IResult<&str, &str> {
 		function_is,
 		function_math,
 		function_meta,
+		function_not,
 		function_parse,
 		function_rand,
 		function_session,
@@ -360,6 +361,10 @@ fn function_meta(i: &str) -> IResult<&str, &str> {
 	alt((tag("meta::id"), tag("meta::table"), tag("meta::tb")))(i)
 }
 
+fn function_not(i: &str) -> IResult<&str, &str> {
+	tag("not")(i)
+}
+
 fn function_parse(i: &str) -> IResult<&str, &str> {
 	alt((
 		tag("parse::email::host"),
@@ -475,6 +480,16 @@ mod tests {
 		let out = res.unwrap().1;
 		assert_eq!("count()", format!("{}", out));
 		assert_eq!(out, Function::Normal(String::from("count"), vec![]));
+	}
+
+	#[test]
+	fn function_single_not() {
+		let sql = "not(1.2345)";
+		let res = function(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!("not(1.2345)", format!("{}", out));
+		assert_eq!(out, Function::Normal("not".to_owned(), vec![1.2345.into()]));
 	}
 
 	#[test]

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -299,3 +299,50 @@ async fn function_string_slice() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn function_not() -> Result<(), Error> {
+	let sql = r#"
+		RETURN not(true);
+		RETURN not(not(true));
+		RETURN not(false);
+		RETURN not(not(false));
+		RETURN not(0);
+		RETURN not(1);
+		RETURN not("hello");
+	"#;
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	assert_eq!(res.len(), 7);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::False;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::True;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::True;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::False;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::True;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::False;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::False;
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

See #1509 - There is a lack of ergonomic boolean negation.

## What does this change do?

Adds a new `not` function:
- `not(true)` is `false`
- `not(false)` is `true`

It is based on the *truthiness* of the input:
- `not(0)` is `true`
- `not(42)` is `false`

## What is your testing strategy?

Added a parsing test and a correctness test.

## Is this related to any issues?

Fixes #1509

Alternative to #1541

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
