### PR TITLE
Fix #1393 - Parse datetime to spec without panic

### DIFF
--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -172,13 +172,13 @@ fn convert(
 	zone: FixedOffset,
 ) -> IResult<&str, Datetime> {
 	let n = NaiveDate::from_ymd_opt(year, mon, day)
-		.ok_or(Err::Error(error_position!(i, ErrorKind::Verify)))?;
+		.ok_or_else(|| Err::Error(error_position!(i, ErrorKind::Verify)))?;
 
 	let d = zone
 		.from_local_date(&n)
 		.unwrap()
 		.and_hms_nano_opt(hour, min, sec, nano)
-		.ok_or(Err::Error(error_position!(i, ErrorKind::Verify)))?
+		.ok_or_else(|| Err::Error(error_position!(i, ErrorKind::Verify)))?
 		.with_timezone(&Utc);
 
 	Ok((i, Datetime(d)))

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -121,7 +121,7 @@ fn date(i: &str) -> IResult<&str, Datetime> {
 	let (i, mon) = month(i)?;
 	let (i, _) = char('-')(i)?;
 	let (i, day) = day(i)?;
-	convert(i, year, mon, day, 0, 0, 0, 0, Utc.fix())
+	convert(i, (year, mon, day), (0, 0, 0, 0), Utc.fix())
 }
 
 fn time(i: &str) -> IResult<&str, Datetime> {
@@ -137,7 +137,7 @@ fn time(i: &str) -> IResult<&str, Datetime> {
 	let (i, _) = char(':')(i)?;
 	let (i, sec) = second(i)?;
 	let (i, zone) = zone(i)?;
-	convert(i, year, mon, day, hour, min, sec, 0, zone)
+	convert(i, (year, mon, day), (hour, min, sec, 0), zone)
 }
 
 fn nano(i: &str) -> IResult<&str, Datetime> {
@@ -154,18 +154,13 @@ fn nano(i: &str) -> IResult<&str, Datetime> {
 	let (i, sec) = second(i)?;
 	let (i, nano) = nanosecond(i)?;
 	let (i, zone) = zone(i)?;
-	convert(i, year, mon, day, hour, min, sec, nano, zone)
+	convert(i, (year, mon, day), (hour, min, sec, nano), zone)
 }
 
 fn convert(
 	i: &str,
-	year: i32,
-	mon: u32,
-	day: u32,
-	hour: u32,
-	min: u32,
-	sec: u32,
-	nano: u32,
+	(year, mon, day): (i32, u32, u32),
+	(hour, min, sec, nano): (u32, u32, u32, u32),
 	zone: FixedOffset,
 ) -> IResult<&str, Datetime> {
 	let n = NaiveDate::from_ymd_opt(year, mon, day)

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -121,7 +121,6 @@ fn date(i: &str) -> IResult<&str, Datetime> {
 	let (i, mon) = month(i)?;
 	let (i, _) = char('-')(i)?;
 	let (i, day) = day(i)?;
-
 	convert(i, year, mon, day, 0, 0, 0, 0, Utc.fix())
 }
 
@@ -138,7 +137,6 @@ fn time(i: &str) -> IResult<&str, Datetime> {
 	let (i, _) = char(':')(i)?;
 	let (i, sec) = second(i)?;
 	let (i, zone) = zone(i)?;
-
 	convert(i, year, mon, day, hour, min, sec, 0, zone)
 }
 
@@ -156,7 +154,6 @@ fn nano(i: &str) -> IResult<&str, Datetime> {
 	let (i, sec) = second(i)?;
 	let (i, nano) = nanosecond(i)?;
 	let (i, zone) = zone(i)?;
-
 	convert(i, year, mon, day, hour, min, sec, nano, zone)
 }
 

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -163,16 +163,17 @@ fn convert(
 	(hour, min, sec, nano): (u32, u32, u32, u32),
 	zone: FixedOffset,
 ) -> IResult<&str, Datetime> {
+	// Attempt to create date
 	let n = NaiveDate::from_ymd_opt(year, mon, day)
 		.ok_or_else(|| Err::Error(error_position!(i, ErrorKind::Verify)))?;
-
+	// Attempt to create time
 	let d = zone
 		.from_local_date(&n)
 		.unwrap()
 		.and_hms_nano_opt(hour, min, sec, nano)
 		.ok_or_else(|| Err::Error(error_position!(i, ErrorKind::Verify)))?
 		.with_timezone(&Utc);
-
+	// This is a valid datetime
 	Ok((i, Datetime(d)))
 }
 

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -200,7 +200,7 @@ fn day(i: &str) -> IResult<&str, u32> {
 }
 
 fn hour(i: &str) -> IResult<&str, u32> {
-	take_digits_range(i, 2, 0..=24)
+	take_digits_range(i, 2, 0..=23)
 }
 
 fn minute(i: &str) -> IResult<&str, u32> {
@@ -208,7 +208,8 @@ fn minute(i: &str) -> IResult<&str, u32> {
 }
 
 fn second(i: &str) -> IResult<&str, u32> {
-	take_digits_range(i, 2, 0..=59)
+	// 60 is for leap seconds
+	take_digits_range(i, 2, 0..=60)
 }
 
 fn nanosecond(i: &str) -> IResult<&str, u32> {

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -200,7 +200,7 @@ fn day(i: &str) -> IResult<&str, u32> {
 }
 
 fn hour(i: &str) -> IResult<&str, u32> {
-	take_digits_range(i, 2, 0..=23)
+	take_digits_range(i, 2, 0..=24)
 }
 
 fn minute(i: &str) -> IResult<&str, u32> {
@@ -208,7 +208,6 @@ fn minute(i: &str) -> IResult<&str, u32> {
 }
 
 fn second(i: &str) -> IResult<&str, u32> {
-	// 60 is for leap seconds
 	take_digits_range(i, 2, 0..=60)
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

See #1393 - Illegal datetimes panic, such as November 31st (`2022-11-31T12:00:00.000Z`)

## What does this change do?

Unifies the parsing of datetimes into one function that errors when invalid dates are entered. The errors comply with how `nom` expects it to and will try a new branch when one does occur; this results in `nom` parsing the invalid datetime as a string.

Additionally, I have changed the ranges for seconds and hours to `0..=60` and `0..=23` respectively. The 60 for seconds is for leap seconds, and 24 is an invalid hour in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) spec (and [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339))

## What is your testing strategy?

Created a new test, `date_time_illegal_date`, in `lib/src/sql/datetime.rs`

## Is this related to any issues?

Fixes #1393 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
