### PR TITLE
fix(readme): build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
     &nbsp;
     <a href="https://github.com/surrealdb/surrealdb"><img src="https://img.shields.io/badge/built_with-Rust-dca282.svg?style=flat-square"></a>
     &nbsp;
-	<a href="https://github.com/surrealdb/surrealdb/actions"><img src="https://img.shields.io/github/workflow/status/surrealdb/surrealdb/Continuous%20integration?style=flat-square"></a>
+	<a href="https://github.com/surrealdb/surrealdb/actions"><img src="https://img.shields.io/github/actions/workflow/status/surrealdb/surrealdb/ci.yml?style=flat-square&branch=main"></a>
     &nbsp;
     <a href="https://status.surrealdb.com"><img src="https://img.shields.io/uptimerobot/ratio/7/m784409192-e472ca350bb615372ededed7?label=cloud%20uptime&style=flat-square"></a>
     &nbsp;


### PR DESCRIPTION
## What is the motivation?

The current build badge is broken due some changes on shields project.
More info [here](https://github.com/badges/shields/issues/8671)

## What does this change do?

Changes the URL according to the new way of using shields links

## What is your testing strategy?

Manually tested

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
