### PR TITLE
Add compile-time guarantees to make `Surreal::delete` safer

### DIFF
--- a/lib/examples/actix/src/person.rs
+++ b/lib/examples/actix/src/person.rs
@@ -32,9 +32,9 @@ pub async fn update(id: Path<String>, person: Json<Person>) -> Result<Json<Perso
 }
 
 #[delete("/person/{id}")]
-pub async fn delete(id: Path<String>) -> Result<Json<()>, Error> {
-	DB.delete((PERSON, &*id)).await?;
-	Ok(Json(()))
+pub async fn delete(id: Path<String>) -> Result<Json<Option<Person>>, Error> {
+	let person = DB.delete((PERSON, &*id)).await?;
+	Ok(Json(person))
 }
 
 #[get("/people")]

--- a/lib/examples/axum/src/person.rs
+++ b/lib/examples/axum/src/person.rs
@@ -39,9 +39,9 @@ pub async fn update(
 	Ok(Json(person))
 }
 
-pub async fn delete(db: Db, id: Path<String>) -> Result<Json<()>, Error> {
-	db.delete((PERSON, &*id)).await?;
-	Ok(Json(()))
+pub async fn delete(db: Db, id: Path<String>) -> Result<Json<Option<Person>>, Error> {
+	let person = db.delete((PERSON, &*id)).await?;
+	Ok(Json(person))
 }
 
 pub async fn list(db: Db) -> Result<Json<Vec<Person>>, Error> {

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -424,10 +424,10 @@ async fn router(
 			Ok(DbResponse::Other(value))
 		}
 		Method::Delete => {
-			let statement = delete_statement(&mut params);
+			let (one, statement) = delete_statement(&mut params);
 			let query = Query(Statements(vec![Statement::Delete(statement)]));
 			let response = kvs.process(query, &*session, Some(vars.clone()), strict).await?;
-			let value = take(true, response).await?;
+			let value = take(one, response).await?;
 			Ok(DbResponse::Other(value))
 		}
 		Method::Query => {

--- a/lib/src/api/engine/mod.rs
+++ b/lib/src/api/engine/mod.rs
@@ -123,11 +123,14 @@ fn select_statement(params: &mut [Value]) -> (bool, SelectStatement) {
 }
 
 #[allow(dead_code)] // used by the the embedded database and `http`
-fn delete_statement(params: &mut [Value]) -> DeleteStatement {
-	let (_, what, _) = split_params(params);
-	DeleteStatement {
-		what,
-		output: Some(Output::None),
-		..Default::default()
-	}
+fn delete_statement(params: &mut [Value]) -> (bool, DeleteStatement) {
+	let (one, what, _) = split_params(params);
+	(
+		one,
+		DeleteStatement {
+			what,
+			output: Some(Output::Before),
+			..Default::default()
+		},
+	)
 }

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -459,10 +459,10 @@ async fn router(
 		}
 		Method::Delete => {
 			let path = base_url.join(SQL_PATH)?;
-			let statement = delete_statement(&mut params);
+			let (one, statement) = delete_statement(&mut params);
 			let request =
 				client.post(path).headers(headers.clone()).auth(auth).body(statement.to_string());
-			let value = take(true, request).await?;
+			let value = take(one, request).await?;
 			Ok(DbResponse::Other(value))
 		}
 		Method::Query => {

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -869,6 +869,9 @@ where
 	/// # Examples
 	///
 	/// ```no_run
+	/// # #[derive(serde::Deserialize)]
+	/// # struct Person;
+	/// #
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -877,10 +880,10 @@ where
 	/// db.use_ns("namespace").use_db("database").await?;
 	///
 	/// // Delete all records from a table
-	/// db.delete("person").await?;
+	/// let people: Vec<Person> = db.delete("person").await?;
 	///
 	/// // Delete a specific record from a table
-	/// db.delete(("person", "h5wxrf2ewk8xjxosxtyc")).await?;
+	/// let person: Option<Person> = db.delete(("person", "h5wxrf2ewk8xjxosxtyc")).await?;
 	/// #
 	/// # Ok(())
 	/// # }

--- a/lib/src/api/method/tests/mod.rs
+++ b/lib/src/api/method/tests/mod.rs
@@ -149,9 +149,9 @@ async fn api() {
 	let _: Option<User> = DB.update((USER, "john")).patch(PatchOp::remove("/name")).await.unwrap();
 
 	// delete
-	let _: () = DB.delete(USER).await.unwrap();
-	let _: () = DB.delete((USER, "john")).await.unwrap();
-	let _: () = DB.delete(USER).range("jane".."john").await.unwrap();
+	let _: Vec<User> = DB.delete(USER).await.unwrap();
+	let _: Option<User> = DB.delete((USER, "john")).await.unwrap();
+	let _: Vec<User> = DB.delete(USER).range("jane".."john").await.unwrap();
 
 	// export
 	let _: () = DB.export("backup.sql").await.unwrap();

--- a/lib/src/api/method/tests/server.rs
+++ b/lib/src/api/method/tests/server.rs
@@ -29,12 +29,10 @@ pub(super) fn mock(route_rx: Receiver<Option<Route>>) {
 					[] => Ok(DbResponse::Other(Value::None)),
 					_ => unreachable!(),
 				},
-				Method::Authenticate | Method::Kill | Method::Unset | Method::Delete => {
-					match &params[..] {
-						[_] => Ok(DbResponse::Other(Value::None)),
-						_ => unreachable!(),
-					}
-				}
+				Method::Authenticate | Method::Kill | Method::Unset => match &params[..] {
+					[_] => Ok(DbResponse::Other(Value::None)),
+					_ => unreachable!(),
+				},
 				Method::Live => match &params[..] {
 					[_] => Ok(DbResponse::Other(
 						"c6c0e36c-e2cf-42cb-b2d5-75415249b261".to_owned().into(),
@@ -71,7 +69,7 @@ pub(super) fn mock(route_rx: Receiver<Option<Route>>) {
 					[_, user] => Ok(DbResponse::Other(user.clone())),
 					_ => unreachable!(),
 				},
-				Method::Select => match &params[..] {
+				Method::Select | Method::Delete => match &params[..] {
 					[Value::Thing(..)] => Ok(DbResponse::Other(to_value(User::default()).unwrap())),
 					[Value::Table(..) | Value::Array(..) | Value::Range(..)] => {
 						Ok(DbResponse::Other(Value::Array(Array(Vec::new()))))

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -431,7 +431,8 @@ async fn delete_table() {
 	let _: RecordId = db.create(table).await.unwrap();
     let users: Vec<RecordId> = db.select(table).await.unwrap();
     assert_eq!(users.len(), 3);
-	db.delete(table).await.unwrap();
+	let users: Vec<RecordId> = db.delete(table).await.unwrap();
+    assert_eq!(users.len(), 3);
     let users: Vec<RecordId> = db.select(table).await.unwrap();
     assert!(users.is_empty());
 }
@@ -443,7 +444,8 @@ async fn delete_record_id() {
     let record_id = ("user", "john");
 	let _: RecordId = db.create(record_id).await.unwrap();
     let _: RecordId = db.select(record_id).await.unwrap();
-	db.delete(record_id).await.unwrap();
+	let john: Option<RecordId> = db.delete(record_id).await.unwrap();
+    assert!(john.is_some());
     let john: Option<RecordId> = db.select(record_id).await.unwrap();
     assert!(john.is_none());
 }
@@ -464,7 +466,17 @@ async fn delete_record_range() {
         .await
         .unwrap();
     response.check().unwrap();
-	db.delete(table).range("jane".."zoey").await.unwrap();
+	let users: Vec<RecordBuf> = db.delete(table).range("jane".."zoey").await.unwrap();
+    assert_eq!(users, &[
+        RecordBuf {
+            id: thing("user:jane").unwrap(),
+            name: "Jane".to_owned(),
+        },
+        RecordBuf {
+            id: thing("user:john").unwrap(),
+            name: "John".to_owned(),
+        },
+    ]);
 	let users: Vec<RecordBuf> = db
 		.select(table)
 		.await

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -220,7 +220,7 @@ async fn delete_all(
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 	// Specify the request statement
-	let sql = "DELETE type::table($table)";
+	let sql = "DELETE type::table($table) RETURN BEFORE";
 	// Specify the request variables
 	let vars = map! {
 		String::from("table") => Value::from(table),
@@ -451,7 +451,7 @@ async fn delete_one(
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 	// Specify the request statement
-	let sql = "DELETE type::thing($table, $id)";
+	let sql = "DELETE type::thing($table, $id) RETURN BEFORE";
 	// Parse the Record ID as a SurrealQL value
 	let rid = match surrealdb::sql::json(&id) {
 		Ok(id) => id,

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -660,7 +660,7 @@ impl Rpc {
 		// Get local copy of options
 		let opt = CF.get().unwrap();
 		// Specify the SQL query string
-		let sql = "DELETE $what";
+		let sql = "DELETE $what RETURN BEFORE";
 		// Specify the query parameters
 		let var = Some(map! {
 			String::from("what") => what.could_be_table(),


### PR DESCRIPTION
## What is the motivation?

Currently it's easy for one to accidentally delete an entire table using `Surreal::delete` by simply feeding it a table name instead of a record ID. This is because the return type is the same (a unit) whether one is deleting a single record or a record set (like a table).

## What does this change do?

Like all the other CRUD methods, `delete` now returns the affected records. It returns all the records deleted. As a result, one now needs to tell the compiler whether they expect the query to delete a single record

```rust
let user: Option<User> = db.delete(("user", "john")).await?;
```

or multiple records, like record ranges

```rust
let users: Vec<User> = db.delete("user").range("jane".."john").await?;
```

or entire tables

```rust
let users: Vec<User> = db.delete("user").await?;
```

Now when one tries to delete the entire table while intending to delete only a single record

```rust
let user: Option<User> = db.select("user").await?;
```

they get a compiler error similar to this one

```
error[E0308]: mismatched types
   --> lib/tests/api/mod.rs:432:34
    |
432 |     let user: Option<User> = db.select("user").await?;
    |               --------------  ^^^^^^^^^^^^^^^^^^^^^^ expected enum `Option`, found struct `Vec`
    |               |
    |               expected due to this
    |
    = note: expected enum `std::option::Option<User>`
             found struct `Vec<_>`
```

## What is your testing strategy?

Ensure all tests still pass.

## Is this related to any issues?

The issue of `delete`'s safety was raised on Discord previously.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
