### PR TITLE
Fix release builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,11 +91,17 @@ jobs:
           vcpkg install openssl:x64-windows-static
 
       - name: Install dependencies
+        if: contains(matrix.arch, 'apple') && endsWith(matrix.arch, '-darwin')
+        run: |
+          brew install protobuf
+
+      - name: Install dependencies
         if: contains(matrix.arch, 'linux') && endsWith(matrix.arch, '-gnu')
         run: |
           sudo apt-get -y update
           sudo apt-get -y install musl-tools qemu-user libc6-dev-arm64-cross
           sudo apt-get -y install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+          sudo apt-get -y install protobuf-compiler
 
       - name: Install FoundationDB
         if: contains(matrix.arch, 'linux') && startsWith(matrix.arch, 'x86_64')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,17 @@ jobs:
           vcpkg install openssl:x64-windows-static
 
       - name: Install dependencies
+        if: contains(matrix.arch, 'apple') && endsWith(matrix.arch, '-darwin')
+        run: |
+          brew install protobuf
+
+      - name: Install dependencies
         if: contains(matrix.arch, 'linux') && endsWith(matrix.arch, '-gnu')
         run: |
           sudo apt-get -y update
           sudo apt-get -y install musl-tools qemu-user libc6-dev-arm64-cross
           sudo apt-get -y install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+          sudo apt-get -y install protobuf-compiler
 
       - name: Install FoundationDB
         if: contains(matrix.arch, 'linux') && startsWith(matrix.arch, 'x86_64')


### PR DESCRIPTION
## What is the motivation?

Currently nightly release builds are broken:

```
error: failed to run custom build command for `tikv-client-proto v0.1.0`

Caused by:
  process didn't exit successfully: `/home/runner/work/surrealdb/surrealdb/target/release/build/tikv-client-proto-6b4621ae63d41224/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'Could not find `protoc` installation and this build crate cannot proceed without
      this knowledge. If `protoc` is installed and this crate had trouble finding
      it, you can set the `PROTOC` environment variable with the specific path to your
      installed `protoc` binary.If you're on debian, try `apt-get install protobuf-compiler` or download it from https://github.com/protocolbuffers/protobuf/releases

  For more information: https://docs.rs/prost-build/#sourcing-protoc
  ', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/prost-build-0.11.6/src/lib.rs:1387:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

## What does this change do?

It ensures that `protoc` is found.

## What is your testing strategy?

Ensure the CI passes.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
