### PR TITLE
Preparation for #1878 - microbenchmarks.

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -119,3 +119,6 @@ ws_stream_wasm = "0.7.4"
 tokio = { version = "1.27.0", default-features = false, features = ["macros", "io-util", "io-std", "fs", "rt-multi-thread"] }
 tokio-tungstenite = { version = "0.18.0", optional = true }
 uuid = { version = "1.3.1", features = ["serde", "v4", "v7"] }
+
+[lib]
+bench = false


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

See https://github.com/surrealdb/surrealdb/pull/1878#issuecomment-1529145394

In summary, #1878's new CI wont pass until either:
- #1878 is merged; then it will pass on future PR's
- This PR is merged; then it will pass on #1878 (after nudging GitHub to run the action again)

## What does this change do?

Makes `surrealdb` more compatible with `criterion` and `boa-dev/criterion-compare-action`.

See also: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

## What is your testing strategy?

CI

## Is this related to any issues?

Prepares for #1878

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
