### PR TITLE
Enable remote engines on the server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.85"
 serde_pack = { version = "1.1.1", package = "rmp-serde" }
-surrealdb = { path = "lib", features = ["parallel", "protocol-http"] }
+surrealdb = { path = "lib", features = ["parallel", "protocol-http", "protocol-ws", "rustls"] }
 thiserror = "1.0.37"
 tokio = { version = "1.21.2", features = ["macros", "signal"] }
 warp = { version = "0.3.3", features = ["compression", "tls", "websocket"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.85"
 serde_pack = { version = "1.1.1", package = "rmp-serde" }
-surrealdb = { path = "lib", default-features = false }
+surrealdb = { path = "lib", features = ["parallel", "protocol-http"] }
 thiserror = "1.0.37"
 tokio = { version = "1.21.2", features = ["macros", "signal"] }
 warp = { version = "0.3.3", features = ["compression", "tls", "websocket"] }


### PR DESCRIPTION
## What is the motivation?

The server does not currently enable the remote engines so they are inaccessible for commands like the SQL command.

## What does this change do?

It enables the WS and HTTP engines.

## What is your testing strategy?

Ensure the CI still passes.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
