### PR TITLE
Fix doc on select example

### DIFF
--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -657,9 +657,6 @@ where
 	///
 	/// // Select a specific record from a table
 	/// let person: Option<Person> = db.select(("person", "h5wxrf2ewk8xjxosxtyc")).await?;
-	///
-	/// // You can skip an unnecessary option if you know the record already exists
-	/// let person: Option<Person> = db.select(("person", "h5wxrf2ewk8xjxosxtyc")).await?;
 	/// #
 	/// # Ok(())
 	/// # }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I noticed something wrong on the example doc of the `select` function:

```rust
// You can skip an unnecessary option if you know the record already exists
let person: Option<Person> = db.select(("person", "h5wxrf2ewk8xjxosxtyc")).await?;
```

It says we can skip the `Option<T>` to use just `T` but the code below the comment does not reflect it.

## What does this change do?

Fix the example documentation

## What is your testing strategy?

N/A

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
