### PR TITLE
Test FoundationDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,27 @@ jobs:
           cargo test --locked --package surrealdb --no-default-features --features kv-tikv --lib kvs
           cargo test --locked --package surrealdb --no-default-features --features kv-tikv --test api api_integration::tikv
 
+  fdb-engine:
+    name: FoundationDB engine
+    runs-on: ubuntu-20.04
+    steps:
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Setup FoundationDB
+        uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+        with:
+          version: "7.1.30"
+
+      - name: Run cargo test
+        run: |
+          cargo test --locked --package surrealdb --no-default-features --features kv-fdb-7_1 --lib kvs
+          cargo test --locked --package surrealdb --no-default-features --features kv-fdb-7_1 --test api api_integration::fdb
+
   any-engine:
     name: Any engine
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,15 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
+      - name: Setup FoundationDB
+        uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+        with:
+          version: "7.1.30"
+
       - name: Run cargo test
         run: |
-          cargo build --locked --no-default-features --features storage-mem
-          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory &)
+          cargo build --locked --no-default-features --features storage-fdb
+          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root fdb:/etc/foundationdb/fdb.cluster &)
           cargo test --locked --package surrealdb --no-default-features --features protocol-ws --test api api_integration::ws
 
   http-engine:
@@ -159,10 +164,15 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
+      - name: Setup FoundationDB
+        uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+        with:
+          version: "7.1.30"
+
       - name: Run cargo test
         run: |
-          cargo build --locked --no-default-features --features storage-mem
-          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory &)
+          cargo build --locked --no-default-features --features storage-fdb
+          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root fdb:/etc/foundationdb/fdb.cluster &)
           cargo test --locked --package surrealdb --no-default-features --features protocol-http --test api api_integration::http
 
   mem-engine:
@@ -294,8 +304,13 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
+      - name: Setup FoundationDB
+        uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+        with:
+          version: "7.1.30"
+
       - name: Run cargo test
         run: |
-          cargo build --locked --no-default-features --features storage-mem
-          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory &)
+          cargo build --locked --no-default-features --features storage-fdb
+          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root fdb:/etc/foundationdb/fdb.cluster &)
           cargo test --locked --package surrealdb --no-default-features --features protocol-http --test api api_integration::any

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
  "clang-sys",
  "lazy_static",
  "lazycell",
+ "log",
  "peeking_take_while",
  "prettyplease 0.2.6",
  "proc-macro2",
@@ -715,6 +716,7 @@ dependencies = [
  "rustc-hash",
  "shlex 1.1.0",
  "syn 2.0.18",
+ "which",
 ]
 
 [[package]]
@@ -1648,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "foundationdb"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69adb701525370e5f8958454b46e8459b276d81ce6391edbf84eae32eeddff75"
+checksum = "8696fd1be198f101eb58aeecf0f504fc02b28c7afcc008b4e4a998a91b305108"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -1660,35 +1662,40 @@ dependencies = [
  "futures 0.3.28",
  "memchr",
  "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "serde_json",
  "static_assertions",
 ]
 
 [[package]]
 name = "foundationdb-gen"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134e1c986a2bb78904f426d4924a55e8c14162ba764e229501eb6f95c8c37489"
+checksum = "62239700f01b041b6372aaeb847c52f960e1a69fd2b1025dc995ea3dd90e3308"
 dependencies = [
  "xml-rs",
 ]
 
 [[package]]
 name = "foundationdb-macros"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2163c7326208be8edc605e10303ec6ae45cf106c12540754a9970bcce0f80cae"
+checksum = "83c8d52fe8b46ab822b4decdcc0d6d85aeedfc98f0d52ba2bd4aec4a97807516"
 dependencies = [
+ "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
+ "try_map",
 ]
 
 [[package]]
 name = "foundationdb-sys"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb26eee771096794dbee1a2a9defa455443a2c150a810386331aa0d6603d356"
+checksum = "98e49545f5393d276b7b888c77e3f9519fd33727435f8244344be72c3284256f"
 dependencies = [
- "bindgen 0.60.1",
+ "bindgen 0.65.1",
 ]
 
 [[package]]
@@ -4188,6 +4195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_cbor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5209,6 +5225,12 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "try_map"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1626d07cb5c1bb2cf17d94c0be4852e8a7c02b041acec9a8c5bdda99f9d580"
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ storage-mem = ["surrealdb/kv-mem"]
 storage-rocksdb = ["surrealdb/kv-rocksdb"]
 storage-speedb = ["surrealdb/kv-speedb"]
 storage-tikv = ["surrealdb/kv-tikv"]
-storage-fdb = ["surrealdb/kv-fdb-6_3"]
+storage-fdb = ["surrealdb/kv-fdb-7_1"]
 scripting = ["surrealdb/scripting"]
 http = ["surrealdb/http"]
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -38,7 +38,7 @@ http = ["dep:reqwest"]
 native-tls = ["dep:native-tls", "reqwest?/native-tls", "tokio-tungstenite?/native-tls"]
 rustls = ["dep:rustls", "reqwest?/rustls-tls", "tokio-tungstenite?/rustls-tls-webpki-roots"]
 # Private features
-kv-fdb = ["foundationdb"]
+kv-fdb = ["foundationdb", "tokio/time"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
@@ -68,7 +68,7 @@ echodb = { version = "0.4.0", optional = true }
 executor = { version = "1.5.1", package = "async-executor" }
 flume = "0.10.14"
 fst = "0.4.7"
-foundationdb = { version = "0.7.0", default-features = false, features = ["embedded-fdb-include"], optional = true }
+foundationdb = { version = "0.8.0", default-features = false, features = ["embedded-fdb-include"], optional = true }
 futures = "0.3.28"
 futures-concurrency = "7.2.0"
 fuzzy-matcher = "0.3.7"

--- a/lib/src/api/engine/any/native.rs
+++ b/lib/src/api/engine/any/native.rs
@@ -18,6 +18,7 @@ use crate::api::DbResponse;
 use crate::api::ExtraFeatures;
 use crate::api::Result;
 use crate::api::Surreal;
+#[allow(unused_imports)]
 use crate::error::Db as DbError;
 use flume::Receiver;
 use once_cell::sync::OnceCell;

--- a/lib/src/kvs/fdb/mod.rs
+++ b/lib/src/kvs/fdb/mod.rs
@@ -394,27 +394,3 @@ impl Transaction {
 		return Ok(res);
 	}
 }
-
-#[cfg(test)]
-mod tests {
-	use crate::kvs::tests::transaction::verify_transaction_isolation;
-	use std::env;
-	use test_log::test;
-
-	/// This environment variable can be used to set the location of `fdb.cluster` file.
-	/// Eg. for MacOS: `/usr/local/etc/foundationdb/fdb.cluster`
-	const ENV_FDB_PATH: &str = "TEST_FDB_PATH";
-
-	/// The default FDB_PATH is the usual path for Linux.
-	/// https://apple.github.io/foundationdb/administration.html
-	const DEFAULT_FDB_PATH: &str = "/etc/foundationdb/fdb.cluster";
-
-	#[test(tokio::test(flavor = "multi_thread", worker_threads = 3))]
-	async fn fdb_transaction() {
-		verify_transaction_isolation(&format!(
-			"fdb:{}",
-			env::var(ENV_FDB_PATH).unwrap_or_else(|_| DEFAULT_FDB_PATH.to_string())
-		))
-		.await;
-	}
-}

--- a/lib/src/kvs/tests/mod.rs
+++ b/lib/src/kvs/tests/mod.rs
@@ -102,7 +102,7 @@ mod fdb {
 	use serial_test::serial;
 
 	async fn new_ds() -> Datastore {
-		let ds = Datastore::new("/etc/foundationdb/fdb.cluster").await.unwrap();
+		let ds = Datastore::new("fdb:/etc/foundationdb/fdb.cluster").await.unwrap();
 		// Clear any previous test entries
 		let mut tx = ds.transaction(true, false).await.unwrap();
 		assert!(tx.delp(vec![], u32::MAX).await.is_ok());

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -240,7 +240,7 @@ mod api_integration {
 				username: ROOT_USER,
 				password: ROOT_PASS,
 			};
-			let db = Surreal::new::<FDb>(("/tmp/fdb.cluster", root)).await.unwrap();
+			let db = Surreal::new::<FDb>(("/etc/foundationdb/fdb.cluster", root)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db
 		}


### PR DESCRIPTION
## What is the motivation?

The FoundationDB engine is not currently tested in the CI.

## What does this change do?

Runs FoundationDB tests and makes remote engines test against FoundationDB instead of the memory engine. Both the memory engine and the foundationdb engine have similar compile times because FoundationDB uses a pre-compiled shared library. I think it's better to run remote engine integration tests against a persistent engine which is actually meant for production use.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
