### PR TITLE
creating new empty Thing

### DIFF
--- a/lib/src/sql/thing.rs
+++ b/lib/src/sql/thing.rs
@@ -93,6 +93,10 @@ impl Thing {
 	pub fn to_raw(&self) -> String {
 		self.to_string()
 	}
+
+	pub fn empty() -> Self {
+		Self::from(("",""))
+	}
 }
 
 impl fmt::Display for Thing {


### PR DESCRIPTION
## What is the motivation?
I like to avoid `Option` and I'm really not a fan of `id: Option<Thing>` which makes using id unnecessary complex. What I like to do is using this:
```
#[serde(skip_serializing)]
id: Thing,
```
which is much cleaner. The only problem is making an empty Thing by typing `Thing::from(("",""))` which is the shortest way every time I create new row.

## What does this change do?
This will create an empty Thing by `Thing::empty()`.

## What is your testing strategy?
I didn't write tests for it, tell me if it's needed. I just ran my project with my branch and it worked.

## Is this related to any issues?
I don't think so.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
