### PR TITLE
Testing - use tokio runtime in executor fuzzer, blacklist `SLEEP`

### DIFF
--- a/lib/fuzz/Cargo.lock
+++ b/lib/fuzz/Cargo.lock
@@ -1395,11 +1395,12 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "storekey"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475592c1aa8849fa7874777c9df46aa93ffc47851c7c60bee88b1745a1adb893"
+checksum = "43c42833834a5d23b344f71d87114e0cc9994766a5c42938f4b50e7b2aef85b2"
 dependencies = [
  "byteorder",
+ "memchr",
  "serde",
  "thiserror",
 ]
@@ -1420,6 +1421,7 @@ dependencies = [
  "async-channel",
  "async-executor",
  "async-recursion",
+ "base64",
  "bcrypt",
  "bigdecimal",
  "bung",
@@ -1465,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-derive"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0f2a75e22417f587cf23a5efa9f680f4002b8655b8481a01ee5e787f15d82b"
+checksum = "7f44db5c0ba9716670cb45585f475e46b2c2e64428736e03a4e4a83a628b8a21"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1481,6 +1483,7 @@ dependencies = [
  "futures",
  "libfuzzer-sys",
  "surrealdb",
+ "tokio",
 ]
 
 [[package]]

--- a/lib/fuzz/Cargo.toml
+++ b/lib/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 libfuzzer-sys = { version= "0.4", features = ["arbitrary-derive"] }
 arbitrary = { version = "1", features = ["derive"] }
 futures = "0.3.28"
+tokio = "1.27.0"
 
 [dependencies.surrealdb]
 path = ".."

--- a/lib/fuzz/fuzz_targets/fuzz_executor.rs
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.rs
@@ -13,7 +13,6 @@ fuzz_target!(|commands: Vec<&str>| {
 
 	tokio::runtime::Builder::new_current_thread()
 		.enable_all()
-		.thread_stack_size(8 * 1024 * 1024)
 		.build()
 		.unwrap()
 		.block_on(async {

--- a/lib/fuzz/fuzz_targets/fuzz_executor.rs
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.rs
@@ -3,7 +3,7 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|commands: Vec<&str>| {
-	let blacklisted_command_strings = ["sleep"];
+	let blacklisted_command_strings = ["sleep", "SLEEP"];
 
 	use surrealdb::{dbs::Session, kvs::Datastore};
 	let max_commands = 500;

--- a/lib/fuzz/fuzz_targets/fuzz_executor.rs
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.rs
@@ -11,19 +11,24 @@ fuzz_target!(|commands: Vec<&str>| {
 		return;
 	}
 
-	futures::executor::block_on(async {
-		let dbs = Datastore::new("memory").await.unwrap();
-		let ses = Session::for_kv().with_ns("test").with_db("test");
-		for command in commands.iter() {
-			for blacklisted_string in blacklisted_command_strings.iter() {
-				if command.contains(blacklisted_string) {
-					return;
+	tokio::runtime::Builder::new_current_thread()
+		.enable_all()
+		.thread_stack_size(8 * 1024 * 1024)
+		.build()
+		.unwrap()
+		.block_on(async {
+			let dbs = Datastore::new("memory").await.unwrap();
+			let ses = Session::for_kv().with_ns("test").with_db("test");
+			for command in commands.iter() {
+				for blacklisted_string in blacklisted_command_strings.iter() {
+					if command.contains(blacklisted_string) {
+						return;
+					}
 				}
+				let _ignore_the_result = dbs.execute(command, &ses, None, false).await;
+	
+				// TODO: Add some async timeout and `tokio::select!` between it and the query
+				// Alternatively, wrap future in `tokio::time::Timeout`.
 			}
-			let _ignore_the_result = dbs.execute(command, &ses, None, false).await;
-
-			// TODO: Add some async timeout and `tokio::select!` between it and the query
-			// Alternatively, wrap future in `tokio::time::Timeout`.
-		}
-	});
+		})
 });


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The fuzzer encountered an error because a `tokio` 1.x runtime wasn't running. Futhermore, the fuzzer should not be executing the `SLEEP` statement (to avoid timeouts).

## What does this change do?

Use a `tokio` runtime, which is representative of real deployments. Blacklist the `SLEEP` statement.

## What is your testing strategy?

Manual.

## Is this related to any issues?

Followup to #1891 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
