### PR TITLE
Fixed discord link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,5 +185,5 @@ Join our growing community around the world, for help, ideas, and discussions re
 - Follow us on [Twitter](https://twitter.com/surrealdb)
 - Connect with us on [LinkedIn](https://www.linkedin.com/company/surrealdb/)
 - Join our [Dev community](https://dev.to/surrealdb)
-- Chat live with us on [Discord](https://discord.gg/GSeTUeA)
+- Chat live with us on [Discord](https://discord.gg/surrealdb)
 - Questions tagged #surrealdb on [StackOverflow](https://stackoverflow.com/questions/tagged/surrealdb)


### PR DESCRIPTION
Previous discord invite linked to the AppWrite server. New one correctly targets the SurrealDB server, matching the link on the website.

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
