### PR TITLE
Docs - Update BUILDING.md regarding protobuf compiler dependency on linux/mac

### DIFF
--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -17,7 +17,7 @@ While installing `rustup`, use the default (`stable`) release channel of Rust fo
 ### ✅ Compile for `apple-darwin` (macOS)
 ```bash
 # Setup
-brew install cmake
+brew install cmake protobuf
 rustup target add x86_64-apple-darwin
 rustup target add aarch64-apple-darwin
 # Compile for x86_64-apple-darwin
@@ -42,7 +42,8 @@ apt-get -y install \
 	musl-tools \
 	libssl-dev \
 	pkg-config \
-	build-essential
+	build-essential \
+	protobuf-compiler
 # Install rustlang and cargo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
@@ -68,7 +69,8 @@ apt-get -y install \
 	musl-tools \
 	libssl-dev \
 	pkg-config \
-	build-essential
+	build-essential \
+	protobuf-compiler
 # Install rustlang and cargo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
@@ -82,7 +84,7 @@ cargo build --release --locked --target x86_64-unknown-linux-gnu
 <sub>This does not yet build successfully</sub>
 ```bash
 # Setup
-brew install cmake mingw-w64
+brew install cmake mingw-w64 protobuf
 rustup target add x86_64-pc-windows-gnu
 # Compile for x86_64-w64-mingw32-gcc
 export CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc
@@ -123,7 +125,8 @@ apt-get -y install \
 	musl-tools \
 	libssl-dev \
 	pkg-config \
-	build-essential
+	build-essential \
+	protobuf-compiler
 # Install rustlang and cargo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
@@ -148,6 +151,7 @@ apt-get -y install \
 	libssl-dev \
 	pkg-config \
 	build-essential \
+	protobuf-compiler \
 	libc6-dev-amd64-cross \
 	crossbuild-essential-amd64
 # Install rustlang and cargo
@@ -232,7 +236,8 @@ apt-get -y install \
 	musl-tools \
 	libssl-dev \
 	pkg-config \
-	build-essential
+	build-essential \
+	protobuf-compiler
 # Install rustlang and cargo
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
@@ -257,6 +262,7 @@ apt-get -y install \
 	libssl-dev \
 	pkg-config \
 	build-essential \
+	protobuf-compiler \
 	libc6-dev-arm64-cross \
 	crossbuild-essential-arm64
 # Install rustlang and cargo
@@ -297,6 +303,7 @@ apt-get -y install \
 	libssl-dev \
 	pkg-config \
 	build-essential \
+	protobuf-compiler \
 	g++-arm-linux-gnueabihf \
 	gcc-arm-linux-gnueabihf
 # Install rustlang and cargo


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Protobuf compiler is now a dependency and trying to compile `surrealdb` without it results in:
```console
   Compiling opentelemetry-proto v0.1.0
error: failed to run custom build command for `opentelemetry-proto v0.1.0`

Caused by:
  process didn't exit successfully: `/home/finnb/git/finnbear/surrealdb/target/debug/build/opentelemetry-proto-40f599ebc3d60712/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=src/proto/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto
  cargo:rerun-if-changed=src/proto/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto
  cargo:rerun-if-changed=src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.proto
  cargo:rerun-if-changed=src/proto/opentelemetry-proto/opentelemetry/proto/trace/v1/trace_config.proto
  cargo:rerun-if-changed=src/proto/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.proto
  cargo:rerun-if-changed=src/proto/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto
  cargo:rerun-if-changed=src/proto/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
  cargo:rerun-if-changed=src/proto/opentelemetry-proto/opentelemetry/proto/logs/v1/logs.proto
  cargo:rerun-if-changed=src/proto/opentelemetry-proto/opentelemetry/proto/collector/logs/v1/logs_service.proto
  cargo:rerun-if-changed=src/proto/opentelemetry-proto

  --- stderr
  thread 'main' panicked at 'Could not find `protoc` installation and this build crate cannot proceed without
      this knowledge. If `protoc` is installed and this crate had trouble finding
      it, you can set the `PROTOC` environment variable with the specific path to your
      installed `protoc` binary.If you're on debian, try `apt-get install protobuf-compiler` or download it from https://github.com/protocolbuffers/protobuf/releases

  For more information: https://docs.rs/prost-build/#sourcing-protoc
  ', /home/finnb/.cargo/registry/src/github.com-1ecc6299db9ec823/prost-build-0.11.8/src/lib.rs:1434:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## What does this change do?

Adds a protobuf installation command to Linux and Mac build instructions. Windows instructions may need a similar update but I'm inclined to leave that to someone who has more experience with and access to Windows (although, upon request, I could try using an AWS EC2 Windows VM).

## What is your testing strategy?

(pending) I tested the Ubuntu 20.04 instructions on a fresh install. I'm inclined to leave MacOS testing to someone with access to a sufficiently powerful MacOS computer (although, upon request, I could try using an AWS EC2 MacOS VM).

## Is this related to any issues?

Related to #1616 which fixed the CI

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
