### PR TITLE
Fix the `version` string

### DIFF
--- a/lib/src/env/mod.rs
+++ b/lib/src/env/mod.rs
@@ -3,11 +3,11 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The operating system of the current machine
 pub fn os() -> &'static str {
-	get_cfg!(os: "windows", "macos", "ios", "linux", "android", "freebsd", "openbsd", "netbsd");
-	os()
+	get_cfg!(target_os: "windows", "macos", "ios", "linux", "android", "freebsd", "openbsd", "netbsd");
+	target_os()
 }
 /// The system architecture of the current machine
 pub fn arch() -> &'static str {
-	get_cfg!(arch: "x86", "x86_64", "mips", "powerpc", "powerpc64", "arm", "aarch64");
-	arch()
+	get_cfg!(target_arch: "x86", "x86_64", "mips", "powerpc", "powerpc64", "arm", "aarch64");
+	target_arch()
 }


### PR DESCRIPTION
## What is the motivation?

Running `surreal version` on main now prints `1.0.0-beta.8+20230107.5fb324d9 for unknown on unknown`.

## What does this change do?

It fixes the `get_cfg` invocation so that it prints something like `1.0.0-beta.8+20230107.a1378b2a for linux on x86_64` again.

## What is your testing strategy?

Ran `cargo run --no-default-features -- version` manually.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
