### PR TITLE
Use new client library in CLI `export` command

### DIFF
--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -1,44 +1,43 @@
 use crate::cli::LOG;
-use crate::cnf::SERVER_AGENT;
 use crate::err::Error;
-use reqwest::blocking::Client;
-use reqwest::header::ACCEPT;
-use reqwest::header::USER_AGENT;
-use std::fs::OpenOptions;
+use surrealdb::engines::any::connect;
+use surrealdb::error::Api as ApiError;
+use surrealdb::opt::auth::Root;
+use surrealdb::Error as SurrealError;
 
-pub fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
+#[tokio::main]
+pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 	// Set the default logging level
-	crate::cli::log::init(3);
+	crate::cli::log::init(1);
 	// Try to parse the file argument
 	let file = matches.value_of("file").unwrap();
-	// Try to open the specified file
-	let mut file = OpenOptions::new().write(true).create(true).truncate(true).open(file)?;
 	// Parse all other cli arguments
-	let user = matches.value_of("user").unwrap();
-	let pass = matches.value_of("pass").unwrap();
-	let conn = matches.value_of("conn").unwrap();
+	let username = matches.value_of("user").unwrap();
+	let password = matches.value_of("pass").unwrap();
+	let endpoint = matches.value_of("conn").unwrap();
 	let ns = matches.value_of("ns").unwrap();
 	let db = matches.value_of("db").unwrap();
-	// Set the correct export URL
-	let conn = format!("{conn}/export");
-	// Export the data from the database
-	let mut res = Client::new()
-		.get(conn)
-		.header(USER_AGENT, SERVER_AGENT)
-		.header(ACCEPT, "application/octet-stream")
-		.basic_auth(user, Some(pass))
-		.header("NS", ns)
-		.header("DB", db)
-		.send()?;
-	// Check import result and report error
-	if res.status().is_success() {
-		res.copy_to(&mut file)?;
-		info!(target: LOG, "The SQL file was exported successfully");
-	} else if res.status().is_client_error() || res.status().is_server_error() {
-		error!(target: LOG, "Request failed with status {}. Body: {}", res.status(), res.text()?);
-	} else {
-		error!(target: LOG, "Unexpected response status {}", res.status());
+	// Connect to the database engine
+	let client = connect(endpoint).await?;
+	// Sign in to the server if the specified dabatabase engine supports it
+	let root = Root {
+		username,
+		password,
+	};
+	if let Err(error) = client.signin(root).await {
+		match error {
+			// Authentication not supported by this engine, we can safely continue
+			SurrealError::Api(ApiError::AuthNotSupported) => {}
+			error => {
+				return Err(error.into());
+			}
+		}
 	}
+	// Use the specified namespace / database
+	client.use_ns(ns).use_db(db).await?;
+	// Export the data from the database
+	client.export(file).await?;
+	info!(target: LOG, "The SQL file was exported successfully");
 	// Everything OK
 	Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -469,7 +469,7 @@ pub fn init() {
 	let matches = setup.get_matches();
 
 	let output = match matches.subcommand() {
-		Some(("sql", m)) => futures::executor::block_on(sql::init(m)),
+		Some(("sql", m)) => sql::init(m),
 		Some(("start", m)) => start::init(m),
 		Some(("backup", m)) => backup::init(m),
 		Some(("import", m)) => import::init(m),

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -11,6 +11,7 @@ use surrealdb::sql::Statement;
 use surrealdb::Error as SurrealError;
 use surrealdb::Response;
 
+#[tokio::main]
 pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 	// Set the default logging level
 	crate::cli::log::init(0);
@@ -22,7 +23,7 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 	let mut db = matches.value_of("db").map(str::to_string);
 	// If we should pretty-print responses
 	let pretty = matches.is_present("pretty");
-	// Make a new remote request
+	// Connect to the database engine
 	let client = connect(endpoint).await?;
 	// Sign in to the server if the specified dabatabase engine supports it
 	let root = Root {


### PR DESCRIPTION
## What is the motivation?

Update the server to use the new client library.

## What does this change do?

Update `cli::export` to use the new API.

## What is your testing strategy?

I ran

```bash
cargo run --no-default-features -F storage-mem -- export --conn memory --ns test --db test export.sql
```

and inspected `export.sql`.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
