### PR TITLE
Add two failing index tests

### DIFF
--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -924,6 +924,108 @@ async fn define_statement_index_multiple_unique_existing() -> Result<(), Error> 
 }
 
 #[tokio::test]
+#[ignore]
+async fn define_statement_index_single_unique_embedded_multiple() -> Result<(), Error> {
+	let sql = "
+		DEFINE INDEX test ON user FIELDS tags UNIQUE;
+		DEFINE INDEX test ON user COLUMNS tags UNIQUE;
+		INFO FOR TABLE user;
+		CREATE user:1 SET tags = ['one', 'two'];
+		CREATE user:2 SET tags = ['two', 'three'];
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	assert_eq!(res.len(), 5);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"{
+			events: {},
+			fields: {},
+			tables: {},
+			indexes: { test: 'DEFINE INDEX test ON user FIELDS tags UNIQUE' },
+		}",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[{ id: user:1, tags: ['one', 'two'] }]");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == "Database index `test` already contains `user:2`"
+	));
+	//
+	Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn define_statement_index_multiple_unique_embedded_multiple() -> Result<(), Error> {
+	let sql = "
+		DEFINE INDEX test ON user FIELDS account, tags UNIQUE;
+		DEFINE INDEX test ON user COLUMNS account, tags UNIQUE;
+		INFO FOR TABLE user;
+		CREATE user:1 SET account = 'apple', tags = ['one', 'two'];
+		CREATE user:2 SET account = 'tesla', tags = ['one', 'two'];
+		CREATE user:3 SET account = 'apple', tags = ['two', 'three'];
+		CREATE user:4 SET account = 'tesla', tags = ['two', 'three'];
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	assert_eq!(res.len(), 7);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"{
+			events: {},
+			fields: {},
+			tables: {},
+			indexes: { test: 'DEFINE INDEX test ON user FIELDS account, tags UNIQUE' },
+		}",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[{ id: user:1, account: 'apple', tags: ['one', 'two'] }]");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[{ id: user:1, account: 'tesla', tags: ['one', 'two'] }]");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == "Database index `test` already contains `user:3`"
+	));
+	//
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == "Database index `test` already contains `user:4`"
+	));
+	//
+	Ok(())
+}
+
+#[tokio::test]
 async fn define_statement_analyzer() -> Result<(), Error> {
 	let sql = "
 		DEFINE ANALYZER english TOKENIZERS blank,class FILTERS lowercase,snowball(english);

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -935,7 +935,7 @@ async fn define_statement_index_single_unique_embedded_multiple() -> Result<(), 
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -982,7 +982,7 @@ async fn define_statement_index_multiple_unique_embedded_multiple() -> Result<()
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(&sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

To keep track of index tests which currently fail, but which should work in due course.

## What does this change do?

Adds the failing tests, but currently sets them to `#[ignore]`

## What is your testing strategy?

This pull request does not change any code, it only adds some failing tests which are currently ignored.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
