### PR TITLE
Feature - Add `time::EPOCH` constant.

### DIFF
--- a/lib/src/api/opt/mod.rs
+++ b/lib/src/api/opt/mod.rs
@@ -9,6 +9,7 @@ mod strict;
 mod tls;
 
 use crate::api::err::Error;
+use crate::sql::constant::ConstantValue;
 use crate::sql::to_value;
 use crate::sql::Thing;
 use crate::sql::Value;
@@ -370,7 +371,10 @@ fn into_json(value: Value, simplify: bool) -> JsonValue {
 		Value::Edges(edges) => json!(edges),
 		Value::Future(future) => json!(future),
 		Value::Constant(constant) => match simplify {
-			true => constant.as_f64().into(),
+			true => match constant.value() {
+				ConstantValue::Datetime(d) => json!(d),
+				ConstantValue::Float(f) => f.into(),
+			},
 			false => json!(constant),
 		},
 		Value::Function(function) => json!(function),

--- a/lib/src/sql/constant.rs
+++ b/lib/src/sql/constant.rs
@@ -4,6 +4,9 @@ use crate::dbs::Transaction;
 use crate::err::Error;
 use crate::sql::error::IResult;
 use crate::sql::value::Value;
+use crate::sql::Datetime;
+use chrono::TimeZone;
+use chrono::Utc;
 use derive::Store;
 use nom::branch::alt;
 use nom::bytes::complete::tag_no_case;
@@ -36,33 +39,43 @@ pub enum Constant {
 	MathPi,
 	MathSqrt2,
 	MathTau,
+	TimeEpoch,
 	// Add new variants here
 }
 
+/// A type of constant that may be converted to a value or JSON.
+pub(crate) enum ConstantValue {
+	Float(f64),
+	Datetime(Datetime),
+}
+
 impl Constant {
-	pub(crate) fn as_f64(&self) -> f64 {
+	pub(crate) fn value(&self) -> ConstantValue {
+		use std::f64::consts as f64c;
 		match self {
-			Self::MathE => std::f64::consts::E,
-			Self::MathFrac1Pi => std::f64::consts::FRAC_1_PI,
-			Self::MathFrac1Sqrt2 => std::f64::consts::FRAC_1_SQRT_2,
-			Self::MathFrac2Pi => std::f64::consts::FRAC_2_PI,
-			Self::MathFrac2SqrtPi => std::f64::consts::FRAC_2_SQRT_PI,
-			Self::MathFracPi2 => std::f64::consts::FRAC_PI_2,
-			Self::MathFracPi3 => std::f64::consts::FRAC_PI_3,
-			Self::MathFracPi4 => std::f64::consts::FRAC_PI_4,
-			Self::MathFracPi6 => std::f64::consts::FRAC_PI_6,
-			Self::MathFracPi8 => std::f64::consts::FRAC_PI_8,
-			Self::MathLn10 => std::f64::consts::LN_10,
-			Self::MathLn2 => std::f64::consts::LN_2,
-			Self::MathLog102 => std::f64::consts::LOG10_2,
-			Self::MathLog10E => std::f64::consts::LOG10_E,
-			Self::MathLog210 => std::f64::consts::LOG2_10,
-			Self::MathLog2E => std::f64::consts::LOG2_E,
-			Self::MathPi => std::f64::consts::PI,
-			Self::MathSqrt2 => std::f64::consts::SQRT_2,
-			Self::MathTau => std::f64::consts::TAU,
+			Self::MathE => ConstantValue::Float(f64c::E),
+			Self::MathFrac1Pi => ConstantValue::Float(f64c::FRAC_1_PI),
+			Self::MathFrac1Sqrt2 => ConstantValue::Float(f64c::FRAC_1_SQRT_2),
+			Self::MathFrac2Pi => ConstantValue::Float(f64c::FRAC_2_PI),
+			Self::MathFrac2SqrtPi => ConstantValue::Float(f64c::FRAC_2_SQRT_PI),
+			Self::MathFracPi2 => ConstantValue::Float(f64c::FRAC_PI_2),
+			Self::MathFracPi3 => ConstantValue::Float(f64c::FRAC_PI_3),
+			Self::MathFracPi4 => ConstantValue::Float(f64c::FRAC_PI_4),
+			Self::MathFracPi6 => ConstantValue::Float(f64c::FRAC_PI_6),
+			Self::MathFracPi8 => ConstantValue::Float(f64c::FRAC_PI_8),
+			Self::MathLn10 => ConstantValue::Float(f64c::LN_10),
+			Self::MathLn2 => ConstantValue::Float(f64c::LN_2),
+			Self::MathLog102 => ConstantValue::Float(f64c::LOG10_2),
+			Self::MathLog10E => ConstantValue::Float(f64c::LOG10_E),
+			Self::MathLog210 => ConstantValue::Float(f64c::LOG2_10),
+			Self::MathLog2E => ConstantValue::Float(f64c::LOG2_E),
+			Self::MathPi => ConstantValue::Float(f64c::PI),
+			Self::MathSqrt2 => ConstantValue::Float(f64c::SQRT_2),
+			Self::MathTau => ConstantValue::Float(f64c::TAU),
+			Self::TimeEpoch => ConstantValue::Datetime(Datetime(Utc.timestamp_nanos(0))),
 		}
 	}
+
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,
@@ -71,7 +84,10 @@ impl Constant {
 		_txn: &Transaction,
 		_doc: Option<&Value>,
 	) -> Result<Value, Error> {
-		Ok(self.as_f64().into())
+		Ok(match self.value() {
+			ConstantValue::Datetime(d) => d.into(),
+			ConstantValue::Float(f) => f.into(),
+		})
 	}
 }
 
@@ -97,12 +113,13 @@ impl fmt::Display for Constant {
 			Self::MathPi => "math::PI",
 			Self::MathSqrt2 => "math::SQRT_2",
 			Self::MathTau => "math::TAU",
+			Self::TimeEpoch => "time::EPOCH",
 		})
 	}
 }
 
 pub fn constant(i: &str) -> IResult<&str, Constant> {
-	alt((constant_math,))(i)
+	alt((constant_math, constant_time))(i)
 }
 
 fn constant_math(i: &str) -> IResult<&str, Constant> {
@@ -130,6 +147,10 @@ fn constant_math(i: &str) -> IResult<&str, Constant> {
 			map(tag_no_case("TAU"), |_| Constant::MathTau),
 		)),
 	)(i)
+}
+
+fn constant_time(i: &str) -> IResult<&str, Constant> {
+	preceded(tag_no_case("time::"), alt((map(tag_no_case("EPOCH"), |_| Constant::TimeEpoch),)))(i)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I noticed there was no constant for the Unix epoch timestamp.

## What does this change do?

- Adds `time::EPOCH` constant which is a `Datetime`
- Lays the groundwork for constant types beyond `f64`

## What is your testing strategy?

![image](https://github.com/surrealdb/surrealdb/assets/20015102/c1a1094e-7c91-4742-8cad-e0dcb7ccca70)

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
