### PR TITLE
Trim text before json parsing

### DIFF
--- a/lib/src/sql/parser.rs
+++ b/lib/src/sql/parser.rs
@@ -29,7 +29,7 @@ pub fn value(input: &str) -> Result<Value, Error> {
 /// Parses JSON into an inert SurrealQL [`Value`]
 #[instrument(name = "parser", skip_all, fields(length = input.len()))]
 pub fn json(input: &str) -> Result<Value, Error> {
-	parse_impl(input, super::value::json)
+	parse_impl(input.trim(), super::value::json)
 }
 
 fn parse_impl<O>(input: &str, parser: impl Fn(&str) -> IResult<&str, O>) -> Result<O, Error> {


### PR DESCRIPTION

## What is the motivation?

Parsing JSON value from text which has trailing white-spaces causes QueryRemaining error. This can occur when parsing http response (application/json) as text (with trailing white-spaces) before attempting to convert into json.

## What does this change do?

Trimming leading/trailing whitespace before json conversion eliminates QueryRemaining error.

## What is your testing strategy?

Have checked it by writing simple test w/o trailing spaces.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

-  [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
