### PR TITLE
Bugfix - Visibly warn if failed to deserialize websocket response.

### DIFF
--- a/lib/src/api/engine/remote/http/native.rs
+++ b/lib/src/api/engine/remote/http/native.rs
@@ -107,7 +107,7 @@ pub(crate) fn router(base_url: Url, client: reqwest::Client, route_rx: Receiver<
 		let mut stream = route_rx.into_stream();
 
 		while let Some(Some(route)) = stream.next().await {
-			match super::router(
+			let result = super::router(
 				route.request,
 				&base_url,
 				&client,
@@ -115,15 +115,8 @@ pub(crate) fn router(base_url: Url, client: reqwest::Client, route_rx: Receiver<
 				&mut vars,
 				&mut auth,
 			)
-			.await
-			{
-				Ok(value) => {
-					let _ = route.response.into_send_async(Ok(value)).await;
-				}
-				Err(error) => {
-					let _ = route.response.into_send_async(Err(error)).await;
-				}
-			}
+			.await;
+			let _ = route.response.into_send_async(result).await;
 		}
 	});
 }

--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -306,7 +306,8 @@ pub(crate) fn router(
 										}
 									}
 									Err(_error) => {
-										trace!(target: LOG, "Failed to deserialise message");
+										// Unfortunately, we don't know which response failed to deserialize
+										warn!(target: LOG, "Failed to deserialise message");
 									}
 								},
 								Err(error) => {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When a websocket message response fails to deserialize, the current behavior is to hang the client indefinitely with no warning.

This makes it difficult to debug serde issues and, if such an issue ever occurred in production, the user wouldn't know what to report.

## What does this change do?

- Raises the log level of websocket deserialization errors from trace to warning so that they are emitted in `make sql`
- Add a comment for why we don't surface the error directly (because websocket messages that fail to deserialize aren't linkable to a request id)
- Remove redundant `match` statement in the http engine

## What is your testing strategy?

Manual.

## Is this related to any issues?

Would have helped debug #1898, #1951, #1991, and others

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
