### PR TITLE
Bugfix - Fix overflow in duration parser

### DIFF
--- a/lib/src/sql/duration.rs
+++ b/lib/src/sql/duration.rs
@@ -269,10 +269,7 @@ fn duration_raw(i: &str) -> IResult<&str, Duration> {
 		"d" => v.checked_mul(SECONDS_PER_DAY).map(time::Duration::from_secs),
 		"w" => v.checked_mul(SECONDS_PER_WEEK).map(time::Duration::from_secs),
 		"y" => v.checked_mul(SECONDS_PER_YEAR).map(time::Duration::from_secs),
-		_ => {
-			debug_assert!(false, "shouldn't have parsed {u} as duration unit");
-			Some(time::Duration::ZERO)
-		}
+		_ => unreachable!("shouldn't have parsed {u} as duration unit"),
 	};
 
 	std_duration.map(|d| (i, Duration(d))).ok_or(nom::Err::Error(crate::sql::Error::Parser(i)))

--- a/lib/src/sql/duration.rs
+++ b/lib/src/sql/duration.rs
@@ -257,22 +257,25 @@ pub fn duration(i: &str) -> IResult<&str, Duration> {
 fn duration_raw(i: &str) -> IResult<&str, Duration> {
 	let (i, v) = part(i)?;
 	let (i, u) = unit(i)?;
-	Ok((
-		i,
-		Duration(match u {
-			"ns" => time::Duration::from_nanos(v),
-			"µs" => time::Duration::from_micros(v),
-			"us" => time::Duration::from_micros(v),
-			"ms" => time::Duration::from_millis(v),
-			"s" => time::Duration::from_secs(v),
-			"m" => time::Duration::from_secs(v * SECONDS_PER_MINUTE),
-			"h" => time::Duration::from_secs(v * SECONDS_PER_HOUR),
-			"d" => time::Duration::from_secs(v * SECONDS_PER_DAY),
-			"w" => time::Duration::from_secs(v * SECONDS_PER_WEEK),
-			"y" => time::Duration::from_secs(v * SECONDS_PER_YEAR),
-			_ => time::Duration::ZERO,
-		}),
-	))
+
+	let std_duration = match u {
+		"ns" => Some(time::Duration::from_nanos(v)),
+		"µs" => Some(time::Duration::from_micros(v)),
+		"us" => Some(time::Duration::from_micros(v)),
+		"ms" => Some(time::Duration::from_millis(v)),
+		"s" => Some(time::Duration::from_secs(v)),
+		"m" => v.checked_mul(SECONDS_PER_MINUTE).map(time::Duration::from_secs),
+		"h" => v.checked_mul(SECONDS_PER_HOUR).map(time::Duration::from_secs),
+		"d" => v.checked_mul(SECONDS_PER_DAY).map(time::Duration::from_secs),
+		"w" => v.checked_mul(SECONDS_PER_WEEK).map(time::Duration::from_secs),
+		"y" => v.checked_mul(SECONDS_PER_YEAR).map(time::Duration::from_secs),
+		_ => {
+			debug_assert!(false, "shouldn't have parsed {u} as duration unit");
+			Some(time::Duration::ZERO)
+		}
+	};
+
+	std_duration.map(|d| (i, Duration(d))).ok_or(nom::Err::Error(crate::sql::Error::Parser(i)))
 }
 
 fn part(i: &str) -> IResult<&str, u64> {
@@ -388,5 +391,12 @@ mod tests {
 		let out = res.unwrap().1;
 		assert_eq!("500ms", format!("{}", out));
 		assert_eq!(out.0, Duration::new(0, 500000000));
+	}
+
+	#[test]
+	fn duration_overflow() {
+		let sql = "10000000000000000d";
+		let res = duration(sql);
+		assert!(res.is_err());
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The duration parser could overflow (crash in debug mode or misbehave in release mode) on large durations:
```rust
test/test> select * from 10000000000000000d
thread 'main' panicked at 'attempt to multiply with overflow', lib/src/sql/duration.rs:270:46
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## What does this change do?

Overflow now causes parser error.

## What is your testing strategy?

Added a test.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
