### PR TITLE
Bugfix - Prevent NUL bytes from existing in UTF-8 strings

### DIFF
--- a/lib/src/sql/id.rs
+++ b/lib/src/sql/id.rs
@@ -24,6 +24,7 @@ use ulid::Ulid;
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 pub enum Id {
 	Number(i64),
+	/// Invariant: Doesn't contain NUL bytes.
 	String(String),
 	Array(Array),
 	Object(Object),

--- a/lib/src/sql/object.rs
+++ b/lib/src/sql/object.rs
@@ -26,9 +26,10 @@ use std::ops::DerefMut;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Object";
 
+/// Invariant: Keys never contain NUL bytes.
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Object")]
-pub struct Object(pub BTreeMap<String, Value>);
+pub struct Object(#[serde(with = "no_nul_bytes_in_keys")] pub BTreeMap<String, Value>);
 
 impl From<BTreeMap<String, Value>> for Object {
 	fn from(v: BTreeMap<String, Value>) -> Self {
@@ -51,13 +52,13 @@ impl From<Option<Self>> for Object {
 impl From<Operation> for Object {
 	fn from(v: Operation) -> Self {
 		Self(map! {
-			String::from("op") => match v.op {
-				Op::None => Value::from("none"),
-				Op::Add => Value::from("add"),
-				Op::Remove => Value::from("remove"),
-				Op::Replace => Value::from("replace"),
-				Op::Change => Value::from("change"),
-			},
+			String::from("op") => Value::from(match v.op {
+				Op::None => "none",
+				Op::Add => "add",
+				Op::Remove => "remove",
+				Op::Replace => "replace",
+				Op::Change => "change",
+			}),
 			String::from("path") => v.path.to_path().into(),
 			String::from("value") => v.value,
 		})
@@ -167,6 +168,60 @@ impl Display for Object {
 	}
 }
 
+mod no_nul_bytes_in_keys {
+	use serde::{
+		de::{self, Visitor},
+		ser::SerializeMap,
+		Deserializer, Serializer,
+	};
+	use std::{collections::BTreeMap, fmt};
+
+	use crate::sql::Value;
+
+	pub(crate) fn serialize<S>(
+		m: &BTreeMap<String, Value>,
+		serializer: S,
+	) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let mut s = serializer.serialize_map(Some(m.len()))?;
+		for (k, v) in m {
+			debug_assert!(!k.contains('\0'));
+			s.serialize_entry(k, v)?;
+		}
+		s.end()
+	}
+
+	pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<BTreeMap<String, Value>, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		struct NoNulBytesInKeysVisitor;
+
+		impl<'de> Visitor<'de> for NoNulBytesInKeysVisitor {
+			type Value = BTreeMap<String, Value>;
+
+			fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+				formatter.write_str("a map without any NUL bytes in its keys")
+			}
+
+			fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+			where
+				A: de::MapAccess<'de>,
+			{
+				let mut ret = BTreeMap::new();
+				while let Some((k, v)) = map.next_entry()? {
+					ret.insert(k, v);
+				}
+				Ok(ret)
+			}
+		}
+
+		deserializer.deserialize_map(NoNulBytesInKeysVisitor)
+	}
+}
+
 pub fn object(i: &str) -> IResult<&str, Object> {
 	let (i, _) = char('{')(i)?;
 	let (i, _) = mightbespace(i)?;
@@ -194,11 +249,11 @@ fn key_none(i: &str) -> IResult<&str, &str> {
 }
 
 fn key_single(i: &str) -> IResult<&str, &str> {
-	delimited(char('\''), is_not("\'"), char('\''))(i)
+	delimited(char('\''), is_not("\'\0"), char('\''))(i)
 }
 
 fn key_double(i: &str) -> IResult<&str, &str> {
-	delimited(char('\"'), is_not("\""), char('\"'))(i)
+	delimited(char('\"'), is_not("\"\0"), char('\"'))(i)
 }
 
 #[cfg(test)]

--- a/lib/src/sql/part.rs
+++ b/lib/src/sql/part.rs
@@ -6,6 +6,7 @@ use crate::sql::graph::{self, Graph};
 use crate::sql::ident::{self, Ident};
 use crate::sql::idiom::Idiom;
 use crate::sql::number::{number, Number};
+use crate::sql::strand::no_nul_bytes;
 use crate::sql::value::{self, Value};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
@@ -27,7 +28,7 @@ pub enum Part {
 	Where(Value),
 	Graph(Graph),
 	Value(Value),
-	Method(String, Vec<Value>),
+	Method(#[serde(with = "no_nul_bytes")] String, Vec<Value>),
 }
 
 impl From<i32> for Part {

--- a/lib/src/sql/range.rs
+++ b/lib/src/sql/range.rs
@@ -5,6 +5,7 @@ use crate::err::Error;
 use crate::sql::error::IResult;
 use crate::sql::id::{id, Id};
 use crate::sql::ident::ident_raw;
+use crate::sql::strand::no_nul_bytes;
 use crate::sql::value::Value;
 use nom::branch::alt;
 use nom::character::complete::char;
@@ -22,6 +23,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Range";
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Range")]
 pub struct Range {
+	#[serde(with = "no_nul_bytes")]
 	pub tb: String,
 	pub beg: Bound<Id>,
 	pub end: Bound<Id>,

--- a/lib/src/sql/regex.rs
+++ b/lib/src/sql/regex.rs
@@ -30,7 +30,11 @@ impl FromStr for Regex {
 	type Err = <regex::Regex as FromStr>::Err;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		regex::Regex::new(&s.replace("\\/", "/")).map(Self)
+		if s.contains('\0') {
+			Err(regex::Error::Syntax("regex contained NUL byte".to_owned()))
+		} else {
+			regex::Regex::new(&s.replace("\\/", "/")).map(Self)
+		}
 	}
 }
 

--- a/lib/src/sql/table.rs
+++ b/lib/src/sql/table.rs
@@ -4,6 +4,7 @@ use crate::sql::escape::escape_ident;
 use crate::sql::fmt::Fmt;
 use crate::sql::id::Id;
 use crate::sql::ident::{ident_raw, Ident};
+use crate::sql::strand::no_nul_bytes;
 use crate::sql::thing::Thing;
 use nom::multi::separated_list1;
 use serde::{Deserialize, Serialize};
@@ -42,7 +43,7 @@ pub fn tables(i: &str) -> IResult<&str, Tables> {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Table")]
-pub struct Table(pub String);
+pub struct Table(#[serde(with = "no_nul_bytes")] pub String);
 
 impl From<String> for Table {
 	fn from(v: String) -> Self {

--- a/lib/src/sql/value/compare.rs
+++ b/lib/src/sql/value/compare.rs
@@ -16,7 +16,7 @@ impl Value {
 			Some(p) => match (self, other) {
 				// Current path part is an object
 				(Value::Object(a), Value::Object(b)) => match p {
-					Part::Field(f) => match (a.get(f as &str), b.get(f as &str)) {
+					Part::Field(f) => match (a.get(f.as_str()), b.get(f.as_str())) {
 						(Some(a), Some(b)) => a.compare(b, path.next(), collate, numeric),
 						(Some(_), None) => Some(Ordering::Greater),
 						(None, Some(_)) => Some(Ordering::Less),

--- a/lib/src/sql/value/cut.rs
+++ b/lib/src/sql/value/cut.rs
@@ -13,10 +13,10 @@ impl Value {
 					if let Part::Field(f) = p {
 						match path.len() {
 							1 => {
-								v.remove(f as &str);
+								v.remove(f.as_str());
 							}
 							_ => {
-								if let Some(v) = v.get_mut(f as &str) {
+								if let Some(v) = v.get_mut(f.as_str()) {
 									v.cut(path.next())
 								}
 							}

--- a/lib/src/sql/value/del.rs
+++ b/lib/src/sql/value/del.rs
@@ -28,10 +28,10 @@ impl Value {
 				Value::Object(v) => match p {
 					Part::Field(f) => match path.len() {
 						1 => {
-							v.remove(f as &str);
+							v.remove(f.as_str());
 							Ok(())
 						}
-						_ => match v.get_mut(f as &str) {
+						_ => match v.get_mut(f.as_str()) {
 							Some(v) if v.is_some() => v.del(ctx, opt, txn, path.next()).await,
 							_ => Ok(()),
 						},

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -402,13 +402,13 @@ impl From<BigDecimal> for Value {
 
 impl From<String> for Value {
 	fn from(v: String) -> Self {
-		Value::Strand(Strand::from(v))
+		Self::Strand(Strand::from(v))
 	}
 }
 
 impl From<&str> for Value {
 	fn from(v: &str) -> Self {
-		Value::Strand(Strand::from(v))
+		Self::Strand(Strand::from(v))
 	}
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

NUL bytes cause problems:
- #1912
- would make the C integration harder

## What does this change do?

Don't allow NUL bytes to be:
- parsed
- de-serialized
- converted from Javascript

## What is your testing strategy?

Awaiting CI.

## Is this related to any issues?

- Fixes #1912

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
