### PR TITLE
Fix building the HTTP feature on Wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run cargo check
-        run: cargo check --locked --package surrealdb --features protocol-ws,protocol-http,kv-mem,kv-indxdb --target wasm32-unknown-unknown
+        run: cargo check --locked --package surrealdb --features protocol-ws,protocol-http,kv-mem,kv-indxdb,http --target wasm32-unknown-unknown
 
   clippy:
     name: Check clippy

--- a/lib/src/fnc/util/http/mod.rs
+++ b/lib/src/fnc/util/http/mod.rs
@@ -26,8 +26,9 @@ pub async fn head(ctx: &Context<'_>, uri: Strand, opts: impl Into<Object>) -> Re
 	}
 	// Send the request and wait
 	let res = match ctx.timeout() {
+		#[cfg(not(target_arch = "wasm32"))]
 		Some(d) => req.timeout(d).send().await?,
-		None => req.send().await?,
+		_ => req.send().await?,
 	};
 	// Check the response status
 	match res.status() {
@@ -51,8 +52,9 @@ pub async fn get(ctx: &Context<'_>, uri: Strand, opts: impl Into<Object>) -> Res
 	}
 	// Send the request and wait
 	let res = match ctx.timeout() {
+		#[cfg(not(target_arch = "wasm32"))]
 		Some(d) => req.timeout(d).send().await?,
-		None => req.send().await?,
+		_ => req.send().await?,
 	};
 	// Check the response status
 	match res.status() {
@@ -100,8 +102,9 @@ pub async fn put(
 	}
 	// Send the request and wait
 	let res = match ctx.timeout() {
+		#[cfg(not(target_arch = "wasm32"))]
 		Some(d) => req.timeout(d).send().await?,
-		None => req.send().await?,
+		_ => req.send().await?,
 	};
 	// Check the response status
 	match res.status() {
@@ -149,8 +152,9 @@ pub async fn post(
 	}
 	// Send the request and wait
 	let res = match ctx.timeout() {
+		#[cfg(not(target_arch = "wasm32"))]
 		Some(d) => req.timeout(d).send().await?,
-		None => req.send().await?,
+		_ => req.send().await?,
 	};
 	// Check the response status
 	match res.status() {
@@ -198,8 +202,9 @@ pub async fn patch(
 	}
 	// Send the request and wait
 	let res = match ctx.timeout() {
+		#[cfg(not(target_arch = "wasm32"))]
 		Some(d) => req.timeout(d).send().await?,
-		None => req.send().await?,
+		_ => req.send().await?,
 	};
 	// Check the response status
 	match res.status() {
@@ -242,8 +247,9 @@ pub async fn delete(
 	}
 	// Send the request and wait
 	let res = match ctx.timeout() {
+		#[cfg(not(target_arch = "wasm32"))]
 		Some(d) => req.timeout(d).send().await?,
-		None => req.send().await?,
+		_ => req.send().await?,
 	};
 	// Check the response status
 	match res.status() {


### PR DESCRIPTION
## What is the motivation?

Building on Wasm with the `http` feature enabled is broken.

## What does this change do?

Fixes the issue, making it possible to build the `http` feature on Wasm.

## What is your testing strategy?

Added the `http` feature flag to the Wasm check on the CI.

## Is this related to any issues?

None.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
