### PR TITLE
Bugfix - error on integer overflow in SurrealQL.

### DIFF
--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -347,23 +347,23 @@ pub enum Error {
 		into: Cow<'static, str>,
 	},
 
-	/// The requested function does not exist
+	/// Cannot perform addition
 	#[error("Cannot perform addition with '{0}' and '{1}'")]
 	TryAdd(String, String),
 
-	/// The requested function does not exist
+	/// Cannot perform subtraction
 	#[error("Cannot perform subtraction with '{0}' and '{1}'")]
 	TrySub(String, String),
 
-	/// The requested function does not exist
+	/// Cannot perform multiplication
 	#[error("Cannot perform multiplication with '{0}' and '{1}'")]
 	TryMul(String, String),
 
-	/// The requested function does not exist
+	/// Cannot perform division
 	#[error("Cannot perform division with '{0}' and '{1}'")]
 	TryDiv(String, String),
 
-	/// The requested function does not exist
+	/// Cannot perform power
 	#[error("Cannot raise the value '{0}' with '{1}'")]
 	TryPow(String, String),
 

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2003,7 +2003,12 @@ impl TryAdd for Value {
 	type Output = Self;
 	fn try_add(self, other: Self) -> Result<Self, Error> {
 		match (self, other) {
-			(Value::Number(v), Value::Number(w)) => Ok(Value::Number(v + w)),
+			(Value::Number(v), Value::Number(w)) => match (v, w) {
+				(Number::Int(v), Number::Int(w)) if v.checked_add(w).is_none() => {
+					Err(Error::TryAdd(v.to_string(), w.to_string()))
+				}
+				(v, w) => Ok(Value::Number(v + w)),
+			},
 			(Value::Strand(v), Value::Strand(w)) => Ok(Value::Strand(v + w)),
 			(Value::Datetime(v), Value::Duration(w)) => Ok(Value::Datetime(w + v)),
 			(Value::Duration(v), Value::Datetime(w)) => Ok(Value::Datetime(v + w)),
@@ -2024,7 +2029,12 @@ impl TrySub for Value {
 	type Output = Self;
 	fn try_sub(self, other: Self) -> Result<Self, Error> {
 		match (self, other) {
-			(Value::Number(v), Value::Number(w)) => Ok(Value::Number(v - w)),
+			(Value::Number(v), Value::Number(w)) => match (v, w) {
+				(Number::Int(v), Number::Int(w)) if v.checked_sub(w).is_none() => {
+					Err(Error::TrySub(v.to_string(), w.to_string()))
+				}
+				(v, w) => Ok(Value::Number(v - w)),
+			},
 			(Value::Datetime(v), Value::Datetime(w)) => Ok(Value::Duration(v - w)),
 			(Value::Datetime(v), Value::Duration(w)) => Ok(Value::Datetime(w - v)),
 			(Value::Duration(v), Value::Datetime(w)) => Ok(Value::Datetime(v - w)),
@@ -2045,7 +2055,12 @@ impl TryMul for Value {
 	type Output = Self;
 	fn try_mul(self, other: Self) -> Result<Self, Error> {
 		match (self, other) {
-			(Value::Number(v), Value::Number(w)) => Ok(Value::Number(v * w)),
+			(Value::Number(v), Value::Number(w)) => match (v, w) {
+				(Number::Int(v), Number::Int(w)) if v.checked_mul(w).is_none() => {
+					Err(Error::TryMul(v.to_string(), w.to_string()))
+				}
+				(v, w) => Ok(Value::Number(v * w)),
+			},
 			(v, w) => Err(Error::TryMul(v.to_raw_string(), w.to_raw_string())),
 		}
 	}
@@ -2082,7 +2097,14 @@ impl TryPow for Value {
 	type Output = Self;
 	fn try_pow(self, other: Self) -> Result<Self, Error> {
 		match (self, other) {
-			(Value::Number(v), Value::Number(w)) => Ok(Value::Number(v.pow(w))),
+			(Value::Number(v), Value::Number(w)) => match (v, w) {
+				(Number::Int(v), Number::Int(w))
+					if w.try_into().ok().and_then(|w| v.checked_pow(w)).is_none() =>
+				{
+					Err(Error::TryPow(v.to_string(), w.to_string()))
+				}
+				(v, w) => Ok(Value::Number(v.pow(w))),
+			},
 			(v, w) => Err(Error::TryPow(v.to_raw_string(), w.to_raw_string())),
 		}
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Integer overflow in SurrealDQ expressions isn't handled and results in misbehavior (release mode) or crashing (debug mode)

## What does this change do?

- Returns an error in the event of integer overflow.
- Fixes some related comments

## What is your testing strategy?

Manual.

```
test/test> return 999999999*99999999999;
There was a problem with the database: Cannot perform multiplication with '999999999' and '99999999999'

test/test> return 999999999**99999999999;
There was a problem with the database: Cannot raise the value '999999999' with '99999999999'
```

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
