### PR TITLE
Derive `Serialize` implementations for enums

### DIFF
--- a/lib/src/dbs/channel.rs
+++ b/lib/src/dbs/channel.rs
@@ -334,7 +334,7 @@ impl Iterable {
 									// Parse the data from the store
 									let gra: crate::key::graph::Graph = (&k).into();
 									// Fetch the data from the store
-									let key = thing::new(opt.ns(), opt.db(), &gra.ft, &gra.fk);
+									let key = thing::new(opt.ns(), opt.db(), gra.ft, &gra.fk);
 									let val = txn.clone().lock().await.get(key).await?;
 									let rid = Thing::from((gra.ft, gra.fk));
 									// Parse the data from the store

--- a/lib/src/dbs/iterate.rs
+++ b/lib/src/dbs/iterate.rs
@@ -325,7 +325,7 @@ impl Iterable {
 									// Parse the data from the store
 									let gra: crate::key::graph::Graph = (&k).into();
 									// Fetch the data from the store
-									let key = thing::new(opt.ns(), opt.db(), &gra.ft, &gra.fk);
+									let key = thing::new(opt.ns(), opt.db(), gra.ft, &gra.fk);
 									let val = txn.clone().lock().await.get(key).await?;
 									let rid = Thing::from((gra.ft, gra.fk));
 									// Parse the data from the store

--- a/lib/src/key/namespace.rs
+++ b/lib/src/key/namespace.rs
@@ -8,7 +8,7 @@ pub struct Namespace<'a> {
 	pub ns: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str) -> Namespace<'a> {
+pub fn new(ns: &str) -> Namespace<'_> {
 	Namespace::new(ns)
 }
 

--- a/lib/src/key/ns.rs
+++ b/lib/src/key/ns.rs
@@ -10,7 +10,7 @@ pub struct Ns<'a> {
 	pub ns: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str) -> Ns<'a> {
+pub fn new(ns: &str) -> Ns<'_> {
 	Ns::new(ns)
 }
 

--- a/lib/src/sql/constant.rs
+++ b/lib/src/sql/constant.rs
@@ -14,7 +14,8 @@ use std::fmt;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Constant";
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Deserialize, Store, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
+#[serde(rename = "$surrealdb::private::sql::Constant")]
 pub enum Constant {
 	MathE,
 	MathFrac1Pi,
@@ -35,6 +36,7 @@ pub enum Constant {
 	MathPi,
 	MathSqrt2,
 	MathTau,
+	// Add new variants here
 }
 
 impl Constant {
@@ -96,36 +98,6 @@ impl fmt::Display for Constant {
 			Self::MathSqrt2 => "math::SQRT_2",
 			Self::MathTau => "math::TAU",
 		})
-	}
-}
-
-#[rustfmt::skip]
-impl Serialize for Constant {
-	fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-        match self {
-            Self::MathE => s.serialize_unit_variant(TOKEN, 0, "MathE"),
-            Self::MathFrac1Pi => s.serialize_unit_variant(TOKEN, 1, "MathFrac1Pi"),
-            Self::MathFrac1Sqrt2 => s.serialize_unit_variant(TOKEN, 2, "MathFrac1Sqrt2"),
-            Self::MathFrac2Pi => s.serialize_unit_variant(TOKEN, 3, "MathFrac2Pi"),
-            Self::MathFrac2SqrtPi => s.serialize_unit_variant(TOKEN, 4, "MathFrac2SqrtPi"),
-            Self::MathFracPi2 => s.serialize_unit_variant(TOKEN, 5, "MathFracPi2"),
-            Self::MathFracPi3 => s.serialize_unit_variant(TOKEN, 6, "MathFracPi3"),
-            Self::MathFracPi4 => s.serialize_unit_variant(TOKEN, 7, "MathFracPi4"),
-            Self::MathFracPi6 => s.serialize_unit_variant(TOKEN, 8, "MathFracPi6"),
-            Self::MathFracPi8 => s.serialize_unit_variant(TOKEN, 9, "MathFracPi8"),
-            Self::MathLn10 => s.serialize_unit_variant(TOKEN, 10, "MathLn10"),
-            Self::MathLn2 => s.serialize_unit_variant(TOKEN, 11, "MathLn2"),
-            Self::MathLog102 => s.serialize_unit_variant(TOKEN, 12, "MathLog102"),
-            Self::MathLog10E => s.serialize_unit_variant(TOKEN, 13, "MathLog10E"),
-            Self::MathLog210 => s.serialize_unit_variant(TOKEN, 14, "MathLog210"),
-            Self::MathLog2E => s.serialize_unit_variant(TOKEN, 15, "MathLog2E"),
-            Self::MathPi => s.serialize_unit_variant(TOKEN, 16, "MathPi"),
-            Self::MathSqrt2 => s.serialize_unit_variant(TOKEN, 17, "MathSqrt2"),
-            Self::MathTau => s.serialize_unit_variant(TOKEN, 18, "MathTau"),
-        }
 	}
 }
 

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -23,19 +23,20 @@ use nom::multi::separated_list0;
 use nom::multi::separated_list1;
 use nom::sequence::delimited;
 use nom::sequence::preceded;
-use serde::ser::SerializeTupleVariant;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Function";
 
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[serde(rename = "$surrealdb::private::sql::Function")]
 pub enum Function {
 	Cast(Kind, Value),
 	Normal(String, Vec<Value>),
 	Custom(String, Vec<Value>),
 	Script(Script, Vec<Value>),
+	// Add new variants here
 }
 
 impl PartialOrd for Function {
@@ -217,40 +218,6 @@ impl fmt::Display for Function {
 			Self::Normal(s, e) => write!(f, "{s}({})", Fmt::comma_separated(e)),
 			Self::Custom(s, e) => write!(f, "fn::{s}({})", Fmt::comma_separated(e)),
 			Self::Script(s, e) => write!(f, "function({}) {{{s}}}", Fmt::comma_separated(e)),
-		}
-	}
-}
-
-impl Serialize for Function {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		match self {
-			Self::Cast(s, e) => {
-				let mut serializer = serializer.serialize_tuple_variant(TOKEN, 0, "Cast", 2)?;
-				serializer.serialize_field(s)?;
-				serializer.serialize_field(e)?;
-				serializer.end()
-			}
-			Self::Normal(s, e) => {
-				let mut serializer = serializer.serialize_tuple_variant(TOKEN, 1, "Normal", 2)?;
-				serializer.serialize_field(s)?;
-				serializer.serialize_field(e)?;
-				serializer.end()
-			}
-			Self::Custom(s, e) => {
-				let mut serializer = serializer.serialize_tuple_variant(TOKEN, 2, "Custom", 2)?;
-				serializer.serialize_field(s)?;
-				serializer.serialize_field(e)?;
-				serializer.end()
-			}
-			Self::Script(s, e) => {
-				let mut serializer = serializer.serialize_tuple_variant(TOKEN, 3, "Script", 2)?;
-				serializer.serialize_field(s)?;
-				serializer.serialize_field(e)?;
-				serializer.end()
-			}
 		}
 	}
 }

--- a/lib/src/sql/geometry.rs
+++ b/lib/src/sql/geometry.rs
@@ -27,7 +27,8 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Geometry";
 const SINGLE: char = '\'';
 const DOUBLE: char = '\"';
 
-#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename = "$surrealdb::private::sql::Geometry")]
 pub enum Geometry {
 	Point(Point<f64>),
 	Line(LineString<f64>),
@@ -36,6 +37,7 @@ pub enum Geometry {
 	MultiLine(MultiLineString<f64>),
 	MultiPolygon(MultiPolygon<f64>),
 	Collection(Vec<Geometry>),
+	// Add new variants here
 }
 
 impl PartialOrd for Geometry {
@@ -460,23 +462,6 @@ impl fmt::Display for Geometry {
 					Fmt::comma_separated(v)
 				)
 			}
-		}
-	}
-}
-
-impl Serialize for Geometry {
-	fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		match self {
-			Self::Point(v) => s.serialize_newtype_variant(TOKEN, 0, "Point", v),
-			Self::Line(v) => s.serialize_newtype_variant(TOKEN, 1, "Line", v),
-			Self::Polygon(v) => s.serialize_newtype_variant(TOKEN, 2, "Polygon", v),
-			Self::MultiPoint(v) => s.serialize_newtype_variant(TOKEN, 3, "MultiPoint", v),
-			Self::MultiLine(v) => s.serialize_newtype_variant(TOKEN, 4, "MultiLine", v),
-			Self::MultiPolygon(v) => s.serialize_newtype_variant(TOKEN, 5, "MultiPolygon", v),
-			Self::Collection(v) => s.serialize_newtype_variant(TOKEN, 6, "Collection", v),
 		}
 	}
 }

--- a/lib/src/sql/model.rs
+++ b/lib/src/sql/model.rs
@@ -6,7 +6,6 @@ use crate::sql::ident::ident_raw;
 use crate::sql::thing::Thing;
 use nom::branch::alt;
 use nom::character::complete::char;
-use serde::ser::SerializeTupleVariant;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -47,10 +46,12 @@ impl Iterator for IntoIter {
 	}
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[serde(rename = "$surrealdb::private::sql::Model")]
 pub enum Model {
 	Count(String, u64),
 	Range(String, u64, u64),
+	// Add new variants here
 }
 
 impl IntoIterator for Model {
@@ -72,29 +73,6 @@ impl fmt::Display for Model {
 			}
 			Model::Range(tb, b, e) => {
 				write!(f, "|{}:{}..{}|", escape_ident(tb), b, e)
-			}
-		}
-	}
-}
-
-impl Serialize for Model {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		match self {
-			Self::Count(tb, c) => {
-				let mut serializer = serializer.serialize_tuple_variant(TOKEN, 0, "Count", 2)?;
-				serializer.serialize_field(tb)?;
-				serializer.serialize_field(c)?;
-				serializer.end()
-			}
-			Self::Range(tb, b, e) => {
-				let mut serializer = serializer.serialize_tuple_variant(TOKEN, 1, "Range", 3)?;
-				serializer.serialize_field(tb)?;
-				serializer.serialize_field(b)?;
-				serializer.serialize_field(e)?;
-				serializer.end()
 			}
 		}
 	}

--- a/lib/src/sql/number.rs
+++ b/lib/src/sql/number.rs
@@ -22,11 +22,13 @@ use std::str::FromStr;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Number";
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename = "$surrealdb::private::sql::Number")]
 pub enum Number {
 	Int(i64),
 	Float(f64),
 	Decimal(BigDecimal),
+	// Add new variants here
 }
 
 impl Default for Number {
@@ -162,19 +164,6 @@ impl Display for Number {
 			Number::Int(v) => Display::fmt(v, f),
 			Number::Float(v) => Display::fmt(v, f),
 			Number::Decimal(v) => Display::fmt(v, f),
-		}
-	}
-}
-
-impl Serialize for Number {
-	fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		match self {
-			Number::Int(v) => s.serialize_newtype_variant(TOKEN, 0, "Int", v),
-			Number::Float(v) => s.serialize_newtype_variant(TOKEN, 1, "Float", v),
-			Number::Decimal(v) => s.serialize_newtype_variant(TOKEN, 2, "Decimal", v),
 		}
 	}
 }

--- a/lib/src/sql/subquery.rs
+++ b/lib/src/sql/subquery.rs
@@ -23,7 +23,8 @@ use std::fmt::{self, Display, Formatter};
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Subquery";
 
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[serde(rename = "$surrealdb::private::sql::Subquery")]
 pub enum Subquery {
 	Value(Value),
 	Ifelse(IfelseStatement),
@@ -34,6 +35,7 @@ pub enum Subquery {
 	Delete(DeleteStatement),
 	Relate(RelateStatement),
 	Insert(InsertStatement),
+	// Add new variants here
 }
 
 impl PartialOrd for Subquery {
@@ -220,25 +222,6 @@ impl Display for Subquery {
 			Self::Relate(v) => write!(f, "({v})"),
 			Self::Insert(v) => write!(f, "({v})"),
 			Self::Ifelse(v) => Display::fmt(v, f),
-		}
-	}
-}
-
-impl Serialize for Subquery {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		match self {
-			Self::Value(v) => serializer.serialize_newtype_variant(TOKEN, 0, "Value", v),
-			Self::Ifelse(v) => serializer.serialize_newtype_variant(TOKEN, 1, "Ifelse", v),
-			Self::Output(v) => serializer.serialize_newtype_variant(TOKEN, 2, "Output", v),
-			Self::Select(v) => serializer.serialize_newtype_variant(TOKEN, 3, "Select", v),
-			Self::Create(v) => serializer.serialize_newtype_variant(TOKEN, 4, "Create", v),
-			Self::Update(v) => serializer.serialize_newtype_variant(TOKEN, 5, "Update", v),
-			Self::Delete(v) => serializer.serialize_newtype_variant(TOKEN, 6, "Delete", v),
-			Self::Relate(v) => serializer.serialize_newtype_variant(TOKEN, 7, "Relate", v),
-			Self::Insert(v) => serializer.serialize_newtype_variant(TOKEN, 8, "Insert", v),
 		}
 	}
 }

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -103,7 +103,8 @@ pub fn whats(i: &str) -> IResult<&str, Values> {
 	Ok((i, Values(v)))
 }
 
-#[derive(Clone, Debug, Default, PartialEq, PartialOrd, Deserialize, Store, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
+#[serde(rename = "$surrealdb::private::sql::Value")]
 #[format(Named)]
 pub enum Value {
 	#[default]
@@ -134,6 +135,7 @@ pub enum Value {
 	Function(Box<Function>),
 	Subquery(Box<Subquery>),
 	Expression(Box<Expression>),
+	// Add new variants here
 }
 
 impl Eq for Value {}
@@ -1945,42 +1947,6 @@ impl Value {
 			Value::Subquery(v) => v.compute(ctx, opt, txn, doc).await,
 			Value::Expression(v) => v.compute(ctx, opt, txn, doc).await,
 			_ => Ok(self.to_owned()),
-		}
-	}
-}
-
-impl Serialize for Value {
-	fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		match self {
-			Value::None => s.serialize_unit_variant(TOKEN, 0, "None"),
-			Value::Null => s.serialize_unit_variant(TOKEN, 1, "Null"),
-			Value::Bool(v) => s.serialize_newtype_variant(TOKEN, 2, "Bool", v),
-			Value::Number(v) => s.serialize_newtype_variant(TOKEN, 3, "Number", v),
-			Value::Strand(v) => s.serialize_newtype_variant(TOKEN, 4, "Strand", v),
-			Value::Duration(v) => s.serialize_newtype_variant(TOKEN, 5, "Duration", v),
-			Value::Datetime(v) => s.serialize_newtype_variant(TOKEN, 6, "Datetime", v),
-			Value::Uuid(v) => s.serialize_newtype_variant(TOKEN, 7, "Uuid", v),
-			Value::Array(v) => s.serialize_newtype_variant(TOKEN, 8, "Array", v),
-			Value::Object(v) => s.serialize_newtype_variant(TOKEN, 9, "Object", v),
-			Value::Geometry(v) => s.serialize_newtype_variant(TOKEN, 10, "Geometry", v),
-			Value::Bytes(v) => s.serialize_newtype_variant(TOKEN, 11, "Bytes", v),
-			Value::Param(v) => s.serialize_newtype_variant(TOKEN, 12, "Param", v),
-			Value::Idiom(v) => s.serialize_newtype_variant(TOKEN, 13, "Idiom", v),
-			Value::Table(v) => s.serialize_newtype_variant(TOKEN, 14, "Table", v),
-			Value::Thing(v) => s.serialize_newtype_variant(TOKEN, 15, "Thing", v),
-			Value::Model(v) => s.serialize_newtype_variant(TOKEN, 16, "Model", v),
-			Value::Regex(v) => s.serialize_newtype_variant(TOKEN, 17, "Regex", v),
-			Value::Block(v) => s.serialize_newtype_variant(TOKEN, 18, "Block", v),
-			Value::Range(v) => s.serialize_newtype_variant(TOKEN, 19, "Range", v),
-			Value::Edges(v) => s.serialize_newtype_variant(TOKEN, 20, "Edges", v),
-			Value::Future(v) => s.serialize_newtype_variant(TOKEN, 21, "Future", v),
-			Value::Constant(v) => s.serialize_newtype_variant(TOKEN, 22, "Constant", v),
-			Value::Function(v) => s.serialize_newtype_variant(TOKEN, 23, "Function", v),
-			Value::Subquery(v) => s.serialize_newtype_variant(TOKEN, 24, "Subquery", v),
-			Value::Expression(v) => s.serialize_newtype_variant(TOKEN, 25, "Expression", v),
 		}
 	}
 }


### PR DESCRIPTION
## What is the motivation?

Some enums are still using manual `Serialize` implementations when they can be derived now. 

## What does this change do?

It deletes the manual implementations and derives them instead. 

## What is your testing strategy?

Ensure tests still pass.

## Is this related to any issues?

It is a follow up PR for https://github.com/surrealdb/surrealdb/pull/1881.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
