### PR TITLE
[gh actions] Fix the nightly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+# Setting the shell option, it will run 'bash --noprofile --norc -eo pipefail {0}'
+defaults:
+  run:
+    shell: bash
+
 jobs:
 
   test:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,6 +67,7 @@ jobs:
     name: Build ${{ matrix.arch }}
     needs: [test, lint]
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: x86_64-apple-darwin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+# Setting the shell option, it will run 'bash --noprofile --norc -eo pipefail {0}'
+defaults:
+  run:
+    shell: bash
+
 jobs:
 
   test:
@@ -99,6 +104,7 @@ jobs:
         run: |
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static
+          choco install protoc
 
       - name: Install dependencies
         if: contains(matrix.arch, 'apple') && endsWith(matrix.arch, '-darwin')
@@ -110,8 +116,16 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get -y install musl-tools qemu-user libc6-dev-arm64-cross
-          sudo apt-get -y install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+          sudo apt-get -y install g++-aarch64-linux-gnu g++-10-aarch64-linux-gnu gcc-aarch64-linux-gnu gcc-10-aarch64-linux-gnu
           sudo apt-get -y install protobuf-compiler
+
+          # TODO(sgirones): Work around for the gprc-sys build error
+          # grpc-rs crate depends on a version of grpc-sys that depends on a version of absl that is not compatible with gcc >= 11.
+          set -x
+          sudo ln -fs gcc-10 /usr/bin/gcc
+          sudo ln -fs g++-10 /usr/bin/g++
+          sudo ln -fs aarch64-linux-gnu-gcc-10 /usr/bin/aarch64-linux-gnu-gcc
+          sudo ln -fs aarch64-linux-gnu-g++-10 /usr/bin/aarch64-linux-gnu-g++
 
       - name: Install FoundationDB
         if: contains(matrix.arch, 'linux') && startsWith(matrix.arch, 'x86_64')
@@ -126,7 +140,7 @@ jobs:
           targets: ${{ matrix.arch }}
 
       - name: Output package versions
-        run: go version ; cargo version ; rustc --version ; cmake --version ; gcc --version ; g++ --version ; perl -v
+        run: set -x; go version ; cargo version ; rustc --version ; cmake --version ; gcc --version ; g++ --version ; perl -v
 
       - name: Run cargo build
         run: cargo build ${{ matrix.opts }} --release --locked --target ${{ matrix.arch }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,6 +4,11 @@ on:
   - pull_request
   - push
 
+# Setting the shell option, it will run 'bash --noprofile --norc -eo pipefail {0}'
+defaults:
+  run:
+    shell: bash
+
 jobs:
 
   build-static:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*.*.*"
 
+# Setting the shell option, it will run 'bash --noprofile --norc -eo pipefail {0}'
+defaults:
+  run:
+    shell: bash
+
 jobs:
 
   test:
@@ -94,6 +99,7 @@ jobs:
         run: |
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static
+          choco install protoc
 
       - name: Install dependencies
         if: contains(matrix.arch, 'apple') && endsWith(matrix.arch, '-darwin')
@@ -105,8 +111,16 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get -y install musl-tools qemu-user libc6-dev-arm64-cross
-          sudo apt-get -y install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+          sudo apt-get -y install g++-aarch64-linux-gnu g++-10-aarch64-linux-gnu gcc-aarch64-linux-gnu gcc-10-aarch64-linux-gnu
           sudo apt-get -y install protobuf-compiler
+
+          # TODO(sgirones): Work around for the gprc-sys build error
+          # grpc-rs crate depends on a version of grpc-sys that depends on a version of absl that is not compatible with gcc >= 11.
+          set -x
+          sudo ln -fs gcc-10 /usr/bin/gcc
+          sudo ln -fs g++-10 /usr/bin/g++
+          sudo ln -fs aarch64-linux-gnu-gcc-10 /usr/bin/aarch64-linux-gnu-gcc
+          sudo ln -fs aarch64-linux-gnu-g++-10 /usr/bin/aarch64-linux-gnu-g++
 
       - name: Install FoundationDB
         if: contains(matrix.arch, 'linux') && startsWith(matrix.arch, 'x86_64')
@@ -121,7 +135,7 @@ jobs:
           targets: ${{ matrix.arch }}
 
       - name: Output package versions
-        run: go version ; cargo version ; rustc --version ; cmake --version ; gcc --version ; g++ --version ; perl -v
+        run: set -x; go version ; cargo version ; rustc --version ; cmake --version ; gcc --version ; g++ --version ; perl -v
 
       - name: Run cargo build
         run: cargo build ${{ matrix.opts }} --release --locked --target ${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
     name: Build ${{ matrix.arch }}
     needs: [test, lint]
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: x86_64-apple-darwin


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I'm figuring out why the nightly workflow fails: https://github.com/surrealdb/surrealdb/actions/runs/4559109203/jobs/8043133123#step:10:1077

## What does this change do?

* Installs the `protoc` compiler in the windows runner
* Downgrades the `gcc` and `g++` compilers to v10 so it can compile the `grpc-sys` crate

Others:
* Set the `run` shell to bash so it uses all the args defined by Github (see [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell))
* Sets `fail-fast: false` so we wait until all jobs finish and can see if more than one failed

## What is your testing strategy?

I copy&pasted the `build` steps from the `build`job in the nightly.yaml workflow to the ci.yaml workflow and fixed the errors:
* Here you see that only aarch64-linux and windows failed: https://github.com/surrealdb/surrealdb/actions/runs/4565746745
* Here you see a successful build of aarch64-linux: https://github.com/surrealdb/surrealdb/actions/runs/4566128149/jobs/8058192977
* Here you see a successful build of windows: https://github.com/surrealdb/surrealdb/actions/runs/4567799275/jobs/8062038965

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
