### PR TITLE
change rpc modify to return AFTER instead of DIFF

### DIFF
--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -629,7 +629,7 @@ impl Rpc {
 		// Get local copy of options
 		let opt = CF.get().unwrap();
 		// Specify the SQL query string
-		let sql = "UPDATE $what PATCH $data RETURN DIFF";
+		let sql = "UPDATE $what PATCH $data RETURN AFTER";
 		// Specify the query parameters
 		let var = Some(map! {
 			String::from("what") => what.could_be_table(),


### PR DESCRIPTION
## What is the motivation?

Currently rpc `modify` query is set to returns DIFF instead of AFTER whereas `change` returns AFTER . Are there any specific reason for this?

## What does this change do?

This PR makes the rpc modify query to return AFTER instead of DIFF.

## What is your testing strategy?

Ran a build and everything works fine.

## Is this related to any issues?

This may fix #1998 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
