### PR TITLE
Remove http crate from axum example

### DIFF
--- a/lib/examples/axum/Cargo.toml
+++ b/lib/examples/axum/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 axum = "0.6.12"
-http = "0.2.9"
 serde = { version = "1.0.159", features = ["derive"] }
 surrealdb = { path = "../.." }
 thiserror = "1.0.40"

--- a/lib/examples/axum/src/error.rs
+++ b/lib/examples/axum/src/error.rs
@@ -1,7 +1,7 @@
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::response::Response;
 use axum::Json;
-use http::StatusCode;
 use thiserror::Error;
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `axum` already has the `http` [re-exports](https://docs.rs/axum/latest/axum/index.html#reexports).

## What does this change do?

Remove `http` crate from the `axum` example

## What is your testing strategy?

Ensure tests still pass.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
