### PR TITLE
Security - Limit output size of all string functions.

### DIFF
--- a/lib/src/fnc/string.rs
+++ b/lib/src/fnc/string.rs
@@ -39,7 +39,10 @@ pub fn join(args: Vec<Value>) -> Result<Value, Error> {
 	let strings = args.collect::<Vec<_>>();
 	limit(
 		"string::join",
-		strings.len().saturating_mul(chr.len() + strings.iter().map(String::len).sum::<usize>()),
+		strings
+			.len()
+			.saturating_mul(chr.len())
+			.saturating_add(strings.iter().map(String::len).sum::<usize>()),
 	)?;
 
 	// FIXME: Use intersperse to avoid intermediate allocation once stable

--- a/lib/src/fnc/string.rs
+++ b/lib/src/fnc/string.rs
@@ -2,8 +2,23 @@ use crate::err::Error;
 use crate::fnc::util::string;
 use crate::sql::value::Value;
 
+/// Returns `true` if a string of this length is too much to allocate.
+fn limit(name: &str, n: usize) -> Result<(), Error> {
+	const LIMIT: usize = 2usize.pow(20);
+	if n > LIMIT {
+		Err(Error::InvalidArguments {
+			name: name.to_owned(),
+			message: format!("Output must not exceed {LIMIT} bytes."),
+		})
+	} else {
+		Ok(())
+	}
+}
+
 pub fn concat(args: Vec<Value>) -> Result<Value, Error> {
-	Ok(args.into_iter().map(|x| x.as_string()).collect::<Vec<_>>().concat().into())
+	let strings = args.into_iter().map(Value::as_string).collect::<Vec<_>>();
+	limit("string::concat", strings.iter().map(String::len).sum::<usize>())?;
+	Ok(strings.concat().into())
 }
 
 pub fn contains((val, check): (String, String)) -> Result<Value, Error> {
@@ -20,10 +35,16 @@ pub fn join(args: Vec<Value>) -> Result<Value, Error> {
 		name: String::from("string::join"),
 		message: String::from("Expected at least one argument"),
 	})?;
+
+	let strings = args.collect::<Vec<_>>();
+	limit(
+		"string::join",
+		strings.len().saturating_mul(chr.len() + strings.iter().map(String::len).sum::<usize>()),
+	)?;
+
 	// FIXME: Use intersperse to avoid intermediate allocation once stable
 	// https://github.com/rust-lang/rust/issues/79524
-	let val = args.collect::<Vec<_>>().join(&chr);
-	Ok(val.into())
+	Ok(strings.join(&chr).into())
 }
 
 pub fn len((string,): (String,)) -> Result<Value, Error> {
@@ -36,18 +57,18 @@ pub fn lowercase((string,): (String,)) -> Result<Value, Error> {
 }
 
 pub fn repeat((val, num): (String, usize)) -> Result<Value, Error> {
-	const LIMIT: usize = 2usize.pow(20);
-	if val.len().saturating_mul(num) > LIMIT {
-		Err(Error::InvalidArguments {
-			name: String::from("string::repeat"),
-			message: format!("Output must not exceed {LIMIT} bytes."),
-		})
-	} else {
-		Ok(val.repeat(num).into())
-	}
+	limit("string::repeat", val.len().saturating_mul(num))?;
+	Ok(val.repeat(num).into())
 }
 
 pub fn replace((val, old, new): (String, String, String)) -> Result<Value, Error> {
+	if new.len() > old.len() {
+		let increase = new.len() - old.len();
+		limit(
+			"string::replace",
+			val.len().saturating_add(val.matches(&old).count().saturating_mul(increase)),
+		)?;
+	}
 	Ok(val.replace(&old, &new).into())
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

In a previous PR, I limited the output size of `string::repeat`. However, other string functions are also capable of producing excessively long strings, which could deprive the SurrealDB server of memory.

## What does this change do?

Limits the output size of any string function that could possibly increase the length of its inputs (to 2^20 = 1048576 bytes).

## What is your testing strategy?

```
create foo set bar = string::replace(string::repeat("a", 1000), "a", string::repeat("a", 10000));
There was a problem with the database: Incorrect arguments for function string::replace(). Output must not exceed 1048576 bytes.
```

Awaiting CI.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
