### PR TITLE
Bugfix - make NS, DB optional in sql cli.

### DIFF
--- a/src/cli/abstraction/mod.rs
+++ b/src/cli/abstraction/mod.rs
@@ -23,6 +23,21 @@ pub struct DatabaseSelectionArguments {
 }
 
 #[derive(Args, Debug)]
+pub struct DatabaseSelectionOptionalArguments {
+	#[arg(help = "The namespace selected for the operation")]
+	#[arg(env = "SURREAL_NAMESPACE", long = "namespace", visible_alias = "ns")]
+	pub(crate) namespace: Option<String>,
+	#[arg(help = "The database selected for the operation")]
+	#[arg(
+		env = "SURREAL_DATABASE",
+		long = "database",
+		visible_alias = "db",
+		requires = "namespace"
+	)]
+	pub(crate) database: Option<String>,
+}
+
+#[derive(Args, Debug)]
 pub struct DatabaseConnectionArguments {
 	#[arg(help = "Remote database server url to connect to")]
 	#[arg(short = 'e', long = "endpoint", visible_aliases = ["conn"])]

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -1,5 +1,5 @@
 use crate::cli::abstraction::{
-	AuthArguments, DatabaseConnectionArguments, DatabaseSelectionArguments,
+	AuthArguments, DatabaseConnectionArguments, DatabaseSelectionOptionalArguments,
 };
 use crate::err::Error;
 use clap::Args;
@@ -19,7 +19,7 @@ pub struct SqlCommandArguments {
 	#[command(flatten)]
 	auth: AuthArguments,
 	#[command(flatten)]
-	sel: DatabaseSelectionArguments,
+	sel: Option<DatabaseSelectionOptionalArguments>,
 	/// Whether database responses should be pretty printed
 	#[arg(long)]
 	pretty: bool,
@@ -37,10 +37,7 @@ pub async fn init(
 		conn: DatabaseConnectionArguments {
 			endpoint,
 		},
-		sel: DatabaseSelectionArguments {
-			namespace,
-			database,
-		},
+		sel,
 		pretty,
 		multi,
 		..
@@ -74,8 +71,15 @@ pub async fn init(
 	// Load the command-line history
 	let _ = rl.load_history("history.txt");
 	// Keep track of current namespace/database.
-	let mut ns = Some(namespace);
-	let mut db = Some(database);
+	let (mut ns, mut db) = if let Some(DatabaseSelectionOptionalArguments {
+		namespace,
+		database,
+	}) = sel
+	{
+		(namespace, database)
+	} else {
+		(None, None)
+	};
 	// Configure the prompt
 	let mut prompt = "> ".to_owned();
 	// Loop over each command-line input

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -191,13 +191,13 @@ mod cli_integration {
 				.output()
 				.unwrap();
 
-			assert!(output.contains("thing:success"), "missing success in {output:?}");
-			assert!(output.contains("rgument"), "missing argument error in {output:?}");
+			assert!(output.contains("thing:success"), "missing success in {output}");
+			assert!(output.contains("rgument"), "missing argument error in {output}");
 			assert!(
 				output.contains("time") && output.contains("out"),
-				"missing timeout error in {output:?}"
+				"missing timeout error in {output}"
 			);
-			assert!(output.contains("thing:also_success"), "missing also_success in {output:?}")
+			assert!(output.contains("thing:also_success"), "missing also_success in {output}")
 		}
 
 		// Multi-statement (and multi-line) transaction including error(s) over WS
@@ -223,7 +223,33 @@ mod cli_integration {
 				3,
 				"missing failed txn errors in {output:?}"
 			);
-			assert!(output.contains("rgument"), "missing argument error in {output:?}");
+			assert!(output.contains("rgument"), "missing argument error in {output}");
+		}
+
+		// Pass neither ns nor db
+		{
+			let args = format!("sql --conn http://{addr} --user root --pass {pass}");
+			let output = run(&args)
+				.input("USE NS N5 DB D5; CREATE thing:one;\n")
+				.output()
+				.expect("neither ns nor db");
+			assert!(output.contains("thing:one"), "missing thing:one in {output}");
+		}
+
+		// Pass only ns
+		{
+			let args = format!("sql --conn http://{addr} --user root --pass {pass} --ns N5");
+			let output = run(&args)
+				.input("USE DB D5; SELECT * FROM thing:one;\n")
+				.output()
+				.expect("only ns");
+			assert!(output.contains("thing:one"), "missing thing:one in {output}");
+		}
+
+		// Pass only db and expect an error
+		{
+			let args = format!("sql --conn http://{addr} --user root --pass {pass} --db D5");
+			run(&args).output().expect_err("only db");
 		}
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?


#2015 accidentally requires users to pass `--ns` and `--db` to `surreal sql`.

https://github.com/surrealdb/surrealdb/pull/2015#issuecomment-1560637281

## What does this change do?

Makes them optional*

*if you pass db, you must pass ns.

## What is your testing strategy?

Adds comprehensive tests.

## Is this related to any issues?

Followup to #2015

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
