### PR TITLE
Upgrade `install-nix-action`

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v20
       - uses: cachix/cachix-action@v12
         with:
           name: surrealdb
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v20
       - uses: cachix/cachix-action@v12
         with:
           name: surrealdb
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v20
       - uses: cachix/cachix-action@v12
         with:
           name: surrealdb


### PR DESCRIPTION
## What is the motivation?

Current Cachix action is now broken.

## What does this change do?

It upgrades the `cachix/install-nix-action`.

## What is your testing strategy?

Make sure tests pass.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
