### PR TITLE
Add simple benchmarking command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ check:
 clean:
 	cargo clean
 
+.PHONY: bench
+bench:
+	cargo bench --package surrealdb --no-default-features --features kv-mem,http,scripting
+
 .PHONY: serve
 serve:
 	cargo run $(DEV_FEATURES) -- start --log trace --user root --pass root memory


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

We want to have a simple benchmarking command in the Makefile, which can be run easily when developing.

## What does this change do?

Adds a simple benchmarking command to the Makefile, which simplifies running the benchmarking tests in development.

## What is your testing strategy?

Doesn't affect any tests.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
