### PR TITLE
Use `wasm_bindgen_futures::spawn_local` instead of `tokio::spawn` on WASM

### DIFF
--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -22,6 +22,10 @@ use std::future::IntoFuture;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::spawn;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::spawn_local as spawn;
 
 /// A specialized `Result` type
 pub type Result<T> = std::result::Result<T, crate::Error>;
@@ -140,7 +144,7 @@ where
 {
 	fn check_server_version(&self) {
 		let conn = self.clone();
-		tokio::spawn(async move {
+		spawn(async move {
 			let (versions, build_meta) = SUPPORTED_VERSIONS;
 			// invalid version requirements should be caught during development
 			let req = VersionReq::parse(versions).expect("valid supported versions");


### PR DESCRIPTION
## What is the motivation?

`tokio::spawn` requires a Tokio runtime. While it's possible to use a Tokio runtime (`rt`) on WASM, it's not necessary.

## What does this change do?

It switches to `wasm_bindgen_futures::spawn_local` on WASM instead of `tokio::spawn`.

## What is your testing strategy?

Ensure the CI still passes.

## Is this related to any issues?

It partly addresses https://github.com/surrealdb/surrealdb/issues/1590.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
