### PR TITLE
Fix http body encoding

### DIFF
--- a/lib/src/fnc/util/http/mod.rs
+++ b/lib/src/fnc/util/http/mod.rs
@@ -14,7 +14,7 @@ pub(crate) fn uri_is_valid(uri: &str) -> bool {
 fn encode_body(req: RequestBuilder, body: Value) -> RequestBuilder {
 	match body {
 		Value::Bytes(bytes) => req.header(CONTENT_TYPE, "application/octet-stream").body(bytes.0),
-		_ if body.is_some() => req.json(&body),
+		_ if body.is_some() => req.json(&serde_json::Value::from(body)),
 		_ => req,
 	}
 }


### PR DESCRIPTION
## What is the motivation?

`sql::value` should be converted to `serde_json::value` as suggested by @rushmorem  before encoding as http body.

## What does this change do?

This PR converts `sql::value ` type as `serde_json::value` before http json body encoding.

## What is your testing strategy?
let val = sql::json(r#"{ "amount": "500", "purpose": "rent"}"#).unwrap();
let s = serde_json::Value::from(val);
println!("{}" s.to_string());
/// Printed { "amount": "500", "purpose": "rent"} which is ok.
```

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
