### PR TITLE
Fix #1698 - reduce code duplication in TiKV txn.

### DIFF
--- a/lib/src/kvs/tikv/mod.rs
+++ b/lib/src/kvs/tikv/mod.rs
@@ -32,6 +32,7 @@ impl Datastore {
 	}
 	/// Start a new transaction
 	pub async fn transaction(&self, write: bool, lock: bool) -> Result<Transaction, Error> {
+		// Set whether this should be an optimistic or pessimistic transaction
 		let mut opt = if lock {
 			TransactionOptions::new_pessimistic()
 		} else {
@@ -43,7 +44,7 @@ impl Datastore {
 		if !write {
 			opt = opt.read_only();
 		}
-		// Create a new optimistic transaction
+		// Create a new distributed transaction
 		match self.db.begin_with_options(opt).await {
 			Ok(tx) => Ok(Transaction {
 				ok: false,


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Excessive duplication was spotted in TiKV transaction code, giving the false impression that the `lock` argument doesn't matter.

## What does this change do?

Factors out the duplicate code.

## What is your testing strategy?

N/A

## Is this related to any issues?

Fixes #1698 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
