### PR TITLE
Sur 191 refactor bootstrap

### DIFF
--- a/lib/src/dbs/notification.rs
+++ b/lib/src/dbs/notification.rs
@@ -1,5 +1,6 @@
 use crate::sql::Value;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use uuid::Uuid;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -9,10 +10,30 @@ pub struct Notification {
 	pub result: Value,
 }
 
+impl fmt::Display for Notification {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(
+			f,
+			"Notification {{ id: {}, action: {}, result: {} }}",
+			self.id, self.action, self.result
+		)
+	}
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Action {
 	Create,
 	Update,
 	Delete,
+}
+
+impl fmt::Display for Action {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match *self {
+			Action::Create => write!(f, "CREATE"),
+			Action::Update => write!(f, "UPDATE"),
+			Action::Delete => write!(f, "DELETE"),
+		}
+	}
 }

--- a/lib/src/dbs/options.rs
+++ b/lib/src/dbs/options.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 #[derive(Clone, Debug)]
 pub struct Options {
 	/// Current Node ID
-	pub id: Arc<Uuid>,
+	pub id: Uuid,
 	/// Currently selected NS
 	pub ns: Option<Arc<str>>,
 	/// Currently selected DB
@@ -50,7 +50,7 @@ pub struct Options {
 
 impl Options {
 	/// Create a new Options object
-	pub fn new(id: Arc<Uuid>, send: Sender<Notification>) -> Options {
+	pub fn new(id: Uuid, send: Sender<Notification>) -> Options {
 		Options {
 			id,
 			ns: None,
@@ -72,7 +72,7 @@ impl Options {
 
 	/// Get current Node ID
 	pub fn id(&self) -> &Uuid {
-		self.id.as_ref()
+		&self.id
 	}
 
 	/// Get currently selected NS

--- a/lib/src/dbs/test.rs
+++ b/lib/src/dbs/test.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 impl Default for Options {
 	fn default() -> Self {
 		Options {
-			id: Arc::new(Uuid::default()),
+			id: Uuid::default(),
 			ns: None,
 			db: None,
 			dive: 0,

--- a/lib/src/key/cl.rs
+++ b/lib/src/key/cl.rs
@@ -13,10 +13,6 @@ pub struct Cl {
 	pub nd: Uuid,
 }
 
-pub fn new(nd: &Uuid) -> Cl {
-	Cl::new(nd.to_owned())
-}
-
 impl Cl {
 	pub fn new(nd: Uuid) -> Self {
 		Self {

--- a/lib/src/key/hb.rs
+++ b/lib/src/key/hb.rs
@@ -14,10 +14,6 @@ pub struct Hb {
 	pub nd: Uuid,
 }
 
-pub fn new(hb: Timestamp, nd: &Uuid) -> Hb {
-	Hb::new(hb, nd.to_owned())
-}
-
 impl Hb {
 	pub fn new(hb: Timestamp, nd: Uuid) -> Self {
 		Self {

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -18,7 +18,6 @@ use channel::Sender;
 use futures::lock::Mutex;
 use std::fmt;
 use std::sync::Arc;
-use tracing::callsite::register;
 use tracing::instrument;
 use uuid::Uuid;
 

--- a/lib/src/kvs/tests.rs
+++ b/lib/src/kvs/tests.rs
@@ -81,7 +81,7 @@ pub(crate) mod transaction {
 				Inner::RocksDB(ds) => {
 					let (send, recv) = channel::bounded(100);
 					Datastore {
-						id: Arc::new(Uuid::default()),
+						id: Uuid::default(),
 						inner: Inner::RocksDB(ds.clone()),
 						send,
 						recv,

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -763,7 +763,7 @@ impl Transaction {
 		}
 	}
 
-	fn clock(&self) -> Timestamp {
+	pub fn clock(&self) -> Timestamp {
 		// Use a timestamp oracle if available
 		let now: u128 = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
 		return Timestamp {
@@ -772,15 +772,14 @@ impl Transaction {
 	}
 
 	// Set heartbeat
-	pub async fn set_hb(&mut self, id: Uuid) -> Result<(), Error> {
-		let now = self.clock();
-		let key = crate::key::hb::Hb::new(now.clone(), id.0);
+	pub async fn set_hb(&mut self, timestamp: Timestamp, id: Uuid) -> Result<(), Error> {
+		let key = crate::key::hb::Hb::new(timestamp.clone(), id.0);
 		// We do not need to do a read, we always want to overwrite
 		self.put(
 			key,
 			ClusterMembership {
 				name: id.0.to_string(),
-				heartbeat: now,
+				heartbeat: timestamp,
 			},
 		)
 		.await?;

--- a/lib/src/sql/statements/live.rs
+++ b/lib/src/sql/statements/live.rs
@@ -56,7 +56,7 @@ impl LiveStatement {
 				// Clone the current statement
 				let mut stm = self.clone();
 				// Store the current Node ID
-				stm.node = *opt.id;
+				stm.node = opt.id.clone();
 				// Insert the node live query
 				let key = crate::key::lq::new(opt.id(), opt.ns(), opt.db(), &self.id);
 				run.putc(key, tb.as_str(), None).await?;

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -16,7 +16,7 @@ pub async fn init() -> Result<(), Error> {
 		false => info!(target: LOG, "Database strict mode is disabled"),
 	};
 	// Parse and setup the desired kv datastore
-	let dbs = Datastore::new(&opt.path).await?;
+	let dbs = Datastore::new_with_bootstrap(&opt.path).await?;
 	// Store database instance
 	let _ = DB.set(dbs);
 	// All ok


### PR DESCRIPTION
## What is the motivation?

I am refactoring Datastore bootstrapping. This is necessary for testing, but I wanted to separate out the change to make it easier to review.

## What does this change do?

The stages of bootstraping are separated and clearer. Also I changed Arc<UUID> to owned data. Same for timestamps. Everything is now injectable for tests.

## What is your testing strategy?

`make serve`, but the other branches are testing this in greater detail.

## Is this related to any issues?

Service discovery, live queries, testing, bootstrapping 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
