### PR TITLE
Expose the range parser

### DIFF
--- a/lib/src/sql/range.rs
+++ b/lib/src/sql/range.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt;
 use std::ops::Bound;
+use std::str::FromStr;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Range";
 
@@ -27,6 +28,23 @@ pub struct Range {
 	pub tb: String,
 	pub beg: Bound<Id>,
 	pub end: Bound<Id>,
+}
+
+impl FromStr for Range {
+	type Err = ();
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Self::try_from(s)
+	}
+}
+
+impl TryFrom<&str> for Range {
+	type Error = ();
+	fn try_from(v: &str) -> Result<Self, Self::Error> {
+		match range(v) {
+			Ok((_, v)) => Ok(v),
+			_ => Err(()),
+		}
+	}
 }
 
 impl Range {


### PR DESCRIPTION
## What is the motivation?

We need access to the range parser to parse ranges in the Wasm library.

## What does this change do?

It publicly exposes the ability to parse ranges from strings.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
