### PR TITLE
Bugfix - CLI show results despite errors in multistatement query.

### DIFF
--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -178,7 +178,10 @@ fn process(pretty: bool, res: surrealdb::Result<Response>) -> Result<String, Err
 	let value = if num_statements > 1 {
 		let mut output = Vec::<Value>::with_capacity(num_statements);
 		for index in 0..num_statements {
-			output.push(response.take(index)?);
+			output.push(match response.take(index) {
+				Ok(v) => v,
+				Err(e) => e.to_string().into(),
+			});
 		}
 		Value::from(output)
 	} else {

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -212,7 +212,7 @@ impl Validator for InputValidator {
 		let input = input.trim();
 		// Process the input to check if we can send the query
 		let result = if self.multi && !input.ends_with(';') {
-			Incomplete // The line ends with a ; and we are in multi mode
+			Incomplete // The line doesn't end with a ; and we are in multi mode
 		} else if self.multi && input.is_empty() {
 			Incomplete // The line was empty and we are in multi mode
 		} else if input.ends_with('\\') {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When there are multiple statements in a query and one fails, the CLI omits any other results including successful results:
```
test/test> create oh:1 set field = 1000000000000*100000000000; create no:1 set foo = 'bar';
There was a problem with the database: Cannot perform multiplication with '1000000000000' and '100000000000'
```
*`no:1` is still created!

## What does this change do?

- Does not change behavior with single-statement queries:
```
test/test> create foo set bar = rand("invalid");
There was a problem with the database: Incorrect arguments for function rand(). Expected no arguments.
```
- Prints all results of multi-statement queries, regardless of error:
```
test/test> create oh:1 set field = 1000000000000*100000000000; create no:1 set foo = 'bar';
[
        "Cannot perform multiplication with '1000000000000' and '100000000000'",
        [
                {
                        foo: 'bar',
                        id: no:1
                }
        ]
]

test/test> create oh:1 set field = 1000000000000*100000000000; create no:1 set foo = 'bar'; create no:2 set bar = 'baz'; select * from crypto::bcrypt::generate("a") timeout 10ns;
[
        "Cannot perform multiplication with '1000000000000' and '100000000000'",
        'Database record `no:1` already exists',
        [
                {
                        bar: 'baz',
                        id: no:2
                }
        ],
        'The query was not executed because it exceeded the timeout'
]

test/test> begin; create oh:1 set field = 1000000000000*100000000000; create no:1 set foo = 'bar'; create no:2 set bar = 'baz'; select * from crypto::bcrypt::generate("a") timeout 10ns; commit;
[
        "Cannot perform multiplication with '1000000000000' and '100000000000'",
        'The query was not executed due to a failed transaction',
        'The query was not executed due to a failed transaction',
        'The query was not executed due to a failed transaction'
]
```

## What is your testing strategy?

Manual (see above) and add two tests (non-txn and txn)

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
