### PR TITLE
Feature: Add unset clause for update statement

### DIFF
--- a/lib/src/doc/alter.rs
+++ b/lib/src/doc/alter.rs
@@ -63,6 +63,11 @@ impl<'a> Document<'a> {
 						}
 					}
 				}
+				Data::UnsetExpression(i) => {
+					for i in i.iter() {
+						self.current.to_mut().del(ctx, opt, txn, &i).await?
+					}
+				}
 				Data::UpdateExpression(x) => {
 					// Duplicate context
 					let mut ctx = Context::new(ctx);

--- a/lib/src/sql/data.rs
+++ b/lib/src/sql/data.rs
@@ -21,8 +21,8 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum Data {
 	EmptyExpression,
-	UnsetExpression(Vec<Idiom>),
 	SetExpression(Vec<(Idiom, Operator, Value)>),
+	UnsetExpression(Vec<Idiom>),
 	PatchExpression(Value),
 	MergeExpression(Value),
 	ReplaceExpression(Value),

--- a/lib/src/sql/data.rs
+++ b/lib/src/sql/data.rs
@@ -68,15 +68,6 @@ impl Data {
 				// This SET expression had no 'id' field
 				_ => Ok(tb.generate()),
 			},
-			Self::UnsetExpression(v) => match v.iter().find(|f| f.is_id()) {
-				Some(v) => {
-					println!("Id");
-					// This SET expression has an 'id' field
-					v.compute(ctx, opt, txn, None).await?.generate(tb, false)
-				}
-				// This SET expression had no 'id' field
-				_ => Ok(tb.generate()),
-			},
 			// Generate a random id for all other data clauses
 			_ => Ok(tb.generate()),
 		}
@@ -242,6 +233,24 @@ mod tests {
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
 		assert_eq!("SET field = true, other.field = false", format!("{}", out));
+	}
+
+	#[test]
+	fn unset_statement() {
+		let sql = "UNSET field";
+		let res = data(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!("UNSET field", format!("{}", out));
+	}
+
+	#[test]
+	fn unset_statement_multiple_fields() {
+		let sql = "UNSET field, other.field";
+		let res = data(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!("UNSET field, other.field", format!("{}", out));
 	}
 
 	#[test]


### PR DESCRIPTION
## What is the motivation?

Removing fields using SET clause on update seems more verbose like `SET age = NONE, address.street = NONE`. So as per the suggestions given on #1979. I have added unset clause to update statement.

## What does this change do?

This PR adds `unset` functionality to update statement so that removing fields can be done like
```
UPDATE person:wick UNSET age, address.street;
```

## What is your testing strategy?

Have added few tests & ran a build everything works fine.

## Is this related to any issues?

This closes #1979 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
