### PR TITLE
Change `cargo` commands to only build `storage-mem` in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,19 +35,19 @@ cargo run -- help
 To run the SurrealDB database server, use the following command:
 
 ```bash
-cargo run -- start --log trace --user root --pass root memory
+cargo run --no-default-features --features storage-mem,http,scripting -- start --log trace --user root --pass root memory
 ```
 
 To listen to code changes as you develop, use the following command:
 
 ```bash
-cargo watch -x 'run -- start --log trace --user root --pass root memory'
+cargo watch -x 'run --no-default-features --features storage-mem,http,scripting -- start --log trace --user root --pass root memory'
 ```
 
 SurrealDB runs by default on port 8000. To change the default port, use the following command:
 
 ```bash
-cargo run -- start --log trace --user root --pass root --bind 0.0.0.0:9000 memory
+cargo run --no-default-features --features storage-mem,http,scripting -- start --log trace --user root --pass root --bind 0.0.0.0:9000 memory
 ```
 
 To run all tests manually, use the SurrealDB command-line from your terminal:


### PR DESCRIPTION
## What is the motivation?

Commands in `CONTRIBUTING.md` currently build all the default features but only use the `memory` engine.

## What does this change do?

It drops `storage-rocksdb` from the features built, improving compile times considerably.

## What is your testing strategy?

Manually tested all the commands.

## Is this related to any issues?

It was inspired by [this Discord message](https://discord.com/channels/902568124350599239/970338835990974484/1096080826116100096).

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
