### PR TITLE
[nix] Support aarch64-darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1682749232,
-        "narHash": "sha256-tZdhmgUIuSrRB8j1fTa5JVdewdNf0crNwDMnNIKfYqE=",
+        "lastModified": 1683699806,
+        "narHash": "sha256-Nw3pzHv9oRdIDmgetGWG5mqLDK78v3fTsReqANMjZ1Q=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "30d4a659367f2399cdc9e813c516ae53d46ab266",
+        "rev": "71e7505152ef95dfddd0f5f0e5a755f4c3bbee86",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682682915,
-        "narHash": "sha256-haR0u/j/nUvlMloYlaOYq1FMXTvkNHw+wGxc+0qXisM=",
+        "lastModified": 1683627095,
+        "narHash": "sha256-8u9SejRpL2TrMuHBdhYh4FKc1OGPDLyWTpIbNTtoHsA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09f1b33fcc0f59263137e23e935c1bb03ec920e4",
+        "rev": "a08e061a4ee8329747d54ddf1566d34c55c895eb",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1682710505,
-        "narHash": "sha256-03cthpkTbEdQF7wpmJjPuBvwcQ5eSV4jDfWj8Evg4Lk=",
+        "lastModified": 1683653808,
+        "narHash": "sha256-GiKwJySG/YCPIKwz9wSm9fJa5e4CU3GvTYAKZzjBhFo=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "370b72c7dd3dcdb1efe92224ab1622e44639cb07",
+        "rev": "b7cdd93f3e1533e96d4cfa1ac8573e6210a2bedf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     # are used to express the output but not themselves paths in the output.
     let
 
-      nativeSystems = [ aarch64-linux x86_64-darwin x86_64-linux ];
+      nativeSystems = [ aarch64-darwin aarch64-linux x86_64-darwin x86_64-linux ];
 
       # Build the output set for each default system and map system sets into
       # attributes, resulting in paths such as:

--- a/pkg/nix/spec/aarch64-apple-darwin.nix
+++ b/pkg/nix/spec/aarch64-apple-darwin.nix
@@ -6,7 +6,7 @@
   features = with util.features; [ default storage-tikv ];
 
   buildSpec = with pkgs; {
-    depsBuildBuild = [ clang protobuf perl ];
+    depsBuildBuild = [ cmake clang protobuf perl ];
 
     nativeBuildInputs = [ pkg-config ];
 

--- a/pkg/nix/spec/aarch64-apple-darwin.nix
+++ b/pkg/nix/spec/aarch64-apple-darwin.nix
@@ -6,9 +6,9 @@
   features = with util.features; [ default storage-tikv ];
 
   buildSpec = with pkgs; {
-    depsBuildBuild = [ cmake clang protobuf perl ];
+    depsBuildBuild = [ clang protobuf perl ];
 
-    nativeBuildInputs = [ pkg-config ];
+    nativeBuildInputs = [ cmake pkg-config ];
 
     buildInputs = [ openssl libiconv darwin.apple_sdk.frameworks.Security ];
 

--- a/pkg/nix/spec/aarch64-apple-darwin.nix
+++ b/pkg/nix/spec/aarch64-apple-darwin.nix
@@ -12,8 +12,11 @@
 
     buildInputs = [ openssl libiconv darwin.apple_sdk.frameworks.Security ];
 
-    PROTOC = "${protobuf}/bin/protoc";
-    PROTOC_INCLUDE = "${protobuf}/include";
+    # From https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/rocksdb/default.nix#LL43C7-L52C6
+    NIX_CFLAGS_COMPILE = toString ([
+      "-Wno-error=unused-private-field"
+      "-faligned-allocation"
+    ]);
 
     CARGO_BUILD_TARGET = target;
   };

--- a/pkg/nix/spec/x86_64-apple-darwin.nix
+++ b/pkg/nix/spec/x86_64-apple-darwin.nix
@@ -8,7 +8,7 @@
   buildSpec = with pkgs; {
     depsBuildBuild = [ clang protobuf perl ];
 
-    nativeBuildInputs = [ pkg-config ];
+    nativeBuildInputs = [ cmake pkg-config ];
 
     buildInputs = [ openssl libiconv darwin.apple_sdk.frameworks.Security ];
 

--- a/pkg/nix/spec/x86_64-apple-darwin.nix
+++ b/pkg/nix/spec/x86_64-apple-darwin.nix
@@ -12,8 +12,11 @@
 
     buildInputs = [ openssl libiconv darwin.apple_sdk.frameworks.Security ];
 
-    PROTOC = "${protobuf}/bin/protoc";
-    PROTOC_INCLUDE = "${protobuf}/include";
+    # From https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/rocksdb/default.nix#LL43C7-L52C6
+    NIX_CFLAGS_COMPILE = toString ([
+      "-Wno-error=unused-private-field"
+      "-faligned-allocation"
+    ]);
 
     CARGO_BUILD_TARGET = target;
   };


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Add Nix support for M1 mac users

## What does this change do?

Allow M1 mac users to develop SurrealDB using Nix

## What is your testing strategy?

I ran `nix-collect-garbage -d && nix build` on a M1 Max MBP and on an i9 MBP. Both running `macOS 13.3.1`

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
