### PR TITLE
Fix bug that prevented the fuzzers from using dictionaries properly

### DIFF
--- a/lib/fuzz/Cargo.lock
+++ b/lib/fuzz/Cargo.lock
@@ -442,11 +442,10 @@ dependencies = [
 
 [[package]]
 name = "dmp"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1796e147190351ab441586c68b74494b18a70b0e39fb9bf8e84e38635bf4c92a"
+checksum = "bfaa1135a34d26e5cc5b4927a8935af887d4f30a5653a797c33b9a4222beb6d9"
 dependencies = [
- "regex",
  "urlencoding",
 ]
 


### PR DESCRIPTION
## What is the motivation?
Improve fuzzing coverage

## What does this change do?

The original fuzzers where using the arbitrary::Arbitrary derivations to generate a Vec of surql commands to pass to the database. However when elements of the dictionary where inserted into the fuzzing stream the arbitrary::Arbitrary derive generator was mangling the input before it got the database. To fix this we've just converted the Vec to a single string, which doesn't mangle the input. Then we split on ';' to generate an equivalent Vec of commands.

## What is your testing strategy?
Improves existing fuzz tests.

## Is this related to any issues?

Closes: #2027

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
