### PR TITLE
Fix HTTP string errors deserialization

### DIFF
--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -5,6 +5,8 @@ mod api_integration {
 	use serde_json::json;
 	use std::borrow::Cow;
 	use std::ops::Bound;
+	use surrealdb::error::Api as ApiError;
+	use surrealdb::error::Db as DbError;
 	use surrealdb::opt::auth::Database;
 	use surrealdb::opt::auth::Jwt;
 	use surrealdb::opt::auth::Namespace;
@@ -16,6 +18,7 @@ mod api_integration {
 	use surrealdb::sql::statements::CommitStatement;
 	use surrealdb::sql::thing;
 	use surrealdb::sql::Thing;
+	use surrealdb::Error;
 	use surrealdb::Surreal;
 	use ulid::Ulid;
 

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -9,7 +9,16 @@ async fn connect() {
 #[tokio::test]
 async fn yuse() {
 	let db = new_db().await;
-	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+    let item = Ulid::new().to_string();
+    let error = db.create::<Vec<()>>(item.as_str()).await.unwrap_err();
+    match error {
+        // Local engines return this error
+        Error::Db(DbError::NsEmpty) => {}
+        // Remote engines return this error
+        Error::Api(ApiError::Query(error)) if error.contains("Specify a namespace to use") => {}
+        error => panic!("{:?}", error),
+    }
+	db.use_ns(NS).use_db(item).await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What is the motivation?

When using the HTTP engine it sometimes returns errors that cannot be deserialised. For example

```bash
$ surreal sql --conn http://localhost:8000
> CREATE item
There was a problem with the database: Failed to deserialize a binary response: unknown variant `Specify a namespace to use`, expected one of `None`, `Null`, `False`, `True`, `Number`, `Strand`, `Duration`, `Datetime`, `Uuid`, `Array`, `Object`, `Geometry`, `Bytes`, `Param`, `Idiom`, `Table`, `Thing`, `Model`, `Regex`, `Block`, `Range`, `Edges`, `Future`, `Constant`, `Function`, `Subquery`, `Expression`
```

## What does this change do?

It handles such errors so that a proper error is returned. After this PR

```bash
$ cargo run --no-default-features -F storage-mem -- sql --conn http://localhost:8000
    Finished dev [unoptimized + debuginfo] target(s) in 1.77s
     Running `target/debug/surreal sql --conn 'http://localhost:8000'`
> CREATE item
There was a problem with the database: Specify a namespace to use
```

## What is your testing strategy?

Updated the `yuse` test to catch such issues.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
