### PR TITLE
Bugfix #2069 - Properly escape '\' in strings

### DIFF
--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -1,7 +1,7 @@
 use crate::sql::common::{take_digits, take_digits_range, take_u32_len};
 use crate::sql::duration::Duration;
 use crate::sql::error::IResult;
-use crate::sql::escape::escape_str;
+use crate::sql::escape::quote_str;
 use crate::sql::strand::Strand;
 use chrono::{DateTime, FixedOffset, Offset, SecondsFormat, TimeZone, Utc};
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -89,7 +89,7 @@ impl Datetime {
 
 impl Display for Datetime {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		Display::fmt(&escape_str(&self.0.to_rfc3339_opts(SecondsFormat::AutoSi, true)), f)
+		Display::fmt(&quote_str(&self.0.to_rfc3339_opts(SecondsFormat::AutoSi, true)), f)
 	}
 }
 

--- a/lib/src/sql/statements/define.rs
+++ b/lib/src/sql/statements/define.rs
@@ -10,7 +10,7 @@ use crate::sql::comment::{mightbespace, shouldbespace};
 use crate::sql::common::commas;
 use crate::sql::duration::{duration, Duration};
 use crate::sql::error::IResult;
-use crate::sql::escape::escape_str;
+use crate::sql::escape::quote_str;
 use crate::sql::filter::{filters, Filter};
 use crate::sql::fmt::is_pretty;
 use crate::sql::fmt::pretty_indent;
@@ -452,7 +452,7 @@ impl DefineLoginStatement {
 
 impl Display for DefineLoginStatement {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "DEFINE LOGIN {} ON {} PASSHASH {}", self.name, self.base, escape_str(&self.hash))
+		write!(f, "DEFINE LOGIN {} ON {} PASSHASH {}", self.name, self.base, quote_str(&self.hash))
 	}
 }
 
@@ -601,7 +601,7 @@ impl Display for DefineTokenStatement {
 			self.name,
 			self.base,
 			self.kind,
-			escape_str(&self.code)
+			quote_str(&self.code)
 		)
 	}
 }

--- a/lib/src/sql/strand.rs
+++ b/lib/src/sql/strand.rs
@@ -1,6 +1,6 @@
 use crate::sql::error::Error::Parser;
 use crate::sql::error::IResult;
-use crate::sql::escape::escape_str;
+use crate::sql::escape::quote_str;
 use nom::branch::alt;
 use nom::bytes::complete::{escaped_transform, is_not, tag, take, take_while_m_n};
 use nom::character::complete::char;
@@ -73,7 +73,7 @@ impl Strand {
 
 impl Display for Strand {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		Display::fmt(&escape_str(&self.0), f)
+		Display::fmt(&quote_str(&self.0), f)
 	}
 }
 

--- a/lib/src/sql/uuid.rs
+++ b/lib/src/sql/uuid.rs
@@ -1,6 +1,6 @@
 use crate::sql::common::is_hex;
 use crate::sql::error::IResult;
-use crate::sql::escape::escape_str;
+use crate::sql::escape::quote_str;
 use crate::sql::strand::Strand;
 use nom::branch::alt;
 use nom::bytes::complete::take_while_m_n;
@@ -99,7 +99,7 @@ impl Uuid {
 
 impl Display for Uuid {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		Display::fmt(&escape_str(&self.0.to_string()), f)
+		Display::fmt(&quote_str(&self.0.to_string()), f)
 	}
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The escape character, `\`, was not escaped when displaying `Strand`s, leading strings to be unescaped twice.

## What does this change do?

- Escapes `\` within strings i.e. with `\\`
- Renames `escape_str` to `quote_str` to be more clear
- Optimizes `quote_str` by removing redundant allocations and scanning
- `quote_str` no longer returns a `Cow` because it always allocated anyway (necessary to add quotation marks)

## What is your testing strategy?

Manual (e.g. see below); Awaiting CI

```
test/test> create foo set value = "bar's \\n baz";
[
        {
                id: foo:fviyshq6o7cdu9dndmnn,
                value: "bar's \\n baz"
        }
]
```

## Is this related to any issues?

Fixes #2069

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
