### PR TITLE
Bypass deserialisation for `sql::Value`s on `Response::take`

### DIFF
--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -317,6 +317,10 @@ mod tests {
 	#[test]
 	fn take_from_an_empty_response() {
 		let mut response = Response(Default::default());
+		let value: Value = response.take(0).unwrap();
+		assert!(value.is_none());
+
+		let mut response = Response(Default::default());
 		let option: Option<String> = response.take(0).unwrap();
 		assert!(option.is_none());
 
@@ -334,6 +338,10 @@ mod tests {
 	#[test]
 	fn take_from_empty_records() {
 		let mut response = Response(to_map(vec![Ok(vec![])]));
+		let value: Value = response.take(0).unwrap();
+		assert_eq!(value, Value::Array(Default::default()));
+
+		let mut response = Response(to_map(vec![Ok(vec![])]));
 		let option: Option<String> = response.take(0).unwrap();
 		assert!(option.is_none());
 
@@ -347,6 +355,10 @@ mod tests {
 		let scalar = 265;
 
 		let mut response = Response(to_map(vec![Ok(vec![scalar.into()])]));
+		let value: Value = response.take(0).unwrap();
+		assert_eq!(value, vec![Value::from(scalar)].into());
+
+		let mut response = Response(to_map(vec![Ok(vec![scalar.into()])]));
 		let option: Option<_> = response.take(0).unwrap();
 		assert_eq!(option, Some(scalar));
 
@@ -355,6 +367,10 @@ mod tests {
 		assert_eq!(vec, vec![scalar]);
 
 		let scalar = true;
+
+		let mut response = Response(to_map(vec![Ok(vec![scalar.into()])]));
+		let value: Value = response.take(0).unwrap();
+		assert_eq!(value, vec![Value::from(scalar)].into());
 
 		let mut response = Response(to_map(vec![Ok(vec![scalar.into()])]));
 		let option: Option<_> = response.take(0).unwrap();
@@ -389,10 +405,8 @@ mod tests {
             panic!("query not found");
         };
 		assert_eq!(zero, 0);
-		let Some(one): Option<i32> = response.take(1).unwrap() else {
-            panic!("query not found");
-        };
-		assert_eq!(one, 1);
+		let one: Value = response.take(1).unwrap();
+		assert_eq!(one, vec![Value::from(1)].into());
 	}
 
 	#[test]
@@ -401,6 +415,10 @@ mod tests {
 			title: "Lorem Ipsum".to_owned(),
 		};
 		let value = to_value(summary.clone()).unwrap();
+
+		let mut response = Response(to_map(vec![Ok(vec![value.clone()])]));
+		let title: Value = response.take("title").unwrap();
+		assert_eq!(title, vec![Value::from(summary.title.as_str())].into());
 
 		let mut response = Response(to_map(vec![Ok(vec![value.clone()])]));
 		let Some(title): Option<String> = response.take("title").unwrap() else {
@@ -428,13 +446,21 @@ mod tests {
         };
 		assert_eq!(body, article.body);
 
-		let mut response = Response(to_map(vec![Ok(vec![value])]));
+		let mut response = Response(to_map(vec![Ok(vec![value.clone()])]));
 		let vec: Vec<String> = response.take("title").unwrap();
-		assert_eq!(vec, vec![article.title]);
+		assert_eq!(vec, vec![article.title.clone()]);
+
+		let mut response = Response(to_map(vec![Ok(vec![value])]));
+		let value: Value = response.take("title").unwrap();
+		assert_eq!(value, vec![Value::from(article.title)].into());
 	}
 
 	#[test]
 	fn take_partial_records() {
+		let mut response = Response(to_map(vec![Ok(vec![true.into(), false.into()])]));
+		let value: Value = response.take(0).unwrap();
+		assert_eq!(value, vec![Value::from(true), Value::from(false)].into());
+
 		let mut response = Response(to_map(vec![Ok(vec![true.into(), false.into()])]));
 		let vec: Vec<bool> = response.take(0).unwrap();
 		assert_eq!(vec, vec![true, false]);
@@ -500,9 +526,7 @@ mod tests {
             panic!("statement not found");
         };
 		assert_eq!(value, 2);
-		let Some(value): Option<i32> = response.take(4).unwrap() else {
-            panic!("statement not found");
-        };
-		assert_eq!(value, 3);
+		let value: Value = response.take(4).unwrap();
+		assert_eq!(value, vec![Value::from(3)].into());
 	}
 }

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -84,8 +84,7 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 								}
 								Statement::Set(stmt) => {
 									if let Err(e) = client.set(&stmt.name, &stmt.what).await {
-										eprintln!("{e}");
-										eprintln!();
+										eprintln!("{e}\n");
 									}
 								}
 								_ => {}
@@ -95,18 +94,15 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 						// Get the request response
 						match process(pretty, res) {
 							Ok(v) => {
-								println!("{v}");
-								println!();
+								println!("{v}\n");
 							}
 							Err(e) => {
-								eprintln!("{e}");
-								eprintln!();
+								eprintln!("{e}\n");
 							}
 						}
 					}
 					Err(e) => {
-						eprintln!("{e}");
-						eprintln!();
+						eprintln!("{e}\n");
 					}
 				}
 			}
@@ -132,24 +128,19 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 }
 
 fn process(pretty: bool, res: surrealdb::Result<Response>) -> Result<String, Error> {
-	use surrealdb::error::Api;
-	use surrealdb::Error;
-	// Extract `Value` from the response
-	let value = match res?.take::<Option<Value>>(0) {
-		Ok(value) => value.unwrap_or_default(),
-		Err(Error::Api(Api::FromValue {
-			value,
-			..
-		})) => value,
-		Err(Error::Api(Api::LossyTake(mut res))) => match res.take::<Vec<Value>>(0) {
-			Ok(mut value) => value.pop().unwrap_or_default(),
-			Err(Error::Api(Api::FromValue {
-				value,
-				..
-			})) => value,
-			Err(error) => return Err(error.into()),
-		},
-		Err(error) => return Err(error.into()),
+	// Check query response for an error
+	let mut response = res?;
+	// Get the number of statements the query contained
+	let num_statements = response.num_statements();
+	// Prepare a single value from the query response
+	let value = if num_statements > 1 {
+		let mut output = Vec::<Value>::with_capacity(num_statements);
+		for index in 0..num_statements {
+			output.push(response.take(index)?);
+		}
+		Value::from(output)
+	} else {
+		response.take(0)?
 	};
 	// Check if we should prettify
 	Ok(match pretty {


### PR DESCRIPTION
## What is the motivation?

There is no need to deserialise `sql::Value`s into `sql::Value`s when calling `take` on a query `Response`.

## What does this change do?

It bypasses `sql::Value` deserialisation when necessary on queries and updates the CLI accordingly.

## What is your testing strategy?

Added more unit tests.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
