### PR TITLE
Add a `sql::Value::into_json()` method

### DIFF
--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -53,6 +53,7 @@ use nom::multi::separated_list0;
 use nom::multi::separated_list1;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use serde_json::Value as Json;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -1018,6 +1019,14 @@ impl Value {
 				message: String::from("Operations must be an array"),
 			}),
 		}
+	}
+
+	/// Converts a `surrealdb::sq::Value` into a `serde_json::Value`
+	///
+	/// This converts certain types like `Thing` into their simpler formats
+	/// instead of the format used internally by SurrealDB.
+	pub fn into_json(self) -> Json {
+		self.into()
 	}
 
 	// -----------------------------------


### PR DESCRIPTION
## What is the motivation?

Make `sql::Value` to JSON conversion more discover-able and avoid needless `serde_json::Value` imports where possible.

## What does this change do?

Adds an `into_json` conversion method on `sql::Value`.

## What is your testing strategy?

Ensure tests still pass.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
