### PR TITLE
Switch to bincode serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4450,7 +4450,6 @@ version = "1.0.0-beta.9"
 dependencies = [
  "argon2",
  "base64 0.21.2",
- "bung",
  "bytes",
  "chrono",
  "clap 4.3.0",
@@ -4578,9 +4577,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f44db5c0ba9716670cb45585f475e46b2c2e64428736e03a4e4a83a628b8a21"
+checksum = "6ffbdb550fac410f0fc5a58df07e9956bb91f73dbf3905405d4dda5ea6208892"
 dependencies = [
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ strip = false
 [dependencies]
 argon2 = "0.5.0"
 base64 = "0.21.1"
-bung = "0.1.0"
 bytes = "1.4.0"
 chrono = { version = "0.4.24", features = ["serde"] }
 clap = { version = "4.2.1", features = ["env", "derive", "wrap_help", "unicode"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -62,7 +62,7 @@ bincode = "1.3.3"
 bung = "0.1.0"
 channel = { version = "1.8.0", package = "async-channel" }
 chrono = { version = "0.4.24", features = ["serde"] }
-derive = { version = "0.8.0", package = "surrealdb-derive" }
+derive = { version = "0.9.0", package = "surrealdb-derive" }
 deunicode = "1.3.3"
 dmp = "0.2.0"
 echodb = { version = "0.4.0", optional = true }

--- a/lib/fuzz/Cargo.lock
+++ b/lib/fuzz/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +82,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
+
+[[package]]
 name = "async-channel"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +139,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
+name = "async-trait"
+version = "0.1.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "async_io_stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,9 +186,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -174,7 +208,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df288bec72232f78c1ec5fe4e8f1d108aa0265476e93097593c803c8c02062a"
 dependencies = [
- "base64",
+ "base64 0.21.2",
  "blowfish",
  "getrandom",
  "subtle",
@@ -182,14 +216,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "bigdecimal"
-version = "0.3.0"
+name = "bincode"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
  "serde",
 ]
 
@@ -246,21 +277,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+dependencies = [
+ "borsh-derive",
+ "hashbrown",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
-name = "bung"
-version = "0.1.0"
+name = "bytecheck"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da8bcf29331f126c3b4f20a6698909d58004290723aac75e3eafab41ae3c2953"
+checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
 dependencies = [
- "byteorder",
- "rmp",
- "serde",
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
 ]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
@@ -300,7 +393,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -462,6 +555,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,7 +591,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -503,6 +602,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "funty"
@@ -646,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d640a4dd1d1c98b45f4653c841a8ec15f461a71b86bc30533ae64c6f20f268"
+checksum = "c07ac450e9e7d8c08e58d2723d46bd0328bb6cc1d7b18f4f37a1e15a311098b0"
 dependencies = [
  "float_next_after",
  "geo-types",
@@ -708,6 +813,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heapless"
@@ -718,7 +826,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version",
- "spin",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -842,11 +950,25 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.2",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -955,6 +1077,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,7 +1168,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1052,12 +1183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
-
-[[package]]
 name = "pbkdf2"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1192,15 @@ dependencies = [
  "hmac",
  "password-hash",
  "sha2",
+]
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -1124,6 +1258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,10 +1282,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
-name = "quote"
-version = "1.0.26"
+name = "ptr_meta"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1152,6 +1315,17 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+ "serde",
+]
 
 [[package]]
 name = "rand"
@@ -1203,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1214,19 +1388,78 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
-name = "rmp"
-version = "0.8.11"
+name = "rend"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "hashbrown",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "roaring"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0fb5e826a8bde011ecae6a8539dd333884335c57ff0f003fbe27c25bbe8f71"
+dependencies = [
+ "bytemuck",
  "byteorder",
- "num-traits",
- "paste",
+ "retain_mut",
+ "serde",
 ]
 
 [[package]]
@@ -1244,6 +1477,24 @@ dependencies = [
  "heapless",
  "num-traits",
  "smallvec",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bd36b60561ee1fb5ec2817f198b6fd09fa571c897a5e86d1487cfc2b096dfc"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytecheck",
+ "byteorder",
+ "bytes",
+ "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1295,6 +1546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,18 +1568,18 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1363,6 +1620,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time 0.3.22",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1651,18 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "snap"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -1420,19 +1707,21 @@ dependencies = [
  "async-channel",
  "async-executor",
  "async-recursion",
- "base64",
+ "async-trait",
+ "base64 0.21.2",
  "bcrypt",
- "bigdecimal",
- "bung",
+ "bincode",
  "chrono",
  "dmp",
  "echodb",
  "flume",
+ "fst",
  "futures",
  "futures-concurrency",
  "fuzzy-matcher",
  "geo",
  "indexmap",
+ "jsonwebtoken",
  "lexicmp",
  "log",
  "md-5",
@@ -1442,14 +1731,18 @@ dependencies = [
  "pbkdf2",
  "pharos",
  "pin-project-lite",
+ "radix_trie",
  "rand",
  "regex",
+ "roaring",
+ "rust_decimal",
  "scrypt",
  "semver",
  "serde",
  "serde_json",
  "sha-1",
  "sha2",
+ "snap",
  "storekey",
  "surrealdb-derive",
  "thiserror",
@@ -1466,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f44db5c0ba9716670cb45585f475e46b2c2e64428736e03a4e4a83a628b8a21"
+checksum = "6ffbdb550fac410f0fc5a58df07e9956bb91f73dbf3905405d4dda5ea6208892"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1564,6 +1857,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,27 +1900,36 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes",
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1690,6 +2019,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,9 +2043,9 @@ checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "uuid"
-version = "1.3.1"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
  "atomic",
  "getrandom",
@@ -1744,9 +2079,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1754,24 +2089,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1781,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1791,22 +2126,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasmtimer"
@@ -1878,6 +2213,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]

--- a/lib/src/api/engine/any/wasm.rs
+++ b/lib/src/api/engine/any/wasm.rs
@@ -50,9 +50,7 @@ impl Connection for Any {
 					#[cfg(feature = "kv-fdb")]
 					{
 						engine::local::wasm::router(address, conn_tx, route_rx);
-						if let Err(error) = conn_rx.into_recv_async().await? {
-							return Err(error);
-						}
+						conn_rx.into_recv_async().await??;
 					}
 
 					#[cfg(not(feature = "kv-fdb"))]
@@ -65,9 +63,7 @@ impl Connection for Any {
 					#[cfg(feature = "kv-indxdb")]
 					{
 						engine::local::wasm::router(address, conn_tx, route_rx);
-						if let Err(error) = conn_rx.into_recv_async().await? {
-							return Err(error);
-						}
+						conn_rx.into_recv_async().await??;
 					}
 
 					#[cfg(not(feature = "kv-indxdb"))]
@@ -80,9 +76,7 @@ impl Connection for Any {
 					#[cfg(feature = "kv-mem")]
 					{
 						engine::local::wasm::router(address, conn_tx, route_rx);
-						if let Err(error) = conn_rx.into_recv_async().await? {
-							return Err(error);
-						}
+						conn_rx.into_recv_async().await??;
 					}
 
 					#[cfg(not(feature = "kv-mem"))]
@@ -95,9 +89,7 @@ impl Connection for Any {
 					#[cfg(feature = "kv-rocksdb")]
 					{
 						engine::local::wasm::router(address, conn_tx, route_rx);
-						if let Err(error) = conn_rx.into_recv_async().await? {
-							return Err(error);
-						}
+						conn_rx.into_recv_async().await??;
 					}
 
 					#[cfg(not(feature = "kv-rocksdb"))]
@@ -111,9 +103,7 @@ impl Connection for Any {
 					#[cfg(feature = "kv-speedb")]
 					{
 						engine::local::wasm::router(address, conn_tx, route_rx);
-						if let Err(error) = conn_rx.into_recv_async().await? {
-							return Err(error);
-						}
+						conn_rx.into_recv_async().await??;
 					}
 
 					#[cfg(not(feature = "kv-speedb"))]
@@ -127,9 +117,7 @@ impl Connection for Any {
 					#[cfg(feature = "kv-tikv")]
 					{
 						engine::local::wasm::router(address, conn_tx, route_rx);
-						if let Err(error) = conn_rx.into_recv_async().await? {
-							return Err(error);
-						}
+						conn_rx.into_recv_async().await??;
 					}
 
 					#[cfg(not(feature = "kv-tikv"))]
@@ -157,9 +145,7 @@ impl Connection for Any {
 						let mut address = address;
 						address.endpoint = address.endpoint.join(engine::remote::ws::PATH)?;
 						engine::remote::ws::wasm::router(address, capacity, conn_tx, route_rx);
-						if let Err(error) = conn_rx.into_recv_async().await? {
-							return Err(error);
-						}
+						conn_rx.into_recv_async().await??;
 					}
 
 					#[cfg(not(feature = "protocol-ws"))]

--- a/lib/src/api/engine/local/wasm.rs
+++ b/lib/src/api/engine/local/wasm.rs
@@ -48,9 +48,7 @@ impl Connection for Db {
 
 			router(address, conn_tx, route_rx);
 
-			if let Err(error) = conn_rx.into_recv_async().await? {
-				return Err(error);
-			}
+			conn_rx.into_recv_async().await??;
 
 			Ok(Surreal {
 				router: OnceCell::with_value(Arc::new(Router {

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -12,7 +12,6 @@ use crate::api::engine::create_statement;
 use crate::api::engine::delete_statement;
 use crate::api::engine::merge_statement;
 use crate::api::engine::patch_statement;
-use crate::api::engine::remote::Status;
 use crate::api::engine::select_statement;
 use crate::api::engine::update_statement;
 use crate::api::err::Error;
@@ -22,6 +21,7 @@ use crate::api::Connect;
 use crate::api::Response as QueryResponse;
 use crate::api::Result;
 use crate::api::Surreal;
+use crate::dbs::Status;
 use crate::opt::IntoEndpoint;
 use crate::sql::serde::deserialize;
 use crate::sql::Array;
@@ -139,14 +139,7 @@ impl Authenticate for RequestBuilder {
 	}
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum HttpValue {
-	Value(Value),
-	String(String),
-}
-
-type HttpQueryResponse = (String, Status, HttpValue);
+type HttpQueryResponse = (String, Status, Value);
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Root {
@@ -159,7 +152,6 @@ struct Root {
 struct AuthResponse {
 	code: u16,
 	details: String,
-	#[serde(default)]
 	token: Option<String>,
 }
 
@@ -188,10 +180,6 @@ async fn query(request: RequestBuilder) -> Result<QueryResponse> {
 	for (index, (_time, status, value)) in responses.into_iter().enumerate() {
 		match status {
 			Status::Ok => {
-				let value = match value {
-					HttpValue::Value(value) => value,
-					HttpValue::String(value) => value.into(),
-				};
 				match value {
 					Value::Array(Array(array)) => map.insert(index, Ok(array)),
 					Value::None | Value::Null => map.insert(index, Ok(vec![])),
@@ -199,11 +187,7 @@ async fn query(request: RequestBuilder) -> Result<QueryResponse> {
 				};
 			}
 			Status::Err => {
-				let error = match value {
-					HttpValue::String(message) => message,
-					HttpValue::Value(value) => value.to_string(),
-				};
-				map.insert(index, Err(Error::Query(error).into()));
+				map.insert(index, Err(Error::Query(value.as_raw_string()).into()));
 			}
 		}
 	}

--- a/lib/src/api/engine/remote/http/wasm.rs
+++ b/lib/src/api/engine/remote/http/wasm.rs
@@ -48,9 +48,7 @@ impl Connection for Client {
 
 			router(address, conn_tx, route_rx);
 
-			if let Err(error) = conn_rx.into_recv_async().await? {
-				return Err(error);
-			}
+			conn_rx.into_recv_async().await??;
 
 			Ok(Surreal {
 				router: OnceCell::with_value(Arc::new(Router {
@@ -104,7 +102,7 @@ pub(crate) fn router(
 				client
 			}
 			Err(error) => {
-				let _ = conn_tx.into_send_async(Err(error.into())).await;
+				let _ = conn_tx.into_send_async(Err(error)).await;
 				return;
 			}
 		};

--- a/lib/src/api/engine/remote/mod.rs
+++ b/lib/src/api/engine/remote/mod.rs
@@ -1,7 +1,5 @@
 //! Protocols for communicating with the server
 
-use serde::Deserialize;
-
 #[cfg(feature = "protocol-http")]
 #[cfg_attr(docsrs, doc(cfg(feature = "protocol-http")))]
 pub mod http;
@@ -9,10 +7,3 @@ pub mod http;
 #[cfg(feature = "protocol-ws")]
 #[cfg_attr(docsrs, doc(cfg(feature = "protocol-ws")))]
 pub mod ws;
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
-pub(crate) enum Status {
-	Ok,
-	Err,
-}

--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -17,6 +17,7 @@ use crate::api::opt::Tls;
 use crate::api::Result;
 use crate::api::Surreal;
 use crate::engine::remote::ws::IntervalStream;
+use crate::sql::serde::deserialize;
 use crate::sql::Strand;
 use crate::sql::Value;
 use flume::Receiver;
@@ -387,7 +388,7 @@ impl Response {
 				trace!(target: LOG, "Received an unexpected text message; {text}");
 				Ok(None)
 			}
-			Message::Binary(binary) => bung::from_slice(&binary).map(Some).map_err(|error| {
+			Message::Binary(binary) => deserialize(&binary).map(Some).map_err(|error| {
 				Error::ResponseFromBinary {
 					binary,
 					error,

--- a/lib/src/api/engine/remote/ws/wasm.rs
+++ b/lib/src/api/engine/remote/ws/wasm.rs
@@ -28,6 +28,7 @@ use once_cell::sync::OnceCell;
 use pharos::Channel;
 use pharos::Observable;
 use pharos::ObserveConfig;
+use serde::Deserialize;
 use std::collections::hash_map::Entry;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -79,9 +80,7 @@ impl Connection for Client {
 
 			router(address, capacity, conn_tx, route_rx);
 
-			if let Err(error) = conn_rx.into_recv_async().await? {
-				return Err(error);
-			}
+			conn_rx.into_recv_async().await??;
 
 			Ok(Surreal {
 				router: OnceCell::with_value(Arc::new(Router {
@@ -258,24 +257,45 @@ pub(crate) fn router(
 					}
 					Either::Response(message) => {
 						last_activity = Instant::now();
-						match Response::try_from(message) {
+						match Response::try_from(&message) {
 							Ok(option) => {
 								if let Some(response) = option {
 									trace!(target: LOG, "{response:?}");
 									if let Some(Ok(id)) = response.id.map(Value::coerce_to_i64) {
-										if let Some((method, sender)) = routes.remove(&id) {
-											let _ = sender
-												.into_send_async(DbResponse::from((
-													method,
-													response.content,
-												)))
+										if let Some((_method, sender)) = routes.remove(&id) {
+											let _res = sender
+												.into_send_async(DbResponse::from(response.result))
 												.await;
 										}
 									}
 								}
 							}
-							Err(_error) => {
-								trace!(target: LOG, "Failed to deserialise message");
+							Err(error) => {
+								#[derive(Deserialize)]
+								struct Response {
+									id: Option<Value>,
+								}
+
+								// Let's try to find out the ID of the response that failed to deserialise
+								if let Message::Binary(binary) = message {
+									if let Ok(Response {
+										id,
+									}) = deserialize(&binary)
+									{
+										// Return an error if an ID was returned
+										if let Some(Ok(id)) = id.map(Value::coerce_to_i64) {
+											if let Some((_method, sender)) = routes.remove(&id) {
+												let _res = sender.into_send_async(Err(error)).await;
+											}
+										}
+									} else {
+										// Unfortunately, we don't know which response failed to deserialize
+										warn!(
+											target: LOG,
+											"Failed to deserialise message; {error:?}"
+										);
+									}
+								}
 							}
 						}
 					}
@@ -364,15 +384,15 @@ pub(crate) fn router(
 }
 
 impl Response {
-	fn try_from(message: Message) -> Result<Option<Self>> {
+	fn try_from(message: &Message) -> Result<Option<Self>> {
 		match message {
 			Message::Text(text) => {
 				trace!(target: LOG, "Received an unexpected text message; {text}");
 				Ok(None)
 			}
-			Message::Binary(binary) => deserialize(&binary).map(Some).map_err(|error| {
+			Message::Binary(binary) => deserialize(binary).map(Some).map_err(|error| {
 				Error::ResponseFromBinary {
-					binary,
+					binary: binary.clone(),
 					error,
 				}
 				.into()

--- a/lib/src/api/engine/remote/ws/wasm.rs
+++ b/lib/src/api/engine/remote/ws/wasm.rs
@@ -15,6 +15,7 @@ use crate::api::opt::Endpoint;
 use crate::api::Result;
 use crate::api::Surreal;
 use crate::engine::remote::ws::IntervalStream;
+use crate::sql::serde::deserialize;
 use crate::sql::Strand;
 use crate::sql::Value;
 use flume::Receiver;
@@ -369,7 +370,7 @@ impl Response {
 				trace!(target: LOG, "Received an unexpected text message; {text}");
 				Ok(None)
 			}
-			Message::Binary(binary) => bung::from_slice(&binary).map(Some).map_err(|error| {
+			Message::Binary(binary) => deserialize(&binary).map(Some).map_err(|error| {
 				Error::ResponseFromBinary {
 					binary,
 					error,

--- a/lib/src/api/err/mod.rs
+++ b/lib/src/api/err/mod.rs
@@ -99,7 +99,7 @@ pub enum Error {
 	#[error("Failed to deserialize a binary response: {error}")]
 	ResponseFromBinary {
 		binary: Vec<u8>,
-		error: bung::decode::Error,
+		error: bincode::Error,
 	},
 
 	/// Failed to serialize `sql::Value` to JSON string

--- a/lib/src/api/opt/resource.rs
+++ b/lib/src/api/opt/resource.rs
@@ -8,13 +8,10 @@ use crate::sql::Object;
 use crate::sql::Table;
 use crate::sql::Thing;
 use crate::sql::Value;
-use serde::Serialize;
 use std::ops;
 use std::ops::Bound;
 
 /// A database resource
-#[derive(Serialize)]
-#[serde(untagged)]
 #[derive(Debug)]
 pub enum Resource {
 	/// Table name

--- a/lib/src/dbs/mod.rs
+++ b/lib/src/dbs/mod.rs
@@ -15,13 +15,13 @@ mod transaction;
 mod variables;
 
 pub use self::auth::*;
+pub use self::notification::*;
 pub use self::options::*;
 pub use self::response::*;
 pub use self::session::*;
 
 pub(crate) use self::executor::*;
 pub(crate) use self::iterator::*;
-pub(crate) use self::notification::*;
 pub(crate) use self::statement::*;
 pub(crate) use self::transaction::*;
 pub(crate) use self::variables::*;

--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -71,6 +71,7 @@ pub(crate) mod view;
 #[cfg(test)]
 pub(crate) mod test;
 
+pub mod serde;
 pub mod statements;
 
 pub use self::parser::*;

--- a/lib/src/sql/serde.rs
+++ b/lib/src/sql/serde.rs
@@ -22,6 +22,7 @@ where
 		.with_no_limit()
 		.with_little_endian()
 		.with_varint_encoding()
-		.reject_trailing_bytes()
+		// Ignore extra fields so we can pull out the ID only from responses that fail to deserialise
+		.allow_trailing_bytes()
 		.deserialize(bytes)
 }

--- a/lib/src/sql/serde.rs
+++ b/lib/src/sql/serde.rs
@@ -1,0 +1,27 @@
+use bincode::Options;
+use bincode::Result;
+use serde::{Deserialize, Serialize};
+
+pub fn serialize<T: ?Sized>(value: &T) -> Result<Vec<u8>>
+where
+	T: Serialize,
+{
+	bincode::options()
+		.with_no_limit()
+		.with_little_endian()
+		.with_varint_encoding()
+		.reject_trailing_bytes()
+		.serialize(value)
+}
+
+pub fn deserialize<'a, T>(bytes: &'a [u8]) -> Result<T>
+where
+	T: Deserialize<'a>,
+{
+	bincode::options()
+		.with_no_limit()
+		.with_little_endian()
+		.with_varint_encoding()
+		.reject_trailing_bytes()
+		.deserialize(bytes)
+}

--- a/lib/src/sql/statements/define.rs
+++ b/lib/src/sql/statements/define.rs
@@ -44,7 +44,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Write};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub enum DefineStatement {
 	Namespace(DefineNamespaceStatement),
 	Database(DefineDatabaseStatement),
@@ -121,7 +120,6 @@ pub fn define(i: &str) -> IResult<&str, DefineStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineNamespaceStatement {
 	pub name: Ident,
 }
@@ -170,7 +168,6 @@ fn namespace(i: &str) -> IResult<&str, DefineNamespaceStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineDatabaseStatement {
 	pub name: Ident,
 	pub changefeed: Option<ChangeFeed>,
@@ -247,7 +244,6 @@ fn database_opts(i: &str) -> IResult<&str, DefineDatabaseOption> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineFunctionStatement {
 	pub name: Ident,
 	pub args: Vec<(Ident, Kind)>,
@@ -395,7 +391,6 @@ pub(crate) fn analyzer(i: &str) -> IResult<&str, DefineAnalyzerStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineLoginStatement {
 	pub name: Ident,
 	pub base: Base,
@@ -514,7 +509,6 @@ fn login_hash(i: &str) -> IResult<&str, DefineLoginOption> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineTokenStatement {
 	pub name: Ident,
 	pub base: Base,
@@ -629,7 +623,6 @@ fn token(i: &str) -> IResult<&str, DefineTokenStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineScopeStatement {
 	pub name: Ident,
 	pub code: String,
@@ -747,7 +740,6 @@ fn scope_signin(i: &str) -> IResult<&str, DefineScopeOption> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineParamStatement {
 	pub name: Ident,
 	pub value: Value,
@@ -805,7 +797,6 @@ fn param(i: &str) -> IResult<&str, DefineParamStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineTableStatement {
 	pub name: Ident,
 	pub drop: bool,
@@ -1006,7 +997,6 @@ fn table_permissions(i: &str) -> IResult<&str, DefineTableOption> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineEventStatement {
 	pub name: Ident,
 	pub what: Ident,
@@ -1084,7 +1074,6 @@ fn event(i: &str) -> IResult<&str, DefineEventStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineFieldStatement {
 	pub name: Idiom,
 	pub what: Ident,
@@ -1244,7 +1233,6 @@ fn field_permissions(i: &str) -> IResult<&str, DefineFieldOption> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct DefineIndexStatement {
 	pub name: Ident,
 	pub what: Ident,
@@ -1346,7 +1334,7 @@ mod tests {
 		let stm = DefineStatement::Namespace(DefineNamespaceStatement {
 			name: Ident::from("test"),
 		});
-		assert_eq!(22, stm.to_vec().len());
+		assert_eq!(6, stm.to_vec().len());
 	}
 
 	#[test]

--- a/lib/src/sql/statements/remove.rs
+++ b/lib/src/sql/statements/remove.rs
@@ -21,7 +21,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub enum RemoveStatement {
 	Namespace(RemoveNamespaceStatement),
 	Database(RemoveDatabaseStatement),
@@ -98,7 +97,6 @@ pub fn remove(i: &str) -> IResult<&str, RemoveStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveNamespaceStatement {
 	pub name: Ident,
 }
@@ -150,7 +148,6 @@ fn namespace(i: &str) -> IResult<&str, RemoveNamespaceStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveDatabaseStatement {
 	pub name: Ident,
 }
@@ -202,7 +199,6 @@ fn database(i: &str) -> IResult<&str, RemoveDatabaseStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveFunctionStatement {
 	pub name: Ident,
 }
@@ -307,7 +303,6 @@ fn analyzer(i: &str) -> IResult<&str, RemoveAnalyzerStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveLoginStatement {
 	pub name: Ident,
 	pub base: Base,
@@ -382,7 +377,6 @@ fn login(i: &str) -> IResult<&str, RemoveLoginStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveTokenStatement {
 	pub name: Ident,
 	pub base: Base,
@@ -472,7 +466,6 @@ fn token(i: &str) -> IResult<&str, RemoveTokenStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveScopeStatement {
 	pub name: Ident,
 }
@@ -524,7 +517,6 @@ fn scope(i: &str) -> IResult<&str, RemoveScopeStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveParamStatement {
 	pub name: Ident,
 }
@@ -574,7 +566,6 @@ fn param(i: &str) -> IResult<&str, RemoveParamStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveTableStatement {
 	pub name: Ident,
 }
@@ -626,7 +617,6 @@ fn table(i: &str) -> IResult<&str, RemoveTableStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveEventStatement {
 	pub name: Ident,
 	pub what: Ident,
@@ -685,7 +675,6 @@ fn event(i: &str) -> IResult<&str, RemoveEventStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveFieldStatement {
 	pub name: Idiom,
 	pub what: Ident,
@@ -745,7 +734,6 @@ fn field(i: &str) -> IResult<&str, RemoveFieldStatement> {
 // --------------------------------------------------
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
-#[format(Named)]
 pub struct RemoveIndexStatement {
 	pub name: Ident,
 	pub what: Ident,
@@ -813,6 +801,6 @@ mod tests {
 		let stm = RemoveStatement::Namespace(RemoveNamespaceStatement {
 			name: Ident::from("test"),
 		});
-		assert_eq!(22, stm.to_vec().len());
+		assert_eq!(6, stm.to_vec().len());
 	}
 }

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -106,7 +106,6 @@ pub fn whats(i: &str) -> IResult<&str, Values> {
 
 #[derive(Clone, Debug, Default, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Value")]
-#[format(Named)]
 pub enum Value {
 	// These value types are simple values which
 	// can be used in query responses sent to
@@ -2942,13 +2941,13 @@ mod tests {
 
 	#[test]
 	fn check_serialize() {
-		assert_eq!(5, Value::None.to_vec().len());
-		assert_eq!(5, Value::Null.to_vec().len());
-		assert_eq!(7, Value::Bool(true).to_vec().len());
-		assert_eq!(7, Value::Bool(false).to_vec().len());
-		assert_eq!(13, Value::from("test").to_vec().len());
-		assert_eq!(29, Value::parse("{ hello: 'world' }").to_vec().len());
-		assert_eq!(45, Value::parse("{ compact: true, schema: 0 }").to_vec().len());
+		assert_eq!(1, Value::None.to_vec().len());
+		assert_eq!(1, Value::Null.to_vec().len());
+		assert_eq!(2, Value::Bool(true).to_vec().len());
+		assert_eq!(2, Value::Bool(false).to_vec().len());
+		assert_eq!(6, Value::from("test").to_vec().len());
+		assert_eq!(15, Value::parse("{ hello: 'world' }").to_vec().len());
+		assert_eq!(22, Value::parse("{ compact: true, schema: 0 }").to_vec().len());
 	}
 
 	#[test]

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -1001,7 +1001,7 @@ async fn define_statement_search_index() -> Result<(), Error> {
 	check_path(&tmp, &["doc_ids", "keys_count"], |v| assert_eq!(v, Value::from(2)));
 	check_path(&tmp, &["doc_ids", "max_depth"], |v| assert_eq!(v, Value::from(1)));
 	check_path(&tmp, &["doc_ids", "nodes_count"], |v| assert_eq!(v, Value::from(1)));
-	check_path(&tmp, &["doc_ids", "total_size"], |v| assert_eq!(v, Value::from(72)));
+	check_path(&tmp, &["doc_ids", "total_size"], |v| assert_eq!(v, Value::from(65)));
 
 	check_path(&tmp, &["doc_lengths", "keys_count"], |v| assert_eq!(v, Value::from(2)));
 	check_path(&tmp, &["doc_lengths", "max_depth"], |v| assert_eq!(v, Value::from(1)));

--- a/src/net/fail.rs
+++ b/src/net/fail.rs
@@ -5,7 +5,6 @@ use warp::http::StatusCode;
 #[derive(Serialize)]
 struct Message {
 	code: u16,
-	#[serde(skip_serializing_if = "Option::is_none")]
 	details: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	description: Option<String>,

--- a/src/net/import.rs
+++ b/src/net/import.rs
@@ -45,7 +45,7 @@ async fn handler(
 					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
-					"application/bung" => Ok(output::full(&res)),
+					"application/surrealdb" => Ok(output::full(&res)),
 					// Return nothing
 					"application/octet-stream" => Ok(output::none()),
 					// An incorrect content-type was requested

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -176,7 +176,7 @@ async fn select_all(
 			"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 			"application/pack" => Ok(output::pack(&output::simplify(res))),
 			// Internal serialization
-			"application/bung" => Ok(output::full(&res)),
+			"application/surrealdb" => Ok(output::full(&res)),
 			// An incorrect content-type was requested
 			_ => Err(warp::reject::custom(Error::InvalidType)),
 		},
@@ -217,7 +217,7 @@ async fn create_all(
 					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
-					"application/bung" => Ok(output::full(&res)),
+					"application/surrealdb" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
 					_ => Err(warp::reject::custom(Error::InvalidType)),
 				},
@@ -261,7 +261,7 @@ async fn update_all(
 					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
-					"application/bung" => Ok(output::full(&res)),
+					"application/surrealdb" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
 					_ => Err(warp::reject::custom(Error::InvalidType)),
 				},
@@ -305,7 +305,7 @@ async fn modify_all(
 					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
-					"application/bung" => Ok(output::full(&res)),
+					"application/surrealdb" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
 					_ => Err(warp::reject::custom(Error::InvalidType)),
 				},
@@ -342,7 +342,7 @@ async fn delete_all(
 			"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 			"application/pack" => Ok(output::pack(&output::simplify(res))),
 			// Internal serialization
-			"application/bung" => Ok(output::full(&res)),
+			"application/surrealdb" => Ok(output::full(&res)),
 			// An incorrect content-type was requested
 			_ => Err(warp::reject::custom(Error::InvalidType)),
 		},
@@ -385,7 +385,7 @@ async fn select_one(
 			"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 			"application/pack" => Ok(output::pack(&output::simplify(res))),
 			// Internal serialization
-			"application/bung" => Ok(output::full(&res)),
+			"application/surrealdb" => Ok(output::full(&res)),
 			// An incorrect content-type was requested
 			_ => Err(warp::reject::custom(Error::InvalidType)),
 		},
@@ -433,7 +433,7 @@ async fn create_one(
 					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
-					"application/bung" => Ok(output::full(&res)),
+					"application/surrealdb" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
 					_ => Err(warp::reject::custom(Error::InvalidType)),
 				},
@@ -484,7 +484,7 @@ async fn update_one(
 					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
-					"application/bung" => Ok(output::full(&res)),
+					"application/surrealdb" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
 					_ => Err(warp::reject::custom(Error::InvalidType)),
 				},
@@ -535,7 +535,7 @@ async fn modify_one(
 					"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 					"application/pack" => Ok(output::pack(&output::simplify(res))),
 					// Internal serialization
-					"application/bung" => Ok(output::full(&res)),
+					"application/surrealdb" => Ok(output::full(&res)),
 					// An incorrect content-type was requested
 					_ => Err(warp::reject::custom(Error::InvalidType)),
 				},
@@ -579,7 +579,7 @@ async fn delete_one(
 			"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 			"application/pack" => Ok(output::pack(&output::simplify(res))),
 			// Internal serialization
-			"application/bung" => Ok(output::full(&res)),
+			"application/surrealdb" => Ok(output::full(&res)),
 			// An incorrect content-type was requested
 			_ => Err(warp::reject::custom(Error::InvalidType)),
 		},

--- a/src/net/output.rs
+++ b/src/net/output.rs
@@ -56,7 +56,7 @@ pub fn full<T>(val: &T) -> Output
 where
 	T: Serialize,
 {
-	match bung::to_vec(val) {
+	match surrealdb::sql::serde::serialize(val) {
 		Ok(v) => Output::Full(v),
 		Err(_) => Output::Fail,
 	}
@@ -96,7 +96,7 @@ impl warp::Reply for Output {
 			}
 			Output::Full(v) => {
 				let mut res = warp::reply::Response::new(v.into());
-				let con = HeaderValue::from_static("application/bung");
+				let con = HeaderValue::from_static("application/surrealdb");
 				res.headers_mut().insert(CONTENT_TYPE, con);
 				res
 			}

--- a/src/net/signin.rs
+++ b/src/net/signin.rs
@@ -17,7 +17,6 @@ const MAX: u64 = 1024; // 1 KiB
 struct Success {
 	code: u16,
 	details: String,
-	#[serde(skip_serializing_if = "Option::is_none")]
 	token: Option<String>,
 }
 

--- a/src/net/signin.rs
+++ b/src/net/signin.rs
@@ -74,16 +74,16 @@ async fn handler(
 			{
 				// Authentication was successful
 				Ok(v) => match output.as_deref() {
+					// Return nothing
+					None => Ok(output::none()),
+					// Text serialization
+					Some("text/plain") => Ok(output::text(v.unwrap_or_default())),
 					// Simple serialization
 					Some("application/json") => Ok(output::json(&Success::new(v))),
 					Some("application/cbor") => Ok(output::cbor(&Success::new(v))),
 					Some("application/pack") => Ok(output::pack(&Success::new(v))),
 					// Internal serialization
-					Some("application/bung") => Ok(output::full(&Success::new(v))),
-					// Text serialization
-					Some("text/plain") => Ok(output::text(v.unwrap_or_default())),
-					// Return nothing
-					None => Ok(output::none()),
+					Some("application/surrealdb") => Ok(output::full(&Success::new(v))),
 					// An incorrect content-type was requested
 					_ => Err(warp::reject::custom(Error::InvalidType)),
 				},

--- a/src/net/signup.rs
+++ b/src/net/signup.rs
@@ -16,7 +16,6 @@ const MAX: u64 = 1024; // 1 KiB
 struct Success {
 	code: u16,
 	details: String,
-	#[serde(skip_serializing_if = "Option::is_none")]
 	token: Option<String>,
 }
 

--- a/src/net/signup.rs
+++ b/src/net/signup.rs
@@ -69,16 +69,16 @@ async fn handler(
 			{
 				// Authentication was successful
 				Ok(v) => match output.as_deref() {
+					// Return nothing
+					None => Ok(output::none()),
+					// Text serialization
+					Some("text/plain") => Ok(output::text(v.unwrap_or_default())),
 					// Simple serialization
 					Some("application/json") => Ok(output::json(&Success::new(v))),
 					Some("application/cbor") => Ok(output::cbor(&Success::new(v))),
 					Some("application/pack") => Ok(output::pack(&Success::new(v))),
 					// Internal serialization
-					Some("application/bung") => Ok(output::full(&Success::new(v))),
-					// Text serialization
-					Some("text/plain") => Ok(output::text(v.unwrap_or_default())),
-					// Return nothing
-					None => Ok(output::none()),
+					Some("application/surrealdb") => Ok(output::full(&Success::new(v))),
 					// An incorrect content-type was requested
 					_ => Err(warp::reject::custom(Error::InvalidType)),
 				},

--- a/src/net/sql.rs
+++ b/src/net/sql.rs
@@ -58,7 +58,7 @@ async fn handler(
 			"application/cbor" => Ok(output::cbor(&output::simplify(res))),
 			"application/pack" => Ok(output::pack(&output::simplify(res))),
 			// Internal serialization
-			"application/bung" => Ok(output::full(&res)),
+			"application/surrealdb" => Ok(output::full(&res)),
 			// An incorrect content-type was requested
 			_ => Err(warp::reject::custom(Error::InvalidType)),
 		},

--- a/src/rpc/res.rs
+++ b/src/rpc/res.rs
@@ -1,10 +1,15 @@
 use serde::Serialize;
-use serde_json::Value as Json;
+use serde_json::{json, Value as Json};
 use std::borrow::Cow;
 use surrealdb::channel::Sender;
+use surrealdb::dbs;
+use surrealdb::dbs::Notification;
 use surrealdb::sql;
 use surrealdb::sql::Value;
+use tracing::instrument;
 use warp::ws::Message;
+
+const LOG: &str = "surrealdb::rpc::res";
 
 #[derive(Clone)]
 pub enum Output {
@@ -14,52 +19,93 @@ pub enum Output {
 	Full, // Full type serialization
 }
 
-#[derive(Serialize)]
-pub struct Response<T> {
+/// The data returned by the database
+// The variants here should be in exactly the same order as `surrealdb::engine::remote::ws::Data`
+// In future, they will possibly be merged to avoid having to keep them in sync.
+#[derive(Debug, Serialize)]
+pub enum Data {
+	/// Generally methods return a `sql::Value`
+	Other(Value),
+	/// The query methods, `query` and `query_with` return a `Vec` of responses
+	Query(Vec<dbs::Response>),
+	/// Live queries return a notification
+	Live(Notification),
+	// Add new variants here
+}
+
+impl From<Value> for Data {
+	fn from(v: Value) -> Self {
+		Data::Other(v)
+	}
+}
+
+impl From<Vec<dbs::Response>> for Data {
+	fn from(v: Vec<dbs::Response>) -> Self {
+		Data::Query(v)
+	}
+}
+
+impl From<Notification> for Data {
+	fn from(n: Notification) -> Self {
+		Data::Live(n)
+	}
+}
+
+#[derive(Debug, Serialize)]
+pub struct Response {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	id: Option<Value>,
-	#[serde(flatten)]
-	content: Content<T>,
+	result: Result<Data, Failure>,
 }
 
-#[derive(Serialize)]
-enum Content<T> {
-	#[serde(rename = "result")]
-	Success(T),
-	#[serde(rename = "error")]
-	Failure(Failure),
-}
-
-impl<T: Serialize> Response<T> {
+impl Response {
 	/// Convert and simplify the value into JSON
 	#[inline]
 	fn simplify(self) -> Json {
-		sql::to_value(self).unwrap().into()
+		let mut value = match self.result {
+			Ok(data) => {
+				let value = match data {
+					Data::Query(vec) => sql::to_value(vec).unwrap(),
+					Data::Live(nofication) => sql::to_value(nofication).unwrap(),
+					Data::Other(value) => value,
+				};
+				json!({
+					"result": Json::from(value),
+				})
+			}
+			Err(failure) => json!({
+				"error": failure,
+			}),
+		};
+		if let Some(id) = self.id {
+			value["id"] = id.into();
+		}
+		value
 	}
+
 	/// Send the response to the WebSocket channel
+	#[instrument(skip_all, name = "rpc response", fields(response = ?self))]
 	pub async fn send(self, out: Output, chn: Sender<Message>) {
-		match out {
+		let message = match out {
 			Output::Json => {
 				let res = serde_json::to_string(&self.simplify()).unwrap();
-				let res = Message::text(res);
-				let _ = chn.send(res).await;
+				Message::text(res)
 			}
 			Output::Cbor => {
 				let res = serde_cbor::to_vec(&self.simplify()).unwrap();
-				let res = Message::binary(res);
-				let _ = chn.send(res).await;
+				Message::binary(res)
 			}
 			Output::Pack => {
 				let res = serde_pack::to_vec(&self.simplify()).unwrap();
-				let res = Message::binary(res);
-				let _ = chn.send(res).await;
+				Message::binary(res)
 			}
 			Output::Full => {
 				let res = surrealdb::sql::serde::serialize(&self).unwrap();
-				let res = Message::binary(res);
-				let _ = chn.send(res).await;
+				Message::binary(res)
 			}
-		}
+		};
+		let _ = chn.send(message).await;
+		trace!(target: LOG, "Response sent");
 	}
 }
 
@@ -107,17 +153,17 @@ impl Failure {
 }
 
 /// Create a JSON RPC result response
-pub fn success<S: Serialize>(id: Option<Value>, val: S) -> Response<S> {
+pub fn success<T: Into<Data>>(id: Option<Value>, data: T) -> Response {
 	Response {
 		id,
-		content: Content::Success(val),
+		result: Ok(data.into()),
 	}
 }
 
 /// Create a JSON RPC failure response
-pub fn failure(id: Option<Value>, err: Failure) -> Response<Value> {
+pub fn failure(id: Option<Value>, err: Failure) -> Response {
 	Response {
 		id,
-		content: Content::Failure(err),
+		result: Err(err),
 	}
 }

--- a/src/rpc/res.rs
+++ b/src/rpc/res.rs
@@ -55,7 +55,7 @@ impl<T: Serialize> Response<T> {
 				let _ = chn.send(res).await;
 			}
 			Output::Full => {
-				let res = bung::to_vec(&self).unwrap();
+				let res = surrealdb::sql::serde::serialize(&self).unwrap();
 				let res = Message::binary(res);
 				let _ = chn.send(res).await;
 			}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Serialisation is currently using MessagePack, a self-describing serialisation format, which was, but is no longer needed. As a result we can improve the speed and efficiency of the data storage both for on-disk, across the network, and over the WebSocket binary protocol.

## What does this change do?

Change the internal storage serialisation format to `bincode` and also uses this same serialisation format for the binary WebSocket protocol.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
