### PR TITLE
Feature: Add function `string::contains`

### DIFF
--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -274,6 +274,7 @@
 # "sleep("
 "string"
 "string::concat("
+"string::contains("
 "string::endsWith("
 "string::join("
 "string::len("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -273,6 +273,7 @@
 "sleep("
 "string"
 "string::concat("
+"string::contains("
 "string::endsWith("
 "string::join("
 "string::len("

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -201,6 +201,7 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"session::token" => session::token(ctx),
 		//
 		"string::concat" => string::concat,
+		"string::contains" => string::contains,
 		"string::endsWith" => string::ends_with,
 		"string::join" => string::join,
 		"string::len" => string::len,

--- a/lib/src/fnc/script/modules/surrealdb/functions/string.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/string.rs
@@ -19,6 +19,7 @@ impl ModuleDef for Package {
 	fn load<'js>(_ctx: Ctx<'js>, module: &Module<'js, Created>) -> Result<()> {
 		module.add("default")?;
 		module.add("concat")?;
+		module.add("contains")?;
 		module.add("endsWith")?;
 		module.add("join")?;
 		module.add("len")?;
@@ -39,6 +40,7 @@ impl ModuleDef for Package {
 	fn eval<'js>(ctx: Ctx<'js>, module: &Module<'js, Loaded<Native>>) -> Result<()> {
 		// Set specific exports
 		module.set("concat", Func::from(|v: Any| run("string::concat", v.0)))?;
+		module.set("contains", Func::from(|v: Any| run("string::contains", v.0)))?;
 		module.set("endsWith", Func::from(|v: Any| run("string::endsWith", v.0)))?;
 		module.set("join", Func::from(|v: Any| run("string::join", v.0)))?;
 		module.set("len", Func::from(|v: Any| run("string::len", v.0)))?;
@@ -56,6 +58,7 @@ impl ModuleDef for Package {
 		// Set default export
 		let default = Object::new(ctx)?;
 		default.set("concat", Func::from(|v: Any| run("string::concat", v.0)))?;
+		default.set("contains", Func::from(|v: Any| run("string::contains", v.0)))?;
 		default.set("endsWith", Func::from(|v: Any| run("string::endsWith", v.0)))?;
 		default.set("join", Func::from(|v: Any| run("string::join", v.0)))?;
 		default.set("len", Func::from(|v: Any| run("string::len", v.0)))?;

--- a/lib/src/fnc/string.rs
+++ b/lib/src/fnc/string.rs
@@ -111,8 +111,8 @@ pub fn words((string,): (String,)) -> Result<Value, Error> {
 
 #[cfg(test)]
 mod tests {
-	use super::slice;
-	use crate::{sql::Value, fnc::string::contains};
+	use super::{slice, contains};
+	use crate::sql::Value;
 
 	#[test]
 	fn string_slice() {

--- a/lib/src/fnc/string.rs
+++ b/lib/src/fnc/string.rs
@@ -6,6 +6,10 @@ pub fn concat(args: Vec<Value>) -> Result<Value, Error> {
 	Ok(args.into_iter().map(|x| x.as_string()).collect::<Vec<_>>().concat().into())
 }
 
+pub fn contains((val, check): (String, String)) -> Result<Value, Error> {
+	Ok(val.contains(&check).into())
+}
+
 pub fn ends_with((val, chr): (String, String)) -> Result<Value, Error> {
 	Ok(val.ends_with(&chr).into())
 }
@@ -108,7 +112,7 @@ pub fn words((string,): (String,)) -> Result<Value, Error> {
 #[cfg(test)]
 mod tests {
 	use super::slice;
-	use crate::sql::Value;
+	use crate::{sql::Value, fnc::string::contains};
 
 	#[test]
 	fn string_slice() {
@@ -130,5 +134,17 @@ mod tests {
 		test(string, Some(1), None, "好世界");
 		test(string, Some(-1), None, "界");
 		test(string, Some(-2), Some(1), "世");
+	}
+
+	#[test]
+	fn string_contains() {
+		fn test(base: &str, contained: &str, expected: bool) {
+			assert_eq!(contains((base.to_string(), contained.to_string())).unwrap(), Value::from(expected));
+		}
+
+		test("abcde", "bcd", true);
+		test("abcde", "cbcd", false);
+		test("好世界", "世", true);
+		test("好世界", "你好", false);
 	}
 }

--- a/lib/src/fnc/string.rs
+++ b/lib/src/fnc/string.rs
@@ -111,7 +111,7 @@ pub fn words((string,): (String,)) -> Result<Value, Error> {
 
 #[cfg(test)]
 mod tests {
-	use super::{slice, contains};
+	use super::{contains, slice};
 	use crate::sql::Value;
 
 	#[test]
@@ -139,9 +139,15 @@ mod tests {
 	#[test]
 	fn string_contains() {
 		fn test(base: &str, contained: &str, expected: bool) {
-			assert_eq!(contains((base.to_string(), contained.to_string())).unwrap(), Value::from(expected));
+			assert_eq!(
+				contains((base.to_string(), contained.to_string())).unwrap(),
+				Value::from(expected)
+			);
 		}
 
+		test("", "", true);
+		test("", "a", false);
+		test("a", "", true);
 		test("abcde", "bcd", true);
 		test("abcde", "cbcd", false);
 		test("好世界", "世", true);

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -485,6 +485,7 @@ fn function_session(i: &str) -> IResult<&str, &str> {
 fn function_string(i: &str) -> IResult<&str, &str> {
 	alt((
 		tag("concat"),
+		tag("contains"),
 		tag("endsWith"),
 		tag("join"),
 		tag("len"),

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -2950,15 +2950,85 @@ async fn function_string_concat() -> Result<(), Error> {
 #[tokio::test]
 async fn function_string_contains() -> Result<(), Error> {
 	let sql = r#"
+		RETURN string::contains("", "");
+		RETURN string::contains("a", "");
+		RETURN string::contains("abcdefg", "");
 		RETURN string::contains("abcdefg", "bcd");
+		RETURN string::contains("abcdefg", "abcd");
+		RETURN string::contains("abcdefg", "xxabcd");
+		RETURN string::contains("abcdefg", "hij");
+		RETURN string::contains("ประเทศไทย中华", "ประเ");
+		RETURN string::contains("ประเทศไทย中华", "ะเ");
+		RETURN string::contains("ประเทศไทย中华", "ไท华");
+		RETURN string::contains("1234567ah012345678901ah", "hah");
+		RETURN string::contains("00abc01234567890123456789abc", "bcabc");
+		RETURN string::contains("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaba");
+		RETURN string::contains("* \t", " ");
+		RETURN string::contains("* \t", "?");
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
-	assert_eq!(res.len(), 1);
-	//
+	assert_eq!(res.len(), 15);
+	// 1
 	let tmp = res.remove(0).result?;
 	let val = Value::Bool(true);
+	assert_eq!(tmp, val);
+	// 2
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(true);
+	assert_eq!(tmp, val);
+	// 3
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(true);
+	assert_eq!(tmp, val);
+	// 4
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(true);
+	assert_eq!(tmp, val);
+	// 5
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(true);
+	assert_eq!(tmp, val);
+	// 6
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(false);
+	assert_eq!(tmp, val);
+	// 7
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(false);
+	assert_eq!(tmp, val);
+	// 8
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(true);
+	assert_eq!(tmp, val);
+	// 9
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(true);
+	assert_eq!(tmp, val);
+	// 10
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(false);
+	assert_eq!(tmp, val);
+	// 11
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(false);
+	assert_eq!(tmp, val);
+	// 12
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(false);
+	assert_eq!(tmp, val);
+	// 13
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(false);
+	assert_eq!(tmp, val);
+	// 14
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(true);
+	assert_eq!(tmp, val);
+	// 15
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(false);
 	assert_eq!(tmp, val);
 	//
 	Ok(())

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -2948,6 +2948,23 @@ async fn function_string_concat() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn function_string_contains() -> Result<(), Error> {
+	let sql = r#"
+		RETURN string::contains("abcdefg", "bcd");
+	"#;
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	assert_eq!(res.len(), 1);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::Bool(true);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_string_ends_with() -> Result<(), Error> {
 	let sql = r#"
 		RETURN string::endsWith("", "");


### PR DESCRIPTION
## What is the motivation?

I saw [this](https://discord.com/channels/902568124350599239/970336107206176768/1100868468926054491) message on Discord by GiveMeFox#1706 and really liked the idea and opened a discussion #1905.

Given that there is already a wide range of string functions, a `contains` function seems logical. Currently you can do:
```sql
SELECT * FROM "bcd" in "abcdefg"
```
which works completely fine, but a dedicated string function might convey the intent more clearly. This pull request allows the above statement to be written like this:
```sql
SELECT * FROM string::contains("abcdefg", "bcd")
```

## What does this change do?

This pull request implements the above described function using underlying Rust strings and the Rust method [`str::contains`](https://doc.rust-lang.org/std/primitive.str.html#method.contains). It also registers the function like the other existing string functions in the modules. I have added some unit tests and one integration test. It also adds the SurQL string to the newly added fuzzing targets.

## What is your testing strategy?

I took inspiration of the string function `string::slice` testing strategy and implement a few simple unit tests, testing the basic functionality. I also implemented one integration test under `lib/tests/functions.rs`

## Is this related to any issues?
No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
