### PR TITLE
Remove a redundant health check from the `isready` command

### DIFF
--- a/src/cli/isready.rs
+++ b/src/cli/isready.rs
@@ -8,9 +8,7 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 	// Parse all other cli arguments
 	let endpoint = matches.value_of("conn").unwrap();
 	// Connect to the database engine
-	let client = connect(endpoint).await?;
-	// Check if the database engine is healthy
-	client.health().await?;
+	connect(endpoint).await?;
 	println!("OK");
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

Currently the `isready` command calls `client.health()` soon after connecting. This is not necessary for the HTTP engine because successfully establishing a connection already does a health check.

## What does this change do?

It removes the health check for the `isready` command.

## What is your testing strategy?

Ran

```bash
cargo run --no-default-features -F storage-mem -- isready
```

and inspected the server logs.

## Is this related to any issues?

It's inspired by [this Discord message](https://discord.com/channels/902568124350599239/970338835990974484/1099443636124532767).

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
