### PR TITLE
Security - add global query timeouts

### DIFF
--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -587,7 +587,8 @@ async fn router(
 				}
 				.into());
 			}
-			let responses = kvs.execute(&statements, &*session, Some(vars.clone()), ds_opts).await?;
+			let responses =
+				kvs.execute(&statements, &*session, Some(vars.clone()), ds_opts).await?;
 			for response in responses {
 				response.result?;
 			}

--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -312,10 +312,10 @@ impl<'a> Executor<'a> {
 									None => stm.compute(&ctx, &opt, &self.txn(), None).await,
 								};
 								// Catch global or statement timeout
-								match ctx.is_timedout() {
+								let res = match ctx.is_timedout() {
 									true => Err(Error::QueryTimedout),
 									false => res,
-								}
+								};
 								// Finalise transaction and return the result.
 								if res.is_ok() && stm.writeable() {
 									if let Err(e) = self.commit(loc).await {

--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -307,7 +307,6 @@ impl<'a> Executor<'a> {
 										ctx.add_timeout(timeout);
 										// Process the statement
 										stm.compute(&ctx, &opt, &self.txn(), None).await
-										
 									}
 									// There is no timeout clause
 									None => stm.compute(&ctx, &opt, &self.txn(), None).await,

--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -306,16 +306,17 @@ impl<'a> Executor<'a> {
 										let mut ctx = Context::new(&ctx);
 										ctx.add_timeout(timeout);
 										// Process the statement
-										let res = stm.compute(&ctx, &opt, &self.txn(), None).await;
-										// Catch statement timeout
-										match ctx.is_timedout() {
-											true => Err(Error::QueryTimedout),
-											false => res,
-										}
+										stm.compute(&ctx, &opt, &self.txn(), None).await
+										
 									}
 									// There is no timeout clause
 									None => stm.compute(&ctx, &opt, &self.txn(), None).await,
 								};
+								// Catch global or statement timeout
+								match ctx.is_timedout() {
+									true => Err(Error::QueryTimedout),
+									false => res,
+								}
 								// Finalise transaction and return the result.
 								if res.is_ok() && stm.writeable() {
 									if let Err(e) = self.commit(loc).await {

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -336,7 +336,7 @@ mod tests {
 					format!("RETURN function() {{ return typeof surrealdb.functions.{name}; }}");
 				let dbs = crate::kvs::Datastore::new("memory").await.unwrap();
 				let ses = crate::dbs::Session::for_kv().with_ns("test").with_db("test");
-				let res = &mut dbs.execute(&sql, &ses, None, false).await.unwrap();
+				let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await.unwrap();
 				let tmp = res.remove(0).result.unwrap();
 				if tmp == Value::from("object") {
 					// Assume this function is superseded by a module of the same name.

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -13,9 +13,9 @@ use crate::sql::Query;
 use crate::sql::Value;
 use channel::Sender;
 use futures::lock::Mutex;
-use std::time::Duration;
 use std::fmt;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::instrument;
 
 /// The underlying datastore instance which stores the dataset.
@@ -316,7 +316,10 @@ impl Datastore {
 		txt: &str,
 		sess: &Session,
 		vars: Variables,
-		DsOpts{strict, query_timeout}: DsOpts,
+		DsOpts {
+			strict,
+			query_timeout,
+		}: DsOpts,
 	) -> Result<Vec<Response>, Error> {
 		// Create a new query options
 		let mut opt = Options::default();
@@ -370,7 +373,10 @@ impl Datastore {
 		ast: Query,
 		sess: &Session,
 		vars: Variables,
-		DsOpts{strict, query_timeout}: DsOpts,
+		DsOpts {
+			strict,
+			query_timeout,
+		}: DsOpts,
 	) -> Result<Vec<Response>, Error> {
 		// Create a new query options
 		let mut opt = Options::default();
@@ -423,7 +429,10 @@ impl Datastore {
 		val: Value,
 		sess: &Session,
 		vars: Variables,
-		DsOpts{strict, query_timeout}: DsOpts,
+		DsOpts {
+			strict,
+			query_timeout,
+		}: DsOpts,
 	) -> Result<Value, Error> {
 		// Start a new transaction
 		let txn = self.transaction(val.writeable(), false).await?;

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -306,7 +306,7 @@ impl Datastore {
 	///     let ds = Datastore::new("memory").await?;
 	///     let ses = Session::for_kv();
 	///     let ast = "USE NS test DB test; SELECT * FROM person;";
-	///     let res = ds.execute(ast, &ses, None, false).await?;
+	///     let res = ds.execute(ast, &ses, None, Default::default()).await?;
 	///     Ok(())
 	/// }
 	/// ```
@@ -363,7 +363,7 @@ impl Datastore {
 	///     let ds = Datastore::new("memory").await?;
 	///     let ses = Session::for_kv();
 	///     let ast = parse("USE NS test DB test; SELECT * FROM person;")?;
-	///     let res = ds.process(ast, &ses, None, false).await?;
+	///     let res = ds.process(ast, &ses, None, Default::default()).await?;
 	///     Ok(())
 	/// }
 	/// ```
@@ -419,7 +419,7 @@ impl Datastore {
 	///     let ds = Datastore::new("memory").await?;
 	///     let ses = Session::for_kv();
 	///     let val = Value::Future(Box::new(Future::from(Value::Bool(true))));
-	///     let res = ds.compute(val, &ses, None, false).await?;
+	///     let res = ds.compute(val, &ses, None, Default::default()).await?;
 	///     Ok(())
 	/// }
 	/// ```

--- a/lib/tests/cache.rs
+++ b/lib/tests/cache.rs
@@ -17,7 +17,7 @@ async fn clear_transaction_cache_table() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -73,7 +73,7 @@ async fn clear_transaction_cache_field() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/compare.rs
+++ b/lib/tests/compare.rs
@@ -19,7 +19,7 @@ async fn compare_empty() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/complex.rs
+++ b/lib/tests/complex.rs
@@ -203,7 +203,9 @@ async fn run_queries(
 > {
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	dbs.execute(&sql, &ses, None, Default::default()).await.map(|v| v.into_iter().map(|res| res.result))
+	dbs.execute(&sql, &ses, None, Default::default())
+		.await
+		.map(|v| v.into_iter().map(|res| res.result))
 }
 
 fn with_enough_stack(

--- a/lib/tests/complex.rs
+++ b/lib/tests/complex.rs
@@ -203,7 +203,7 @@ async fn run_queries(
 > {
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	dbs.execute(&sql, &ses, None, false).await.map(|v| v.into_iter().map(|res| res.result))
+	dbs.execute(&sql, &ses, None, Default::default()).await.map(|v| v.into_iter().map(|res| res.result))
 }
 
 fn with_enough_stack(

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -18,7 +18,7 @@ async fn create_with_id() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/datetimes.rs
+++ b/lib/tests/datetimes.rs
@@ -14,7 +14,7 @@ async fn datetimes_conversion() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -13,7 +13,7 @@ async fn define_statement_namespace() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -38,7 +38,7 @@ async fn define_statement_database() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -67,7 +67,7 @@ async fn define_statement_function() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -100,7 +100,7 @@ async fn define_statement_table_drop() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -131,7 +131,7 @@ async fn define_statement_table_schemaless() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -163,7 +163,7 @@ async fn define_statement_table_schemafull() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -197,7 +197,7 @@ async fn define_statement_table_schemaful() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -237,7 +237,7 @@ async fn define_statement_event() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -294,7 +294,7 @@ async fn define_statement_event_when_event() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -351,7 +351,7 @@ async fn define_statement_event_when_logic() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -400,7 +400,7 @@ async fn define_statement_field() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -432,7 +432,7 @@ async fn define_statement_field_type() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -464,7 +464,7 @@ async fn define_statement_field_value() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -496,7 +496,7 @@ async fn define_statement_field_assert() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -528,7 +528,7 @@ async fn define_statement_field_type_value_assert() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -564,7 +564,7 @@ async fn define_statement_index_single_simple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -612,7 +612,7 @@ async fn define_statement_index_single() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -656,7 +656,7 @@ async fn define_statement_index_multiple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -708,7 +708,7 @@ async fn define_statement_index_single_unique() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -766,7 +766,7 @@ async fn define_statement_index_multiple_unique() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 12);
 	//
 	let tmp = res.remove(0).result;
@@ -841,7 +841,7 @@ async fn define_statement_index_single_unique_existing() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 6);
 	//
 	for _ in 0..3 {
@@ -888,7 +888,7 @@ async fn define_statement_index_multiple_unique_existing() -> Result<(), Error> 
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	for _ in 0..4 {
@@ -931,7 +931,7 @@ async fn define_statement_analyzer() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -974,7 +974,7 @@ async fn define_statement_search_index() -> Result<(), Error> {
 
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	for _ in 0..6 {

--- a/lib/tests/escape.rs
+++ b/lib/tests/escape.rs
@@ -18,7 +18,7 @@ async fn complex_ids() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -96,7 +96,7 @@ async fn complex_strings() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/fetch.rs
+++ b/lib/tests/fetch.rs
@@ -23,7 +23,7 @@ async fn create_relate_select() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 12);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -20,7 +20,7 @@ async fn field_definition_value_assert_failure() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result;
@@ -86,7 +86,7 @@ async fn field_definition_value_assert_success() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -135,7 +135,7 @@ async fn field_definition_empty_nested_objects() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result;
@@ -189,7 +189,7 @@ async fn field_definition_empty_nested_arrays() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result;
@@ -241,7 +241,7 @@ async fn field_definition_empty_nested_flexible() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -20,7 +20,7 @@ async fn function_array_add() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;
@@ -57,7 +57,7 @@ async fn function_array_all() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -86,7 +86,7 @@ async fn function_array_any() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -115,7 +115,7 @@ async fn function_array_append() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -144,7 +144,7 @@ async fn function_array_combine() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -173,7 +173,7 @@ async fn function_array_complement() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -202,7 +202,7 @@ async fn function_array_concat() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -231,7 +231,7 @@ async fn function_array_difference() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -259,7 +259,7 @@ async fn function_array_distinct() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -289,7 +289,7 @@ async fn function_array_flatten() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -322,7 +322,7 @@ async fn function_array_group() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -352,7 +352,7 @@ async fn function_array_insert() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -383,7 +383,7 @@ async fn function_array_intersect() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -413,7 +413,7 @@ async fn function_string_join_arr() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -444,7 +444,7 @@ async fn function_array_len() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -473,7 +473,7 @@ async fn function_array_max() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -502,7 +502,7 @@ async fn function_array_min() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -531,7 +531,7 @@ async fn function_array_pop() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -560,7 +560,7 @@ async fn function_array_prepend() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -589,7 +589,7 @@ async fn function_array_push() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -619,7 +619,7 @@ async fn function_array_remove() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -650,7 +650,7 @@ async fn function_array_reverse() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -683,7 +683,7 @@ async fn function_array_slice() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -732,7 +732,7 @@ async fn function_array_sort() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -777,7 +777,7 @@ async fn function_array_sort_asc() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -806,7 +806,7 @@ async fn function_array_sort_desc() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -835,7 +835,7 @@ async fn function_array_union() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -869,7 +869,7 @@ async fn function_bytes_len() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -908,7 +908,7 @@ async fn function_count() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;
@@ -945,7 +945,7 @@ async fn function_crypto_md5() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -962,7 +962,7 @@ async fn function_crypto_sha1() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -979,7 +979,7 @@ async fn function_crypto_sha256() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -996,7 +996,7 @@ async fn function_crypto_sha512() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1019,7 +1019,7 @@ async fn function_duration_days() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1046,7 +1046,7 @@ async fn function_duration_hours() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1073,7 +1073,7 @@ async fn function_duration_micros() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1100,7 +1100,7 @@ async fn function_duration_millis() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1127,7 +1127,7 @@ async fn function_duration_mins() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1154,7 +1154,7 @@ async fn function_duration_nanos() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1181,7 +1181,7 @@ async fn function_duration_secs() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1208,7 +1208,7 @@ async fn function_duration_weeks() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1235,7 +1235,7 @@ async fn function_duration_years() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1261,7 +1261,7 @@ async fn function_duration_from_days() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1283,7 +1283,7 @@ async fn function_duration_from_hours() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1305,7 +1305,7 @@ async fn function_duration_from_micros() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1327,7 +1327,7 @@ async fn function_duration_from_millis() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1349,7 +1349,7 @@ async fn function_duration_from_mins() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1371,7 +1371,7 @@ async fn function_duration_from_nanos() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1393,7 +1393,7 @@ async fn function_duration_from_secs() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1415,7 +1415,7 @@ async fn function_duration_from_weeks() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1441,7 +1441,7 @@ async fn function_encoding_base64_decode() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1463,7 +1463,7 @@ async fn function_encoding_base64_encode() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1495,7 +1495,7 @@ async fn function_parse_geo_area() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1521,7 +1521,7 @@ async fn function_parse_geo_bearing() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1545,7 +1545,7 @@ async fn function_parse_geo_centroid() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1579,7 +1579,7 @@ async fn function_parse_geo_distance() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1599,7 +1599,7 @@ async fn function_parse_geo_hash_encode() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1616,7 +1616,7 @@ async fn function_parse_geo_hash_decode() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1646,7 +1646,7 @@ async fn function_parse_is_alphanum() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1668,7 +1668,7 @@ async fn function_parse_is_alpha() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1690,7 +1690,7 @@ async fn function_parse_is_ascii() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1712,7 +1712,7 @@ async fn function_parse_is_datetime() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1734,7 +1734,7 @@ async fn function_parse_is_domain() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1756,7 +1756,7 @@ async fn function_parse_is_email() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1778,7 +1778,7 @@ async fn function_parse_is_hexadecimal() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1800,7 +1800,7 @@ async fn function_parse_is_latitude() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1822,7 +1822,7 @@ async fn function_parse_is_longitude() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1844,7 +1844,7 @@ async fn function_parse_is_numeric() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1866,7 +1866,7 @@ async fn function_parse_is_semver() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1888,7 +1888,7 @@ async fn function_parse_is_url() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1910,7 +1910,7 @@ async fn function_parse_is_uuid() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1937,7 +1937,7 @@ async fn function_math_abs() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1964,7 +1964,7 @@ async fn function_math_bottom() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -1992,7 +1992,7 @@ async fn function_math_ceil() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2015,7 +2015,7 @@ async fn function_math_fixed() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -2043,7 +2043,7 @@ async fn function_math_floor() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2066,7 +2066,7 @@ async fn function_math_interquartile() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2092,7 +2092,7 @@ async fn function_math_max() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2119,7 +2119,7 @@ async fn function_math_mean() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2145,7 +2145,7 @@ async fn function_math_median() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2172,7 +2172,7 @@ async fn function_math_midhinge() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2198,7 +2198,7 @@ async fn function_math_min() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2225,7 +2225,7 @@ async fn function_math_mode() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2251,7 +2251,7 @@ async fn function_math_nearestrank() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2277,7 +2277,7 @@ async fn function_math_percentile() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2302,7 +2302,7 @@ async fn function_math_pow() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2325,7 +2325,7 @@ async fn function_math_product() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2351,7 +2351,7 @@ async fn function_math_round() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2374,7 +2374,7 @@ async fn function_math_spread() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2399,7 +2399,7 @@ async fn function_math_sqrt() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2422,7 +2422,7 @@ async fn function_math_stddev() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2448,7 +2448,7 @@ async fn function_math_sum() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2475,7 +2475,7 @@ async fn function_math_top() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -2504,7 +2504,7 @@ async fn function_math_trimean() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2530,7 +2530,7 @@ async fn function_math_variance() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2558,7 +2558,7 @@ async fn function_parse_meta_id() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2575,7 +2575,7 @@ async fn function_parse_meta_table() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2592,7 +2592,7 @@ async fn function_parse_meta_tb() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2619,7 +2619,7 @@ async fn function_not() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -2664,7 +2664,7 @@ async fn function_parse_email_host() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2681,7 +2681,7 @@ async fn function_parse_email_user() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2698,7 +2698,7 @@ async fn function_parse_url_domain() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2715,7 +2715,7 @@ async fn function_parse_url_fragment() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2732,7 +2732,7 @@ async fn function_parse_url_host() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2749,7 +2749,7 @@ async fn function_parse_url_path() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2766,7 +2766,7 @@ async fn function_parse_url_port() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2783,7 +2783,7 @@ async fn function_parse_url_query() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2800,7 +2800,7 @@ async fn function_parse_url_scheme() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2821,7 +2821,7 @@ async fn function_rand() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2837,7 +2837,7 @@ async fn function_rand_bool() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2853,7 +2853,7 @@ async fn function_rand_enum() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2870,7 +2870,7 @@ async fn function_rand_float() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2891,7 +2891,7 @@ async fn function_rand_guid() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2914,7 +2914,7 @@ async fn function_rand_int() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2935,7 +2935,7 @@ async fn function_rand_string() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2958,7 +2958,7 @@ async fn function_rand_time() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2977,7 +2977,7 @@ async fn function_rand_ulid() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2993,7 +2993,7 @@ async fn function_rand_uuid() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -3009,7 +3009,7 @@ async fn function_rand_uuid_v4() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -3025,7 +3025,7 @@ async fn function_rand_uuid_v7() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -3047,7 +3047,7 @@ async fn function_string_concat() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3086,7 +3086,7 @@ async fn function_string_contains() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 15);
 	// 1
 	let tmp = res.remove(0).result?;
@@ -3161,7 +3161,7 @@ async fn function_string_ends_with() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3188,7 +3188,7 @@ async fn function_string_join() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3215,7 +3215,7 @@ async fn function_string_len() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3242,7 +3242,7 @@ async fn function_string_lowercase() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3269,7 +3269,7 @@ async fn function_string_repeat() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3296,7 +3296,7 @@ async fn function_string_replace() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3323,7 +3323,7 @@ async fn function_string_reverse() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3354,7 +3354,7 @@ async fn function_string_slice() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -3397,7 +3397,7 @@ async fn function_string_slug() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3424,7 +3424,7 @@ async fn function_string_split() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3451,7 +3451,7 @@ async fn function_string_starts_with() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3478,7 +3478,7 @@ async fn function_string_trim() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3505,7 +3505,7 @@ async fn function_string_uppercase() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3532,7 +3532,7 @@ async fn function_string_words() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3563,7 +3563,7 @@ async fn function_time_ceil() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3589,7 +3589,7 @@ async fn function_time_day() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3611,7 +3611,7 @@ async fn function_time_floor() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3637,7 +3637,7 @@ async fn function_time_format() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3659,7 +3659,7 @@ async fn function_time_group() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3681,7 +3681,7 @@ async fn function_time_hour() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3702,7 +3702,7 @@ async fn function_time_minute() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3723,7 +3723,7 @@ async fn function_time_month() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3744,7 +3744,7 @@ async fn function_time_nano() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3764,7 +3764,7 @@ async fn function_time_now() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -3781,7 +3781,7 @@ async fn function_time_round() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3803,7 +3803,7 @@ async fn function_time_second() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3824,7 +3824,7 @@ async fn function_time_unix() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3845,7 +3845,7 @@ async fn function_time_wday() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3866,7 +3866,7 @@ async fn function_time_week() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3887,7 +3887,7 @@ async fn function_time_yday() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3908,7 +3908,7 @@ async fn function_time_year() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3929,7 +3929,7 @@ async fn function_time_from_micros() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3951,7 +3951,7 @@ async fn function_time_from_millis() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3973,7 +3973,7 @@ async fn function_time_from_secs() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3995,7 +3995,7 @@ async fn function_time_from_unix() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4021,7 +4021,7 @@ async fn function_type_bool() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4043,7 +4043,7 @@ async fn function_type_datetime() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4065,7 +4065,7 @@ async fn function_type_decimal() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4087,7 +4087,7 @@ async fn function_type_duration() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4109,7 +4109,7 @@ async fn function_type_float() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4131,7 +4131,7 @@ async fn function_type_int() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4153,7 +4153,7 @@ async fn function_type_number() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4175,7 +4175,7 @@ async fn function_type_point() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4213,7 +4213,7 @@ async fn function_type_string() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4235,7 +4235,7 @@ async fn function_type_table() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4259,7 +4259,7 @@ async fn function_type_thing() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/future.rs
+++ b/lib/tests/future.rs
@@ -14,7 +14,7 @@ async fn future_function_simple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -46,7 +46,7 @@ async fn future_function_arguments() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -93,7 +93,7 @@ async fn concurrency() -> Result<(), Error> {
 		let sql = query(limit, MILLIS);
 		let dbs = Datastore::new("memory").await?;
 		let ses = Session::for_kv().with_ns("test").with_db("test");
-		let res = dbs.execute(&sql, &ses, None, false).await;
+		let res = dbs.execute(&sql, &ses, None, Default::default()).await;
 
 		if matches!(res, Err(Error::QueryTimedout)) {
 			Ok(false)

--- a/lib/tests/geometry.rs
+++ b/lib/tests/geometry.rs
@@ -13,7 +13,7 @@ async fn geometry_point() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -70,7 +70,7 @@ async fn geometry_polygon() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -163,7 +163,7 @@ async fn geometry_multipoint() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -241,7 +241,7 @@ async fn geometry_multipolygon() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/group.rs
+++ b/lib/tests/group.rs
@@ -22,7 +22,7 @@ async fn select_limit_fetch() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 11);
 	//
 	let tmp = res.remove(0).result?;
@@ -246,7 +246,7 @@ async fn select_multi_aggregate() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result?;
@@ -351,7 +351,7 @@ async fn select_multi_aggregate_composed() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/insert.rs
+++ b/lib/tests/insert.rs
@@ -16,7 +16,7 @@ async fn insert_statement_object_single() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -44,7 +44,7 @@ async fn insert_statement_object_multiple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -66,7 +66,7 @@ async fn insert_statement_values_single() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -83,7 +83,7 @@ async fn insert_statement_values_multiple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -105,7 +105,7 @@ async fn insert_statement_values_retable_id() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -128,7 +128,7 @@ async fn insert_statement_on_duplicate_key() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -149,7 +149,7 @@ async fn insert_statement_output() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/limit.rs
+++ b/lib/tests/limit.rs
@@ -17,7 +17,7 @@ async fn select_limit_fetch() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/merge.rs
+++ b/lib/tests/merge.rs
@@ -19,7 +19,7 @@ async fn merge_record() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/model.rs
+++ b/lib/tests/model.rs
@@ -13,7 +13,7 @@ async fn model_count() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -38,7 +38,7 @@ async fn model_range() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/param.rs
+++ b/lib/tests/param.rs
@@ -16,7 +16,7 @@ async fn define_global_param() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -59,7 +59,7 @@ async fn define_protected_param() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/relate.rs
+++ b/lib/tests/relate.rs
@@ -14,7 +14,7 @@ async fn relate_with_parameters() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -51,7 +51,7 @@ async fn relate_and_overwrite() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -15,7 +15,7 @@ async fn remove_statement_table() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -49,7 +49,7 @@ async fn remove_statement_analyzer() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	// Analyzer is defined
 	let tmp = res.remove(0).result;

--- a/lib/tests/script.rs
+++ b/lib/tests/script.rs
@@ -19,7 +19,7 @@ async fn script_function_error() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -46,7 +46,7 @@ async fn script_function_simple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -75,7 +75,7 @@ async fn script_function_context() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -109,7 +109,7 @@ async fn script_function_arguments() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -152,7 +152,7 @@ async fn script_function_types() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -182,7 +182,7 @@ async fn script_function_module_os() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -15,7 +15,7 @@ async fn select_field_value() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -77,7 +77,7 @@ async fn select_writeable_subqueries() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/strict.rs
+++ b/lib/tests/strict.rs
@@ -2,7 +2,7 @@ mod parse;
 use parse::Parse;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
+use surrealdb::kvs::{DsOpts, Datastore};
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -17,7 +17,7 @@ async fn strict_mode_no_namespace() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, true).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, DsOpts::default().strict(true)).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -75,7 +75,7 @@ async fn strict_mode_no_database() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, true).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, DsOpts::default().strict(true)).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -128,7 +128,7 @@ async fn strict_mode_no_table() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, true).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, DsOpts::default().strict(true)).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -176,7 +176,7 @@ async fn strict_mode_all_ok() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, true).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, DsOpts::default().strict(true)).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result;
@@ -215,7 +215,7 @@ async fn loose_mode_all_ok() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/strict.rs
+++ b/lib/tests/strict.rs
@@ -2,7 +2,7 @@ mod parse;
 use parse::Parse;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::{DsOpts, Datastore};
+use surrealdb::kvs::{Datastore, DsOpts};
 use surrealdb::sql::Value;
 
 #[tokio::test]

--- a/lib/tests/subquery.rs
+++ b/lib/tests/subquery.rs
@@ -25,7 +25,7 @@ async fn subquery_select() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -137,7 +137,7 @@ async fn subquery_ifelse_set() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result?;
@@ -252,7 +252,7 @@ async fn subquery_ifelse_array() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/table.rs
+++ b/lib/tests/table.rs
@@ -28,7 +28,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/typing.rs
+++ b/lib/tests/typing.rs
@@ -20,7 +20,7 @@ async fn strict_typing_inline() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result;
@@ -144,7 +144,7 @@ async fn strict_typing_defined() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 8);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/update.rs
+++ b/lib/tests/update.rs
@@ -31,7 +31,7 @@ async fn update_simple_with_input() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -111,7 +111,7 @@ async fn update_complex_with_input() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/yuse.rs
+++ b/lib/tests/yuse.rs
@@ -14,7 +14,7 @@ async fn use_statement_set_ns() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -40,7 +40,7 @@ async fn use_statement_set_db() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -66,7 +66,7 @@ async fn use_statement_set_both() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None, Default::default()).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,11 +1,12 @@
 use once_cell::sync::OnceCell;
+use surrealdb::kvs::DsOpts;
 use std::{net::SocketAddr, path::PathBuf};
 
 pub static CF: OnceCell<Config> = OnceCell::new();
 
 #[derive(Clone, Debug)]
 pub struct Config {
-	pub strict: bool,
+	pub ds_opts: DsOpts,
 	pub bind: SocketAddr,
 	pub path: String,
 	pub user: String,

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,6 +1,6 @@
 use once_cell::sync::OnceCell;
-use surrealdb::kvs::DsOpts;
 use std::{net::SocketAddr, path::PathBuf};
+use surrealdb::kvs::DsOpts;
 
 pub static CF: OnceCell<Config> = OnceCell::new();
 

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -10,10 +10,10 @@ use crate::iam;
 use crate::net;
 use clap::Args;
 use ipnet::IpNet;
-use surrealdb::kvs::DsOpts;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
+use surrealdb::kvs::DsOpts;
 
 #[derive(Args, Debug)]
 pub struct StartCommandArguments {
@@ -113,7 +113,7 @@ pub async fn init(
 	}
 	// Setup the cli options
 	let _ = config::CF.set(Config {
-		ds_opts: DsOpts{
+		ds_opts: DsOpts {
 			strict,
 			query_timeout,
 		},

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::{path::{Path, PathBuf}, time::Duration, str::FromStr};
 
 pub(crate) mod parser;
 
@@ -62,4 +62,8 @@ pub(crate) fn key_valid(v: &str) -> Result<String, String> {
 		32 => Ok(v.to_string()),
 		_ => Err(String::from("Ensure your database encryption key is 16, 24, or 32 bytes long")),
 	}
+}
+
+pub(crate) fn duration(v: &str) -> Result<Duration, String> {
+	surrealdb::sql::Duration::from_str(v).map(|d| d.0).map_err(|_| String::from("invalid duration"))
 }

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -1,4 +1,8 @@
-use std::{path::{Path, PathBuf}, time::Duration, str::FromStr};
+use std::{
+	path::{Path, PathBuf},
+	str::FromStr,
+	time::Duration,
+};
 
 pub(crate) mod parser;
 

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -11,7 +11,7 @@ pub async fn init() -> Result<(), Error> {
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 	// Log authentication options
-	match opt.strict {
+	match opt.ds_opts.strict {
 		true => info!(target: LOG, "Database strict mode is enabled"),
 		false => info!(target: LOG, "Database strict mode is disabled"),
 	};

--- a/src/iam/signin.rs
+++ b/src/iam/signin.rs
@@ -113,7 +113,7 @@ pub async fn sc(
 					// Setup the query session
 					let sess = Session::for_db(&ns, &db);
 					// Compute the value with the params
-					match kvs.compute(val, &sess, vars, opt.strict).await {
+					match kvs.compute(val, &sess, vars, opt.ds_opts).await {
 						// The signin value succeeded
 						Ok(val) => match val.record() {
 							// There is a record returned

--- a/src/iam/signup.rs
+++ b/src/iam/signup.rs
@@ -54,7 +54,7 @@ pub async fn sc(
 					// Setup the query session
 					let sess = Session::for_db(&ns, &db);
 					// Compute the value with the params
-					match kvs.compute(val, &sess, vars, opt.strict).await {
+					match kvs.compute(val, &sess, vars, opt.ds_opts).await {
 						// The signin value succeeded
 						Ok(val) => match val.record() {
 							// There is a record returned

--- a/src/net/import.rs
+++ b/src/net/import.rs
@@ -38,7 +38,7 @@ async fn handler(
 			// Convert the body to a byte slice
 			let sql = bytes_to_utf8(&sql)?;
 			// Execute the sql query in the database
-			match db.execute(sql, &session, None, opt.strict).await {
+			match db.execute(sql, &session, None, opt.ds_opts).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
 					"application/json" => Ok(output::json(&output::simplify(res))),

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -169,7 +169,7 @@ async fn select_all(
 		String::from("table") => Value::from(table),
 	};
 	// Execute the query and return the result
-	match db.execute(sql.as_str(), &session, Some(vars), opt.strict).await {
+	match db.execute(sql.as_str(), &session, Some(vars), opt.ds_opts).await {
 		Ok(ref res) => match output.as_ref() {
 			// Simple serialization
 			"application/json" => Ok(output::json(&output::simplify(res))),
@@ -210,7 +210,7 @@ async fn create_all(
 				=> params.parse()
 			};
 			// Execute the query and return the result
-			match db.execute(sql, &session, Some(vars), opt.strict).await {
+			match db.execute(sql, &session, Some(vars), opt.ds_opts).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
 					"application/json" => Ok(output::json(&output::simplify(res))),
@@ -254,7 +254,7 @@ async fn update_all(
 				=> params.parse()
 			};
 			// Execute the query and return the result
-			match db.execute(sql, &session, Some(vars), opt.strict).await {
+			match db.execute(sql, &session, Some(vars), opt.ds_opts).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
 					"application/json" => Ok(output::json(&output::simplify(res))),
@@ -298,7 +298,7 @@ async fn modify_all(
 				=> params.parse()
 			};
 			// Execute the query and return the result
-			match db.execute(sql, &session, Some(vars), opt.strict).await {
+			match db.execute(sql, &session, Some(vars), opt.ds_opts).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
 					"application/json" => Ok(output::json(&output::simplify(res))),
@@ -335,7 +335,7 @@ async fn delete_all(
 		=> params.parse()
 	};
 	// Execute the query and return the result
-	match db.execute(sql, &session, Some(vars), opt.strict).await {
+	match db.execute(sql, &session, Some(vars), opt.ds_opts).await {
 		Ok(res) => match output.as_ref() {
 			// Simple serialization
 			"application/json" => Ok(output::json(&output::simplify(res))),
@@ -378,7 +378,7 @@ async fn select_one(
 		String::from("id") => rid,
 	};
 	// Execute the query and return the result
-	match db.execute(sql, &session, Some(vars), opt.strict).await {
+	match db.execute(sql, &session, Some(vars), opt.ds_opts).await {
 		Ok(res) => match output.as_ref() {
 			// Simple serialization
 			"application/json" => Ok(output::json(&output::simplify(res))),
@@ -426,7 +426,7 @@ async fn create_one(
 				=> params.parse()
 			};
 			// Execute the query and return the result
-			match db.execute(sql, &session, Some(vars), opt.strict).await {
+			match db.execute(sql, &session, Some(vars), opt.ds_opts).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
 					"application/json" => Ok(output::json(&output::simplify(res))),
@@ -477,7 +477,7 @@ async fn update_one(
 				=> params.parse()
 			};
 			// Execute the query and return the result
-			match db.execute(sql, &session, Some(vars), opt.strict).await {
+			match db.execute(sql, &session, Some(vars), opt.ds_opts).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
 					"application/json" => Ok(output::json(&output::simplify(res))),
@@ -528,7 +528,7 @@ async fn modify_one(
 				=> params.parse()
 			};
 			// Execute the query and return the result
-			match db.execute(sql, &session, Some(vars), opt.strict).await {
+			match db.execute(sql, &session, Some(vars), opt.ds_opts).await {
 				Ok(res) => match output.as_ref() {
 					// Simple serialization
 					"application/json" => Ok(output::json(&output::simplify(res))),
@@ -572,7 +572,7 @@ async fn delete_one(
 		=> params.parse()
 	};
 	// Execute the query and return the result
-	match db.execute(sql, &session, Some(vars), opt.strict).await {
+	match db.execute(sql, &session, Some(vars), opt.ds_opts).await {
 		Ok(res) => match output.as_ref() {
 			// Simple serialization
 			"application/json" => Ok(output::json(&output::simplify(res))),

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -419,7 +419,7 @@ impl Rpc {
 		// Specify the SQL query string
 		let sql = "SELECT * FROM $auth";
 		// Execute the query on the database
-		let mut res = kvs.execute(sql, &self.session, None, opt.strict).await?;
+		let mut res = kvs.execute(sql, &self.session, None, opt.ds_opts).await?;
 		// Extract the first value from the result
 		let res = res.remove(0).result?.first();
 		// Return the result to the client
@@ -465,7 +465,7 @@ impl Rpc {
 			=> &self.vars
 		});
 		// Execute the query on the database
-		let mut res = kvs.execute(sql, &self.session, var, opt.strict).await?;
+		let mut res = kvs.execute(sql, &self.session, var, opt.ds_opts).await?;
 		// Extract the first query result
 		let res = res.remove(0).result?;
 		// Return the result to the client
@@ -486,7 +486,7 @@ impl Rpc {
 			=> &self.vars
 		});
 		// Execute the query on the database
-		let mut res = kvs.execute(sql, &self.session, var, opt.strict).await?;
+		let mut res = kvs.execute(sql, &self.session, var, opt.ds_opts).await?;
 		// Extract the first query result
 		let res = res.remove(0).result?;
 		// Return the result to the client
@@ -513,7 +513,7 @@ impl Rpc {
 			=> &self.vars
 		});
 		// Execute the query on the database
-		let mut res = kvs.execute(sql, &self.session, var, opt.strict).await?;
+		let mut res = kvs.execute(sql, &self.session, var, opt.ds_opts).await?;
 		// Extract the first query result
 		let res = match one {
 			true => res.remove(0).result?.first(),
@@ -544,7 +544,7 @@ impl Rpc {
 			=> &self.vars
 		});
 		// Execute the query on the database
-		let mut res = kvs.execute(sql, &self.session, var, opt.strict).await?;
+		let mut res = kvs.execute(sql, &self.session, var, opt.ds_opts).await?;
 		// Extract the first query result
 		let res = match one {
 			true => res.remove(0).result?.first(),
@@ -575,7 +575,7 @@ impl Rpc {
 			=> &self.vars
 		});
 		// Execute the query on the database
-		let mut res = kvs.execute(sql, &self.session, var, opt.strict).await?;
+		let mut res = kvs.execute(sql, &self.session, var, opt.ds_opts).await?;
 		// Extract the first query result
 		let res = match one {
 			true => res.remove(0).result?.first(),
@@ -606,7 +606,7 @@ impl Rpc {
 			=> &self.vars
 		});
 		// Execute the query on the database
-		let mut res = kvs.execute(sql, &self.session, var, opt.strict).await?;
+		let mut res = kvs.execute(sql, &self.session, var, opt.ds_opts).await?;
 		// Extract the first query result
 		let res = match one {
 			true => res.remove(0).result?.first(),
@@ -637,7 +637,7 @@ impl Rpc {
 			=> &self.vars
 		});
 		// Execute the query on the database
-		let mut res = kvs.execute(sql, &self.session, var, opt.strict).await?;
+		let mut res = kvs.execute(sql, &self.session, var, opt.ds_opts).await?;
 		// Extract the first query result
 		let res = match one {
 			true => res.remove(0).result?.first(),
@@ -667,7 +667,7 @@ impl Rpc {
 			=> &self.vars
 		});
 		// Execute the query on the database
-		let mut res = kvs.execute(sql, &self.session, var, opt.strict).await?;
+		let mut res = kvs.execute(sql, &self.session, var, opt.ds_opts).await?;
 		// Extract the first query result
 		let res = match one {
 			true => res.remove(0).result?.first(),
@@ -690,7 +690,7 @@ impl Rpc {
 		// Specify the query parameters
 		let var = Some(self.vars.clone());
 		// Execute the query on the database
-		let res = kvs.execute(&sql, &self.session, var, opt.strict).await?;
+		let res = kvs.execute(&sql, &self.session, var, opt.ds_opts).await?;
 		// Return the result to the client
 		Ok(res)
 	}
@@ -704,7 +704,7 @@ impl Rpc {
 		// Specify the query parameters
 		let var = Some(mrg! { vars.0, &self.vars });
 		// Execute the query on the database
-		let res = kvs.execute(&sql, &self.session, var, opt.strict).await?;
+		let res = kvs.execute(&sql, &self.session, var, opt.ds_opts).await?;
 		// Return the result to the client
 		Ok(res)
 	}

--- a/src/net/sql.rs
+++ b/src/net/sql.rs
@@ -50,7 +50,7 @@ async fn handler(
 	// Convert the received sql query
 	let sql = bytes_to_utf8(&sql)?;
 	// Execute the received sql query
-	match db.execute(sql, &session, params.parse().into(), opt.strict).await {
+	match db.execute(sql, &session, params.parse().into(), opt.ds_opts).await {
 		// Convert the response to JSON
 		Ok(res) => match output.as_ref() {
 			// Simple serialization
@@ -79,7 +79,7 @@ async fn socket(ws: WebSocket, session: Session) {
 				// Get local copy of options
 				let opt = CF.get().unwrap();
 				// Execute the received sql query
-				let _ = match db.execute(sql, &session, None, opt.strict).await {
+				let _ = match db.execute(sql, &session, None, opt.ds_opts).await {
 					// Convert the response to JSON
 					Ok(v) => match serde_json::to_string(&v) {
 						// Send the JSON response to the client


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Long-running or infinite queries consume server resources. 

## What does this change do?

- Adds a `--query-timeout <duration>` flag (or `SURREAL_QUERY_TIMEOUT` env var) to set a global query timeout (default is no timeout)
- Replaces `strict: bool` with `ds_opts: DsOpts` to allow more settings to be passed to the `Datastore` in the future (txn timeouts, http limits, scripting limits, etc.)

## Alternative implementation strategy

See #2097 for an alternate implementation strategy.

## What is your testing strategy?

Adds new CLI tests

## Is this related to any issues?

SUR-214

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
