### PR TITLE
Use static str where possible for context param names

### DIFF
--- a/lib/src/ctx/context.rs
+++ b/lib/src/ctx/context.rs
@@ -28,7 +28,7 @@ pub struct Context<'a> {
 	// Whether or not this context is cancelled.
 	cancelled: Arc<AtomicBool>,
 	// A collection of read only values stored in this context.
-	values: HashMap<String, Cow<'a, Value>>,
+	values: HashMap<Cow<'static, str>, Cow<'a, Value>>,
 }
 
 impl<'a> Default for Context<'a> {
@@ -93,11 +93,12 @@ impl<'a> Context<'a> {
 
 	/// Add a value to the context. It overwrites any previously set values
 	/// with the same key.
-	pub fn add_value<V>(&mut self, key: String, value: V)
+	pub fn add_value<K, V>(&mut self, key: K, value: V)
 	where
+		K: Into<Cow<'static, str>>,
 		V: Into<Cow<'a, Value>>,
 	{
-		self.values.insert(key, value.into());
+		self.values.insert(key.into(), value.into());
 	}
 
 	/// Get the timeout for this operation, if any. This is useful for

--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -110,14 +110,14 @@ impl<'a> Executor<'a> {
 	async fn set_ns(&self, ctx: &mut Context<'_>, opt: &mut Options, ns: &str) {
 		let mut session = ctx.value("session").unwrap_or(&Value::None).clone();
 		session.put(NS.as_ref(), ns.to_owned().into());
-		ctx.add_value(String::from("session"), session);
+		ctx.add_value("session", session);
 		opt.ns = Some(ns.into());
 	}
 
 	async fn set_db(&self, ctx: &mut Context<'_>, opt: &mut Options, db: &str) {
 		let mut session = ctx.value("session").unwrap_or(&Value::None).clone();
 		session.put(DB.as_ref(), db.to_owned().into());
-		ctx.add_value(String::from("session"), session);
+		ctx.add_value("session", session);
 		opt.db = Some(db.into());
 	}
 

--- a/lib/src/dbs/session.rs
+++ b/lib/src/dbs/session.rs
@@ -93,19 +93,15 @@ impl Session {
 	/// Convert a session into a runtime
 	pub(crate) fn context<'a>(&self, mut ctx: Context<'a>) -> Context<'a> {
 		// Add auth data
-		let key = String::from("auth");
 		let val: Value = self.sd.to_owned().into();
-		ctx.add_value(key, val);
+		ctx.add_value("auth", val);
 		// Add scope data
-		let key = String::from("scope");
 		let val: Value = self.sc.to_owned().into();
-		ctx.add_value(key, val);
+		ctx.add_value("scope", val);
 		// Add token data
-		let key = String::from("token");
 		let val: Value = self.tk.to_owned().into();
-		ctx.add_value(key, val);
+		ctx.add_value("token", val);
 		// Add session value
-		let key = String::from("session");
 		let val: Value = Value::from(map! {
 			"db".to_string() => self.db.to_owned().into(),
 			"id".to_string() => self.id.to_owned().into(),
@@ -116,7 +112,7 @@ impl Session {
 			"sd".to_string() => self.sd.to_owned().into(),
 			"tk".to_string() => self.tk.to_owned().into(),
 		});
-		ctx.add_value(key, val);
+		ctx.add_value("session", val);
 		// Output context
 		ctx
 	}

--- a/lib/src/doc/alter.rs
+++ b/lib/src/doc/alter.rs
@@ -68,7 +68,7 @@ impl<'a> Document<'a> {
 					let mut ctx = Context::new(ctx);
 					// Add insertable value
 					if let Workable::Insert(value) = &self.extras {
-						ctx.add_value("input".into(), value);
+						ctx.add_value("input", value);
 					}
 					// Process ON DUPLICATE KEY clause
 					for x in x.iter() {

--- a/lib/src/doc/event.rs
+++ b/lib/src/doc/event.rs
@@ -37,10 +37,10 @@ impl<'a> Document<'a> {
 			};
 			// Configure the context
 			let mut ctx = Context::new(ctx);
-			ctx.add_value("event".into(), met);
-			ctx.add_value("value".into(), self.current.deref());
-			ctx.add_value("after".into(), self.current.deref());
-			ctx.add_value("before".into(), self.initial.deref());
+			ctx.add_value("event", met);
+			ctx.add_value("value", self.current.deref());
+			ctx.add_value("after", self.current.deref());
+			ctx.add_value("before", self.initial.deref());
 			// Process conditional clause
 			let val = ev.when.compute(&ctx, opt, txn, Some(&self.current)).await?;
 			// Execute event if value is truthy

--- a/lib/src/doc/field.rs
+++ b/lib/src/doc/field.rs
@@ -62,10 +62,10 @@ impl<'a> Document<'a> {
 				if let Some(expr) = &fd.value {
 					// Configure the context
 					let mut ctx = Context::new(ctx);
-					ctx.add_value("input".into(), &inp);
-					ctx.add_value("value".into(), &val);
-					ctx.add_value("after".into(), &val);
-					ctx.add_value("before".into(), &old);
+					ctx.add_value("input", &inp);
+					ctx.add_value("value", &val);
+					ctx.add_value("after", &val);
+					ctx.add_value("before", &old);
 					// Process the VALUE clause
 					val = expr.compute(&ctx, opt, txn, Some(&self.current)).await?;
 				}
@@ -90,10 +90,10 @@ impl<'a> Document<'a> {
 				if let Some(expr) = &fd.assert {
 					// Configure the context
 					let mut ctx = Context::new(ctx);
-					ctx.add_value("input".into(), &inp);
-					ctx.add_value("value".into(), &val);
-					ctx.add_value("after".into(), &val);
-					ctx.add_value("before".into(), &old);
+					ctx.add_value("input", &inp);
+					ctx.add_value("value", &val);
+					ctx.add_value("after", &val);
+					ctx.add_value("before", &old);
 					// Process the ASSERT clause
 					if !expr.compute(&ctx, opt, txn, Some(&self.current)).await?.is_truthy() {
 						return Err(Error::FieldValue {
@@ -121,10 +121,10 @@ impl<'a> Document<'a> {
 							let opt = &opt.perms(false);
 							// Configure the context
 							let mut ctx = Context::new(ctx);
-							ctx.add_value("input".into(), &inp);
-							ctx.add_value("value".into(), &val);
-							ctx.add_value("after".into(), &val);
-							ctx.add_value("before".into(), &old);
+							ctx.add_value("input", &inp);
+							ctx.add_value("value", &val);
+							ctx.add_value("after", &val);
+							ctx.add_value("before", &old);
 							// Process the PERMISSION clause
 							if !e.compute(&ctx, opt, txn, Some(&self.current)).await?.is_truthy() {
 								val = old

--- a/lib/src/doc/pluck.rs
+++ b/lib/src/doc/pluck.rs
@@ -72,7 +72,7 @@ impl<'a> Document<'a> {
 								let val = self.current.pick(k);
 								// Configure the context
 								let mut ctx = Context::new(ctx);
-								ctx.add_value("value".into(), &val);
+								ctx.add_value("value", &val);
 								// Process the PERMISSION clause
 								if !e
 									.compute(&ctx, opt, txn, Some(&self.current))

--- a/lib/src/sql/subquery.rs
+++ b/lib/src/sql/subquery.rs
@@ -81,7 +81,7 @@ impl Subquery {
 				let mut ctx = Context::new(ctx);
 				// Add parent document
 				if let Some(doc) = doc {
-					ctx.add_value("parent".into(), doc);
+					ctx.add_value("parent", doc);
 				}
 				// Process subquery
 				match v.compute(&ctx, opt, txn, doc).await? {
@@ -103,7 +103,7 @@ impl Subquery {
 				let mut ctx = Context::new(ctx);
 				// Add parent document
 				if let Some(doc) = doc {
-					ctx.add_value("parent".into(), doc);
+					ctx.add_value("parent", doc);
 				}
 				// Process subquery
 				match v.compute(&ctx, opt, txn, doc).await? {
@@ -125,7 +125,7 @@ impl Subquery {
 				let mut ctx = Context::new(ctx);
 				// Add parent document
 				if let Some(doc) = doc {
-					ctx.add_value("parent".into(), doc);
+					ctx.add_value("parent", doc);
 				}
 				// Process subquery
 				match v.compute(&ctx, opt, txn, doc).await? {
@@ -147,7 +147,7 @@ impl Subquery {
 				let mut ctx = Context::new(ctx);
 				// Add parent document
 				if let Some(doc) = doc {
-					ctx.add_value("parent".into(), doc);
+					ctx.add_value("parent", doc);
 				}
 				// Process subquery
 				match v.compute(&ctx, opt, txn, doc).await? {
@@ -169,7 +169,7 @@ impl Subquery {
 				let mut ctx = Context::new(ctx);
 				// Add parent document
 				if let Some(doc) = doc {
-					ctx.add_value("parent".into(), doc);
+					ctx.add_value("parent", doc);
 				}
 				// Process subquery
 				match v.compute(&ctx, opt, txn, doc).await? {
@@ -191,7 +191,7 @@ impl Subquery {
 				let mut ctx = Context::new(ctx);
 				// Add parent document
 				if let Some(doc) = doc {
-					ctx.add_value("parent".into(), doc);
+					ctx.add_value("parent", doc);
 				}
 				// Process subquery
 				match v.compute(&ctx, opt, txn, doc).await? {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When storing parameter values on the query Context, currently we are converting `static str` values to `String` in order to store them on the Context `HashMap`. This is unnecessarily inefficient.

## What does this change do?

Instead of storing owned `String` values we now use a `Cow<'static, str>` so that we can store static strings, or owned strings, depending on whether it is a built-in variable or not.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
