### PR TITLE
Add a missing `impl<T> IntoEndpoint for (T, native_tls::TlsConnector)` for the any engine

### DIFF
--- a/lib/src/api/engine/any/mod.rs
+++ b/lib/src/api/engine/any/mod.rs
@@ -140,6 +140,20 @@ impl IntoEndpoint for String {
 	}
 }
 
+#[cfg(feature = "native-tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
+impl<T> IntoEndpoint for (T, native_tls::TlsConnector)
+where
+	T: Into<String>,
+{
+	fn into_endpoint(self) -> Result<Endpoint> {
+		let (address, config) = self;
+		let mut address = address.into().into_endpoint()?;
+		address.tls_config = Some(Tls::Native(config));
+		Ok(address)
+	}
+}
+
 #[cfg(feature = "rustls")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
 impl<T> IntoEndpoint for (T, rustls::ClientConfig)


### PR DESCRIPTION
## What is the motivation?

The any engine is missing an `impl<T> IntoEndpoint for (T, native_tls::TlsConnector)`.

## What does this change do?

Adds the missing `impl<T> IntoEndpoint for (T, native_tls::TlsConnector)` for the any engine.

## What is your testing strategy?

Ensure tests are still passing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
