### PR TITLE
Add precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos: 
+- repo: local
+  hooks:
+    - id: fmt
+      name: fmt
+      description: Format files with cargo fmt.
+      entry: cargo fmt
+      language: system
+      types: [rust]
+      args: ["--all", "--", "--check"]
+    - id: clippy
+      name: clippy
+      description: Lint rust sources
+      entry: cargo clippy
+      language: system
+      args: ["--", "-W", "warnings"]
+      types: [rust]
+      pass_filenames: false
+
+
+ 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,3 @@ repos:
       args: ["--", "-W", "warnings"]
       types: [rust]
       pass_filenames: false
-
-
- 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,45 +117,51 @@ Where `TYPE` can be one of the following:
 For the initial start, fork the project and use git clone command to download the repository to your computer. A standard procedure for working on an issue would be to:
 
 1. Clone the `surrealdb` repository and download to your computer.
-```bash
-git clone https://github.com/surrealdb/surrealdb
-```
+    ```bash
+    git clone https://github.com/surrealdb/surrealdb
+    ```
 
-1. Pull all changes from the upstream `main` branch, before creating a new branch - to ensure that your `main` branch is up-to-date with the latest changes:
-```bash
-git pull
-```
+    (Optional): Install [pre-commit](https://pre-commit.com/#install) to run the checks before each commit and run:
 
-2. Create new branch from `main` like: `bugfix-548-ensure-queries-execute-sequentially`:
-```bash
-git checkout -b "[the name of your branch]"
-```
+    ```bash
+    pre-commit install
+    ```
 
-3. Make changes to the code, and ensure all code changes are formatted correctly:
-```bash
-cargo fmt
-```
+2. Pull all changes from the upstream `main` branch, before creating a new branch - to ensure that your `main` branch is up-to-date with the latest changes:
+    ```bash
+    git pull
+    ```
 
-4. Commit your changes when finished:
-```bash
-git add -A
-git commit -m "[your commit message]"
-```
+3. Create new branch from `main` like: `bugfix-548-ensure-queries-execute-sequentially`:
+    ```bash
+    git checkout -b "[the name of your branch]"
+    ```
 
-5. Push changes to GitHub:
-```bash
-git push origin "[the name of your branch]"
-```
+4. Make changes to the code, and ensure all code changes are formatted correctly:
+    ```bash
+    cargo fmt
+    ```
 
-6. Submit your changes for review, by going to your repository on GitHub and clicking the `Compare & pull request` button.
+5. Commit your changes when finished:
+    ```bash
+    git add -A
+    git commit -m "[your commit message]"
+    ```
 
-7. Ensure that you have entered a commit message which details about the changes, and what the pull request is for.
+6. Push changes to GitHub:
+    ```bash
+    git push origin "[the name of your branch]"
+    ```
 
-8. Now submit the pull request by clicking the `Create pull request` button.
+7. Submit your changes for review, by going to your repository on GitHub and clicking the `Compare & pull request` button.
 
-9. Wait for code review and approval.
+8. Ensure that you have entered a commit message which details about the changes, and what the pull request is for.
 
-10. After approval, merge your pull request.
+9. Now submit the pull request by clicking the `Create pull request` button.
+
+10. Wait for code review and approval.
+
+11. After approval, merge your pull request.
 
 ## Other Ways to Help
 

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,7 @@
             hardeningDisable = [ "fortify" ];
 
             depsBuildBuild = buildSpec.depsBuildBuild or [ ]
-              ++ [ rustToolchain ] ++ (with pkgs; [ nixfmt cargo-watch wasm-pack ]);
+              ++ [ rustToolchain ] ++ (with pkgs; [ nixfmt cargo-watch wasm-pack pre-commit]);
 
             inherit (util) SURREAL_BUILD_METADATA;
           })) util.platforms);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Verify code before creating commits.

## What does this change do?

Add pre-commit hooks to run cargo fmt and cargo clippy  

## What is your testing strategy?

I tested manually: 
* Commit without failures
* Commit with failures in cargo fmt
* Commit with failures in cargo clippy 

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
