### PR TITLE
Add Axum example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-example"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "http",
+ "serde",
+ "surrealdb",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +2186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
 name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,6 +3241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
 name = "rustyline"
 version = "10.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3352,6 +3425,15 @@ checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db0969fff533976baadd92e08b1d102c5a3d8a8049eadfd69d4d1e3c5b2ed189"
+dependencies = [
  "serde",
 ]
 
@@ -3638,6 +3720,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tap"
@@ -3971,6 +4059,28 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ scripting = ["surrealdb/scripting"]
 http = ["surrealdb/http"]
 
 [workspace]
-members = ["lib", "lib/examples/actix"]
+members = ["lib", "lib/examples/actix", "lib/examples/axum"]
 
 [profile.release]
 lto = true

--- a/lib/examples/axum/Cargo.toml
+++ b/lib/examples/axum/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "axum-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = "0.6.11"
+http = "0.2.9"
+serde = { version = "1.0.152", features = ["derive"] }
+surrealdb = { path = "../.." }
+thiserror = "1.0.38"
+tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }

--- a/lib/examples/axum/src/error.rs
+++ b/lib/examples/axum/src/error.rs
@@ -1,0 +1,24 @@
+use axum::response::IntoResponse;
+use axum::response::Response;
+use axum::Json;
+use http::StatusCode;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+	#[error("database error")]
+	Db,
+}
+
+impl IntoResponse for Error {
+	fn into_response(self) -> Response {
+		(StatusCode::INTERNAL_SERVER_ERROR, Json(self.to_string())).into_response()
+	}
+}
+
+impl From<surrealdb::Error> for Error {
+	fn from(error: surrealdb::Error) -> Self {
+		eprintln!("{error}");
+		Self::Db
+	}
+}

--- a/lib/examples/axum/src/main.rs
+++ b/lib/examples/axum/src/main.rs
@@ -1,0 +1,36 @@
+mod error;
+mod person;
+
+use axum::routing::{delete, get, post, put};
+use axum::{Router, Server};
+use std::net::SocketAddr;
+use surrealdb::engine::remote::ws::Ws;
+use surrealdb::opt::auth::Root;
+use surrealdb::Surreal;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+	let db = Surreal::new::<Ws>("localhost:8000").await?;
+
+	db.signin(Root {
+		username: "root",
+		password: "root",
+	})
+	.await?;
+
+	db.use_ns("namespace").use_db("database").await?;
+
+	let app = Router::new()
+		.route("/person/:id", post(person::create))
+		.route("/person/:id", get(person::read))
+		.route("/person/:id", put(person::update))
+		.route("/person/:id", delete(person::delete))
+		.route("/people", get(person::list))
+		.with_state(db);
+
+	let addr = SocketAddr::from(([127, 0, 0, 1], 8080));
+
+	Server::bind(&addr).serve(app.into_make_service()).await?;
+
+	Ok(())
+}

--- a/lib/examples/axum/src/person.rs
+++ b/lib/examples/axum/src/person.rs
@@ -1,0 +1,50 @@
+use crate::error::Error;
+use axum::extract::Path;
+use axum::extract::State;
+use axum::Json;
+use serde::Deserialize;
+use serde::Serialize;
+use surrealdb::engine::remote::ws::Client;
+use surrealdb::Surreal;
+
+const PERSON: &str = "person";
+
+type Db = State<Surreal<Client>>;
+
+#[derive(Serialize, Deserialize)]
+pub struct Person {
+	name: String,
+}
+
+pub async fn create(
+	db: Db,
+	id: Path<String>,
+	Json(person): Json<Person>,
+) -> Result<Json<Person>, Error> {
+	let person = db.create((PERSON, &*id)).content(person).await?;
+	Ok(Json(person))
+}
+
+pub async fn read(db: Db, id: Path<String>) -> Result<Json<Option<Person>>, Error> {
+	let person = db.select((PERSON, &*id)).await?;
+	Ok(Json(person))
+}
+
+pub async fn update(
+	db: Db,
+	id: Path<String>,
+	Json(person): Json<Person>,
+) -> Result<Json<Person>, Error> {
+	let person = db.update((PERSON, &*id)).content(person).await?;
+	Ok(Json(person))
+}
+
+pub async fn delete(db: Db, id: Path<String>) -> Result<Json<()>, Error> {
+	db.delete((PERSON, &*id)).await?;
+	Ok(Json(()))
+}
+
+pub async fn list(db: Db) -> Result<Json<Vec<Person>>, Error> {
+	let people = db.select(PERSON).await?;
+	Ok(Json(people))
+}


### PR DESCRIPTION
## What is the motivation?

We already have an Actix Web example that shows how to use the static client with a web server. That's partly because Actix Web automatically wraps its state in an `Arc`, which is not necessary with `Surreal<_>`.

## What does this change do?

This PR adds an Axum example, showcasing how one can pass around `Surreal<_>` without wrapping it in an `Arc`.

## What is your testing strategy?

Ensure tests still pass.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
