### PR TITLE
Bugfix - ret. QueryNotExecuted if implicit txn. fails to commit.

### DIFF
--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -296,14 +296,22 @@ impl<'a> Executor<'a> {
 									// There is no timeout clause
 									None => stm.compute(&ctx, &opt, &self.txn(), None).await,
 								};
-								// Finalise transaction
+								// Finalise transaction and return the result.
 								if res.is_ok() && stm.writeable() {
 									self.commit(loc).await;
+									if self.err {
+										// The commit failed
+										Err(Error::QueryNotExecuted)
+									} else {
+										// Successful, committed result
+										res
+									}
 								} else {
 									self.cancel(loc).await;
+
+									// An error
+									res
 								}
-								// Return the result
-								res
 							}
 						}
 					}

--- a/lib/src/kvs/tikv/mod.rs
+++ b/lib/src/kvs/tikv/mod.rs
@@ -86,7 +86,7 @@ impl Transaction {
 		}
 		// Mark this transaction as done
 		self.ok = true;
-		// Cancel this transaction
+		// Commit this transaction
 		self.tx.commit().await?;
 		// Continue
 		Ok(())


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Some implicit txn's may fail to commit, but surrealdb may act as if they succeeded.


The following txn will fail when executed against TiKV i.e. due to its size:
```
test/test> create |b:100000|;
<100000 "created" items">
test/test> select * from b;
<no items>
```

## What does this change do?

```
test/test> create |b:100000|;
There was a problem with the database: The query was not executed due to a failed transaction
```

## What is your testing strategy?

Manual; see above.

## Is this related to any issues?

I noticed this issue [here](https://github.com/surrealdb/surrealdb/pull/1819#discussion_r1168129971)

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
