### PR TITLE
Feature - Add message to query not executed error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,7 @@ dependencies = [
  "temp-dir",
  "thiserror",
  "tikv-client",
+ "tikv-client-proto",
  "time 0.3.21",
  "tokio",
  "tokio-tungstenite",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,13 +17,13 @@ resolver = "2"
 
 [features]
 # Public features
-default = ["protocol-ws", "rustls"]
+default = ["protocol-ws", "rustls", "kv-tikv"]
 protocol-http = ["dep:reqwest", "dep:tokio-util"]
 protocol-ws = ["dep:tokio-tungstenite", "tokio/time"]
 kv-mem = ["dep:echodb", "tokio/time"]
 kv-indxdb = ["dep:indxdb"]
 kv-rocksdb = ["dep:rocksdb", "tokio/time"]
-kv-tikv = ["dep:tikv"]
+kv-tikv = ["dep:tikv", "dep:tikv-client-proto"]
 kv-fdb-5_1 = ["foundationdb/fdb-5_1", "kv-fdb"]
 kv-fdb-5_2 = ["foundationdb/fdb-5_2", "kv-fdb"]
 kv-fdb-6_0 = ["foundationdb/fdb-6_0", "kv-fdb"]
@@ -96,6 +96,7 @@ sha2 = "0.10.6"
 storekey = "0.5.0"
 thiserror = "1.0.40"
 tikv = { version = "0.1.0", package = "tikv-client", optional = true }
+tikv-client-proto = { version = "0.1.0", optional = true }
 tokio-util = { version = "0.7.8", optional = true, features = ["compat"] }
 tracing = "0.1.37"
 trice = "0.3.1"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 
 [features]
 # Public features
-default = ["protocol-ws", "rustls", "kv-tikv"]
+default = ["protocol-ws", "rustls"]
 protocol-http = ["dep:reqwest", "dep:tokio-util"]
 protocol-ws = ["dep:tokio-tungstenite", "tokio/time"]
 kv-mem = ["dep:echodb", "tokio/time"]

--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -34,7 +34,7 @@ impl<'a> Executor<'a> {
 	}
 
 	fn txn(&self) -> Transaction {
-		self.txn.clone().unwrap()
+		self.txn.clone().expect("unreachable: txn was None after successful begin")
 	}
 
 	/// # Return

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -44,6 +44,18 @@ pub enum Error {
 	#[error("The key being inserted already exists")]
 	TxKeyAlreadyExists,
 
+	/// The key exceeds a limit set by the KV store
+	#[error("Record id or key is too large")]
+	TxKeyTooLarge,
+
+	/// The value exceeds a limit set by the KV store
+	#[error("Record or value is too large")]
+	TxValueTooLarge,
+
+	/// The transaction writes too much data for the KV store
+	#[error("Transaction is too large")]
+	TxTooLarge,
+
 	/// No namespace has been selected
 	#[error("Specify a namespace to use")]
 	NsEmpty,
@@ -432,11 +444,11 @@ impl From<tikv::Error> for Error {
 			tikv::Error::KeyError(tikv_client_proto::kvrpcpb::KeyError {
 				abort,
 				..
-			}) if abort.contains("KeyTooLarge") => Error::Tx("key too large".to_owned()),
+			}) if abort.contains("KeyTooLarge") => Error::TxKeyTooLarge,
 			tikv::Error::RegionError(tikv_client_proto::errorpb::Error {
 				raft_entry_too_large,
 				..
-			}) if raft_entry_too_large.is_some() => Error::Tx("txn too large".to_owned()),
+			}) if raft_entry_too_large.is_some() => Error::TxTooLarge,
 			_ => Error::Tx(e.to_string()),
 		}
 	}

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -152,6 +152,12 @@ pub enum Error {
 	#[error("The query was not executed due to a failed transaction")]
 	QueryNotExecuted,
 
+	/// The query did not execute, because the transaction has failed (with a message)
+	#[error("The query was not executed due to a failed transaction. {message}")]
+	QueryNotExecutedDetail {
+		message: String,
+	},
+
 	/// The permissions do not allow for performing the specified query
 	#[error("You don't have permission to perform this query type")]
 	QueryPermissions,


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

There are many reasons why a transaction might fail to commit, but the error introduced in #2039 doesn't provide that information.

See https://github.com/surrealdb/surrealdb/pull/2039#issuecomment-1560541674

## What does this change do?

- When a commit fails, include the error in the message.

```console
test/test> create |thing:10000| set value = string::repeat("a", 1000);
There was a problem with the database: The query was not executed due to a failed transaction. There was a problem with a datastore transaction: txn too large

test/test> create thing:[string::repeat('a', 10000)];
There was a problem with the database: The query was not executed due to a failed transaction. There was a problem with a datastore transaction: key too large
```

*concise error descriptions like "txn too large" and "key too large" are detected on a best-effort basis (this is an area for future improvement)

- This commit also adds some documentation and removes an `Arc::clone` on every commit/cancel.

## What is your testing strategy?

Manual, see above.

## Is this related to any issues?

Followup to #2039

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
