### PR TITLE
Security - Begin adding network rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
       - name: Run cargo test
-        run: cargo test --locked --no-default-features --features storage-mem,scripting,http --workspace -- --skip api_integration --include-ignored
+        run: SURREAL_RATE_LIMIT=none cargo test --locked --no-default-features --features storage-mem,scripting,http --workspace -- --skip api_integration --include-ignored
 
   ws-engine:
     name: WebSocket engine
@@ -123,7 +123,7 @@ jobs:
 
       - name: Run cargo test
         run: |
-          cargo build --locked --no-default-features --features storage-mem
+          SURREAL_RATE_LIMIT=none cargo build --locked --no-default-features --features storage-mem
           (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory &)
           cargo test --locked --package surrealdb --no-default-features --features protocol-ws --test api api_integration::ws
 
@@ -145,7 +145,7 @@ jobs:
 
       - name: Run cargo test
         run: |
-          cargo build --locked --no-default-features --features storage-mem
+          SURREAL_RATE_LIMIT=none cargo build --locked --no-default-features --features storage-mem
           (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory &)
           cargo test --locked --package surrealdb --no-default-features --features protocol-http --test api api_integration::http
 
@@ -195,6 +195,6 @@ jobs:
 
       - name: Run cargo test
         run: |
-          cargo build --locked --no-default-features --features storage-mem
+          SURREAL_RATE_LIMIT=none cargo build --locked --no-default-features --features storage-mem
           (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory &)
           cargo test --locked --package surrealdb --no-default-features --features protocol-http --test api api_integration::any

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
       - name: Run cargo test
-        run: SURREAL_RATE_LIMIT=none cargo test --locked --no-default-features --features storage-mem,scripting,http --workspace -- --skip api_integration --include-ignored
+        run: cargo test --locked --no-default-features --features storage-mem,scripting,http --workspace -- --skip api_integration --include-ignored
 
   ws-engine:
     name: WebSocket engine
@@ -123,8 +123,8 @@ jobs:
 
       - name: Run cargo test
         run: |
-          SURREAL_RATE_LIMIT=none cargo build --locked --no-default-features --features storage-mem
-          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory &)
+          cargo build --locked --no-default-features --features storage-mem
+          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory --rate-limit-ip none --rate-limit-ns none &)
           cargo test --locked --package surrealdb --no-default-features --features protocol-ws --test api api_integration::ws
 
   http-engine:
@@ -145,8 +145,8 @@ jobs:
 
       - name: Run cargo test
         run: |
-          SURREAL_RATE_LIMIT=none cargo build --locked --no-default-features --features storage-mem
-          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory &)
+          cargo build --locked --no-default-features --features storage-mem
+          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory --rate-limit-ip none --rate-limit-ns none &)
           cargo test --locked --package surrealdb --no-default-features --features protocol-http --test api api_integration::http
 
   mem-engine:
@@ -195,6 +195,6 @@ jobs:
 
       - name: Run cargo test
         run: |
-          SURREAL_RATE_LIMIT=none cargo build --locked --no-default-features --features storage-mem
-          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory &)
+          cargo build --locked --no-default-features --features storage-mem
+          (&>/dev/null ./target/debug/surreal start --log trace --user root --pass root memory --rate-limit-ip none --rate-limit-ns none &)
           cargo test --locked --package surrealdb --no-default-features --features protocol-http --test api api_integration::any

--- a/src/cli/abstraction/mod.rs
+++ b/src/cli/abstraction/mod.rs
@@ -7,7 +7,7 @@ pub(crate) struct AuthArguments {
 	#[arg(default_value = "root")]
 	pub(crate) username: String,
 	#[arg(help = "Database authentication password to use when connecting")]
-	#[arg(short = 'p', long = "password", visible_alias = "pass", requires = "username")]
+	#[arg(short = 'p', long = "password", visible_alias = "pass")]
 	#[arg(env = "SURREAL_PASS", default_value = "root")]
 	pub(crate) password: String,
 }

--- a/src/cli/abstraction/mod.rs
+++ b/src/cli/abstraction/mod.rs
@@ -4,10 +4,11 @@ use clap::Args;
 pub(crate) struct AuthArguments {
 	#[arg(help = "Database authentication username to use when connecting")]
 	#[arg(env = "SURREAL_USER", short = 'u', long = "username", visible_alias = "user")]
+	#[arg(default_value = "root")]
 	pub(crate) username: String,
 	#[arg(help = "Database authentication password to use when connecting")]
 	#[arg(short = 'p', long = "password", visible_alias = "pass", requires = "username")]
-	#[arg(env = "SURREAL_PASS")]
+	#[arg(env = "SURREAL_PASS", default_value = "root")]
 	pub(crate) password: String,
 }
 

--- a/src/cli/abstraction/mod.rs
+++ b/src/cli/abstraction/mod.rs
@@ -4,12 +4,23 @@ use clap::Args;
 pub(crate) struct AuthArguments {
 	#[arg(help = "Database authentication username to use when connecting")]
 	#[arg(env = "SURREAL_USER", short = 'u', long = "username", visible_alias = "user")]
-	#[arg(default_value = "root")]
 	pub(crate) username: String,
 	#[arg(help = "Database authentication password to use when connecting")]
-	#[arg(short = 'p', long = "password", visible_alias = "pass")]
-	#[arg(env = "SURREAL_PASS", default_value = "root")]
+	#[arg(short = 'p', long = "password", visible_alias = "pass", requires = "username")]
+	#[arg(env = "SURREAL_PASS")]
 	pub(crate) password: String,
+}
+
+#[derive(Args, Debug)]
+#[group(requires_all = ["username", "password"])]
+pub(crate) struct AuthOptionalArguments {
+	#[arg(help = "Database authentication username to use when connecting")]
+	#[arg(env = "SURREAL_USER", short = 'u', long = "username", visible_alias = "user")]
+	pub(crate) username: Option<String>,
+	#[arg(help = "Database authentication password to use when connecting")]
+	#[arg(short = 'p', long = "password", visible_alias = "pass", requires = "username")]
+	#[arg(env = "SURREAL_PASS")]
+	pub(crate) password: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -45,11 +45,11 @@ pub struct StartCommandArguments {
 	#[arg(default_value = "10", value_parser = super::validator::rate_limit)]
 	rate_limit_ns: core::option::Option<NonZeroU16>,
 	#[arg(help = "Rate limit burst for new connections and requests per anonymous IP")]
-	#[arg(env = "SURREAL_RATE_BURST_LIMIT_IP", long)]
+	#[arg(env = "SURREAL_BURST_LIMIT_IP", long)]
 	#[arg(default_value = "5")]
 	burst_limit_ip: u16,
 	#[arg(help = "Rate limit burst for new connections and requests per namespace")]
-	#[arg(env = "SURREAL_RATE_BURST_LIMIT_NS", long)]
+	#[arg(env = "SURREAL_BURST_LIMIT_NS", long)]
 	#[arg(default_value = "5")]
 	burst_limit_ns: u16,
 	#[arg(help = "The hostname or ip address to listen for connections on")]

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+	num::NonZeroU16,
+	path::{Path, PathBuf},
+};
 
 pub(crate) mod parser;
 
@@ -60,5 +63,15 @@ pub(crate) fn key_valid(v: &str) -> Result<String, String> {
 		24 => Ok(v.to_string()),
 		32 => Ok(v.to_string()),
 		_ => Err(String::from("Ensure your database encryption key is 16, 24, or 32 bytes long")),
+	}
+}
+
+pub(crate) fn rate_limit(v: &str) -> Result<Option<NonZeroU16>, String> {
+	if let Ok(rate_limit) = v.parse::<NonZeroU16>() {
+		Ok(Some(rate_limit))
+	} else if v == "none" {
+		Ok(None)
+	} else {
+		Err(String::from("Rate limit must be a number from 1 to 65535 or 'none'"))
 	}
 }

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -30,7 +30,7 @@ pub const MAX_CONCURRENT_CALLS: usize = 24;
 
 /// Rate limit for new connections and requests (per second per anon IP or authed NS).
 pub static RATE_LIMIT: Lazy<u64> = Lazy::new(|| {
-	option_env!("SURREAL_RATE_LIMIT").map(|s| s.parse::<u64>().unwrap_or(u64::MAX)).unwrap_or(2)
+	option_env!("SURREAL_RATE_LIMIT").map(|s| s.parse::<u64>().unwrap_or(u64::MAX)).unwrap_or(5)
 });
 
 /// Maximum burst above the rate limit.

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -28,16 +28,6 @@ pub const APP_ENDPOINT: &str = "https://surrealdb.com/app";
 /// How many concurrent tasks can be handled in a WebSocket
 pub const MAX_CONCURRENT_CALLS: usize = 24;
 
-/// Rate limit for new connections and requests (per second per anon IP or authed NS).
-pub static RATE_LIMIT: Lazy<u64> = Lazy::new(|| {
-	option_env!("SURREAL_RATE_LIMIT").map(|s| s.parse::<u64>().unwrap_or(u64::MAX)).unwrap_or(5)
-});
-
-/// Maximum burst above the rate limit.
-pub static RATE_LIMIT_BURST: Lazy<usize> = Lazy::new(|| {
-	option_env!("SURREAL_RATE_LIMIT_BURST").and_then(|s| s.parse::<usize>().ok()).unwrap_or(5)
-});
-
 /// Specifies the frequency with which ping messages should be sent to the client
 pub const WEBSOCKET_PING_FREQUENCY: Duration = Duration::from_secs(5);
 

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -29,10 +29,14 @@ pub const APP_ENDPOINT: &str = "https://surrealdb.com/app";
 pub const MAX_CONCURRENT_CALLS: usize = 24;
 
 /// Rate limit for new connections and requests (per second per anon IP or authed NS).
-pub const RATE_LIMIT: u64 = 2;
+pub static RATE_LIMIT: Lazy<u64> = Lazy::new(|| {
+	option_env!("SURREAL_RATE_LIMIT").map(|s| s.parse::<u64>().unwrap_or(u64::MAX)).unwrap_or(2)
+});
 
 /// Maximum burst above the rate limit.
-pub const RATE_LIMIT_BURST: usize = 5;
+pub static RATE_LIMIT_BURST: Lazy<usize> = Lazy::new(|| {
+	option_env!("SURREAL_RATE_LIMIT_BURST").and_then(|s| s.parse::<usize>().ok()).unwrap_or(5)
+});
 
 /// Specifies the frequency with which ping messages should be sent to the client
 pub const WEBSOCKET_PING_FREQUENCY: Duration = Duration::from_secs(5);

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -28,6 +28,12 @@ pub const APP_ENDPOINT: &str = "https://surrealdb.com/app";
 /// How many concurrent tasks can be handled in a WebSocket
 pub const MAX_CONCURRENT_CALLS: usize = 24;
 
+/// Rate limit for new connections and requests (per second per anon IP or authed NS).
+pub const RATE_LIMIT: u64 = 2;
+
+/// Maximum burst above the rate limit.
+pub const RATE_LIMIT_BURST: usize = 5;
+
 /// Specifies the frequency with which ping messages should be sent to the client
 pub const WEBSOCKET_PING_FREQUENCY: Duration = Duration::from_secs(5);
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -24,6 +24,9 @@ pub enum Error {
 	#[error("There was a problem with authentication")]
 	InvalidAuth,
 
+	#[error("Too many requests")]
+	TooManyRequests,
+
 	#[error("The specified media type is unsupported")]
 	InvalidType,
 

--- a/src/net/limiter.rs
+++ b/src/net/limiter.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, net::IpAddr, time::Instant, sync::Mutex};
+use std::{collections::HashMap, net::IpAddr, sync::Mutex, time::Instant};
 
 use argon2::Block;
 use chrono::Duration;
 use once_cell::sync::OnceCell;
-use surrealdb::dbs::{Session, Auth};
+use surrealdb::dbs::{Auth, Session};
 
 pub static LIM: OnceCell<Limiter> = OnceCell::new();
 
@@ -17,76 +17,75 @@ pub async fn init() -> Result<(), Error> {
 	Ok(())
 }
 
-
 #[derive(Debug, Eq, PartialEq, Hash)]
 enum BlockableUnit {
-    /// IPv4 address or IPv6 address
-    // (TODO: only store /48 prefix for IPv6)
-    Ip(Box<str>),
-    /// Authed access to a namespace
-    Namespace(Box<str>),
+	/// IPv4 address or IPv6 address
+	// (TODO: only store /48 prefix for IPv6)
+	Ip(Box<str>),
+	/// Authed access to a namespace
+	Namespace(Box<str>),
 }
 
 struct Limits {
-    /// How long previous request(s) are counted against the client
-    rate_limited_until: Instant,
-    /// How many extra requests have been allowed (counted towards a limit)
-    burst_used: usize,
-    // TODO: Concurrent connections to this particular server
-    //local_concurrency: usize,
-    // TODO: Concurrent connections to all servers (reported by KVS)
-    //total_concurrency: usize,
+	/// How long previous request(s) are counted against the client
+	rate_limited_until: Instant,
+	/// How many extra requests have been allowed (counted towards a limit)
+	burst_used: usize,
+	// TODO: Concurrent connections to this particular server
+	//local_concurrency: usize,
+	// TODO: Concurrent connections to all servers (reported by KVS)
+	//total_concurrency: usize,
 }
 
 #[derive(Default)]
 struct Limiter {
-    limits: Mutex<HashMap<BlockableUnit, Limits>>
+	limits: Mutex<HashMap<BlockableUnit, Limits>>,
 }
 
 impl Limiter {
-    /// Returns whether a new connection by this
-    /// session should be blocked.
-    pub(crate) fn should_allow(&mut self, session: &Session) -> bool {
-        let blockable_unit = match (&session.au, &session.ip) {
-            (Auth::Ns(ns) | Auth::Db(ns, _), _) => BlockableUnit::Namespace(Box::from(ns.as_str())),
-            (_, Some(ip)) => BlockableUnit::Ip(Box::from(ip.as_str())),
-            _ => {
-                // It's fine not to have namespace auth but lack of IP means something
-                // wrong involving warp.
-                debug_assert!(false, "no IP in session");
-                return false;
-            }
-        };
+	/// Returns whether a new connection by this
+	/// session should be blocked.
+	pub(crate) fn should_allow(&mut self, session: &Session) -> bool {
+		let blockable_unit = match (&session.au, &session.ip) {
+			(Auth::Ns(ns) | Auth::Db(ns, _), _) => BlockableUnit::Namespace(Box::from(ns.as_str())),
+			(_, Some(ip)) => BlockableUnit::Ip(Box::from(ip.as_str())),
+			_ => {
+				// It's fine not to have namespace auth but lack of IP means something
+				// wrong involving warp.
+				debug_assert!(false, "no IP in session");
+				return false;
+			}
+		};
 
-        // TODO: asynchronously consult the KVs for heavy-hitters.
+		// TODO: asynchronously consult the KVs for heavy-hitters.
 
-        let now = Instant::now();
+		let now = Instant::now();
 
-        let limits = self.limits.lock().unwrap();
-        let limits = limits.entry(blockable_unit).or_insert(Limits{
-            rate_limited_until: now,
-            burst_used: 0
-        });
+		let limits = self.limits.lock().unwrap();
+		let limits = limits.entry(blockable_unit).or_insert(Limits {
+			rate_limited_until: now,
+			burst_used: 0,
+		});
 
-        let ok = if now > limits.rate_limited_until {
-            // Limit has fully expired.
-            limits.burst_used = 0;
-            true
-        } else if limits.burst_used < BURST {
-            // Allowable burst
-            limits.burst_used += 1;
-            true
-        } else {
-            // Excessive burst
-            false
-        };
+		let ok = if now > limits.rate_limited_until {
+			// Limit has fully expired.
+			limits.burst_used = 0;
+			true
+		} else if limits.burst_used < BURST {
+			// Allowable burst
+			limits.burst_used += 1;
+			true
+		} else {
+			// Excessive burst
+			false
+		};
 
-        if ok {
-            limits.rate_limited_until += RATE_LIMIT;
-        }
+		if ok {
+			limits.rate_limited_until += RATE_LIMIT;
+		}
 
-        // TODO: Check concurrent connections
+		// TODO: Check concurrent connections
 
-        ok
-    }
+		ok
+	}
 }

--- a/src/net/limiter.rs
+++ b/src/net/limiter.rs
@@ -2,15 +2,26 @@ use std::{collections::HashMap, net::IpAddr, time::Instant, sync::Mutex};
 
 use argon2::Block;
 use chrono::Duration;
+use once_cell::sync::OnceCell;
 use surrealdb::dbs::{Session, Auth};
 
+pub static LIM: OnceCell<Limiter> = OnceCell::new();
+
+// TODO: Make configurable.
 const RATE_LIMIT: Duration = Duration::from_secs(1);
 const BURST: usize = 2;
+
+pub async fn init() -> Result<(), Error> {
+	let _ = LIM.set(Default::default());
+	// All ok
+	Ok(())
+}
+
 
 #[derive(Debug, Eq, PartialEq, Hash)]
 enum BlockableUnit {
     /// IPv4 address or IPv6 address
-    // (TODO: /48 prefix only for IPv6)
+    // (TODO: only store /48 prefix for IPv6)
     Ip(Box<str>),
     /// Authed access to a namespace
     Namespace(Box<str>),
@@ -19,12 +30,15 @@ enum BlockableUnit {
 struct Limits {
     /// How long previous request(s) are counted against the client
     rate_limited_until: Instant,
-    /// How many extra requests have been allowed (counted towards a limit).
+    /// How many extra requests have been allowed (counted towards a limit)
     burst_used: usize,
-    // TODO: Concurrent connections to this server
+    // TODO: Concurrent connections to this particular server
     //local_concurrency: usize,
+    // TODO: Concurrent connections to all servers (reported by KVS)
+    //total_concurrency: usize,
 }
 
+#[derive(Default)]
 struct Limiter {
     limits: Mutex<HashMap<BlockableUnit, Limits>>
 }
@@ -32,7 +46,7 @@ struct Limiter {
 impl Limiter {
     /// Returns whether a new connection by this
     /// session should be blocked.
-    fn should_block(&mut self, session: &Session) -> bool {
+    pub(crate) fn should_allow(&mut self, session: &Session) -> bool {
         let blockable_unit = match (&session.au, &session.ip) {
             (Auth::Ns(ns) | Auth::Db(ns, _), _) => BlockableUnit::Namespace(Box::from(ns.as_str())),
             (_, Some(ip)) => BlockableUnit::Ip(Box::from(ip.as_str())),
@@ -44,14 +58,35 @@ impl Limiter {
             }
         };
 
-        // TODO: consult the KVs for heavy-hitters.
+        // TODO: asynchronously consult the KVs for heavy-hitters.
 
         let now = Instant::now();
 
         let limits = self.limits.lock().unwrap();
         let limits = limits.entry(blockable_unit).or_insert(Limits{
             rate_limited_until: now,
-            burst_used: 
+            burst_used: 0
+        });
+
+        let ok = if now > limits.rate_limited_until {
+            // Limit has fully expired.
+            limits.burst_used = 0;
+            true
+        } else if limits.burst_used < BURST {
+            // Allowable burst
+            limits.burst_used += 1;
+            true
+        } else {
+            // Excessive burst
+            false
+        };
+
+        if ok {
+            limits.rate_limited_until += RATE_LIMIT;
         }
+
+        // TODO: Check concurrent connections
+
+        ok
     }
 }

--- a/src/net/limiter.rs
+++ b/src/net/limiter.rs
@@ -1,0 +1,57 @@
+use std::{collections::HashMap, net::IpAddr, time::Instant, sync::Mutex};
+
+use argon2::Block;
+use chrono::Duration;
+use surrealdb::dbs::{Session, Auth};
+
+const RATE_LIMIT: Duration = Duration::from_secs(1);
+const BURST: usize = 2;
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+enum BlockableUnit {
+    /// IPv4 address or IPv6 address
+    // (TODO: /48 prefix only for IPv6)
+    Ip(Box<str>),
+    /// Authed access to a namespace
+    Namespace(Box<str>),
+}
+
+struct Limits {
+    /// How long previous request(s) are counted against the client
+    rate_limited_until: Instant,
+    /// How many extra requests have been allowed (counted towards a limit).
+    burst_used: usize,
+    // TODO: Concurrent connections to this server
+    //local_concurrency: usize,
+}
+
+struct Limiter {
+    limits: Mutex<HashMap<BlockableUnit, Limits>>
+}
+
+impl Limiter {
+    /// Returns whether a new connection by this
+    /// session should be blocked.
+    fn should_block(&mut self, session: &Session) -> bool {
+        let blockable_unit = match (&session.au, &session.ip) {
+            (Auth::Ns(ns) | Auth::Db(ns, _), _) => BlockableUnit::Namespace(Box::from(ns.as_str())),
+            (_, Some(ip)) => BlockableUnit::Ip(Box::from(ip.as_str())),
+            _ => {
+                // It's fine not to have namespace auth but lack of IP means something
+                // wrong involving warp.
+                debug_assert!(false, "no IP in session");
+                return false;
+            }
+        };
+
+        // TODO: consult the KVs for heavy-hitters.
+
+        let now = Instant::now();
+
+        let limits = self.limits.lock().unwrap();
+        let limits = limits.entry(blockable_unit).or_insert(Limits{
+            rate_limited_until: now,
+            burst_used: 
+        }
+    }
+}

--- a/src/net/limiter.rs
+++ b/src/net/limiter.rs
@@ -13,8 +13,6 @@ use surrealdb::dbs::{Auth, Session};
 
 pub static LIM: OnceCell<Limiter> = OnceCell::new();
 
-const RATE_LIMIT_DURATION_PER_REQ: Duration = Duration::from_nanos(1_000_000_000 / RATE_LIMIT);
-
 pub fn init() -> Result<(), Error> {
 	#[cfg(test)]
 	let _ = LIM.set(Limiter {
@@ -114,6 +112,9 @@ impl Limiter {
 			burst_used: 0,
 		});
 
+		const RATE_LIMIT_DURATION_PER_REQ: Duration =
+			Duration::from_nanos(1_000_000_000 / RATE_LIMIT);
+
 		let ok = if now > limits.rate_limited_until {
 			// Limit has fully expired
 			limits.burst_used = 0;
@@ -184,7 +185,7 @@ mod tests {
 		};
 
 		for ten_times_rate in
-			(RATE_LIMIT.saturating_sub(10) + 1) * 10..=(RATE_LIMIT.saturating_add(10) * 10)
+			(RATE_LIMIT.saturating_sub(10) + 1) * 10..=RATE_LIMIT.saturating_add(10) * 10
 		{
 			let rate = ten_times_rate as f64 * 0.1;
 			assert_eq!(is_allowed(rate), rate <= RATE_LIMIT as f64, "rate: {:.1}", rate);

--- a/src/net/limiter.rs
+++ b/src/net/limiter.rs
@@ -16,12 +16,12 @@ pub static LIM: OnceCell<Limiter> = OnceCell::new();
 const RATE_LIMIT_DURATION_PER_REQ: Duration = Duration::from_nanos(1_000_000_000 / RATE_LIMIT);
 
 pub fn init() -> Result<(), Error> {
+	#[cfg(test)]
 	let _ = LIM.set(Limiter {
-		inner: Mutex::new(Inner {
-			limits: Default::default(),
-			last_prune: Instant::now(),
-		}),
+		inner: None,
 	});
+	#[cfg(not(test))]
+	let _ = LIM.set(Default::default());
 	// All ok
 	Ok(())
 }
@@ -46,7 +46,18 @@ struct Limits {
 }
 
 pub struct Limiter {
-	inner: Mutex<Inner>,
+	inner: Option<Mutex<Inner>>,
+}
+
+impl Default for Limiter {
+	fn default() -> Self {
+		Self {
+			inner: Some(Mutex::new(Inner {
+				limits: Default::default(),
+				last_prune: Instant::now(),
+			})),
+		}
+	}
 }
 
 struct Inner {
@@ -56,8 +67,13 @@ struct Inner {
 
 impl Limiter {
 	/// Returns whether a new connection by this
-	/// session should be blocked.
+	/// session should be blocked
 	pub fn should_allow(&self, session: &Session) -> bool {
+		self.should_allow_at(session, Instant::now())
+	}
+
+	/// Allows mocking the time in a test
+	fn should_allow_at(&self, session: &Session, now: Instant) -> bool {
 		let blockable_unit = match (&*session.au, session.ip.as_deref()) {
 			(Auth::Kv, _) => {
 				// If you have the root password, you are never rate-limited
@@ -80,15 +96,19 @@ impl Limiter {
 				// It's fine not to have namespace auth but lack of IP means something
 				// wrong involving warp
 				debug_assert!(false, "no IP in session");
-				return false;
+				return true;
 			}
 		};
 
 		// TODO: asynchronously consult the KVs for heavy-hitters.
 
-		let now = Instant::now();
+		let mut inner = if let Some(inner) = &self.inner {
+			inner.lock().unwrap()
+		} else {
+			// Rate limiting disabled e.g. during tests.
+			return true;
+		};
 
-		let mut inner = self.inner.lock().unwrap();
 		let limits = inner.limits.entry(blockable_unit).or_insert(Limits {
 			rate_limited_until: now,
 			burst_used: 0,
@@ -99,7 +119,7 @@ impl Limiter {
 			limits.burst_used = 0;
 			limits.rate_limited_until = now;
 			true
-		} else if limits.burst_used < RATE_LIMIT_BURST {
+		} else if limits.burst_used <= RATE_LIMIT_BURST {
 			// Allowable burst
 			limits.burst_used += 1;
 			limits.rate_limited_until += RATE_LIMIT_DURATION_PER_REQ;
@@ -121,8 +141,93 @@ impl Limiter {
 			inner.limits.retain(|_, l| l.rate_limited_until > now);
 		}
 
-		println!("len = {}", inner.limits.len());
-
 		ok
+	}
+
+	/// Returns number of tracked blockable units
+	#[cfg(test)]
+	fn len(&self) -> usize {
+		self.inner.as_ref().map(|inner| inner.lock().unwrap().limits.len()).unwrap_or(0)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Limiter;
+	use crate::cnf::{RATE_LIMIT, RATE_LIMIT_BURST};
+	use rand::{thread_rng, Rng};
+	use std::{
+		net::Ipv4Addr,
+		time::{Duration, Instant},
+	};
+	use surrealdb::dbs::Session;
+
+	#[test]
+	fn rate() {
+		let session = Session {
+			ip: Some("0.0.0.0".to_owned()),
+			..Default::default()
+		};
+
+		// Returns true iff requests at this rate are all allowed
+		let is_allowed = |rate: f64| {
+			let limiter = Limiter::default();
+			let mut now = Instant::now();
+
+			for _ in 0..RATE_LIMIT_BURST * 1000 {
+				if !limiter.should_allow_at(&session, now) {
+					return false;
+				}
+				now += Duration::from_nanos(1 + (1_000_000_000 as f64 / rate) as u64)
+			}
+			true
+		};
+
+		for ten_times_rate in
+			(RATE_LIMIT.saturating_sub(10) + 1) * 10..=(RATE_LIMIT.saturating_add(10) * 10)
+		{
+			let rate = ten_times_rate as f64 * 0.1;
+			assert_eq!(is_allowed(rate), rate <= RATE_LIMIT as f64, "rate: {:.1}", rate);
+		}
+	}
+
+	#[test]
+	fn burst() {
+		let limiter = Limiter::default();
+		let mut now = Instant::now();
+
+		let session = Session {
+			ip: Some("0.0.0.0".to_owned()),
+			..Default::default()
+		};
+
+		for i in 0..RATE_LIMIT_BURST * 1000 {
+			// Essentially zero time has passed
+			assert_eq!(limiter.should_allow_at(&session, now), i <= RATE_LIMIT_BURST, "{i}");
+			now += Duration::from_nanos(1);
+		}
+	}
+
+	#[test]
+	fn expiry() {
+		let limiter = Limiter::default();
+
+		let mut rng = thread_rng();
+		let mut now = Instant::now();
+
+		for _ in 0..1000 {
+			let session = Session {
+				ip: Some(Ipv4Addr::new(rng.gen(), rng.gen(), rng.gen(), rng.gen()).to_string()),
+				..Default::default()
+			};
+
+			assert!(limiter.should_allow_at(&session, now));
+
+			now += Duration::from_secs(1);
+
+			assert!(limiter.len() < 100, "{}", limiter.len());
+		}
+
+		println!("blockable units remaining: {}", limiter.len());
 	}
 }

--- a/src/net/limiter.rs
+++ b/src/net/limiter.rs
@@ -47,9 +47,10 @@ impl Default for Limiter {
 #[derive(Debug)]
 struct Inner {
 	/// Keys may be:
-	/// - IPv4 address or IPv6 /48 prefixes
-	/// - Authed access to a namespace (which never
-	///   contain '.' or ':' so they don't overlap with IPs)
+	/// - IPv4 address e.g. 1.2.3.4
+	/// - IPv6 /48 prefixes e.g. 5629:1e38:8843::
+	/// - Namespace name (which never contain '.' or ':'
+	///   so they don't overlap with the above)
 	limits: HashMap<Box<str>, Limits>,
 	last_prune: Instant,
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -6,7 +6,7 @@ mod import;
 mod index;
 mod input;
 mod key;
-pub mod limiter;
+mod limiter;
 mod log;
 mod output;
 mod params;
@@ -20,13 +20,28 @@ mod status;
 mod sync;
 mod version;
 
+use self::limiter::LimiterOptions;
 use crate::cli::CF;
 use crate::err::Error;
+use clap::Args;
 use warp::Filter;
 
 const LOG: &str = "surrealdb::net";
 
-pub async fn init() -> Result<(), Error> {
+#[derive(Args, Debug)]
+pub struct NetOptions {
+	#[command(flatten)]
+	limiter: LimiterOptions,
+}
+
+pub async fn init(
+	NetOptions {
+		limiter,
+	}: NetOptions,
+) -> Result<(), Error> {
+	// Configure rate limiting
+	limiter::init(limiter)?;
+
 	// Setup web routes
 	let net = index::config()
 		// Version endpoint

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -6,7 +6,7 @@ mod import;
 mod index;
 mod input;
 mod key;
-mod limiter;
+pub mod limiter;
 mod log;
 mod output;
 mod params;
@@ -27,8 +27,6 @@ use warp::Filter;
 const LOG: &str = "surrealdb::net";
 
 pub async fn init() -> Result<(), Error> {
-	limiter::init()?;
-
 	// Setup web routes
 	let net = index::config()
 		// Version endpoint

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -18,6 +18,7 @@ mod sql;
 mod status;
 mod sync;
 mod version;
+mod limiter;
 
 use crate::cli::CF;
 use crate::err::Error;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -27,6 +27,8 @@ use warp::Filter;
 const LOG: &str = "surrealdb::net";
 
 pub async fn init() -> Result<(), Error> {
+	limiter::init()?;
+
 	// Setup web routes
 	let net = index::config()
 		// Version endpoint

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -6,6 +6,7 @@ mod import;
 mod index;
 mod input;
 mod key;
+mod limiter;
 mod log;
 mod output;
 mod params;
@@ -18,7 +19,6 @@ mod sql;
 mod status;
 mod sync;
 mod version;
-mod limiter;
 
 use crate::cli::CF;
 use crate::err::Error;

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -5,7 +5,7 @@ use crate::cnf::PKG_VERSION;
 use crate::cnf::WEBSOCKET_PING_FREQUENCY;
 use crate::dbs::DB;
 use crate::err::Error;
-use crate::net::limiter::LIM;
+use crate::net::limiter;
 use crate::net::session;
 use crate::net::LOG;
 use crate::rpc::args::Take;
@@ -220,7 +220,7 @@ impl Rpc {
 			let rpc = rpc.read().await;
 
 			// Check rate limit.
-			if !LIM.get().unwrap().should_allow(&rpc.session) {
+			if !limiter::should_allow(&rpc.session) {
 				return res::failure(id, Failure::custom("Too many requests")).send(out, chn).await;
 			}
 		}

--- a/src/net/session.rs
+++ b/src/net/session.rs
@@ -1,4 +1,4 @@
-use super::limiter::LIM;
+use super::limiter;
 use crate::err::Error;
 use crate::iam::verify::{basic, token};
 use crate::iam::BASIC;
@@ -50,7 +50,7 @@ async fn process(
 		// No authentication data was supplied
 		None => Ok(()),
 	}?;
-	if LIM.get().unwrap().should_allow(&session) {
+	if limiter::should_allow(&session) {
 		// Pass the authenticated session through
 		Ok(session)
 	} else {

--- a/src/net/session.rs
+++ b/src/net/session.rs
@@ -55,6 +55,6 @@ async fn process(
 		// Pass the authenticated session through
 		Ok(session)
 	} else {
-		Err(Error::TooManyRequests)
+		Err(Error::TooManyRequests.into())
 	}
 }

--- a/src/net/session.rs
+++ b/src/net/session.rs
@@ -1,3 +1,4 @@
+use super::limiter::LIM;
 use crate::err::Error;
 use crate::iam::verify::{basic, token};
 use crate::iam::BASIC;
@@ -5,8 +6,6 @@ use crate::iam::TOKEN;
 use std::net::SocketAddr;
 use surrealdb::dbs::Session;
 use warp::Filter;
-
-use super::limiter::LIM;
 
 pub fn build() -> impl Filter<Extract = (Session,), Error = warp::Rejection> + Clone {
 	// Enable on any path

--- a/src/net/sql.rs
+++ b/src/net/sql.rs
@@ -1,3 +1,4 @@
+use super::limiter::LIM;
 use crate::cli::CF;
 use crate::dbs::DB;
 use crate::err::Error;
@@ -10,8 +11,6 @@ use futures::{SinkExt, StreamExt};
 use surrealdb::dbs::Session;
 use warp::ws::{Message, WebSocket, Ws};
 use warp::Filter;
-
-use super::limiter::LIM;
 
 const MAX: u64 = 1024 * 1024; // 1 MiB
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -106,7 +106,7 @@ mod cli_integration {
 		let pass = rng.gen::<u64>().to_string();
 
 		let start_args =
-			format!("start --bind {addr} --user root --pass {pass} memory --no-banner --log info");
+			format!("start --bind {addr} --user root --pass {pass} memory --no-banner --log info --burst-limit-ip 32 --burst-limit-ns 16");
 
 		println!("starting server with args: {start_args}");
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Allowing arbitrary request volumes could make surrealdb servers vulnerable to denial-of-service attacks.

Importantly, these are just a subset of the required/planned limits.

## What does this change do?

- Adds an in-memory rate limiter with rate limits that are configurable using CLI flags
  - `--rate-limit-ip <n or 'none'>`
  - `--rate-limit-ns <n or 'none'>`
  - `--burst-limit-ip <n>`
  - `--burst-limit-ns <n>`
- IPv6 addresses are bucketized to /48 prefixes (e.g. like LetsEncrypt uses for their rate limiting)
- Makes user/pass optional for `surreal sql` to allow connecting as unauthenticated user

This only affects the `surreal` server, not the `surrealdb` library.

## Unanswered questions for reviewing PR

- What is the best default rate limit? (no change, higher, lower, none at all?)
- Is it necessary to implement any of the "Future work" before this is useful enough to merge?

## Future (related) work

- per-scope limits, configurable via DCL/DDL e.g. (`DEFINE SCOPE @name RATELIMIT 2 BURSTLIMIT 5`)
  - (unlike the limits in this PR) these are to protect users against malicious clients, not a cloud-hosted server against malicious users, as malicious users could create arbitrarily many scopes
  - as such, scoped users should still be subject to per-NS ratelimiting
- coordinate rate limits using the KVs
  - Need to be careful to not overwhelm the KVs while enforcing rate limits
     - Need to keep the in-memory limiter too
  - Need to handle clock skew (somehow)
- enforce stricter timeouts for queries
- enforce limits on functions esp. http
- etc.

## What is your testing strategy?

Adds unit tests to confirm the rate limit, burst limit, expiry, and IPv6 all work.

**The wasm-related CI failure is unrelated to this PR**

## Is this related to any issues?

Related to #2016

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
