### PR TITLE
added From<Vec<String> implementation to Value

### DIFF
--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -415,6 +415,12 @@ impl From<Vec<&str>> for Value {
 	}
 }
 
+impl From<Vec<String>> for Value {
+	fn from(v: Vec<String>) -> Self {
+		Value::Array(Array::from(v))
+	}
+}
+
 impl From<Vec<i32>> for Value {
 	fn from(v: Vec<i32>) -> Self {
 		Value::Array(Array::from(v))


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

currently working on a project using surrealDB that has Vec\<String\> struct fields that i want to turn int to Value

## What does this change do?

Adds From<Vec\<String\>> implementation for Value

## What is your testing strategy?

Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

https://github.com/surrealdb/surrealdb/issues/1687

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
