### PR TITLE
Feature #2080 - support empty custom fn's

### DIFF
--- a/lib/src/sql/block.rs
+++ b/lib/src/sql/block.rs
@@ -20,7 +20,7 @@ use crate::sql::value::{value, Value};
 use nom::branch::alt;
 use nom::combinator::map;
 use nom::multi::many0;
-use nom::multi::separated_list1;
+use nom::multi::separated_list0;
 use nom::sequence::delimited;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -117,6 +117,7 @@ impl Display for Block {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
 		let mut f = Pretty::from(f);
 		match (self.len(), self.first()) {
+			(0, _) => f.write_str("{}"),
 			(1, Some(Entry::Value(v))) => {
 				write!(f, "{{ {v} }}")
 			}
@@ -159,7 +160,7 @@ impl Display for Block {
 
 pub fn block(i: &str) -> IResult<&str, Block> {
 	let (i, _) = openbraces(i)?;
-	let (i, v) = separated_list1(colons, entry)(i)?;
+	let (i, v) = separated_list0(colons, entry)(i)?;
 	let (i, _) = many0(alt((colons, comment)))(i)?;
 	let (i, _) = closebraces(i)?;
 	Ok((i, Block(v)))
@@ -244,6 +245,15 @@ pub fn entry(i: &str) -> IResult<&str, Entry> {
 mod tests {
 
 	use super::*;
+
+	#[test]
+	fn block_empty() {
+		let sql = "{}";
+		let res = block(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(sql, format!("{}", out))
+	}
 
 	#[test]
 	fn block_value() {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I'm not aware of a reason why we can't or shouldn't support no-op functions

## What does this change do?

Adds support for parsing and formatting empty `Block`'s.

## What is your testing strategy?

Adds a test for formatting. Manual testing:

```
test/test> DEFINE FUNCTION fn::test() {

};
[]

test/test> INFO FOR DB;
[
        {
                functions: {
                        test: 'DEFINE FUNCTION fn::test() {}'
                },
                ...
        }
]

test/test> RETURN fn::test();
[]
```

## Is this related to any issues?

Fixes #2080

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
