### PR TITLE
Bugfix - time::ceil function edge case.

### DIFF
--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -3559,11 +3559,12 @@ async fn function_time_ceil() -> Result<(), Error> {
 	let sql = r#"
 		RETURN time::ceil("1987-06-22T08:30:45Z", 1w);
 		RETURN time::ceil("1987-06-22T08:30:45Z", 1y);
+		RETURN time::ceil("2023-05-11T03:09:00Z", 1s);
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
-	assert_eq!(res.len(), 2);
+	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse("'1987-06-25T00:00:00Z'");
@@ -3571,6 +3572,10 @@ async fn function_time_ceil() -> Result<(), Error> {
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse("'1987-12-28T00:00:00Z'");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("'2023-05-11T03:09:00Z'");
 	assert_eq!(tmp, val);
 	//
 	Ok(())
@@ -3602,11 +3607,12 @@ async fn function_time_floor() -> Result<(), Error> {
 	let sql = r#"
 		RETURN time::floor("1987-06-22T08:30:45Z", 1w);
 		RETURN time::floor("1987-06-22T08:30:45Z", 1y);
+		RETURN time::ceil("2023-05-11T03:09:00Z", 1s);
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
-	assert_eq!(res.len(), 2);
+	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse("'1987-06-18T00:00:00Z'");
@@ -3614,6 +3620,10 @@ async fn function_time_floor() -> Result<(), Error> {
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse("'1986-12-28T00:00:00Z'");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("'2023-05-11T03:09:00Z'");
 	assert_eq!(tmp, val);
 	//
 	Ok(())

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -3607,7 +3607,7 @@ async fn function_time_floor() -> Result<(), Error> {
 	let sql = r#"
 		RETURN time::floor("1987-06-22T08:30:45Z", 1w);
 		RETURN time::floor("1987-06-22T08:30:45Z", 1y);
-		RETURN time::ceil("2023-05-11T03:09:00Z", 1s);
+		RETURN time::floor("2023-05-11T03:09:00Z", 1s);
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

In #1975, I forgot to handle the case where the date time argument is already divisible by the duration argument.

## What does this change do?

Fixes the `time::ceil` function by handling that edge case.

## What is your testing strategy?

Adds a check for that edge case to both `time::ceil` and `time::floor` tests.

## Is this related to any issues?

Not yet :)

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
