### PR TITLE
Shorten database error messages

### DIFF
--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -29,7 +29,7 @@ pub enum Error {
 	#[error("There was a problem connecting with the storage engine")]
 	InvalidStorage,
 
-	#[error("There was a problem with the database: {0}")]
+	#[error("{0}")]
 	Db(#[from] SurrealError),
 
 	#[error("Couldn't open the specified file: {0}")]


### PR DESCRIPTION
## What is the motivation?

Currently the database error variant leads to messages like

> There was a problem with the database: Database error: Specify a namespace to use

## What does this change do?

It shortens the message to something like

> Database error: Specify a namespace to use

## What is your testing strategy?

Ensure CI passes.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
