### PR TITLE
Allow `memory` as an address endpoint

### DIFF
--- a/lib/src/api/engines/any/mod.rs
+++ b/lib/src/api/engines/any/mod.rs
@@ -115,8 +115,12 @@ pub trait IntoEndpoint {
 
 impl IntoEndpoint for &str {
 	fn into_endpoint(self) -> Result<Endpoint> {
+		let url = match self {
+			"memory" => "mem://",
+			_ => self,
+		};
 		Ok(Endpoint {
-			endpoint: Url::parse(self).map_err(|_| Error::InvalidUrl(self.to_owned()))?,
+			endpoint: Url::parse(url).map_err(|_| Error::InvalidUrl(self.to_owned()))?,
 			strict: false,
 			#[cfg(any(feature = "native-tls", feature = "rustls"))]
 			tls_config: None,
@@ -132,12 +136,7 @@ impl IntoEndpoint for &String {
 
 impl IntoEndpoint for String {
 	fn into_endpoint(self) -> Result<Endpoint> {
-		Ok(Endpoint {
-			endpoint: Url::parse(&self).map_err(|_| Error::InvalidUrl(self))?,
-			strict: false,
-			#[cfg(any(feature = "native-tls", feature = "rustls"))]
-			tls_config: None,
-		})
+		self.as_str().into_endpoint()
 	}
 }
 

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -103,7 +103,7 @@ mod mem {
 
 	#[tokio::test]
 	async fn memory_allowed_as_address() {
-		any::connect("memory").unwrap();
+		any::connect("memory").await.unwrap();
 	}
 
 	include!("api/mod.rs");

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -93,11 +93,17 @@ mod http {
 #[cfg(feature = "kv-mem")]
 mod mem {
 	use super::*;
+	use surrealdb::engines::any;
 	use surrealdb::engines::local::Db;
 	use surrealdb::engines::local::Mem;
 
 	async fn new_db() -> Surreal<Db> {
 		Surreal::new::<Mem>(()).await.unwrap()
+	}
+
+	#[tokio::test]
+	async fn memory_allowed_as_address() {
+		any::connect("memory").unwrap();
 	}
 
 	include!("api/mod.rs");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -28,7 +28,13 @@ We would love it if you could star the repository (https://github.com/surrealdb/
 ";
 
 fn split_endpoint(v: &str) -> (&str, &str) {
-	v.split_once("://").unwrap_or_default()
+	match v {
+		"memory" => ("mem", ""),
+		v => match v.split_once("://") {
+			Some(parts) => parts,
+			None => v.split_once(':').unwrap_or_default(),
+		},
+	}
 }
 
 fn file_valid(v: &str) -> Result<(), String> {


### PR DESCRIPTION
## What is the motivation?

Currently `any::connect` and `Surreal::<Any>::connect` do not allow "memory" as an address, only "mem://".

## What does this change do?

It allows "memory" as an address.

## What is your testing strategy?

Added a test.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
