### PR TITLE
Bugfix #2001 - Error instead of panic when applying malformed patches.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "dmp"
 version = "0.1.3"
-source = "git+https://github.com/finnbear/surrealdb_dmp?branch=bugfix_cleanup#fbe830eb408f613c388ef60309daf824433c7253"
+source = "git+https://github.com/finnbear/surrealdb_dmp?branch=bugfix_cleanup#0d4ae203f010af41bd697f64e4ad57f5fa1012c2"
 dependencies = [
  "urlencoding",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,8 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "dmp"
-version = "0.1.3"
-source = "git+https://github.com/finnbear/surrealdb_dmp?branch=bugfix_cleanup#0d4ae203f010af41bd697f64e4ad57f5fa1012c2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfaa1135a34d26e5cc5b4927a8935af887d4f30a5653a797c33b9a4222beb6d9"
 dependencies = [
  "urlencoding",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,10 +1232,8 @@ dependencies = [
 [[package]]
 name = "dmp"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1796e147190351ab441586c68b74494b18a70b0e39fb9bf8e84e38635bf4c92a"
+source = "git+https://github.com/finnbear/surrealdb_dmp?branch=bugfix_cleanup#fbe830eb408f613c388ef60309daf824433c7253"
 dependencies = [
- "regex",
  "urlencoding",
 ]
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -61,7 +61,7 @@ bung = "0.1.0"
 channel = { version = "1.8.0", package = "async-channel" }
 chrono = { version = "0.4.24", features = ["serde"] }
 derive = { version = "0.8.0", package = "surrealdb-derive" }
-dmp = "0.1.3"
+dmp = { version = "0.1.3", git = "https://github.com/finnbear/surrealdb_dmp", branch = "bugfix_cleanup" }
 echodb = { version = "0.4.0", optional = true }
 executor = { version = "1.5.1", package = "async-executor" }
 flume = "0.10.14"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -61,7 +61,7 @@ bung = "0.1.0"
 channel = { version = "1.8.0", package = "async-channel" }
 chrono = { version = "0.4.24", features = ["serde"] }
 derive = { version = "0.8.0", package = "surrealdb-derive" }
-dmp = { version = "0.1.3", git = "https://github.com/finnbear/surrealdb_dmp", branch = "bugfix_cleanup" }
+dmp = "0.2.0"
 echodb = { version = "0.4.0", optional = true }
 executor = { version = "1.5.1", package = "async-executor" }
 flume = "0.10.14"

--- a/lib/src/sql/value/diff.rs
+++ b/lib/src/sql/value/diff.rs
@@ -65,7 +65,7 @@ impl Value {
 				op: Op::Change,
 				path,
 				value: {
-					let mut dmp = dmp::new();
+					let dmp = dmp::new();
 					let mut pch = dmp.patch_make1(a, b);
 					let txt = dmp.patch_to_text(&mut pch);
 					txt.into()

--- a/lib/src/sql/value/diff.rs
+++ b/lib/src/sql/value/diff.rs
@@ -66,8 +66,8 @@ impl Value {
 				path,
 				value: {
 					let dmp = dmp::new();
-					let mut pch = dmp.patch_make1(a, b);
-					let txt = dmp.patch_to_text(&mut pch);
+					let pch = dmp.patch_make1(a, b);
+					let txt = dmp.patch_to_text(&pch);
 					txt.into()
 				},
 			}),


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Invalid patches cause panics when they are applied.

## What does this change do?

Returns error instead of panicking on invalid patches.

## What is your testing strategy?

Adds a test.

## Is this related to any issues?

Depends on https://github.com/surrealdb/dmp/pull/1 (:heavy_check_mark:)
Fixes #2001 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
