### PR TITLE
Fix simple ID serialisation in the WebSocket protocol

### DIFF
--- a/src/rpc/res.rs
+++ b/src/rpc/res.rs
@@ -31,21 +31,9 @@ enum Content<T> {
 }
 
 impl<T: Serialize> Response<T> {
-	fn json(self) -> Response<Json> {
-		let Response {
-			id,
-			content,
-		} = self;
-		let content = match content {
-			Content::Success(response) => {
-				Content::Success(Json::from(sql::to_value(response).unwrap()))
-			}
-			Content::Failure(failure) => Content::Failure(failure),
-		};
-		Response {
-			id,
-			content,
-		}
+	#[inline]
+	fn json(self) -> Json {
+		sql::to_value(self).unwrap().into()
 	}
 
 	/// Send the response to the channel


### PR DESCRIPTION
## What is the motivation?

Simple serialisation for WebSocket responses does not convert the `id` parameter to a simple format when necessary.

## What does this change do?

It converts the entire response to make sure it's completely represented correctly.

## What is your testing strategy?

Manually created a WebSocket connection and inspected its responses .

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
