### PR TITLE
update sql macro to remove extra space produces as a result of the stringify function

### DIFF
--- a/lib/src/mac/mod.rs
+++ b/lib/src/mac/mod.rs
@@ -38,7 +38,7 @@ macro_rules! get_cfg {
 #[macro_export]
 macro_rules! sql {
 	($($query:tt)*) => {
-		match $crate::sql::parse(stringify!($($query)*)) {
+		match $crate::sql::parse(stringify!($($query)*).replace(" :: ", "::").as_str()) {
 			Ok(v) => v,
 			Err(e) => { return Err(e.into()); },
 		}

--- a/lib/src/mac/mod.rs
+++ b/lib/src/mac/mod.rs
@@ -37,10 +37,11 @@ macro_rules! get_cfg {
 /// ```
 #[macro_export]
 macro_rules! sql {
-	($($query:tt)*) => {
-		match $crate::sql::parse(stringify!($($query)*).replace(" :: ", "::").as_str()) {
+	($($query:tt)*) => {{
+		let query = format!("{}", stringify!($($query)*)).replace(" :: ", "::");
+		match $crate::sql::parse(&query) {
 			Ok(v) => v,
-			Err(e) => { return Err(e.into()); },
+			Err(e) => return Err(e.into()),
 		}
-	};
+	}};
 }


### PR DESCRIPTION
## What is the motivation?
Fix the `sql!  macro` that is not correctly parsing queries with functions e.g. `time::now()`.
Extra space is produced as a result of the stringify function. 

This is probably not the best fix hence I am open to any other suggestions. 

## What does this change do?

Updates the `sql! macro` to remove extra spaces around the `::`.

## What is your testing strategy?

Tested by running `example/query/main.rs` with the code mentioned in the original issue
`db.query(sql!(SELECT * FROM time::now())).await?.take(0)? `

Code was not included in the existing example. 

## Is this related to any issues?

[If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.](https://github.com/surrealdb/surrealdb/issues/1586)

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
