### PR TITLE
Bugfix - Include index part when patching object value

### DIFF
--- a/lib/src/sql/value/cut.rs
+++ b/lib/src/sql/value/cut.rs
@@ -9,20 +9,29 @@ impl Value {
 			// Get the current path part
 			match self {
 				// Current path part is an object
-				Value::Object(v) => {
-					if let Part::Field(f) = p {
-						match path.len() {
-							1 => {
-								v.remove(f.as_str());
-							}
-							_ => {
-								if let Some(v) = v.get_mut(f.as_str()) {
-									v.cut(path.next())
-								}
+				Value::Object(v) => match p {
+					Part::Field(f) => match path.len() {
+						1 => {
+							v.remove(f.as_str());
+						}
+						_ => {
+							if let Some(v) = v.get_mut(f.as_str()) {
+								v.cut(path.next())
 							}
 						}
-					}
-				}
+					},
+					Part::Index(i) => match path.len() {
+						1 => {
+							v.remove(&i.to_string());
+						}
+						_ => {
+							if let Some(v) = v.get_mut(&i.to_string()) {
+								v.cut(path.next())
+							}
+						}
+					},
+					_ => {}
+				},
 				// Current path part is an array
 				Value::Array(v) => match p {
 					Part::All => match path.len() {

--- a/lib/src/sql/value/del.rs
+++ b/lib/src/sql/value/del.rs
@@ -36,6 +36,16 @@ impl Value {
 							_ => Ok(()),
 						},
 					},
+					Part::Index(i) => match path.len() {
+						1 => {
+							v.remove(&i.to_string());
+							Ok(())
+						}
+						_ => match v.get_mut(&i.to_string()) {
+							Some(v) if v.is_some() => v.del(ctx, opt, txn, path.next()).await,
+							_ => Ok(()),
+						},
+					},
 					_ => Ok(()),
 				},
 				// Current path part is an array

--- a/lib/src/sql/value/fetch.rs
+++ b/lib/src/sql/value/fetch.rs
@@ -34,6 +34,10 @@ impl Value {
 						Some(v) => v.fetch(ctx, opt, txn, path.next()).await,
 						None => Ok(()),
 					},
+					Part::Index(i) => match v.get_mut(&i.to_string()) {
+						Some(v) => v.fetch(ctx, opt, txn, path.next()).await,
+						None => Ok(()),
+					},
 					Part::All => self.fetch(ctx, opt, txn, path.next()).await,
 					_ => Ok(()),
 				},

--- a/lib/src/sql/value/pick.rs
+++ b/lib/src/sql/value/pick.rs
@@ -14,6 +14,10 @@ impl Value {
 						Some(v) => v.pick(path.next()),
 						None => Value::None,
 					},
+					Part::Index(i) => match v.get(&i.to_string()) {
+						Some(v) => v.pick(path.next()),
+						None => Value::None,
+					},
 					Part::All => self.pick(path.next()),
 					_ => Value::None,
 				},

--- a/lib/src/sql/value/put.rs
+++ b/lib/src/sql/value/put.rs
@@ -26,6 +26,14 @@ impl Value {
 							v.insert(f.to_raw(), obj);
 						}
 					},
+					Part::Index(i) => match v.get_mut(&i.to_string()) {
+						Some(v) if v.is_some() => v.put(path.next(), val),
+						_ => {
+							let mut obj = Value::base();
+							obj.put(path.next(), val);
+							v.insert(i.to_string(), obj);
+						}
+					},
 					_ => (),
 				},
 				// Current path part is an array

--- a/lib/src/sql/value/set.rs
+++ b/lib/src/sql/value/set.rs
@@ -43,6 +43,15 @@ impl Value {
 							Ok(())
 						}
 					},
+					Part::Index(i) => match v.get_mut(&i.to_string()) {
+						Some(v) if v.is_some() => v.set(ctx, opt, txn, path.next(), val).await,
+						_ => {
+							let mut obj = Value::base();
+							obj.set(ctx, opt, txn, path.next(), val).await?;
+							v.insert(i.to_string(), obj);
+							Ok(())
+						}
+					},
 					_ => Ok(()),
 				},
 				// Current path part is an array

--- a/lib/src/sql/value/walk.rs
+++ b/lib/src/sql/value/walk.rs
@@ -17,6 +17,10 @@ impl Value {
 						Some(v) => v._walk(path.next(), prev.push(p.clone())),
 						None => Value::None._walk(path.next(), prev.push(p.clone())),
 					},
+					Part::Index(i) => match v.get(&i.to_string()) {
+						Some(v) => v._walk(path.next(), prev.push(p.clone())),
+						None => Value::None._walk(path.next(), prev.push(p.clone())),
+					},
 					Part::All => self._walk(path.next(), prev.push(p.clone())),
 					_ => vec![],
 				},


### PR DESCRIPTION
## What is the motivation?

Currently object values gets patched only when the path part type is `Part::Field` or `Part::Graph`.  But JSON Pointer patch document can have unsigned number keys as well. currently numeric strings get parsed as `Part::Index` which will not be considered for patching when value is of type `Value::Object`. 

## What does this change do?

This change patches object values even when part is `Part::Index`. I have just included `Part::Index` under the match arm when patching `Value::Object`.  Not sure this is the right way to fix it or we may need to consider changing `Part` parsing method.

## What is your testing strategy?

Ran build and it worked.

## Is this related to any issues?

This PR kinda fixes #1982 .

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
