### PR TITLE
Security - reject incorrect root creds in const. time

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -77,12 +77,18 @@ pub fn init(matches: &clap::ArgMatches) {
 #[cfg(test)]
 mod tests {
 	use super::Config;
+	use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 	#[test]
 	fn verify_root() {
 		let mut cfg = Config {
 			user: "root".to_owned(),
-			..Default::default()
+			pass: None,
+			strict: Default::default(),
+			bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+			path: Default::default(),
+			crt: Default::default(),
+			key: Default::default(),
 		};
 
 		assert!(!cfg.verify_root("root", "any"));
@@ -91,6 +97,6 @@ mod tests {
 
 		assert!(!cfg.verify_root("admin", "secret"));
 		assert!(!cfg.verify_root("root", "12345"));
-		assert!(cfg.verify_root("root", "root"));
+		assert!(cfg.verify_root("root", "secret"));
 	}
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -36,7 +36,7 @@ impl Config {
 			// Intended to block incorrect credentials in constant time
 			// to avoid a timing side-channel.
 			if hash(&self.user, p) == hash(user, pass) {
-				p == pass & user == self.user
+				p == pass && user == self.user
 			} else {
 				// Hash(es) didn't match
 				false
@@ -76,11 +76,11 @@ pub fn init(matches: &clap::ArgMatches) {
 
 #[cfg(test)]
 mod tests {
-    use super::Config;
+	use super::Config;
 
 	#[test]
 	fn verify_root() {
-		let mut cfg = Config{
+		let mut cfg = Config {
 			user: "root".to_owned(),
 			..Default::default()
 		};

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -3,7 +3,7 @@ use std::{
 	collections::hash_map::DefaultHasher,
 	hash::{Hash, Hasher},
 	net::SocketAddr,
-  path::PathBuf,
+	path::PathBuf,
 };
 
 pub static CF: OnceCell<Config> = OnceCell::new();

--- a/src/iam/signin.rs
+++ b/src/iam/signin.rs
@@ -290,11 +290,9 @@ pub async fn su(
 	// Get the config options
 	let opts = CF.get().unwrap();
 	// Attempt to verify the root user
-	if let Some(root) = &opts.pass {
-		if user == opts.user && &pass == root {
-			session.au = Arc::new(Auth::Kv);
-			return Ok(None);
-		}
+	if opts.verify_root(&user, &pass) {
+		session.au = Arc::new(Auth::Kv);
+		return Ok(None);
 	}
 	// The specified user login does not exist
 	Err(Error::InvalidAuth)

--- a/src/iam/verify.rs
+++ b/src/iam/verify.rs
@@ -104,14 +104,12 @@ pub async fn basic(session: &mut Session, auth: String) -> Result<(), Error> {
 			return Err(Error::InvalidAuth);
 		}
 		// Check if this is root authentication
-		if let Some(root) = &opts.pass {
-			if user == opts.user && pass == root {
-				// Log the authentication type
-				debug!(target: LOG, "Authenticated as super user");
-				// Store the authentication data
-				session.au = Arc::new(Auth::Kv);
-				return Ok(());
-			}
+		if opts.verify_root(user, pass) {
+			// Log the authentication type
+			debug!(target: LOG, "Authenticated as super user");
+			// Store the authentication data
+			session.au = Arc::new(Auth::Kv);
+			return Ok(());
 		}
 		// Check if this is NS authentication
 		if let Some(ns) = &session.ns {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The root username and password of surrealdb servers are compared using `impl PartialEq for &str` which ends up executing the following code:
```rust
    default fn equal(&self, other: &[B]) -> bool {
        if self.len() != other.len() {
            return false;
        }

        self.iter().zip(other.iter()).all(|(x, y)| x == y)
    }
```

- Due to the early return, there will be a relatively large time difference if the provided credential isn't the same length as the correct credential
- Due to the short circuiting of `all`, as the provided credential is a longer prefix of the correct credential, the time taken will increase

=> If this time increase is detectable (e.g. by averaging many attempts), then the characters of the credentials can be guessed independently which defeats their security.

## What does this change do?

If the username and password are not both completely correct (barring a hash collision), reject them in an amount of time that doesn't depend on how good the guess was.

## What is your testing strategy?

Adds a test.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
