### PR TITLE
Dev tools - Streamline Makefile compilation and fix a minor typo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DEV_FEATURES := --no-default-features --features storage-mem,http,scripting
+
 .PHONY: default
 default:
 	@echo "Choose a Makefile target:"
@@ -14,7 +16,7 @@ docs:
 
 .PHONY: test
 test:
-	cargo test --workspace
+	cargo test --workspace $(DEV_FEATURES)
 
 .PHONY: check
 check:
@@ -28,11 +30,11 @@ clean:
 
 .PHONY: serve
 serve:
-	cargo run -- start --log trace --user root --pass root memory
+	cargo run $(DEV_FEATURES) -- start --log trace --user root --pass root memory
 
 .PHONY: sql
 sql:
-	cargo run -- sql --conn ws://0.0.0.0:8000 --user root --pass root --ns test --db test --pretty
+	cargo run $(DEV_FEATURES) -- sql --conn ws://0.0.0.0:8000 --user root --pass root --ns test --db test --pretty
 
 .PHONY: quick
 quick:

--- a/lib/src/api/opt/auth.rs
+++ b/lib/src/api/opt/auth.rs
@@ -113,6 +113,6 @@ impl From<Jwt> for Value {
 
 impl fmt::Debug for Jwt {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "Jwt(REDUCTED)")
+		write!(f, "Jwt(REDACTED)")
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

- The `make serve` and `make sql` commands in `Makefile` are slow due to compiling RocksDB
- There was a small typo that didn't justify an entire PR

## What does this change do?

- Removes the RocksDB feature from the `Makefile`. Note that `make serve` used to explicitly create an in-memory KV store, so removing RocksDB shouldn't hurt
- Fixes a small typo elsewhere in the code

## What is your testing strategy?

I tested the `serve`, `sql`, and `test ` targets (the ones I changed)

## Is this related to any issues?

Analogous to [#1354](https://github.com/surrealdb/surrealdb/pull/1814) which applied the same change to the build documentation.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
