### PR TITLE
Optimization - Store parsed regex::Regex in Value.

### DIFF
--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -4,7 +4,7 @@ use crate::sql::number::Number;
 use crate::sql::table::Table;
 use crate::sql::thing::Thing;
 use crate::sql::value::Value;
-use crate::sql::{Regex, Strand};
+use crate::sql::Strand;
 
 pub fn bool((arg,): (Value,)) -> Result<Value, Error> {
 	Ok(arg.is_truthy().into())

--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -5,7 +5,6 @@ use crate::sql::table::Table;
 use crate::sql::thing::Thing;
 use crate::sql::value::Value;
 use crate::sql::{Regex, Strand};
-use std::str::FromStr;
 
 pub fn bool((arg,): (Value,)) -> Result<Value, Error> {
 	Ok(arg.is_truthy().into())
@@ -68,7 +67,7 @@ pub fn point((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 
 pub fn regex((arg,): (Value,)) -> Result<Value, Error> {
 	Ok(match arg {
-		Value::Strand(v) => Regex::from_str(v.as_str()).map(Value::Regex).unwrap_or(Value::None),
+		Value::Strand(v) => v.parse().map(Value::Regex).unwrap_or(Value::None),
 		_ => Value::None,
 	})
 }

--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -4,7 +4,8 @@ use crate::sql::number::Number;
 use crate::sql::table::Table;
 use crate::sql::thing::Thing;
 use crate::sql::value::Value;
-use crate::sql::Strand;
+use crate::sql::{Regex, Strand};
+use std::str::FromStr;
 
 pub fn bool((arg,): (Value,)) -> Result<Value, Error> {
 	Ok(arg.is_truthy().into())
@@ -66,10 +67,10 @@ pub fn point((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 }
 
 pub fn regex((arg,): (Value,)) -> Result<Value, Error> {
-	match arg {
-		Value::Strand(v) => Ok(Value::Regex(v.as_str().into())),
-		_ => Ok(Value::None),
-	}
+	Ok(match arg {
+		Value::Strand(v) => Regex::from_str(v.as_str()).map(Value::Regex).unwrap_or(Value::None),
+		_ => Value::None,
+	})
 }
 
 pub fn string((arg,): (Strand,)) -> Result<Value, Error> {

--- a/lib/src/sql/regex.rs
+++ b/lib/src/sql/regex.rs
@@ -4,51 +4,120 @@ use nom::bytes::complete::escaped;
 use nom::bytes::complete::is_not;
 use nom::character::complete::anychar;
 use nom::character::complete::char;
-use serde::{Deserialize, Serialize};
-use std::fmt;
+use serde::{
+	de::{self, Visitor},
+	Deserialize, Deserializer, Serialize, Serializer,
+};
+use std::cmp::Ordering;
+use std::fmt::Debug;
+use std::fmt::{self, Display, Formatter};
+use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::str;
+use std::str::FromStr;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Regex";
 
-#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Deserialize, Hash)]
-pub struct Regex(pub(super) String);
+#[derive(Clone)]
+pub struct Regex(pub(super) regex::Regex);
 
+impl PartialEq for Regex {
+	fn eq(&self, other: &Self) -> bool {
+		self.as_str().eq(other.as_str())
+	}
+}
+
+impl Eq for Regex {}
+
+impl Ord for Regex {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.as_str().cmp(other.as_str())
+	}
+}
+
+impl PartialOrd for Regex {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl Hash for Regex {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.as_str().hash(state);
+	}
+}
+
+impl FromStr for Regex {
+	type Err = <regex::Regex as FromStr>::Err;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		regex::Regex::new(&s.replace("\\/", "/")).map(Self)
+	}
+}
+
+/*
 impl From<&str> for Regex {
 	fn from(r: &str) -> Self {
 		Self(r.replace("\\/", "/"))
 	}
 }
+*/
 
 impl Deref for Regex {
-	type Target = String;
+	type Target = regex::Regex;
 	fn deref(&self) -> &Self::Target {
 		&self.0
 	}
 }
 
-impl fmt::Display for Regex {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "/{}/", &self.0)
+impl Debug for Regex {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		Debug::fmt(&self.0, f)
 	}
 }
 
-impl Regex {
-	pub fn regex(&self) -> Option<regex::Regex> {
-		regex::Regex::new(&self.0).ok()
+impl Display for Regex {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		Display::fmt(&self.0, f)
 	}
 }
 
 impl Serialize for Regex {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
-		S: serde::Serializer,
+		S: Serializer,
 	{
 		if is_internal_serialization() {
-			serializer.serialize_newtype_struct(TOKEN, &self.0)
+			serializer.serialize_newtype_struct(TOKEN, self.as_str())
 		} else {
 			serializer.serialize_none()
 		}
+	}
+}
+
+pub struct RegexVisitor;
+
+impl<'de> Visitor<'de> for RegexVisitor {
+	type Value = Regex;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		formatter.write_str("a regex str")
+	}
+
+	fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+	where
+		E: de::Error,
+	{
+		Regex::from_str(value).map_err(|_| de::Error::custom("invalid regex"))
+	}
+}
+
+impl<'de> Deserialize<'de> for Regex {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_str(RegexVisitor)
 	}
 }
 
@@ -56,7 +125,8 @@ pub fn regex(i: &str) -> IResult<&str, Regex> {
 	let (i, _) = char('/')(i)?;
 	let (i, v) = escaped(is_not("\\/"), '\\', anychar)(i)?;
 	let (i, _) = char('/')(i)?;
-	Ok((i, Regex::from(v)))
+	let regex = Regex::from_str(v).map_err(|_| nom::Err::Error(crate::sql::Error::Parser(v)))?;
+	Ok((i, regex))
 }
 
 #[cfg(test)]
@@ -71,7 +141,7 @@ mod tests {
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
 		assert_eq!("/test/", format!("{}", out));
-		assert_eq!(out, Regex::from("test"));
+		assert_eq!(out, Regex::from_str("test").unwrap());
 	}
 
 	#[test]
@@ -81,6 +151,6 @@ mod tests {
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
 		assert_eq!(r"/(?i)test/[a-z]+/\s\d\w{1}.*/", format!("{}", out));
-		assert_eq!(out, Regex::from(r"(?i)test/[a-z]+/\s\d\w{1}.*"));
+		assert_eq!(out, Regex::from_str(r"(?i)test/[a-z]+/\s\d\w{1}.*").unwrap());
 	}
 }

--- a/lib/src/sql/regex.rs
+++ b/lib/src/sql/regex.rs
@@ -55,14 +55,6 @@ impl FromStr for Regex {
 	}
 }
 
-/*
-impl From<&str> for Regex {
-	fn from(r: &str) -> Self {
-		Self(r.replace("\\/", "/"))
-	}
-}
-*/
-
 impl Deref for Regex {
 	type Target = regex::Regex;
 	fn deref(&self) -> &Self::Target {

--- a/lib/src/sql/regex.rs
+++ b/lib/src/sql/regex.rs
@@ -78,7 +78,7 @@ impl Debug for Regex {
 
 impl Display for Regex {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		Display::fmt(&self.0, f)
+		write!(f, "/{}/", &self.0)
 	}
 }
 

--- a/lib/src/sql/regex.rs
+++ b/lib/src/sql/regex.rs
@@ -12,7 +12,6 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::fmt::{self, Display, Formatter};
 use std::hash::{Hash, Hasher};
-use std::ops::Deref;
 use std::str;
 use std::str::FromStr;
 
@@ -23,7 +22,7 @@ pub struct Regex(pub(super) regex::Regex);
 
 impl PartialEq for Regex {
 	fn eq(&self, other: &Self) -> bool {
-		self.as_str().eq(other.as_str())
+		self.0.as_str().eq(other.0.as_str())
 	}
 }
 
@@ -31,7 +30,7 @@ impl Eq for Regex {}
 
 impl Ord for Regex {
 	fn cmp(&self, other: &Self) -> Ordering {
-		self.as_str().cmp(other.as_str())
+		self.0.as_str().cmp(other.0.as_str())
 	}
 }
 
@@ -43,7 +42,7 @@ impl PartialOrd for Regex {
 
 impl Hash for Regex {
 	fn hash<H: Hasher>(&self, state: &mut H) {
-		self.as_str().hash(state);
+		self.0.as_str().hash(state);
 	}
 }
 
@@ -55,16 +54,16 @@ impl FromStr for Regex {
 	}
 }
 
-impl Deref for Regex {
-	type Target = regex::Regex;
-	fn deref(&self) -> &Self::Target {
+impl Regex {
+	// Deref would expose `regex::Regex::as_str` which wouldn't have the '/' delimiters.
+	pub fn regex(&self) -> &regex::Regex {
 		&self.0
 	}
 }
 
 impl Debug for Regex {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		Debug::fmt(&self.0, f)
+		Display::fmt(self, f)
 	}
 }
 
@@ -80,7 +79,7 @@ impl Serialize for Regex {
 		S: Serializer,
 	{
 		if is_internal_serialization() {
-			serializer.serialize_newtype_struct(TOKEN, self.as_str())
+			serializer.serialize_newtype_struct(TOKEN, self.0.as_str())
 		} else {
 			serializer.serialize_none()
 		}

--- a/lib/src/sql/regex.rs
+++ b/lib/src/sql/regex.rs
@@ -20,6 +20,21 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Regex";
 #[derive(Clone)]
 pub struct Regex(pub(super) regex::Regex);
 
+impl Regex {
+	// Deref would expose `regex::Regex::as_str` which wouldn't have the '/' delimiters.
+	pub fn regex(&self) -> &regex::Regex {
+		&self.0
+	}
+}
+
+impl FromStr for Regex {
+	type Err = <regex::Regex as FromStr>::Err;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		regex::Regex::new(&s.replace("\\/", "/")).map(Self)
+	}
+}
+
 impl PartialEq for Regex {
 	fn eq(&self, other: &Self) -> bool {
 		self.0.as_str().eq(other.0.as_str())
@@ -43,21 +58,6 @@ impl PartialOrd for Regex {
 impl Hash for Regex {
 	fn hash<H: Hasher>(&self, state: &mut H) {
 		self.0.as_str().hash(state);
-	}
-}
-
-impl FromStr for Regex {
-	type Err = <regex::Regex as FromStr>::Err;
-
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		regex::Regex::new(&s.replace("\\/", "/")).map(Self)
-	}
-}
-
-impl Regex {
-	// Deref would expose `regex::Regex::as_str` which wouldn't have the '/' delimiters.
-	pub fn regex(&self) -> &regex::Regex {
-		&self.0
 	}
 }
 

--- a/lib/src/sql/value/serde/ser/value/mod.rs
+++ b/lib/src/sql/value/serde/ser/value/mod.rs
@@ -36,6 +36,7 @@ use serde::ser::Serialize;
 use serde::ser::SerializeMap as _;
 use serde::ser::SerializeSeq as _;
 use std::fmt::Display;
+use std::str::FromStr;
 use storekey::encode::Error as EncodeError;
 use vec::SerializeValueVec;
 
@@ -210,9 +211,9 @@ impl ser::Serializer for Serializer {
 			sql::future::TOKEN => Ok(Value::Future(Box::new(Future(Block(
 				value.serialize(ser::block::entry::vec::Serializer.wrap())?,
 			))))),
-			sql::regex::TOKEN => {
-				Ok(Value::Regex(Regex(value.serialize(ser::string::Serializer.wrap())?)))
-			}
+			sql::regex::TOKEN => Ok(Value::Regex(
+				Regex::from_str(&value.serialize(ser::string::Serializer.wrap())?).unwrap(),
+			)),
 			sql::table::TOKEN => {
 				Ok(Value::Table(Table(value.serialize(ser::string::Serializer.wrap())?)))
 			}
@@ -563,6 +564,7 @@ mod tests {
 	use crate::sql::*;
 	use ::serde::Serialize;
 	use std::ops::Bound;
+	use std::str::FromStr;
 
 	#[test]
 	fn none() {
@@ -743,7 +745,7 @@ mod tests {
 
 	#[test]
 	fn regex() {
-		let regex = Regex::default();
+		let regex = Regex::from_str("abc").unwrap();
 		let value = to_value(&regex).unwrap();
 		let expected = Value::Regex(regex);
 		assert_eq!(value, expected);

--- a/lib/src/sql/value/serde/ser/value/mod.rs
+++ b/lib/src/sql/value/serde/ser/value/mod.rs
@@ -17,7 +17,6 @@ use crate::sql::Future;
 use crate::sql::Ident;
 use crate::sql::Idiom;
 use crate::sql::Param;
-use crate::sql::Regex;
 use crate::sql::Strand;
 use crate::sql::Table;
 use crate::sql::Uuid;
@@ -36,7 +35,6 @@ use serde::ser::Serialize;
 use serde::ser::SerializeMap as _;
 use serde::ser::SerializeSeq as _;
 use std::fmt::Display;
-use std::str::FromStr;
 use storekey::encode::Error as EncodeError;
 use vec::SerializeValueVec;
 
@@ -564,7 +562,6 @@ mod tests {
 	use crate::sql::*;
 	use ::serde::Serialize;
 	use std::ops::Bound;
-	use std::str::FromStr;
 
 	#[test]
 	fn none() {

--- a/lib/src/sql/value/serde/ser/value/mod.rs
+++ b/lib/src/sql/value/serde/ser/value/mod.rs
@@ -211,9 +211,9 @@ impl ser::Serializer for Serializer {
 			sql::future::TOKEN => Ok(Value::Future(Box::new(Future(Block(
 				value.serialize(ser::block::entry::vec::Serializer.wrap())?,
 			))))),
-			sql::regex::TOKEN => Ok(Value::Regex(
-				Regex::from_str(&value.serialize(ser::string::Serializer.wrap())?).unwrap(),
-			)),
+			sql::regex::TOKEN => {
+				Ok(Value::Regex(value.serialize(ser::string::Serializer.wrap())?.parse().unwrap()))
+			}
 			sql::table::TOKEN => {
 				Ok(Value::Table(Table(value.serialize(ser::string::Serializer.wrap())?)))
 			}
@@ -745,7 +745,7 @@ mod tests {
 
 	#[test]
 	fn regex() {
-		let regex = Regex::from_str("abc").unwrap();
+		let regex = "abc".parse().unwrap();
 		let value = to_value(&regex).unwrap();
 		let expected = Value::Regex(regex);
 		assert_eq!(value, expected);

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -1179,22 +1179,13 @@ impl Value {
 			Value::False => other.is_false(),
 			Value::Thing(v) => match other {
 				Value::Thing(w) => v == w,
-				Value::Regex(w) => match w.regex() {
-					Some(ref r) => r.is_match(v.to_string().as_str()),
-					None => false,
-				},
+				Value::Regex(w) => w.is_match(v.to_string().as_str()),
 				_ => false,
 			},
 			Value::Regex(v) => match other {
 				Value::Regex(w) => v == w,
-				Value::Number(w) => match v.regex() {
-					Some(ref r) => r.is_match(w.to_string().as_str()),
-					None => false,
-				},
-				Value::Strand(w) => match v.regex() {
-					Some(ref r) => r.is_match(w.as_str()),
-					None => false,
-				},
+				Value::Number(w) => v.is_match(w.to_string().as_str()),
+				Value::Strand(w) => v.is_match(w.as_str()),
 				_ => false,
 			},
 			Value::Uuid(v) => match other {
@@ -1211,19 +1202,13 @@ impl Value {
 			},
 			Value::Strand(v) => match other {
 				Value::Strand(w) => v == w,
-				Value::Regex(w) => match w.regex() {
-					Some(ref r) => r.is_match(v.as_str()),
-					None => false,
-				},
+				Value::Regex(w) => w.is_match(v.as_str()),
 				_ => v == &other.to_strand(),
 			},
 			Value::Number(v) => match other {
 				Value::Number(w) => v == w,
 				Value::Strand(_) => v == &other.to_number(),
-				Value::Regex(w) => match w.regex() {
-					Some(ref r) => r.is_match(v.to_string().as_str()),
-					None => false,
-				},
+				Value::Regex(w) => w.is_match(v.to_string().as_str()),
 				_ => false,
 			},
 			Value::Geometry(v) => match other {

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -1179,13 +1179,13 @@ impl Value {
 			Value::False => other.is_false(),
 			Value::Thing(v) => match other {
 				Value::Thing(w) => v == w,
-				Value::Regex(w) => w.is_match(v.to_string().as_str()),
+				Value::Regex(w) => w.regex().is_match(v.to_string().as_str()),
 				_ => false,
 			},
 			Value::Regex(v) => match other {
 				Value::Regex(w) => v == w,
-				Value::Number(w) => v.is_match(w.to_string().as_str()),
-				Value::Strand(w) => v.is_match(w.as_str()),
+				Value::Number(w) => v.regex().is_match(w.to_string().as_str()),
+				Value::Strand(w) => v.regex().is_match(w.as_str()),
 				_ => false,
 			},
 			Value::Uuid(v) => match other {
@@ -1202,13 +1202,13 @@ impl Value {
 			},
 			Value::Strand(v) => match other {
 				Value::Strand(w) => v == w,
-				Value::Regex(w) => w.is_match(v.as_str()),
+				Value::Regex(w) => w.regex().is_match(v.as_str()),
 				_ => v == &other.to_strand(),
 			},
 			Value::Number(v) => match other {
 				Value::Number(w) => v == w,
 				Value::Strand(_) => v == &other.to_number(),
-				Value::Regex(w) => w.is_match(v.to_string().as_str()),
+				Value::Regex(w) => w.regex().is_match(v.to_string().as_str()),
 				_ => false,
 			},
 			Value::Geometry(v) => match other {
@@ -1871,7 +1871,7 @@ mod tests {
 		assert_eq!(24, std::mem::size_of::<crate::sql::table::Table>());
 		assert_eq!(56, std::mem::size_of::<crate::sql::thing::Thing>());
 		assert_eq!(48, std::mem::size_of::<crate::sql::model::Model>());
-		assert_eq!(24, std::mem::size_of::<crate::sql::regex::Regex>());
+		assert_eq!(16, std::mem::size_of::<crate::sql::regex::Regex>());
 		assert_eq!(8, std::mem::size_of::<Box<crate::sql::range::Range>>());
 		assert_eq!(8, std::mem::size_of::<Box<crate::sql::edges::Edges>>());
 		assert_eq!(8, std::mem::size_of::<Box<crate::sql::function::Function>>());


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Regexes are stored as strings and parsed on every use.

## What does this change do?

Store parsed regexes in `Value`.

## What is your testing strategy?

Awaiting CI test results.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
