### PR TITLE
Make `cli::sql` default to using a WS connection instead of HTTP

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -439,7 +439,7 @@ pub fn init() -> ExitCode {
 					.alias("host")
 					.forbid_empty_values(true)
 					.validator(conn_valid)
-					.default_value("https://cloud.surrealdb.com")
+					.default_value("wss://cloud.surrealdb.com")
 					.help("Remote database server url to connect to"),
 			)
 			.arg(


### PR DESCRIPTION
## What is the motivation?

Currently `--conn` defaults to `https://cloud.surrealdb.com` for the SQL cli.

## What does this change do?

Make it default to `wss://cloud.surrealdb.com`.

## What is your testing strategy?

Ensure the CI still passes.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
