### PR TITLE
Bugfix - Allow {time, duration}::from::* to be parsed

### DIFF
--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -384,7 +384,7 @@ fn function_duration(i: &str) -> IResult<&str, &str> {
 		tag("weeks"),
 		tag("years"),
 		preceded(
-			tag("from"),
+			tag("from::"),
 			alt((
 				tag("days"),
 				tag("hours"),
@@ -554,7 +554,7 @@ fn function_time(i: &str) -> IResult<&str, &str> {
 		tag("week"),
 		tag("yday"),
 		tag("year"),
-		preceded(tag("from"), alt((tag("micros"), tag("millis"), tag("secs"), tag("unix")))),
+		preceded(tag("from::"), alt((tag("micros"), tag("millis"), tag("secs"), tag("unix")))),
 	))(i)
 }
 


### PR DESCRIPTION

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The new `{time, duration}::from::*` functions cannot be parsed correctly due to two small typos. The parser accepts `{time, duration}::from*` instead (note the missing `::`, which results in a panic later on):
```console
2023-04-29T18:56:12.026687Z DEBUG rpc query_with:execute:executor: surrealdb::dbs: Executing: SELECT * FROM duration::fromdays(1)     websocket="55bbc198-c14c-48cc-8ff4-48cd027dd9f7"
thread 'tokio-runtime-worker' panicked at 'internal error: entered unreachable code', lib/src/fnc/mod.rs:64:5
```

## What does this change do?

Fixes two small typos.

## What is your testing strategy?

Tested via CLI.

## Is this related to any issues?

IIRC these functions were added in #1861 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
