### PR TITLE
Optimisation - only loop over document fields when processing PERMISSIONS clauses

### DIFF
--- a/lib/src/dbs/options.rs
+++ b/lib/src/dbs/options.rs
@@ -13,31 +13,31 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Options {
-	// Currently selected NS
+	/// Currently selected NS
 	pub ns: Option<Arc<str>>,
-	// Currently selected DB
+	/// Currently selected DB
 	pub db: Option<Arc<str>>,
-	// Connection authentication data
+	/// Connection authentication data
 	pub auth: Arc<Auth>,
-	// Approximately how large is the current call stack?
+	/// Approximately how large is the current call stack?
 	dive: u8,
-	// Whether live queries are allowed?
+	/// Whether live queries are allowed?
 	pub live: bool,
-	// Should we force tables/events to re-run?
+	/// Should we force tables/events to re-run?
 	pub force: bool,
-	// Should we run permissions checks?
+	/// Should we run permissions checks?
 	pub perms: bool,
-	// Should we error if tables don't exist?
+	/// Should we error if tables don't exist?
 	pub strict: bool,
-	// Should we process field queries?
+	/// Should we process field queries?
 	pub fields: bool,
-	// Should we process event queries?
+	/// Should we process event queries?
 	pub events: bool,
-	// Should we process table queries?
+	/// Should we process table queries?
 	pub tables: bool,
-	// Should we process index queries?
+	/// Should we process index queries?
 	pub indexes: bool,
-	// Should we process function futures?
+	/// Should we process function futures?
 	pub futures: bool,
 }
 

--- a/lib/src/doc/pluck.rs
+++ b/lib/src/doc/pluck.rs
@@ -55,13 +55,13 @@ impl<'a> Document<'a> {
 		}?;
 		// Check if this record exists
 		if self.id.is_some() {
-			// Loop through all field statements
-			for fd in self.fd(opt, txn).await?.iter() {
-				// Loop over each field in document
-				for k in out.each(&fd.name).iter() {
-					// Check for a PERMISSIONS clause
-					if opt.perms && opt.auth.perms() {
-						// Process field permissions
+			// Should we run permissions checks?
+			if opt.perms && opt.auth.perms() {
+				// Loop through all field statements
+				for fd in self.fd(opt, txn).await?.iter() {
+					// Loop over each field in document
+					for k in out.each(&fd.name).iter() {
+						// Process the field permissions
 						match &fd.permissions.select {
 							Permission::Full => (),
 							Permission::None => out.del(ctx, opt, txn, k).await?,


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When selecting records, fields were unnecessarily looped over and extracted from each document in order to process `PERMISSIONS` checks, regardless of whether permissions were needed to be checked at all (as the user was authenticated as `root`, a `namespace` user, or a `database` user).

## What does this change do?

This ensures that we check whether permissions need to be run first, before looping over every field in each document.

## What is your testing strategy?

Tests in GitHub Actions.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
