### PR TITLE
Address more CI warnings

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -145,7 +145,7 @@ jobs:
           BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu: "-I/usr/aarch64-linux-gnu/include/"
 
       - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: us-east-2
           aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
@@ -203,7 +203,7 @@ jobs:
           path: arm64
 
       - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: us-east-2
           aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
@@ -230,7 +230,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: us-east-2
           aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,11 +71,11 @@ jobs:
       matrix:
         include:
           - arch: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-11
             file: surreal-nightly.darwin-amd64
             opts: --features storage-tikv
           - arch: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-11
             file: surreal-nightly.darwin-arm64
             opts: --features storage-tikv
           - arch: x86_64-unknown-linux-gnu
@@ -187,7 +187,7 @@ jobs:
   package:
     name: Package macOS
     needs: [build]
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
 
       - name: Download amd64 binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu: "-I/usr/aarch64-linux-gnu/include/"
 
       - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: us-east-2
           aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
@@ -204,7 +204,7 @@ jobs:
           path: arm64
 
       - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: us-east-2
           aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
@@ -231,7 +231,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: us-east-2
           aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,11 +72,11 @@ jobs:
       matrix:
         include:
           - arch: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-11
             file: surreal-${{ github.ref_name }}.darwin-amd64
             opts: --features storage-tikv
           - arch: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-11
             file: surreal-${{ github.ref_name }}.darwin-arm64
             opts: --features storage-tikv
           - arch: x86_64-unknown-linux-gnu
@@ -188,7 +188,7 @@ jobs:
   package:
     name: Package macOS
     needs: [build]
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
 
       - name: Download amd64 binary


### PR DESCRIPTION
## What is the motivation?

https://github.com/surrealdb/surrealdb/pull/1551 got rid of all warnings on PR builds. The nightly build, however, is down to 15 warnings from the previous 46.

## What does this change do?

It addresses the warnings displayed at https://github.com/surrealdb/surrealdb/actions/runs/3784109352 by switching `aws-actions/configure-aws-credentials` from `v1` to `v1-node16` (`v2` hasn't been released yet) and pinning `macOS` to `v11`.

## What is your testing strategy?

Will check the nightly build after it runs once to make sure it ran correctly.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
