### PR TITLE
[net] Capture SIGTERM/SIGINT and start a graceful shutdown

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -76,7 +76,7 @@ pub async fn init() -> Result<(), Error> {
 			.key_path(k)
 			.bind_with_graceful_shutdown(opt.bind, async move {
 				// Capture the shutdown signals and log that the graceful shutdown has started
-				let result = signals::shutdown_signals().await.expect("Failed to listen to shutdown signal");
+				let result = signals::listen().await.expect("Failed to listen to shutdown signal");
 				info!(target: LOG, "{} received. Start graceful shutdown...", result);
 			});
 		// Log the server startup status
@@ -89,7 +89,7 @@ pub async fn init() -> Result<(), Error> {
 		// Bind the server to the desired port
 		let (adr, srv) = warp::serve(net).bind_with_graceful_shutdown(opt.bind, async move {
 			// Capture the shutdown signals and log that the graceful shutdown has started
-			let result = signals::shutdown_signals().await.expect("Failed to listen to shutdown signal");
+			let result = signals::listen().await.expect("Failed to listen to shutdown signal");
 			info!(target: LOG, "{} received. Start graceful shutdown...", result);
 		});
 		// Log the server startup status

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -11,6 +11,7 @@ mod output;
 mod params;
 mod rpc;
 mod session;
+mod signals;
 mod signin;
 mod signup;
 mod sql;
@@ -74,21 +75,29 @@ pub async fn init() -> Result<(), Error> {
 			.cert_path(c)
 			.key_path(k)
 			.bind_with_graceful_shutdown(opt.bind, async move {
-				tokio::signal::ctrl_c().await.expect("Failed to listen to shutdown signal");
+				// Capture the shutdown signals and log that the graceful shutdown has started
+				let result = signals::shutdown_signals().await.expect("Failed to listen to shutdown signal");
+				info!(target: LOG, "{} received. Start graceful shutdown...", result);
 			});
 		// Log the server startup status
 		info!(target: LOG, "Started web server on {}", &adr);
 		// Run the server forever
-		srv.await
+		srv.await;
+		// Log the server shutdown event
+		info!(target: LOG, "Shutdown complete. Bye!")
 	} else {
 		// Bind the server to the desired port
 		let (adr, srv) = warp::serve(net).bind_with_graceful_shutdown(opt.bind, async move {
-			tokio::signal::ctrl_c().await.expect("Failed to listen to shutdown signal");
+			// Capture the shutdown signals and log that the graceful shutdown has started
+			let result = signals::shutdown_signals().await.expect("Failed to listen to shutdown signal");
+			info!(target: LOG, "{} received. Start graceful shutdown...", result);
 		});
 		// Log the server startup status
 		info!(target: LOG, "Started web server on {}", &adr);
 		// Run the server forever
-		srv.await
+		srv.await;
+		// Log the server shutdown event
+		info!(target: LOG, "Shutdown complete. Bye!")
 	};
 
 	Ok(())

--- a/src/net/signals.rs
+++ b/src/net/signals.rs
@@ -5,17 +5,19 @@ use tokio::signal::unix as signal_os;
 #[cfg(windows)]
 use tokio::signal::windows as signal_os;
 
-pub async fn shutdown_signals() -> Result<String, Error> {
-	let mut int_signal = signal_os::signal(signal_os::SignalKind::interrupt())?;
-	let mut term_signal = signal_os::signal(signal_os::SignalKind::terminate())?;
-
+pub async fn listen() -> Result<String, Error> {
+	// Get the operating system signal types
+	let mut interrupt = signal_os::signal(signal_os::SignalKind::interrupt())?;
+	let mut terminate = signal_os::signal(signal_os::SignalKind::terminate())?;
+	// Wait until we receive a shutdown signal
 	tokio::select! {
-        _ = int_signal.recv() => {
-            return Ok(String::from("SIGINT"));
-        }
-
-        _ = term_signal.recv() => {
-            return Ok(String::from("SIGTERM"));
-        }
-    }
+		// Wait for an interrupt signal
+		_ = interrupt.recv() => {
+			Ok(String::from("SIGINT"))
+		}
+		// Wait for a terminate signal
+		_ = terminate.recv() => {
+			Ok(String::from("SIGTERM"))
+		}
+	}
 }

--- a/src/net/signals.rs
+++ b/src/net/signals.rs
@@ -1,0 +1,21 @@
+use crate::err::Error;
+
+#[cfg(unix)]
+use tokio::signal::unix as signal_os;
+#[cfg(windows)]
+use tokio::signal::windows as signal_os;
+
+pub async fn shutdown_signals() -> Result<String, Error> {
+	let mut int_signal = signal_os::signal(signal_os::SignalKind::interrupt())?;
+	let mut term_signal = signal_os::signal(signal_os::SignalKind::terminate())?;
+
+	tokio::select! {
+        _ = int_signal.recv() => {
+            return Ok(String::from("SIGINT"));
+        }
+
+        _ = term_signal.recv() => {
+            return Ok(String::from("SIGTERM"));
+        }
+    }
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Capture SIGTERM and SIGINT (ctrl+c), and start a graceful shutdown. If not handled, the default behaviour is to ignore it.

## What does this change do?

Capture SIGTERM and SIGINT (ctrl+c), and start a graceful shutdown.

## What is your testing strategy?

I tested manually in MacOSX and in a Linux Docker container, this last one for amd64 and arm64

I don't have access to any Windows environment

```
./target/release/surreal start &; sleep 1; kill -TERM $!
[1] 26573

 .d8888b.                                             888 8888888b.  888888b.
d88P  Y88b                                            888 888  'Y88b 888  '88b
Y88b.                                                 888 888    888 888  .88P
 'Y888b.   888  888 888d888 888d888  .d88b.   8888b.  888 888    888 8888888K.
    'Y88b. 888  888 888P'   888P'   d8P  Y8b     '88b 888 888    888 888  'Y88b
      '888 888  888 888     888     88888888 .d888888 888 888    888 888    888
Y88b  d88P Y88b 888 888     888     Y8b.     888  888 888 888  .d88P 888   d88P
 'Y8888P'   'Y88888 888     888      'Y8888  'Y888888 888 8888888P'  8888888P'


[2023-02-05 11:36:07] INFO  surrealdb::env Running 1.0.0-beta.8+20230205.ed166c4d.dirty for macos on aarch64
[2023-02-05 11:36:07] INFO  surrealdb::iam Root authentication is disabled
[2023-02-05 11:36:07] INFO  surrealdb::dbs Database strict mode is disabled
[2023-02-05 11:36:07] INFO  surrealdb::kvs Starting kvs store in memory
[2023-02-05 11:36:07] INFO  surrealdb::kvs Started kvs store in memory
[2023-02-05 11:36:07] INFO  surrealdb::net Starting web server on 0.0.0.0:8000
[2023-02-05 11:36:07] INFO  surrealdb::net Started web server on 0.0.0.0:8000
[2023-02-05 11:36:09] INFO  surrealdb::net SIGTERM received. Start graceful shutdown...
[2023-02-05 11:36:09] INFO  surrealdb::net Shutdown complete. Bye!
[1]  + 26573 done       ./target/release/surreal start
```
```
./target/release/surreal start &; sleep 1; kill -INT $!
[1] 26680

 .d8888b.                                             888 8888888b.  888888b.
d88P  Y88b                                            888 888  'Y88b 888  '88b
Y88b.                                                 888 888    888 888  .88P
 'Y888b.   888  888 888d888 888d888  .d88b.   8888b.  888 888    888 8888888K.
    'Y88b. 888  888 888P'   888P'   d8P  Y8b     '88b 888 888    888 888  'Y88b
      '888 888  888 888     888     88888888 .d888888 888 888    888 888    888
Y88b  d88P Y88b 888 888     888     Y8b.     888  888 888 888  .d88P 888   d88P
 'Y8888P'   'Y88888 888     888      'Y8888  'Y888888 888 8888888P'  8888888P'


[2023-02-05 11:36:36] INFO  surrealdb::env Running 1.0.0-beta.8+20230205.ed166c4d.dirty for macos on aarch64
[2023-02-05 11:36:36] INFO  surrealdb::iam Root authentication is disabled
[2023-02-05 11:36:36] INFO  surrealdb::dbs Database strict mode is disabled
[2023-02-05 11:36:36] INFO  surrealdb::kvs Starting kvs store in memory
[2023-02-05 11:36:36] INFO  surrealdb::kvs Started kvs store in memory
[2023-02-05 11:36:36] INFO  surrealdb::net Starting web server on 0.0.0.0:8000
[2023-02-05 11:36:36] INFO  surrealdb::net Started web server on 0.0.0.0:8000
[2023-02-05 11:36:37] INFO  surrealdb::net SIGINT received. Start graceful shutdown...
[2023-02-05 11:36:37] INFO  surrealdb::net Shutdown complete. Bye!
[1]  + 26680 done       ./target/release/surreal start
```

Testing the test case from the issue, it now takes less than the 10s Docker stop timeout:
```
docker run -d --name surreal --platform linux/arm64 surreal:arm64 start >/dev/null ; \
    sleep 1; \
    time docker stop surreal
surreal
docker stop surreal  0.03s user 0.01s system 22% cpu 0.187 total
```



## Is this related to any issues?

Yes, it fixes #1637 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
