### PR TITLE
Check for zero duration before trunc and round datetime

### DIFF
--- a/lib/src/fnc/time.rs
+++ b/lib/src/fnc/time.rs
@@ -15,7 +15,10 @@ pub fn ceil((val, duration): (Datetime, Duration)) -> Result<Value, Error> {
 					floor.checked_add_signed(d)
 				}
 			};
-
+			// Check for zero duration.
+			if d.is_zero() {
+				return Ok(Value::Datetime(val));
+			}
 			let result = val
 				.duration_trunc(d)
 				.ok()
@@ -45,12 +48,18 @@ pub fn day((val,): (Option<Datetime>,)) -> Result<Value, Error> {
 
 pub fn floor((val, duration): (Datetime, Duration)) -> Result<Value, Error> {
 	match chrono::Duration::from_std(*duration) {
-		Ok(d) => match val.duration_trunc(d){
-			Ok(v) => Ok(v.into()),
-			_ => Err(Error::InvalidArguments {
-				name: String::from("time::floor"),
-				message: String::from("The second argument must be a duration, and must be able to be represented as nanoseconds."),
-			}),
+		Ok(d) => {
+			// Check for zero duration
+			if d.is_zero() {
+				return Ok(Value::Datetime(val));
+			}
+			match val.duration_trunc(d){
+				Ok(v) => Ok(v.into()),
+				_ => Err(Error::InvalidArguments {
+					name: String::from("time::floor"),
+					message: String::from("The second argument must be a duration, and must be able to be represented as nanoseconds."),
+				}),
+			}
 		},
 		_ => Err(Error::InvalidArguments {
 			name: String::from("time::floor"),
@@ -136,12 +145,18 @@ pub fn now(_: ()) -> Result<Value, Error> {
 
 pub fn round((val, duration): (Datetime, Duration)) -> Result<Value, Error> {
 	match chrono::Duration::from_std(*duration) {
-		Ok(d) => match val.duration_round(d) {
-			Ok(v) => Ok(v.into()),
-			_ => Err(Error::InvalidArguments {
-				name: String::from("time::round"),
-				message: String::from("The second argument must be a duration, and must be able to be represented as nanoseconds."),
-			}),
+		Ok(d) => {
+			// Check for zero duration
+			if d.is_zero() {
+				return Ok(Value::Datetime(val));
+			}
+			match val.duration_round(d) {
+				Ok(v) => Ok(v.into()),
+				_ => Err(Error::InvalidArguments {
+					name: String::from("time::round"),
+					message: String::from("The second argument must be a duration, and must be able to be represented as nanoseconds."),
+				}),
+			}
 		},
 		_ => Err(Error::InvalidArguments {
 			name: String::from("time::round"),


### PR DESCRIPTION
## What is the motivation?

Truncating or rounding datetime with zero duration panics division by zero. And also rounding to zero duration is unnecessary as well. So I added a check to skip the process when the duration is zero.

## What does this change do?

This change returns the input datetime instead of truncating or rounding it when the duration is set to zero. We can also return as error instead of returning the input datetime. Cant decide which one is better to do. Feel free to give any suggestions on this.

## What is your testing strategy?

Have tested round, ceil & floor functions and ran a build .

## Is this related to any issues?

Fixes #2062.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
