### PR TITLE
Add more `#[must_use]` attributes

### DIFF
--- a/lib/src/api/method/authenticate.rs
+++ b/lib/src/api/method/authenticate.rs
@@ -12,6 +12,7 @@ use std::pin::Pin;
 
 /// An authentication future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Authenticate<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) token: Jwt,

--- a/lib/src/api/method/begin.rs
+++ b/lib/src/api/method/begin.rs
@@ -11,6 +11,7 @@ use std::pin::Pin;
 
 /// A beginning of a transaction
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Begin<C: Connection> {
 	pub(super) client: Surreal<C>,
 }
@@ -34,6 +35,7 @@ where
 
 /// An ongoing transaction
 #[derive(Debug)]
+#[must_use = "transactions must be committed or cancelled to complete them"]
 pub struct Transaction<C: Connection> {
 	client: Surreal<C>,
 }

--- a/lib/src/api/method/cancel.rs
+++ b/lib/src/api/method/cancel.rs
@@ -8,6 +8,7 @@ use std::pin::Pin;
 
 /// A transaction cancellation future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Cancel<C: Connection> {
 	pub(crate) client: Surreal<C>,
 }

--- a/lib/src/api/method/commit.rs
+++ b/lib/src/api/method/commit.rs
@@ -8,6 +8,7 @@ use std::pin::Pin;
 
 /// A transaction commit future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Commit<C: Connection> {
 	pub(crate) client: Surreal<C>,
 }

--- a/lib/src/api/method/content.rs
+++ b/lib/src/api/method/content.rs
@@ -18,6 +18,7 @@ use std::pin::Pin;
 ///
 /// Content inserts or replaces the contents of a record entirely
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Content<'r, C: Connection, D, R> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) method: Method,

--- a/lib/src/api/method/create.rs
+++ b/lib/src/api/method/create.rs
@@ -14,6 +14,7 @@ use std::pin::Pin;
 
 /// A record create future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Create<'r, C: Connection, R> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) resource: Result<Resource>,

--- a/lib/src/api/method/delete.rs
+++ b/lib/src/api/method/delete.rs
@@ -14,6 +14,7 @@ use std::pin::Pin;
 
 /// A record delete future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Delete<'r, C: Connection, R> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) resource: Result<Resource>,

--- a/lib/src/api/method/export.rs
+++ b/lib/src/api/method/export.rs
@@ -12,6 +12,7 @@ use std::pin::Pin;
 
 /// A database export future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Export<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) file: PathBuf,

--- a/lib/src/api/method/health.rs
+++ b/lib/src/api/method/health.rs
@@ -9,6 +9,7 @@ use std::pin::Pin;
 
 /// A health check future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Health<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 }

--- a/lib/src/api/method/import.rs
+++ b/lib/src/api/method/import.rs
@@ -12,6 +12,7 @@ use std::pin::Pin;
 
 /// An database import future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Import<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) file: PathBuf,

--- a/lib/src/api/method/invalidate.rs
+++ b/lib/src/api/method/invalidate.rs
@@ -11,6 +11,7 @@ use std::pin::Pin;
 
 /// A session invalidate future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Invalidate<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 }

--- a/lib/src/api/method/kill.rs
+++ b/lib/src/api/method/kill.rs
@@ -10,6 +10,7 @@ use std::pin::Pin;
 
 /// A live query kill future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Kill<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) query_id: Uuid,

--- a/lib/src/api/method/live.rs
+++ b/lib/src/api/method/live.rs
@@ -12,6 +12,7 @@ use std::pin::Pin;
 
 /// A live query future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Live<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) table_name: String,

--- a/lib/src/api/method/merge.rs
+++ b/lib/src/api/method/merge.rs
@@ -16,6 +16,7 @@ use std::pin::Pin;
 
 /// A merge future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Merge<'r, C: Connection, D, R> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) resource: Result<Resource>,

--- a/lib/src/api/method/patch.rs
+++ b/lib/src/api/method/patch.rs
@@ -18,6 +18,7 @@ use std::result::Result as StdResult;
 
 /// A patch future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Patch<'r, C: Connection, R> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) resource: Result<Resource>,

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -25,6 +25,7 @@ use std::pin::Pin;
 
 /// A query future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Query<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) query: Vec<Result<Vec<Statement>>>,

--- a/lib/src/api/method/select.rs
+++ b/lib/src/api/method/select.rs
@@ -14,6 +14,7 @@ use std::pin::Pin;
 
 /// A select future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Select<'r, C: Connection, R> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) resource: Result<Resource>,

--- a/lib/src/api/method/set.rs
+++ b/lib/src/api/method/set.rs
@@ -10,6 +10,7 @@ use std::pin::Pin;
 
 /// A set future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Set<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) key: String,

--- a/lib/src/api/method/signin.rs
+++ b/lib/src/api/method/signin.rs
@@ -14,6 +14,7 @@ use std::pin::Pin;
 
 /// A signin future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Signin<'r, C: Connection, R> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) credentials: Result<Value>,

--- a/lib/src/api/method/signup.rs
+++ b/lib/src/api/method/signup.rs
@@ -14,6 +14,7 @@ use std::pin::Pin;
 
 /// A signup future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Signup<'r, C: Connection, R> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) credentials: Result<Value>,

--- a/lib/src/api/method/unset.rs
+++ b/lib/src/api/method/unset.rs
@@ -9,6 +9,7 @@ use std::pin::Pin;
 
 /// An unset future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Unset<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) key: String,

--- a/lib/src/api/method/update.rs
+++ b/lib/src/api/method/update.rs
@@ -19,6 +19,7 @@ use std::pin::Pin;
 
 /// An update future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Update<'r, C: Connection, R> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) resource: Result<Resource>,

--- a/lib/src/api/method/use_db.rs
+++ b/lib/src/api/method/use_db.rs
@@ -9,6 +9,7 @@ use std::future::IntoFuture;
 use crate::sql::Value;
 
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct UseDb<'r, C: Connection> {
     pub(super) router: Result<&'r Router<C>>,
     pub(super) db: String,

--- a/lib/src/api/method/use_ns.rs
+++ b/lib/src/api/method/use_ns.rs
@@ -9,6 +9,7 @@ use std::pin::Pin;
 
 /// Stores the namespace to use
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct UseNs<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) ns: String,
@@ -16,6 +17,7 @@ pub struct UseNs<'r, C: Connection> {
 
 /// A use NS and DB future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct UseNsDb<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 	pub(super) ns: String,

--- a/lib/src/api/method/version.rs
+++ b/lib/src/api/method/version.rs
@@ -10,6 +10,7 @@ use std::pin::Pin;
 
 /// A version future
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Version<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
 }

--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -38,6 +38,7 @@ pub trait Connection: conn::Connection {}
 
 /// The future returned when creating a new SurrealDB instance
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Connect<'r, C: Connection, Response> {
 	router: Option<&'r OnceCell<Arc<Router<C>>>>,
 	address: Result<Endpoint>,
@@ -76,7 +77,6 @@ where
 	/// # Ok(())
 	/// # }
 	/// ```
-	#[must_use]
 	pub const fn with_capacity(mut self, capacity: usize) -> Self {
 		self.capacity = capacity;
 		self

--- a/lib/src/api/opt/mod.rs
+++ b/lib/src/api/opt/mod.rs
@@ -59,6 +59,7 @@ enum InnerOp<'a, T> {
 ///
 /// [JSON Patch]: https://jsonpatch.com/
 #[derive(Debug)]
+#[must_use]
 pub struct PatchOp(pub(crate) Result<Value, crate::err::Error>);
 
 impl PatchOp {
@@ -75,7 +76,6 @@ impl PatchOp {
 	/// PatchOp::add("/biscuits/1", json!({ "name": "Ginger Nut" }))
 	/// # ;
 	/// ```
-	#[must_use]
 	pub fn add<T>(path: &str, value: T) -> Self
 	where
 		T: Serialize,
@@ -104,7 +104,6 @@ impl PatchOp {
 	/// PatchOp::remove("/biscuits/0")
 	/// # ;
 	/// ```
-	#[must_use]
 	pub fn remove(path: &str) -> Self {
 		Self(to_value(UnitOp::Remove {
 			path,
@@ -122,7 +121,6 @@ impl PatchOp {
 	/// PatchOp::replace("/biscuits/0/name", "Chocolate Digestive")
 	/// # ;
 	/// ```
-	#[must_use]
 	pub fn replace<T>(path: &str, value: T) -> Self
 	where
 		T: Serialize,
@@ -134,7 +132,6 @@ impl PatchOp {
 	}
 
 	/// Changes a value
-	#[must_use]
 	pub fn change(path: &str, diff: Diff) -> Self {
 		Self(to_value(UnitOp::Change {
 			path,


### PR DESCRIPTION
## What is the motivation?

Futures are currently missing `must_use` attributes.

## What does this change do?

Adds `must_use` attributes for warnings to be printed when the types are not consumed.

## What is your testing strategy?

Ensure tests are still passing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
