### PR TITLE
Add `isready` CLI command for checking server health

### DIFF
--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -19,7 +19,7 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 	let db = matches.value_of("db").unwrap();
 	// Connect to the database engine
 	let client = connect(endpoint).await?;
-	// Sign in to the server if the specified dabatabase engine supports it
+	// Sign in to the server if the specified database engine supports it
 	let root = Root {
 		username,
 		password,

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -19,7 +19,7 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 	let db = matches.value_of("db").unwrap();
 	// Connect to the database engine
 	let client = connect(endpoint).await?;
-	// Sign in to the server if the specified dabatabase engine supports it
+	// Sign in to the server if the specified database engine supports it
 	let root = Root {
 		username,
 		password,

--- a/src/cli/isready.rs
+++ b/src/cli/isready.rs
@@ -1,0 +1,16 @@
+use crate::err::Error;
+use surrealdb::engine::any::connect;
+
+#[tokio::main]
+pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
+	// Set the default logging level
+	crate::cli::log::init(0);
+	// Parse all other cli arguments
+	let endpoint = matches.value_of("conn").unwrap();
+	// Connect to the database engine
+	let client = connect(endpoint).await?;
+	// Check if the database engine is healthy
+	client.health().await?;
+	println!("OK");
+	Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@ mod backup;
 mod config;
 mod export;
 mod import;
+mod isready;
 mod log;
 mod sql;
 mod start;
@@ -467,6 +468,22 @@ pub fn init() -> ExitCode {
 			),
 	);
 
+	let setup = setup.subcommand(
+		Command::new("isready")
+			.display_order(7)
+			.about("Check if the SurrealDB server is ready to accept connections")
+			.arg(
+				Arg::new("conn")
+					.short('c')
+					.long("conn")
+					.alias("host")
+					.forbid_empty_values(true)
+					.validator(conn_valid)
+					.default_value("http://localhost:8000")
+					.help("Remote database server url to connect to"),
+			),
+	);
+
 	let matches = setup.get_matches();
 
 	let output = match matches.subcommand() {
@@ -476,6 +493,7 @@ pub fn init() -> ExitCode {
 		Some(("import", m)) => import::init(m),
 		Some(("export", m)) => export::init(m),
 		Some(("version", m)) => version::init(m),
+		Some(("isready", m)) => isready::init(m),
 		_ => Ok(()),
 	};
 

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -25,7 +25,7 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 	let pretty = matches.is_present("pretty");
 	// Connect to the database engine
 	let client = connect(endpoint).await?;
-	// Sign in to the server if the specified dabatabase engine supports it
+	// Sign in to the server if the specified database engine supports it
 	let root = Root {
 		username,
 		password,


### PR DESCRIPTION
## What is the motivation?

This is useful for Docker/Kubernetes to run a probe when curl/wget is not available.

## What does this change do?

This PR adds a new CLI command `isready` which connects to the specified surreal instance (default is `http://localhost:8000`) and invokes `health` API.
It exists with non-zero code in case of error.

## What is your testing strategy?

1. `cargo run -- isready` returns `0 OK` when db is up
2. `cargo run -- isready` returns `1` when db is down
3. `cargo run -- isready` returns `1` when db is up but a different port/scheme specified

## Is this related to any issues?

Resolves #1355

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
