### PR TITLE
Use trice::Duration instead of std::time::Duration

### DIFF
--- a/lib/src/ctx/context.rs
+++ b/lib/src/ctx/context.rs
@@ -7,8 +7,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
-use trice::Instant;
+use trice::{Instant, Duration};
 
 impl<'a> From<Value> for Cow<'a, Value> {
 	fn from(v: Value) -> Cow<'a, Value> {


### PR DESCRIPTION
## What is the motivation?

Get the WASM client running

## What does this change do?

Replaces std::time::Duration which errors on wasm32-unknown-unknown with trice::Duration which doesnt

## What is your testing strategy?

Run any wasm app using the Surreal Client in a browser

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
