### PR TITLE
Improve CLI SQL input with empty input

### DIFF
--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -167,6 +167,7 @@ struct InputValidator {
 	multi: bool,
 }
 
+#[allow(clippy::if_same_then_else)]
 impl Validator for InputValidator {
 	fn validate(&self, ctx: &mut ValidationContext) -> rustyline::Result<ValidationResult> {
 		use ValidationResult::{Incomplete, Invalid, Valid};
@@ -176,19 +177,14 @@ impl Validator for InputValidator {
 		let input = input.trim();
 		// Process the input to check if we can send the query
 		let result = if self.multi && !input.ends_with(';') {
-			// The line ends with a ; and we are in multi mode
-			Incomplete
+			Incomplete // The line ends with a ; and we are in multi mode
 		} else if self.multi && input.is_empty() {
-			// The line was empty and we are in multi mode
-			Incomplete
+			Incomplete // The line was empty and we are in multi mode
 		} else if input.ends_with('\\') {
-			// The line ends with a backslash
-			Incomplete
-		} else if let Err(e) = sql::parse(&input) {
-			// Let's display an inline error
+			Incomplete // The line ends with a backslash
+		} else if let Err(e) = sql::parse(input) {
 			Invalid(Some(format!(" --< {e}")))
 		} else {
-			// This query can be submitted
 			Valid(None)
 		};
 		// Validation complete

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -72,16 +72,12 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 			},
 			(None, None) => {}
 		}
-
 		// Prompt the user to input SQL and check the input.
 		let line = match rl.readline(&prompt) {
 			// The user typed a query
 			Ok(line) => {
+				// Filter out all new lines
 				let line = filter_line_continuations(&line);
-				// Ignore all empty lines
-				if line.is_empty() {
-					continue;
-				}
 				// Add the entry to the history
 				if let Err(e) = rl.add_history_entry(line.as_str()) {
 					eprintln!("{e}");
@@ -98,7 +94,6 @@ pub async fn init(matches: &clap::ArgMatches) -> Result<(), Error> {
 				break;
 			}
 		};
-
 		// Complete the request
 		match sql::parse(&line) {
 			Ok(query) => {
@@ -175,17 +170,28 @@ struct InputValidator {
 impl Validator for InputValidator {
 	fn validate(&self, ctx: &mut ValidationContext) -> rustyline::Result<ValidationResult> {
 		use ValidationResult::{Incomplete, Invalid, Valid};
+		// Filter out all new line characters
 		let input = filter_line_continuations(ctx.input());
-		let result = if (self.multi && !input.trim().ends_with(';'))
-			|| input.ends_with('\\')
-			|| input.is_empty()
-		{
+		// Trim all whitespace from the user input
+		let input = input.trim();
+		// Process the input to check if we can send the query
+		let result = if self.multi && !input.ends_with(';') {
+			// The line ends with a ; and we are in multi mode
+			Incomplete
+		} else if self.multi && input.is_empty() {
+			// The line was empty and we are in multi mode
+			Incomplete
+		} else if input.ends_with('\\') {
+			// The line ends with a backslash
 			Incomplete
 		} else if let Err(e) = sql::parse(&input) {
+			// Let's display an inline error
 			Invalid(Some(format!(" --< {e}")))
 		} else {
+			// This query can be submitted
 			Valid(None)
 		};
+		// Validation complete
 		Ok(result)
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When running the CLI sql tool in normal mode, it was possible to hit enter twice before seeing an `empty input` error, when actually the error should be visible immediately when not running in multi mode.

## What does this change do?

Improve the behaviour when hitting `enter` in the CLI sql tool, when running in normal mode. This does not change behaviour when running in multi mode.

And added some code comments.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
