### PR TITLE
Implement readonly flag for namespace and database users

### DIFF
--- a/lib/src/dbs/session.rs
+++ b/lib/src/dbs/session.rs
@@ -26,6 +26,8 @@ pub struct Session {
 	pub tk: Option<Value>,
 	/// The current scope authentication data
 	pub sd: Option<Value>,
+	/// The current authentication username
+	pub us: Option<String>,
 }
 
 impl Session {
@@ -115,6 +117,7 @@ impl Session {
 			"sc".to_string() => self.sc.to_owned().into(),
 			"sd".to_string() => self.sd.to_owned().into(),
 			"tk".to_string() => self.tk.to_owned().into(),
+			"us".to_string() => self.us.to_owned().into(),
 		});
 		ctx.add_value(key, val);
 		// Output context

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -256,6 +256,8 @@ impl Datastore {
 		// Set current NS and DB
 		opt.ns = sess.ns();
 		opt.db = sess.db();
+		// Set the current user
+		opt.user = sess.us.clone();
 		// Set strict config
 		opt.strict = strict;
 		// Process all statements

--- a/lib/src/sql/statements/create.rs
+++ b/lib/src/sql/statements/create.rs
@@ -53,6 +53,8 @@ impl CreateStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::No)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Create a new iterator
 		let mut i = Iterator::new();
 		// Ensure futures are stored

--- a/lib/src/sql/statements/delete.rs
+++ b/lib/src/sql/statements/delete.rs
@@ -53,6 +53,8 @@ impl DeleteStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::No)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Create a new iterator
 		let mut i = Iterator::new();
 		// Ensure futures are stored

--- a/lib/src/sql/statements/insert.rs
+++ b/lib/src/sql/statements/insert.rs
@@ -56,6 +56,8 @@ impl InsertStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::No)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Create a new iterator
 		let mut i = Iterator::new();
 		// Ensure futures are stored

--- a/lib/src/sql/statements/relate.rs
+++ b/lib/src/sql/statements/relate.rs
@@ -66,6 +66,8 @@ impl RelateStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::No)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Create a new iterator
 		let mut i = Iterator::new();
 		// Ensure futures are stored

--- a/lib/src/sql/statements/remove.rs
+++ b/lib/src/sql/statements/remove.rs
@@ -109,6 +109,8 @@ impl RemoveNamespaceStatement {
 		opt.needs(Level::Kv)?;
 		// Allowed to run?
 		opt.check(Level::Kv)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Clone transaction
 		let run = txn.clone();
 		// Claim transaction
@@ -165,6 +167,8 @@ impl RemoveDatabaseStatement {
 		opt.needs(Level::Ns)?;
 		// Allowed to run?
 		opt.check(Level::Ns)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Clone transaction
 		let run = txn.clone();
 		// Claim transaction
@@ -224,6 +228,8 @@ impl RemoveLoginStatement {
 				opt.needs(Level::Ns)?;
 				// Allowed to run?
 				opt.check(Level::Kv)?;
+				// Has write access?
+				opt.writeable(txn).await?;
 				// Clone transaction
 				let run = txn.clone();
 				// Claim transaction
@@ -239,6 +245,8 @@ impl RemoveLoginStatement {
 				opt.needs(Level::Db)?;
 				// Allowed to run?
 				opt.check(Level::Ns)?;
+				// Has write access?
+				opt.writeable(txn).await?;
 				// Clone transaction
 				let run = txn.clone();
 				// Claim transaction
@@ -303,6 +311,8 @@ impl RemoveTokenStatement {
 				opt.needs(Level::Ns)?;
 				// Allowed to run?
 				opt.check(Level::Kv)?;
+				// Has write access?
+				opt.writeable(txn).await?;
 				// Clone transaction
 				let run = txn.clone();
 				// Claim transaction
@@ -318,6 +328,8 @@ impl RemoveTokenStatement {
 				opt.needs(Level::Db)?;
 				// Allowed to run?
 				opt.check(Level::Ns)?;
+				// Has write access?
+				opt.writeable(txn).await?;
 				// Clone transaction
 				let run = txn.clone();
 				// Claim transaction
@@ -333,6 +345,8 @@ impl RemoveTokenStatement {
 				opt.needs(Level::Db)?;
 				// Allowed to run?
 				opt.check(Level::Db)?;
+				// Has write access?
+				opt.writeable(txn).await?;
 				// Clone transaction
 				let run = txn.clone();
 				// Claim transaction
@@ -394,6 +408,8 @@ impl RemoveScopeStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::Db)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Clone transaction
 		let run = txn.clone();
 		// Claim transaction
@@ -450,6 +466,8 @@ impl RemoveParamStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::Db)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Clone transaction
 		let run = txn.clone();
 		// Claim transaction
@@ -504,6 +522,8 @@ impl RemoveTableStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::Db)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Clone transaction
 		let run = txn.clone();
 		// Claim transaction
@@ -561,6 +581,8 @@ impl RemoveEventStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::Db)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Clone transaction
 		let run = txn.clone();
 		// Claim transaction
@@ -624,6 +646,8 @@ impl RemoveFieldStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::Db)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Clone transaction
 		let run = txn.clone();
 		// Claim transaction
@@ -687,6 +711,8 @@ impl RemoveIndexStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::Db)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Clone transaction
 		let run = txn.clone();
 		// Claim transaction

--- a/lib/src/sql/statements/update.rs
+++ b/lib/src/sql/statements/update.rs
@@ -54,6 +54,8 @@ impl UpdateStatement {
 		opt.needs(Level::Db)?;
 		// Allowed to run?
 		opt.check(Level::No)?;
+		// Has write access?
+		opt.writeable(txn).await?;
 		// Create a new iterator
 		let mut i = Iterator::new();
 		// Ensure futures are stored

--- a/src/iam/signin.rs
+++ b/src/iam/signin.rs
@@ -202,7 +202,7 @@ pub async fn db(
 						exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
 						ns: Some(ns.to_owned()),
 						db: Some(db.to_owned()),
-						id: Some(user),
+						id: Some(user.to_owned()),
 						..Claims::default()
 					};
 					// Create the authentication token
@@ -211,6 +211,7 @@ pub async fn db(
 					session.tk = Some(val.into());
 					session.ns = Some(ns.to_owned());
 					session.db = Some(db.to_owned());
+					session.us = Some(user.to_owned());
 					session.au = Arc::new(Auth::Db(ns, db));
 					// Check the authentication token
 					match enc {
@@ -256,7 +257,7 @@ pub async fn ns(
 						nbf: Some(Utc::now().timestamp()),
 						exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
 						ns: Some(ns.to_owned()),
-						id: Some(user),
+						id: Some(user.to_owned()),
 						..Claims::default()
 					};
 					// Create the authentication token
@@ -264,6 +265,7 @@ pub async fn ns(
 					// Set the authentication on the session
 					session.tk = Some(val.into());
 					session.ns = Some(ns.to_owned());
+					session.us = Some(user.to_owned());
 					session.au = Arc::new(Auth::Ns(ns));
 					// Check the authentication token
 					match enc {
@@ -293,6 +295,7 @@ pub async fn su(
 	if let Some(root) = &opts.pass {
 		if user == opts.user && &pass == root {
 			session.au = Arc::new(Auth::Kv);
+			session.us = Some(user);
 			return Ok(None);
 		}
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

As mentioned in #1711 I see benefits to creating NS/DB logins which have restricted readonly access. For example, users who need access to generate reports out of production data should have no chance of accidentally causing harm to the data.

## What does this change do?

In order to get this to work I had to make a few changes
- The username used to sign in with is now stored in the session and options
  - As a side effect this value is now exposed to queries as `$session.us`
- Relevant statements now test whether the current user has write access
  - This is done after `opt.needs()` and `opt.check()`

As this is my first PR and first proper look around the codebase I would understand if there was a better way on doing this. I tried looking at how schema permissions work, but couldn't locate it. Naturally I'm willing to change things around if requested.

## What is your testing strategy?

- I have tested this as much as possible by executing various queries with different authentication modes and logins. 
- I have tested all statements in different situations e.g. as sub queries, within `IF`, etc
- I have tested `$session.us` in various ways

## Is this related to any issues?

See #1711 

## Questions
- Right now I'm returning the existing permission error if the check fails, perhaps it is worth considering adding a separate error clearly mentioning read-only access

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)