### PR TITLE
Lift 'static restriction on connect methods

### DIFF
--- a/lib/src/api/engine/any/mod.rs
+++ b/lib/src/api/engine/any/mod.rs
@@ -256,7 +256,7 @@ impl Surreal<Any> {
 	/// # Ok(())
 	/// # }
 	/// ```
-	pub fn connect(&'static self, address: impl IntoEndpoint) -> Connect<Any, ()> {
+	pub fn connect(&self, address: impl IntoEndpoint) -> Connect<Any, ()> {
 		Connect {
 			router: Some(&self.router),
 			address: address.into_endpoint(),

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -312,10 +312,7 @@ pub struct Db {
 
 impl Surreal<Db> {
 	/// Connects to a specific database endpoint, saving the connection on the static client
-	pub fn connect<P>(
-		&'static self,
-		address: impl IntoEndpoint<P, Client = Db>,
-	) -> Connect<Db, ()> {
+	pub fn connect<P>(&self, address: impl IntoEndpoint<P, Client = Db>) -> Connect<Db, ()> {
 		Connect {
 			router: Some(&self.router),
 			address: address.into_endpoint(),

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -89,7 +89,7 @@ impl Surreal<Client> {
 	/// # }
 	/// ```
 	pub fn connect<P>(
-		&'static self,
+		&self,
 		address: impl IntoEndpoint<P, Client = Client>,
 	) -> Connect<Client, ()> {
 		Connect {

--- a/lib/src/api/engine/remote/ws/mod.rs
+++ b/lib/src/api/engine/remote/ws/mod.rs
@@ -72,7 +72,7 @@ impl Surreal<Client> {
 	/// # }
 	/// ```
 	pub fn connect<P>(
-		&'static self,
+		&self,
 		address: impl IntoEndpoint<P, Client = Client>,
 	) -> Connect<Client, ()> {
 		Connect {

--- a/lib/src/api/method/tests/protocol.rs
+++ b/lib/src/api/method/tests/protocol.rs
@@ -44,7 +44,7 @@ pub struct Client {
 
 impl Surreal<Client> {
 	pub fn connect<P>(
-		&'static self,
+		&self,
 		address: impl IntoEndpoint<P, Client = Client>,
 	) -> Connect<Client, ()> {
 		Connect {


### PR DESCRIPTION
## What is the motivation?

The restriction was never technically necessary. It was only to steer users towards `Surreal::new()` when not calling `Surreal::init()` in static context. We now need to use these methods in Wasm and the way we will use them requires non-static lifetimes.

## What does this change do?

It drops the `'static` lifetimes.

## What is your testing strategy?

Ensure tests still pass.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
