### PR TITLE
Refactor and reduce allocations in query executor.

### DIFF
--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -59,24 +59,17 @@ impl<'a> Executor<'a> {
 	async fn commit(&mut self, local: bool) {
 		if local {
 			if let Some(txn) = self.txn.as_ref() {
-				match &self.err {
-					true => {
-						let txn = txn.clone();
-						let mut txn = txn.lock().await;
-						if txn.cancel().await.is_err() {
-							self.err = true;
-						}
-						self.txn = None;
-					}
-					false => {
-						let txn = txn.clone();
-						let mut txn = txn.lock().await;
-						if txn.commit().await.is_err() {
-							self.err = true;
-						}
-						self.txn = None;
-					}
+				let txn = txn.clone();
+				let mut txn = txn.lock().await;
+				let result = if self.err {
+					txn.cancel().await
+				} else {
+					txn.commit().await
+				};
+				if result.is_err() {
+					self.err = true;
 				}
+				self.txn = None;
 			}
 		}
 	}
@@ -140,7 +133,7 @@ impl<'a> Executor<'a> {
 		// Initialise array of responses
 		let mut out: Vec<Response> = vec![];
 		// Process all statements in query
-		for stm in qry.iter() {
+		for stm in qry.into_iter() {
 			// Log the statement
 			debug!(target: LOG, "Executing: {}", stm);
 			// Reset errors
@@ -149,23 +142,27 @@ impl<'a> Executor<'a> {
 			}
 			// Get the statement start time
 			let now = Instant::now();
+			// Store whether this statement's output
+			// should override all previous output.
+			let is_output = matches!(stm, Statement::Output(_));
 			// Process a single statement
 			let res = match stm {
 				// Specify runtime options
-				Statement::Option(stm) => {
+				Statement::Option(mut stm) => {
 					// Selected DB?
 					opt.needs(Level::Db)?;
 					// Allowed to run?
 					opt.check(Level::Db)?;
 					// Process the option
-					match &stm.name.to_uppercase()[..] {
-						"FIELDS" => opt = opt.fields(stm.what),
-						"EVENTS" => opt = opt.events(stm.what),
-						"TABLES" => opt = opt.tables(stm.what),
-						"IMPORT" => opt = opt.import(stm.what),
-						"FORCE" => opt = opt.force(stm.what),
+					stm.name.0.make_ascii_uppercase();
+					opt = match stm.name.0.as_str() {
+						"FIELDS" => opt.fields(stm.what),
+						"EVENTS" => opt.events(stm.what),
+						"TABLES" => opt.tables(stm.what),
+						"IMPORT" => opt.import(stm.what),
+						"FORCE" => opt.force(stm.what),
 						_ => break,
-					}
+					};
 					// Continue
 					continue;
 				}
@@ -223,7 +220,7 @@ impl<'a> Executor<'a> {
 					Ok(Value::None)
 				}
 				// Process param definition statements
-				Statement::Set(stm) => {
+				Statement::Set(mut stm) => {
 					// Create a transaction
 					let loc = self.begin(stm.writeable()).await;
 					// Check the transaction
@@ -238,16 +235,18 @@ impl<'a> Executor<'a> {
 								false => stm.compute(&ctx, &opt, &self.txn(), None).await,
 								// The user tried to set a protected variable
 								true => Err(Error::InvalidParam {
-									name: stm.name.to_owned(),
+									// Moving the name string is ok since the following error handling doesn't care about it.
+									name: std::mem::take(&mut stm.name),
 								}),
 							};
 							// Check the statement
 							match res {
 								Ok(val) => {
+									let writeable = stm.writeable();
 									// Set the parameter
-									ctx.add_value(stm.name.to_owned(), val);
+									ctx.add_value(stm.name, val);
 									// Finalise transaction
-									match stm.writeable() {
+									match writeable {
 										true => self.commit(loc).await,
 										false => self.cancel(loc).await,
 									}
@@ -297,13 +296,11 @@ impl<'a> Executor<'a> {
 									None => stm.compute(&ctx, &opt, &self.txn(), None).await,
 								};
 								// Finalise transaction
-								match &res {
-									Ok(_) => match stm.writeable() {
-										true => self.commit(loc).await,
-										false => self.cancel(loc).await,
-									},
-									Err(_) => self.cancel(loc).await,
-								};
+								if res.is_ok() && stm.writeable() {
+									self.commit(loc).await;
+								} else {
+									self.cancel(loc).await;
+								}
 								// Return the result
 								res
 							}
@@ -311,36 +308,26 @@ impl<'a> Executor<'a> {
 					}
 				},
 			};
-			// Get the statement end time
-			let dur = now.elapsed();
+
 			// Produce the response
-			let res = match res {
-				Ok(v) => Response {
-					time: dur,
-					result: Ok(v),
-				},
-				Err(e) => {
-					// Produce the response
-					let res = Response {
-						time: dur,
-						result: Err(e),
-					};
-					// Mark the error
+			let res = Response {
+				// Get the statement end time
+				time: now.elapsed(),
+				// TODO: Replace with `inspect_err` once stable.
+				result: res.map_err(|e| {
+					// Mark the error.
 					self.err = true;
-					// Return
-					res
-				}
+					e
+				}),
 			};
 			// Output the response
-			match self.txn {
-				Some(_) => match stm {
-					Statement::Output(_) => {
-						buf.clear();
-						buf.push(res);
-					}
-					_ => buf.push(res),
-				},
-				None => out.push(res),
+			if self.txn.is_some() {
+				if is_output {
+					buf.clear();
+				}
+				buf.push(res);
+			} else {
+				out.push(res)
 			}
 		}
 		// Return responses

--- a/lib/src/sql/query.rs
+++ b/lib/src/sql/query.rs
@@ -25,6 +25,12 @@ impl Display for Query {
 	}
 }
 
+impl Query {
+	pub(crate) fn into_iter(self) -> std::vec::IntoIter<Statement> {
+		self.0.into_iter()
+	}
+}
+
 pub fn query(i: &str) -> IResult<&str, Query> {
 	let (i, v) = all_consuming(statements)(i)?;
 	Ok((i, Query(v)))

--- a/lib/src/sql/query.rs
+++ b/lib/src/sql/query.rs
@@ -19,15 +19,17 @@ impl Deref for Query {
 	}
 }
 
-impl Display for Query {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		write!(Pretty::from(f), "{}", &self.0)
+impl IntoIterator for Query {
+	type Item = Statement;
+	type IntoIter = std::vec::IntoIter<Self::Item>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.into_iter()
 	}
 }
 
-impl Query {
-	pub(crate) fn into_iter(self) -> std::vec::IntoIter<Statement> {
-		self.0.into_iter()
+impl Display for Query {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		write!(Pretty::from(f), "{}", &self.0)
 	}
 }
 

--- a/lib/src/sql/statement.rs
+++ b/lib/src/sql/statement.rs
@@ -49,18 +49,20 @@ impl Deref for Statements {
 	}
 }
 
-impl fmt::Display for Statements {
+impl IntoIterator for Statements {
+	type Item = Statement;
+	type IntoIter = std::vec::IntoIter<Self::Item>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.into_iter()
+	}
+}
+
+impl Display for Statements {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		Display::fmt(
 			&Fmt::one_line_separated(self.0.iter().map(|v| Fmt::new(v, |v, f| write!(f, "{v};")))),
 			f,
 		)
-	}
-}
-
-impl Statements {
-	pub(crate) fn into_iter(self) -> std::vec::IntoIter<Statement> {
-		self.0.into_iter()
 	}
 }
 

--- a/lib/src/sql/statement.rs
+++ b/lib/src/sql/statement.rs
@@ -58,6 +58,12 @@ impl fmt::Display for Statements {
 	}
 }
 
+impl Statements {
+	pub(crate) fn into_iter(self) -> std::vec::IntoIter<Statement> {
+		self.0.into_iter()
+	}
+}
+
 pub fn statements(i: &str) -> IResult<&str, Statements> {
 	let (i, v) = separated_list1(colons, statement)(i)?;
 	let (i, _) = many0(alt((colons, comment)))(i)?;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The query executor:
- Had some code duplication
- Needlessly allocated a few `String`'s on the heap

## What does this change do?

- Reduces code duplication
- Eliminates some needless `String` allocations
- See comments for something I noticed while refactoring...

## What is your testing strategy?

Ran some queries via `make sql`.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
