### PR TITLE
Make client error serializable

### DIFF
--- a/lib/src/api/err/mod.rs
+++ b/lib/src/api/err/mod.rs
@@ -4,6 +4,7 @@ use crate::sql::Edges;
 use crate::sql::Object;
 use crate::sql::Thing;
 use crate::sql::Value;
+use serde::Serialize;
 use std::io;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -198,5 +199,14 @@ impl From<ws_stream_wasm::WsErr> for crate::Error {
 impl From<pharos::PharErr> for crate::Error {
 	fn from(error: pharos::PharErr) -> Self {
 		Self::Api(Error::Ws(error.to_string()))
+	}
+}
+
+impl Serialize for Error {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		serializer.serialize_str(self.to_string().as_str())
 	}
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -157,7 +157,7 @@ pub mod error {
 }
 
 /// An error originating from the SurrealDB client library
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, serde::Serialize)]
 pub enum Error {
 	/// An error with an embedded storage engine
 	#[error("{0}")]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -157,7 +157,7 @@ pub mod error {
 }
 
 /// An error originating from the SurrealDB client library
-#[derive(thiserror::Error, Debug, serde::Serialize)]
+#[derive(Debug, thiserror::Error, serde::Serialize)]
 pub enum Error {
 	/// An error with an embedded storage engine
 	#[error("{0}")]

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -1,6 +1,7 @@
 use base64::DecodeError as Base64Error;
 use jsonwebtoken::errors::Error as JWTError;
 use reqwest::Error as ReqwestError;
+use serde::Serialize;
 use serde_cbor::error::Error as CborError;
 use serde_json::error::Error as JsonError;
 use serde_pack::encode::Error as PackError;
@@ -77,5 +78,14 @@ impl From<JWTError> for Error {
 impl From<surrealdb::error::Db> for Error {
 	fn from(error: surrealdb::error::Db) -> Error {
 		Error::Db(error.into())
+	}
+}
+
+impl Serialize for Error {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		serializer.serialize_str(self.to_string().as_str())
 	}
 }


### PR DESCRIPTION
## What is the motivation?

It would be much useful if client error is serializable. Especially when using rust client library in apps like `tauri`, we can directly send the error to the frontend as it is serializable. 

## What does this change do?

This PR implements serialize for both  `api::Error` & `client::Error`.

## What is your testing strategy?

Ran build and everything looks fine.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
