### PR TITLE
deps - upgrade to `regex`@1.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,13 +3405,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -3431,9 +3431,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "relative-path"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -83,7 +83,7 @@ once_cell = "1.17.1"
 pbkdf2 = { version = "0.12.1", features = ["simple"] }
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
-regex = "1.8.1"
+regex = "1.8.2"
 reqwest = { version = "0.11.18", default-features = false, features = ["json", "stream"], optional = true }
 rocksdb = { version = "0.21.0", optional = true }
 rustls = { version = "0.20.8", optional = true }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`regex`@1.8.2 [fixes](https://github.com/rust-lang/regex/pull/996/commits/841022ac358c1a9181e23efeb2a8ad4427503f15) an integer overflow bug

## What does this change do?

Upgrades to `regex`@1.8.2

## What is your testing strategy?

N/A

## Is this related to any issues?

An issue found by the OSS Fuzz fuzzer.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
