### PR TITLE
Update lock file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
 
       - name: Run cargo test
         run: |
-          (&>/dev/null cargo run --no-default-features -F storage-mem -- start --log trace --user root --pass root memory &)
-          cargo test --workspace --features protocol-ws,protocol-http,kv-rocksdb
+          cargo build --locked --no-default-features --features storage-mem
+          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory &)
+          cargo test --locked --workspace --features protocol-ws,protocol-http,kv-rocksdb
 
   lint:
     name: Lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,6 @@ name = "axum-example"
 version = "0.1.0"
 dependencies = [
  "axum",
- "http",
  "serde",
  "surrealdb",
  "thiserror",


### PR DESCRIPTION
## What is the motivation?

The nightly build is currently broken with the following error message

> error: the lock file /home/runner/work/surrealdb/surrealdb/Cargo.lock needs to be updated but --locked was passed to prevent this

## What does this change do?

It updates the `Cargo.lock` and adds the `--locked` flag to `cargo run` and `cargo test` so that this can be caught in the CI workflow.

## What is your testing strategy?

Make sure the tests still pass.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
