### PR TITLE
Use only regular instances on the CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,11 @@
 name: Benchmark
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [ labeled ]
 
 defaults:
   run:
@@ -9,7 +14,8 @@ defaults:
 jobs:
   bench:
     name: Bench library
-    runs-on: ubuntu-20.04-16-cores
+    if: ${{ github.event.label.name == 'performance' }}
+    runs-on: ubuntu-20.04
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
   check:
     name: Check workspace
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Install stable toolchain
@@ -67,7 +67,7 @@ jobs:
 
   clippy:
     name: Check clippy
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Install stable toolchain
@@ -88,7 +88,7 @@ jobs:
 
   test:
     name: Test workspace
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Install stable toolchain
@@ -107,7 +107,7 @@ jobs:
 
   ws-engine:
     name: WebSocket engine
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Install stable toolchain
@@ -129,7 +129,7 @@ jobs:
 
   http-engine:
     name: HTTP engine
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Install stable toolchain
@@ -165,7 +165,7 @@ jobs:
 
   file-engine:
     name: File engine
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Install stable toolchain
@@ -179,7 +179,7 @@ jobs:
 
   any-engine:
     name: Any engine
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Install stable toolchain

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Checkout sources
@@ -34,7 +34,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Checkout sources
@@ -79,15 +79,15 @@ jobs:
             file: surreal-nightly.darwin-arm64
             opts: --features storage-tikv
           - arch: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04-16-cores
+            os: ubuntu-20.04
             file: surreal-nightly.linux-amd64
             opts: --features storage-tikv
           - arch: aarch64-unknown-linux-gnu
-            os: ubuntu-20.04-16-cores
+            os: ubuntu-20.04
             file: surreal-nightly.linux-arm64
             opts: --features storage-tikv
           - arch: x86_64-pc-windows-msvc
-            os: windows-latest-16-cores
+            os: windows-latest
             file: surreal-nightly.windows-amd64
             opts:
     runs-on: ${{ matrix.os }}
@@ -219,7 +219,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [package]
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Checkout sources
@@ -246,7 +246,7 @@ jobs:
   docker:
     name: Docker
     needs: [build]
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Checkout sources

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,6 +1,9 @@
 name: Nix
 
-on: push
+on:
+  push:
+    branches:
+      - main
 
 # Setting the shell option, it will run 'bash --noprofile --norc -eo pipefail {0}'
 defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Checkout sources
@@ -34,7 +34,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Checkout sources
@@ -79,15 +79,15 @@ jobs:
             file: surreal-${{ github.ref_name }}.darwin-arm64
             opts: --features storage-tikv
           - arch: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04-16-cores
+            os: ubuntu-20.04
             file: surreal-${{ github.ref_name }}.linux-amd64
             opts: --features storage-tikv
           - arch: aarch64-unknown-linux-gnu
-            os: ubuntu-20.04-16-cores
+            os: ubuntu-20.04
             file: surreal-${{ github.ref_name }}.linux-arm64
             opts: --features storage-tikv
           - arch: x86_64-pc-windows-msvc
-            os: windows-latest-16-cores
+            os: windows-latest
             file: surreal-${{ github.ref_name }}.windows-amd64
             opts:
     runs-on: ${{ matrix.os }}
@@ -219,7 +219,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [package]
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Checkout sources
@@ -261,7 +261,7 @@ jobs:
   docker:
     name: Docker
     needs: [build]
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-20.04
     steps:
 
       - name: Checkout sources


### PR DESCRIPTION
## What is the motivation?

To avoid some issues with the 16-cores instances and unblock the CI.

## What does this change do?

It switches all workflows to use only the regular instances. It also makes the bench workflow only run on PRs labelled `performance` and every change that lands on main.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
