### PR TITLE
Implement `to_value` for `sql::Value`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Run cargo test
         run: |
-          (&>/dev/null cargo run -- start --log trace --user root --pass root memory &)
+          (&>/dev/null cargo run --no-default-features -F storage-mem -- start --log trace --user root --pass root memory &)
           cargo test --workspace --features protocol-ws,protocol-http,kv-rocksdb
 
   lint:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Run cargo test
         run: |
-          (&>/dev/null cargo run -- start --log trace --user root --pass root memory &)
+          (&>/dev/null cargo run --no-default-features -F storage-mem -- start --log trace --user root --pass root memory &)
           cargo test --workspace --features protocol-ws,protocol-http,kv-rocksdb
 
   lint:

--- a/lib/README.md
+++ b/lib/README.md
@@ -44,6 +44,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::borrow::Cow;
 use surrealdb::sql;
+use surrealdb::sql::Thing;
 use surrealdb::Surreal;
 use surrealdb::engine::remote::ws::Ws;
 use surrealdb::opt::auth::Root;
@@ -57,7 +58,7 @@ struct Name {
 #[derive(Serialize, Deserialize)]
 struct Person {
     #[serde(skip_serializing)]
-    id: Option<String>,
+    id: Option<Thing>,
     title: Cow<'static, str>,
     name: Name,
     marketing: bool,
@@ -107,7 +108,7 @@ async fn main() -> surrealdb::Result<()> {
         })
         .await?;
 
-    assert_eq!(jaime.id.unwrap(), "person:jaime");
+    assert_eq!(jaime.id.unwrap().to_string(), "person:jaime");
 
     // Update a person record with a specific ID
     jaime = db

--- a/lib/examples/query/main.rs
+++ b/lib/examples/query/main.rs
@@ -2,12 +2,14 @@ use serde::Deserialize;
 use serde::Serialize;
 use surrealdb::engine::remote::ws::Ws;
 use surrealdb::opt::auth::Root;
+use surrealdb::sql::thing;
+use surrealdb::sql::Thing;
 use surrealdb::Surreal;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[allow(dead_code)]
 struct User {
-	id: String,
+	id: Thing,
 	name: String,
 	company: String,
 }
@@ -29,7 +31,7 @@ async fn main() -> surrealdb::Result<()> {
 	let mut results = db
 		.query(sql)
 		.bind(User {
-			id: "john".to_owned(),
+			id: thing("user:john")?,
 			name: "John Doe".to_owned(),
 			company: "ACME Corporation".to_owned(),
 		})

--- a/lib/examples/select/main.rs
+++ b/lib/examples/select/main.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use surrealdb::engine::remote::ws::Ws;
 use surrealdb::opt::auth::Root;
+use surrealdb::sql::Thing;
 use surrealdb::Surreal;
 
 const ACCOUNT: &str = "account";
@@ -8,7 +9,7 @@ const ACCOUNT: &str = "account";
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct Account {
-	id: String,
+	id: Thing,
 	balance: String,
 }
 

--- a/lib/src/api/engine/any/native.rs
+++ b/lib/src/api/engine/any/native.rs
@@ -203,7 +203,7 @@ impl Connection for Any {
 		Box::pin(async move {
 			let response = receiver.into_recv_async().await?;
 			match response? {
-				DbResponse::Other(value) => from_value(value),
+				DbResponse::Other(value) => from_value(value).map_err(Into::into),
 				DbResponse::Query(..) => unreachable!(),
 			}
 		})

--- a/lib/src/api/engine/any/wasm.rs
+++ b/lib/src/api/engine/any/wasm.rs
@@ -158,7 +158,7 @@ impl Connection for Any {
 		Box::pin(async move {
 			let response = receiver.into_recv_async().await?;
 			match response? {
-				DbResponse::Other(value) => from_value(value),
+				DbResponse::Other(value) => from_value(value).map_err(Into::into),
 				DbResponse::Query(..) => unreachable!(),
 			}
 		})

--- a/lib/src/api/engine/local/native.rs
+++ b/lib/src/api/engine/local/native.rs
@@ -91,7 +91,7 @@ impl Connection for Db {
 		Box::pin(async move {
 			let response = rx.into_recv_async().await?;
 			match response? {
-				DbResponse::Other(value) => from_value(value),
+				DbResponse::Other(value) => from_value(value).map_err(Into::into),
 				DbResponse::Query(..) => unreachable!(),
 			}
 		})

--- a/lib/src/api/engine/local/wasm.rs
+++ b/lib/src/api/engine/local/wasm.rs
@@ -92,7 +92,7 @@ impl Connection for Db {
 			let response = rx.into_recv_async().await?;
 			trace!(target: LOG, "Response {response:?}");
 			match response? {
-				DbResponse::Other(value) => from_value(value),
+				DbResponse::Other(value) => from_value(value).map_err(Into::into),
 				DbResponse::Query(..) => unreachable!(),
 			}
 		})

--- a/lib/src/api/engine/remote/http/native.rs
+++ b/lib/src/api/engine/remote/http/native.rs
@@ -116,7 +116,7 @@ impl Connection for Client {
 			let response = rx.into_recv_async().await?;
 			trace!(target: LOG, "Response {response:?}");
 			match response? {
-				DbResponse::Other(value) => from_value(value),
+				DbResponse::Other(value) => from_value(value).map_err(Into::into),
 				DbResponse::Query(..) => unreachable!(),
 			}
 		})

--- a/lib/src/api/engine/remote/http/wasm.rs
+++ b/lib/src/api/engine/remote/http/wasm.rs
@@ -100,7 +100,7 @@ impl Connection for Client {
 			let response = rx.into_recv_async().await?;
 			trace!(target: LOG, "Response {response:?}");
 			match response? {
-				DbResponse::Other(value) => from_value(value),
+				DbResponse::Other(value) => from_value(value).map_err(Into::into),
 				DbResponse::Query(..) => unreachable!(),
 			}
 		})

--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -172,7 +172,7 @@ impl Connection for Client {
 		Box::pin(async move {
 			let response = rx.into_recv_async().await?;
 			match response? {
-				DbResponse::Other(value) => from_value(value),
+				DbResponse::Other(value) => from_value(value).map_err(Into::into),
 				DbResponse::Query(..) => unreachable!(),
 			}
 		})

--- a/lib/src/api/engine/remote/ws/wasm.rs
+++ b/lib/src/api/engine/remote/ws/wasm.rs
@@ -126,7 +126,7 @@ impl Connection for Client {
 		Box::pin(async move {
 			let response = rx.into_recv_async().await?;
 			match response? {
-				DbResponse::Other(value) => from_value(value),
+				DbResponse::Other(value) => from_value(value).map_err(Into::into),
 				DbResponse::Query(..) => unreachable!(),
 			}
 		})

--- a/lib/src/api/method/content.rs
+++ b/lib/src/api/method/content.rs
@@ -1,15 +1,14 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
 use crate::api::conn::Router;
-use crate::api::opt::from_json;
 use crate::api::opt::Range;
 use crate::api::opt::Resource;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::sql::to_value;
 use crate::sql::Id;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_json::json;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
@@ -39,8 +38,8 @@ where
 			Some(range) => resource.with_range(range)?,
 			None => resource.into(),
 		};
-		let content = json!(self.content);
-		let param = Param::new(vec![param, from_json(content)]);
+		let content = to_value(self.content)?;
+		let param = Param::new(vec![param, content]);
 		Ok((self.router?, self.method, param))
 	}
 }

--- a/lib/src/api/method/merge.rs
+++ b/lib/src/api/method/merge.rs
@@ -1,15 +1,14 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
 use crate::api::conn::Router;
-use crate::api::opt::from_json;
 use crate::api::opt::Range;
 use crate::api::opt::Resource;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::sql::to_value;
 use crate::sql::Id;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_json::json;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
@@ -36,8 +35,8 @@ where
 			Some(range) => resource.with_range(range)?,
 			None => resource.into(),
 		};
-		let content = json!(self.content);
-		let param = Param::new(vec![param, from_json(content)]);
+		let content = to_value(self.content)?;
+		let param = Param::new(vec![param, content]);
 		Ok((self.router?, Method::Merge, param))
 	}
 }

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -67,16 +67,15 @@ use crate::api::opt;
 use crate::api::opt::auth;
 use crate::api::opt::auth::Credentials;
 use crate::api::opt::auth::Jwt;
-use crate::api::opt::from_json;
 use crate::api::opt::IntoEndpoint;
 use crate::api::Connect;
 use crate::api::Connection;
 use crate::api::ExtractRouter;
 use crate::api::Surreal;
+use crate::sql::to_value;
 use crate::sql::Uuid;
 use once_cell::sync::OnceCell;
 use serde::Serialize;
-use serde_json::json;
 use std::marker::PhantomData;
 use std::path::Path;
 
@@ -300,7 +299,7 @@ where
 		Set {
 			router: self.router.extract(),
 			key: key.into(),
-			value: Ok(from_json(json!(value))),
+			value: to_value(value).map_err(Into::into),
 		}
 	}
 
@@ -402,7 +401,7 @@ where
 	pub fn signup<R>(&self, credentials: impl Credentials<auth::Signup, R>) -> Signup<C, R> {
 		Signup {
 			router: self.router.extract(),
-			credentials: Ok(from_json(json!(credentials))),
+			credentials: to_value(credentials).map_err(Into::into),
 			response_type: PhantomData,
 		}
 	}
@@ -525,7 +524,7 @@ where
 	pub fn signin<R>(&self, credentials: impl Credentials<auth::Signin, R>) -> Signin<C, R> {
 		Signin {
 			router: self.router.extract(),
-			credentials: Ok(from_json(json!(credentials))),
+			credentials: to_value(credentials).map_err(Into::into),
 			response_type: PhantomData,
 		}
 	}

--- a/lib/src/api/method/tests/protocol.rs
+++ b/lib/src/api/method/tests/protocol.rs
@@ -123,7 +123,7 @@ impl Connection for Client {
 		Box::pin(async move {
 			let result = rx.into_recv_async().await.unwrap();
 			match result.unwrap() {
-				DbResponse::Other(value) => from_value(value),
+				DbResponse::Other(value) => from_value(value).map_err(Into::into),
 				DbResponse::Query(..) => unreachable!(),
 			}
 		})

--- a/lib/src/api/method/tests/server.rs
+++ b/lib/src/api/method/tests/server.rs
@@ -1,16 +1,15 @@
-use super::types::Credentials;
+use super::types::Root;
 use super::types::User;
 use crate::api::conn::DbResponse;
 use crate::api::conn::Method;
 use crate::api::conn::Route;
-use crate::api::opt::from_json;
 use crate::api::opt::from_value;
 use crate::api::Response as QueryResponse;
+use crate::sql::to_value;
 use crate::sql::Array;
 use crate::sql::Value;
 use flume::Receiver;
 use futures::StreamExt;
-use serde_json::json;
 use std::mem;
 
 pub(super) fn mock(route_rx: Receiver<Option<Route>>) {
@@ -51,15 +50,12 @@ pub(super) fn mock(route_rx: Receiver<Option<Route>>) {
 					_ => unreachable!(),
 				},
 				Method::Signup | Method::Signin => match &mut params[..] {
-					[credentials] => {
-						let credentials: Credentials = from_value(mem::take(credentials)).unwrap();
-						match credentials {
-							Credentials::Root {
-								..
-							} => Ok(DbResponse::Other(Value::None)),
-							_ => Ok(DbResponse::Other("jwt".to_owned().into())),
-						}
-					}
+					[credentials] => match from_value(mem::take(credentials)) {
+						Ok(Root {
+							..
+						}) => Ok(DbResponse::Other(Value::None)),
+						_ => Ok(DbResponse::Other("jwt".to_owned().into())),
+					},
 					_ => unreachable!(),
 				},
 				Method::Set => match &params[..] {
@@ -71,12 +67,12 @@ pub(super) fn mock(route_rx: Receiver<Option<Route>>) {
 					_ => unreachable!(),
 				},
 				Method::Create => match &params[..] {
-					[_] => Ok(DbResponse::Other(from_json(json!(User::default())))),
+					[_] => Ok(DbResponse::Other(to_value(User::default()).unwrap())),
 					[_, user] => Ok(DbResponse::Other(user.clone())),
 					_ => unreachable!(),
 				},
 				Method::Select => match &params[..] {
-					[Value::Thing(..)] => Ok(DbResponse::Other(from_json(json!(User::default())))),
+					[Value::Thing(..)] => Ok(DbResponse::Other(to_value(User::default()).unwrap())),
 					[Value::Table(..) | Value::Array(..) | Value::Range(..)] => {
 						Ok(DbResponse::Other(Value::Array(Array(Vec::new()))))
 					}
@@ -84,7 +80,7 @@ pub(super) fn mock(route_rx: Receiver<Option<Route>>) {
 				},
 				Method::Update | Method::Merge | Method::Patch => match &params[..] {
 					[Value::Thing(..)] | [Value::Thing(..), _] => {
-						Ok(DbResponse::Other(from_json(json!(User::default()))))
+						Ok(DbResponse::Other(to_value(User::default()).unwrap()))
 					}
 					[Value::Table(..) | Value::Array(..) | Value::Range(..)]
 					| [Value::Table(..) | Value::Array(..) | Value::Range(..), _] => {

--- a/lib/src/api/method/tests/types.rs
+++ b/lib/src/api/method/tests/types.rs
@@ -10,28 +10,10 @@ pub struct User {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum Credentials {
-	Database {
-		ns: String,
-		db: String,
-		user: String,
-		pass: String,
-	},
-	Namespace {
-		ns: String,
-		user: String,
-		pass: String,
-	},
-	Root {
-		user: String,
-		pass: String,
-	},
-	Scope {
-		ns: String,
-		db: String,
-		sc: String,
-	},
+#[serde(deny_unknown_fields)]
+pub struct Root {
+	user: String,
+	pass: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/lib/src/api/opt/mod.rs
+++ b/lib/src/api/opt/mod.rs
@@ -9,14 +9,14 @@ mod strict;
 mod tls;
 
 use crate::api::err::Error;
-use crate::api::Result;
-use crate::sql;
+use crate::sql::serde::serialize_internal;
+use crate::sql::to_value;
 use crate::sql::Thing;
 use crate::sql::Value;
 use dmp::Diff;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use serde_json::json;
+use serde_json::Map;
 use serde_json::Value as JsonValue;
 
 pub use endpoint::*;
@@ -59,7 +59,7 @@ enum InnerOp<'a, T> {
 ///
 /// [JSON Patch]: https://jsonpatch.com/
 #[derive(Debug)]
-pub struct PatchOp(pub(crate) Value);
+pub struct PatchOp(pub(crate) Result<Value, crate::err::Error>);
 
 impl PatchOp {
 	/// Adds a value to an object or inserts it into an array.
@@ -80,11 +80,10 @@ impl PatchOp {
 	where
 		T: Serialize,
 	{
-		let value = from_json(json!(InnerOp::Add {
+		Self(to_value(InnerOp::Add {
 			path,
-			value
-		}));
-		Self(value)
+			value,
+		}))
 	}
 
 	/// Removes a value from an object or array.
@@ -107,10 +106,9 @@ impl PatchOp {
 	/// ```
 	#[must_use]
 	pub fn remove(path: &str) -> Self {
-		let value = from_json(json!(UnitOp::Remove {
-			path
-		}));
-		Self(value)
+		Self(to_value(UnitOp::Remove {
+			path,
+		}))
 	}
 
 	/// Replaces a value.
@@ -129,53 +127,143 @@ impl PatchOp {
 	where
 		T: Serialize,
 	{
-		let value = from_json(json!(InnerOp::Replace {
+		Self(to_value(InnerOp::Replace {
 			path,
-			value
-		}));
-		Self(value)
+			value,
+		}))
 	}
 
 	/// Changes a value
 	#[must_use]
 	pub fn change(path: &str, diff: Diff) -> Self {
-		let value = from_json(json!(UnitOp::Change {
+		Self(to_value(UnitOp::Change {
 			path,
 			value: diff.text,
-		}));
-		Self(value)
+		}))
+	}
+}
+
+fn into_json(value: Value) -> serde_json::Result<JsonValue> {
+	use crate::sql;
+	use crate::sql::Number;
+	use serde_json::Error;
+
+	#[derive(Serialize)]
+	struct Array(Vec<JsonValue>);
+
+	impl TryFrom<sql::Array> for Array {
+		type Error = Error;
+
+		fn try_from(arr: sql::Array) -> Result<Self, Self::Error> {
+			let mut vec = Vec::with_capacity(arr.0.len());
+			for value in arr.0 {
+				vec.push(into_json(value)?);
+			}
+			Ok(Self(vec))
+		}
+	}
+
+	#[derive(Serialize)]
+	struct Object(Map<String, JsonValue>);
+
+	impl TryFrom<sql::Object> for Object {
+		type Error = Error;
+
+		fn try_from(obj: sql::Object) -> Result<Self, Self::Error> {
+			let mut map = Map::with_capacity(obj.0.len());
+			for (key, value) in obj.0 {
+				map.insert(key.to_owned(), into_json(value)?);
+			}
+			Ok(Self(map))
+		}
+	}
+
+	#[derive(Serialize)]
+	enum Id {
+		Number(i64),
+		String(String),
+		Array(Array),
+		Object(Object),
+	}
+
+	impl TryFrom<sql::Id> for Id {
+		type Error = Error;
+
+		fn try_from(id: sql::Id) -> Result<Self, Self::Error> {
+			use sql::Id::*;
+			Ok(match id {
+				Number(n) => Id::Number(n),
+				String(s) => Id::String(s),
+				Array(arr) => Id::Array(arr.try_into()?),
+				Object(obj) => Id::Object(obj.try_into()?),
+			})
+		}
+	}
+
+	#[derive(Serialize)]
+	struct Thing {
+		tb: String,
+		id: Id,
+	}
+
+	impl TryFrom<sql::Thing> for Thing {
+		type Error = Error;
+
+		fn try_from(thing: sql::Thing) -> Result<Self, Self::Error> {
+			Ok(Self {
+				tb: thing.tb,
+				id: thing.id.try_into()?,
+			})
+		}
+	}
+
+	match value {
+		Value::None | Value::Null => Ok(JsonValue::Null),
+		Value::False => Ok(false.into()),
+		Value::True => Ok(true.into()),
+		Value::Number(Number::Int(n)) => Ok(n.into()),
+		Value::Number(Number::Float(n)) => Ok(n.into()),
+		Value::Number(Number::Decimal(n)) => serde_json::to_value(n),
+		Value::Strand(strand) => Ok(strand.0.into()),
+		Value::Duration(d) => serde_json::to_value(d),
+		Value::Datetime(d) => serde_json::to_value(d),
+		Value::Uuid(uuid) => serde_json::to_value(uuid),
+		Value::Array(arr) => Ok(JsonValue::Array(Array::try_from(arr)?.0)),
+		Value::Object(obj) => Ok(JsonValue::Object(Object::try_from(obj)?.0)),
+		Value::Geometry(geometry) => serde_json::to_value(geometry),
+		Value::Param(param) => serde_json::to_value(param),
+		Value::Idiom(idiom) => serde_json::to_value(idiom),
+		Value::Table(table) => serde_json::to_value(table),
+		Value::Thing(thing) => serde_json::to_value(thing),
+		Value::Model(model) => serde_json::to_value(model),
+		Value::Regex(regex) => serde_json::to_value(regex),
+		Value::Block(block) => serde_json::to_value(block),
+		Value::Range(range) => serde_json::to_value(range),
+		Value::Edges(edges) => serde_json::to_value(edges),
+		Value::Future(future) => serde_json::to_value(future),
+		Value::Constant(constant) => serde_json::to_value(constant),
+		Value::Function(function) => serde_json::to_value(function),
+		Value::Subquery(subquery) => serde_json::to_value(subquery),
+		Value::Expression(expression) => serde_json::to_value(expression),
 	}
 }
 
 /// Deserializes a value `T` from `SurrealDB` [`Value`]
-pub(crate) fn from_value<T>(value: sql::Value) -> Result<T>
+pub(crate) fn from_value<T>(value: Value) -> Result<T, Error>
 where
 	T: DeserializeOwned,
 {
-	let bytes = match msgpack::to_vec(&value) {
-		Ok(bytes) => bytes,
+	let json = match serialize_internal(|| into_json(value.clone())) {
+		Ok(json) => json,
 		Err(error) => {
 			return Err(Error::FromValue {
 				value,
 				error: error.to_string(),
-			}
-			.into());
+			})
 		}
 	};
-	match msgpack::from_slice(&bytes) {
-		Ok(response) => Ok(response),
-		Err(error) => Err(Error::FromValue {
-			value,
-			error: error.to_string(),
-		}
-		.into()),
-	}
-}
-
-pub(crate) fn from_json(json: JsonValue) -> sql::Value {
-	match sql::json(&json.to_string()) {
-		Ok(value) => value,
-		// It shouldn't get to this as `JsonValue` will always produce valid JSON
-		Err(_) => unreachable!(),
-	}
+	serde_json::from_value(json).map_err(|error| Error::FromValue {
+		value,
+		error: error.to_string(),
+	})
 }

--- a/lib/src/api/opt/query.rs
+++ b/lib/src/api/opt/query.rs
@@ -206,7 +206,7 @@ where
 			[] => Ok(None),
 			[value] => {
 				let value = mem::take(value);
-				from_value(value)
+				from_value(value).map_err(Into::into)
 			}
 			_ => Err(Error::LossyTake(QueryResponse(mem::take(map))).into()),
 		};
@@ -257,7 +257,7 @@ where
 				let Some(value) = object.remove(key) else {
                     return Ok(None);
                 };
-				from_value(value)
+				from_value(value).map_err(Into::into)
 			}
 			_ => Ok(None),
 		}
@@ -275,7 +275,7 @@ where
 				return Ok(vec![]);
 			}
 		};
-		from_value(vec.into())
+		from_value(vec.into()).map_err(Into::into)
 	}
 }
 
@@ -306,7 +306,7 @@ where
 				}
 			}
 		}
-		from_value(vec.into())
+		from_value(vec.into()).map_err(Into::into)
 	}
 }
 

--- a/lib/src/dbs/response.rs
+++ b/lib/src/dbs/response.rs
@@ -4,6 +4,8 @@ use serde::ser::SerializeStruct;
 use serde::Serialize;
 use std::time::Duration;
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Response";
+
 /// The return value when running a query set on the database.
 #[derive(Debug)]
 pub struct Response {
@@ -29,14 +31,14 @@ impl Serialize for Response {
 	{
 		match &self.result {
 			Ok(v) => {
-				let mut val = serializer.serialize_struct("Response", 3)?;
+				let mut val = serializer.serialize_struct(TOKEN, 3)?;
 				val.serialize_field("time", self.speed().as_str())?;
 				val.serialize_field("status", "OK")?;
 				val.serialize_field("result", v)?;
 				val.end()
 			}
 			Err(e) => {
-				let mut val = serializer.serialize_struct("Response", 3)?;
+				let mut val = serializer.serialize_struct(TOKEN, 3)?;
 				val.serialize_field("time", self.speed().as_str())?;
 				val.serialize_field("status", "ERR")?;
 				val.serialize_field("detail", e)?;

--- a/lib/src/sql/array.rs
+++ b/lib/src/sql/array.rs
@@ -21,6 +21,8 @@ use std::ops;
 use std::ops::Deref;
 use std::ops::DerefMut;
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Array";
+
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Deserialize, Hash)]
 pub struct Array(pub Vec<Value>);
 
@@ -163,9 +165,9 @@ impl Serialize for Array {
 		S: serde::Serializer,
 	{
 		if is_internal_serialization() {
-			serializer.serialize_newtype_struct("Array", &self.0)
+			serializer.serialize_newtype_struct(TOKEN, &self.0)
 		} else {
-			serializer.serialize_some(&self.0)
+			serializer.serialize_some(&self.to_string())
 		}
 	}
 }

--- a/lib/src/sql/constant.rs
+++ b/lib/src/sql/constant.rs
@@ -12,6 +12,8 @@ use nom::combinator::map;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Constant";
+
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Deserialize, Store, Hash)]
 pub enum Constant {
 	MathE,
@@ -101,25 +103,25 @@ impl Serialize for Constant {
 	{
 		if is_internal_serialization() {
 			match self {
-				Self::MathE => s.serialize_unit_variant("Constant", 0, "MathE"),
-				Self::MathFrac1Pi => s.serialize_unit_variant("Constant", 1, "MathFrac1Pi"),
-				Self::MathFrac1Sqrt2 => s.serialize_unit_variant("Constant", 2, "MathFrac1Sqrt2"),
-				Self::MathFrac2Pi => s.serialize_unit_variant("Constant", 3, "MathFrac2Pi"),
-				Self::MathFrac2SqrtPi => s.serialize_unit_variant("Constant", 4, "MathFrac2SqrtPi"),
-				Self::MathFracPi2 => s.serialize_unit_variant("Constant", 5, "MathFracPi2"),
-				Self::MathFracPi3 => s.serialize_unit_variant("Constant", 6, "MathFracPi3"),
-				Self::MathFracPi4 => s.serialize_unit_variant("Constant", 7, "MathFracPi4"),
-				Self::MathFracPi6 => s.serialize_unit_variant("Constant", 8, "MathFracPi6"),
-				Self::MathFracPi8 => s.serialize_unit_variant("Constant", 9, "MathFracPi8"),
-				Self::MathLn10 => s.serialize_unit_variant("Constant", 10, "MathLn10"),
-				Self::MathLn2 => s.serialize_unit_variant("Constant", 11, "MathLn2"),
-				Self::MathLog102 => s.serialize_unit_variant("Constant", 12, "MathLog102"),
-				Self::MathLog10E => s.serialize_unit_variant("Constant", 13, "MathLog10E"),
-				Self::MathLog210 => s.serialize_unit_variant("Constant", 14, "MathLog210"),
-				Self::MathLog2E => s.serialize_unit_variant("Constant", 15, "MathLog2E"),
-				Self::MathPi => s.serialize_unit_variant("Constant", 16, "MathPi"),
-				Self::MathSqrt2 => s.serialize_unit_variant("Constant", 17, "MathSqrt2"),
-				Self::MathTau => s.serialize_unit_variant("Constant", 18, "MathTau"),
+				Self::MathE => s.serialize_unit_variant(TOKEN, 0, "MathE"),
+				Self::MathFrac1Pi => s.serialize_unit_variant(TOKEN, 1, "MathFrac1Pi"),
+				Self::MathFrac1Sqrt2 => s.serialize_unit_variant(TOKEN, 2, "MathFrac1Sqrt2"),
+				Self::MathFrac2Pi => s.serialize_unit_variant(TOKEN, 3, "MathFrac2Pi"),
+				Self::MathFrac2SqrtPi => s.serialize_unit_variant(TOKEN, 4, "MathFrac2SqrtPi"),
+				Self::MathFracPi2 => s.serialize_unit_variant(TOKEN, 5, "MathFracPi2"),
+				Self::MathFracPi3 => s.serialize_unit_variant(TOKEN, 6, "MathFracPi3"),
+				Self::MathFracPi4 => s.serialize_unit_variant(TOKEN, 7, "MathFracPi4"),
+				Self::MathFracPi6 => s.serialize_unit_variant(TOKEN, 8, "MathFracPi6"),
+				Self::MathFracPi8 => s.serialize_unit_variant(TOKEN, 9, "MathFracPi8"),
+				Self::MathLn10 => s.serialize_unit_variant(TOKEN, 10, "MathLn10"),
+				Self::MathLn2 => s.serialize_unit_variant(TOKEN, 11, "MathLn2"),
+				Self::MathLog102 => s.serialize_unit_variant(TOKEN, 12, "MathLog102"),
+				Self::MathLog10E => s.serialize_unit_variant(TOKEN, 13, "MathLog10E"),
+				Self::MathLog210 => s.serialize_unit_variant(TOKEN, 14, "MathLog210"),
+				Self::MathLog2E => s.serialize_unit_variant(TOKEN, 15, "MathLog2E"),
+				Self::MathPi => s.serialize_unit_variant(TOKEN, 16, "MathPi"),
+				Self::MathSqrt2 => s.serialize_unit_variant(TOKEN, 17, "MathSqrt2"),
+				Self::MathTau => s.serialize_unit_variant(TOKEN, 18, "MathTau"),
 			}
 		} else {
 			match self {

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -17,6 +17,8 @@ use std::ops;
 use std::ops::Deref;
 use std::str;
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Datetime";
+
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Deserialize, Hash)]
 pub struct Datetime(pub DateTime<Utc>);
 
@@ -73,9 +75,9 @@ impl Serialize for Datetime {
 		S: serde::Serializer,
 	{
 		if is_internal_serialization() {
-			serializer.serialize_newtype_struct("Datetime", &self.0)
+			serializer.serialize_newtype_struct(TOKEN, &self.0)
 		} else {
-			serializer.serialize_some(&self.0)
+			serializer.serialize_some(&self.to_string())
 		}
 	}
 }

--- a/lib/src/sql/duration.rs
+++ b/lib/src/sql/duration.rs
@@ -21,6 +21,8 @@ static SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
 static SECONDS_PER_MINUTE: u64 = 60;
 static NANOSECONDS_PER_MILLISECOND: u32 = 1000000;
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Duration";
+
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Deserialize, Hash)]
 pub struct Duration(pub time::Duration);
 
@@ -161,7 +163,7 @@ impl Serialize for Duration {
 		S: serde::Serializer,
 	{
 		if is_internal_serialization() {
-			serializer.serialize_newtype_struct("Duration", &self.0)
+			serializer.serialize_newtype_struct(TOKEN, &self.0)
 		} else {
 			serializer.serialize_some(&self.to_string())
 		}

--- a/lib/src/sql/edges.rs
+++ b/lib/src/sql/edges.rs
@@ -1,15 +1,19 @@
 use crate::sql::comment::mightbespace;
 use crate::sql::dir::{dir, Dir};
 use crate::sql::error::IResult;
+use crate::sql::serde::is_internal_serialization;
 use crate::sql::table::{table, tables, Tables};
 use crate::sql::thing::{thing, Thing};
 use nom::branch::alt;
 use nom::character::complete::char;
 use nom::combinator::map;
+use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Edges";
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Deserialize, Hash)]
 pub struct Edges {
 	pub dir: Dir,
 	pub from: Thing,
@@ -22,6 +26,23 @@ impl fmt::Display for Edges {
 			0 => write!(f, "{}{}?", self.from, self.dir,),
 			1 => write!(f, "{}{}{}", self.from, self.dir, self.what),
 			_ => write!(f, "{}{}({})", self.from, self.dir, self.what),
+		}
+	}
+}
+
+impl Serialize for Edges {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		if is_internal_serialization() {
+			let mut val = serializer.serialize_struct(TOKEN, 3)?;
+			val.serialize_field("dir", &self.dir)?;
+			val.serialize_field("from", &self.from)?;
+			val.serialize_field("what", &self.what)?;
+			val.end()
+		} else {
+			serializer.serialize_none()
 		}
 	}
 }

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -10,6 +10,7 @@ use crate::sql::error::IResult;
 use crate::sql::fmt::Fmt;
 use crate::sql::idiom::Idiom;
 use crate::sql::script::{script as func, Script};
+use crate::sql::serde::is_internal_serialization;
 use crate::sql::value::{single, value, Value};
 use async_recursion::async_recursion;
 use futures::future::try_join_all;
@@ -18,11 +19,14 @@ use nom::bytes::complete::tag;
 use nom::bytes::complete::take_while1;
 use nom::character::complete::char;
 use nom::multi::separated_list0;
+use serde::ser::SerializeTupleVariant;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Function";
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Hash)]
 pub enum Function {
 	Cast(String, Value),
 	Normal(String, Vec<Value>),
@@ -212,6 +216,47 @@ impl fmt::Display for Function {
 			Self::Normal(s, e) => write!(f, "{s}({})", Fmt::comma_separated(e)),
 			Self::Custom(s, e) => write!(f, "fn::{s}({})", Fmt::comma_separated(e)),
 			Self::Script(s, e) => write!(f, "function({}) {{{s}}}", Fmt::comma_separated(e)),
+		}
+	}
+}
+
+impl Serialize for Function {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		if is_internal_serialization() {
+			match self {
+				Self::Cast(s, e) => {
+					let mut serializer = serializer.serialize_tuple_variant(TOKEN, 0, "Cast", 2)?;
+					serializer.serialize_field(s)?;
+					serializer.serialize_field(e)?;
+					serializer.end()
+				}
+				Self::Normal(s, e) => {
+					let mut serializer =
+						serializer.serialize_tuple_variant(TOKEN, 1, "Normal", 2)?;
+					serializer.serialize_field(s)?;
+					serializer.serialize_field(e)?;
+					serializer.end()
+				}
+				Self::Custom(s, e) => {
+					let mut serializer =
+						serializer.serialize_tuple_variant(TOKEN, 2, "Custom", 2)?;
+					serializer.serialize_field(s)?;
+					serializer.serialize_field(e)?;
+					serializer.end()
+				}
+				Self::Script(s, e) => {
+					let mut serializer =
+						serializer.serialize_tuple_variant(TOKEN, 3, "Script", 2)?;
+					serializer.serialize_field(s)?;
+					serializer.serialize_field(e)?;
+					serializer.end()
+				}
+			}
+		} else {
+			serializer.serialize_none()
 		}
 	}
 }

--- a/lib/src/sql/future.rs
+++ b/lib/src/sql/future.rs
@@ -5,13 +5,16 @@ use crate::err::Error;
 use crate::sql::block::{block, Block};
 use crate::sql::comment::mightbespace;
 use crate::sql::error::IResult;
+use crate::sql::serde::is_internal_serialization;
 use crate::sql::value::Value;
 use nom::bytes::complete::tag;
 use nom::character::complete::char;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Future";
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Deserialize, Hash)]
 pub struct Future(pub Block);
 
 impl From<Value> for Future {
@@ -41,6 +44,19 @@ impl Future {
 impl fmt::Display for Future {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "<future> {}", self.0)
+	}
+}
+
+impl Serialize for Future {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		if is_internal_serialization() {
+			serializer.serialize_newtype_struct(TOKEN, &self.0)
+		} else {
+			serializer.serialize_none()
+		}
 	}
 }
 

--- a/lib/src/sql/geometry.rs
+++ b/lib/src/sql/geometry.rs
@@ -24,6 +24,8 @@ use std::cmp::Ordering;
 use std::iter::{once, FromIterator};
 use std::{fmt, hash};
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Geometry";
+
 const SINGLE: char = '\'';
 const DOUBLE: char = '\"';
 
@@ -471,15 +473,13 @@ impl Serialize for Geometry {
 	{
 		if is_internal_serialization() {
 			match self {
-				Self::Point(v) => s.serialize_newtype_variant("Geometry", 0, "Point", v),
-				Self::Line(v) => s.serialize_newtype_variant("Geometry", 1, "Line", v),
-				Self::Polygon(v) => s.serialize_newtype_variant("Geometry", 2, "Polygon", v),
-				Self::MultiPoint(v) => s.serialize_newtype_variant("Geometry", 3, "MultiPoint", v),
-				Self::MultiLine(v) => s.serialize_newtype_variant("Geometry", 4, "MultiLine", v),
-				Self::MultiPolygon(v) => {
-					s.serialize_newtype_variant("Geometry", 5, "MultiPolygon", v)
-				}
-				Self::Collection(v) => s.serialize_newtype_variant("Geometry", 6, "Collection", v),
+				Self::Point(v) => s.serialize_newtype_variant(TOKEN, 0, "Point", v),
+				Self::Line(v) => s.serialize_newtype_variant(TOKEN, 1, "Line", v),
+				Self::Polygon(v) => s.serialize_newtype_variant(TOKEN, 2, "Polygon", v),
+				Self::MultiPoint(v) => s.serialize_newtype_variant(TOKEN, 3, "MultiPoint", v),
+				Self::MultiLine(v) => s.serialize_newtype_variant(TOKEN, 4, "MultiLine", v),
+				Self::MultiPolygon(v) => s.serialize_newtype_variant(TOKEN, 5, "MultiPolygon", v),
+				Self::Collection(v) => s.serialize_newtype_variant(TOKEN, 6, "Collection", v),
 			}
 		} else {
 			match self {

--- a/lib/src/sql/id.rs
+++ b/lib/src/sql/id.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 use ulid::Ulid;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 pub enum Id {
 	Number(i64),
 	String(String),

--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -129,3 +129,5 @@ pub use self::value::Value;
 pub use self::value::Values;
 pub use self::version::Version;
 pub use self::view::View;
+
+pub(crate) use self::value::serde::to_value;

--- a/lib/src/sql/number.rs
+++ b/lib/src/sql/number.rs
@@ -19,6 +19,8 @@ use std::iter::Sum;
 use std::ops;
 use std::str::FromStr;
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Number";
+
 #[derive(Clone, Debug, Deserialize)]
 pub enum Number {
 	Int(i64),
@@ -175,9 +177,9 @@ impl Serialize for Number {
 	{
 		if is_internal_serialization() {
 			match self {
-				Number::Int(v) => s.serialize_newtype_variant("Number", 0, "Int", v),
-				Number::Float(v) => s.serialize_newtype_variant("Number", 1, "Float", v),
-				Number::Decimal(v) => s.serialize_newtype_variant("Number", 2, "Decimal", v),
+				Number::Int(v) => s.serialize_newtype_variant(TOKEN, 0, "Int", v),
+				Number::Float(v) => s.serialize_newtype_variant(TOKEN, 1, "Float", v),
+				Number::Decimal(v) => s.serialize_newtype_variant(TOKEN, 2, "Decimal", v),
 			}
 		} else {
 			match self {

--- a/lib/src/sql/object.rs
+++ b/lib/src/sql/object.rs
@@ -26,6 +26,8 @@ use std::fmt::{self, Display, Formatter, Write};
 use std::ops::Deref;
 use std::ops::DerefMut;
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Object";
+
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Deserialize, Hash)]
 pub struct Object(pub BTreeMap<String, Value>);
 
@@ -170,7 +172,7 @@ impl Serialize for Object {
 		S: serde::Serializer,
 	{
 		if is_internal_serialization() {
-			serializer.serialize_newtype_struct("Object", &self.0)
+			serializer.serialize_newtype_struct(TOKEN, &self.0)
 		} else {
 			let mut map = serializer.serialize_map(Some(self.len()))?;
 			for (ref k, ref v) in &self.0 {

--- a/lib/src/sql/strand.rs
+++ b/lib/src/sql/strand.rs
@@ -15,6 +15,8 @@ use std::ops;
 use std::ops::Deref;
 use std::str;
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Strand";
+
 const SINGLE: char = '\'';
 const SINGLE_ESC: &str = r#"\'"#;
 
@@ -78,9 +80,9 @@ impl Serialize for Strand {
 		S: serde::Serializer,
 	{
 		if is_internal_serialization() {
-			serializer.serialize_newtype_struct("Strand", &self.0)
+			serializer.serialize_newtype_struct(TOKEN, &self.0)
 		} else {
-			serializer.serialize_some(&self.0)
+			serializer.serialize_some(&self.to_string())
 		}
 	}
 }

--- a/lib/src/sql/subquery.rs
+++ b/lib/src/sql/subquery.rs
@@ -5,6 +5,7 @@ use crate::err::Error;
 use crate::sql::comment::mightbespace;
 use crate::sql::ending::subquery as ending;
 use crate::sql::error::IResult;
+use crate::sql::serde::is_internal_serialization;
 use crate::sql::statements::create::{create, CreateStatement};
 use crate::sql::statements::delete::{delete, DeleteStatement};
 use crate::sql::statements::ifelse::{ifelse, IfelseStatement};
@@ -21,7 +22,9 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Subquery";
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Hash)]
 pub enum Subquery {
 	Value(Value),
 	Ifelse(IfelseStatement),
@@ -218,6 +221,29 @@ impl Display for Subquery {
 			Self::Relate(v) => write!(f, "({v})"),
 			Self::Insert(v) => write!(f, "({v})"),
 			Self::Ifelse(v) => Display::fmt(v, f),
+		}
+	}
+}
+
+impl Serialize for Subquery {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		if is_internal_serialization() {
+			match self {
+				Self::Value(v) => serializer.serialize_newtype_variant(TOKEN, 0, "Value", v),
+				Self::Ifelse(v) => serializer.serialize_newtype_variant(TOKEN, 1, "Ifelse", v),
+				Self::Output(v) => serializer.serialize_newtype_variant(TOKEN, 2, "Output", v),
+				Self::Select(v) => serializer.serialize_newtype_variant(TOKEN, 3, "Select", v),
+				Self::Create(v) => serializer.serialize_newtype_variant(TOKEN, 4, "Create", v),
+				Self::Update(v) => serializer.serialize_newtype_variant(TOKEN, 5, "Update", v),
+				Self::Delete(v) => serializer.serialize_newtype_variant(TOKEN, 6, "Delete", v),
+				Self::Relate(v) => serializer.serialize_newtype_variant(TOKEN, 7, "Relate", v),
+				Self::Insert(v) => serializer.serialize_newtype_variant(TOKEN, 8, "Insert", v),
+			}
+		} else {
+			serializer.serialize_none()
 		}
 	}
 }

--- a/lib/src/sql/table.rs
+++ b/lib/src/sql/table.rs
@@ -4,12 +4,15 @@ use crate::sql::escape::escape_ident;
 use crate::sql::fmt::Fmt;
 use crate::sql::id::Id;
 use crate::sql::ident::{ident_raw, Ident};
+use crate::sql::serde::is_internal_serialization;
 use crate::sql::thing::Thing;
 use nom::multi::separated_list1;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 use std::str;
+
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Table";
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 pub struct Tables(pub Vec<Table>);
@@ -38,7 +41,7 @@ pub fn tables(i: &str) -> IResult<&str, Tables> {
 	Ok((i, Tables(v)))
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Deserialize, Hash)]
 pub struct Table(pub String);
 
 impl From<String> for Table {
@@ -78,6 +81,19 @@ impl Table {
 impl Display for Table {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&escape_ident(&self.0), f)
+	}
+}
+
+impl Serialize for Table {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		if is_internal_serialization() {
+			serializer.serialize_newtype_struct(TOKEN, &self.0)
+		} else {
+			serializer.serialize_none()
+		}
 	}
 }
 

--- a/lib/src/sql/thing.rs
+++ b/lib/src/sql/thing.rs
@@ -18,7 +18,9 @@ use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Deserialize, Store, Hash)]
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Thing";
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Deserialize, Store, Hash)]
 pub struct Thing {
 	pub tb: String,
 	pub id: Id,
@@ -79,7 +81,7 @@ impl Serialize for Thing {
 		S: serde::Serializer,
 	{
 		if is_internal_serialization() {
-			let mut val = serializer.serialize_struct("Thing", 2)?;
+			let mut val = serializer.serialize_struct(TOKEN, 2)?;
 			val.serialize_field("tb", &self.tb)?;
 			val.serialize_field("id", &self.id)?;
 			val.end()

--- a/lib/src/sql/uuid.rs
+++ b/lib/src/sql/uuid.rs
@@ -13,6 +13,8 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 use std::str;
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Uuid";
+
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Deserialize, Hash)]
 pub struct Uuid(pub uuid::Uuid);
 
@@ -86,9 +88,9 @@ impl Serialize for Uuid {
 		S: serde::Serializer,
 	{
 		if is_internal_serialization() {
-			serializer.serialize_newtype_struct("Uuid", &self.0)
+			serializer.serialize_newtype_struct(TOKEN, &self.0)
 		} else {
-			serializer.serialize_some(&self.0)
+			serializer.serialize_some(&self.to_string())
 		}
 	}
 }

--- a/lib/src/sql/value/mod.rs
+++ b/lib/src/sql/value/mod.rs
@@ -1,5 +1,7 @@
 pub use self::value::*;
 
+pub(super) mod serde;
+
 #[allow(clippy::module_inception)]
 mod value;
 

--- a/lib/src/sql/value/serde/mod.rs
+++ b/lib/src/sql/value/serde/mod.rs
@@ -1,0 +1,3 @@
+mod ser;
+
+pub(crate) use ser::to_value;

--- a/lib/src/sql/value/serde/ser/block/entry/mod.rs
+++ b/lib/src/sql/value/serde/ser/block/entry/mod.rs
@@ -1,0 +1,145 @@
+pub mod vec;
+
+use crate::err::Error;
+use crate::sql::block::Entry;
+use crate::sql::value::serde::ser;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Entry;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Entry, Error>;
+	type SerializeTuple = Impossible<Entry, Error>;
+	type SerializeTupleStruct = Impossible<Entry, Error>;
+	type SerializeTupleVariant = Impossible<Entry, Error>;
+	type SerializeMap = Impossible<Entry, Error>;
+	type SerializeStruct = Impossible<Entry, Error>;
+	type SerializeStructVariant = Impossible<Entry, Error>;
+
+	const EXPECTED: &'static str = "an enum `Entry`";
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"Value" => Ok(Entry::Value(value.serialize(ser::value::Serializer.wrap())?)),
+			"Set" => Ok(Entry::Set(value.serialize(ser::statement::set::Serializer.wrap())?)),
+			"Ifelse" => {
+				Ok(Entry::Ifelse(value.serialize(ser::statement::ifelse::Serializer.wrap())?))
+			}
+			"Select" => {
+				Ok(Entry::Select(value.serialize(ser::statement::select::Serializer.wrap())?))
+			}
+			"Create" => {
+				Ok(Entry::Create(value.serialize(ser::statement::create::Serializer.wrap())?))
+			}
+			"Update" => {
+				Ok(Entry::Update(value.serialize(ser::statement::update::Serializer.wrap())?))
+			}
+			"Delete" => {
+				Ok(Entry::Delete(value.serialize(ser::statement::delete::Serializer.wrap())?))
+			}
+			"Relate" => {
+				Ok(Entry::Relate(value.serialize(ser::statement::relate::Serializer.wrap())?))
+			}
+			"Insert" => {
+				Ok(Entry::Insert(value.serialize(ser::statement::insert::Serializer.wrap())?))
+			}
+			"Output" => {
+				Ok(Entry::Output(value.serialize(ser::statement::output::Serializer.wrap())?))
+			}
+			variant => Err(Error::custom(format!("unexpected variant `{name}::{variant}`"))),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn value() {
+		let entry = Entry::Value(Default::default());
+		let serialized = serialize_internal(|| entry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(entry, serialized);
+	}
+
+	#[test]
+	fn set() {
+		let entry = Entry::Set(Default::default());
+		let serialized = serialize_internal(|| entry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(entry, serialized);
+	}
+
+	#[test]
+	fn ifelse() {
+		let entry = Entry::Ifelse(Default::default());
+		let serialized = serialize_internal(|| entry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(entry, serialized);
+	}
+
+	#[test]
+	fn select() {
+		let entry = Entry::Select(Default::default());
+		let serialized = serialize_internal(|| entry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(entry, serialized);
+	}
+
+	#[test]
+	fn create() {
+		let entry = Entry::Create(Default::default());
+		let serialized = serialize_internal(|| entry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(entry, serialized);
+	}
+
+	#[test]
+	fn update() {
+		let entry = Entry::Update(Default::default());
+		let serialized = serialize_internal(|| entry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(entry, serialized);
+	}
+
+	#[test]
+	fn delete() {
+		let entry = Entry::Delete(Default::default());
+		let serialized = serialize_internal(|| entry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(entry, serialized);
+	}
+
+	#[test]
+	fn relate() {
+		let entry = Entry::Relate(Default::default());
+		let serialized = serialize_internal(|| entry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(entry, serialized);
+	}
+
+	#[test]
+	fn insert() {
+		let entry = Entry::Insert(Default::default());
+		let serialized = serialize_internal(|| entry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(entry, serialized);
+	}
+
+	#[test]
+	fn output() {
+		let entry = Entry::Output(Default::default());
+		let serialized = serialize_internal(|| entry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(entry, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/block/entry/vec.rs
+++ b/lib/src/sql/value/serde/ser/block/entry/vec.rs
@@ -1,0 +1,78 @@
+use crate::err::Error;
+use crate::sql::block::Entry;
+use crate::sql::value::serde::ser;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Entry>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeEntryVec;
+	type SerializeTuple = Impossible<Vec<Entry>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Entry>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Entry>, Error>;
+	type SerializeMap = Impossible<Vec<Entry>, Error>;
+	type SerializeStruct = Impossible<Vec<Entry>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Entry>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Entry>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeEntryVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializeEntryVec(Vec<Entry>);
+
+impl serde::ser::SerializeSeq for SerializeEntryVec {
+	type Ok = Vec<Entry>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(super::Serializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Entry> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Entry::Value(Default::default())];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/block/mod.rs
+++ b/lib/src/sql/value/serde/ser/block/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod entry;

--- a/lib/src/sql/value/serde/ser/cond/mod.rs
+++ b/lib/src/sql/value/serde/ser/cond/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod opt;

--- a/lib/src/sql/value/serde/ser/cond/opt.rs
+++ b/lib/src/sql/value/serde/ser/cond/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Cond;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Cond>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Cond>, Error>;
+	type SerializeTuple = Impossible<Option<Cond>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Cond>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Cond>, Error>;
+	type SerializeMap = Impossible<Option<Cond>, Error>;
+	type SerializeStruct = Impossible<Option<Cond>, Error>;
+	type SerializeStructVariant = Impossible<Option<Cond>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Cond>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(Cond(value.serialize(ser::value::Serializer.wrap())?)))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Cond> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(Cond::default());
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/constant/mod.rs
+++ b/lib/src/sql/value/serde/ser/constant/mod.rs
@@ -1,0 +1,194 @@
+use crate::err::Error;
+use crate::sql::constant::Constant;
+use crate::sql::value::serde::ser;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Constant;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Constant, Error>;
+	type SerializeTuple = Impossible<Constant, Error>;
+	type SerializeTupleStruct = Impossible<Constant, Error>;
+	type SerializeTupleVariant = Impossible<Constant, Error>;
+	type SerializeMap = Impossible<Constant, Error>;
+	type SerializeStruct = Impossible<Constant, Error>;
+	type SerializeStructVariant = Impossible<Constant, Error>;
+
+	const EXPECTED: &'static str = "an enum `Constant`";
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		match variant {
+			"MathE" => Ok(Constant::MathE),
+			"MathFrac1Pi" => Ok(Constant::MathFrac1Pi),
+			"MathFrac1Sqrt2" => Ok(Constant::MathFrac1Sqrt2),
+			"MathFrac2Pi" => Ok(Constant::MathFrac2Pi),
+			"MathFrac2SqrtPi" => Ok(Constant::MathFrac2SqrtPi),
+			"MathFracPi2" => Ok(Constant::MathFracPi2),
+			"MathFracPi3" => Ok(Constant::MathFracPi3),
+			"MathFracPi4" => Ok(Constant::MathFracPi4),
+			"MathFracPi6" => Ok(Constant::MathFracPi6),
+			"MathFracPi8" => Ok(Constant::MathFracPi8),
+			"MathLn10" => Ok(Constant::MathLn10),
+			"MathLn2" => Ok(Constant::MathLn2),
+			"MathLog102" => Ok(Constant::MathLog102),
+			"MathLog10E" => Ok(Constant::MathLog10E),
+			"MathLog210" => Ok(Constant::MathLog210),
+			"MathLog2E" => Ok(Constant::MathLog2E),
+			"MathPi" => Ok(Constant::MathPi),
+			"MathSqrt2" => Ok(Constant::MathSqrt2),
+			"MathTau" => Ok(Constant::MathTau),
+			variant => Err(Error::custom(format!("unknown variant `{name}::{variant}`"))),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn math_e() {
+		let constant = Constant::MathE;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_frac_1pi() {
+		let constant = Constant::MathFrac1Pi;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_frac_1sqrt2() {
+		let constant = Constant::MathFrac1Sqrt2;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_frac_2pi() {
+		let constant = Constant::MathFrac2Pi;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_frac_2sqrt_pi() {
+		let constant = Constant::MathFrac2SqrtPi;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_frac_pi2() {
+		let constant = Constant::MathFracPi2;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_frac_pi3() {
+		let constant = Constant::MathFracPi3;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_frac_pi4() {
+		let constant = Constant::MathFracPi4;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_frac_pi6() {
+		let constant = Constant::MathFracPi6;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_frac_pi8() {
+		let constant = Constant::MathFracPi8;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_ln10() {
+		let constant = Constant::MathLn10;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_ln2() {
+		let constant = Constant::MathLn2;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_log102() {
+		let constant = Constant::MathLog102;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_log10_e() {
+		let constant = Constant::MathLog10E;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_log210() {
+		let constant = Constant::MathLog210;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_log2_e() {
+		let constant = Constant::MathLog2E;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_pi() {
+		let constant = Constant::MathPi;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_sqrt2() {
+		let constant = Constant::MathSqrt2;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+
+	#[test]
+	fn math_tau() {
+		let constant = Constant::MathTau;
+		let serialized = serialize_internal(|| constant.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(constant, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/data/mod.rs
+++ b/lib/src/sql/value/serde/ser/data/mod.rs
@@ -1,0 +1,408 @@
+pub(super) mod opt;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Data;
+use crate::sql::Idiom;
+use crate::sql::Operator;
+use crate::sql::Value;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Data;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Data, Error>;
+	type SerializeTuple = Impossible<Data, Error>;
+	type SerializeTupleStruct = Impossible<Data, Error>;
+	type SerializeTupleVariant = Impossible<Data, Error>;
+	type SerializeMap = Impossible<Data, Error>;
+	type SerializeStruct = Impossible<Data, Error>;
+	type SerializeStructVariant = Impossible<Data, Error>;
+
+	const EXPECTED: &'static str = "an enum `Data`";
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		match variant {
+			"EmptyExpression" => Ok(Data::EmptyExpression),
+			variant => Err(Error::custom(format!("unexpected unit variant `{name}::{variant}`"))),
+		}
+	}
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"SetExpression" => {
+				Ok(Data::SetExpression(value.serialize(IdiomOperatorValueVecSerializer.wrap())?))
+			}
+			"PatchExpression" => {
+				Ok(Data::PatchExpression(value.serialize(ser::value::Serializer.wrap())?))
+			}
+			"MergeExpression" => {
+				Ok(Data::MergeExpression(value.serialize(ser::value::Serializer.wrap())?))
+			}
+			"ReplaceExpression" => {
+				Ok(Data::ReplaceExpression(value.serialize(ser::value::Serializer.wrap())?))
+			}
+			"ContentExpression" => {
+				Ok(Data::ContentExpression(value.serialize(ser::value::Serializer.wrap())?))
+			}
+			"SingleExpression" => {
+				Ok(Data::SingleExpression(value.serialize(ser::value::Serializer.wrap())?))
+			}
+			"ValuesExpression" => {
+				Ok(Data::ValuesExpression(value.serialize(IdiomValueVecVecSerializer.wrap())?))
+			}
+			"UpdateExpression" => {
+				Ok(Data::UpdateExpression(value.serialize(IdiomOperatorValueVecSerializer.wrap())?))
+			}
+			variant => {
+				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
+			}
+		}
+	}
+}
+
+type IdiomOperatorValueTuple = (Idiom, Operator, Value);
+
+struct IdiomOperatorValueVecSerializer;
+
+impl ser::Serializer for IdiomOperatorValueVecSerializer {
+	type Ok = Vec<IdiomOperatorValueTuple>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeIdiomOperatorValueVec;
+	type SerializeTuple = Impossible<Vec<IdiomOperatorValueTuple>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<IdiomOperatorValueTuple>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<IdiomOperatorValueTuple>, Error>;
+	type SerializeMap = Impossible<Vec<IdiomOperatorValueTuple>, Error>;
+	type SerializeStruct = Impossible<Vec<IdiomOperatorValueTuple>, Error>;
+	type SerializeStructVariant = Impossible<Vec<IdiomOperatorValueTuple>, Error>;
+
+	const EXPECTED: &'static str = "an `(Idiom, Operator, Value)`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeIdiomOperatorValueVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+}
+
+struct SerializeIdiomOperatorValueVec(Vec<IdiomOperatorValueTuple>);
+
+impl serde::ser::SerializeSeq for SerializeIdiomOperatorValueVec {
+	type Ok = Vec<IdiomOperatorValueTuple>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(IdiomOperatorValueTupleSerializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+struct IdiomOperatorValueTupleSerializer;
+
+impl ser::Serializer for IdiomOperatorValueTupleSerializer {
+	type Ok = IdiomOperatorValueTuple;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<IdiomOperatorValueTuple, Error>;
+	type SerializeTuple = SerializeIdiomOperatorValueTuple;
+	type SerializeTupleStruct = Impossible<IdiomOperatorValueTuple, Error>;
+	type SerializeTupleVariant = Impossible<IdiomOperatorValueTuple, Error>;
+	type SerializeMap = Impossible<IdiomOperatorValueTuple, Error>;
+	type SerializeStruct = Impossible<IdiomOperatorValueTuple, Error>;
+	type SerializeStructVariant = Impossible<IdiomOperatorValueTuple, Error>;
+
+	const EXPECTED: &'static str = "an `(Idiom, Operator, Value)`";
+
+	fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+		Ok(SerializeIdiomOperatorValueTuple::default())
+	}
+}
+
+#[derive(Default)]
+struct SerializeIdiomOperatorValueTuple {
+	index: usize,
+	idiom: Option<Idiom>,
+	operator: Option<Operator>,
+	value: Option<Value>,
+}
+
+impl serde::ser::SerializeTuple for SerializeIdiomOperatorValueTuple {
+	type Ok = IdiomOperatorValueTuple;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		match self.index {
+			0 => {
+				self.idiom = Some(Idiom(value.serialize(ser::part::vec::Serializer.wrap())?));
+			}
+			1 => {
+				self.operator = Some(value.serialize(ser::operator::Serializer.wrap())?);
+			}
+			2 => {
+				self.value = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			index => {
+				return Err(Error::custom(format!(
+					"unexpected tuple index `{index}` for `(Idiom, Operator, Value)`"
+				)));
+			}
+		}
+		self.index += 1;
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		match (self.idiom, self.operator, self.value) {
+			(Some(idiom), Some(operator), Some(value)) => Ok((idiom, operator, value)),
+			_ => Err(Error::custom("`(Idiom, Operator, Value)` missing required value(s)")),
+		}
+	}
+}
+
+type IdiomValueTuple = (Idiom, Value);
+
+struct IdiomValueVecVecSerializer;
+
+impl ser::Serializer for IdiomValueVecVecSerializer {
+	type Ok = Vec<Vec<IdiomValueTuple>>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeIdiomValueVecVec;
+	type SerializeTuple = Impossible<Vec<Vec<IdiomValueTuple>>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Vec<IdiomValueTuple>>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Vec<IdiomValueTuple>>, Error>;
+	type SerializeMap = Impossible<Vec<Vec<IdiomValueTuple>>, Error>;
+	type SerializeStruct = Impossible<Vec<Vec<IdiomValueTuple>>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Vec<IdiomValueTuple>>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Vec<(Idiom, Value)>>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeIdiomValueVecVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+}
+
+struct SerializeIdiomValueVecVec(Vec<Vec<IdiomValueTuple>>);
+
+impl serde::ser::SerializeSeq for SerializeIdiomValueVecVec {
+	type Ok = Vec<Vec<IdiomValueTuple>>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(IdiomValueVecSerializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+struct IdiomValueVecSerializer;
+
+impl ser::Serializer for IdiomValueVecSerializer {
+	type Ok = Vec<IdiomValueTuple>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeIdiomValueVec;
+	type SerializeTuple = Impossible<Vec<IdiomValueTuple>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<IdiomValueTuple>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<IdiomValueTuple>, Error>;
+	type SerializeMap = Impossible<Vec<IdiomValueTuple>, Error>;
+	type SerializeStruct = Impossible<Vec<IdiomValueTuple>, Error>;
+	type SerializeStructVariant = Impossible<Vec<IdiomValueTuple>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<(Idiom, Value)>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeIdiomValueVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+}
+
+struct SerializeIdiomValueVec(Vec<IdiomValueTuple>);
+
+impl serde::ser::SerializeSeq for SerializeIdiomValueVec {
+	type Ok = Vec<IdiomValueTuple>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(IdiomValueTupleSerializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+struct IdiomValueTupleSerializer;
+
+impl ser::Serializer for IdiomValueTupleSerializer {
+	type Ok = IdiomValueTuple;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<IdiomValueTuple, Error>;
+	type SerializeTuple = SerializeIdiomValueTuple;
+	type SerializeTupleStruct = Impossible<IdiomValueTuple, Error>;
+	type SerializeTupleVariant = Impossible<IdiomValueTuple, Error>;
+	type SerializeMap = Impossible<IdiomValueTuple, Error>;
+	type SerializeStruct = Impossible<IdiomValueTuple, Error>;
+	type SerializeStructVariant = Impossible<IdiomValueTuple, Error>;
+
+	const EXPECTED: &'static str = "an `(Idiom, Value)`";
+
+	fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+		Ok(SerializeIdiomValueTuple::default())
+	}
+}
+
+#[derive(Default)]
+struct SerializeIdiomValueTuple {
+	index: usize,
+	idiom: Option<Idiom>,
+	value: Option<Value>,
+}
+
+impl serde::ser::SerializeTuple for SerializeIdiomValueTuple {
+	type Ok = IdiomValueTuple;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		match self.index {
+			0 => {
+				self.idiom = Some(Idiom(value.serialize(ser::part::vec::Serializer.wrap())?));
+			}
+			1 => {
+				self.value = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			index => {
+				return Err(Error::custom(format!(
+					"unexpected tuple index `{index}` for `(Idiom, Value)`"
+				)));
+			}
+		}
+		self.index += 1;
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		match (self.idiom, self.value) {
+			(Some(idiom), Some(value)) => Ok((idiom, value)),
+			_ => Err(Error::custom("`(Idiom, Value)` missing required value(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty_expression() {
+		let data = Data::EmptyExpression;
+		let serialized = serialize_internal(|| data.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(data, serialized);
+	}
+
+	#[test]
+	fn set_expression() {
+		let data =
+			Data::SetExpression(vec![(Default::default(), Default::default(), Default::default())]);
+		let serialized = serialize_internal(|| data.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(data, serialized);
+	}
+
+	#[test]
+	fn patch_expression() {
+		let data = Data::PatchExpression(Default::default());
+		let serialized = serialize_internal(|| data.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(data, serialized);
+	}
+
+	#[test]
+	fn merge_expression() {
+		let data = Data::MergeExpression(Default::default());
+		let serialized = serialize_internal(|| data.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(data, serialized);
+	}
+
+	#[test]
+	fn replace_expression() {
+		let data = Data::ReplaceExpression(Default::default());
+		let serialized = serialize_internal(|| data.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(data, serialized);
+	}
+
+	#[test]
+	fn content_expression() {
+		let data = Data::ContentExpression(Default::default());
+		let serialized = serialize_internal(|| data.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(data, serialized);
+	}
+
+	#[test]
+	fn single_expression() {
+		let data = Data::SingleExpression(Default::default());
+		let serialized = serialize_internal(|| data.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(data, serialized);
+	}
+
+	#[test]
+	fn values_expression() {
+		let data = Data::ValuesExpression(vec![vec![(Default::default(), Default::default())]]);
+		let serialized = serialize_internal(|| data.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(data, serialized);
+	}
+
+	#[test]
+	fn update_expression() {
+		let data = Data::UpdateExpression(vec![(
+			Default::default(),
+			Default::default(),
+			Default::default(),
+		)]);
+		let serialized = serialize_internal(|| data.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(data, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/data/opt.rs
+++ b/lib/src/sql/value/serde/ser/data/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Data;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Data>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Data>, Error>;
+	type SerializeTuple = Impossible<Option<Data>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Data>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Data>, Error>;
+	type SerializeMap = Impossible<Option<Data>, Error>;
+	type SerializeStruct = Impossible<Option<Data>, Error>;
+	type SerializeStructVariant = Impossible<Option<Data>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Data>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(super::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Data> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(Data::default());
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/datetime/mod.rs
+++ b/lib/src/sql/value/serde/ser/datetime/mod.rs
@@ -1,0 +1,60 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use chrono::offset::Utc;
+use chrono::DateTime;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::Serialize;
+use std::fmt::Display;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = DateTime<Utc>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<DateTime<Utc>, Error>;
+	type SerializeTuple = Impossible<DateTime<Utc>, Error>;
+	type SerializeTupleStruct = Impossible<DateTime<Utc>, Error>;
+	type SerializeTupleVariant = Impossible<DateTime<Utc>, Error>;
+	type SerializeMap = Impossible<DateTime<Utc>, Error>;
+	type SerializeStruct = Impossible<DateTime<Utc>, Error>;
+	type SerializeStructVariant = Impossible<DateTime<Utc>, Error>;
+
+	const EXPECTED: &'static str = "a struct `DateTime<Utc>`";
+
+	#[inline]
+	fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: Display,
+	{
+		value.to_string().parse().map_err(Error::custom)
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn now() {
+		let dt = Utc::now();
+		let serialized = serialize_internal(|| dt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dt, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/decimal/mod.rs
+++ b/lib/src/sql/value/serde/ser/decimal/mod.rs
@@ -1,0 +1,46 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use bigdecimal::BigDecimal;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use std::fmt::Display;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = BigDecimal;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<BigDecimal, Error>;
+	type SerializeTuple = Impossible<BigDecimal, Error>;
+	type SerializeTupleStruct = Impossible<BigDecimal, Error>;
+	type SerializeTupleVariant = Impossible<BigDecimal, Error>;
+	type SerializeMap = Impossible<BigDecimal, Error>;
+	type SerializeStruct = Impossible<BigDecimal, Error>;
+	type SerializeStructVariant = Impossible<BigDecimal, Error>;
+
+	const EXPECTED: &'static str = "a struct `BigDecimal`";
+
+	#[inline]
+	fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: Display,
+	{
+		value.to_string().parse::<BigDecimal>().map_err(Error::custom)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn from_i32() {
+		let decimal = BigDecimal::from(25);
+		let serialized = serialize_internal(|| decimal.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(decimal, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/dir/mod.rs
+++ b/lib/src/sql/value/serde/ser/dir/mod.rs
@@ -1,0 +1,66 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Dir;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Dir;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Dir, Error>;
+	type SerializeTuple = Impossible<Dir, Error>;
+	type SerializeTupleStruct = Impossible<Dir, Error>;
+	type SerializeTupleVariant = Impossible<Dir, Error>;
+	type SerializeMap = Impossible<Dir, Error>;
+	type SerializeStruct = Impossible<Dir, Error>;
+	type SerializeStructVariant = Impossible<Dir, Error>;
+
+	const EXPECTED: &'static str = "an enum `Dir`";
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		match variant {
+			"In" => Ok(Dir::In),
+			"Out" => Ok(Dir::Out),
+			"Both" => Ok(Dir::Both),
+			variant => Err(Error::custom(format!("unexpected unit variant `{name}::{variant}`"))),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn r#in() {
+		let dir = Dir::In;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn out() {
+		let dir = Dir::Out;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn both() {
+		let dir = Dir::Both;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/duration/mod.rs
+++ b/lib/src/sql/value/serde/ser/duration/mod.rs
@@ -1,0 +1,97 @@
+pub(super) mod opt;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+use std::time::Duration;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Duration;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Duration, Error>;
+	type SerializeTuple = Impossible<Duration, Error>;
+	type SerializeTupleStruct = Impossible<Duration, Error>;
+	type SerializeTupleVariant = Impossible<Duration, Error>;
+	type SerializeMap = Impossible<Duration, Error>;
+	type SerializeStruct = SerializeDuration;
+	type SerializeStructVariant = Impossible<Duration, Error>;
+
+	const EXPECTED: &'static str = "a struct `Duration`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeDuration::default())
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeDuration {
+	secs: Option<u64>,
+	nanos: Option<u32>,
+}
+
+impl serde::ser::SerializeStruct for SerializeDuration {
+	type Ok = Duration;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"secs" => {
+				self.secs = Some(value.serialize(ser::primitive::u64::Serializer.wrap())?);
+			}
+			"nanos" => {
+				self.nanos = Some(value.serialize(ser::primitive::u32::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `Duration::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.secs, self.nanos) {
+			(Some(secs), Some(nanos)) => Ok(Duration::new(secs, nanos)),
+			_ => Err(Error::custom("`Duration` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use serde::Serialize;
+
+	#[test]
+	fn default() {
+		let duration = Duration::default();
+		let serialized = serialize_internal(|| duration.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(duration, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/duration/opt.rs
+++ b/lib/src/sql/value/serde/ser/duration/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+use std::time::Duration;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Duration>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Duration>, Error>;
+	type SerializeTuple = Impossible<Option<Duration>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Duration>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Duration>, Error>;
+	type SerializeMap = Impossible<Option<Duration>, Error>;
+	type SerializeStruct = Impossible<Option<Duration>, Error>;
+	type SerializeStructVariant = Impossible<Option<Duration>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Duration>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(super::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Duration> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(Duration::default());
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/edges/mod.rs
+++ b/lib/src/sql/value/serde/ser/edges/mod.rs
@@ -1,0 +1,99 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Dir;
+use crate::sql::Edges;
+use crate::sql::Tables;
+use crate::sql::Thing;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Edges;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Edges, Error>;
+	type SerializeTuple = Impossible<Edges, Error>;
+	type SerializeTupleStruct = Impossible<Edges, Error>;
+	type SerializeTupleVariant = Impossible<Edges, Error>;
+	type SerializeMap = Impossible<Edges, Error>;
+	type SerializeStruct = SerializeEdges;
+	type SerializeStructVariant = Impossible<Edges, Error>;
+
+	const EXPECTED: &'static str = "a struct `Edges`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeEdges::default())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeEdges {
+	dir: Option<Dir>,
+	from: Option<Thing>,
+	what: Option<Tables>,
+}
+
+impl serde::ser::SerializeStruct for SerializeEdges {
+	type Ok = Edges;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"dir" => {
+				self.dir = Some(value.serialize(ser::dir::Serializer.wrap())?);
+			}
+			"from" => {
+				self.from = Some(value.serialize(ser::thing::Serializer.wrap())?);
+			}
+			"what" => {
+				self.what = Some(Tables(value.serialize(ser::table::vec::Serializer.wrap())?));
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `Edges::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.dir, self.from, self.what) {
+			(Some(dir), Some(from), Some(what)) => Ok(Edges {
+				dir,
+				from,
+				what,
+			}),
+			_ => Err(Error::custom("`Edges` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use crate::sql::thing;
+	use serde::Serialize;
+
+	#[test]
+	fn edges() {
+		let edges = Edges {
+			dir: Dir::Both,
+			from: thing("foo:bar").unwrap(),
+			what: Tables(Vec::new()),
+		};
+		let serialized = serialize_internal(|| edges.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(edges, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/expression/mod.rs
+++ b/lib/src/sql/value/serde/ser/expression/mod.rs
@@ -1,0 +1,104 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Expression;
+use crate::sql::Operator;
+use crate::sql::Value;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Expression;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Expression, Error>;
+	type SerializeTuple = Impossible<Expression, Error>;
+	type SerializeTupleStruct = Impossible<Expression, Error>;
+	type SerializeTupleVariant = Impossible<Expression, Error>;
+	type SerializeMap = Impossible<Expression, Error>;
+	type SerializeStruct = SerializeExpression;
+	type SerializeStructVariant = Impossible<Expression, Error>;
+
+	const EXPECTED: &'static str = "a struct `Expression`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeExpression::default())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeExpression {
+	l: Option<Value>,
+	o: Option<Operator>,
+	r: Option<Value>,
+}
+
+impl serde::ser::SerializeStruct for SerializeExpression {
+	type Ok = Expression;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"l" => {
+				self.l = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			"o" => {
+				self.o = Some(value.serialize(ser::operator::Serializer.wrap())?);
+			}
+			"r" => {
+				self.r = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `Expression::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.l, self.o, self.r) {
+			(Some(l), Some(o), Some(r)) => Ok(Expression {
+				l,
+				o,
+				r,
+			}),
+			_ => Err(Error::custom("`Expression` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use serde::Serialize;
+
+	#[test]
+	fn default() {
+		let expression = Expression::default();
+		let serialized = serialize_internal(|| expression.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(expression, serialized);
+	}
+
+	#[test]
+	fn foo_equals_bar() {
+		let expression = Expression {
+			l: "foo".into(),
+			o: Operator::Equal,
+			r: "Bar".into(),
+		};
+		let serialized = serialize_internal(|| expression.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(expression, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/fetch/mod.rs
+++ b/lib/src/sql/value/serde/ser/fetch/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod vec;

--- a/lib/src/sql/value/serde/ser/fetch/vec/mod.rs
+++ b/lib/src/sql/value/serde/ser/fetch/vec/mod.rs
@@ -1,0 +1,81 @@
+pub mod opt;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Fetch;
+use crate::sql::Idiom;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Fetch>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeFetchVec;
+	type SerializeTuple = Impossible<Vec<Fetch>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Fetch>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Fetch>, Error>;
+	type SerializeMap = Impossible<Vec<Fetch>, Error>;
+	type SerializeStruct = Impossible<Vec<Fetch>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Fetch>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Fetch>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeFetchVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializeFetchVec(Vec<Fetch>);
+
+impl serde::ser::SerializeSeq for SerializeFetchVec {
+	type Ok = Vec<Fetch>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(Fetch(Idiom(value.serialize(ser::part::vec::Serializer.wrap())?)));
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Fetch> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Fetch::default()];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/fetch/vec/opt.rs
+++ b/lib/src/sql/value/serde/ser/fetch/vec/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Fetch;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Vec<Fetch>>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Vec<Fetch>>, Error>;
+	type SerializeTuple = Impossible<Option<Vec<Fetch>>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Vec<Fetch>>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Vec<Fetch>>, Error>;
+	type SerializeMap = Impossible<Option<Vec<Fetch>>, Error>;
+	type SerializeStruct = Impossible<Option<Vec<Fetch>>, Error>;
+	type SerializeStructVariant = Impossible<Option<Vec<Fetch>>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Vec<Fetch>>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(super::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Vec<Fetch>> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(vec![Fetch::default()]);
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/field/mod.rs
+++ b/lib/src/sql/value/serde/ser/field/mod.rs
@@ -1,0 +1,139 @@
+pub(super) mod vec;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Field;
+use crate::sql::Idiom;
+use crate::sql::Value;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Field;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Field, Error>;
+	type SerializeTuple = Impossible<Field, Error>;
+	type SerializeTupleStruct = Impossible<Field, Error>;
+	type SerializeTupleVariant = SerializeValueIdiomTuple;
+	type SerializeMap = Impossible<Field, Error>;
+	type SerializeStruct = Impossible<Field, Error>;
+	type SerializeStructVariant = Impossible<Field, Error>;
+
+	const EXPECTED: &'static str = "an enum `Field`";
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		match variant {
+			"All" => Ok(Field::All),
+			variant => Err(Error::custom(format!("unexpected unit variant `{name}::{variant}`"))),
+		}
+	}
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"Alone" => Ok(Field::Alone(value.serialize(ser::value::Serializer.wrap())?)),
+			variant => {
+				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
+			}
+		}
+	}
+
+	fn serialize_tuple_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeTupleVariant, Self::Error> {
+		match variant {
+			"Alias" => Ok(SerializeValueIdiomTuple::default()),
+			variant => Err(Error::custom(format!("unexpected tuple variant `{name}::{variant}`"))),
+		}
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeValueIdiomTuple {
+	index: usize,
+	value: Option<Value>,
+	idiom: Option<Idiom>,
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeValueIdiomTuple {
+	type Ok = Field;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		match self.index {
+			0 => {
+				self.value = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			1 => {
+				self.idiom = Some(Idiom(value.serialize(ser::part::vec::Serializer.wrap())?));
+			}
+			index => {
+				return Err(Error::custom(format!("unexpected `Field::Alias` index `{index}`")));
+			}
+		}
+		self.index += 1;
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		match (self.value, self.idiom) {
+			(Some(value), Some(idiom)) => Ok(Field::Alias(value, idiom)),
+			_ => Err(Error::custom("`Field::Alias` missing required value(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use serde::Serialize;
+
+	#[test]
+	fn all() {
+		let field = Field::All;
+		let serialized = serialize_internal(|| field.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(field, serialized);
+	}
+
+	#[test]
+	fn alone() {
+		let field = Field::Alone(Default::default());
+		let serialized = serialize_internal(|| field.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(field, serialized);
+	}
+
+	#[test]
+	fn alias() {
+		let field = Field::Alias(Default::default(), Default::default());
+		let serialized = serialize_internal(|| field.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(field, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/field/vec.rs
+++ b/lib/src/sql/value/serde/ser/field/vec.rs
@@ -1,0 +1,78 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Field;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Field>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeFieldVec;
+	type SerializeTuple = Impossible<Vec<Field>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Field>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Field>, Error>;
+	type SerializeMap = Impossible<Vec<Field>, Error>;
+	type SerializeStruct = Impossible<Vec<Field>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Field>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Field>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeFieldVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializeFieldVec(Vec<Field>);
+
+impl serde::ser::SerializeSeq for SerializeFieldVec {
+	type Ok = Vec<Field>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(ser::field::Serializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Field> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Field::default()];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/fields/mod.rs
+++ b/lib/src/sql/value/serde/ser/fields/mod.rs
@@ -1,0 +1,91 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Field;
+use crate::sql::Fields;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Fields;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Fields, Error>;
+	type SerializeTuple = Impossible<Fields, Error>;
+	type SerializeTupleStruct = SerializeFields;
+	type SerializeTupleVariant = Impossible<Fields, Error>;
+	type SerializeMap = Impossible<Fields, Error>;
+	type SerializeStruct = Impossible<Fields, Error>;
+	type SerializeStructVariant = Impossible<Fields, Error>;
+
+	const EXPECTED: &'static str = "a struct `Fields`";
+
+	fn serialize_tuple_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeTupleStruct, Error> {
+		Ok(SerializeFields::default())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeFields {
+	index: usize,
+	fields: Option<Vec<Field>>,
+	boolean: Option<bool>,
+}
+
+impl serde::ser::SerializeTupleStruct for SerializeFields {
+	type Ok = Fields;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		match self.index {
+			0 => {
+				self.fields = Some(value.serialize(ser::field::vec::Serializer.wrap())?);
+			}
+			1 => {
+				self.boolean = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			index => {
+				return Err(Error::custom(format!("unexpected `Fields` index `{index}`")));
+			}
+		}
+		self.index += 1;
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		match (self.fields, self.boolean) {
+			(Some(fields), Some(boolean)) => Ok(Fields(fields, boolean)),
+			_ => Err(Error::custom("`Fields` missing required value(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let fields = Fields::default();
+		let serialized = serialize_internal(|| fields.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(fields, serialized);
+	}
+
+	#[test]
+	fn all() {
+		let fields = Fields(vec![Field::All], true);
+		let serialized = serialize_internal(|| fields.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(fields, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/function/mod.rs
+++ b/lib/src/sql/value/serde/ser/function/mod.rs
@@ -1,0 +1,153 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Function;
+use crate::sql::Script;
+use crate::sql::Value;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Function;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Function, Error>;
+	type SerializeTuple = Impossible<Function, Error>;
+	type SerializeTupleStruct = Impossible<Function, Error>;
+	type SerializeTupleVariant = SerializeFunction;
+	type SerializeMap = Impossible<Function, Error>;
+	type SerializeStruct = Impossible<Function, Error>;
+	type SerializeStructVariant = Impossible<Function, Error>;
+
+	const EXPECTED: &'static str = "an enum `Function`";
+
+	fn serialize_tuple_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeTupleVariant, Self::Error> {
+		let inner = match variant {
+			"Cast" => Inner::Cast(None, None),
+			"Normal" => Inner::Normal(None, None),
+			"Custom" => Inner::Custom(None, None),
+			"Script" => Inner::Script(None, None),
+			variant => {
+				return Err(Error::custom(format!("unexpected tuple variant `{name}::{variant}`")));
+			}
+		};
+		Ok(SerializeFunction {
+			inner,
+			index: 0,
+		})
+	}
+}
+
+pub(super) struct SerializeFunction {
+	index: usize,
+	inner: Inner,
+}
+
+enum Inner {
+	Cast(Option<String>, Option<Value>),
+	Normal(Option<String>, Option<Vec<Value>>),
+	Custom(Option<String>, Option<Vec<Value>>),
+	Script(Option<Script>, Option<Vec<Value>>),
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeFunction {
+	type Ok = Function;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		match (self.index, &mut self.inner) {
+			(
+				0,
+				Inner::Cast(ref mut var, _)
+				| Inner::Normal(ref mut var, _)
+				| Inner::Custom(ref mut var, _),
+			) => {
+				*var = Some(value.serialize(ser::string::Serializer.wrap())?);
+			}
+			(0, Inner::Script(ref mut var, _)) => {
+				*var = Some(Script(value.serialize(ser::string::Serializer.wrap())?));
+			}
+			(1, Inner::Cast(_, ref mut var)) => {
+				*var = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			(
+				1,
+				Inner::Normal(_, ref mut var)
+				| Inner::Custom(_, ref mut var)
+				| Inner::Script(_, ref mut var),
+			) => {
+				*var = Some(value.serialize(ser::value::vec::Serializer.wrap())?);
+			}
+			(index, inner) => {
+				let variant = match inner {
+					Inner::Cast(..) => "Cast",
+					Inner::Normal(..) => "Normal",
+					Inner::Custom(..) => "Custom",
+					Inner::Script(..) => "Script",
+				};
+				return Err(Error::custom(format!(
+					"unexpected `Function::{variant}` index `{index}`"
+				)));
+			}
+		}
+		self.index += 1;
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		match self.inner {
+			Inner::Cast(Some(one), Some(two)) => Ok(Function::Cast(one, two)),
+			Inner::Normal(Some(one), Some(two)) => Ok(Function::Normal(one, two)),
+			Inner::Custom(Some(one), Some(two)) => Ok(Function::Custom(one, two)),
+			Inner::Script(Some(one), Some(two)) => Ok(Function::Script(one, two)),
+			_ => Err(Error::custom("`Function` missing required value(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use serde::Serialize;
+
+	#[test]
+	fn cast() {
+		let function = Function::Cast(Default::default(), Default::default());
+		let serialized = serialize_internal(|| function.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(function, serialized);
+	}
+
+	#[test]
+	fn normal() {
+		let function = Function::Normal(Default::default(), vec![Default::default()]);
+		let serialized = serialize_internal(|| function.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(function, serialized);
+	}
+
+	#[test]
+	fn custom() {
+		let function = Function::Custom(Default::default(), vec![Default::default()]);
+		let serialized = serialize_internal(|| function.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(function, serialized);
+	}
+
+	#[test]
+	fn script() {
+		let function = Function::Script(Default::default(), vec![Default::default()]);
+		let serialized = serialize_internal(|| function.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(function, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/geometry/coord/mod.rs
+++ b/lib/src/sql/value/serde/ser/geometry/coord/mod.rs
@@ -1,0 +1,99 @@
+pub mod vec;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use geo::Coord;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Coord<f64>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Coord<f64>, Error>;
+	type SerializeTuple = Impossible<Coord<f64>, Error>;
+	type SerializeTupleStruct = Impossible<Coord<f64>, Error>;
+	type SerializeTupleVariant = Impossible<Coord<f64>, Error>;
+	type SerializeMap = Impossible<Coord<f64>, Error>;
+	type SerializeStruct = SerializeCoord;
+	type SerializeStructVariant = Impossible<Coord<f64>, Error>;
+
+	const EXPECTED: &'static str = "a struct `Coord<f64>`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeCoord::default())
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeCoord {
+	x: Option<f64>,
+	y: Option<f64>,
+}
+
+impl serde::ser::SerializeStruct for SerializeCoord {
+	type Ok = Coord;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"x" => {
+				self.x = Some(value.serialize(ser::primitive::f64::Serializer.wrap())?);
+			}
+			"y" => {
+				self.y = Some(value.serialize(ser::primitive::f64::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `Coord::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.x, self.y) {
+			(Some(x), Some(y)) => Ok(Coord {
+				x,
+				y,
+			}),
+			_ => Err(Error::custom("`Coord` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let coord = Coord::default();
+		let serialized = serialize_internal(|| coord.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(coord, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/geometry/coord/vec.rs
+++ b/lib/src/sql/value/serde/ser/geometry/coord/vec.rs
@@ -1,0 +1,78 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use geo::Coord;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Coord<f64>>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeCoordVec;
+	type SerializeTuple = Impossible<Vec<Coord<f64>>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Coord<f64>>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Coord<f64>>, Error>;
+	type SerializeMap = Impossible<Vec<Coord<f64>>, Error>;
+	type SerializeStruct = Impossible<Vec<Coord<f64>>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Coord<f64>>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Coord<f64>>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeCoordVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializeCoordVec(Vec<Coord<f64>>);
+
+impl serde::ser::SerializeSeq for SerializeCoordVec {
+	type Ok = Vec<Coord<f64>>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(super::Serializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Coord<f64>> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Coord::default()];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/geometry/line_string/mod.rs
+++ b/lib/src/sql/value/serde/ser/geometry/line_string/mod.rs
@@ -1,0 +1,1 @@
+pub mod vec;

--- a/lib/src/sql/value/serde/ser/geometry/line_string/vec.rs
+++ b/lib/src/sql/value/serde/ser/geometry/line_string/vec.rs
@@ -1,0 +1,79 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use geo::LineString;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<LineString<f64>>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeLineStringVec;
+	type SerializeTuple = Impossible<Vec<LineString<f64>>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<LineString<f64>>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<LineString<f64>>, Error>;
+	type SerializeMap = Impossible<Vec<LineString<f64>>, Error>;
+	type SerializeStruct = Impossible<Vec<LineString<f64>>, Error>;
+	type SerializeStructVariant = Impossible<Vec<LineString<f64>>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<LineString<f64>>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeLineStringVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializeLineStringVec(Vec<LineString<f64>>);
+
+impl serde::ser::SerializeSeq for SerializeLineStringVec {
+	type Ok = Vec<LineString<f64>>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(LineString(value.serialize(ser::geometry::coord::vec::Serializer.wrap())?));
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use geo::Coord;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<LineString<f64>> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![LineString(vec![Coord::default()])];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/geometry/mod.rs
+++ b/lib/src/sql/value/serde/ser/geometry/mod.rs
@@ -1,0 +1,156 @@
+pub(super) mod coord;
+pub(super) mod line_string;
+pub(super) mod point;
+pub(super) mod polygon;
+pub(super) mod vec;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Geometry;
+use geo::LineString;
+use geo::MultiLineString;
+use geo::MultiPoint;
+use geo::MultiPolygon;
+use geo::Point;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Geometry;
+	type Error = Error;
+
+	type SerializeSeq = SerializeGeometryVec;
+	type SerializeTuple = Impossible<Geometry, Error>;
+	type SerializeTupleStruct = Impossible<Geometry, Error>;
+	type SerializeTupleVariant = Impossible<Geometry, Error>;
+	type SerializeMap = Impossible<Geometry, Error>;
+	type SerializeStruct = Impossible<Geometry, Error>;
+	type SerializeStructVariant = Impossible<Geometry, Error>;
+
+	const EXPECTED: &'static str = "an enum `Geometry`";
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"Point" => Ok(Geometry::Point(Point(
+				value.serialize(ser::geometry::coord::Serializer.wrap())?,
+			))),
+			"Line" => Ok(Geometry::Line(LineString(
+				value.serialize(ser::geometry::coord::vec::Serializer.wrap())?,
+			))),
+			"Polygon" => {
+				Ok(Geometry::Polygon(value.serialize(ser::geometry::polygon::Serializer.wrap())?))
+			}
+			"MultiPoint" => Ok(Geometry::MultiPoint(MultiPoint(
+				value.serialize(ser::geometry::point::vec::Serializer.wrap())?,
+			))),
+			"MultiLine" => Ok(Geometry::MultiLine(MultiLineString(
+				value.serialize(ser::geometry::line_string::vec::Serializer.wrap())?,
+			))),
+			"MultiPolygon" => Ok(Geometry::MultiPolygon(MultiPolygon(
+				value.serialize(ser::geometry::polygon::vec::Serializer.wrap())?,
+			))),
+			"Collection" => {
+				Ok(Geometry::Collection(value.serialize(ser::geometry::vec::Serializer.wrap())?))
+			}
+			variant => {
+				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
+			}
+		}
+	}
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		let serialize_seq = vec::SerializeGeometryVec(Vec::with_capacity(len.unwrap_or_default()));
+		Ok(SerializeGeometryVec(serialize_seq))
+	}
+}
+
+pub(super) struct SerializeGeometryVec(vec::SerializeGeometryVec);
+
+impl serde::ser::SerializeSeq for SerializeGeometryVec {
+	type Ok = Geometry;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.serialize_element(value)
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(Geometry::Collection(self.0.end()?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use geo::Coord;
+	use geo::Polygon;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn point() {
+		let geometry = Geometry::Point(Default::default());
+		let serialized = serialize_internal(|| geometry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(geometry, serialized);
+	}
+
+	#[test]
+	fn line() {
+		let geometry = Geometry::Line(LineString(vec![Coord::default()]));
+		let serialized = serialize_internal(|| geometry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(geometry, serialized);
+	}
+
+	#[test]
+	fn polygon() {
+		let polygon = Polygon::new(LineString(Vec::new()), Vec::new());
+		let geometry = Geometry::Polygon(polygon);
+		let serialized = serialize_internal(|| geometry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(geometry, serialized);
+	}
+
+	#[test]
+	fn multi_point() {
+		let geometry = Geometry::MultiPoint(vec![(0., 0.), (1., 2.)].into());
+		let serialized = serialize_internal(|| geometry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(geometry, serialized);
+	}
+
+	#[test]
+	fn multi_line() {
+		let geometry = Geometry::MultiLine(MultiLineString::new(Vec::new()));
+		let serialized = serialize_internal(|| geometry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(geometry, serialized);
+	}
+
+	#[test]
+	fn multi_polygon() {
+		let geometry = Geometry::MultiPolygon(MultiPolygon::new(Vec::new()));
+		let serialized = serialize_internal(|| geometry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(geometry, serialized);
+	}
+
+	#[test]
+	fn collection() {
+		let geometry = Geometry::Collection(vec![Geometry::Point(Default::default())]);
+		let serialized = serialize_internal(|| geometry.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(geometry, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/geometry/point/mod.rs
+++ b/lib/src/sql/value/serde/ser/geometry/point/mod.rs
@@ -1,0 +1,1 @@
+pub mod vec;

--- a/lib/src/sql/value/serde/ser/geometry/point/vec.rs
+++ b/lib/src/sql/value/serde/ser/geometry/point/vec.rs
@@ -1,0 +1,78 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use geo::Point;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Point<f64>>;
+	type Error = Error;
+
+	type SerializeSeq = SerializePointVec;
+	type SerializeTuple = Impossible<Vec<Point<f64>>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Point<f64>>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Point<f64>>, Error>;
+	type SerializeMap = Impossible<Vec<Point<f64>>, Error>;
+	type SerializeStruct = Impossible<Vec<Point<f64>>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Point<f64>>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Point<f64>>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializePointVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializePointVec(Vec<Point<f64>>);
+
+impl serde::ser::SerializeSeq for SerializePointVec {
+	type Ok = Vec<Point<f64>>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(Point(value.serialize(ser::geometry::coord::Serializer.wrap())?));
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Point<f64>> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Point::default()];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/geometry/polygon/mod.rs
+++ b/lib/src/sql/value/serde/ser/geometry/polygon/mod.rs
@@ -1,0 +1,88 @@
+pub mod vec;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use geo::LineString;
+use geo::Polygon;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Polygon<f64>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Polygon<f64>, Error>;
+	type SerializeTuple = Impossible<Polygon<f64>, Error>;
+	type SerializeTupleStruct = Impossible<Polygon<f64>, Error>;
+	type SerializeTupleVariant = Impossible<Polygon<f64>, Error>;
+	type SerializeMap = Impossible<Polygon<f64>, Error>;
+	type SerializeStruct = SerializePolygon;
+	type SerializeStructVariant = Impossible<Polygon<f64>, Error>;
+
+	const EXPECTED: &'static str = "a struct `Polygon<f64>`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializePolygon::default())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializePolygon {
+	exterior: Option<LineString<f64>>,
+	interiors: Option<Vec<LineString<f64>>>,
+}
+
+impl serde::ser::SerializeStruct for SerializePolygon {
+	type Ok = Polygon<f64>;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"exterior" => {
+				self.exterior = Some(LineString(
+					value.serialize(ser::geometry::coord::vec::Serializer.wrap())?,
+				));
+			}
+			"interiors" => {
+				self.interiors =
+					Some(value.serialize(ser::geometry::line_string::vec::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `Polygon::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.exterior, self.interiors) {
+			(Some(exterior), Some(interiors)) => Ok(Polygon::new(exterior, interiors)),
+			_ => Err(Error::custom("`Polygon` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let polygon = Polygon::new(LineString(Vec::new()), Vec::new());
+		let serialized = serialize_internal(|| polygon.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(polygon, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/geometry/polygon/vec.rs
+++ b/lib/src/sql/value/serde/ser/geometry/polygon/vec.rs
@@ -1,0 +1,79 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use geo::Polygon;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Polygon<f64>>;
+	type Error = Error;
+
+	type SerializeSeq = SerializePolygonVec;
+	type SerializeTuple = Impossible<Vec<Polygon<f64>>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Polygon<f64>>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Polygon<f64>>, Error>;
+	type SerializeMap = Impossible<Vec<Polygon<f64>>, Error>;
+	type SerializeStruct = Impossible<Vec<Polygon<f64>>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Polygon<f64>>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Polygon<f64>>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializePolygonVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializePolygonVec(Vec<Polygon<f64>>);
+
+impl serde::ser::SerializeSeq for SerializePolygonVec {
+	type Ok = Vec<Polygon<f64>>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(super::Serializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use geo::LineString;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Polygon<f64>> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Polygon::new(LineString(Vec::new()), Vec::new())];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/geometry/vec.rs
+++ b/lib/src/sql/value/serde/ser/geometry/vec.rs
@@ -1,0 +1,66 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Geometry;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Geometry>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeGeometryVec;
+	type SerializeTuple = Impossible<Vec<Geometry>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Geometry>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Geometry>, Error>;
+	type SerializeMap = Impossible<Vec<Geometry>, Error>;
+	type SerializeStruct = Impossible<Vec<Geometry>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Geometry>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Geometry>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeGeometryVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+}
+
+pub struct SerializeGeometryVec(pub(super) Vec<Geometry>);
+
+impl serde::ser::SerializeSeq for SerializeGeometryVec {
+	type Ok = Vec<Geometry>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(ser::geometry::Serializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Geometry> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Geometry::Point(Default::default())];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/graph/mod.rs
+++ b/lib/src/sql/value/serde/ser/graph/mod.rs
@@ -1,0 +1,120 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Cond;
+use crate::sql::Dir;
+use crate::sql::Graph;
+use crate::sql::Idiom;
+use crate::sql::Tables;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Graph;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Graph, Error>;
+	type SerializeTuple = Impossible<Graph, Error>;
+	type SerializeTupleStruct = Impossible<Graph, Error>;
+	type SerializeTupleVariant = Impossible<Graph, Error>;
+	type SerializeMap = Impossible<Graph, Error>;
+	type SerializeStruct = SerializeGraph;
+	type SerializeStructVariant = Impossible<Graph, Error>;
+
+	const EXPECTED: &'static str = "a struct `Graph`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeGraph::default())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeGraph {
+	dir: Option<Dir>,
+	what: Option<Tables>,
+	cond: Option<Cond>,
+	alias: Option<Idiom>,
+}
+
+impl serde::ser::SerializeStruct for SerializeGraph {
+	type Ok = Graph;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"dir" => {
+				self.dir = Some(value.serialize(ser::dir::Serializer.wrap())?);
+			}
+			"what" => {
+				self.what = Some(Tables(value.serialize(ser::table::vec::Serializer.wrap())?));
+			}
+			"cond" => {
+				self.cond = value.serialize(ser::cond::opt::Serializer.wrap())?;
+			}
+			"alias" => {
+				self.alias = value.serialize(ser::part::vec::opt::Serializer.wrap())?.map(Idiom);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `Graph::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.dir, self.what) {
+			(Some(dir), Some(what)) => Ok(Graph {
+				dir,
+				what,
+				cond: self.cond,
+				alias: self.alias,
+			}),
+			_ => Err(Error::custom("`Graph` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use serde::Serialize;
+
+	#[test]
+	fn default() {
+		let graph = Graph::default();
+		let serialized = serialize_internal(|| graph.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(graph, serialized);
+	}
+
+	#[test]
+	fn with_cond() {
+		let graph = Graph {
+			cond: Some(Default::default()),
+			..Default::default()
+		};
+		let serialized = serialize_internal(|| graph.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(graph, serialized);
+	}
+
+	#[test]
+	fn with_alias() {
+		let graph = Graph {
+			alias: Some(Default::default()),
+			..Default::default()
+		};
+		let serialized = serialize_internal(|| graph.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(graph, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/group/mod.rs
+++ b/lib/src/sql/value/serde/ser/group/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod vec;

--- a/lib/src/sql/value/serde/ser/group/vec/mod.rs
+++ b/lib/src/sql/value/serde/ser/group/vec/mod.rs
@@ -1,0 +1,81 @@
+pub mod opt;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Group;
+use crate::sql::Idiom;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Group>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeGroupVec;
+	type SerializeTuple = Impossible<Vec<Group>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Group>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Group>, Error>;
+	type SerializeMap = Impossible<Vec<Group>, Error>;
+	type SerializeStruct = Impossible<Vec<Group>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Group>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Group>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeGroupVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializeGroupVec(Vec<Group>);
+
+impl serde::ser::SerializeSeq for SerializeGroupVec {
+	type Ok = Vec<Group>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(Group(Idiom(value.serialize(ser::part::vec::Serializer.wrap())?)));
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Group> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Group::default()];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/group/vec/opt.rs
+++ b/lib/src/sql/value/serde/ser/group/vec/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Group;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Vec<Group>>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Vec<Group>>, Error>;
+	type SerializeTuple = Impossible<Option<Vec<Group>>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Vec<Group>>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Vec<Group>>, Error>;
+	type SerializeMap = Impossible<Option<Vec<Group>>, Error>;
+	type SerializeStruct = Impossible<Option<Vec<Group>>, Error>;
+	type SerializeStructVariant = Impossible<Option<Vec<Group>>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Vec<Group>>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(super::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Vec<Group>> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(vec![Group::default()]);
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/id/mod.rs
+++ b/lib/src/sql/value/serde/ser/id/mod.rs
@@ -1,0 +1,85 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Array;
+use crate::sql::Id;
+use crate::sql::Object;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Id;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Id, Error>;
+	type SerializeTuple = Impossible<Id, Error>;
+	type SerializeTupleStruct = Impossible<Id, Error>;
+	type SerializeTupleVariant = Impossible<Id, Error>;
+	type SerializeMap = Impossible<Id, Error>;
+	type SerializeStruct = Impossible<Id, Error>;
+	type SerializeStructVariant = Impossible<Id, Error>;
+
+	const EXPECTED: &'static str = "an enum `Id`";
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"Number" => Ok(Id::Number(value.serialize(ser::primitive::i64::Serializer.wrap())?)),
+			"String" => Ok(Id::String(value.serialize(ser::string::Serializer.wrap())?)),
+			"Array" => Ok(Id::Array(Array(value.serialize(ser::value::vec::Serializer.wrap())?))),
+			"Object" => {
+				Ok(Id::Object(Object(value.serialize(ser::value::map::Serializer.wrap())?)))
+			}
+			variant => {
+				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn number() {
+		let id = Id::Number(Default::default());
+		let serialized = serialize_internal(|| id.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(id, serialized);
+	}
+
+	#[test]
+	fn string() {
+		let id = Id::String(Default::default());
+		let serialized = serialize_internal(|| id.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(id, serialized);
+	}
+
+	#[test]
+	fn array() {
+		let id = Id::Array(Default::default());
+		let serialized = serialize_internal(|| id.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(id, serialized);
+	}
+
+	#[test]
+	fn object() {
+		let id = Id::Object(Default::default());
+		let serialized = serialize_internal(|| id.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(id, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/limit/mod.rs
+++ b/lib/src/sql/value/serde/ser/limit/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod opt;

--- a/lib/src/sql/value/serde/ser/limit/opt.rs
+++ b/lib/src/sql/value/serde/ser/limit/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Limit;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Limit>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Limit>, Error>;
+	type SerializeTuple = Impossible<Option<Limit>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Limit>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Limit>, Error>;
+	type SerializeMap = Impossible<Option<Limit>, Error>;
+	type SerializeStruct = Impossible<Option<Limit>, Error>;
+	type SerializeStructVariant = Impossible<Option<Limit>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Limit>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(Limit(value.serialize(ser::value::Serializer.wrap())?)))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Limit> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(Limit::default());
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/mod.rs
+++ b/lib/src/sql/value/serde/ser/mod.rs
@@ -1,0 +1,480 @@
+mod block;
+mod cond;
+mod constant;
+mod data;
+mod datetime;
+mod decimal;
+mod dir;
+mod duration;
+mod edges;
+mod expression;
+mod fetch;
+mod field;
+mod fields;
+mod function;
+mod geometry;
+mod graph;
+mod group;
+mod id;
+mod limit;
+mod model;
+mod number;
+mod operator;
+mod order;
+mod output;
+mod part;
+mod primitive;
+mod range;
+mod split;
+mod start;
+mod statement;
+mod string;
+mod subquery;
+mod table;
+mod thing;
+mod timeout;
+mod uuid;
+mod value;
+mod version;
+
+use serde::ser::Error;
+use serde::ser::Serialize;
+use serde::ser::SerializeMap;
+use serde::ser::SerializeSeq;
+use serde::ser::SerializeStruct;
+use serde::ser::SerializeStructVariant;
+use serde::ser::SerializeTuple;
+use serde::ser::SerializeTupleStruct;
+use serde::ser::SerializeTupleVariant;
+use std::fmt::Display;
+
+pub(crate) use value::to_value;
+
+trait Serializer: Sized {
+	type Ok;
+	type Error: Error;
+
+	type SerializeSeq: SerializeSeq<Ok = Self::Ok, Error = Self::Error>;
+	type SerializeTuple: SerializeTuple<Ok = Self::Ok, Error = Self::Error>;
+	type SerializeTupleStruct: SerializeTupleStruct<Ok = Self::Ok, Error = Self::Error>;
+	type SerializeTupleVariant: SerializeTupleVariant<Ok = Self::Ok, Error = Self::Error>;
+	type SerializeMap: SerializeMap<Ok = Self::Ok, Error = Self::Error>;
+	type SerializeStruct: SerializeStruct<Ok = Self::Ok, Error = Self::Error>;
+	type SerializeStructVariant: SerializeStructVariant<Ok = Self::Ok, Error = Self::Error>;
+
+	const EXPECTED: &'static str;
+
+	fn unexpected(typ: &str, value: Option<impl Display>) -> Self::Error {
+		let message = match value {
+			Some(value) => format!("unexpected {typ} `{value}`, expected {}", Self::EXPECTED),
+			None => format!("unexpected {typ}, expected {}", Self::EXPECTED),
+		};
+		Self::Error::custom(message)
+	}
+
+	#[inline]
+	fn wrap(self) -> Wrapper<Self> {
+		Wrapper(self)
+	}
+
+	fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("bool", Some(value)))
+	}
+
+	fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("i8", Some(value)))
+	}
+
+	fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("i16", Some(value)))
+	}
+
+	fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("i32", Some(value)))
+	}
+
+	fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("i64", Some(value)))
+	}
+
+	fn serialize_i128(self, value: i128) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("i128", Some(value)))
+	}
+
+	fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("u8", Some(value)))
+	}
+
+	fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("u16", Some(value)))
+	}
+
+	fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("u32", Some(value)))
+	}
+
+	fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("u64", Some(value)))
+	}
+
+	fn serialize_u128(self, value: u128) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("u128", Some(value)))
+	}
+
+	fn serialize_f32(self, value: f32) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("f32", Some(value)))
+	}
+
+	fn serialize_f64(self, value: f64) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("f64", Some(value)))
+	}
+
+	fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("char", Some(value)))
+	}
+
+	fn serialize_str(self, _value: &str) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("str", None::<String>))
+	}
+
+	fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("bytes", None::<String>))
+	}
+
+	fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("unit", None::<String>))
+	}
+
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("unit variant", Some(format!("{name}::{variant}"))))
+	}
+
+	fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("unit struct", Some(name)))
+	}
+
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		_variant: &'static str,
+		_value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Err(Self::unexpected("newtype variant", Some(name)))
+	}
+
+	fn serialize_newtype_struct<T>(
+		self,
+		name: &'static str,
+		_value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Err(Self::unexpected("newtype struct", Some(name)))
+	}
+
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Err(Self::unexpected("none", None::<String>))
+	}
+
+	fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Err(Self::unexpected("some", None::<String>))
+	}
+
+	fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+		Err(Self::unexpected("sequence", None::<String>))
+	}
+
+	fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+		Err(Self::unexpected("tuple", None::<String>))
+	}
+
+	fn serialize_tuple_struct(
+		self,
+		name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeTupleStruct, Self::Error> {
+		Err(Self::unexpected("tuple struct", Some(name)))
+	}
+
+	fn serialize_tuple_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		_variant: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeTupleVariant, Self::Error> {
+		Err(Self::unexpected("tuple variant", Some(name)))
+	}
+
+	fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+		Err(Self::unexpected("map", None::<String>))
+	}
+
+	fn serialize_struct(
+		self,
+		name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Self::Error> {
+		Err(Self::unexpected("struct", Some(name)))
+	}
+
+	fn serialize_struct_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		_variant: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStructVariant, Self::Error> {
+		Err(Self::unexpected("struct variant", Some(name)))
+	}
+
+	fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: Display,
+	{
+		self.serialize_str(&value.to_string())
+	}
+
+	#[inline]
+	fn is_human_readable(&self) -> bool {
+		false
+	}
+}
+
+struct Wrapper<S: Serializer>(S);
+
+impl<S> serde::ser::Serializer for Wrapper<S>
+where
+	S: Serializer,
+{
+	type Ok = S::Ok;
+	type Error = S::Error;
+
+	type SerializeSeq = S::SerializeSeq;
+	type SerializeTuple = S::SerializeTuple;
+	type SerializeTupleStruct = S::SerializeTupleStruct;
+	type SerializeTupleVariant = S::SerializeTupleVariant;
+	type SerializeMap = S::SerializeMap;
+	type SerializeStruct = S::SerializeStruct;
+	type SerializeStructVariant = S::SerializeStructVariant;
+
+	#[inline]
+	fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_bool(value)
+	}
+
+	#[inline]
+	fn serialize_i8(self, value: i8) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_i8(value)
+	}
+
+	#[inline]
+	fn serialize_i16(self, value: i16) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_i16(value)
+	}
+
+	#[inline]
+	fn serialize_i32(self, value: i32) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_i32(value)
+	}
+
+	#[inline]
+	fn serialize_i64(self, value: i64) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_i64(value)
+	}
+
+	#[inline]
+	fn serialize_i128(self, value: i128) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_i128(value)
+	}
+
+	#[inline]
+	fn serialize_u8(self, value: u8) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_u8(value)
+	}
+
+	#[inline]
+	fn serialize_u16(self, value: u16) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_u16(value)
+	}
+
+	#[inline]
+	fn serialize_u32(self, value: u32) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_u32(value)
+	}
+
+	#[inline]
+	fn serialize_u64(self, value: u64) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_u64(value)
+	}
+
+	#[inline]
+	fn serialize_u128(self, value: u128) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_u128(value)
+	}
+
+	#[inline]
+	fn serialize_f32(self, value: f32) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_f32(value)
+	}
+
+	#[inline]
+	fn serialize_f64(self, value: f64) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_f64(value)
+	}
+
+	#[inline]
+	fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_char(value)
+	}
+
+	#[inline]
+	fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_str(value)
+	}
+
+	#[inline]
+	fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_bytes(value)
+	}
+
+	#[inline]
+	fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_unit()
+	}
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_unit_variant(name, variant_index, variant)
+	}
+
+	#[inline]
+	fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_unit_struct(name)
+	}
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		self.0.serialize_newtype_variant(name, variant_index, variant, value)
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		self.0.serialize_newtype_struct(name, value)
+	}
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		self.0.serialize_none()
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		self.0.serialize_some(value)
+	}
+
+	#[inline]
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+		self.0.serialize_seq(len)
+	}
+
+	#[inline]
+	fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+		self.0.serialize_tuple(len)
+	}
+
+	#[inline]
+	fn serialize_tuple_struct(
+		self,
+		name: &'static str,
+		len: usize,
+	) -> Result<Self::SerializeTupleStruct, Self::Error> {
+		self.0.serialize_tuple_struct(name, len)
+	}
+
+	#[inline]
+	fn serialize_tuple_variant(
+		self,
+		name: &'static str,
+		variant_index: u32,
+		variant: &'static str,
+		len: usize,
+	) -> Result<Self::SerializeTupleVariant, Self::Error> {
+		self.0.serialize_tuple_variant(name, variant_index, variant, len)
+	}
+
+	#[inline]
+	fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+		self.0.serialize_map(len)
+	}
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		name: &'static str,
+		len: usize,
+	) -> Result<Self::SerializeStruct, Self::Error> {
+		self.0.serialize_struct(name, len)
+	}
+
+	#[inline]
+	fn serialize_struct_variant(
+		self,
+		name: &'static str,
+		variant_index: u32,
+		variant: &'static str,
+		len: usize,
+	) -> Result<Self::SerializeStructVariant, Self::Error> {
+		self.0.serialize_struct_variant(name, variant_index, variant, len)
+	}
+
+	#[inline]
+	fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: Display,
+	{
+		self.0.collect_str(value)
+	}
+
+	#[inline]
+	fn is_human_readable(&self) -> bool {
+		self.0.is_human_readable()
+	}
+}

--- a/lib/src/sql/value/serde/ser/model/mod.rs
+++ b/lib/src/sql/value/serde/ser/model/mod.rs
@@ -1,0 +1,116 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Model;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Model;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Model, Error>;
+	type SerializeTuple = Impossible<Model, Error>;
+	type SerializeTupleStruct = Impossible<Model, Error>;
+	type SerializeTupleVariant = SerializeModel;
+	type SerializeMap = Impossible<Model, Error>;
+	type SerializeStruct = Impossible<Model, Error>;
+	type SerializeStructVariant = Impossible<Model, Error>;
+
+	const EXPECTED: &'static str = "an enum `Model`";
+
+	fn serialize_tuple_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeTupleVariant, Self::Error> {
+		let inner = match variant {
+			"Count" => Inner::Count(None, None),
+			"Range" => Inner::Range(None, None, None),
+			variant => {
+				return Err(Error::custom(format!("unexpected tuple variant `{name}::{variant}`")));
+			}
+		};
+		Ok(SerializeModel {
+			inner,
+			index: 0,
+		})
+	}
+}
+
+pub(super) struct SerializeModel {
+	index: usize,
+	inner: Inner,
+}
+
+enum Inner {
+	Count(Option<String>, Option<u64>),
+	Range(Option<String>, Option<u64>, Option<u64>),
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeModel {
+	type Ok = Model;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		match (self.index, &mut self.inner) {
+			(0, Inner::Count(ref mut var, _) | Inner::Range(ref mut var, ..)) => {
+				*var = Some(value.serialize(ser::string::Serializer.wrap())?);
+			}
+			(1, Inner::Count(_, ref mut var) | Inner::Range(_, ref mut var, _)) => {
+				*var = Some(value.serialize(ser::primitive::u64::Serializer.wrap())?);
+			}
+			(2, Inner::Range(.., ref mut var)) => {
+				*var = Some(value.serialize(ser::primitive::u64::Serializer.wrap())?);
+			}
+			(index, inner) => {
+				let variant = match inner {
+					Inner::Count(..) => "Count",
+					Inner::Range(..) => "Range",
+				};
+				return Err(Error::custom(format!(
+					"unexpected `Model::{variant}` index `{index}`"
+				)));
+			}
+		}
+		self.index += 1;
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		match self.inner {
+			Inner::Count(Some(one), Some(two)) => Ok(Model::Count(one, two)),
+			Inner::Range(Some(one), Some(two), Some(three)) => Ok(Model::Range(one, two, three)),
+			_ => Err(Error::custom("`Model` missing required value(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use serde::Serialize;
+
+	#[test]
+	fn count() {
+		let model = Model::Count(Default::default(), Default::default());
+		let serialized = serialize_internal(|| model.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(model, serialized);
+	}
+
+	#[test]
+	fn range() {
+		let model = Model::Range(Default::default(), 1, 2);
+		let serialized = serialize_internal(|| model.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(model, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/number/mod.rs
+++ b/lib/src/sql/value/serde/ser/number/mod.rs
@@ -1,0 +1,145 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Number;
+use bigdecimal::BigDecimal;
+use bigdecimal::FromPrimitive as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Number;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Number, Error>;
+	type SerializeTuple = Impossible<Number, Error>;
+	type SerializeTupleStruct = Impossible<Number, Error>;
+	type SerializeTupleVariant = Impossible<Number, Error>;
+	type SerializeMap = Impossible<Number, Error>;
+	type SerializeStruct = Impossible<Number, Error>;
+	type SerializeStructVariant = Impossible<Number, Error>;
+
+	const EXPECTED: &'static str = "an enum `Number`";
+
+	#[inline]
+	fn serialize_i8(self, value: i8) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_i16(self, value: i16) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_i32(self, value: i32) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_i64(self, value: i64) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	fn serialize_i128(self, value: i128) -> Result<Self::Ok, Error> {
+		match BigDecimal::from_i128(value) {
+			Some(decimal) => Ok(decimal.into()),
+			None => Err(Error::TryFromError(value.to_string(), "BigDecimal")),
+		}
+	}
+
+	#[inline]
+	fn serialize_u8(self, value: u8) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_u16(self, value: u16) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_u32(self, value: u32) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_u64(self, value: u64) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	fn serialize_u128(self, value: u128) -> Result<Self::Ok, Error> {
+		match BigDecimal::from_u128(value) {
+			Some(decimal) => Ok(decimal.into()),
+			None => Err(Error::TryFromError(value.to_string(), "BigDecimal")),
+		}
+	}
+
+	#[inline]
+	fn serialize_f32(self, value: f32) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_f64(self, value: f64) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_str(self, value: &str) -> Result<Self::Ok, Error> {
+		let decimal = value.parse::<BigDecimal>().map_err(Error::custom)?;
+		Ok(decimal.into())
+	}
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"Int" => Ok(Number::Int(value.serialize(ser::primitive::i64::Serializer.wrap())?)),
+			"Float" => Ok(Number::Float(value.serialize(ser::primitive::f64::Serializer.wrap())?)),
+			"Decimal" => Ok(Number::Decimal(value.serialize(ser::decimal::Serializer.wrap())?)),
+			variant => {
+				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn int() {
+		let number = Number::Int(Default::default());
+		let serialized = serialize_internal(|| number.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(number, serialized);
+	}
+
+	#[test]
+	fn float() {
+		let number = Number::Float(Default::default());
+		let serialized = serialize_internal(|| number.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(number, serialized);
+	}
+
+	#[test]
+	fn decimal() {
+		let number = Number::Decimal(Default::default());
+		let serialized = serialize_internal(|| number.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(number, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/operator/mod.rs
+++ b/lib/src/sql/value/serde/ser/operator/mod.rs
@@ -1,0 +1,330 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Operator;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Operator;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Operator, Error>;
+	type SerializeTuple = Impossible<Operator, Error>;
+	type SerializeTupleStruct = Impossible<Operator, Error>;
+	type SerializeTupleVariant = Impossible<Operator, Error>;
+	type SerializeMap = Impossible<Operator, Error>;
+	type SerializeStruct = Impossible<Operator, Error>;
+	type SerializeStructVariant = Impossible<Operator, Error>;
+
+	const EXPECTED: &'static str = "an enum `Operator`";
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		match variant {
+			"Or" => Ok(Operator::Or),
+			"And" => Ok(Operator::And),
+			"Tco" => Ok(Operator::Tco),
+			"Nco" => Ok(Operator::Nco),
+			"Add" => Ok(Operator::Add),
+			"Sub" => Ok(Operator::Sub),
+			"Mul" => Ok(Operator::Mul),
+			"Div" => Ok(Operator::Div),
+			"Pow" => Ok(Operator::Pow),
+			"Inc" => Ok(Operator::Inc),
+			"Dec" => Ok(Operator::Dec),
+			"Equal" => Ok(Operator::Equal),
+			"Exact" => Ok(Operator::Exact),
+			"NotEqual" => Ok(Operator::NotEqual),
+			"AllEqual" => Ok(Operator::AllEqual),
+			"AnyEqual" => Ok(Operator::AnyEqual),
+			"Like" => Ok(Operator::Like),
+			"NotLike" => Ok(Operator::NotLike),
+			"AllLike" => Ok(Operator::AllLike),
+			"AnyLike" => Ok(Operator::AnyLike),
+			"LessThan" => Ok(Operator::LessThan),
+			"LessThanOrEqual" => Ok(Operator::LessThanOrEqual),
+			"MoreThan" => Ok(Operator::MoreThan),
+			"MoreThanOrEqual" => Ok(Operator::MoreThanOrEqual),
+			"Contain" => Ok(Operator::Contain),
+			"NotContain" => Ok(Operator::NotContain),
+			"ContainAll" => Ok(Operator::ContainAll),
+			"ContainAny" => Ok(Operator::ContainAny),
+			"ContainNone" => Ok(Operator::ContainNone),
+			"Inside" => Ok(Operator::Inside),
+			"NotInside" => Ok(Operator::NotInside),
+			"AllInside" => Ok(Operator::AllInside),
+			"AnyInside" => Ok(Operator::AnyInside),
+			"NoneInside" => Ok(Operator::NoneInside),
+			"Outside" => Ok(Operator::Outside),
+			"Intersects" => Ok(Operator::Intersects),
+			variant => Err(Error::custom(format!("unexpected unit variant `{name}::{variant}`"))),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn or() {
+		let dir = Operator::Or;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn and() {
+		let dir = Operator::And;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn tco() {
+		let dir = Operator::Tco;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn nco() {
+		let dir = Operator::Nco;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn add() {
+		let dir = Operator::Add;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn sub() {
+		let dir = Operator::Sub;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn mul() {
+		let dir = Operator::Mul;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn div() {
+		let dir = Operator::Div;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn pow() {
+		let dir = Operator::Pow;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn inc() {
+		let dir = Operator::Inc;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn dec() {
+		let dir = Operator::Dec;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn equal() {
+		let dir = Operator::Equal;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn exact() {
+		let dir = Operator::Exact;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn not_equal() {
+		let dir = Operator::NotEqual;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn all_equal() {
+		let dir = Operator::AllEqual;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn any_equal() {
+		let dir = Operator::AnyEqual;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn like() {
+		let dir = Operator::Like;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn not_like() {
+		let dir = Operator::NotLike;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn all_like() {
+		let dir = Operator::AllLike;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn any_like() {
+		let dir = Operator::AnyLike;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn less_than() {
+		let dir = Operator::LessThan;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn less_than_or_equal() {
+		let dir = Operator::LessThanOrEqual;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn more_than() {
+		let dir = Operator::MoreThan;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn more_than_or_equal() {
+		let dir = Operator::MoreThanOrEqual;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn contain() {
+		let dir = Operator::Contain;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn not_contain() {
+		let dir = Operator::NotContain;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn contain_all() {
+		let dir = Operator::ContainAll;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn contain_any() {
+		let dir = Operator::ContainAny;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn contain_none() {
+		let dir = Operator::ContainNone;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn inside() {
+		let dir = Operator::Inside;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn not_inside() {
+		let dir = Operator::NotInside;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn all_inside() {
+		let dir = Operator::AllInside;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn any_inside() {
+		let dir = Operator::AnyInside;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn none_inside() {
+		let dir = Operator::NoneInside;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn outside() {
+		let dir = Operator::Outside;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+
+	#[test]
+	fn intersects() {
+		let dir = Operator::Intersects;
+		let serialized = serialize_internal(|| dir.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(dir, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/order/mod.rs
+++ b/lib/src/sql/value/serde/ser/order/mod.rs
@@ -1,0 +1,106 @@
+pub(super) mod vec;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Idiom;
+use crate::sql::Order;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Order;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Order, Error>;
+	type SerializeTuple = Impossible<Order, Error>;
+	type SerializeTupleStruct = Impossible<Order, Error>;
+	type SerializeTupleVariant = Impossible<Order, Error>;
+	type SerializeMap = Impossible<Order, Error>;
+	type SerializeStruct = SerializeOrder;
+	type SerializeStructVariant = Impossible<Order, Error>;
+
+	const EXPECTED: &'static str = "a struct `Order`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeOrder::default())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeOrder {
+	order: Option<Idiom>,
+	random: Option<bool>,
+	collate: Option<bool>,
+	numeric: Option<bool>,
+	direction: Option<bool>,
+}
+
+impl serde::ser::SerializeStruct for SerializeOrder {
+	type Ok = Order;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"order" => {
+				self.order = Some(Idiom(value.serialize(ser::part::vec::Serializer.wrap())?));
+			}
+			"random" => {
+				self.random = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			"collate" => {
+				self.collate = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			"numeric" => {
+				self.numeric = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			"direction" => {
+				self.direction = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `Order::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.order, self.random, self.collate, self.numeric, self.direction) {
+			(Some(order), Some(random), Some(collate), Some(numeric), Some(direction)) => {
+				Ok(Order {
+					order,
+					random,
+					collate,
+					numeric,
+					direction,
+				})
+			}
+			_ => Err(Error::custom("`Order` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use serde::Serialize;
+
+	#[test]
+	fn default() {
+		let order = Order::default();
+		let serialized = serialize_internal(|| order.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(order, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/order/vec/mod.rs
+++ b/lib/src/sql/value/serde/ser/order/vec/mod.rs
@@ -1,0 +1,80 @@
+pub mod opt;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Order;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Order>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeOrderVec;
+	type SerializeTuple = Impossible<Vec<Order>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Order>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Order>, Error>;
+	type SerializeMap = Impossible<Vec<Order>, Error>;
+	type SerializeStruct = Impossible<Vec<Order>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Order>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Order>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeOrderVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializeOrderVec(Vec<Order>);
+
+impl serde::ser::SerializeSeq for SerializeOrderVec {
+	type Ok = Vec<Order>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(super::Serializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Order> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Order::default()];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/order/vec/opt.rs
+++ b/lib/src/sql/value/serde/ser/order/vec/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Order;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Vec<Order>>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Vec<Order>>, Error>;
+	type SerializeTuple = Impossible<Option<Vec<Order>>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Vec<Order>>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Vec<Order>>, Error>;
+	type SerializeMap = Impossible<Option<Vec<Order>>, Error>;
+	type SerializeStruct = Impossible<Option<Vec<Order>>, Error>;
+	type SerializeStructVariant = Impossible<Option<Vec<Order>>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Vec<Order>>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(super::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Vec<Order>> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(vec![Order::default()]);
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/output/mod.rs
+++ b/lib/src/sql/value/serde/ser/output/mod.rs
@@ -1,0 +1,110 @@
+pub(super) mod opt;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Output;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Output;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Output, Error>;
+	type SerializeTuple = Impossible<Output, Error>;
+	type SerializeTupleStruct = Impossible<Output, Error>;
+	type SerializeTupleVariant = Impossible<Output, Error>;
+	type SerializeMap = Impossible<Output, Error>;
+	type SerializeStruct = Impossible<Output, Error>;
+	type SerializeStructVariant = Impossible<Output, Error>;
+
+	const EXPECTED: &'static str = "an enum `Output`";
+
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		match variant {
+			"None" => Ok(Output::None),
+			"Null" => Ok(Output::Null),
+			"Diff" => Ok(Output::Diff),
+			"After" => Ok(Output::After),
+			"Before" => Ok(Output::Before),
+			variant => Err(Error::custom(format!("unexpected unit variant `{name}::{variant}`"))),
+		}
+	}
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"Fields" => Ok(Output::Fields(value.serialize(ser::fields::Serializer.wrap())?)),
+			variant => {
+				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn none() {
+		let output = Output::None;
+		let serialized = serialize_internal(|| output.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(output, serialized);
+	}
+
+	#[test]
+	fn null() {
+		let output = Output::Null;
+		let serialized = serialize_internal(|| output.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(output, serialized);
+	}
+
+	#[test]
+	fn diff() {
+		let output = Output::Diff;
+		let serialized = serialize_internal(|| output.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(output, serialized);
+	}
+
+	#[test]
+	fn after() {
+		let output = Output::After;
+		let serialized = serialize_internal(|| output.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(output, serialized);
+	}
+
+	#[test]
+	fn before() {
+		let output = Output::Before;
+		let serialized = serialize_internal(|| output.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(output, serialized);
+	}
+
+	#[test]
+	fn fields() {
+		let output = Output::Fields(Default::default());
+		let serialized = serialize_internal(|| output.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(output, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/output/opt.rs
+++ b/lib/src/sql/value/serde/ser/output/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Output;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Output>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Output>, Error>;
+	type SerializeTuple = Impossible<Option<Output>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Output>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Output>, Error>;
+	type SerializeMap = Impossible<Option<Output>, Error>;
+	type SerializeStruct = Impossible<Option<Output>, Error>;
+	type SerializeStructVariant = Impossible<Option<Output>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Output>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(super::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Output> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(Output::default());
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/part/mod.rs
+++ b/lib/src/sql/value/serde/ser/part/mod.rs
@@ -1,0 +1,129 @@
+pub(super) mod vec;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Ident;
+use crate::sql::Part;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Part;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Part, Error>;
+	type SerializeTuple = Impossible<Part, Error>;
+	type SerializeTupleStruct = Impossible<Part, Error>;
+	type SerializeTupleVariant = Impossible<Part, Error>;
+	type SerializeMap = Impossible<Part, Error>;
+	type SerializeStruct = Impossible<Part, Error>;
+	type SerializeStructVariant = Impossible<Part, Error>;
+
+	const EXPECTED: &'static str = "an enum `Part`";
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		match variant {
+			"All" => Ok(Part::All),
+			"Last" => Ok(Part::Last),
+			"First" => Ok(Part::First),
+			variant => Err(Error::custom(format!("unexpected unit variant `{name}::{variant}`"))),
+		}
+	}
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"Field" => Ok(Part::Field(Ident(value.serialize(ser::string::Serializer.wrap())?))),
+			"Index" => Ok(Part::Index(value.serialize(ser::number::Serializer.wrap())?)),
+			"Where" => Ok(Part::Where(value.serialize(ser::value::Serializer.wrap())?)),
+			"Thing" => Ok(Part::Thing(value.serialize(ser::thing::Serializer.wrap())?)),
+			"Graph" => Ok(Part::Graph(value.serialize(ser::graph::Serializer.wrap())?)),
+			variant => {
+				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn all() {
+		let part = Part::All;
+		let serialized = serialize_internal(|| part.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(part, serialized);
+	}
+
+	#[test]
+	fn last() {
+		let part = Part::Last;
+		let serialized = serialize_internal(|| part.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(part, serialized);
+	}
+
+	#[test]
+	fn first() {
+		let part = Part::First;
+		let serialized = serialize_internal(|| part.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(part, serialized);
+	}
+
+	#[test]
+	fn field() {
+		let part = Part::Field(Default::default());
+		let serialized = serialize_internal(|| part.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(part, serialized);
+	}
+
+	#[test]
+	fn index() {
+		let part = Part::Index(Default::default());
+		let serialized = serialize_internal(|| part.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(part, serialized);
+	}
+
+	#[test]
+	fn r#where() {
+		let part = Part::Where(Default::default());
+		let serialized = serialize_internal(|| part.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(part, serialized);
+	}
+
+	#[test]
+	fn thing() {
+		let part = Part::Thing(sql::thing("foo:bar").unwrap());
+		let serialized = serialize_internal(|| part.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(part, serialized);
+	}
+
+	#[test]
+	fn graph() {
+		let part = Part::Graph(Default::default());
+		let serialized = serialize_internal(|| part.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(part, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/part/vec/mod.rs
+++ b/lib/src/sql/value/serde/ser/part/vec/mod.rs
@@ -1,0 +1,80 @@
+pub mod opt;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Part;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Part>;
+	type Error = Error;
+
+	type SerializeSeq = SerializePartVec;
+	type SerializeTuple = Impossible<Vec<Part>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Part>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Part>, Error>;
+	type SerializeMap = Impossible<Vec<Part>, Error>;
+	type SerializeStruct = Impossible<Vec<Part>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Part>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Part>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializePartVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializePartVec(Vec<Part>);
+
+impl serde::ser::SerializeSeq for SerializePartVec {
+	type Ok = Vec<Part>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(ser::part::Serializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Part> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Part::All];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/part/vec/opt.rs
+++ b/lib/src/sql/value/serde/ser/part/vec/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Part;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Vec<Part>>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Vec<Part>>, Error>;
+	type SerializeTuple = Impossible<Option<Vec<Part>>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Vec<Part>>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Vec<Part>>, Error>;
+	type SerializeMap = Impossible<Option<Vec<Part>>, Error>;
+	type SerializeStruct = Impossible<Option<Vec<Part>>, Error>;
+	type SerializeStructVariant = Impossible<Option<Vec<Part>>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Vec<Part>>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(super::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Vec<Part>> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(vec![Part::All]);
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/primitive/bool.rs
+++ b/lib/src/sql/value/serde/ser/primitive/bool.rs
@@ -1,0 +1,25 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use serde::ser::Impossible;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = bool;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<bool, Error>;
+	type SerializeTuple = Impossible<bool, Error>;
+	type SerializeTupleStruct = Impossible<bool, Error>;
+	type SerializeTupleVariant = Impossible<bool, Error>;
+	type SerializeMap = Impossible<bool, Error>;
+	type SerializeStruct = Impossible<bool, Error>;
+	type SerializeStructVariant = Impossible<bool, Error>;
+
+	const EXPECTED: &'static str = "a boolean";
+
+	#[inline]
+	fn serialize_bool(self, value: bool) -> Result<Self::Ok, Error> {
+		Ok(value)
+	}
+}

--- a/lib/src/sql/value/serde/ser/primitive/f64.rs
+++ b/lib/src/sql/value/serde/ser/primitive/f64.rs
@@ -1,0 +1,25 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use serde::ser::Impossible;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = f64;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<f64, Error>;
+	type SerializeTuple = Impossible<f64, Error>;
+	type SerializeTupleStruct = Impossible<f64, Error>;
+	type SerializeTupleVariant = Impossible<f64, Error>;
+	type SerializeMap = Impossible<f64, Error>;
+	type SerializeStruct = Impossible<f64, Error>;
+	type SerializeStructVariant = Impossible<f64, Error>;
+
+	const EXPECTED: &'static str = "an f64";
+
+	#[inline]
+	fn serialize_f64(self, value: f64) -> Result<Self::Ok, Error> {
+		Ok(value)
+	}
+}

--- a/lib/src/sql/value/serde/ser/primitive/i64.rs
+++ b/lib/src/sql/value/serde/ser/primitive/i64.rs
@@ -1,0 +1,25 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use serde::ser::Impossible;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = i64;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<i64, Error>;
+	type SerializeTuple = Impossible<i64, Error>;
+	type SerializeTupleStruct = Impossible<i64, Error>;
+	type SerializeTupleVariant = Impossible<i64, Error>;
+	type SerializeMap = Impossible<i64, Error>;
+	type SerializeStruct = Impossible<i64, Error>;
+	type SerializeStructVariant = Impossible<i64, Error>;
+
+	const EXPECTED: &'static str = "an i64";
+
+	#[inline]
+	fn serialize_i64(self, value: i64) -> Result<Self::Ok, Error> {
+		Ok(value)
+	}
+}

--- a/lib/src/sql/value/serde/ser/primitive/mod.rs
+++ b/lib/src/sql/value/serde/ser/primitive/mod.rs
@@ -1,0 +1,5 @@
+pub mod bool;
+pub mod f64;
+pub mod i64;
+pub mod u32;
+pub mod u64;

--- a/lib/src/sql/value/serde/ser/primitive/u32.rs
+++ b/lib/src/sql/value/serde/ser/primitive/u32.rs
@@ -1,0 +1,25 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use serde::ser::Impossible;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = u32;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<u32, Error>;
+	type SerializeTuple = Impossible<u32, Error>;
+	type SerializeTupleStruct = Impossible<u32, Error>;
+	type SerializeTupleVariant = Impossible<u32, Error>;
+	type SerializeMap = Impossible<u32, Error>;
+	type SerializeStruct = Impossible<u32, Error>;
+	type SerializeStructVariant = Impossible<u32, Error>;
+
+	const EXPECTED: &'static str = "a u32";
+
+	#[inline]
+	fn serialize_u32(self, value: u32) -> Result<Self::Ok, Error> {
+		Ok(value)
+	}
+}

--- a/lib/src/sql/value/serde/ser/primitive/u64.rs
+++ b/lib/src/sql/value/serde/ser/primitive/u64.rs
@@ -1,0 +1,25 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use serde::ser::Impossible;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = u64;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<u64, Error>;
+	type SerializeTuple = Impossible<u64, Error>;
+	type SerializeTupleStruct = Impossible<u64, Error>;
+	type SerializeTupleVariant = Impossible<u64, Error>;
+	type SerializeMap = Impossible<u64, Error>;
+	type SerializeStruct = Impossible<u64, Error>;
+	type SerializeStructVariant = Impossible<u64, Error>;
+
+	const EXPECTED: &'static str = "a u64";
+
+	#[inline]
+	fn serialize_u64(self, value: u64) -> Result<Self::Ok, Error> {
+		Ok(value)
+	}
+}

--- a/lib/src/sql/value/serde/ser/range/bound.rs
+++ b/lib/src/sql/value/serde/ser/range/bound.rs
@@ -1,0 +1,85 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Id;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+use std::ops::Bound;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Bound<Id>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Bound<Id>, Error>;
+	type SerializeTuple = Impossible<Bound<Id>, Error>;
+	type SerializeTupleStruct = Impossible<Bound<Id>, Error>;
+	type SerializeTupleVariant = Impossible<Bound<Id>, Error>;
+	type SerializeMap = Impossible<Bound<Id>, Error>;
+	type SerializeStruct = Impossible<Bound<Id>, Error>;
+	type SerializeStructVariant = Impossible<Bound<Id>, Error>;
+
+	const EXPECTED: &'static str = "an enum `Bound<Id>`";
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		match variant {
+			"Unbounded" => Ok(Bound::Unbounded),
+			variant => Err(Error::custom(format!("unexpected unit variant `{name}::{variant}`"))),
+		}
+	}
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"Included" => Ok(Bound::Included(value.serialize(ser::id::Serializer.wrap())?)),
+			"Excluded" => Ok(Bound::Excluded(value.serialize(ser::id::Serializer.wrap())?)),
+			variant => {
+				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn unbounded() {
+		let bound = Bound::Unbounded;
+		let serialized = serialize_internal(|| bound.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(bound, serialized);
+	}
+
+	#[test]
+	fn included() {
+		let bound = Bound::Included(Id::rand());
+		let serialized = serialize_internal(|| bound.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(bound, serialized);
+	}
+
+	#[test]
+	fn excluded() {
+		let bound = Bound::Excluded(Id::rand());
+		let serialized = serialize_internal(|| bound.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(bound, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/range/mod.rs
+++ b/lib/src/sql/value/serde/ser/range/mod.rs
@@ -1,0 +1,99 @@
+mod bound;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Id;
+use crate::sql::Range;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+use std::ops::Bound;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Range;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Range, Error>;
+	type SerializeTuple = Impossible<Range, Error>;
+	type SerializeTupleStruct = Impossible<Range, Error>;
+	type SerializeTupleVariant = Impossible<Range, Error>;
+	type SerializeMap = Impossible<Range, Error>;
+	type SerializeStruct = SerializeRange;
+	type SerializeStructVariant = Impossible<Range, Error>;
+
+	const EXPECTED: &'static str = "a struct `Range`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeRange::default())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeRange {
+	tb: Option<String>,
+	beg: Option<Bound<Id>>,
+	end: Option<Bound<Id>>,
+}
+
+impl serde::ser::SerializeStruct for SerializeRange {
+	type Ok = Range;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"tb" => {
+				self.tb = Some(value.serialize(ser::string::Serializer.wrap())?);
+			}
+			"beg" => {
+				self.beg = Some(value.serialize(bound::Serializer.wrap())?);
+			}
+			"end" => {
+				self.end = Some(value.serialize(bound::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `Range::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.tb, self.beg, self.end) {
+			(Some(tb), Some(beg), Some(end)) => Ok(Range {
+				tb,
+				beg,
+				end,
+			}),
+			_ => Err(Error::custom("`Range` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use serde::Serialize;
+
+	#[test]
+	fn range() {
+		let range = Range {
+			tb: "foobar".to_owned(),
+			beg: Bound::Included("bar".into()),
+			end: Bound::Excluded("foo".into()),
+		};
+		let serialized = serialize_internal(|| range.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(range, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/split/mod.rs
+++ b/lib/src/sql/value/serde/ser/split/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod vec;

--- a/lib/src/sql/value/serde/ser/split/vec/mod.rs
+++ b/lib/src/sql/value/serde/ser/split/vec/mod.rs
@@ -1,0 +1,81 @@
+pub mod opt;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Idiom;
+use crate::sql::Split;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Split>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeSplitVec;
+	type SerializeTuple = Impossible<Vec<Split>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Split>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Split>, Error>;
+	type SerializeMap = Impossible<Vec<Split>, Error>;
+	type SerializeStruct = Impossible<Vec<Split>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Split>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Split>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeSplitVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializeSplitVec(Vec<Split>);
+
+impl serde::ser::SerializeSeq for SerializeSplitVec {
+	type Ok = Vec<Split>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(Split(Idiom(value.serialize(ser::part::vec::Serializer.wrap())?)));
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Split> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Split::default()];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/split/vec/opt.rs
+++ b/lib/src/sql/value/serde/ser/split/vec/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Split;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Vec<Split>>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Vec<Split>>, Error>;
+	type SerializeTuple = Impossible<Option<Vec<Split>>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Vec<Split>>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Vec<Split>>, Error>;
+	type SerializeMap = Impossible<Option<Vec<Split>>, Error>;
+	type SerializeStruct = Impossible<Option<Vec<Split>>, Error>;
+	type SerializeStructVariant = Impossible<Option<Vec<Split>>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Vec<Split>>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(super::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Vec<Split>> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(vec![Split::default()]);
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/start/mod.rs
+++ b/lib/src/sql/value/serde/ser/start/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod opt;

--- a/lib/src/sql/value/serde/ser/start/opt.rs
+++ b/lib/src/sql/value/serde/ser/start/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Start;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Start>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Start>, Error>;
+	type SerializeTuple = Impossible<Option<Start>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Start>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Start>, Error>;
+	type SerializeMap = Impossible<Option<Start>, Error>;
+	type SerializeStruct = Impossible<Option<Start>, Error>;
+	type SerializeStructVariant = Impossible<Option<Start>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Start>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(Start(value.serialize(ser::value::Serializer.wrap())?)))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Start> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(Start::default());
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/create.rs
+++ b/lib/src/sql/value/serde/ser/statement/create.rs
@@ -1,0 +1,141 @@
+use crate::err::Error;
+use crate::sql::statements::CreateStatement;
+use crate::sql::value::serde::ser;
+use crate::sql::Data;
+use crate::sql::Duration;
+use crate::sql::Output;
+use crate::sql::Timeout;
+use crate::sql::Values;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = CreateStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<CreateStatement, Error>;
+	type SerializeTuple = Impossible<CreateStatement, Error>;
+	type SerializeTupleStruct = Impossible<CreateStatement, Error>;
+	type SerializeTupleVariant = Impossible<CreateStatement, Error>;
+	type SerializeMap = Impossible<CreateStatement, Error>;
+	type SerializeStruct = SerializeCreateStatement;
+	type SerializeStructVariant = Impossible<CreateStatement, Error>;
+
+	const EXPECTED: &'static str = "a struct `CreateStatement`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeCreateStatement::default())
+	}
+}
+
+#[derive(Default)]
+pub struct SerializeCreateStatement {
+	what: Option<Values>,
+	data: Option<Data>,
+	output: Option<Output>,
+	timeout: Option<Timeout>,
+	parallel: Option<bool>,
+}
+
+impl serde::ser::SerializeStruct for SerializeCreateStatement {
+	type Ok = CreateStatement;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"what" => {
+				self.what = Some(Values(value.serialize(ser::value::vec::Serializer.wrap())?));
+			}
+			"data" => {
+				self.data = value.serialize(ser::data::opt::Serializer.wrap())?;
+			}
+			"output" => {
+				self.output = value.serialize(ser::output::opt::Serializer.wrap())?;
+			}
+			"timeout" => {
+				if let Some(duration) = value.serialize(ser::duration::opt::Serializer.wrap())? {
+					self.timeout = Some(Timeout(Duration(duration)));
+				}
+			}
+			"parallel" => {
+				self.parallel = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `CreateStatement::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.what, self.parallel) {
+			(Some(what), Some(parallel)) => Ok(CreateStatement {
+				what,
+				parallel,
+				data: self.data,
+				output: self.output,
+				timeout: self.timeout,
+			}),
+			_ => Err(Error::custom("`CreateStatement` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let stmt = CreateStatement::default();
+		let value: CreateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_data() {
+		let stmt = CreateStatement {
+			data: Some(Default::default()),
+			..Default::default()
+		};
+		let value: CreateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_output() {
+		let stmt = CreateStatement {
+			output: Some(Default::default()),
+			..Default::default()
+		};
+		let value: CreateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_timeout() {
+		let stmt = CreateStatement {
+			timeout: Some(Default::default()),
+			..Default::default()
+		};
+		let value: CreateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/delete.rs
+++ b/lib/src/sql/value/serde/ser/statement/delete.rs
@@ -1,0 +1,138 @@
+use crate::err::Error;
+use crate::sql::statements::DeleteStatement;
+use crate::sql::value::serde::ser;
+use crate::sql::Cond;
+use crate::sql::Output;
+use crate::sql::Timeout;
+use crate::sql::Values;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = DeleteStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<DeleteStatement, Error>;
+	type SerializeTuple = Impossible<DeleteStatement, Error>;
+	type SerializeTupleStruct = Impossible<DeleteStatement, Error>;
+	type SerializeTupleVariant = Impossible<DeleteStatement, Error>;
+	type SerializeMap = Impossible<DeleteStatement, Error>;
+	type SerializeStruct = SerializeDeleteStatement;
+	type SerializeStructVariant = Impossible<DeleteStatement, Error>;
+
+	const EXPECTED: &'static str = "a struct `DeleteStatement`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeDeleteStatement::default())
+	}
+}
+
+#[derive(Default)]
+pub struct SerializeDeleteStatement {
+	what: Option<Values>,
+	cond: Option<Cond>,
+	output: Option<Output>,
+	timeout: Option<Timeout>,
+	parallel: Option<bool>,
+}
+
+impl serde::ser::SerializeStruct for SerializeDeleteStatement {
+	type Ok = DeleteStatement;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"what" => {
+				self.what = Some(Values(value.serialize(ser::value::vec::Serializer.wrap())?));
+			}
+			"cond" => {
+				self.cond = value.serialize(ser::cond::opt::Serializer.wrap())?;
+			}
+			"output" => {
+				self.output = value.serialize(ser::output::opt::Serializer.wrap())?;
+			}
+			"timeout" => {
+				self.timeout = value.serialize(ser::timeout::opt::Serializer.wrap())?;
+			}
+			"parallel" => {
+				self.parallel = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `DeleteStatement::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.what, self.parallel) {
+			(Some(what), Some(parallel)) => Ok(DeleteStatement {
+				what,
+				parallel,
+				cond: self.cond,
+				output: self.output,
+				timeout: self.timeout,
+			}),
+			_ => Err(Error::custom("`DeleteStatement` missing required value(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let stmt = DeleteStatement::default();
+		let value: DeleteStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_cond() {
+		let stmt = DeleteStatement {
+			cond: Some(Default::default()),
+			..Default::default()
+		};
+		let value: DeleteStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_output() {
+		let stmt = DeleteStatement {
+			output: Some(Default::default()),
+			..Default::default()
+		};
+		let value: DeleteStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_timeout() {
+		let stmt = DeleteStatement {
+			timeout: Some(Default::default()),
+			..Default::default()
+		};
+		let value: DeleteStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/ifelse.rs
+++ b/lib/src/sql/value/serde/ser/statement/ifelse.rs
@@ -1,0 +1,209 @@
+use crate::err::Error;
+use crate::sql::statements::IfelseStatement;
+use crate::sql::value::serde::ser;
+use crate::sql::Value;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = IfelseStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<IfelseStatement, Error>;
+	type SerializeTuple = Impossible<IfelseStatement, Error>;
+	type SerializeTupleStruct = Impossible<IfelseStatement, Error>;
+	type SerializeTupleVariant = Impossible<IfelseStatement, Error>;
+	type SerializeMap = Impossible<IfelseStatement, Error>;
+	type SerializeStruct = SerializeIfelseStatement;
+	type SerializeStructVariant = Impossible<IfelseStatement, Error>;
+
+	const EXPECTED: &'static str = "a struct `IfelseStatement`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeIfelseStatement::default())
+	}
+}
+
+type ValueValueTuple = (Value, Value);
+
+#[derive(Default)]
+pub struct SerializeIfelseStatement {
+	exprs: Vec<ValueValueTuple>,
+	close: Option<Value>,
+}
+
+impl serde::ser::SerializeStruct for SerializeIfelseStatement {
+	type Ok = IfelseStatement;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"exprs" => {
+				self.exprs = value.serialize(ValueValueVecSerializer.wrap())?;
+			}
+			"close" => {
+				self.close = value.serialize(ser::value::opt::Serializer.wrap())?;
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `IfelseStatement::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		Ok(IfelseStatement {
+			exprs: self.exprs,
+			close: self.close,
+		})
+	}
+}
+
+pub struct ValueValueVecSerializer;
+
+impl ser::Serializer for ValueValueVecSerializer {
+	type Ok = Vec<ValueValueTuple>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeValueValueVec;
+	type SerializeTuple = Impossible<Vec<ValueValueTuple>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<ValueValueTuple>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<ValueValueTuple>, Error>;
+	type SerializeMap = Impossible<Vec<ValueValueTuple>, Error>;
+	type SerializeStruct = Impossible<Vec<ValueValueTuple>, Error>;
+	type SerializeStructVariant = Impossible<Vec<ValueValueTuple>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<(Value, Value)>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeValueValueVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+}
+
+pub struct SerializeValueValueVec(Vec<ValueValueTuple>);
+
+impl serde::ser::SerializeSeq for SerializeValueValueVec {
+	type Ok = Vec<ValueValueTuple>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(ValueValueTupleSerializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+struct ValueValueTupleSerializer;
+
+impl ser::Serializer for ValueValueTupleSerializer {
+	type Ok = ValueValueTuple;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<ValueValueTuple, Error>;
+	type SerializeTuple = SerializeValueValueTuple;
+	type SerializeTupleStruct = Impossible<ValueValueTuple, Error>;
+	type SerializeTupleVariant = Impossible<ValueValueTuple, Error>;
+	type SerializeMap = Impossible<ValueValueTuple, Error>;
+	type SerializeStruct = Impossible<ValueValueTuple, Error>;
+	type SerializeStructVariant = Impossible<ValueValueTuple, Error>;
+
+	const EXPECTED: &'static str = "a `(Value, Value)`";
+
+	fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+		Ok(SerializeValueValueTuple::default())
+	}
+}
+
+#[derive(Default)]
+struct SerializeValueValueTuple {
+	index: usize,
+	zero: Option<Value>,
+	one: Option<Value>,
+}
+
+impl serde::ser::SerializeTuple for SerializeValueValueTuple {
+	type Ok = ValueValueTuple;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		match self.index {
+			0 => {
+				self.zero = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			1 => {
+				self.one = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			index => {
+				return Err(Error::custom(format!(
+					"unexpected tuple index `{index}` for `(Value, Value)`"
+				)));
+			}
+		}
+		self.index += 1;
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		match (self.zero, self.one) {
+			(Some(zero), Some(one)) => Ok((zero, one)),
+			_ => Err(Error::custom("`(Value, Value)` missing required value(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let stmt = IfelseStatement::default();
+		let value: IfelseStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_exprs() {
+		let stmt = IfelseStatement {
+			exprs: vec![(Default::default(), Default::default())],
+			..Default::default()
+		};
+		let value: IfelseStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_close() {
+		let stmt = IfelseStatement {
+			close: Some(Default::default()),
+			..Default::default()
+		};
+		let value: IfelseStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/insert.rs
+++ b/lib/src/sql/value/serde/ser/statement/insert.rs
@@ -1,0 +1,148 @@
+use crate::err::Error;
+use crate::sql::statements::InsertStatement;
+use crate::sql::value::serde::ser;
+use crate::sql::Data;
+use crate::sql::Output;
+use crate::sql::Table;
+use crate::sql::Timeout;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = InsertStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<InsertStatement, Error>;
+	type SerializeTuple = Impossible<InsertStatement, Error>;
+	type SerializeTupleStruct = Impossible<InsertStatement, Error>;
+	type SerializeTupleVariant = Impossible<InsertStatement, Error>;
+	type SerializeMap = Impossible<InsertStatement, Error>;
+	type SerializeStruct = SerializeInsertStatement;
+	type SerializeStructVariant = Impossible<InsertStatement, Error>;
+
+	const EXPECTED: &'static str = "a struct `InsertStatement`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeInsertStatement::default())
+	}
+}
+
+#[derive(Default)]
+pub struct SerializeInsertStatement {
+	into: Option<Table>,
+	data: Option<Data>,
+	ignore: Option<bool>,
+	update: Option<Data>,
+	output: Option<Output>,
+	timeout: Option<Timeout>,
+	parallel: Option<bool>,
+}
+
+impl serde::ser::SerializeStruct for SerializeInsertStatement {
+	type Ok = InsertStatement;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"into" => {
+				self.into = Some(Table(value.serialize(ser::string::Serializer.wrap())?));
+			}
+			"data" => {
+				self.data = Some(value.serialize(ser::data::Serializer.wrap())?);
+			}
+			"ignore" => {
+				self.ignore = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			"update" => {
+				self.update = value.serialize(ser::data::opt::Serializer.wrap())?;
+			}
+			"output" => {
+				self.output = value.serialize(ser::output::opt::Serializer.wrap())?;
+			}
+			"timeout" => {
+				self.timeout = value.serialize(ser::timeout::opt::Serializer.wrap())?;
+			}
+			"parallel" => {
+				self.parallel = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `InsertStatement::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.into, self.data, self.ignore, self.parallel) {
+			(Some(into), Some(data), Some(ignore), Some(parallel)) => Ok(InsertStatement {
+				into,
+				data,
+				ignore,
+				parallel,
+				update: self.update,
+				output: self.output,
+				timeout: self.timeout,
+			}),
+			_ => Err(Error::custom("`InsertStatement` missing required value(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let stmt = InsertStatement::default();
+		let value: InsertStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_update() {
+		let stmt = InsertStatement {
+			update: Some(Default::default()),
+			..Default::default()
+		};
+		let value: InsertStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_output() {
+		let stmt = InsertStatement {
+			output: Some(Default::default()),
+			..Default::default()
+		};
+		let value: InsertStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_timeout() {
+		let stmt = InsertStatement {
+			timeout: Some(Default::default()),
+			..Default::default()
+		};
+		let value: InsertStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/mod.rs
+++ b/lib/src/sql/value/serde/ser/statement/mod.rs
@@ -1,0 +1,9 @@
+pub mod create;
+pub mod delete;
+pub mod ifelse;
+pub mod insert;
+pub mod output;
+pub mod relate;
+pub mod select;
+pub mod set;
+pub mod update;

--- a/lib/src/sql/value/serde/ser/statement/output.rs
+++ b/lib/src/sql/value/serde/ser/statement/output.rs
@@ -1,0 +1,99 @@
+use crate::err::Error;
+use crate::sql::statements::OutputStatement;
+use crate::sql::value::serde::ser;
+use crate::sql::Fetchs;
+use crate::sql::Value;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = OutputStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<OutputStatement, Error>;
+	type SerializeTuple = Impossible<OutputStatement, Error>;
+	type SerializeTupleStruct = Impossible<OutputStatement, Error>;
+	type SerializeTupleVariant = Impossible<OutputStatement, Error>;
+	type SerializeMap = Impossible<OutputStatement, Error>;
+	type SerializeStruct = SerializeOutputStatement;
+	type SerializeStructVariant = Impossible<OutputStatement, Error>;
+
+	const EXPECTED: &'static str = "a struct `OutputStatement`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeOutputStatement::default())
+	}
+}
+
+#[derive(Default)]
+pub struct SerializeOutputStatement {
+	what: Option<Value>,
+	fetch: Option<Fetchs>,
+}
+
+impl serde::ser::SerializeStruct for SerializeOutputStatement {
+	type Ok = OutputStatement;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"what" => {
+				self.what = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			"fetch" => {
+				self.fetch = value.serialize(ser::fetch::vec::opt::Serializer.wrap())?.map(Fetchs);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `OutputStatement::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match self.what {
+			Some(what) => Ok(OutputStatement {
+				what,
+				fetch: self.fetch,
+			}),
+			None => Err(Error::custom("`OutputStatement` missing required value(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let stmt = OutputStatement::default();
+		let value: OutputStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_fetch() {
+		let stmt = OutputStatement {
+			fetch: Some(Default::default()),
+			..Default::default()
+		};
+		let value: OutputStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/relate.rs
+++ b/lib/src/sql/value/serde/ser/statement/relate.rs
@@ -1,0 +1,155 @@
+use crate::err::Error;
+use crate::sql::statements::RelateStatement;
+use crate::sql::value::serde::ser;
+use crate::sql::Data;
+use crate::sql::Output;
+use crate::sql::Timeout;
+use crate::sql::Value;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = RelateStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<RelateStatement, Error>;
+	type SerializeTuple = Impossible<RelateStatement, Error>;
+	type SerializeTupleStruct = Impossible<RelateStatement, Error>;
+	type SerializeTupleVariant = Impossible<RelateStatement, Error>;
+	type SerializeMap = Impossible<RelateStatement, Error>;
+	type SerializeStruct = SerializeRelateStatement;
+	type SerializeStructVariant = Impossible<RelateStatement, Error>;
+
+	const EXPECTED: &'static str = "a struct `RelateStatement`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeRelateStatement::default())
+	}
+}
+
+#[derive(Default)]
+pub struct SerializeRelateStatement {
+	kind: Option<Value>,
+	from: Option<Value>,
+	with: Option<Value>,
+	uniq: Option<bool>,
+	data: Option<Data>,
+	output: Option<Output>,
+	timeout: Option<Timeout>,
+	parallel: Option<bool>,
+}
+
+impl serde::ser::SerializeStruct for SerializeRelateStatement {
+	type Ok = RelateStatement;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"kind" => {
+				self.kind = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			"from" => {
+				self.from = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			"with" => {
+				self.with = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			"uniq" => {
+				self.uniq = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			"data" => {
+				self.data = value.serialize(ser::data::opt::Serializer.wrap())?;
+			}
+			"output" => {
+				self.output = value.serialize(ser::output::opt::Serializer.wrap())?;
+			}
+			"timeout" => {
+				self.timeout = value.serialize(ser::timeout::opt::Serializer.wrap())?;
+			}
+			"parallel" => {
+				self.parallel = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `RelateStatement::{key}`",)));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.kind, self.from, self.with, self.uniq, self.parallel) {
+			(Some(kind), Some(from), Some(with), Some(uniq), Some(parallel)) => {
+				Ok(RelateStatement {
+					kind,
+					from,
+					with,
+					uniq,
+					parallel,
+					data: self.data,
+					output: self.output,
+					timeout: self.timeout,
+				})
+			}
+			_ => Err(Error::custom("`RelateStatement` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let stmt = RelateStatement::default();
+		let value: RelateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_data() {
+		let stmt = RelateStatement {
+			data: Some(Default::default()),
+			..Default::default()
+		};
+		let value: RelateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_output() {
+		let stmt = RelateStatement {
+			output: Some(Default::default()),
+			..Default::default()
+		};
+		let value: RelateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_timeout() {
+		let stmt = RelateStatement {
+			timeout: Some(Default::default()),
+			..Default::default()
+		};
+		let value: RelateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/select.rs
+++ b/lib/src/sql/value/serde/ser/statement/select.rs
@@ -1,0 +1,246 @@
+use crate::err::Error;
+use crate::sql::statements::SelectStatement;
+use crate::sql::value::serde::ser;
+use crate::sql::Cond;
+use crate::sql::Fetchs;
+use crate::sql::Fields;
+use crate::sql::Groups;
+use crate::sql::Limit;
+use crate::sql::Orders;
+use crate::sql::Splits;
+use crate::sql::Start;
+use crate::sql::Timeout;
+use crate::sql::Values;
+use crate::sql::Version;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = SelectStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<SelectStatement, Error>;
+	type SerializeTuple = Impossible<SelectStatement, Error>;
+	type SerializeTupleStruct = Impossible<SelectStatement, Error>;
+	type SerializeTupleVariant = Impossible<SelectStatement, Error>;
+	type SerializeMap = Impossible<SelectStatement, Error>;
+	type SerializeStruct = SerializeSelectStatement;
+	type SerializeStructVariant = Impossible<SelectStatement, Error>;
+
+	const EXPECTED: &'static str = "a struct `SelectStatement`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeSelectStatement::default())
+	}
+}
+
+#[derive(Default)]
+pub struct SerializeSelectStatement {
+	expr: Option<Fields>,
+	what: Option<Values>,
+	cond: Option<Cond>,
+	split: Option<Splits>,
+	group: Option<Groups>,
+	order: Option<Orders>,
+	limit: Option<Limit>,
+	start: Option<Start>,
+	fetch: Option<Fetchs>,
+	version: Option<Version>,
+	timeout: Option<Timeout>,
+	parallel: Option<bool>,
+}
+
+impl serde::ser::SerializeStruct for SerializeSelectStatement {
+	type Ok = SelectStatement;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"expr" => {
+				self.expr = Some(value.serialize(ser::fields::Serializer.wrap())?);
+			}
+			"what" => {
+				self.what = Some(Values(value.serialize(ser::value::vec::Serializer.wrap())?));
+			}
+			"cond" => {
+				self.cond = value.serialize(ser::cond::opt::Serializer.wrap())?;
+			}
+			"split" => {
+				self.split = value.serialize(ser::split::vec::opt::Serializer.wrap())?.map(Splits);
+			}
+			"group" => {
+				self.group = value.serialize(ser::group::vec::opt::Serializer.wrap())?.map(Groups);
+			}
+			"order" => {
+				self.order = value.serialize(ser::order::vec::opt::Serializer.wrap())?.map(Orders);
+			}
+			"limit" => {
+				self.limit = value.serialize(ser::limit::opt::Serializer.wrap())?;
+			}
+			"start" => {
+				self.start = value.serialize(ser::start::opt::Serializer.wrap())?;
+			}
+			"fetch" => {
+				self.fetch = value.serialize(ser::fetch::vec::opt::Serializer.wrap())?.map(Fetchs);
+			}
+			"version" => {
+				self.version = value.serialize(ser::version::opt::Serializer.wrap())?;
+			}
+			"timeout" => {
+				self.timeout = value.serialize(ser::timeout::opt::Serializer.wrap())?;
+			}
+			"parallel" => {
+				self.parallel = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `SelectStatement::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.expr, self.what, self.parallel) {
+			(Some(expr), Some(what), Some(parallel)) => Ok(SelectStatement {
+				expr,
+				what,
+				parallel,
+				cond: self.cond,
+				split: self.split,
+				group: self.group,
+				order: self.order,
+				limit: self.limit,
+				start: self.start,
+				fetch: self.fetch,
+				version: self.version,
+				timeout: self.timeout,
+			}),
+			_ => Err(Error::custom("`SelectStatement` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let stmt = SelectStatement::default();
+		let value: SelectStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_cond() {
+		let stmt = SelectStatement {
+			cond: Some(Default::default()),
+			..Default::default()
+		};
+		let value: SelectStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_split() {
+		let stmt = SelectStatement {
+			split: Some(Default::default()),
+			..Default::default()
+		};
+		let value: SelectStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_group() {
+		let stmt = SelectStatement {
+			group: Some(Default::default()),
+			..Default::default()
+		};
+		let value: SelectStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_order() {
+		let stmt = SelectStatement {
+			order: Some(Default::default()),
+			..Default::default()
+		};
+		let value: SelectStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_limit() {
+		let stmt = SelectStatement {
+			limit: Some(Default::default()),
+			..Default::default()
+		};
+		let value: SelectStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_start() {
+		let stmt = SelectStatement {
+			start: Some(Default::default()),
+			..Default::default()
+		};
+		let value: SelectStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_fetch() {
+		let stmt = SelectStatement {
+			fetch: Some(Default::default()),
+			..Default::default()
+		};
+		let value: SelectStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_version() {
+		let stmt = SelectStatement {
+			version: Some(Default::default()),
+			..Default::default()
+		};
+		let value: SelectStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_timeout() {
+		let stmt = SelectStatement {
+			timeout: Some(Default::default()),
+			..Default::default()
+		};
+		let value: SelectStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/set.rs
+++ b/lib/src/sql/value/serde/ser/statement/set.rs
@@ -1,0 +1,86 @@
+use crate::err::Error;
+use crate::sql::statements::SetStatement;
+use crate::sql::value::serde::ser;
+use crate::sql::Value;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = SetStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<SetStatement, Error>;
+	type SerializeTuple = Impossible<SetStatement, Error>;
+	type SerializeTupleStruct = Impossible<SetStatement, Error>;
+	type SerializeTupleVariant = Impossible<SetStatement, Error>;
+	type SerializeMap = Impossible<SetStatement, Error>;
+	type SerializeStruct = SerializeSetStatement;
+	type SerializeStructVariant = Impossible<SetStatement, Error>;
+
+	const EXPECTED: &'static str = "a struct `SetStatement`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeSetStatement::default())
+	}
+}
+
+#[derive(Default)]
+pub struct SerializeSetStatement {
+	name: Option<String>,
+	what: Option<Value>,
+}
+
+impl serde::ser::SerializeStruct for SerializeSetStatement {
+	type Ok = SetStatement;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"name" => {
+				self.name = Some(value.serialize(ser::string::Serializer.wrap())?);
+			}
+			"what" => {
+				self.what = Some(value.serialize(ser::value::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `SetStatement::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.name, self.what) {
+			(Some(name), Some(what)) => Ok(SetStatement {
+				name,
+				what,
+			}),
+			_ => Err(Error::custom("`SetStatement` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let stmt = SetStatement::default();
+		let value: SetStatement = serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/update.rs
+++ b/lib/src/sql/value/serde/ser/statement/update.rs
@@ -1,0 +1,158 @@
+use crate::err::Error;
+use crate::sql::statements::UpdateStatement;
+use crate::sql::value::serde::ser;
+use crate::sql::Cond;
+use crate::sql::Data;
+use crate::sql::Duration;
+use crate::sql::Output;
+use crate::sql::Timeout;
+use crate::sql::Values;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = UpdateStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<UpdateStatement, Error>;
+	type SerializeTuple = Impossible<UpdateStatement, Error>;
+	type SerializeTupleStruct = Impossible<UpdateStatement, Error>;
+	type SerializeTupleVariant = Impossible<UpdateStatement, Error>;
+	type SerializeMap = Impossible<UpdateStatement, Error>;
+	type SerializeStruct = SerializeUpdateStatement;
+	type SerializeStructVariant = Impossible<UpdateStatement, Error>;
+
+	const EXPECTED: &'static str = "a struct `UpdateStatement`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeUpdateStatement::default())
+	}
+}
+
+#[derive(Default)]
+pub struct SerializeUpdateStatement {
+	what: Option<Values>,
+	data: Option<Data>,
+	cond: Option<Cond>,
+	output: Option<Output>,
+	timeout: Option<Timeout>,
+	parallel: Option<bool>,
+}
+
+impl serde::ser::SerializeStruct for SerializeUpdateStatement {
+	type Ok = UpdateStatement;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"what" => {
+				self.what = Some(Values(value.serialize(ser::value::vec::Serializer.wrap())?));
+			}
+			"data" => {
+				self.data = value.serialize(ser::data::opt::Serializer.wrap())?;
+			}
+			"cond" => {
+				self.cond = value.serialize(ser::cond::opt::Serializer.wrap())?;
+			}
+			"output" => {
+				self.output = value.serialize(ser::output::opt::Serializer.wrap())?;
+			}
+			"timeout" => {
+				if let Some(duration) = value.serialize(ser::duration::opt::Serializer.wrap())? {
+					self.timeout = Some(Timeout(Duration(duration)));
+				}
+			}
+			"parallel" => {
+				self.parallel = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `UpdateStatement::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.what, self.parallel) {
+			(Some(what), Some(parallel)) => Ok(UpdateStatement {
+				what,
+				parallel,
+				data: self.data,
+				cond: self.cond,
+				output: self.output,
+				timeout: self.timeout,
+			}),
+			_ => Err(Error::custom("`UpdateStatement` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn default() {
+		let stmt = UpdateStatement::default();
+		let value: UpdateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_data() {
+		let stmt = UpdateStatement {
+			data: Some(Default::default()),
+			..Default::default()
+		};
+		let value: UpdateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_cond() {
+		let stmt = UpdateStatement {
+			cond: Some(Default::default()),
+			..Default::default()
+		};
+		let value: UpdateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_output() {
+		let stmt = UpdateStatement {
+			output: Some(Default::default()),
+			..Default::default()
+		};
+		let value: UpdateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_timeout() {
+		let stmt = UpdateStatement {
+			timeout: Some(Default::default()),
+			..Default::default()
+		};
+		let value: UpdateStatement =
+			serialize_internal(|| stmt.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/string/mod.rs
+++ b/lib/src/sql/value/serde/ser/string/mod.rs
@@ -1,0 +1,77 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use serde::ser::Impossible;
+use serde::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = String;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<String, Error>;
+	type SerializeTuple = Impossible<String, Error>;
+	type SerializeTupleStruct = Impossible<String, Error>;
+	type SerializeTupleVariant = Impossible<String, Error>;
+	type SerializeMap = Impossible<String, Error>;
+	type SerializeStruct = Impossible<String, Error>;
+	type SerializeStructVariant = Impossible<String, Error>;
+
+	const EXPECTED: &'static str = "a string";
+
+	fn serialize_str(self, value: &str) -> Result<Self::Ok, Error> {
+		Ok(value.to_owned())
+	}
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		_name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		self.serialize_str(variant)
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+	use std::borrow::Cow;
+
+	#[test]
+	fn string() {
+		let duration = "foo".to_owned();
+		let serialized = serialize_internal(|| duration.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(duration, serialized);
+	}
+
+	#[test]
+	fn str() {
+		let duration = "bar";
+		let serialized = serialize_internal(|| duration.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(duration, serialized);
+	}
+
+	#[test]
+	fn cow() {
+		let duration = Cow::from("bar");
+		let serialized = serialize_internal(|| duration.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(duration, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/subquery/mod.rs
+++ b/lib/src/sql/value/serde/ser/subquery/mod.rs
@@ -1,0 +1,137 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Subquery;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Subquery;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Subquery, Error>;
+	type SerializeTuple = Impossible<Subquery, Error>;
+	type SerializeTupleStruct = Impossible<Subquery, Error>;
+	type SerializeTupleVariant = Impossible<Subquery, Error>;
+	type SerializeMap = Impossible<Subquery, Error>;
+	type SerializeStruct = Impossible<Subquery, Error>;
+	type SerializeStructVariant = Impossible<Subquery, Error>;
+
+	const EXPECTED: &'static str = "an enum `Subquery`";
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"Value" => Ok(Subquery::Value(value.serialize(ser::value::Serializer.wrap())?)),
+			"Ifelse" => {
+				Ok(Subquery::Ifelse(value.serialize(ser::statement::ifelse::Serializer.wrap())?))
+			}
+			"Output" => {
+				Ok(Subquery::Output(value.serialize(ser::statement::output::Serializer.wrap())?))
+			}
+			"Select" => {
+				Ok(Subquery::Select(value.serialize(ser::statement::select::Serializer.wrap())?))
+			}
+			"Create" => {
+				Ok(Subquery::Create(value.serialize(ser::statement::create::Serializer.wrap())?))
+			}
+			"Update" => {
+				Ok(Subquery::Update(value.serialize(ser::statement::update::Serializer.wrap())?))
+			}
+			"Delete" => {
+				Ok(Subquery::Delete(value.serialize(ser::statement::delete::Serializer.wrap())?))
+			}
+			"Relate" => {
+				Ok(Subquery::Relate(value.serialize(ser::statement::relate::Serializer.wrap())?))
+			}
+			"Insert" => {
+				Ok(Subquery::Insert(value.serialize(ser::statement::insert::Serializer.wrap())?))
+			}
+			variant => {
+				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn value() {
+		let subquery = Subquery::Value(Default::default());
+		let serialized = serialize_internal(|| subquery.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(subquery, serialized);
+	}
+
+	#[test]
+	fn ifelse() {
+		let subquery = Subquery::Ifelse(Default::default());
+		let serialized = serialize_internal(|| subquery.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(subquery, serialized);
+	}
+
+	#[test]
+	fn output() {
+		let subquery = Subquery::Output(Default::default());
+		let serialized = serialize_internal(|| subquery.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(subquery, serialized);
+	}
+
+	#[test]
+	fn select() {
+		let subquery = Subquery::Select(Default::default());
+		let serialized = serialize_internal(|| subquery.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(subquery, serialized);
+	}
+
+	#[test]
+	fn create() {
+		let subquery = Subquery::Create(Default::default());
+		let serialized = serialize_internal(|| subquery.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(subquery, serialized);
+	}
+
+	#[test]
+	fn update() {
+		let subquery = Subquery::Update(Default::default());
+		let serialized = serialize_internal(|| subquery.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(subquery, serialized);
+	}
+
+	#[test]
+	fn delete() {
+		let subquery = Subquery::Delete(Default::default());
+		let serialized = serialize_internal(|| subquery.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(subquery, serialized);
+	}
+
+	#[test]
+	fn relate() {
+		let subquery = Subquery::Relate(Default::default());
+		let serialized = serialize_internal(|| subquery.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(subquery, serialized);
+	}
+
+	#[test]
+	fn insert() {
+		let subquery = Subquery::Insert(Default::default());
+		let serialized = serialize_internal(|| subquery.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(subquery, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/table/mod.rs
+++ b/lib/src/sql/value/serde/ser/table/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod vec;

--- a/lib/src/sql/value/serde/ser/table/vec.rs
+++ b/lib/src/sql/value/serde/ser/table/vec.rs
@@ -1,0 +1,78 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Table;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Table>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeTableVec;
+	type SerializeTuple = Impossible<Vec<Table>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Table>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Table>, Error>;
+	type SerializeMap = Impossible<Vec<Table>, Error>;
+	type SerializeStruct = Impossible<Vec<Table>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Table>, Error>;
+
+	const EXPECTED: &'static str = "a `Table` sequence";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeTableVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializeTableVec(Vec<Table>);
+
+impl serde::ser::SerializeSeq for SerializeTableVec {
+	type Ok = Vec<Table>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(Table(value.serialize(ser::string::Serializer.wrap())?));
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Table> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Table("foo".to_owned())];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/thing/mod.rs
+++ b/lib/src/sql/value/serde/ser/thing/mod.rs
@@ -1,0 +1,93 @@
+use crate::err::Error;
+use crate::sql;
+use crate::sql::value::serde::ser;
+use crate::sql::Id;
+use crate::sql::Thing;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Thing;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Thing, Error>;
+	type SerializeTuple = Impossible<Thing, Error>;
+	type SerializeTupleStruct = Impossible<Thing, Error>;
+	type SerializeTupleVariant = Impossible<Thing, Error>;
+	type SerializeMap = Impossible<Thing, Error>;
+	type SerializeStruct = SerializeThing;
+	type SerializeStructVariant = Impossible<Thing, Error>;
+
+	const EXPECTED: &'static str = "a struct `Thing`";
+
+	fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+		sql::thing(value)
+	}
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeThing::default())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeThing {
+	tb: Option<String>,
+	id: Option<Id>,
+}
+
+impl serde::ser::SerializeStruct for SerializeThing {
+	type Ok = Thing;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"tb" => {
+				self.tb = Some(value.serialize(ser::string::Serializer.wrap())?);
+			}
+			"id" => {
+				self.id = Some(value.serialize(ser::id::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `Thing::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		match (self.tb, self.id) {
+			(Some(tb), Some(id)) => Ok(Thing {
+				tb,
+				id,
+			}),
+			_ => Err(Error::custom("`Thing` missing required field(s)")),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql;
+	use crate::sql::serde::serialize_internal;
+	use serde::Serialize;
+
+	#[test]
+	fn thing() {
+		let thing = sql::thing("foo:bar").unwrap();
+		let serialized = serialize_internal(|| thing.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(thing, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/timeout/mod.rs
+++ b/lib/src/sql/value/serde/ser/timeout/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod opt;

--- a/lib/src/sql/value/serde/ser/timeout/opt.rs
+++ b/lib/src/sql/value/serde/ser/timeout/opt.rs
@@ -1,0 +1,57 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Duration;
+use crate::sql::Timeout;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Timeout>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Timeout>, Error>;
+	type SerializeTuple = Impossible<Option<Timeout>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Timeout>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Timeout>, Error>;
+	type SerializeMap = Impossible<Option<Timeout>, Error>;
+	type SerializeStruct = Impossible<Option<Timeout>, Error>;
+	type SerializeStructVariant = Impossible<Option<Timeout>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Timeout>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(Timeout(Duration(value.serialize(ser::duration::Serializer.wrap())?))))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Timeout> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(Timeout::default());
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/uuid/mod.rs
+++ b/lib/src/sql/value/serde/ser/uuid/mod.rs
@@ -1,0 +1,48 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use uuid::Uuid;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Uuid;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Uuid, Error>;
+	type SerializeTuple = Impossible<Uuid, Error>;
+	type SerializeTupleStruct = Impossible<Uuid, Error>;
+	type SerializeTupleVariant = Impossible<Uuid, Error>;
+	type SerializeMap = Impossible<Uuid, Error>;
+	type SerializeStruct = Impossible<Uuid, Error>;
+	type SerializeStructVariant = Impossible<Uuid, Error>;
+
+	const EXPECTED: &'static str = "a UUID";
+
+	fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
+		Uuid::from_slice(value).map_err(Error::custom)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn nil() {
+		let uuid = Uuid::nil();
+		let serialized = serialize_internal(|| uuid.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(uuid, serialized);
+	}
+
+	#[test]
+	fn max() {
+		let uuid = Uuid::max();
+		let serialized = serialize_internal(|| uuid.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(uuid, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/value/map.rs
+++ b/lib/src/sql/value/serde/ser/value/map.rs
@@ -1,0 +1,100 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Value;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+use std::collections::BTreeMap;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = BTreeMap<String, Value>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<BTreeMap<String, Value>, Error>;
+	type SerializeTuple = Impossible<BTreeMap<String, Value>, Error>;
+	type SerializeTupleStruct = Impossible<BTreeMap<String, Value>, Error>;
+	type SerializeTupleVariant = Impossible<BTreeMap<String, Value>, Error>;
+	type SerializeMap = SerializeValueMap;
+	type SerializeStruct = Impossible<BTreeMap<String, Value>, Error>;
+	type SerializeStructVariant = Impossible<BTreeMap<String, Value>, Error>;
+
+	const EXPECTED: &'static str = "a struct or map";
+
+	fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+		Ok(SerializeValueMap::default())
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+#[derive(Default)]
+pub struct SerializeValueMap {
+	map: BTreeMap<String, Value>,
+	next_key: Option<String>,
+}
+
+impl serde::ser::SerializeMap for SerializeValueMap {
+	type Ok = BTreeMap<String, Value>;
+	type Error = Error;
+
+	fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize,
+	{
+		self.next_key = Some(key.serialize(ser::string::Serializer.wrap())?);
+		Ok(())
+	}
+
+	fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize,
+	{
+		match self.next_key.take() {
+			Some(key) => {
+				let value = value.serialize(ser::value::Serializer.wrap())?;
+				self.map.insert(key, value);
+				Ok(())
+			}
+			None => Err(Error::custom("`serialize_value` called before `serialize_key`")),
+		}
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.map)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let map: BTreeMap<String, Value> = Default::default();
+		let serialized = serialize_internal(|| map.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(map, serialized);
+	}
+
+	#[test]
+	fn map() {
+		let map = map! {
+			String::from("foo") => Value::from("bar"),
+		};
+		let serialized = serialize_internal(|| map.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(map, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/value/mod.rs
+++ b/lib/src/sql/value/serde/ser/value/mod.rs
@@ -1,0 +1,861 @@
+pub(super) mod map;
+pub(super) mod opt;
+pub(super) mod vec;
+
+use crate::err::Error;
+use crate::sql;
+use crate::sql::array::Array;
+use crate::sql::object::Object;
+use crate::sql::serde::serialize_internal;
+use crate::sql::value::serde::ser;
+use crate::sql::value::Value;
+use crate::sql::Block;
+use crate::sql::Datetime;
+use crate::sql::Duration;
+use crate::sql::Future;
+use crate::sql::Idiom;
+use crate::sql::Param;
+use crate::sql::Regex;
+use crate::sql::Strand;
+use crate::sql::Table;
+use crate::sql::Uuid;
+use bigdecimal::BigDecimal;
+use bigdecimal::FromPrimitive;
+use map::SerializeValueMap;
+use ser::edges::SerializeEdges;
+use ser::expression::SerializeExpression;
+use ser::function::SerializeFunction;
+use ser::model::SerializeModel;
+use ser::range::SerializeRange;
+use ser::thing::SerializeThing;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Serialize;
+use serde::ser::SerializeMap as _;
+use serde::ser::SerializeSeq as _;
+use std::fmt::Display;
+use storekey::encode::Error as EncodeError;
+use vec::SerializeValueVec;
+
+/// Convert a `T` into `surrealdb::sql::Value` which is an enum that can represent any valid SQL data.
+pub(crate) fn to_value<T>(value: T) -> Result<Value, Error>
+where
+	T: Serialize,
+{
+	serialize_internal(|| value.serialize(Serializer.wrap()))
+}
+
+impl serde::ser::Error for Error {
+	fn custom<T>(msg: T) -> Self
+	where
+		T: Display,
+	{
+		Self::Encode(EncodeError::Message(msg.to_string()))
+	}
+}
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Value;
+	type Error = Error;
+
+	type SerializeSeq = SerializeArray;
+	type SerializeTuple = SerializeArray;
+	type SerializeTupleStruct = SerializeArray;
+	type SerializeTupleVariant = SerializeTupleVariant;
+	type SerializeMap = SerializeMap;
+	type SerializeStruct = SerializeStruct;
+	type SerializeStructVariant = SerializeStructVariant;
+
+	const EXPECTED: &'static str = "an enum `Value`";
+
+	#[inline]
+	fn serialize_bool(self, value: bool) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_i8(self, value: i8) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_i16(self, value: i16) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_i32(self, value: i32) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_i64(self, value: i64) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	fn serialize_i128(self, value: i128) -> Result<Self::Ok, Error> {
+		match BigDecimal::from_i128(value) {
+			Some(decimal) => Ok(decimal.into()),
+			None => Err(Error::TryFromError(value.to_string(), "BigDecimal")),
+		}
+	}
+
+	#[inline]
+	fn serialize_u8(self, value: u8) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_u16(self, value: u16) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_u32(self, value: u32) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_u64(self, value: u64) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	fn serialize_u128(self, value: u128) -> Result<Self::Ok, Error> {
+		match BigDecimal::from_u128(value) {
+			Some(decimal) => Ok(decimal.into()),
+			None => Err(Error::TryFromError(value.to_string(), "BigDecimal")),
+		}
+	}
+
+	#[inline]
+	fn serialize_f32(self, value: f32) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_f64(self, value: f64) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	#[inline]
+	fn serialize_char(self, value: char) -> Result<Self::Ok, Error> {
+		Ok({
+			let mut s = String::new();
+			s.push(value);
+			s
+		}
+		.into())
+	}
+
+	#[inline]
+	fn serialize_str(self, value: &str) -> Result<Self::Ok, Error> {
+		Ok(value.into())
+	}
+
+	fn serialize_bytes(self, values: &[u8]) -> Result<Self::Ok, Error> {
+		let mut vec = Vec::with_capacity(values.len());
+		for value in values {
+			vec.push(Value::from(*value));
+		}
+		Ok(vec.into())
+	}
+
+	#[inline]
+	fn serialize_unit(self) -> Result<Self::Ok, Error> {
+		Ok(Value::None)
+	}
+
+	#[inline]
+	fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Error> {
+		self.serialize_unit()
+	}
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		match name {
+			sql::constant::TOKEN => ser::constant::Serializer
+				.serialize_unit_variant(name, variant_index, variant)
+				.map(Value::Constant),
+			sql::value::TOKEN => match variant {
+				"None" => Ok(Value::None),
+				"Null" => Ok(Value::Null),
+				"False" => Ok(Value::False),
+				"True" => Ok(Value::True),
+				variant => Err(Error::custom(format!("unknown unit variant `Value::{variant}`"))),
+			},
+			_ => self.serialize_str(variant),
+		}
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(self, name: &'static str, value: &T) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match name {
+			sql::strand::TOKEN => {
+				Ok(Value::Strand(Strand(value.serialize(ser::string::Serializer.wrap())?)))
+			}
+			sql::block::TOKEN => Ok(Value::Block(Box::new(Block(
+				value.serialize(ser::block::entry::vec::Serializer.wrap())?,
+			)))),
+			sql::duration::TOKEN => {
+				Ok(Value::Duration(Duration(value.serialize(ser::duration::Serializer.wrap())?)))
+			}
+			sql::future::TOKEN => Ok(Value::Future(Box::new(Future(Block(
+				value.serialize(ser::block::entry::vec::Serializer.wrap())?,
+			))))),
+			sql::regex::TOKEN => {
+				Ok(Value::Regex(Regex(value.serialize(ser::string::Serializer.wrap())?)))
+			}
+			sql::table::TOKEN => {
+				Ok(Value::Table(Table(value.serialize(ser::string::Serializer.wrap())?)))
+			}
+			sql::idiom::TOKEN => {
+				Ok(Value::Idiom(Idiom(value.serialize(ser::part::vec::Serializer.wrap())?)))
+			}
+			sql::param::TOKEN => {
+				Ok(Value::Param(Param(Idiom(value.serialize(ser::part::vec::Serializer.wrap())?))))
+			}
+			sql::array::TOKEN => Ok(Value::Array(Array(value.serialize(vec::Serializer.wrap())?))),
+			sql::object::TOKEN => {
+				Ok(Value::Object(Object(value.serialize(map::Serializer.wrap())?)))
+			}
+			sql::uuid::TOKEN => {
+				Ok(Value::Uuid(Uuid(value.serialize(ser::uuid::Serializer.wrap())?)))
+			}
+			sql::datetime::TOKEN => {
+				Ok(Value::Datetime(Datetime(value.serialize(ser::datetime::Serializer.wrap())?)))
+			}
+			_ => value.serialize(self.wrap()),
+		}
+	}
+
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match name {
+			sql::number::TOKEN => {
+				Ok(Value::Number(ser::number::Serializer.serialize_newtype_variant(
+					name,
+					variant_index,
+					variant,
+					value,
+				)?))
+			}
+			sql::subquery::TOKEN => {
+				Ok(Value::Subquery(Box::new(ser::subquery::Serializer.serialize_newtype_variant(
+					name,
+					variant_index,
+					variant,
+					value,
+				)?)))
+			}
+			sql::geometry::TOKEN => {
+				Ok(Value::Geometry(ser::geometry::Serializer.serialize_newtype_variant(
+					name,
+					variant_index,
+					variant,
+					value,
+				)?))
+			}
+			sql::value::TOKEN => value.serialize(Serializer.wrap()),
+			_ => Ok(map! {
+				String::from(variant) => value.serialize(Serializer.wrap())?,
+			}
+			.into()),
+		}
+	}
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Error> {
+		self.serialize_unit()
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		let inner = vec::SerializeValueVec(Vec::with_capacity(len.unwrap_or_default()));
+		Ok(SerializeArray(inner))
+	}
+
+	fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Error> {
+		self.serialize_seq(Some(len))
+	}
+
+	fn serialize_tuple_struct(
+		self,
+		_name: &'static str,
+		len: usize,
+	) -> Result<Self::SerializeTupleStruct, Error> {
+		self.serialize_seq(Some(len))
+	}
+
+	fn serialize_tuple_variant(
+		self,
+		name: &'static str,
+		variant_index: u32,
+		variant: &'static str,
+		len: usize,
+	) -> Result<Self::SerializeTupleVariant, Error> {
+		Ok(match name {
+			sql::model::TOKEN => {
+				SerializeTupleVariant::Model(ser::model::Serializer.serialize_tuple_variant(
+					name,
+					variant_index,
+					variant,
+					len,
+				)?)
+			}
+			sql::function::TOKEN => {
+				SerializeTupleVariant::Function(ser::function::Serializer.serialize_tuple_variant(
+					name,
+					variant_index,
+					variant,
+					len,
+				)?)
+			}
+			_ => SerializeTupleVariant::Unknown {
+				variant,
+				fields: SerializeValueVec(Vec::with_capacity(len)),
+			},
+		})
+	}
+
+	fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Error> {
+		Ok(SerializeMap(Default::default()))
+	}
+
+	fn serialize_struct(
+		self,
+		name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(match name {
+			sql::thing::TOKEN => SerializeStruct::Thing(Default::default()),
+			sql::expression::TOKEN => SerializeStruct::Expression(Default::default()),
+			sql::edges::TOKEN => SerializeStruct::Edges(Default::default()),
+			sql::range::TOKEN => SerializeStruct::Range(Default::default()),
+			_ => SerializeStruct::Unknown(Default::default()),
+		})
+	}
+
+	fn serialize_struct_variant(
+		self,
+		_name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStructVariant, Error> {
+		Ok(SerializeStructVariant {
+			name: String::from(variant),
+			map: Object::default(),
+		})
+	}
+}
+
+pub(super) struct SerializeArray(vec::SerializeValueVec);
+
+impl serde::ser::SerializeSeq for SerializeArray {
+	type Ok = Value;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		self.0.serialize_element(value)
+	}
+
+	fn end(self) -> Result<Value, Error> {
+		Ok(Value::Array(Array(self.0.end()?)))
+	}
+}
+
+impl serde::ser::SerializeTuple for SerializeArray {
+	type Ok = Value;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		serde::ser::SerializeSeq::serialize_element(self, value)
+	}
+
+	fn end(self) -> Result<Value, Error> {
+		serde::ser::SerializeSeq::end(self)
+	}
+}
+
+impl serde::ser::SerializeTupleStruct for SerializeArray {
+	type Ok = Value;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		serde::ser::SerializeSeq::serialize_element(self, value)
+	}
+
+	fn end(self) -> Result<Value, Error> {
+		serde::ser::SerializeSeq::end(self)
+	}
+}
+
+pub(super) struct SerializeMap(map::SerializeValueMap);
+
+impl serde::ser::SerializeMap for SerializeMap {
+	type Ok = Value;
+	type Error = Error;
+
+	fn serialize_key<T>(&mut self, key: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		self.0.serialize_key(key)
+	}
+
+	fn serialize_value<T>(&mut self, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		self.0.serialize_value(value)
+	}
+
+	fn end(self) -> Result<Value, Error> {
+		Ok(Value::Object(Object(self.0.end()?)))
+	}
+}
+
+pub(super) enum SerializeTupleVariant {
+	Model(SerializeModel),
+	Function(SerializeFunction),
+	Unknown {
+		variant: &'static str,
+		fields: SerializeValueVec,
+	},
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
+	type Ok = Value;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match self {
+			SerializeTupleVariant::Model(model) => model.serialize_field(value),
+			SerializeTupleVariant::Function(function) => function.serialize_field(value),
+			SerializeTupleVariant::Unknown {
+				ref mut fields,
+				..
+			} => fields.serialize_element(value),
+		}
+	}
+
+	fn end(self) -> Result<Value, Error> {
+		match self {
+			SerializeTupleVariant::Model(model) => Ok(Value::Model(model.end()?)),
+			SerializeTupleVariant::Function(function) => {
+				Ok(Value::Function(Box::new(function.end()?)))
+			}
+			SerializeTupleVariant::Unknown {
+				variant,
+				fields,
+			} => Ok(map! {
+				variant.to_owned() => Value::Array(Array(fields.end()?)),
+			}
+			.into()),
+		}
+	}
+}
+
+pub(super) enum SerializeStruct {
+	Thing(SerializeThing),
+	Expression(SerializeExpression),
+	Edges(SerializeEdges),
+	Range(SerializeRange),
+	Unknown(SerializeValueMap),
+}
+
+impl serde::ser::SerializeStruct for SerializeStruct {
+	type Ok = Value;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match self {
+			SerializeStruct::Thing(thing) => thing.serialize_field(key, value),
+			SerializeStruct::Expression(expr) => expr.serialize_field(key, value),
+			SerializeStruct::Edges(edges) => edges.serialize_field(key, value),
+			SerializeStruct::Range(range) => range.serialize_field(key, value),
+			SerializeStruct::Unknown(map) => map.serialize_entry(key, value),
+		}
+	}
+
+	fn end(self) -> Result<Value, Error> {
+		match self {
+			SerializeStruct::Thing(thing) => Ok(Value::Thing(thing.end()?)),
+			SerializeStruct::Expression(expr) => Ok(Value::Expression(Box::new(expr.end()?))),
+			SerializeStruct::Edges(edges) => Ok(Value::Edges(Box::new(edges.end()?))),
+			SerializeStruct::Range(range) => Ok(Value::Range(Box::new(range.end()?))),
+			SerializeStruct::Unknown(map) => Ok(Value::Object(Object(map.end()?))),
+		}
+	}
+}
+
+pub(super) struct SerializeStructVariant {
+	name: String,
+	map: Object,
+}
+
+impl serde::ser::SerializeStructVariant for SerializeStructVariant {
+	type Ok = Value;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		self.map.0.insert(String::from(key), value.serialize(Serializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Value, Error> {
+		let mut object = Object::default();
+
+		object.insert(self.name, Value::Object(self.map));
+
+		Ok(Value::Object(object))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql;
+	use crate::sql::block::Entry;
+	use crate::sql::constant::Constant;
+	use crate::sql::statements::CreateStatement;
+	use crate::sql::*;
+	use ::serde::Serialize;
+	use std::ops::Bound;
+
+	#[test]
+	fn none() {
+		let expected = Value::None;
+		assert_eq!(expected, to_value(&None::<u32>).unwrap());
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn null() {
+		let expected = Value::Null;
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn r#false() {
+		let expected = Value::False;
+		assert_eq!(expected, to_value(&false).unwrap());
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn r#true() {
+		let expected = Value::True;
+		assert_eq!(expected, to_value(&true).unwrap());
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn number() {
+		let number = Number::Int(Default::default());
+		let value = to_value(&number).unwrap();
+		let expected = Value::Number(number);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+
+		let number = Number::Float(Default::default());
+		let value = to_value(&number).unwrap();
+		let expected = Value::Number(number);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+
+		let number = Number::Decimal(Default::default());
+		let value = to_value(&number).unwrap();
+		let expected = Value::Number(number);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn strand() {
+		let strand = Strand("foobar".to_owned());
+		let value = to_value(&strand).unwrap();
+		let expected = Value::Strand(strand);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+
+		let strand = "foobar".to_owned();
+		let value = to_value(&strand).unwrap();
+		let expected = Value::Strand(Strand(strand));
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+
+		let strand = "foobar";
+		let value = to_value(&strand).unwrap();
+		let expected = Value::Strand(Strand(strand.to_owned()));
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn duration() {
+		let duration = Duration::default();
+		let value = to_value(&duration).unwrap();
+		let expected = Value::Duration(duration);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn datetime() {
+		let datetime = Datetime::default();
+		let value = to_value(&datetime).unwrap();
+		let expected = Value::Datetime(datetime);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn uuid() {
+		let uuid = Uuid::default();
+		let value = to_value(&uuid).unwrap();
+		let expected = Value::Uuid(uuid);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn array() {
+		let array = Array::default();
+		let value = to_value(&array).unwrap();
+		let expected = Value::Array(array);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn object() {
+		let object = Object::default();
+		let value = to_value(&object).unwrap();
+		let expected = Value::Object(object);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn geometry() {
+		let geometry = Geometry::Collection(Vec::new());
+		let value = to_value(&geometry).unwrap();
+		let expected = Value::Geometry(geometry);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn param() {
+		let param = Param::default();
+		let value = to_value(&param).unwrap();
+		let expected = Value::Param(param);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn idiom() {
+		let idiom = Idiom::default();
+		let value = to_value(&idiom).unwrap();
+		let expected = Value::Idiom(idiom);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn table() {
+		let table = Table("foo".to_owned());
+		let value = to_value(&table).unwrap();
+		let expected = Value::Table(table);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn thing() {
+		let record_id = sql::thing("foo:bar").unwrap();
+		let value = to_value(&record_id).unwrap();
+		let expected = Value::Thing(record_id);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn model() {
+		let model = Model::Count("foo".to_owned(), Default::default());
+		let value = to_value(&model).unwrap();
+		let expected = Value::Model(model);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn regex() {
+		let regex = Regex::default();
+		let value = to_value(&regex).unwrap();
+		let expected = Value::Regex(regex);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn block() {
+		let block = Box::new(Block::default());
+		let value = to_value(&block).unwrap();
+		let expected = Value::Block(block);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn range() {
+		let range = Box::new(Range {
+			tb: "foo".to_owned(),
+			beg: Bound::Included("foo".into()),
+			end: Bound::Unbounded,
+		});
+		let value = to_value(&range).unwrap();
+		let expected = Value::Range(range);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn edges() {
+		let edges = Box::new(Edges {
+			dir: Dir::In,
+			from: sql::thing("foo:bar").unwrap(),
+			what: Tables(vec!["foo".into()]),
+		});
+		let value = to_value(&edges).unwrap();
+		let expected = Value::Edges(edges);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn future() {
+		let future = Box::new(Future(Value::default().into()));
+		let value = to_value(&future).unwrap();
+		let expected = Value::Future(future);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+
+		let future = Box::new(Future(Block(vec![Entry::Create(CreateStatement::default())])));
+		let value = to_value(&future).unwrap();
+		let expected = Value::Future(future);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn constant() {
+		let constant = Constant::MathPi;
+		let value = to_value(&constant).unwrap();
+		let expected = Value::Constant(constant);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn function() {
+		let function = Box::new(Function::Cast("foo".to_owned(), Default::default()));
+		let value = to_value(&function).unwrap();
+		let expected = Value::Function(function);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn subquery() {
+		let subquery = Box::new(Subquery::Value(Value::None));
+		let value = to_value(&subquery).unwrap();
+		let expected = Value::Subquery(subquery);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn expression() {
+		let expression = Box::new(Expression {
+			l: "foo".into(),
+			o: Operator::Equal,
+			r: "Bar".into(),
+		});
+		let value = to_value(&expression).unwrap();
+		let expected = Value::Expression(expression);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+
+	#[test]
+	fn unknown_struct() {
+		#[derive(Debug, Serialize)]
+		struct FooBar {
+			foo: String,
+			bar: i32,
+		}
+
+		let foo = "Foo";
+		let bar = Default::default();
+		let foo_bar = FooBar {
+			bar,
+			foo: foo.to_owned(),
+		};
+		let value = to_value(&foo_bar).unwrap();
+		let expected = Value::Object(
+			map! {
+				"foo".to_owned() => foo.into(),
+				"bar".to_owned() => bar.into(),
+			}
+			.into(),
+		);
+		assert_eq!(value, expected);
+		assert_eq!(expected, to_value(&expected).unwrap());
+	}
+}

--- a/lib/src/sql/value/serde/ser/value/opt.rs
+++ b/lib/src/sql/value/serde/ser/value/opt.rs
@@ -1,0 +1,56 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Value;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Value>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Value>, Error>;
+	type SerializeTuple = Impossible<Option<Value>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Value>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Value>, Error>;
+	type SerializeMap = Impossible<Option<Value>, Error>;
+	type SerializeStruct = Impossible<Option<Value>, Error>;
+	type SerializeStructVariant = Impossible<Option<Value>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Value>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(super::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Value> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(Value::default());
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/value/vec.rs
+++ b/lib/src/sql/value/serde/ser/value/vec.rs
@@ -1,0 +1,78 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Value;
+use ser::Serializer as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Vec<Value>;
+	type Error = Error;
+
+	type SerializeSeq = SerializeValueVec;
+	type SerializeTuple = Impossible<Vec<Value>, Error>;
+	type SerializeTupleStruct = Impossible<Vec<Value>, Error>;
+	type SerializeTupleVariant = Impossible<Vec<Value>, Error>;
+	type SerializeMap = Impossible<Vec<Value>, Error>;
+	type SerializeStruct = Impossible<Vec<Value>, Error>;
+	type SerializeStructVariant = Impossible<Vec<Value>, Error>;
+
+	const EXPECTED: &'static str = "a `Vec<Value>`";
+
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Error> {
+		Ok(SerializeValueVec(Vec::with_capacity(len.unwrap_or_default())))
+	}
+
+	#[inline]
+	fn serialize_newtype_struct<T>(
+		self,
+		_name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self.wrap())
+	}
+}
+
+pub struct SerializeValueVec(pub Vec<Value>);
+
+impl serde::ser::SerializeSeq for SerializeValueVec {
+	type Ok = Vec<Value>;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.0.push(value.serialize(ser::value::Serializer.wrap())?);
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(self.0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+
+	#[test]
+	fn empty() {
+		let vec: Vec<Value> = Vec::new();
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+
+	#[test]
+	fn vec() {
+		let vec = vec![Value::default()];
+		let serialized = serialize_internal(|| vec.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(vec, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/version/mod.rs
+++ b/lib/src/sql/value/serde/ser/version/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod opt;

--- a/lib/src/sql/value/serde/ser/version/opt.rs
+++ b/lib/src/sql/value/serde/ser/version/opt.rs
@@ -1,0 +1,57 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Datetime;
+use crate::sql::Version;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Version>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Version>, Error>;
+	type SerializeTuple = Impossible<Option<Version>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Version>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Version>, Error>;
+	type SerializeMap = Impossible<Option<Version>, Error>;
+	type SerializeStruct = Impossible<Option<Version>, Error>;
+	type SerializeStructVariant = Impossible<Option<Version>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Version>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(Version(Datetime(value.serialize(ser::datetime::Serializer.wrap())?))))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::serde::serialize_internal;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Version> = None;
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(Version::default());
+		let serialized = serialize_internal(|| option.serialize(Serializer.wrap())).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -57,6 +57,8 @@ use std::str::FromStr;
 
 static MATCHER: Lazy<SkimMatcherV2> = Lazy::new(|| SkimMatcherV2::default().ignore_case());
 
+pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Value";
+
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct Values(pub Vec<Value>);
 
@@ -1446,32 +1448,32 @@ impl Serialize for Value {
 	{
 		if is_internal_serialization() {
 			match self {
-				Value::None => s.serialize_unit_variant("Value", 0, "None"),
-				Value::Null => s.serialize_unit_variant("Value", 1, "Null"),
-				Value::False => s.serialize_unit_variant("Value", 2, "False"),
-				Value::True => s.serialize_unit_variant("Value", 3, "True"),
-				Value::Number(v) => s.serialize_newtype_variant("Value", 4, "Number", v),
-				Value::Strand(v) => s.serialize_newtype_variant("Value", 5, "Strand", v),
-				Value::Duration(v) => s.serialize_newtype_variant("Value", 6, "Duration", v),
-				Value::Datetime(v) => s.serialize_newtype_variant("Value", 7, "Datetime", v),
-				Value::Uuid(v) => s.serialize_newtype_variant("Value", 8, "Uuid", v),
-				Value::Array(v) => s.serialize_newtype_variant("Value", 9, "Array", v),
-				Value::Object(v) => s.serialize_newtype_variant("Value", 10, "Object", v),
-				Value::Geometry(v) => s.serialize_newtype_variant("Value", 11, "Geometry", v),
-				Value::Param(v) => s.serialize_newtype_variant("Value", 12, "Param", v),
-				Value::Idiom(v) => s.serialize_newtype_variant("Value", 13, "Idiom", v),
-				Value::Table(v) => s.serialize_newtype_variant("Value", 14, "Table", v),
-				Value::Thing(v) => s.serialize_newtype_variant("Value", 15, "Thing", v),
-				Value::Model(v) => s.serialize_newtype_variant("Value", 16, "Model", v),
-				Value::Regex(v) => s.serialize_newtype_variant("Value", 17, "Regex", v),
-				Value::Block(v) => s.serialize_newtype_variant("Value", 18, "Block", v),
-				Value::Range(v) => s.serialize_newtype_variant("Value", 19, "Range", v),
-				Value::Edges(v) => s.serialize_newtype_variant("Value", 20, "Edges", v),
-				Value::Future(v) => s.serialize_newtype_variant("Value", 21, "Future", v),
-				Value::Constant(v) => s.serialize_newtype_variant("Value", 22, "Constant", v),
-				Value::Function(v) => s.serialize_newtype_variant("Value", 23, "Function", v),
-				Value::Subquery(v) => s.serialize_newtype_variant("Value", 24, "Subquery", v),
-				Value::Expression(v) => s.serialize_newtype_variant("Value", 25, "Expression", v),
+				Value::None => s.serialize_unit_variant(TOKEN, 0, "None"),
+				Value::Null => s.serialize_unit_variant(TOKEN, 1, "Null"),
+				Value::False => s.serialize_unit_variant(TOKEN, 2, "False"),
+				Value::True => s.serialize_unit_variant(TOKEN, 3, "True"),
+				Value::Number(v) => s.serialize_newtype_variant(TOKEN, 4, "Number", v),
+				Value::Strand(v) => s.serialize_newtype_variant(TOKEN, 5, "Strand", v),
+				Value::Duration(v) => s.serialize_newtype_variant(TOKEN, 6, "Duration", v),
+				Value::Datetime(v) => s.serialize_newtype_variant(TOKEN, 7, "Datetime", v),
+				Value::Uuid(v) => s.serialize_newtype_variant(TOKEN, 8, "Uuid", v),
+				Value::Array(v) => s.serialize_newtype_variant(TOKEN, 9, "Array", v),
+				Value::Object(v) => s.serialize_newtype_variant(TOKEN, 10, "Object", v),
+				Value::Geometry(v) => s.serialize_newtype_variant(TOKEN, 11, "Geometry", v),
+				Value::Param(v) => s.serialize_newtype_variant(TOKEN, 12, "Param", v),
+				Value::Idiom(v) => s.serialize_newtype_variant(TOKEN, 13, "Idiom", v),
+				Value::Table(v) => s.serialize_newtype_variant(TOKEN, 14, "Table", v),
+				Value::Thing(v) => s.serialize_newtype_variant(TOKEN, 15, "Thing", v),
+				Value::Model(v) => s.serialize_newtype_variant(TOKEN, 16, "Model", v),
+				Value::Regex(v) => s.serialize_newtype_variant(TOKEN, 17, "Regex", v),
+				Value::Block(v) => s.serialize_newtype_variant(TOKEN, 18, "Block", v),
+				Value::Range(v) => s.serialize_newtype_variant(TOKEN, 19, "Range", v),
+				Value::Edges(v) => s.serialize_newtype_variant(TOKEN, 20, "Edges", v),
+				Value::Future(v) => s.serialize_newtype_variant(TOKEN, 21, "Future", v),
+				Value::Constant(v) => s.serialize_newtype_variant(TOKEN, 22, "Constant", v),
+				Value::Function(v) => s.serialize_newtype_variant(TOKEN, 23, "Function", v),
+				Value::Subquery(v) => s.serialize_newtype_variant(TOKEN, 24, "Subquery", v),
+				Value::Expression(v) => s.serialize_newtype_variant(TOKEN, 25, "Expression", v),
 			}
 		} else {
 			match self {

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -11,8 +11,11 @@ use surrealdb::opt::auth::Namespace;
 use surrealdb::opt::auth::Root;
 use surrealdb::opt::auth::Scope;
 use surrealdb::opt::PatchOp;
+use surrealdb::sql::serde::serialize_internal;
 use surrealdb::sql::statements::BeginStatement;
 use surrealdb::sql::statements::CommitStatement;
+use surrealdb::sql::thing;
+use surrealdb::sql::Thing;
 use surrealdb::Surreal;
 use ulid::Ulid;
 
@@ -27,7 +30,7 @@ struct Record<'a> {
 
 #[derive(Debug, Deserialize)]
 struct RecordId {
-	id: String,
+	id: Thing,
 }
 
 #[derive(Debug, Deserialize)]
@@ -37,7 +40,7 @@ struct RecordName {
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 struct RecordBuf {
-	id: String,
+	id: Thing,
 	name: String,
 }
 

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -49,7 +49,7 @@ async fn query_binds() {
     };
     assert_eq!(record.name, "John Doe");
 	let mut response = db.query("SELECT * FROM $record_id")
-        .bind(("record_id", "user:john"))
+        .bind(("record_id", thing("user:john").unwrap()))
         .await
         .unwrap();
     let Some(record): Option<RecordName> = response.take(0).unwrap() else {
@@ -122,7 +122,7 @@ async fn create_record_with_id_with_content() {
 		})
 		.await
 		.unwrap();
-	assert_eq!(record.id, format!("user:john"));
+	assert_eq!(record.id, thing("user:john").unwrap());
 }
 
 #[tokio::test]
@@ -146,7 +146,7 @@ async fn select_record_id() {
 	let Some(record): Option<RecordId> = db.select(record_id).await.unwrap() else {
         panic!("record not found");
     };
-    assert_eq!(record.id, "user:john");
+    assert_eq!(record.id, thing("user:john").unwrap());
 }
 
 #[tokio::test]
@@ -161,7 +161,7 @@ async fn select_record_ranges() {
 	let convert = |users: Vec<RecordId>| -> Vec<String> {
 		users
 			.into_iter()
-			.map(|user| user.id.split_once(':').unwrap().1.to_owned())
+			.map(|user| user.id.id.to_string())
 			.collect()
 	};
 	let users: Vec<RecordId> = db.select(table).range(..).await.unwrap();
@@ -228,19 +228,19 @@ async fn update_table_with_content() {
 		.unwrap();
     let expected = &[
         RecordBuf {
-            id: "user:amos".to_owned(),
+            id: thing("user:amos").unwrap(),
             name: "Doe".to_owned(),
         },
         RecordBuf {
-            id: "user:jane".to_owned(),
+            id: thing("user:jane").unwrap(),
             name: "Doe".to_owned(),
         },
         RecordBuf {
-            id: "user:john".to_owned(),
+            id: thing("user:john").unwrap(),
             name: "Doe".to_owned(),
         },
         RecordBuf {
-            id: "user:zoey".to_owned(),
+            id: thing("user:zoey").unwrap(),
             name: "Doe".to_owned(),
         },
     ];
@@ -278,11 +278,11 @@ async fn update_record_range_with_content() {
 		.unwrap();
     assert_eq!(users, &[
         RecordBuf {
-            id: "user:jane".to_owned(),
+            id: thing("user:jane").unwrap(),
             name: "Doe".to_owned(),
         },
         RecordBuf {
-            id: "user:john".to_owned(),
+            id: thing("user:john").unwrap(),
             name: "Doe".to_owned(),
         },
     ]);
@@ -292,19 +292,19 @@ async fn update_record_range_with_content() {
 		.unwrap();
     assert_eq!(users, &[
         RecordBuf {
-            id: "user:amos".to_owned(),
+            id: thing("user:amos").unwrap(),
             name: "Amos".to_owned(),
         },
         RecordBuf {
-            id: "user:jane".to_owned(),
+            id: thing("user:jane").unwrap(),
             name: "Doe".to_owned(),
         },
         RecordBuf {
-            id: "user:john".to_owned(),
+            id: thing("user:john").unwrap(),
             name: "Doe".to_owned(),
         },
         RecordBuf {
-            id: "user:zoey".to_owned(),
+            id: thing("user:zoey").unwrap(),
             name: "Zoey".to_owned(),
         },
     ]);
@@ -347,7 +347,7 @@ struct Name {
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 struct Person {
     #[serde(skip_serializing)]
-    id: Option<String>,
+    id: Option<Thing>,
     title: Cow<'static, str>,
     name: Name,
     marketing: bool,
@@ -371,7 +371,7 @@ async fn merge_record_id() {
         })
         .await
         .unwrap();
-    assert_eq!(jaime.id.unwrap(), "person:jaime");
+    assert_eq!(jaime.id.unwrap(), thing("person:jaime").unwrap());
     jaime = db
         .update(record_id)
         .merge(json!({ "marketing": true }))
@@ -380,7 +380,7 @@ async fn merge_record_id() {
     assert!(jaime.marketing);
     jaime = db.select(record_id).await.unwrap();
     assert_eq!(jaime, Person {
-        id: Some("person:jaime".into()),
+        id: Some(thing("person:jaime").unwrap()),
         title: "Founder & COO".into(),
         name: Name {
             first: "Jaime".into(),
@@ -413,11 +413,11 @@ async fn patch_record_id() {
 	let value: Option<serde_json::Value> = db.select(("user", id)).await.unwrap();
 	assert_eq!(
 		value,
-		Some(json!({
-			"id": format!("user:{id}"),
+		Some(serialize_internal(|| json!({
+			"id": thing(&format!("user:{id}")).unwrap(),
 			"baz": "boo",
 			"hello": ["world"]
-		}))
+		})))
 	);
 }
 
@@ -471,11 +471,11 @@ async fn delete_record_range() {
 		.unwrap();
     assert_eq!(users, &[
         RecordBuf {
-            id: "user:amos".to_owned(),
+            id: thing("user:amos").unwrap(),
             name: "Amos".to_owned(),
         },
         RecordBuf {
-            id: "user:zoey".to_owned(),
+            id: thing("user:zoey").unwrap(),
             name: "Zoey".to_owned(),
         },
     ]);


### PR DESCRIPTION
## What is the motivation?

`sql::Value` is an integral part of `surrealdb`. It's the internal type used by our storage layer. Because of this, we do a lot of converting between this type and native Rust types. Currently this conversion is done through `JSON` using the `serde_json` crate because we do not have our own custom data format implementation. This works because `SQL` is a superset of `JSON`.  This, however, means that this conversion is lossy and can cause surprises in some cases. For example expecting record IDs to be deserialized into a `String` instead of its corresponding Rust native type.

## What does this change do?

This change implements a custom data format around `sql::Value` and introduces a `to_value` function that facilitates that conversion.

## What is your testing strategy?

Added a bunch of unit tests.

## Is this related to any issues?

Fixes https://github.com/surrealdb/surrealdb/issues/1609.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
