### PR TITLE
Security - Add global query timeouts (attempt 2).

### DIFF
--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -316,6 +316,11 @@ impl<'a> Executor<'a> {
 									// There is no timeout clause
 									None => stm.compute(&ctx, &opt, &self.txn(), None).await,
 								};
+								// Catch global timeout
+								let res = match ctx.is_timedout() {
+									true => Err(Error::QueryTimedout),
+									false => res,
+								};
 								// Finalise transaction and return the result.
 								if res.is_ok() && stm.writeable() {
 									if let Err(e) = self.commit(loc).await {

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -4,7 +4,7 @@ use crate::cli::validator::parser::env_filter::CustomEnvFilter;
 use crate::cli::validator::parser::env_filter::CustomEnvFilterParser;
 use crate::cnf::LOGO;
 use crate::dbs;
-use crate::dbs::StartCommandDsOptions;
+use crate::dbs::StartCommandDbsOptions;
 use crate::env;
 use crate::err::Error;
 use crate::iam;
@@ -37,7 +37,7 @@ pub struct StartCommandArguments {
 	#[arg(default_value = "0.0.0.0:8000")]
 	listen_addresses: Vec<SocketAddr>,
 	#[command(flatten)]
-	ds: StartCommandDsOptions,
+	dbs: StartCommandDbsOptions,
 	#[arg(help = "Encryption key to use for on-disk encryption")]
 	#[arg(env = "SURREAL_KEY", short = 'k', long = "key")]
 	#[arg(value_parser = super::validator::key_valid)]
@@ -92,7 +92,7 @@ pub async fn init(
 		username: user,
 		password: pass,
 		listen_addresses,
-		ds,
+		dbs,
 		web,
 		strict,
 		log: CustomEnvFilter(log),
@@ -123,7 +123,7 @@ pub async fn init(
 	// Initiate master auth
 	iam::init().await?;
 	// Start the kvs server
-	dbs::init(ds).await?;
+	dbs::init(dbs).await?;
 	// Start the web server
 	net::init().await?;
 	// All ok

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -4,6 +4,7 @@ use crate::cli::validator::parser::env_filter::CustomEnvFilter;
 use crate::cli::validator::parser::env_filter::CustomEnvFilterParser;
 use crate::cnf::LOGO;
 use crate::dbs;
+use crate::dbs::StartCommandDsOptions;
 use crate::env;
 use crate::err::Error;
 use crate::iam;
@@ -35,6 +36,8 @@ pub struct StartCommandArguments {
 	#[arg(env = "SURREAL_BIND", short = 'b', long = "bind")]
 	#[arg(default_value = "0.0.0.0:8000")]
 	listen_addresses: Vec<SocketAddr>,
+	#[command(flatten)]
+	ds: StartCommandDsOptions,
 	#[arg(help = "Encryption key to use for on-disk encryption")]
 	#[arg(env = "SURREAL_KEY", short = 'k', long = "key")]
 	#[arg(value_parser = super::validator::key_valid)]
@@ -89,6 +92,7 @@ pub async fn init(
 		username: user,
 		password: pass,
 		listen_addresses,
+		ds,
 		web,
 		strict,
 		log: CustomEnvFilter(log),
@@ -119,7 +123,7 @@ pub async fn init(
 	// Initiate master auth
 	iam::init().await?;
 	// Start the kvs server
-	dbs::init().await?;
+	dbs::init(ds).await?;
 	// Start the web server
 	net::init().await?;
 	// All ok

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -1,4 +1,8 @@
-use std::path::{Path, PathBuf};
+use std::{
+	path::{Path, PathBuf},
+	str::FromStr,
+	time::Duration,
+};
 
 pub(crate) mod parser;
 
@@ -62,4 +66,8 @@ pub(crate) fn key_valid(v: &str) -> Result<String, String> {
 		32 => Ok(v.to_string()),
 		_ => Err(String::from("Ensure your database encryption key is 16, 24, or 32 bytes long")),
 	}
+}
+
+pub(crate) fn duration(v: &str) -> Result<Duration, String> {
+	surrealdb::sql::Duration::from_str(v).map(|d| d.0).map_err(|_| String::from("invalid duration"))
 }

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -1,5 +1,8 @@
+use std::time::Duration;
+
 use crate::cli::CF;
 use crate::err::Error;
+use clap::Args;
 use once_cell::sync::OnceCell;
 use surrealdb::kvs::Datastore;
 
@@ -7,7 +10,19 @@ pub static DB: OnceCell<Datastore> = OnceCell::new();
 
 const LOG: &str = "surrealdb::dbs";
 
-pub async fn init() -> Result<(), Error> {
+#[derive(Args, Debug)]
+pub struct StartCommandDsOptions {
+	#[arg(help = "The maximum duration of any query")]
+	#[arg(env = "SURREAL_QUERY_TIMEOUT", long)]
+	#[arg(value_parser = super::cli::validator::duration)]
+	query_timeout: Option<Duration>,
+}
+
+pub async fn init(
+	StartCommandDsOptions {
+		query_timeout,
+	}: StartCommandDsOptions,
+) -> Result<(), Error> {
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 	// Log authentication options
@@ -16,7 +31,7 @@ pub async fn init() -> Result<(), Error> {
 		false => info!(target: LOG, "Database strict mode is disabled"),
 	};
 	// Parse and setup the desired kv datastore
-	let dbs = Datastore::new(&opt.path).await?;
+	let dbs = Datastore::new(&opt.path).await?.query_timeout(query_timeout);
 	// Store database instance
 	let _ = DB.set(dbs);
 	// All ok

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -11,7 +11,7 @@ pub static DB: OnceCell<Datastore> = OnceCell::new();
 const LOG: &str = "surrealdb::dbs";
 
 #[derive(Args, Debug)]
-pub struct StartCommandDsOptions {
+pub struct StartCommandDbsOptions {
 	#[arg(help = "The maximum duration of any query")]
 	#[arg(env = "SURREAL_QUERY_TIMEOUT", long)]
 	#[arg(value_parser = super::cli::validator::duration)]
@@ -19,9 +19,9 @@ pub struct StartCommandDsOptions {
 }
 
 pub async fn init(
-	StartCommandDsOptions {
+	StartCommandDbsOptions {
 		query_timeout,
-	}: StartCommandDsOptions,
+	}: StartCommandDbsOptions,
 ) -> Result<(), Error> {
 	// Get local copy of options
 	let opt = CF.get().unwrap();


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Long-running or infinite queries consume server resources. 

## What does this change do?

Adds a `--query-timeout <duration>` flag (or `SURREAL_QUERY_TIMEOUT` env var) to set a global query timeout (default is no timeout)

## Alternative implementation strategy

See #2096 for my previous (worse?) attempt.

## What is your testing strategy?

Adds new CLI tests

## Is this related to any issues?

SUR-214

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
