### PR TITLE
Print a newline after a query

### DIFF
--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -95,11 +95,8 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 						// Get the request response
 						match process(pretty, res) {
 							Ok(v) => {
-								let output = v.to_string();
-								println!("{output}");
-								if !output.is_empty() {
-									println!();
-								}
+								println!("{v}");
+								println!();
 							}
 							Err(e) => {
 								eprintln!("{e}");
@@ -154,14 +151,11 @@ fn process(pretty: bool, res: surrealdb::Result<Response>) -> Result<String, Err
 		},
 		Err(error) => return Err(error.into()),
 	};
-	if !value.is_none_or_null() {
-		// Check if we should prettify
-		return Ok(match pretty {
-			// Don't prettify the response
-			false => value.to_string(),
-			// Yes prettify the response
-			true => format!("{value:#}"),
-		});
-	}
-	Ok(String::new())
+	// Check if we should prettify
+	Ok(match pretty {
+		// Don't prettify the response
+		false => value.to_string(),
+		// Yes prettify the response
+		true => format!("{value:#}"),
+	})
 }

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -85,6 +85,7 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 								Statement::Set(stmt) => {
 									if let Err(e) = client.set(&stmt.name, &stmt.what).await {
 										eprintln!("{e}");
+										eprintln!();
 									}
 								}
 								_ => {}
@@ -93,11 +94,23 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 						let res = client.query(query).await;
 						// Get the request response
 						match process(pretty, res) {
-							Ok(v) => println!("{v}"),
-							Err(e) => eprintln!("{e}"),
+							Ok(v) => {
+								let output = v.to_string();
+								println!("{output}");
+								if !output.is_empty() {
+									println!();
+								}
+							}
+							Err(e) => {
+								eprintln!("{e}");
+								eprintln!();
+							}
 						}
 					}
-					Err(e) => eprintln!("{e}"),
+					Err(e) => {
+						eprintln!("{e}");
+						eprintln!();
+					}
 				}
 			}
 			// The user types CTRL-C


### PR DESCRIPTION
## What is the motivation?

When using `surreal sql` we don't currently print a new line after a query output or an error.

```bash
$ surreal sql --conn memory
> USE NS ns DB db

ns/db> CREATE item
{ id: item:xnheevg9ivldhhxqstce }
ns/db> CREATE item
{ id: item:dl2a8b78pxnbbujofvcl }
ns/db> SELECT * FROM item
[{ id: item:dl2a8b78pxnbbujofvcl }, { id: item:xnheevg9ivldhhxqstce }]
ns/db> INVALID QUERY
Parse error on line 1 at character 0 when parsing 'INVALID QUERY'
ns/db> SELECT * FROM item
[{ id: item:dl2a8b78pxnbbujofvcl }, { id: item:xnheevg9ivldhhxqstce }]
ns/db>
```

## What does this change do?

It prints a new line where appropriate to improve readability.

```bash
$ surreal sql --conn memory
> USE NS ns DB db

ns/db> CREATE item
{ id: item:80d5dzw1eogi842a4zzl }

ns/db> CREATE item
{ id: item:3nde52o7ehluu34la6n0 }

ns/db> SELECT * FROM item
[{ id: item:3nde52o7ehluu34la6n0 }, { id: item:80d5dzw1eogi842a4zzl }]

ns/db> INVALID QUERY
Parse error on line 1 at character 0 when parsing 'INVALID QUERY'

ns/db> SELECT * FROM item
[{ id: item:3nde52o7ehluu34la6n0 }, { id: item:80d5dzw1eogi842a4zzl }]

ns/db>
```

## What is your testing strategy?

Tested the changes manually using

```bash
$ cargo run --no-default-features -F storage-mem -- sql --conn memory
```
## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
