### PR TITLE
fix: Value equal implementation in the Bool match case

### DIFF
--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2248,7 +2248,10 @@ impl Value {
 		match self {
 			Value::None => other.is_none(),
 			Value::Null => other.is_null(),
-			Value::Bool(v) => *v,
+			Value::Bool(v) => match other {
+				Value::Bool(w) => v == w,
+				_ => false,
+			},
 			Value::Uuid(v) => match other {
 				Value::Uuid(w) => v == w,
 				Value::Regex(w) => w.regex().is_match(v.to_raw().as_str()),

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -116,12 +116,13 @@ async fn select_where_field_is_bool() -> Result<(), Error> {
 		CREATE test:3 SET active = true;
 		SELECT * FROM test WHERE active = false;
 		SELECT * FROM test WHERE active != true;
+		SELECT * FROM test WHERE active = true;
 	";
 
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
-	assert_eq!(res.len(), 5);
+	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
@@ -181,6 +182,17 @@ async fn select_where_field_is_bool() -> Result<(), Error> {
 			{
 				id: test:2,
 				active: false
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:3,
+				active: true
 			}
 		]",
 	);

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -107,3 +107,84 @@ async fn select_writeable_subqueries() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn t() -> Result<(), Error> {
+	let sql = "
+		CREATE test:1 SET active = false;
+		CREATE test:2 SET active = false;
+		CREATE test:3 SET active = true;
+		SELECT * FROM test WHERE active = false;
+		SELECT * FROM test WHERE active != true;
+	";
+
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	assert_eq!(res.len(), 5);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+				active: false
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:2,
+				active: false
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:3,
+				active: true
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+				active: false
+			},
+			{
+				id: test:2,
+				active: false
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+				active: false
+			},
+			{
+				id: test:2,
+				active: false
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+
+	Ok(())
+}

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -109,7 +109,7 @@ async fn select_writeable_subqueries() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn t() -> Result<(), Error> {
+async fn select_where_field_is_bool() -> Result<(), Error> {
 	let sql = "
 		CREATE test:1 SET active = false;
 		CREATE test:2 SET active = false;


### PR DESCRIPTION
## What is the motivation?

Fixes #2127

## What does this change do?

Fixes the `equal` implementation of `Value` in the `Bool` match case

## What is your testing strategy?

Create a new integration test with the statements presented in the issue

## Is this related to any issues?

#2127 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
