### PR TITLE
Bugfix - export new array::slice to JS and fuzzer.

### DIFF
--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -168,6 +168,7 @@
 "array::push("
 "array::remove("
 "array::reverse("
+"array::slice("
 "array::sort("
 "array::sort::asc("
 "array::sort::desc("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -168,6 +168,7 @@
 "array::push("
 "array::remove("
 "array::reverse("
+"array::slice("
 "array::sort("
 "array::sort::asc("
 "array::sort::desc("

--- a/lib/src/fnc/script/modules/surrealdb/functions/array.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/array.rs
@@ -28,6 +28,7 @@ impl ModuleDef for Package {
 		module.add("insert")?;
 		module.add("intersect")?;
 		module.add("len")?;
+		module.add("slice")?;
 		module.add("sort")?;
 		module.add("union")?;
 		Ok(())
@@ -45,6 +46,7 @@ impl ModuleDef for Package {
 		module.set("insert", Func::from(|v: Any| run("array::insert", v.0)))?;
 		module.set("intersect", Func::from(|v: Any| run("array::intersect", v.0)))?;
 		module.set("len", Func::from(|v: Any| run("array::len", v.0)))?;
+		module.set("slice", Func::from(|v: Any| run("array::slice", v.0)))?;
 		module.set("sort", Func::from(|v: Any| run("array::sort", v.0)))?;
 		module.set("union", Func::from(|v: Any| run("array::union", v.0)))?;
 		// Set default exports
@@ -59,6 +61,7 @@ impl ModuleDef for Package {
 		default.set("insert", Func::from(|v: Any| run("array::insert", v.0)))?;
 		default.set("intersect", Func::from(|v: Any| run("array::intersect", v.0)))?;
 		default.set("len", Func::from(|v: Any| run("array::len", v.0)))?;
+		default.set("slice", Func::from(|v: Any| run("array::slice", v.0)))?;
 		default.set("sort", Func::from(|v: Any| run("array::sort", v.0)))?;
 		default.set("union", Func::from(|v: Any| run("array::union", v.0)))?;
 		module.set("default", default)?;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

In #1855, I didn't realize functions all needed to be exported to JS.

## What does this change do?

Adds `array::slice` to JS exports and fuzzer dictionary.

## What is your testing strategy?

Awaiting CI.

## Is this related to any issues?

Follow up to #1855

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
