### PR TITLE
Testing - Preserve microbenchmark baseline around actions/checkout@v3.

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,8 +28,14 @@ jobs:
       - name: Benchmark baseline
         run: cargo bench --quiet --package surrealdb --no-default-features --features kv-mem -- --save-baseline baseline
 
+      - name: Extract baseline
+        run: cp -r target/criterion /tmp/criterion
+
       - name: Checkout changes
         uses: actions/checkout@v3
+
+      - name: Replace baseline
+        run: cp -r /tmp/criterion target/criterion
 
       - name: Benchmark changes
         run: cargo bench --quiet --package surrealdb --no-default-features --features kv-mem -- --save-baseline changes

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Replace baseline
-        run: cp -r /tmp/criterion target/criterion
+        run: mkdir target && cp -r /tmp/criterion target/criterion
 
       - name: Benchmark changes
         run: cargo bench --quiet --package surrealdb --no-default-features --features kv-mem -- --save-baseline changes


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

In #1878, I didn't notice that `actions/checkout@v3` performed a cleaning step that erased the `target` directory containing the baseline benchmarks.

## What does this change do?

Extracts and restores the baseline benchmarks so the comparison works.

## What is your testing strategy?

Benchmark comparison now works (here's a copy of what the CI printed in the "Compare results" step):
```
group                            baseline                                 changes
-----                            --------                                 -------
executor/create_delete_simple    1.00     29.9±0.10µs 32.7 KElem/sec      1.02     30.3±0.17µs 32.2 KElem/sec
executor/select_future           1.01     23.5±0.07µs 41.6 KElem/sec      1.00     23.3±0.04µs 42.0 KElem/sec
executor/select_record_link      1.00     21.4±0.11µs 45.5 KElem/sec      1.01     21.6±0.06µs 45.2 KElem/sec
executor/select_simple_five      1.00     18.5±0.07µs 52.6 KElem/sec      1.01     18.7±0.07µs 52.1 KElem/sec
executor/select_simple_one       1.00     13.5±0.06µs 72.2 KElem/sec      1.01     13.6±0.04µs 71.6 KElem/sec
executor/update_simple           1.00     31.4±0.20µs 31.1 KElem/sec      1.01     31.6±0.10µs 30.9 KElem/sec
parser/casting_deep              1.01     23.5±0.05µs 41.6 KElem/sec      1.00     23.4±0.03µs 41.8 KElem/sec
parser/datetime                  1.04      6.3±0.01µs 154.2 KElem/sec     1.00      6.1±0.01µs 159.8 KElem/sec
parser/duration                  1.00     64.4±0.07µs 15.2 KElem/sec      1.00     64.2±0.06µs 15.2 KElem/sec
parser/json_geo                  1.00    137.0±0.09µs  7.1 KElem/sec      1.00    136.8±0.10µs  7.1 KElem/sec
parser/json_large_array          1.00     38.0±0.05µs 25.7 KElem/sec      1.00     38.0±0.15µs 25.7 KElem/sec
parser/json_large_object         1.00     60.5±0.32µs 16.1 KElem/sec      1.01     61.1±0.03µs 16.0 KElem/sec
parser/json_number               1.00    646.0±0.50ns 1511.7 KElem/sec    1.00    647.2±0.56ns 1508.9 KElem/sec
parser/json_small_array          1.00   1326.0±6.94ns 736.5 KElem/sec     1.00   1324.4±1.37ns 737.4 KElem/sec
parser/json_small_object         1.00      2.2±0.00µs 441.1 KElem/sec     1.01      2.2±0.00µs 437.7 KElem/sec
parser/select_complex            1.00     39.3±0.09µs 24.8 KElem/sec      1.00     39.4±0.06µs 24.8 KElem/sec
parser/select_simple             1.00      7.0±0.02µs 139.7 KElem/sec     1.00      7.0±0.03µs 140.3 KElem/sec
parser/transaction               1.00     16.2±0.03µs 60.2 KElem/sec      1.00     16.3±0.03µs 60.0 KElem/sec
```

## Is this related to any issues?

Followup to #1878

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
