### PR TITLE
Bugfix: Make range parser to parse quoted strings as well

### DIFF
--- a/lib/src/sql/range.rs
+++ b/lib/src/sql/range.rs
@@ -159,7 +159,7 @@ fn range_double(i: &str) -> IResult<&str, Range> {
 	delimited(char('\"'), range_raw, char('\"'))(i)
 }
 
-pub fn range_raw(i: &str) -> IResult<&str, Range> {
+fn range_raw(i: &str) -> IResult<&str, Range> {
 	let (i, tb) = ident_raw(i)?;
 	let (i, _) = char(':')(i)?;
 	let (i, beg) =

--- a/lib/src/sql/range.rs
+++ b/lib/src/sql/range.rs
@@ -11,6 +11,7 @@ use nom::branch::alt;
 use nom::character::complete::char;
 use nom::combinator::map;
 use nom::combinator::opt;
+use nom::sequence::delimited;
 use nom::sequence::preceded;
 use nom::sequence::terminated;
 use serde::{Deserialize, Serialize};
@@ -147,6 +148,18 @@ impl fmt::Display for Range {
 }
 
 pub fn range(i: &str) -> IResult<&str, Range> {
+	alt((range_raw, range_single, range_double))(i)
+}
+
+fn range_single(i: &str) -> IResult<&str, Range> {
+	delimited(char('\''), range_raw, char('\''))(i)
+}
+
+fn range_double(i: &str) -> IResult<&str, Range> {
+	delimited(char('\"'), range_raw, char('\"'))(i)
+}
+
+pub fn range_raw(i: &str) -> IResult<&str, Range> {
 	let (i, tb) = ident_raw(i)?;
 	let (i, _) = char(':')(i)?;
 	let (i, beg) =


### PR DESCRIPTION
## What is the motivation?

Currently range parser parses only raw literals.  There are cases where the range values are provided as quoted strings. So I think we should update range parser to suit this need as well.

## What does this change do?

This PR makes range parser to parse single & double quoted values as well.

## What is your testing strategy?

Ran few tests & a build, everything seems fine.

## Is this related to any issues?

Fixes #2011.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
