### PR TITLE
Fix Error import

### DIFF
--- a/lib/src/fnc/not.rs
+++ b/lib/src/fnc/not.rs
@@ -1,5 +1,5 @@
+use crate::err::Error;
 use crate::sql::Value;
-use crate::Error;
 
 /// Returns a boolean that is false if the input is truthy and true otherwise.
 pub fn not((val,): (Value,)) -> Result<Value, Error> {


### PR DESCRIPTION
## What is the motivation?

`fnc::not` module is referencing `crate::Error` instead of `crate::err::Error`. This was correct before the client was merged but this is no longer the case.

## What does this change do?

It updates the import.

## What is your testing strategy?

Ran `cargo check`.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
