### PR TITLE
Check for type after value has been processed

### DIFF
--- a/lib/src/doc/field.rs
+++ b/lib/src/doc/field.rs
@@ -44,22 +44,20 @@ impl<'a> Document<'a> {
 				}
 				// Check for a TYPE clause
 				if let Some(kind) = &fd.kind {
-					if !val.is_none() {
-						val = val.convert_to(kind).map_err(|e| match e {
-							// There was a conversion error
-							Error::ConvertTo {
-								from,
-								..
-							} => Error::FieldCheck {
-								thing: rid.to_string(),
-								field: fd.name.clone(),
-								value: from.to_string(),
-								check: kind.to_string(),
-							},
-							// There was a different error
-							e => e,
-						})?;
-					}
+					val = val.convert_to(kind).map_err(|e| match e {
+						// There was a conversion error
+						Error::ConvertTo {
+							from,
+							..
+						} => Error::FieldCheck {
+							thing: rid.to_string(),
+							field: fd.name.clone(),
+							value: from.to_string(),
+							check: kind.to_string(),
+						},
+						// There was a different error
+						e => e,
+					})?;
 				}
 				// Check for a ASSERT clause
 				if let Some(expr) = &fd.assert {


### PR DESCRIPTION
## What is the motivation?

`TYPE` clause has been checked for field before `VALUE` clause has been processed which makes it obsolete.

## What does this change do?

This PR checks for type clause once the value has been processed.

## What is your testing strategy?

Ran build and ran few queries and it worked.

## Is this related to any issues?

Fixes #1954 .

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
