### PR TITLE
Re-activate integration tests for the HTTP engine

### DIFF
--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -71,7 +71,6 @@ mod ws {
 	include!("api/auth.rs");
 }
 
-/*
 #[cfg(feature = "protocol-http")]
 mod http {
 	use super::*;
@@ -93,7 +92,6 @@ mod http {
 	include!("api/auth.rs");
 	include!("api/backup.rs");
 }
-*/
 
 #[cfg(feature = "kv-mem")]
 mod mem {
@@ -158,7 +156,6 @@ mod fdb {
 	include!("api/backup.rs");
 }
 
-/*
 #[cfg(feature = "protocol-http")]
 mod any {
 	use super::*;
@@ -179,4 +176,3 @@ mod any {
 	include!("api/auth.rs");
 	include!("api/backup.rs");
 }
-*/


### PR DESCRIPTION
## What is the motivation?

HTTP tests are now passing again after the recent changes on main.

## What does this change do?

It un-comments the `http` and `any` engine integration tests. 

## What is your testing strategy?

Ensure the tests still pass.

## Is this related to any issues?

It reverts https://github.com/surrealdb/surrealdb/pull/1744.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
