### PR TITLE
Bugfix #1856 - ensure futures are evaluated in the course of Value::get.

### DIFF
--- a/lib/src/sql/value/get.rs
+++ b/lib/src/sql/value/get.rs
@@ -34,7 +34,12 @@ impl Value {
 						// No further embedded fields, so just return this
 						0 => Ok(Value::Future(v.clone())),
 						// Process the future and fetch the embedded field
-						_ => v.compute(ctx, opt, txn, None).await?.get(ctx, opt, txn, path).await,
+						_ => {
+							v.compute(ctx, &opt.futures(true), txn, None)
+								.await?
+								.get(ctx, opt, txn, path)
+								.await
+						}
 					}
 				}
 				// Current path part is an object

--- a/lib/src/sql/value/get.rs
+++ b/lib/src/sql/value/get.rs
@@ -35,10 +35,10 @@ impl Value {
 						0 => Ok(Value::Future(v.clone())),
 						// Process the future and fetch the embedded field
 						_ => {
-							v.compute(ctx, &opt.futures(true), txn, None)
-								.await?
-								.get(ctx, opt, txn, path)
-								.await
+							// Ensure futures are run
+							let opt = &opt.futures(true);
+							// Fetch the embedded field
+							v.compute(ctx, opt, txn, None).await?.get(ctx, opt, txn, path).await
 						}
 					}
 				}

--- a/lib/src/sql/value/get.rs
+++ b/lib/src/sql/value/get.rs
@@ -35,10 +35,12 @@ impl Value {
 						0 => Ok(Value::Future(v.clone())),
 						// Process the future and fetch the embedded field
 						_ => {
-							// Ensure futures are run
-							let opt = &opt.futures(true);
+							// Ensure the future is processed
+							let fut = &opt.futures(true);
+							// Get the future return value
+							let val = v.compute(ctx, fut, txn, None).await?;
 							// Fetch the embedded field
-							v.compute(ctx, opt, txn, None).await?.get(ctx, opt, txn, path).await
+							val.get(ctx, opt, txn, path).await
 						}
 					}
 				}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Certain queries would cause infinite recursion (stack overflow).

## What does this change do?

Evaluates a future during `Value::get` to avoid infinite recursion.

## What is your testing strategy?

Ran the query from #1856

## Is this related to any issues?

Fix #1856 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
