### PR TITLE
Ensure chained `future` values have access to current document context

### DIFF
--- a/lib/src/dbs/iterator.rs
+++ b/lib/src/dbs/iterator.rs
@@ -225,7 +225,7 @@ impl Iterator {
 								Value::Function(f) if f.is_aggregate() => {
 									let x = vals
 										.all()
-										.get(ctx, opt, txn, v.to_idiom().as_ref())
+										.get(ctx, opt, txn, None, v.to_idiom().as_ref())
 										.await?;
 									let x = f.aggregate(x).compute(ctx, opt, txn, None).await?;
 									obj.set(ctx, opt, txn, v.to_idiom().as_ref(), x).await?;
@@ -241,7 +241,7 @@ impl Iterator {
 						if let Field::Alias(v, i) = field {
 							match v {
 								Value::Function(f) if f.is_aggregate() => {
-									let x = vals.all().get(ctx, opt, txn, i).await?;
+									let x = vals.all().get(ctx, opt, txn, None, i).await?;
 									let x = f.aggregate(x).compute(ctx, opt, txn, None).await?;
 									obj.set(ctx, opt, txn, i, x).await?;
 								}

--- a/lib/src/sql/field.rs
+++ b/lib/src/sql/field.rs
@@ -118,7 +118,7 @@ impl Fields {
 							};
 							// Continue fetching the next idiom part
 							let x = x
-								.get(ctx, opt, txn, v)
+								.get(ctx, opt, txn, Some(doc), v)
 								.await?
 								.compute(ctx, opt, txn, Some(doc))
 								.await?
@@ -174,7 +174,7 @@ impl Fields {
 							};
 							// Continue fetching the next idiom part
 							let x = x
-								.get(ctx, opt, txn, v)
+								.get(ctx, opt, txn, Some(doc), v)
 								.await?
 								.compute(ctx, opt, txn, Some(doc))
 								.await?

--- a/lib/src/sql/idiom.rs
+++ b/lib/src/sql/idiom.rs
@@ -135,7 +135,7 @@ impl Idiom {
 			Some(Part::Value(v)) => {
 				v.compute(ctx, opt, txn, doc)
 					.await?
-					.get(ctx, opt, txn, self.as_ref().next())
+					.get(ctx, opt, txn, doc, self.as_ref().next())
 					.await?
 					.compute(ctx, opt, txn, doc)
 					.await
@@ -143,7 +143,7 @@ impl Idiom {
 			// Otherwise use the current document
 			_ => match doc {
 				// There is a current document
-				Some(v) => v.get(ctx, opt, txn, self).await?.compute(ctx, opt, txn, doc).await,
+				Some(v) => v.get(ctx, opt, txn, doc, self).await?.compute(ctx, opt, txn, doc).await,
 				// There isn't any document
 				None => Ok(Value::None),
 			},

--- a/lib/src/sql/value/decrement.rs
+++ b/lib/src/sql/value/decrement.rs
@@ -16,7 +16,7 @@ impl Value {
 		path: &[Part],
 		val: Value,
 	) -> Result<(), Error> {
-		match self.get(ctx, opt, txn, path).await? {
+		match self.get(ctx, opt, txn, None, path).await? {
 			Value::Number(v) => match val {
 				Value::Number(x) => self.set(ctx, opt, txn, path, Value::from(v - x)).await,
 				_ => Ok(()),

--- a/lib/src/sql/value/extend.rs
+++ b/lib/src/sql/value/extend.rs
@@ -15,7 +15,7 @@ impl Value {
 		path: &[Part],
 		val: Value,
 	) -> Result<(), Error> {
-		match self.get(ctx, opt, txn, path).await? {
+		match self.get(ctx, opt, txn, None, path).await? {
 			Value::Array(v) => match val {
 				Value::Array(x) => self.set(ctx, opt, txn, path, Value::from((v + x).uniq())).await,
 				x => self.set(ctx, opt, txn, path, Value::from((v + x).uniq())).await,

--- a/lib/src/sql/value/fetch.rs
+++ b/lib/src/sql/value/fetch.rs
@@ -94,7 +94,7 @@ impl Value {
 								.compute(ctx, opt, txn, None)
 								.await?
 								.all()
-								.get(ctx, opt, txn, path.next())
+								.get(ctx, opt, txn, None, path.next())
 								.await?
 								.flatten()
 								.ok()?;

--- a/lib/src/sql/value/increment.rs
+++ b/lib/src/sql/value/increment.rs
@@ -16,7 +16,7 @@ impl Value {
 		path: &[Part],
 		val: Value,
 	) -> Result<(), Error> {
-		match self.get(ctx, opt, txn, path).await? {
+		match self.get(ctx, opt, txn, None, path).await? {
 			Value::Number(v) => match val {
 				Value::Number(x) => self.set(ctx, opt, txn, path, Value::from(v + x)).await,
 				_ => Ok(()),


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When attempting to access nested fields within a `future`, currently the future does not have access to the current document context. As a result, accessing document fields for the current document from within the future will return a `NONE` value.

## What does this change do?

This change adds the current document context to fields being fetched, enabling `future` values to access fields on the current document context.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #1901

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
