### PR TITLE
Update rquickjs dependency to new version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,8 +3737,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs"
-version = "0.1.7"
-source = "git+https://github.com/DelSkayn/rquickjs.git?branch=async#501009bc24dc47ee183ab37b7bc5ec3ea57ac636"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb753a1a1fe3cdb2b58bbbf3e037e86875260dca323ca03a273ead03a2f11e"
 dependencies = [
  "rquickjs-core",
  "rquickjs-macro",
@@ -3746,8 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-core"
-version = "0.1.7"
-source = "git+https://github.com/DelSkayn/rquickjs.git?branch=async#501009bc24dc47ee183ab37b7bc5ec3ea57ac636"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604c3fa56fa95f1fedc5e4ce2f1e8754eac3944a7d741a407e1e27f0cb5bd727"
 dependencies = [
  "async-lock",
  "relative-path",
@@ -3756,8 +3758,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-macro"
-version = "0.1.7"
-source = "git+https://github.com/DelSkayn/rquickjs.git?branch=async#501009bc24dc47ee183ab37b7bc5ec3ea57ac636"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f1fc43fa9c9afc738b8cabf53772b897f1a371ab7dbe896d2f71095780cfc0"
 dependencies = [
  "darling",
  "fnv",
@@ -3773,8 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.1.7"
-source = "git+https://github.com/DelSkayn/rquickjs.git?branch=async#501009bc24dc47ee183ab37b7bc5ec3ea57ac636"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cebb235d91be0b8c58bd07bb0dfc6864d47b29c7a8bc68910bae7c9a9d3ce28b"
 dependencies = [
  "bindgen 0.60.1",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash 0.8.3",
- "base64 0.21.1",
+ "base64 0.21.2",
  "bitflags",
  "brotli",
  "bytes",
@@ -265,6 +265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,7 +434,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -450,7 +456,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -467,7 +473,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -596,9 +602,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -612,7 +618,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df288bec72232f78c1ec5fe4e8f1d108aa0265476e93097593c803c8c02062a"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
  "blowfish",
  "getrandom 0.2.9",
  "subtle",
@@ -714,13 +720,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.5",
+ "prettyplease 0.2.6",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex 1.1.0",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -807,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.2"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bung"
@@ -901,13 +907,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
  "time 0.1.45",
@@ -1014,7 +1020,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1675,9 +1681,9 @@ dependencies = [
 
 [[package]]
 name = "futures-concurrency"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ce9739c5655304eced9aaea4220e4393b8f60a3a5f1b84d09a206d6a5078a9"
+checksum = "32f9eed2df6a47eb0338716fcf2a3bcd0f0e84b81dcd54ada4bb64e23b7f3f70"
 dependencies = [
  "bitvec",
  "futures-core",
@@ -1731,7 +1737,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2265,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -2340,7 +2346,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
  "pem",
  "ring",
  "serde",
@@ -2477,12 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "lz4-sys"
@@ -2584,14 +2587,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2767,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "oorandom"
@@ -2779,9 +2782,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2800,7 +2803,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2811,18 +2814,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.3+1.1.1t"
+version = "111.26.0+1.1.1u"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924757a6a226bf60da5f7dd0311a34d2b52283dd82ddeb103208ddc66362f80c"
+checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
 dependencies = [
  "cc",
  "libc",
@@ -3074,7 +3077,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3163,12 +3166,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617feabb81566b593beb4886fb8c1f38064169dae4dccad0e3220160c3b37203"
+checksum = "3b69d39aab54d069e7f2fe8cb970493e7834601ca2d8c65fd7bbd183578080d1"
 dependencies = [
  "proc-macro2",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3207,9 +3210,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -3388,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -3557,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3599,7 +3602,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3735,8 +3738,7 @@ dependencies = [
 [[package]]
 name = "rquickjs"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc022cc82b5de6f38b2f4ddb8ed9c49cdbd7ce112e650b181598e102157257de"
+source = "git+https://github.com/DelSkayn/rquickjs.git?branch=async#501009bc24dc47ee183ab37b7bc5ec3ea57ac636"
 dependencies = [
  "rquickjs-core",
  "rquickjs-macro",
@@ -3745,13 +3747,9 @@ dependencies = [
 [[package]]
 name = "rquickjs-core"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa1ecc1c84b31da87e5b26ce2b5218d36ffeb5c322141c78b79fa86a6ee3b9"
+source = "git+https://github.com/DelSkayn/rquickjs.git?branch=async#501009bc24dc47ee183ab37b7bc5ec3ea57ac636"
 dependencies = [
- "async-task",
- "flume",
- "futures-lite",
- "pin-project-lite",
+ "async-lock",
  "relative-path",
  "rquickjs-sys",
 ]
@@ -3759,8 +3757,7 @@ dependencies = [
 [[package]]
 name = "rquickjs-macro"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59ea6b93ccb811b02fefef0eec225d7fed0366b929ebf849afb22013c2953a0"
+source = "git+https://github.com/DelSkayn/rquickjs.git?branch=async#501009bc24dc47ee183ab37b7bc5ec3ea57ac636"
 dependencies = [
  "darling",
  "fnv",
@@ -3777,8 +3774,7 @@ dependencies = [
 [[package]]
 name = "rquickjs-sys"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24311952af42d8252e399cf48e7d470cb413b1a11a1a5b7fab648cd2edec76c5"
+source = "git+https://github.com/DelSkayn/rquickjs.git?branch=async#501009bc24dc47ee183ab37b7bc5ec3ea57ac636"
 dependencies = [
  "bindgen 0.60.1",
  "cc",
@@ -3860,7 +3856,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.1",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -4046,7 +4042,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -4265,7 +4261,7 @@ name = "surreal"
 version = "1.0.0-beta.9"
 dependencies = [
  "argon2",
- "base64 0.21.1",
+ "base64 0.21.2",
  "bung",
  "bytes",
  "chrono",
@@ -4316,7 +4312,7 @@ dependencies = [
  "async-executor",
  "async-recursion",
  "async-trait",
- "base64 0.21.1",
+ "base64 0.21.2",
  "bcrypt",
  "bigdecimal",
  "bincode",
@@ -4429,9 +4425,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4531,7 +4527,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -4695,9 +4691,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4730,7 +4726,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -4816,9 +4812,9 @@ checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.9"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d964908cec0d030b812013af25a0e57fddfadb1e066ecc6681d86253129d4f"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4923,7 +4919,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -5061,9 +5057,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -5251,7 +5247,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -5285,7 +5281,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5597,9 +5593,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.11"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1690519550bfa95525229b9ca2350c63043a4857b3b0013811b2ccf4a2420b01"
+checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
 
 [[package]]
 name = "yasna"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -76,7 +76,7 @@ fuzzy-matcher = "0.3.7"
 geo = { version = "0.25.0", features = ["use-serde"] }
 indexmap = { version = "1.9.3", features = ["serde"] }
 indxdb = { version = "0.3.0", optional = true }
-js = { version = "0.1.7", package = "rquickjs", features = ["array-buffer", "bindgen", "classes", "futures", "loader", "macro", "parallel", "properties"], optional = true }
+js = { git = "https://github.com/DelSkayn/rquickjs.git", branch = "async", package = "rquickjs", features = ["array-buffer", "bindgen", "classes", "futures", "loader", "macro", "parallel", "properties"], optional = true }
 lexicmp = "0.1.0"
 log = "0.4.17"
 md-5 = "0.10.5"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -76,7 +76,7 @@ fuzzy-matcher = "0.3.7"
 geo = { version = "0.25.0", features = ["use-serde"] }
 indexmap = { version = "1.9.3", features = ["serde"] }
 indxdb = { version = "0.3.0", optional = true }
-js = { git = "https://github.com/DelSkayn/rquickjs.git", branch = "async", package = "rquickjs", features = ["array-buffer", "bindgen", "classes", "futures", "loader", "macro", "parallel", "properties"], optional = true }
+js = { version = "0.2.1" , package = "rquickjs", features = ["array-buffer", "bindgen", "classes", "futures", "loader", "macro", "parallel", "properties"], optional = true }
 lexicmp = "0.1.0"
 log = "0.4.17"
 md-5 = "0.10.5"

--- a/lib/src/fnc/script/classes/blob.rs
+++ b/lib/src/fnc/script/classes/blob.rs
@@ -5,7 +5,7 @@
 #[allow(clippy::module_inception)]
 pub mod blob {
 
-	use js::Rest;
+	use js::function::Rest;
 	use js::Value;
 
 	#[derive(Clone)]

--- a/lib/src/fnc/script/classes/blob.rs
+++ b/lib/src/fnc/script/classes/blob.rs
@@ -9,12 +9,9 @@ pub mod blob {
 	use js::Value;
 
 	#[derive(Clone)]
-	#[quickjs(class)]
 	#[quickjs(cloneable)]
 	pub struct Blob {
-		#[quickjs(hide)]
 		pub(crate) mime: String,
-		#[quickjs(hide)]
 		pub(crate) data: Vec<u8>,
 	}
 

--- a/lib/src/fnc/script/classes/duration.rs
+++ b/lib/src/fnc/script/classes/duration.rs
@@ -10,10 +10,8 @@ pub mod duration {
 	use js::function::Rest;
 
 	#[derive(Clone)]
-	#[quickjs(class)]
 	#[quickjs(cloneable)]
 	pub struct Duration {
-		#[quickjs(hide)]
 		pub(crate) value: Option<duration::Duration>,
 	}
 

--- a/lib/src/fnc/script/classes/duration.rs
+++ b/lib/src/fnc/script/classes/duration.rs
@@ -7,7 +7,7 @@ pub mod duration {
 
 	use crate::sql::duration;
 	use crate::sql::value::Value;
-	use js::Rest;
+	use js::function::Rest;
 
 	#[derive(Clone)]
 	#[quickjs(class)]

--- a/lib/src/fnc/script/classes/headers.rs
+++ b/lib/src/fnc/script/classes/headers.rs
@@ -13,11 +13,9 @@ pub mod headers {
 	use std::str::FromStr;
 
 	#[derive(Clone)]
-	#[quickjs(class)]
 	#[quickjs(cloneable)]
 	#[allow(dead_code)]
 	pub struct Headers {
-		#[quickjs(hide)]
 		pub(crate) inner: RefCell<HashMap<HeaderName, Vec<String>>>,
 	}
 

--- a/lib/src/fnc/script/classes/headers.rs
+++ b/lib/src/fnc/script/classes/headers.rs
@@ -5,9 +5,10 @@
 #[allow(clippy::module_inception)]
 pub mod headers {
 
-	use js::Rest;
+	use js::function::Rest;
 	use js::Value;
 	use reqwest::header::HeaderName;
+	use std::cell::RefCell;
 	use std::collections::HashMap;
 	use std::str::FromStr;
 
@@ -17,7 +18,7 @@ pub mod headers {
 	#[allow(dead_code)]
 	pub struct Headers {
 		#[quickjs(hide)]
-		pub(crate) inner: HashMap<HeaderName, Vec<String>>,
+		pub(crate) inner: RefCell<HashMap<HeaderName, Vec<String>>>,
 	}
 
 	impl Headers {
@@ -28,7 +29,7 @@ pub mod headers {
 		#[quickjs(constructor)]
 		pub fn new(args: Rest<Value>) -> Self {
 			Self {
-				inner: HashMap::new(),
+				inner: RefCell::new(HashMap::new()),
 			}
 		}
 
@@ -42,28 +43,27 @@ pub mod headers {
 		}
 
 		// Adds or appends a new value to a header
-		pub fn append(&mut self, key: String, val: String, args: Rest<Value>) -> js::Result<()> {
+		pub fn append(
+			&self,
+			ctx: js::Ctx<'_>,
+			key: String,
+			val: String,
+			args: Rest<Value>,
+		) -> js::Result<()> {
 			// Process and check the header name is valid
-			let key = HeaderName::from_str(&key).map_err(|e| throw!(e))?;
+			let key = HeaderName::from_str(&key).map_err(|e| throw!(ctx, e))?;
 			// Insert and overwrite the header entry
-			match self.inner.get_mut(&key) {
-				Some(v) => {
-					v.push(val);
-				}
-				None => {
-					self.inner.insert(key, vec![val]);
-				}
-			}
+			self.inner.borrow_mut().entry(key).or_insert_with(Vec::new).push(val);
 			// Everything ok
 			Ok(())
 		}
 
 		// Deletes a header from the header set
-		pub fn delete(&mut self, key: String, args: Rest<Value>) -> js::Result<()> {
+		pub fn delete(&self, ctx: js::Ctx<'_>, key: String, args: Rest<Value>) -> js::Result<()> {
 			// Process and check the header name is valid
-			let key = HeaderName::from_str(&key).map_err(|e| throw!(e))?;
+			let key = HeaderName::from_str(&key).map_err(|e| throw!(ctx, e))?;
 			// Remove the header entry from the map
-			self.inner.remove(&key);
+			self.inner.borrow_mut().remove(&key);
 			// Everything ok
 			Ok(())
 		}
@@ -71,6 +71,7 @@ pub mod headers {
 		// Returns all header entries in the header set
 		pub fn entries(&self, args: Rest<Value>) -> Vec<(String, String)> {
 			self.inner
+				.borrow()
 				.iter()
 				.map(|(k, v)| {
 					(
@@ -82,35 +83,47 @@ pub mod headers {
 		}
 
 		// Returns all values of a header in the header set
-		pub fn get(&self, key: String, args: Rest<Value>) -> js::Result<Option<String>> {
+		pub fn get(
+			&self,
+			ctx: js::Ctx<'_>,
+			key: String,
+			args: Rest<Value>,
+		) -> js::Result<Option<String>> {
 			// Process and check the header name is valid
-			let key = HeaderName::from_str(&key).map_err(|e| throw!(e))?;
+			let key = HeaderName::from_str(&key).map_err(|e| throw!(ctx, e))?;
 			// Convert the header values to strings
 			Ok(self
 				.inner
+				.borrow()
 				.get(&key)
 				.map(|v| v.iter().map(|v| v.as_str()).collect::<Vec<&str>>().join(",")))
 		}
 
 		// Checks to see if the header set contains a header
-		pub fn has(&self, key: String, args: Rest<Value>) -> js::Result<bool> {
+		pub fn has(&self, ctx: js::Ctx<'_>, key: String, args: Rest<Value>) -> js::Result<bool> {
 			// Process and check the header name is valid
-			let key = HeaderName::from_str(&key).map_err(|e| throw!(e))?;
+			let key = HeaderName::from_str(&key).map_err(|e| throw!(ctx, e))?;
 			// Check if the header entry exists
-			Ok(self.inner.contains_key(&key))
+			Ok(self.inner.borrow().contains_key(&key))
 		}
 
 		// Returns all header keys contained in the header set
 		pub fn keys(&self, args: Rest<Value>) -> Vec<String> {
-			self.inner.keys().map(|v| v.as_str().to_owned()).collect::<Vec<String>>()
+			self.inner.borrow().keys().map(|v| v.as_str().to_owned()).collect::<Vec<String>>()
 		}
 
 		// Sets a new value or adds a header to the header set
-		pub fn set(&mut self, key: String, val: String, args: Rest<Value>) -> js::Result<()> {
+		pub fn set(
+			&self,
+			ctx: js::Ctx<'_>,
+			key: String,
+			val: String,
+			args: Rest<Value>,
+		) -> js::Result<()> {
 			// Process and check the header name is valid
-			let key = HeaderName::from_str(&key).map_err(|e| throw!(e))?;
+			let key = HeaderName::from_str(&key).map_err(|e| throw!(ctx, e))?;
 			// Insert and overwrite the header entry
-			self.inner.insert(key, vec![val]);
+			self.inner.borrow_mut().insert(key, vec![val]);
 			// Everything ok
 			Ok(())
 		}
@@ -118,6 +131,7 @@ pub mod headers {
 		// Returns all header values contained in the header set
 		pub fn values(&self, args: Rest<Value>) -> Vec<String> {
 			self.inner
+				.borrow()
 				.values()
 				.map(|v| v.iter().map(|v| v.as_str()).collect::<Vec<&str>>().join(","))
 				.collect::<Vec<String>>()

--- a/lib/src/fnc/script/classes/record.rs
+++ b/lib/src/fnc/script/classes/record.rs
@@ -7,7 +7,7 @@ pub mod record {
 
 	use crate::sql::thing;
 	use crate::sql::value::Value;
-	use js::Rest;
+	use js::function::Rest;
 
 	#[derive(Clone)]
 	#[quickjs(class)]

--- a/lib/src/fnc/script/classes/record.rs
+++ b/lib/src/fnc/script/classes/record.rs
@@ -10,10 +10,8 @@ pub mod record {
 	use js::function::Rest;
 
 	#[derive(Clone)]
-	#[quickjs(class)]
 	#[quickjs(cloneable)]
 	pub struct Record {
-		#[quickjs(hide)]
 		pub(crate) value: thing::Thing,
 	}
 

--- a/lib/src/fnc/script/classes/request.rs
+++ b/lib/src/fnc/script/classes/request.rs
@@ -7,7 +7,7 @@ pub mod request {
 
 	use super::super::blob::blob::Blob;
 	use crate::sql::value::Value;
-	use js::Rest;
+	use js::function::Rest;
 
 	#[derive(Clone)]
 	#[quickjs(class)]
@@ -62,23 +62,23 @@ pub mod request {
 		}
 
 		// Returns a promise with the request body as a Blob
-		pub async fn blob(self, args: Rest<Value>) -> js::Result<Blob> {
-			Err(throw!("Not yet implemented"))
+		pub async fn blob(self, ctx: js::Ctx<'_>, args: Rest<Value>) -> js::Result<Blob> {
+			Err(throw!(ctx, "Not yet implemented"))
 		}
 
 		// Returns a promise with the request body as FormData
-		pub async fn formData(self, args: Rest<Value>) -> js::Result<Value> {
-			Err(throw!("Not yet implemented"))
+		pub async fn formData(self, ctx: js::Ctx<'_>, args: Rest<Value>) -> js::Result<Value> {
+			Err(throw!(ctx, "Not yet implemented"))
 		}
 
 		// Returns a promise with the request body as JSON
-		pub async fn json(self, args: Rest<Value>) -> js::Result<Value> {
-			Err(throw!("Not yet implemented"))
+		pub async fn json(self, ctx: js::Ctx<'_>, args: Rest<Value>) -> js::Result<Value> {
+			Err(throw!(ctx, "Not yet implemented"))
 		}
 
 		// Returns a promise with the request body as text
-		pub async fn text(self, args: Rest<Value>) -> js::Result<Value> {
-			Err(throw!("Not yet implemented"))
+		pub async fn text(self, ctx: js::Ctx<'_>, args: Rest<Value>) -> js::Result<Value> {
+			Err(throw!(ctx, "Not yet implemented"))
 		}
 	}
 }

--- a/lib/src/fnc/script/classes/request.rs
+++ b/lib/src/fnc/script/classes/request.rs
@@ -10,11 +10,9 @@ pub mod request {
 	use js::function::Rest;
 
 	#[derive(Clone)]
-	#[quickjs(class)]
 	#[quickjs(cloneable)]
 	#[allow(dead_code)]
 	pub struct Request {
-		#[quickjs(hide)]
 		pub(crate) url: Option<String>,
 		pub(crate) credentials: Option<String>,
 		pub(crate) headers: Option<String>,

--- a/lib/src/fnc/script/classes/response.rs
+++ b/lib/src/fnc/script/classes/response.rs
@@ -10,11 +10,9 @@ pub mod response {
 	use js::function::Rest;
 
 	#[derive(Clone)]
-	#[quickjs(class)]
 	#[quickjs(cloneable)]
 	#[allow(dead_code)]
 	pub struct Response {
-		#[quickjs(hide)]
 		pub(crate) url: Option<String>,
 		pub(crate) credentials: Option<String>,
 		pub(crate) headers: Option<String>,

--- a/lib/src/fnc/script/classes/response.rs
+++ b/lib/src/fnc/script/classes/response.rs
@@ -7,7 +7,7 @@ pub mod response {
 
 	use super::super::blob::blob::Blob;
 	use crate::sql::value::Value;
-	use js::Rest;
+	use js::function::Rest;
 
 	#[derive(Clone)]
 	#[quickjs(class)]
@@ -62,23 +62,23 @@ pub mod response {
 		}
 
 		// Returns a promise with the response body as a Blob
-		pub async fn blob(self, args: Rest<Value>) -> js::Result<Blob> {
-			Err(throw!("Not yet implemented"))
+		pub async fn blob(self, ctx: js::Ctx<'_>, args: Rest<Value>) -> js::Result<Blob> {
+			Err(throw!(ctx, "Not yet implemented"))
 		}
 
 		// Returns a promise with the response body as FormData
-		pub async fn formData(self, args: Rest<Value>) -> js::Result<Value> {
-			Err(throw!("Not yet implemented"))
+		pub async fn formData(self, ctx: js::Ctx<'_>, args: Rest<Value>) -> js::Result<Value> {
+			Err(throw!(ctx, "Not yet implemented"))
 		}
 
 		// Returns a promise with the response body as JSON
-		pub async fn json(self, args: Rest<Value>) -> js::Result<Value> {
-			Err(throw!("Not yet implemented"))
+		pub async fn json(self, ctx: js::Ctx<'_>, args: Rest<Value>) -> js::Result<Value> {
+			Err(throw!(ctx, "Not yet implemented"))
 		}
 
 		// Returns a promise with the response body as text
-		pub async fn text(self, args: Rest<Value>) -> js::Result<Value> {
-			Err(throw!("Not yet implemented"))
+		pub async fn text(self, ctx: js::Ctx<'_>, args: Rest<Value>) -> js::Result<Value> {
+			Err(throw!(ctx, "Not yet implemented"))
 		}
 
 		// ------------------------------
@@ -86,13 +86,13 @@ pub mod response {
 		// ------------------------------
 
 		// Returns a new response representing a network error
-		pub fn error(args: Rest<Value>) -> js::Result<Response> {
-			Err(throw!("Not yet implemented"))
+		pub fn error(ctx: js::Ctx<'_>, args: Rest<Value>) -> js::Result<Response> {
+			Err(throw!(ctx, "Not yet implemented"))
 		}
 
 		// Creates a new response with a different URL
-		pub fn redirect(args: Rest<Value>) -> js::Result<Response> {
-			Err(throw!("Not yet implemented"))
+		pub fn redirect(ctx: js::Ctx<'_>, args: Rest<Value>) -> js::Result<Response> {
+			Err(throw!(ctx, "Not yet implemented"))
 		}
 	}
 }

--- a/lib/src/fnc/script/classes/uuid.rs
+++ b/lib/src/fnc/script/classes/uuid.rs
@@ -7,7 +7,7 @@ pub mod uuid {
 
 	use crate::sql::uuid;
 	use crate::sql::value::Value;
-	use js::Rest;
+	use js::function::Rest;
 
 	#[derive(Clone)]
 	#[quickjs(class)]

--- a/lib/src/fnc/script/classes/uuid.rs
+++ b/lib/src/fnc/script/classes/uuid.rs
@@ -10,10 +10,8 @@ pub mod uuid {
 	use js::function::Rest;
 
 	#[derive(Clone)]
-	#[quickjs(class)]
 	#[quickjs(cloneable)]
 	pub struct Uuid {
-		#[quickjs(hide)]
 		pub(crate) value: Option<uuid::Uuid>,
 	}
 

--- a/lib/src/fnc/script/error.rs
+++ b/lib/src/fnc/script/error.rs
@@ -1,31 +1,29 @@
 use crate::err::Error;
 
-impl From<js::Error> for Error {
-	fn from(e: js::Error) -> Error {
+impl From<js::CaughtError<'_>> for Error {
+	fn from(e: js::CaughtError) -> Error {
 		match e {
-			js::Error::Exception {
-				message,
-				stack,
-				file,
-				line,
-			} => Error::InvalidScript {
-				message: format!(
-					"An exception occurred{}: {}{}",
-					match file.is_empty() {
-						false => format!(" at {file}:{line}"),
-						true => String::default(),
-					},
-					match message.is_empty() {
-						false => message,
-						true => String::default(),
-					},
-					match stack.is_empty() {
-						false => format!("\n{stack}"),
-						true => String::default(),
-					}
-				),
-			},
-			js::Error::Unknown => Error::InvalidScript {
+			js::CaughtError::Exception(e) => {
+				let line = e.line().unwrap_or(-1);
+				Error::InvalidScript {
+					message: format!(
+						"An exception occurred{}: {}{}",
+						match e.file() {
+							Some(file) => format!(" at {file}:{line}"),
+							None => String::default(),
+						},
+						match e.message() {
+							Some(message) => message,
+							None => String::default(),
+						},
+						match e.stack() {
+							Some(stack) => format!("\n{stack}"),
+							None => String::default(),
+						}
+					),
+				}
+			}
+			js::CaughtError::Error(js::Error::Unknown) => Error::InvalidScript {
 				message: "An unknown error occurred".to_string(),
 			},
 			_ => Error::InvalidScript {

--- a/lib/src/fnc/script/from.rs
+++ b/lib/src/fnc/script/from.rs
@@ -7,6 +7,7 @@ use crate::sql::Id;
 use chrono::{TimeZone, Utc};
 use js::Ctx;
 use js::Error;
+use js::Exception;
 use js::FromAtom;
 use js::FromJs;
 
@@ -48,12 +49,9 @@ impl<'js> FromJs<'js> for Value {
 				// Check to see if this object is an error
 				if v.is_error() {
 					let e: String = v.get("message")?;
-					return Err(Error::Exception {
-						line: -1,
-						message: e,
-						file: String::new(),
-						stack: String::new(),
-					});
+					// Ignore error since ok and err ar both Error::Exception.
+					Exception::from_message(ctx, &e).map(|x| x.throw()).ok();
+					return Err(Error::Exception);
 				}
 				// Check to see if this object is a record
 				if (v).instance_of::<classes::record::record::Record>() {
@@ -87,7 +85,7 @@ impl<'js> FromJs<'js> for Value {
 				let date: js::Object = ctx.globals().get("Date")?;
 				if (v).is_instance_of(&date) {
 					let f: js::Function = v.get("getTime")?;
-					let m: i64 = f.call((js::This(v),))?;
+					let m: i64 = f.call((js::prelude::This(v),))?;
 					let d = Utc.timestamp_millis_opt(m).unwrap();
 					return Ok(Datetime::from(d).into());
 				}

--- a/lib/src/fnc/script/from.rs
+++ b/lib/src/fnc/script/from.rs
@@ -49,9 +49,8 @@ impl<'js> FromJs<'js> for Value {
 				// Check to see if this object is an error
 				if v.is_error() {
 					let e: String = v.get("message")?;
-					// Ignore error since ok and err ar both Error::Exception.
-					Exception::from_message(ctx, &e).map(|x| x.throw()).ok();
-					return Err(Error::Exception);
+					let (Ok(e) | Err(e)) = Exception::from_message(ctx, &e).map(|x| x.throw());
+					return Err(e);
 				}
 				// Check to see if this object is a record
 				if (v).instance_of::<classes::record::record::Record>() {

--- a/lib/src/fnc/script/globals/console.rs
+++ b/lib/src/fnc/script/globals/console.rs
@@ -5,7 +5,7 @@ pub mod console {
 	// Specify the imports
 	use crate::fnc::script::LOG;
 	use crate::sql::value::Value;
-	use js::Rest;
+	use js::prelude::Rest;
 	/// Log the input values as INFO
 	pub fn log(args: Rest<Value>) {
 		info!(

--- a/lib/src/fnc/script/globals/fetch.rs
+++ b/lib/src/fnc/script/globals/fetch.rs
@@ -1,5 +1,5 @@
 use crate::sql::value::Value;
-use js::Rest;
+use js::prelude::Rest;
 use js::Result;
 
 #[js::bind(object, public)]

--- a/lib/src/fnc/script/main.rs
+++ b/lib/src/fnc/script/main.rs
@@ -1,5 +1,4 @@
 use super::classes;
-use super::executor::Executor;
 use super::globals;
 use super::modules;
 use super::modules::loader;
@@ -9,11 +8,17 @@ use crate::dbs::Options;
 use crate::dbs::Transaction;
 use crate::err::Error;
 use crate::sql::value::Value;
+use js::async_with;
+use js::prelude::Promise;
+use js::prelude::Rest;
+use js::prelude::This;
+use js::CatchResultExt;
 use js::Function;
 use js::Module;
-use js::Promise;
-use js::Rest;
-use js::This;
+
+fn is_send<T: Send>(s: T) -> T {
+	s
+}
 
 pub async fn run(
 	ctx: &Context<'_>,
@@ -27,63 +32,54 @@ pub async fn run(
 	if ctx.is_done() {
 		return Ok(Value::None);
 	}
-	// Create a new agent
-	let exe = Executor::default();
 	// Create an JavaScript context
-	let run = js::Runtime::new().unwrap();
+	let run = js::AsyncRuntime::new().unwrap();
 	// Explicitly set max stack size to 256 KiB
-	run.set_max_stack_size(262_144);
+	is_send(run.set_max_stack_size(262_144)).await;
 	// Explicitly set max memory size to 2 MB
-	run.set_memory_limit(2_000_000);
+	is_send(run.set_memory_limit(2_000_000)).await;
 	// Ensure scripts are cancelled with context
 	let cancellation = ctx.cancellation();
-	run.set_interrupt_handler(Some(Box::new(move || cancellation.is_done())));
+	is_send(run.set_interrupt_handler(Some(Box::new(move || cancellation.is_done())))).await;
 	// Create an execution context
-	let ctx = js::Context::full(&run).unwrap();
+	let ctx = js::AsyncContext::full(&run).await.unwrap();
 	// Set the module resolver and loader
-	run.set_loader(resolver(), loader());
-	// Enable async code in the runtime
-	run.spawn_executor(&exe).detach();
+	is_send(run.set_loader(resolver(), loader())).await;
 	// Create the main function structure
 	let src = format!(
 		"export default async function() {{ try {{ {src} }} catch(e) {{ return (e instanceof Error) ? e : new Error(e); }} }}"
 	);
+
 	// Attempt to execute the script
-	let res: Result<Promise<Value>, js::Error> = ctx.with(|ctx| {
-		// Get the context global object
-		let global = ctx.globals();
-		// Register the surrealdb module as a global object
-		global.set(
-			"surrealdb",
-			Module::new_def::<modules::surrealdb::Package, _>(ctx, "surrealdb")?
-				.eval()?
-				.get::<_, js::Value>("default")?,
-		)?;
-		// Register the fetch function to the globals
-		global.init_def::<globals::fetch::Fetch>()?;
-		// Register the console function to the globals
-		global.init_def::<globals::console::Console>()?;
-		// Register the special SurrealDB types as classes
-		global.init_def::<classes::duration::Duration>()?;
-		global.init_def::<classes::record::Record>()?;
-		global.init_def::<classes::uuid::Uuid>()?;
-		// Attempt to compile the script
-		let res = ctx.compile("script", src)?;
-		// Attempt to fetch the main export
-		let fnc = res.get::<_, Function>("default")?;
-		// Execute the main function
-		fnc.call((This(doc), Rest(arg)))
-	});
-	// Return the script result
-	match res {
-		// The script executed successfully
-		Ok(v) => match exe.run(v).await {
-			// The promise fulfilled successfully
-			Ok(v) => Ok(v),
-			// There was an error awaiting the promise
-			Err(e) => Err(Error::from(e)),
-		},
-		// There was an error running the script
-		Err(e) => Err(Error::from(e)),
-	}
+	async_with!(ctx => |ctx|{
+
+		let res = async move {
+			// Get the context global object
+			let global = ctx.globals();
+			// Register the surrealdb module as a global object
+			global.set(
+				"surrealdb",
+				Module::evaluate_def::<modules::surrealdb::Package, _>(ctx, "surrealdb")?
+					.get::<_, js::Value>("default")?,
+			)?;
+			// Register the fetch function to the globals
+			global.init_def::<globals::fetch::Fetch>()?;
+			// Register the console function to the globals
+			global.init_def::<globals::console::Console>()?;
+			// Register the special SurrealDB types as classes
+			global.init_def::<classes::duration::Duration>()?;
+			global.init_def::<classes::record::Record>()?;
+			global.init_def::<classes::uuid::Uuid>()?;
+			// Attempt to compile the script
+			let res = ctx.compile("script", src)?;
+			// Attempt to fetch the main export
+			let fnc = res.get::<_, Function>("default")?;
+			// Execute the main function
+			let promise: Promise<Value> = fnc.call((This(doc), Rest(arg)))?;
+			promise.await
+		}.await;
+
+		res.catch(ctx).map_err(Error::from)
+	})
+	.await
 }

--- a/lib/src/fnc/script/mod.rs
+++ b/lib/src/fnc/script/mod.rs
@@ -6,7 +6,6 @@ pub use main::run;
 
 mod classes;
 mod error;
-mod executor;
 mod from;
 mod globals;
 mod into;

--- a/lib/src/fnc/script/modules/mod.rs
+++ b/lib/src/fnc/script/modules/mod.rs
@@ -22,6 +22,8 @@ macro_rules! impl_module_def {
 	};
 	($ctx: expr, $path: literal, $name: literal, $call: ident, Async) => {
 		{
+			// It is currently impossible to create closures which capture Ctx in a returned future.
+			// So instead we define a normal function for async.
             async fn f<'js>(ctx: js::Ctx<'js>, v: js::function::Rest<crate::sql::value::Value>) -> js::Result<crate::sql::value::Value>{
                 $call(ctx,if $path == "" { $name } else { concat!($path, "::", $name) }, v.0).await
             }

--- a/lib/src/fnc/script/modules/mod.rs
+++ b/lib/src/fnc/script/modules/mod.rs
@@ -1,8 +1,7 @@
 pub mod os;
 pub mod surrealdb;
 
-use js::BuiltinResolver;
-use js::ModuleLoader;
+use js::loader::{BuiltinResolver, ModuleLoader};
 
 pub fn resolver() -> BuiltinResolver {
 	BuiltinResolver::default().with_module("os").with_module("surrealdb")
@@ -21,10 +20,20 @@ macro_rules! impl_module_def {
 			crate::fnc::script::modules::surrealdb::pkg::<$module::$pkg>($ctx, $name)
 		}
 	};
-	// Call a (possibly-async) function.
-	($ctx: expr, $path: literal, $name: literal, $call: ident, $($wrapper: ident)?) => {
+	($ctx: expr, $path: literal, $name: literal, $call: ident, Async) => {
 		{
-			js::Func::from($($wrapper)? (|v: js::Rest<crate::sql::value::Value>| $call(if $path == "" { $name } else { concat!($path, "::", $name) }, v.0)))
+            async fn f<'js>(ctx: js::Ctx<'js>, v: js::function::Rest<crate::sql::value::Value>) -> js::Result<crate::sql::value::Value>{
+                $call(ctx,if $path == "" { $name } else { concat!($path, "::", $name) }, v.0).await
+            }
+			js::function::Func::from(Async(f))
+		}
+	};
+	// Call a (possibly-async) function.
+	($ctx: expr, $path: literal, $name: literal, $call: ident, ) => {
+		{
+
+
+			js::function::Func::from(|ctx: js::Ctx<'_>, v: js::function::Rest<crate::sql::value::Value>| $call(ctx,if $path == "" { $name } else { concat!($path, "::", $name) }, v.0))
 		}
 	};
 	// Return the value of an expression that can be converted to JS.
@@ -34,22 +43,22 @@ macro_rules! impl_module_def {
 		}
 	};
 	($pkg: ident, $path: literal, $($name: literal => $action: tt $($wrapper: ident)?),*) => {
-		impl js::ModuleDef for Package {
-			fn load<'js>(_ctx: js::Ctx<'js>, module: &js::Module<'js, js::Created>) -> js::Result<()> {
-				module.add("default")?;
+		impl js::module::ModuleDef for Package {
+			fn declare(decls: &mut js::module::Declarations) -> js::Result<()> {
+				decls.declare("default")?;
 				$(
-					module.add($name)?;
+					decls.declare($name)?;
 				)*
 				Ok(())
 			}
 
-			fn eval<'js>(ctx: js::Ctx<'js>, module: &js::Module<'js, js::Loaded<js::Native>>) -> js::Result<()> {
+			fn evaluate<'js>(ctx: js::Ctx<'js>, exports: &mut js::module::Exports<'js>) -> js::Result<()> {
 				let default = js::Object::new(ctx)?;
 				$(
-					module.set($name, crate::fnc::script::modules::impl_module_def!(ctx, $path, $name, $action, $($wrapper)?))?;
+					exports.export($name, crate::fnc::script::modules::impl_module_def!(ctx, $path, $name, $action, $($wrapper)?))?;
 					default.set($name, crate::fnc::script::modules::impl_module_def!(ctx, $path, $name, $action, $($wrapper)?))?;
 				)*
-				module.set("default", default)?;
+				exports.export("default", default)?;
 				Ok(())
 			}
 		}

--- a/lib/src/fnc/script/modules/surrealdb/functions/http.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/http.rs
@@ -1,6 +1,6 @@
 use super::fut;
 use crate::fnc::script::modules::impl_module_def;
-use js::Async;
+use js::prelude::Async;
 
 pub struct Package;
 

--- a/lib/src/fnc/script/modules/surrealdb/functions/mod.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/mod.rs
@@ -2,7 +2,8 @@ use crate::ctx::Context;
 use crate::fnc;
 use crate::fnc::script::modules::impl_module_def;
 use crate::sql::Value;
-use js::{Async, Result};
+use js::prelude::Async;
+use js::Result;
 
 mod array;
 mod bytes;
@@ -48,30 +49,28 @@ impl_module_def!(
 	"type" => (r#type::Package)
 );
 
-fn run(name: &str, args: Vec<Value>) -> Result<Value> {
+fn run(js_ctx: js::Ctx<'_>, name: &str, args: Vec<Value>) -> Result<Value> {
 	// Create a default context
 	let ctx = Context::background();
 	// Process the called function
 	let res = fnc::synchronous(&ctx, name, args);
 	// Convert any response error
-	res.map_err(|err| js::Error::Exception {
-		message: err.to_string(),
-		file: String::from(""),
-		line: -1,
-		stack: String::from(""),
+	res.map_err(|err| {
+		js::Exception::from_message(js_ctx, &err.to_string())
+			.map(js::Exception::throw)
+			.unwrap_or(js::Error::Exception)
 	})
 }
 
-async fn fut(name: &str, args: Vec<Value>) -> Result<Value> {
+async fn fut(js_ctx: js::Ctx<'_>, name: &str, args: Vec<Value>) -> Result<Value> {
 	// Create a default context
 	let ctx = Context::background();
 	// Process the called function
 	let res = fnc::asynchronous(&ctx, name, args).await;
 	// Convert any response error
-	res.map_err(|err| js::Error::Exception {
-		message: err.to_string(),
-		file: String::from(""),
-		line: -1,
-		stack: String::from(""),
+	res.map_err(|err| {
+		js::Exception::from_message(js_ctx, &err.to_string())
+			.map(js::Exception::throw)
+			.unwrap_or(js::Error::Exception)
 	})
 }

--- a/lib/src/fnc/script/modules/surrealdb/mod.rs
+++ b/lib/src/fnc/script/modules/surrealdb/mod.rs
@@ -1,5 +1,5 @@
 use crate::fnc::script::modules::impl_module_def;
-use js::{Ctx, Module, ModuleDef, Result, Value};
+use js::{module::ModuleDef, Ctx, Module, Result, Value};
 
 mod functions;
 
@@ -16,5 +16,5 @@ fn pkg<'js, D>(ctx: Ctx<'js>, name: &str) -> Result<Value<'js>>
 where
 	D: ModuleDef,
 {
-	Module::new_def::<D, _>(ctx, name)?.eval()?.get::<_, js::Value>("default")
+	Module::evaluate_def::<D, _>(ctx, name)?.get::<_, js::Value>("default")
 }

--- a/lib/src/mac/mod.rs
+++ b/lib/src/mac/mod.rs
@@ -23,20 +23,32 @@ macro_rules! get_cfg {
 
 #[cfg(feature = "scripting")]
 macro_rules! throw {
-	($e:ident) => {
+	($ctx:expr,$e:ident) => {
+		js::Exception::from_message($ctx, &$e.to_string())
+			.map(js::Exception::throw)
+			.unwrap_or(js::Error::Exception)
+		/*
+		 * TODO: add line and file back in later
 		js::Error::Exception {
 			line: line!() as i32,
 			message: $e.to_string(),
 			file: file!().to_owned(),
 			stack: "".to_owned(),
 		}
+		*/
 	};
-	($str:expr) => {
+	($ctx:expr,$str:expr) => {
+		js::Exception::from_message($ctx, &$str)
+			.map(js::Exception::throw)
+			.unwrap_or(js::Error::Exception)
+		/*
+		 * TODO: add line and file back in later
 		js::Error::Exception {
 			line: line!() as i32,
 			message: $str.to_owned(),
 			file: file!().to_owned(),
 			stack: "".to_owned(),
 		}
+		*/
 	};
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The rquickjs library has changed significantly and fixed a bunch of unsoundness problems. 
SurrealDB should change there implementation to the new version.

## What does this change do?

This PR updates the scripting functionality of SurrealDB to use the new rquickjs version.

## What is your testing strategy?

The implementation hasn't fundamentally changed on the SurrealDB side, the only differences are due differences in API of the new rquickjs version. Everything should continue working as previously.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
