### PR TITLE
Use new client library in CLI `import` command

### DIFF
--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -1,48 +1,43 @@
 use crate::cli::LOG;
-use crate::cnf::SERVER_AGENT;
 use crate::err::Error;
-use reqwest::blocking::Client;
-use reqwest::header::ACCEPT;
-use reqwest::header::USER_AGENT;
-use std::fs::OpenOptions;
-use std::io::prelude::Read;
+use surrealdb::engines::any::connect;
+use surrealdb::error::Api as ApiError;
+use surrealdb::opt::auth::Root;
+use surrealdb::Error as SurrealError;
 
-pub fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
+#[tokio::main]
+pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 	// Set the default logging level
-	crate::cli::log::init(3);
+	crate::cli::log::init(1);
 	// Try to parse the file argument
 	let file = matches.value_of("file").unwrap();
-	// Try to open the specified file
-	let mut file = OpenOptions::new().read(true).open(file)?;
-	// Read the full contents of the file
-	let mut body = String::new();
-	file.read_to_string(&mut body)?;
 	// Parse all other cli arguments
-	let user = matches.value_of("user").unwrap();
-	let pass = matches.value_of("pass").unwrap();
-	let conn = matches.value_of("conn").unwrap();
+	let username = matches.value_of("user").unwrap();
+	let password = matches.value_of("pass").unwrap();
+	let endpoint = matches.value_of("conn").unwrap();
 	let ns = matches.value_of("ns").unwrap();
 	let db = matches.value_of("db").unwrap();
-	// Set the correct import URL
-	let conn = format!("{conn}/import");
-	// Import the data into the database
-	let res = Client::new()
-		.post(conn)
-		.header(USER_AGENT, SERVER_AGENT)
-		.header(ACCEPT, "application/octet-stream")
-		.basic_auth(user, Some(pass))
-		.header("NS", ns)
-		.header("DB", db)
-		.body(body)
-		.send()?;
-	// Check import result and report error
-	if res.status().is_success() {
-		info!(target: LOG, "The SQL file was imported successfully");
-	} else if res.status().is_client_error() || res.status().is_server_error() {
-		error!(target: LOG, "Request failed with status {}. Body: {}", res.status(), res.text()?);
-	} else {
-		error!(target: LOG, "Unexpected response status {}", res.status());
+	// Connect to the database engine
+	let client = connect(endpoint).await?;
+	// Sign in to the server if the specified dabatabase engine supports it
+	let root = Root {
+		username,
+		password,
+	};
+	if let Err(error) = client.signin(root).await {
+		match error {
+			// Authentication not supported by this engine, we can safely continue
+			SurrealError::Api(ApiError::AuthNotSupported) => {}
+			error => {
+				return Err(error.into());
+			}
+		}
 	}
+	// Use the specified namespace / database
+	client.use_ns(ns).use_db(db).await?;
+	// Import the data into the database
+	client.import(file).await?;
+	info!(target: LOG, "The SQL file was imported successfully");
 	// Everything OK
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

Update the server to use the new client library.

## What does this change do?

Update `cli::import` to use the new API.

## What is your testing strategy?

I ran

```bash
cargo run --no-default-features -F storage-mem -- import --conn memory --ns test --db test export.sql
```

and inspected the output.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
