### PR TITLE
Ensure HTTP REST API responses are simplified when serialized

### DIFF
--- a/src/net/import.rs
+++ b/src/net/import.rs
@@ -41,9 +41,9 @@ async fn handler(
 			match db.execute(sql, &session, None, opt.strict).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
-					"application/json" => Ok(output::json(&res)),
-					"application/cbor" => Ok(output::cbor(&res)),
-					"application/pack" => Ok(output::pack(&res)),
+					"application/json" => Ok(output::json(&output::simplify(res))),
+					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
 					"application/bung" => Ok(output::full(&res)),
 					// Return nothing

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -368,7 +368,7 @@ async fn select_one(
 	// Specify the request statement
 	let sql = "SELECT * FROM type::thing($table, $id)";
 	// Parse the Record ID as a SurrealQL value
-	let rid = match surrealdb::sql::value(&id) {
+	let rid = match surrealdb::sql::json(&id) {
 		Ok(id) => id,
 		Err(_) => Value::from(id),
 	};
@@ -409,7 +409,7 @@ async fn create_one(
 	// Convert the HTTP request body
 	let data = bytes_to_utf8(&body)?;
 	// Parse the Record ID as a SurrealQL value
-	let rid = match surrealdb::sql::value(&id) {
+	let rid = match surrealdb::sql::json(&id) {
 		Ok(id) => id,
 		Err(_) => Value::from(id),
 	};
@@ -460,7 +460,7 @@ async fn update_one(
 	// Convert the HTTP request body
 	let data = bytes_to_utf8(&body)?;
 	// Parse the Record ID as a SurrealQL value
-	let rid = match surrealdb::sql::value(&id) {
+	let rid = match surrealdb::sql::json(&id) {
 		Ok(id) => id,
 		Err(_) => Value::from(id),
 	};
@@ -511,7 +511,7 @@ async fn modify_one(
 	// Convert the HTTP request body
 	let data = bytes_to_utf8(&body)?;
 	// Parse the Record ID as a SurrealQL value
-	let rid = match surrealdb::sql::value(&id) {
+	let rid = match surrealdb::sql::json(&id) {
 		Ok(id) => id,
 		Err(_) => Value::from(id),
 	};
@@ -561,7 +561,7 @@ async fn delete_one(
 	// Specify the request statement
 	let sql = "DELETE type::thing($table, $id) RETURN BEFORE";
 	// Parse the Record ID as a SurrealQL value
-	let rid = match surrealdb::sql::value(&id) {
+	let rid = match surrealdb::sql::json(&id) {
 		Ok(id) => id,
 		Err(_) => Value::from(id),
 	};

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -172,9 +172,9 @@ async fn select_all(
 	match db.execute(sql.as_str(), &session, Some(vars), opt.strict).await {
 		Ok(ref res) => match output.as_ref() {
 			// Simple serialization
-			"application/json" => Ok(output::json(&res)),
-			"application/cbor" => Ok(output::cbor(&res)),
-			"application/pack" => Ok(output::pack(&res)),
+			"application/json" => Ok(output::json(&output::simplify(res))),
+			"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+			"application/pack" => Ok(output::pack(&output::simplify(res))),
 			// Internal serialization
 			"application/bung" => Ok(output::full(&res)),
 			// An incorrect content-type was requested
@@ -213,9 +213,9 @@ async fn create_all(
 			match db.execute(sql, &session, Some(vars), opt.strict).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
-					"application/json" => Ok(output::json(&res)),
-					"application/cbor" => Ok(output::cbor(&res)),
-					"application/pack" => Ok(output::pack(&res)),
+					"application/json" => Ok(output::json(&output::simplify(res))),
+					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
 					"application/bung" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -257,9 +257,9 @@ async fn update_all(
 			match db.execute(sql, &session, Some(vars), opt.strict).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
-					"application/json" => Ok(output::json(&res)),
-					"application/cbor" => Ok(output::cbor(&res)),
-					"application/pack" => Ok(output::pack(&res)),
+					"application/json" => Ok(output::json(&output::simplify(res))),
+					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
 					"application/bung" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -301,9 +301,9 @@ async fn modify_all(
 			match db.execute(sql, &session, Some(vars), opt.strict).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
-					"application/json" => Ok(output::json(&res)),
-					"application/cbor" => Ok(output::cbor(&res)),
-					"application/pack" => Ok(output::pack(&res)),
+					"application/json" => Ok(output::json(&output::simplify(res))),
+					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
 					"application/bung" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -338,9 +338,9 @@ async fn delete_all(
 	match db.execute(sql, &session, Some(vars), opt.strict).await {
 		Ok(res) => match output.as_ref() {
 			// Simple serialization
-			"application/json" => Ok(output::json(&res)),
-			"application/cbor" => Ok(output::cbor(&res)),
-			"application/pack" => Ok(output::pack(&res)),
+			"application/json" => Ok(output::json(&output::simplify(res))),
+			"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+			"application/pack" => Ok(output::pack(&output::simplify(res))),
 			// Internal serialization
 			"application/bung" => Ok(output::full(&res)),
 			// An incorrect content-type was requested
@@ -381,9 +381,9 @@ async fn select_one(
 	match db.execute(sql, &session, Some(vars), opt.strict).await {
 		Ok(res) => match output.as_ref() {
 			// Simple serialization
-			"application/json" => Ok(output::json(&res)),
-			"application/cbor" => Ok(output::cbor(&res)),
-			"application/pack" => Ok(output::pack(&res)),
+			"application/json" => Ok(output::json(&output::simplify(res))),
+			"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+			"application/pack" => Ok(output::pack(&output::simplify(res))),
 			// Internal serialization
 			"application/bung" => Ok(output::full(&res)),
 			// An incorrect content-type was requested
@@ -429,9 +429,9 @@ async fn create_one(
 			match db.execute(sql, &session, Some(vars), opt.strict).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
-					"application/json" => Ok(output::json(&res)),
-					"application/cbor" => Ok(output::cbor(&res)),
-					"application/pack" => Ok(output::pack(&res)),
+					"application/json" => Ok(output::json(&output::simplify(res))),
+					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
 					"application/bung" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -480,9 +480,9 @@ async fn update_one(
 			match db.execute(sql, &session, Some(vars), opt.strict).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
-					"application/json" => Ok(output::json(&res)),
-					"application/cbor" => Ok(output::cbor(&res)),
-					"application/pack" => Ok(output::pack(&res)),
+					"application/json" => Ok(output::json(&output::simplify(res))),
+					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
 					"application/bung" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -531,9 +531,9 @@ async fn modify_one(
 			match db.execute(sql, &session, Some(vars), opt.strict).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
-					"application/json" => Ok(output::json(&res)),
-					"application/cbor" => Ok(output::cbor(&res)),
-					"application/pack" => Ok(output::pack(&res)),
+					"application/json" => Ok(output::json(&output::simplify(res))),
+					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
 					"application/bung" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -575,9 +575,9 @@ async fn delete_one(
 	match db.execute(sql, &session, Some(vars), opt.strict).await {
 		Ok(res) => match output.as_ref() {
 			// Simple serialization
-			"application/json" => Ok(output::json(&res)),
-			"application/cbor" => Ok(output::cbor(&res)),
-			"application/pack" => Ok(output::pack(&res)),
+			"application/json" => Ok(output::json(&output::simplify(res))),
+			"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+			"application/pack" => Ok(output::pack(&output::simplify(res))),
 			// Internal serialization
 			"application/bung" => Ok(output::full(&res)),
 			// An incorrect content-type was requested

--- a/src/net/output.rs
+++ b/src/net/output.rs
@@ -1,6 +1,8 @@
 use http::header::{HeaderValue, CONTENT_TYPE};
 use http::StatusCode;
 use serde::Serialize;
+use serde_json::Value as Json;
+use surrealdb::sql;
 
 pub enum Output {
 	None,
@@ -58,6 +60,11 @@ where
 		Ok(v) => Output::Full(v),
 		Err(_) => Output::Fail,
 	}
+}
+
+/// Convert and simplify the value into JSON
+pub fn simplify<T: Serialize>(v: T) -> Json {
+	sql::to_value(v).unwrap().into()
 }
 
 impl warp::Reply for Output {

--- a/src/net/sql.rs
+++ b/src/net/sql.rs
@@ -7,10 +7,7 @@ use crate::net::params::Params;
 use crate::net::session;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
-use serde_json::Value as Json;
-use surrealdb::dbs::Response;
 use surrealdb::dbs::Session;
-use surrealdb::sql;
 use warp::ws::{Message, WebSocket, Ws};
 use warp::Filter;
 
@@ -40,10 +37,6 @@ pub fn config() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejecti
 	opts.or(post).or(sock)
 }
 
-fn json(res: Vec<Response>) -> Json {
-	sql::to_value(res).unwrap().into()
-}
-
 async fn handler(
 	output: String,
 	sql: Bytes,
@@ -61,9 +54,9 @@ async fn handler(
 		// Convert the response to JSON
 		Ok(res) => match output.as_ref() {
 			// Simple serialization
-			"application/json" => Ok(output::json(&json(res))),
-			"application/cbor" => Ok(output::cbor(&json(res))),
-			"application/pack" => Ok(output::pack(&json(res))),
+			"application/json" => Ok(output::json(&output::simplify(res))),
+			"application/cbor" => Ok(output::cbor(&output::simplify(res))),
+			"application/pack" => Ok(output::pack(&output::simplify(res))),
 			// Internal serialization
 			"application/bung" => Ok(output::full(&res)),
 			// An incorrect content-type was requested

--- a/src/rpc/res.rs
+++ b/src/rpc/res.rs
@@ -33,24 +33,24 @@ enum Content<T> {
 impl<T: Serialize> Response<T> {
 	/// Convert and simplify the value into JSON
 	#[inline]
-	fn json(self) -> Json {
+	fn simplify(self) -> Json {
 		sql::to_value(self).unwrap().into()
 	}
 	/// Send the response to the WebSocket channel
 	pub async fn send(self, out: Output, chn: Sender<Message>) {
 		match out {
 			Output::Json => {
-				let res = serde_json::to_string(&self.json()).unwrap();
+				let res = serde_json::to_string(&self.simplify()).unwrap();
 				let res = Message::text(res);
 				let _ = chn.send(res).await;
 			}
 			Output::Cbor => {
-				let res = serde_cbor::to_vec(&self.json()).unwrap();
+				let res = serde_cbor::to_vec(&self.simplify()).unwrap();
 				let res = Message::binary(res);
 				let _ = chn.send(res).await;
 			}
 			Output::Pack => {
-				let res = serde_pack::to_vec(&self.json()).unwrap();
+				let res = serde_pack::to_vec(&self.simplify()).unwrap();
 				let res = Message::binary(res);
 				let _ = chn.send(res).await;
 			}

--- a/src/rpc/res.rs
+++ b/src/rpc/res.rs
@@ -31,12 +31,12 @@ enum Content<T> {
 }
 
 impl<T: Serialize> Response<T> {
+	/// Convert and simplify the value into JSON
 	#[inline]
 	fn json(self) -> Json {
 		sql::to_value(self).unwrap().into()
 	}
-
-	/// Send the response to the channel
+	/// Send the response to the WebSocket channel
 	pub async fn send(self, out: Output, chn: Sender<Message>) {
 		match out {
 			Output::Json => {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

HTTP REST API responses are serialized using full SurrealQL type information, instead of a more simplified JSON-like representation. This was an unintended breaking change.

## What does this change do?

This change ensures that all HTTP REST API responses are simplified when serialized when requested using `application/json`, `application/cbor`, and `application/pack`.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #1922.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
