### PR TITLE
Exit with non-zero code on errors

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@ pub use config::CF;
 
 use crate::cnf::LOGO;
 use clap::{Arg, Command};
+use std::process::ExitCode;
 
 pub const LOG: &str = "surrealdb::cli";
 
@@ -118,7 +119,7 @@ fn key_valid(v: &str) -> Result<(), String> {
 	}
 }
 
-pub fn init() {
+pub fn init() -> ExitCode {
 	let setup = Command::new("SurrealDB command-line interface and server")
 		.about(INFO)
 		.before_help(LOGO)
@@ -480,5 +481,8 @@ pub fn init() {
 
 	if let Err(e) = output {
 		error!(target: LOG, "{}", e);
+		return ExitCode::FAILURE;
 	}
+
+	ExitCode::SUCCESS
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ mod iam;
 mod net;
 mod rpc;
 
-fn main() {
-	cli::init(); // Initiate the command line
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+	cli::init() // Initiate the command line
 }


### PR DESCRIPTION
## What is the motivation?

> This will allow error handling in scripts and early exit using `set -e` in bash.

## What does this change do?

Update `main` to return an appropriate `ExitCode`.

## What is your testing strategy?

Ran commands with good inputs and ran commands with bad inputs to verify their exit codes.

## Is this related to any issues?

It fixes https://github.com/surrealdb/surrealdb/issues/1456.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
