### PR TITLE
Fix #1732 - casting string containing decimal to int.

### DIFF
--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -777,7 +777,7 @@ impl Value {
 	pub fn as_int(self) -> i64 {
 		match self {
 			Value::True => 1,
-			Value::Strand(v) => v.parse::<i64>().unwrap_or(0),
+			Value::Strand(v) => Number::from(v.as_str()).as_int(),
 			Value::Number(v) => v.as_int(),
 			Value::Duration(v) => v.as_secs() as i64,
 			Value::Datetime(v) => v.timestamp(),


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Contrary to the documentation, a string containing a decimal number couldn't be casted to an integer.

## What does this change do?

If `Value::as_int` (which `<int>` uses) can't parse as int directly, falls back to parsing as a big decimal before converting to int. This behavior is due to `Number::from`.

## What is your testing strategy?

Manually tested a decimal string.

## Is this related to any issues?

Fixes #1732

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
