### PR TITLE
Docs #1580 - Suggest the stable release channel of Rust.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ To set up a working **development environment**, you can either [use the Nix pac
 > Please note that these instructions are for setting up a functional dev environment. If you just want to install SurrealDB for day-to-day usage and not as a code maintainer use this [installation guide](https://surrealdb.com/docs/install). If you want to get started integrating SurrealDB into your app, view the [integration tutorials](https://surrealdb.com/docs/integration).
 
 ```bash
+# Use the default (stable) release channel if prompted
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 git clone git@github.com:[YOUR_FORK_HERE]/surrealdb.git
 cd surrealdb

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -2,6 +2,8 @@
 
 This file contains a set of instructions for building SurrealDB on a number of different platforms. Currently, SurrealDB is built for release automatically in a [Github Actions](https://github.com/surrealdb/surrealdb/actions) continuous-integration environment, on macOS, Ubuntu, and Windows.
 
+While installing `rustup`, use the default (`stable`) release channel of Rust for best results. If you already have a different release channel, you can run `rustup override set stable` from within the top level directory of this repository.
+
 <!-- -------------------------------------------------- -->
 <!-- -------------------------------------------------- -->
 <!-- -------------------------------------------------- -->


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Use of non-`stable` Rust can stop `surrealdb` from compiling.

## What does this change do?

Suggest using `stable` Rust in the contribution guide and building documentation.

## What is your testing strategy?

N/A

## Is this related to any issues?

Fixes #1580 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
