### PR TITLE
feat: Change Feeds Enabling/Writing/Reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4556,11 +4556,11 @@ dependencies = [
  "speedb",
  "storekey",
  "surrealdb-derive",
+ "surrealdb-tikv-client",
+ "surrealdb-tikv-client-proto",
  "temp-dir",
  "test-log",
  "thiserror",
- "tikv-client",
- "tikv-client-proto",
  "time 0.3.21",
  "tokio",
  "tokio-tungstenite",
@@ -4583,6 +4583,92 @@ checksum = "7f44db5c0ba9716670cb45585f475e46b2c2e64428736e03a4e4a83a628b8a21"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "surrealdb-tikv-client"
+version = "0.1.0-surreal.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8762cfabb7201a2a4794ca106a8293100d61a40809dce9902d5e694d3703809c"
+dependencies = [
+ "async-trait",
+ "derive-new",
+ "fail",
+ "futures 0.3.28",
+ "futures-timer",
+ "grpcio",
+ "lazy_static",
+ "log",
+ "prometheus",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_derive",
+ "surrealdb-tikv-client-common",
+ "surrealdb-tikv-client-pd",
+ "surrealdb-tikv-client-proto",
+ "surrealdb-tikv-client-store",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "surrealdb-tikv-client-common"
+version = "0.1.0-surreal.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc78f67bf4526f33401570bbfb3332d4c3ca8d5d80ee0e10618f4b7071b2047"
+dependencies = [
+ "futures 0.3.28",
+ "grpcio",
+ "lazy_static",
+ "log",
+ "regex",
+ "surrealdb-tikv-client-proto",
+ "thiserror",
+]
+
+[[package]]
+name = "surrealdb-tikv-client-pd"
+version = "0.1.0-surreal.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fcfd012b2665a5470cc71e71a6492144eb623e353612816962dcac5a2816fec"
+dependencies = [
+ "async-trait",
+ "futures 0.3.28",
+ "grpcio",
+ "log",
+ "surrealdb-tikv-client-common",
+ "surrealdb-tikv-client-proto",
+]
+
+[[package]]
+name = "surrealdb-tikv-client-proto"
+version = "0.1.0-surreal.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e97cfa7017ebdeed47679844e64c0bf7eccfaaeda933c0a4101011b1cc87d1"
+dependencies = [
+ "futures 0.3.28",
+ "grpcio",
+ "lazy_static",
+ "prost 0.7.0",
+ "prost-derive 0.7.0",
+ "protobuf",
+ "protobuf-build",
+]
+
+[[package]]
+name = "surrealdb-tikv-client-store"
+version = "0.1.0-surreal.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab86692ac2ef65f1a869451c9a4cb8e851da539e41c8154c2376cfa93dd52781"
+dependencies = [
+ "async-trait",
+ "derive-new",
+ "futures 0.3.28",
+ "grpcio",
+ "log",
+ "surrealdb-tikv-client-common",
+ "surrealdb-tikv-client-proto",
 ]
 
 [[package]]
@@ -4734,92 +4820,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "tikv-client"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26904b386ca52ce25b3a620b397e6e4e93c4fd06d13c2c5936d9ac597f897263"
-dependencies = [
- "async-trait",
- "derive-new",
- "fail",
- "futures 0.3.28",
- "futures-timer",
- "grpcio",
- "lazy_static",
- "log",
- "prometheus",
- "rand 0.8.5",
- "regex",
- "serde",
- "serde_derive",
- "thiserror",
- "tikv-client-common",
- "tikv-client-pd",
- "tikv-client-proto",
- "tikv-client-store",
- "tokio",
-]
-
-[[package]]
-name = "tikv-client-common"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72fc3bb3fbec1f2a3354d4bbe48501b23ea47b79da2ffaedeadcc8a6183188e4"
-dependencies = [
- "futures 0.3.28",
- "grpcio",
- "lazy_static",
- "log",
- "regex",
- "thiserror",
- "tikv-client-proto",
-]
-
-[[package]]
-name = "tikv-client-pd"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cadef1633d4e7952d9a3a88211f03f71e9f90769a5b50c40b5eccc06408977"
-dependencies = [
- "async-trait",
- "futures 0.3.28",
- "grpcio",
- "log",
- "tikv-client-common",
- "tikv-client-proto",
-]
-
-[[package]]
-name = "tikv-client-proto"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9707c63c11c19b87b6eb3df40c6103d0f1e2f06b53445bad91a8c9e06407d9b"
-dependencies = [
- "futures 0.3.28",
- "grpcio",
- "lazy_static",
- "prost 0.7.0",
- "prost-derive 0.7.0",
- "protobuf",
- "protobuf-build",
-]
-
-[[package]]
-name = "tikv-client-store"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab348b60ef0a384985c488e25bf35721956b3b45332945f0841f9ac8a693586"
-dependencies = [
- "async-trait",
- "derive-new",
- "futures 0.3.28",
- "grpcio",
- "log",
- "tikv-client-common",
- "tikv-client-proto",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -106,8 +106,8 @@ sha2 = "0.10.6"
 speedb = { version = "0.0.2", optional = true }
 storekey = "0.5.0"
 thiserror = "1.0.40"
-tikv = { version = "0.1.0", package = "tikv-client", optional = true }
-tikv-client-proto = { version = "0.1.0", optional = true }
+tikv = { version = "0.1.0-surreal.1", package = "surrealdb-tikv-client", optional = true }
+tikv-client-proto = { version = "0.1.0-surreal.1", package = "surrealdb-tikv-client-proto", optional = true }
 tokio-util = { version = "0.7.8", optional = true, features = ["compat"] }
 tracing = "0.1.37"
 trice = "0.3.1"

--- a/lib/src/cf/gc.rs
+++ b/lib/src/cf/gc.rs
@@ -1,0 +1,50 @@
+use crate::err::Error;
+use crate::key::cf;
+use crate::kvs::Transaction;
+use crate::vs;
+use std::str;
+
+// gc_all deletes all change feed entries that are older than the given watermark.
+#[allow(unused)]
+pub async fn gc_all(tx: &mut Transaction, watermark: u64, limit: Option<u32>) -> Result<(), Error> {
+	let nses = tx.all_ns().await?;
+	let nses = nses.as_ref();
+	for ns in nses {
+		gc_ns(tx, ns.name.as_str(), watermark, limit).await?;
+	}
+	Ok(())
+}
+
+// gc_ns deletes all change feed entries in the given namespace that are older than the given watermark.
+#[allow(unused)]
+pub async fn gc_ns(
+	tx: &mut Transaction,
+	ns: &str,
+	watermark: u64,
+	limit: Option<u32>,
+) -> Result<(), Error> {
+	let dbs = tx.all_db(ns).await?;
+	let dbs = dbs.as_ref();
+	for db in dbs {
+		gc_db(tx, ns, db.name.as_str(), watermark, limit).await?;
+	}
+	Ok(())
+}
+
+// gc_db deletes all change feed entries in the given database that are older than the given watermark.
+pub async fn gc_db(
+	tx: &mut Transaction,
+	ns: &str,
+	db: &str,
+	watermark: u64,
+	limit: Option<u32>,
+) -> Result<(), Error> {
+	let beg = cf::ts_prefix(ns, db, vs::u64_to_versionstamp(0));
+	let end = cf::ts_prefix(ns, db, vs::u64_to_versionstamp(watermark));
+
+	let limit = limit.unwrap_or(100);
+
+	tx.delr(beg..end, limit).await?;
+
+	Ok(())
+}

--- a/lib/src/cf/mod.rs
+++ b/lib/src/cf/mod.rs
@@ -1,0 +1,7 @@
+pub(crate) mod gc;
+pub(crate) mod reader;
+pub(crate) mod writer;
+
+pub use self::gc::*;
+pub use self::reader::read;
+pub use self::writer::Writer;

--- a/lib/src/cf/reader.rs
+++ b/lib/src/cf/reader.rs
@@ -1,0 +1,96 @@
+use crate::err::Error;
+use crate::key::cf;
+use crate::key::dv;
+use crate::kvs::Transaction;
+use crate::sql::changefeed::{ChangeSet, DatabaseMutation, TableMutations};
+use crate::vs;
+
+use std::ascii::escape_default;
+use std::str;
+
+fn show(bs: &[u8]) -> String {
+	let mut visible = String::new();
+	for &b in bs {
+		let part: Vec<u8> = escape_default(b).collect();
+		visible.push_str(str::from_utf8(&part).unwrap());
+	}
+	visible
+}
+
+// Reads the change feed for a specific database or a table,
+// starting from a specific versionstamp.
+//
+// The limit parameter is the maximum number of change sets to return.
+// If the limit is not specified, the default is 100.
+//
+// You can use this to read the change feed in chunks.
+// The second call would start from the last versionstamp + 1 of the first call.
+pub async fn read(
+	tx: &mut Transaction,
+	ns: &str,
+	db: &str,
+	tb: Option<&str>,
+	start: Option<u64>,
+	limit: Option<u32>,
+) -> Result<Vec<ChangeSet>, Error> {
+	// Get the current timestamp
+	let seq = dv::new(ns, db);
+
+	let beg = match start {
+		Some(x) => cf::ts_prefix(ns, db, vs::u64_to_versionstamp(x)),
+		None => {
+			let ts = tx.get_timestamp(seq, false).await?;
+			cf::ts_prefix(ns, db, ts)
+		} // None => dc::prefix(ns, db),
+	};
+	let end = cf::suffix(ns, db);
+
+	let limit = limit.unwrap_or(100);
+
+	let _x = tx.scan(beg..end, limit).await?;
+
+	let mut vs: Option<[u8; 10]> = None;
+	let mut buf: Vec<TableMutations> = Vec::new();
+
+	let mut r = Vec::<ChangeSet>::new();
+	// iterate over _x and put decoded elements to r
+	for (k, v) in _x {
+		println!("read: k={}", show(k.as_slice()));
+
+		let dec = crate::key::cf::Cf::decode(&k).unwrap();
+
+		if let Some(tb) = tb {
+			if dec.tb != tb {
+				continue;
+			}
+		}
+
+		let _tb = dec.tb;
+		let ts = dec.vs;
+
+		// Decode the byte array into a vector of operations
+		let tb_muts: TableMutations = v.into();
+
+		match vs {
+			Some(x) => {
+				if ts != x {
+					let db_mut = DatabaseMutation(buf);
+					r.push(ChangeSet(x, db_mut));
+					buf = Vec::new();
+					vs = Some(ts)
+				}
+			}
+			None => {
+				vs = Some(ts);
+			}
+		}
+		buf.push(tb_muts);
+	}
+
+	if !buf.is_empty() {
+		let db_mut = DatabaseMutation(buf);
+		r.push(ChangeSet(vs.unwrap(), db_mut));
+	}
+
+	Ok(r)
+}

--- a/lib/src/cf/writer.rs
+++ b/lib/src/cf/writer.rs
@@ -1,0 +1,221 @@
+use crate::kvs::Key;
+use crate::sql::changefeed::{TableMutation, TableMutations};
+use crate::sql::ident::Ident;
+use crate::sql::thing::Thing;
+use crate::sql::value::Value;
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+// PreparedWrite is a tuple of (versionstamp key, key prefix, key suffix, serialized table mutations).
+// The versionstamp key is the key that contains the current versionstamp and might be used by the
+// specific transaction implementation to make the versionstamp unique and monotonic.
+// The key prefix and key suffix are used to construct the key for the table mutations.
+// The consumer of this library should write KV pairs with the following format:
+// key = key_prefix + versionstamp + key_suffix
+// value = serialized table mutations
+type PreparedWrite = (Vec<u8>, Vec<u8>, Vec<u8>, crate::kvs::Val);
+
+pub struct Writer {
+	buf: Buffer,
+}
+
+pub struct Buffer {
+	pub b: HashMap<String, TableMutations>,
+}
+
+impl Buffer {
+	pub fn new() -> Self {
+		Self {
+			b: HashMap::new(),
+		}
+	}
+
+	pub fn push(&mut self, tb: String, m: TableMutation) {
+		let tb2 = tb.clone();
+		let ms = self.b.entry(tb).or_insert(TableMutations::new(tb2));
+		ms.1.push(m);
+	}
+}
+
+// Writer is a helper for writing table mutations to a transaction.
+impl Writer {
+	pub(crate) fn new() -> Self {
+		Self {
+			buf: Buffer::new(),
+		}
+	}
+
+	pub(crate) fn update(&mut self, tb: Ident, id: Thing, v: Cow<'_, Value>) {
+		if v.is_some() {
+			self.buf.push(tb.0, TableMutation::Set(id, v.into_owned()));
+		} else {
+			self.buf.push(tb.0, TableMutation::Del(id));
+		}
+	}
+
+	// get returns all the mutations buffered for this transaction,
+	// that are to be written onto the key composed of the specified prefix + the current timestamp + the specified suffix.
+	pub(crate) fn get(&self, ns: &str, db: &str) -> Vec<PreparedWrite> {
+		let mut r = Vec::<(Vec<u8>, Vec<u8>, Vec<u8>, crate::kvs::Val)>::new();
+		// Get the current timestamp
+		for (table, mutations) in self.buf.b.iter() {
+			let ts_key: Key = crate::key::dv::new(ns, db).into();
+			let tc_key_prefix: Key = crate::key::cf::versionstamped_key_prefix(ns, db);
+			let tc_key_suffix: Key = crate::key::cf::versionstamped_key_suffix(table.as_str());
+
+			r.push((ts_key, tc_key_prefix, tc_key_suffix, mutations.into()))
+		}
+		r
+	}
+}
+
+// fn tb_mutations(ts: u64, tb: &str, changes: Vec<(ID, Patch))
+
+#[cfg(test)]
+mod tests {
+	use std::borrow::Cow;
+	use std::time::Duration;
+
+	use crate::kvs::Datastore;
+	use crate::sql::changefeed::{
+		ChangeFeed, ChangeSet, DatabaseMutation, TableMutation, TableMutations,
+	};
+	use crate::sql::id::Id;
+	use crate::sql::statements::DefineTableStatement;
+	use crate::sql::thing::Thing;
+	use crate::sql::value::Value;
+	use crate::vs;
+
+	#[tokio::test]
+	async fn test_changefeed_read_write() {
+		let ns = "myns";
+		let db = "mydb";
+		let tb = super::Ident("mytb".to_string());
+		let mut dtb = DefineTableStatement::default();
+		dtb.name = tb.clone();
+		dtb.changefeed = Some(ChangeFeed {
+			expiry: Duration::from_secs(0),
+		});
+
+		let ds = Datastore::new("memory").await.unwrap();
+
+		let mut tx1 = ds.transaction(true, false).await.unwrap();
+		let thing_a = Thing {
+			tb: tb.clone().0,
+			id: Id::String("A".to_string()),
+		};
+		let value_a: super::Value = "a".into();
+		tx1.record_change(&dtb, &thing_a, Cow::Borrowed(&value_a));
+		tx1.complete_changes(ns, db, true).await.unwrap();
+		let _r1 = tx1.commit().await.unwrap();
+
+		let mut tx2 = ds.transaction(true, false).await.unwrap();
+		let thing_c = Thing {
+			tb: tb.clone().0,
+			id: Id::String("C".to_string()),
+		};
+		let value_c: Value = "c".into();
+		tx2.record_change(&dtb, &thing_c, Cow::Borrowed(&value_c));
+		tx2.complete_changes(ns, db, true).await.unwrap();
+		let _r2 = tx2.commit().await.unwrap();
+
+		let x = ds.transaction(true, false).await;
+		let mut tx3 = x.unwrap();
+		let thing_b = Thing {
+			tb: tb.clone().0,
+			id: Id::String("B".to_string()),
+		};
+		let value_b: Value = "b".into();
+		tx3.record_change(&dtb, &thing_b, Cow::Borrowed(&value_b));
+		let thing_c2 = Thing {
+			tb: tb.clone().0,
+			id: Id::String("C".to_string()),
+		};
+		let value_c2: Value = "c2".into();
+		tx3.record_change(&dtb, &thing_c2, Cow::Borrowed(&value_c2));
+		tx3.complete_changes(ns, db, true).await.unwrap();
+		tx3.commit().await.unwrap();
+
+		// Note that we committed tx1, tx2, and tx3 in this order so far.
+		// Therfore, the change feeds should give us
+		// the mutations in the commit order, which is tx1, tx3, then tx2.
+
+		let start: u64 = 0;
+
+		let mut tx4 = ds.transaction(true, false).await.unwrap();
+		let tb = tb.clone();
+		let tb = Some(tb.0.as_ref());
+		let r = crate::cf::read(&mut tx4, ns, db, tb, Some(start), Some(10)).await.unwrap();
+		tx4.commit().await.unwrap();
+
+		let mut want: Vec<ChangeSet> = Vec::new();
+		want.push(ChangeSet(
+			vs::u64_to_versionstamp(1),
+			DatabaseMutation(vec![TableMutations(
+				"mytb".to_string(),
+				vec![TableMutation::Set(
+					Thing::from(("mytb".to_string(), "A".to_string())),
+					Value::from("a"),
+				)],
+			)]),
+		));
+		want.push(ChangeSet(
+			vs::u64_to_versionstamp(2),
+			DatabaseMutation(vec![TableMutations(
+				"mytb".to_string(),
+				vec![TableMutation::Set(
+					Thing::from(("mytb".to_string(), "C".to_string())),
+					Value::from("c"),
+				)],
+			)]),
+		));
+		want.push(ChangeSet(
+			vs::u64_to_versionstamp(3),
+			DatabaseMutation(vec![TableMutations(
+				"mytb".to_string(),
+				vec![
+					TableMutation::Set(
+						Thing::from(("mytb".to_string(), "B".to_string())),
+						Value::from("b"),
+					),
+					TableMutation::Set(
+						Thing::from(("mytb".to_string(), "C".to_string())),
+						Value::from("c2"),
+					),
+				],
+			)]),
+		));
+
+		assert_eq!(r, want);
+
+		let mut tx5 = ds.transaction(true, false).await.unwrap();
+		// gc_all needs to be committed before we can read the changes
+		crate::cf::gc_db(&mut tx5, ns, db, 3, Some(10)).await.unwrap();
+		// We now commit tx5, which should persist the gc_all resullts
+		tx5.commit().await.unwrap();
+
+		// Now we should see the gc_all results
+		let mut tx6 = ds.transaction(true, false).await.unwrap();
+		let r = crate::cf::read(&mut tx6, ns, db, tb, Some(start), Some(10)).await.unwrap();
+		tx6.commit().await.unwrap();
+
+		let mut want: Vec<ChangeSet> = Vec::new();
+		want.push(ChangeSet(
+			vs::u64_to_versionstamp(3),
+			DatabaseMutation(vec![TableMutations(
+				"mytb".to_string(),
+				vec![
+					TableMutation::Set(
+						Thing::from(("mytb".to_string(), "B".to_string())),
+						Value::from("b"),
+					),
+					TableMutation::Set(
+						Thing::from(("mytb".to_string(), "C".to_string())),
+						Value::from("c2"),
+					),
+				],
+			)]),
+		));
+		assert_eq!(r, want);
+	}
+}

--- a/lib/src/doc/changefeeds.rs
+++ b/lib/src/doc/changefeeds.rs
@@ -1,0 +1,36 @@
+use crate::ctx::Context;
+use crate::dbs::Options;
+use crate::dbs::Statement;
+use crate::doc::Document;
+use crate::err::Error;
+
+impl<'a> Document<'a> {
+	pub async fn changefeeds(
+		&self,
+		ctx: &Context<'_>,
+		opt: &Options,
+		_stm: &Statement<'_>,
+	) -> Result<(), Error> {
+		// Check if forced
+		if !opt.force && !self.changed() {
+			return Ok(());
+		}
+		// Get the record id
+		let txn = ctx.try_clone_transaction()?;
+		let _ = self.id.as_ref().unwrap();
+		let tb = self.tb(opt, &txn).await?;
+		let tb = tb.as_ref();
+		if tb.changefeed.is_some() {
+			// Clone transaction
+			let txn = ctx.try_clone_transaction()?;
+			// Claim transaction
+			let mut run = txn.lock().await;
+
+			let id = &(*self.id.as_ref().unwrap()).clone();
+			// Create the changefeed entry
+			run.record_change(tb, id, self.current.clone());
+		}
+		// Carry on
+		Ok(())
+	}
+}

--- a/lib/src/doc/create.rs
+++ b/lib/src/doc/create.rs
@@ -32,6 +32,8 @@ impl<'a> Document<'a> {
 		self.table(ctx, opt, stm).await?;
 		// Run lives queries
 		self.lives(ctx, opt, stm).await?;
+		// Run change feeds queries
+		self.changefeeds(ctx, opt, stm).await?;
 		// Run event queries
 		self.event(ctx, opt, stm).await?;
 		// Yield document

--- a/lib/src/doc/delete.rs
+++ b/lib/src/doc/delete.rs
@@ -26,6 +26,8 @@ impl<'a> Document<'a> {
 		self.table(ctx, opt, stm).await?;
 		// Run lives queries
 		self.lives(ctx, opt, stm).await?;
+		// Run change feeds queries
+		self.changefeeds(ctx, opt, stm).await?;
 		// Run event queries
 		self.event(ctx, opt, stm).await?;
 		// Yield document

--- a/lib/src/doc/insert.rs
+++ b/lib/src/doc/insert.rs
@@ -36,6 +36,8 @@ impl<'a> Document<'a> {
 				self.table(ctx, opt, stm).await?;
 				// Run lives queries
 				self.lives(ctx, opt, stm).await?;
+				// Run change feeds queries
+				self.changefeeds(ctx, opt, stm).await?;
 				// Run event queries
 				self.event(ctx, opt, stm).await?;
 				// Yield document
@@ -63,6 +65,8 @@ impl<'a> Document<'a> {
 				self.table(ctx, opt, stm).await?;
 				// Run lives queries
 				self.lives(ctx, opt, stm).await?;
+				// Run change feeds queries
+				self.changefeeds(ctx, opt, stm).await?;
 				// Run event queries
 				self.event(ctx, opt, stm).await?;
 				// Yield document

--- a/lib/src/doc/mod.rs
+++ b/lib/src/doc/mod.rs
@@ -20,6 +20,7 @@ mod update; // Processes a UPDATE statement for this document
 
 mod allow; // Checks whether the query can access this document
 mod alter; // Modifies and updates the fields in this document
+mod changefeeds; // Processes any change feeds relevant for this document
 mod check; // Checks whether the WHERE clauses matches this document
 mod clean; // Ensures records adhere to the table schema
 mod edges; // Attempts to store the edge data for this document

--- a/lib/src/doc/update.rs
+++ b/lib/src/doc/update.rs
@@ -34,6 +34,8 @@ impl<'a> Document<'a> {
 		self.table(ctx, opt, stm).await?;
 		// Run lives queries
 		self.lives(ctx, opt, stm).await?;
+		// Run change feeds queries
+		self.changefeeds(ctx, opt, stm).await?;
 		// Run event queries
 		self.event(ctx, opt, stm).await?;
 		// Yield document

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -1,6 +1,7 @@
 use crate::idx::ft::MatchRef;
 use crate::sql::idiom::Idiom;
 use crate::sql::value::Value;
+use crate::vs::Error as VersionstampError;
 use base64_lib::DecodeError as Base64Error;
 use bincode::Error as BincodeError;
 use bung::encode::Error as SerdeError;
@@ -462,6 +463,9 @@ pub enum Error {
 	/// The index has been found to be inconsistent
 	#[error("Index is corrupted")]
 	CorruptedIndex,
+
+	#[error("Versionstamp in key is corrupted: {0}")]
+	CorruptedVersionstampInKey(#[from] VersionstampError),
 
 	/// The query planner did not find an index able to support the match @@ operator on a given expression
 	#[error("There was no suitable full-text index supporting the expression '{value}'")]

--- a/lib/src/key/mod.rs
+++ b/lib/src/key/mod.rs
@@ -16,7 +16,7 @@
 ///
 /// Database        /*{ns}*{db}
 /// AZ              /*{ns}*{db}!az{az}
-/// CF /*{ns}*{db}!cf{ts}
+/// CF              /*{ns}*{db}!cf{ts}
 /// DL              /*{ns}*{db}!dl{us}
 /// DT              /*{ns}*{db}!dt{tk}
 /// PA              /*{ns}*{db}!pa{pa}

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -1,4 +1,5 @@
 use super::tx::Transaction;
+use crate::cf;
 use crate::ctx::Context;
 use crate::dbs::Attach;
 use crate::dbs::Executor;
@@ -300,6 +301,7 @@ impl Datastore {
 		Ok(Transaction {
 			inner,
 			cache: super::cache::Cache::default(),
+			cf: cf::Writer::new(),
 		})
 	}
 

--- a/lib/src/kvs/fdb/mod.rs
+++ b/lib/src/kvs/fdb/mod.rs
@@ -5,6 +5,7 @@ use futures::TryStreamExt;
 use crate::err::Error;
 use crate::kvs::Key;
 use crate::kvs::Val;
+use crate::vs::{u64_to_versionstamp, Versionstamp};
 use std::ops::Range;
 use std::sync::Arc;
 // We use it to work-around the fact that foundationdb-rs' Transaction
@@ -15,6 +16,7 @@ use std::sync::Arc;
 // self or the fdb-rs Transaction it contains.
 //
 // We use mutex from the futures crate instead of the std's due to https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/alan_thinks_he_needs_async_locks.html.
+use foundationdb::options::MutationType;
 use futures::lock::Mutex;
 use once_cell::sync::Lazy;
 
@@ -193,6 +195,29 @@ impl Transaction {
 			.map(|v| v.as_ref().map(|v| v.to_vec()))
 			.map_err(|e| Error::Tx(format!("Unable to get kv from FoundationDB: {}", e)))
 	}
+	/// Obtain a new change timestamp for a key
+	/// which is replaced with the current timestamp when the transaction is committed.
+	/// NOTE: This should be called when composing the change feed entries for this transaction,
+	/// which should be done immediately before the transaction commit.
+	/// That is to keep other transactions commit delay(pessimistic) or conflict(optimistic) as less as possible.
+	#[allow(unused)]
+	pub async fn get_timestamp(&mut self) -> Result<Versionstamp, Error> {
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		let tx = self.tx.lock().await;
+		let tx = tx.as_ref().unwrap();
+		let res = tx
+			.get_read_version()
+			.await
+			.map_err(|e| Error::Tx(format!("Unable to get read version from FDB: {}", e)))?;
+		let res: u64 = res.try_into().unwrap();
+		let res = u64_to_versionstamp(res);
+
+		// Return the uint64 representation of the timestamp as the result
+		Ok(res)
+	}
 	/// Insert or update a key in the database
 	pub async fn set<K, V>(&mut self, key: K, val: V) -> Result<(), Error>
 	where
@@ -293,6 +318,49 @@ impl Transaction {
 			(Err(e), _) => return Err(e),
 			_ => return Err(Error::TxConditionNotMet),
 		};
+		// Return result
+		Ok(())
+	}
+	// Sets the value for a versionstamped key prefixed with the user-supplied key.
+	pub async fn set_versionstamped_key<K, V>(
+		&mut self,
+		prefix: K,
+		suffix: K,
+		val: V,
+	) -> Result<(), Error>
+	where
+		K: Into<Key>,
+		V: Into<Val>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Check to see if transaction is writable
+		if !self.rw {
+			return Err(Error::TxReadonly);
+		}
+		// Set the key
+		let mut k: Vec<u8> = prefix.into();
+		let pos = k.len();
+		let pos: u32 = pos.try_into().unwrap();
+		// The incomplete versionstamp is 10 bytes long.
+		// See the documentation of SetVersionstampedKey for more information.
+		let mut ts_placeholder: Vec<u8> =
+			vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+		k.append(&mut ts_placeholder);
+		k.append(&mut suffix.into());
+		// FDB's SetVersionstampedKey expects the parameter, the start position of the 10-bytes placeholder
+		// to be replaced by the versionstamp, to be in little endian.
+		let mut posbs: Vec<u8> = pos.to_le_bytes().to_vec();
+		k.append(&mut posbs);
+
+		let key: &[u8] = &k[..];
+		let val: Vec<u8> = val.into();
+		let val: &[u8] = &val[..];
+		let tx = self.tx.lock().await;
+		let tx = tx.as_ref().unwrap();
+		tx.atomic_op(key, val, MutationType::SetVersionstampedKey);
 		// Return result
 		Ok(())
 	}

--- a/lib/src/kvs/indxdb/mod.rs
+++ b/lib/src/kvs/indxdb/mod.rs
@@ -3,6 +3,7 @@
 use crate::err::Error;
 use crate::kvs::Key;
 use crate::kvs::Val;
+use crate::vs::{try_to_u64_be, u64_to_versionstamp, Versionstamp};
 use std::ops::Range;
 
 pub struct Datastore {
@@ -103,6 +104,68 @@ impl Transaction {
 		let res = self.tx.get(key.into()).await?;
 		// Return result
 		Ok(res)
+	}
+	/// Obtain a new change timestamp for a key
+	/// which is replaced with the current timestamp when the transaction is committed.
+	/// NOTE: This should be called when composing the change feed entries for this transaction,
+	/// which should be done immediately before the transaction commit.
+	/// That is to keep other transactions commit delay(pessimistic) or conflict(optimistic) as less as possible.
+	#[allow(unused)]
+	pub async fn get_timestamp<K>(&mut self, key: K) -> Result<Versionstamp, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Write the timestamp to the "last-write-timestamp" key
+		// to ensure that no other transactions can commit with older timestamps.
+		let k: Key = key.into();
+		let prev = self.tx.get(k.clone()).await?;
+		let ver = match prev {
+			Some(prev) => {
+				let slice = prev.as_slice();
+				let res: Result<[u8; 10], Error> = match slice.try_into() {
+					Ok(ba) => Ok(ba),
+					Err(e) => Err(Error::Ds(e.to_string())),
+				};
+				let array = res?;
+				let prev: u64 = try_to_u64_be(array)?;
+				prev + 1
+			}
+			None => 1,
+		};
+
+		let verbytes = u64_to_versionstamp(ver);
+
+		self.tx.put(k, verbytes.to_vec()).await?;
+		// Return the uint64 representation of the timestamp as the result
+		Ok(verbytes)
+	}
+	/// Obtain a new key that is suffixed with the change timestamp
+	pub async fn get_versionstamped_key<K>(
+		&mut self,
+		ts_key: K,
+		prefix: K,
+		suffix: K,
+	) -> Result<Vec<u8>, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Check to see if transaction is writable
+		if !self.rw {
+			return Err(Error::TxReadonly);
+		}
+		let ts = self.get_timestamp(ts_key).await?;
+		let mut k: Vec<u8> = prefix.into();
+		k.append(&mut ts.to_vec());
+		k.append(&mut suffix.into());
+		Ok(k)
 	}
 	/// Insert or update a key in the database
 	pub async fn set<K, V>(&mut self, key: K, val: V) -> Result<(), Error>

--- a/lib/src/kvs/mem/mod.rs
+++ b/lib/src/kvs/mem/mod.rs
@@ -3,7 +3,20 @@
 use crate::err::Error;
 use crate::kvs::Key;
 use crate::kvs::Val;
+use crate::vs::{try_to_u64_be, u64_to_versionstamp, Versionstamp};
 use std::ops::Range;
+
+use std::ascii::escape_default;
+use std::str;
+
+fn show(bs: &[u8]) -> String {
+	let mut visible = String::new();
+	for &b in bs {
+		let part: Vec<u8> = escape_default(b).collect();
+		visible.push_str(str::from_utf8(&part).unwrap());
+	}
+	visible
+}
 
 pub struct Datastore {
 	db: echodb::Db<Key, Val>,
@@ -101,6 +114,84 @@ impl Transaction {
 		// Return result
 		Ok(res)
 	}
+	/// Obtain a new change timestamp for a key
+	/// which is replaced with the current timestamp when the transaction is committed.
+	/// NOTE: This should be called when composing the change feed entries for this transaction,
+	/// which should be done immediately before the transaction commit.
+	/// That is to keep other transactions commit delay(pessimistic) or conflict(optimistic) as less as possible.
+	#[allow(unused)]
+	pub fn get_timestamp<K>(&mut self, key: K) -> Result<Versionstamp, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Write the timestamp to the "last-write-timestamp" key
+		// to ensure that no other transactions can commit with older timestamps.
+		let k: Key = key.into();
+		let prev = self.tx.get(k.clone())?;
+		let ver = match prev {
+			Some(prev) => {
+				let slice = prev.as_slice();
+				let res: Result<[u8; 10], Error> = match slice.try_into() {
+					Ok(ba) => Ok(ba),
+					Err(e) => Err(Error::Ds(e.to_string())),
+				};
+				let array = res?;
+				let prev = try_to_u64_be(array)?;
+				prev + 1
+			}
+			None => 1,
+		};
+
+		let verbytes = u64_to_versionstamp(ver);
+
+		self.tx.set(k, verbytes.to_vec())?;
+		// Return the uint64 representation of the timestamp as the result
+		Ok(verbytes)
+	}
+	/// Obtain a new key that is suffixed with the change timestamp
+	pub async fn get_versionstamped_key<K>(
+		&mut self,
+		ts_key: K,
+		prefix: K,
+		suffix: K,
+	) -> Result<Vec<u8>, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Check to see if transaction is writable
+		if !self.rw {
+			return Err(Error::TxReadonly);
+		}
+
+		let ts_key: Key = ts_key.into();
+		let prefix: Key = prefix.into();
+		let suffix: Key = suffix.into();
+
+		let ts = self.get_timestamp(ts_key.clone())?;
+		let mut k: Vec<u8> = prefix.clone();
+		k.append(&mut ts.to_vec());
+		k.append(&mut suffix.clone());
+
+		println!(
+			"get_versionstamped_key: ts_key={} prefix={} r={} suffix={} k={}",
+			show(ts_key.as_slice()),
+			show(prefix.as_slice()),
+			show(ts.as_slice()),
+			show(suffix.as_slice()),
+			show(k.as_slice())
+		);
+
+		Ok(k)
+	}
+
 	/// Insert or update a key in the database
 	pub fn set<K, V>(&mut self, key: K, val: V) -> Result<(), Error>
 	where

--- a/lib/src/kvs/speedb/mod.rs
+++ b/lib/src/kvs/speedb/mod.rs
@@ -3,6 +3,7 @@
 use crate::err::Error;
 use crate::kvs::Key;
 use crate::kvs::Val;
+use crate::vs::{try_to_u64_be, u64_to_versionstamp, Versionstamp};
 use futures::lock::Mutex;
 use speedb::{OptimisticTransactionDB, OptimisticTransactionOptions, ReadOptions, WriteOptions};
 use std::ops::Range;
@@ -135,6 +136,68 @@ impl Transaction {
 		let res = self.tx.lock().await.as_ref().unwrap().get_opt(key.into(), &self.ro)?;
 		// Return result
 		Ok(res)
+	}
+	/// Obtain a new change timestamp for a key
+	/// which is replaced with the current timestamp when the transaction is committed.
+	/// NOTE: This should be called when composing the change feed entries for this transaction,
+	/// which should be done immediately before the transaction commit.
+	/// That is to keep other transactions commit delay(pessimistic) or conflict(optimistic) as less as possible.
+	#[allow(unused)]
+	pub async fn get_timestamp<K>(&mut self, key: K) -> Result<Versionstamp, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Write the timestamp to the "last-write-timestamp" key
+		// to ensure that no other transactions can commit with older timestamps.
+		let k: Key = key.into();
+		let prev = self.tx.lock().await.as_ref().unwrap().get_opt(k.clone(), &self.ro)?;
+		let ver = match prev {
+			Some(prev) => {
+				let slice = prev.as_slice();
+				let res: Result<[u8; 10], Error> = match slice.try_into() {
+					Ok(ba) => Ok(ba),
+					Err(e) => Err(Error::Ds(e.to_string())),
+				};
+				let array = res?;
+				let prev = try_to_u64_be(array)?;
+				prev + 1
+			}
+			None => 1,
+		};
+
+		let verbytes = u64_to_versionstamp(ver);
+
+		self.tx.lock().await.as_ref().unwrap().put(k, verbytes)?;
+		// Return the uint64 representation of the timestamp as the result
+		Ok(verbytes)
+	}
+	/// Obtain a new key that is suffixed with the change timestamp
+	pub async fn get_versionstamped_key<K>(
+		&mut self,
+		ts_key: K,
+		prefix: K,
+		suffix: K,
+	) -> Result<Vec<u8>, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Check to see if transaction is writable
+		if !self.rw {
+			return Err(Error::TxReadonly);
+		}
+		let ts = self.get_timestamp(ts_key).await?;
+		let mut k: Vec<u8> = prefix.into();
+		k.append(&mut ts.to_vec());
+		k.append(&mut suffix.into());
+		Ok(k)
 	}
 	/// Insert or update a key in the database
 	pub async fn set<K, V>(&mut self, key: K, val: V) -> Result<(), Error>

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -2,6 +2,7 @@ use super::kv::Add;
 use super::kv::Convert;
 use super::Key;
 use super::Val;
+use crate::cf;
 use crate::dbs::cl::ClusterMembership;
 use crate::dbs::cl::Timestamp;
 use crate::err::Error;
@@ -14,6 +15,7 @@ use crate::sql::paths::IN;
 use crate::sql::paths::OUT;
 use crate::sql::thing::Thing;
 use crate::sql::{Uuid, Value};
+use crate::vs::Versionstamp;
 use channel::Sender;
 use sql::permission::Permissions;
 use sql::statements::DefineAnalyzerStatement;
@@ -29,6 +31,7 @@ use sql::statements::DefineScopeStatement;
 use sql::statements::DefineTableStatement;
 use sql::statements::DefineTokenStatement;
 use sql::statements::LiveStatement;
+use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
 use std::ops::Range;
@@ -43,6 +46,7 @@ const LOG: &str = "surrealdb::txn";
 pub struct Transaction {
 	pub(super) inner: Inner,
 	pub(super) cache: Cache,
+	pub(super) cf: cf::Writer,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -389,6 +393,120 @@ impl Transaction {
 				inner: Inner::FoundationDB(v),
 				..
 			} => v.set(key, val).await,
+			#[allow(unreachable_patterns)]
+			_ => unreachable!(),
+		}
+	}
+
+	/// Obtain a new change timestamp for a key
+	/// which is replaced with the current timestamp when the transaction is committed.
+	/// NOTE: This should be called when composing the change feed entries for this transaction,
+	/// which should be done immediately before the transaction commit.
+	/// That is to keep other transactions commit delay(pessimistic) or conflict(optimistic) as less as possible.
+	#[allow(unused)]
+	pub async fn get_timestamp<K>(&mut self, key: K, lock: bool) -> Result<Versionstamp, Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		#[cfg(debug_assertions)]
+		trace!(target: LOG, "Get Timestamp {:?}", key);
+		match self {
+			#[cfg(feature = "kv-mem")]
+			Transaction {
+				inner: Inner::Mem(v),
+				..
+			} => v.get_timestamp(key),
+			#[cfg(feature = "kv-rocksdb")]
+			Transaction {
+				inner: Inner::RocksDB(v),
+				..
+			} => v.get_timestamp(key).await,
+			#[cfg(feature = "kv-indxdb")]
+			Transaction {
+				inner: Inner::IndxDB(v),
+				..
+			} => v.get_timestamp(key).await,
+			#[cfg(feature = "kv-tikv")]
+			Transaction {
+				inner: Inner::TiKV(v),
+				..
+			} => v.get_timestamp(key, lock).await,
+			#[cfg(feature = "kv-fdb")]
+			Transaction {
+				inner: Inner::FoundationDB(v),
+				..
+			} => v.get_timestamp().await,
+			#[cfg(feature = "kv-speedb")]
+			Transaction {
+				inner: Inner::SpeeDB(v),
+				..
+			} => v.get_timestamp(key).await,
+			#[allow(unreachable_patterns)]
+			_ => unreachable!(),
+		}
+	}
+
+	/// Insert or update a key in the datastore.
+	#[allow(unused_variables)]
+	pub async fn set_versionstamped_key<K, V>(
+		&mut self,
+		ts_key: K,
+		prefix: K,
+		suffix: K,
+		val: V,
+	) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+		V: Into<Val> + Debug,
+	{
+		#[cfg(debug_assertions)]
+		trace!(target: LOG, "Set {:?} <ts> {:?} => {:?}", prefix, suffix, val);
+		match self {
+			#[cfg(feature = "kv-mem")]
+			Transaction {
+				inner: Inner::Mem(v),
+				..
+			} => {
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
+				v.set(k, val)
+			}
+			#[cfg(feature = "kv-rocksdb")]
+			Transaction {
+				inner: Inner::RocksDB(v),
+				..
+			} => {
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
+				v.set(k, val).await
+			}
+			#[cfg(feature = "kv-indxdb")]
+			Transaction {
+				inner: Inner::IndxDB(v),
+				..
+			} => {
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
+				v.set(k, val).await
+			}
+			#[cfg(feature = "kv-tikv")]
+			Transaction {
+				inner: Inner::TiKV(v),
+				..
+			} => {
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
+				v.set(k, val).await
+			}
+			#[cfg(feature = "kv-fdb")]
+			Transaction {
+				inner: Inner::FoundationDB(v),
+				..
+			} => v.set_versionstamped_key(prefix, suffix, val).await,
+			#[cfg(feature = "kv-speedb")]
+			Transaction {
+				inner: Inner::SpeeDB(v),
+				..
+			} => {
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
+				v.set(k, val).await
+			}
 			#[allow(unreachable_patterns)]
 			_ => unreachable!(),
 		}
@@ -1490,6 +1608,7 @@ impl Transaction {
 					let val = DefineTableStatement {
 						name: tb.to_owned().into(),
 						permissions: Permissions::none(),
+						changefeed: None,
 						..DefineTableStatement::default()
 					};
 					self.put(key, &val).await?;
@@ -1646,6 +1765,7 @@ impl Transaction {
 					let val = DefineTableStatement {
 						name: tb.to_owned().into(),
 						permissions: Permissions::none(),
+						changefeed: None,
 						..DefineTableStatement::default()
 					};
 					self.put(key, &val).await?;
@@ -1909,6 +2029,49 @@ impl Transaction {
 			}
 		}
 		// Everything exported
+		Ok(())
+	}
+
+	// change will record the change in the changefeed if enabled.
+	// To actually persist the record changes into the underlying kvs,
+	// you must call the `complete_changes` function and then commit the transaction.
+	pub(crate) fn record_change(
+		&mut self,
+		tb: &DefineTableStatement,
+		id: &Thing,
+		v: Cow<'_, Value>,
+	) {
+		if tb.changefeed.is_some() {
+			self.cf.update(tb.name.to_owned(), id.clone(), v)
+		}
+	}
+
+	// complete_changes will complete the changefeed recording for the given namespace and database.
+	//
+	// Under the hood, this function calls the transaction's `set_versionstamped_key` for each change.
+	// Every change must be recorded by calling this struct's `record_change` function beforehand.
+	// If there was no preceeding `record_change` function calls for this transaction, this function will do nothing.
+	//
+	// This function should be called only after all the changes have been made to the transaction.
+	// Otherwise, changes are missed in the change feed.
+	//
+	// This function should be called immediately before calling the commit function to guarantee that
+	// the lock, if needed by lock=true, is held only for the duration of the commit, not the entire transaction.
+	//
+	// This function is here because it needs access to mutably borrow the transaction.
+	//
+	// Lastly, you should set lock=true if you want the changefeed to be correctly ordered for
+	// non-FDB backends.
+	pub(crate) async fn complete_changes(
+		&mut self,
+		ns: &str,
+		db: &str,
+		_lock: bool,
+	) -> Result<(), Error> {
+		let changes = self.cf.get(ns, db);
+		for (tskey, prefix, suffix, v) in changes {
+			self.set_versionstamped_key(tskey, prefix, suffix, v).await?
+		}
 		Ok(())
 	}
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -107,6 +107,7 @@ extern crate log;
 mod mac;
 
 mod api;
+mod cf;
 mod ctx;
 mod doc;
 mod exe;

--- a/lib/src/sql/changefeed.rs
+++ b/lib/src/sql/changefeed.rs
@@ -1,6 +1,7 @@
 use crate::sql::comment::shouldbespace;
 use crate::sql::duration::{duration, Duration};
 use crate::sql::error::IResult;
+pub use crate::sql::mutations::*;
 use nom::bytes::complete::tag_no_case;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};

--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod kind;
 pub(crate) mod language;
 pub(crate) mod limit;
 pub(crate) mod model;
+pub(crate) mod mutations;
 pub(crate) mod number;
 pub(crate) mod object;
 pub(crate) mod operation;

--- a/lib/src/sql/mutations.rs
+++ b/lib/src/sql/mutations.rs
@@ -1,0 +1,138 @@
+use crate::sql::array::Array;
+use crate::sql::object::Object;
+use crate::sql::thing::Thing;
+use crate::sql::value::Value;
+use crate::vs::to_u128_be;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::{self, Display, Formatter};
+
+use derive::Store;
+
+// Mutation is a single mutation to a table.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
+pub enum TableMutation {
+	// Although the Value is supposed to contain a field "id" of Thing,
+	// we do include it in the first field for convenience.
+	Set(Thing, Value),
+	Del(Thing),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
+pub struct TableMutations(pub String, pub Vec<TableMutation>);
+
+impl TableMutations {
+	pub fn new(tb: String) -> Self {
+		Self(tb, Vec::new())
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
+pub struct DatabaseMutation(pub Vec<TableMutations>);
+
+impl DatabaseMutation {
+	pub fn new() -> Self {
+		Self(Vec::new())
+	}
+}
+
+impl Default for DatabaseMutation {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+// Change is a set of mutations made to a table at the specific timestamp.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
+pub struct ChangeSet(pub [u8; 10], pub DatabaseMutation);
+
+impl TableMutation {
+	pub fn into_value(self) -> Value {
+		let (k, v) = match self {
+			TableMutation::Set(_t, v) => ("update".to_string(), v),
+			TableMutation::Del(t) => {
+				let mut h = BTreeMap::<String, Value>::new();
+				h.insert("id".to_string(), Value::Thing(t));
+				let o = Object::from(h);
+				("delete".to_string(), Value::Object(o))
+			}
+		};
+
+		let mut h = BTreeMap::<String, Value>::new();
+		h.insert(k, v);
+		let o = crate::sql::object::Object::from(h);
+		Value::Object(o)
+	}
+}
+
+impl DatabaseMutation {
+	pub fn into_value(self) -> Value {
+		let mut changes = Vec::<Value>::new();
+		for tbs in self.0 {
+			for tb in tbs.1 {
+				changes.push(tb.into_value());
+			}
+		}
+		Value::Array(Array::from(changes))
+	}
+}
+
+impl ChangeSet {
+	pub fn into_value(self) -> Value {
+		let mut m = BTreeMap::<String, Value>::new();
+		let vs = to_u128_be(self.0);
+		m.insert("versionstamp".to_string(), Value::from(vs));
+		m.insert("changes".to_string(), self.1.into_value());
+		let so: Object = m.into();
+		Value::Object(so)
+	}
+}
+
+impl Display for TableMutation {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		match self {
+			TableMutation::Set(id, v) => write!(f, "SET {} {}", id, v),
+			TableMutation::Del(id) => write!(f, "DEL {}", id),
+		}
+	}
+}
+
+impl Display for TableMutations {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		let tb = &self.0;
+		let muts = &self.1;
+		write!(f, "{}", tb)?;
+		muts.iter().try_for_each(|v| write!(f, "{}", v))
+	}
+}
+
+impl Display for DatabaseMutation {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		let x = &self.0;
+
+		x.iter().try_for_each(|v| write!(f, "{}", v))
+	}
+}
+
+impl Display for ChangeSet {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		let x = &self.1;
+
+		write!(f, "{}", x)
+	}
+}
+
+// WriteMutationSet is a set of mutations to be to a table at the specific timestamp.
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
+pub struct WriteMutationSet(pub Vec<TableMutations>);
+
+impl WriteMutationSet {
+	pub fn new() -> Self {
+		Self(Vec::new())
+	}
+}
+
+impl Default for WriteMutationSet {
+	fn default() -> Self {
+		Self::new()
+	}
+}

--- a/lib/src/sql/statements/define.rs
+++ b/lib/src/sql/statements/define.rs
@@ -971,12 +971,6 @@ fn table_drop(i: &str) -> IResult<&str, DefineTableOption> {
 	Ok((i, DefineTableOption::Drop))
 }
 
-fn table_changefeed(i: &str) -> IResult<&str, DefineTableOption> {
-	let (i, _) = shouldbespace(i)?;
-	let (i, v) = changefeed(i)?;
-	Ok((i, DefineTableOption::ChangeFeed(v)))
-}
-
 fn table_view(i: &str) -> IResult<&str, DefineTableOption> {
 	let (i, _) = shouldbespace(i)?;
 	let (i, v) = view(i)?;
@@ -999,6 +993,12 @@ fn table_permissions(i: &str) -> IResult<&str, DefineTableOption> {
 	let (i, _) = shouldbespace(i)?;
 	let (i, v) = permissions(i)?;
 	Ok((i, DefineTableOption::Permissions(v)))
+}
+
+fn table_changefeed(i: &str) -> IResult<&str, DefineTableOption> {
+	let (i, _) = shouldbespace(i)?;
+	let (i, v) = changefeed(i)?;
+	Ok((i, DefineTableOption::ChangeFeed(v)))
 }
 
 // --------------------------------------------------

--- a/lib/src/vs/conv.rs
+++ b/lib/src/vs/conv.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use thiserror::Error;
 
 // u64_to_versionstamp converts a u64 to a 10-byte versionstamp
 // assuming big-endian and the the last two bytes are zero.
@@ -86,7 +87,9 @@ pub fn to_u128_be(vs: [u8; 10]) -> u128 {
 	u128::from_be_bytes(buf)
 }
 
+#[derive(Error)]
 pub enum Error {
+	#[error("invalid versionstamp")]
 	// InvalidVersionstamp is returned when a versionstamp has an unexpected length.
 	InvalidVersionstamp,
 }

--- a/lib/src/vs/mod.rs
+++ b/lib/src/vs/mod.rs
@@ -6,5 +6,7 @@
 pub type Versionstamp = [u8; 10];
 
 pub(crate) mod conv;
+pub(crate) mod oracle;
 
 pub use self::conv::*;
+pub use self::oracle::*;

--- a/lib/src/vs/oracle.rs
+++ b/lib/src/vs/oracle.rs
@@ -1,0 +1,169 @@
+//! System time based versionstamp.
+//! This module provides a kind of Hybrid Logical Clock (HLC) based on system time.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::{u16_u64_to_versionstamp, u64_to_versionstamp, u64_u16_to_versionstamp, Versionstamp};
+
+// A versionstamp oracle is a source of truth for the current versionstamp of the database.
+// There are several kinds of versionstamp oracles, each provides a different versionstamp
+// generation strategy, varying in the trade-off between the monotonicity of the versionstamps
+// and the performance of the versionstamp generation.
+#[allow(unused)]
+pub enum Oracle {
+	// SysTimeCounter versionstamp oracle is a HLC based on system time in seconds as the physical time and the
+	// in-memory counter that resets every second as the logical time.
+	//
+	// This is supposed to be only used for one-node installation and is not suitable for multi-node
+	// installation of the database.
+	//
+	// There are two cases this oracle can be not monotonic.
+	//
+	// First, it can be not monotonic if the system time is not monotonic,
+	// because this module does nothing to prevent the system clock from going backwards,
+	// and there's no additional mechanism to detect and handle the clock going backwards.
+	//
+	// Second, it can be not monotonic if the database is restarted within a second,
+	// because the in-memory counter resets to 0 on restart and the physical time uses the glanularity
+	// of seconds.
+	//
+	// Do also note that the produced versionstamp's monotonicity needs to be guaranteed
+	// by the caller of the oracle too.
+	// For example, if it is going to be used as the commit versionstamp of a transaction,
+	// the caller needs to ensure that the commit versionstamp is always increasing.
+	// Otherwise, the transaction might be committed with a versionstamp that is smaller than
+	// the versionstamp of a previous transaction.
+	// This is because the versionstamp oracle does not know the context of the versionstamp
+	// and cannot guarantee the monotonicity of the versionstamp by itself.
+	// Implementation-wise, this can imply that the database needs to ensure that the only one
+	// transaction is executing and committing at a time.
+	SysTimeCounter(SysTimeCounter),
+	// EpochCounter versionstamp oracle provides a vector clock that uses the "epoch" as the first logical time
+	// and the in-memory counter for the second logical time.
+	//
+	// The epoch is supposed to be persisted in the underlying KVS and increased by one on each database restart.
+	// The in-memory counter resets on each database restart and increased by one on each now() call.
+	//
+	// EpochCounter is designed to be used instead of the SysTimeCounter when the runtime environment
+	// does not provide a monotonic system clock, and the database is running in a single-node mode.
+	EpochCounter(EpochCounter),
+}
+
+impl Oracle {
+	#[allow(unused)]
+	pub fn now(&mut self) -> Versionstamp {
+		match self {
+			Oracle::SysTimeCounter(sys) => sys.now(),
+			Oracle::EpochCounter(epoch) => epoch.now(),
+		}
+	}
+}
+
+pub struct SysTimeCounter {
+	// The first element is the saved physical time of the last versionstamp.
+	// The second element is the in-memory counter that resets every second.
+	state: Mutex<(u64, u16)>,
+
+	stale: (u64, u16),
+}
+
+impl SysTimeCounter {
+	pub fn now(&mut self) -> Versionstamp {
+		// Increment the counter and get the current number as the logical time
+		// only if the current physical time is the same as the last physical time.
+		// Otherwise, reset the counter to 0 and get the current number as the logical time.
+		// This is to ensure that the logical time is always increasing.
+		let state = self.state.lock();
+		if let Ok(mut state) = state {
+			let (last_physical_time, counter) = *state;
+			let current_physical_time = secs_since_unix_epoch();
+			let current_logical_time = if last_physical_time == current_physical_time {
+				counter
+			} else {
+				state.1 = 0;
+				0
+			};
+			state.0 = current_physical_time;
+			state.1 += 1;
+			self.stale = (current_physical_time, current_logical_time);
+			u64_u16_to_versionstamp(current_physical_time, current_logical_time)
+		} else {
+			u64_u16_to_versionstamp(self.stale.0, self.stale.1)
+		}
+	}
+}
+
+// EpochCounter versionstamp oracle providers a vector clock uses the "epoch" as the first time
+// and the in-memory counter for the second logical time.
+// The epoch is supposed to be persisted in the underlying KVS and increased by one on each database restart.
+// The in-memory counter resets on each database restart and increased by one on each now() call.
+// TODO: Refer to a paper that describes this concept and use the correct terminology.
+pub struct EpochCounter {
+	// epoch is the first half of the versionstamp that persists
+	// until the database restarts.
+	// This needs to be persisted externally so that the epoch increases by one
+	// on each database restart.
+	epoch: u16,
+
+	// state is the in-memory counter increases by one on each now() call.
+	counter: AtomicU64,
+}
+
+impl EpochCounter {
+	#[allow(unused)]
+	pub fn now(&mut self) -> Versionstamp {
+		let counter = self.counter.fetch_add(1, Ordering::SeqCst);
+		u16_u64_to_versionstamp(self.epoch, counter)
+	}
+}
+
+#[allow(unused)]
+fn now() -> Versionstamp {
+	let secs = secs_since_unix_epoch();
+	u64_to_versionstamp(secs)
+}
+
+#[allow(unused)]
+// Returns the number of seconds since the Unix Epoch (January 1st, 1970 at UTC).
+fn secs_since_unix_epoch() -> u64 {
+	let start = SystemTime::now();
+	let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards");
+	since_the_epoch.as_secs()
+}
+
+mod tests {
+	#[allow(unused)]
+	use super::*;
+	#[allow(unused)]
+	use crate::vs::to_u128_be;
+
+	#[test]
+	fn systime_counter() {
+		let mut o = Oracle::SysTimeCounter(SysTimeCounter {
+			state: Mutex::new((0, 0)),
+			stale: (0, 0),
+		});
+		let a = to_u128_be(o.now());
+		let b = to_u128_be(o.now());
+		assert!(a < b, "a = {}, b = {}", a, b);
+	}
+
+	#[test]
+	fn epoch_counter() {
+		let mut o1 = Oracle::EpochCounter(EpochCounter {
+			epoch: 0,
+			counter: AtomicU64::new(0),
+		});
+		let a = to_u128_be(o1.now());
+		let b = to_u128_be(o1.now());
+		assert!(a < b, "a = {}, b = {}", a, b);
+		let mut o2 = Oracle::EpochCounter(EpochCounter {
+			epoch: 1,
+			counter: AtomicU64::new(0),
+		});
+		let c = to_u128_be(o2.now());
+		assert!(b < c, "b = {}, c = {}", b, c);
+	}
+}

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -672,6 +672,139 @@ async fn delete_record_range() {
 }
 
 #[tokio::test]
+async fn changefeed() {
+	let db = new_db().await;
+	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+	// Enable change feeds
+	let sql = "
+	DEFINE TABLE user CHANGEFEED 1h;
+	";
+	let response = db.query(sql).await.unwrap();
+	response.check().unwrap();
+	// Create and update users
+	let sql = "
+        CREATE user:amos SET name = 'Amos';
+        CREATE user:jane SET name = 'Jane';
+        UPDATE user:amos SET name = 'AMOS';
+    ";
+	let table = "user";
+	let response = db.query(sql).await.unwrap();
+	response.check().unwrap();
+	let users: Vec<RecordBuf> = db
+		.update(table)
+		.content(Record {
+			name: "Doe",
+		})
+		.await
+		.unwrap();
+	let expected = &[
+		RecordBuf {
+			id: thing("user:amos").unwrap(),
+			name: "Doe".to_owned(),
+		},
+		RecordBuf {
+			id: thing("user:jane").unwrap(),
+			name: "Doe".to_owned(),
+		},
+	];
+	assert_eq!(users, expected);
+	let users: Vec<RecordBuf> = db.select(table).await.unwrap();
+	assert_eq!(users, expected);
+	let sql = "
+        SHOW CHANGES FOR TABLE user SINCE 0 LIMIT 10;
+    ";
+	let mut response = db.query(sql).await.unwrap();
+	let value: Value = response.take(0).unwrap();
+	let Value::Array(array) = value.clone() else { unreachable!() };
+	assert_eq!(array.len(), 4);
+	// UPDATE user:amos
+	let a = array.get(0).unwrap();
+	let Value::Object(a) = a else { unreachable!() };
+	let Value::Number(versionstamp1) = a.get("versionstamp").unwrap() else { unreachable!() };
+	let changes = a.get("changes").unwrap().to_owned();
+	assert_eq!(
+		changes,
+		surrealdb::sql::value(
+			"[
+		{
+			update: {
+				id: user:amos,
+				name: 'Amos'
+			}
+		}
+	]"
+		)
+		.unwrap()
+	);
+	// UPDATE user:jane
+	let a = array.get(1).unwrap();
+	let Value::Object(a) = a else { unreachable!() };
+	let Value::Number(versionstamp2) = a.get("versionstamp").unwrap() else { unreachable!() };
+	assert!(versionstamp1 < versionstamp2);
+	let changes = a.get("changes").unwrap().to_owned();
+	assert_eq!(
+		changes,
+		surrealdb::sql::value(
+			"[
+		{
+			update: {
+				id: user:jane,
+				name: 'Jane'
+			}
+		}
+	]"
+		)
+		.unwrap()
+	);
+	// UPDATE user:amos
+	let a = array.get(2).unwrap();
+	let Value::Object(a) = a else { unreachable!() };
+	let Value::Number(versionstamp3) = a.get("versionstamp").unwrap() else { unreachable!() };
+	assert!(versionstamp2 < versionstamp3);
+	let changes = a.get("changes").unwrap().to_owned();
+	assert_eq!(
+		changes,
+		surrealdb::sql::value(
+			"[
+		{
+			update: {
+				id: user:amos,
+				name: 'AMOS'
+			}
+		}
+	]"
+		)
+		.unwrap()
+	);
+	// UPDATE table
+	let a = array.get(3).unwrap();
+	let Value::Object(a) = a else { unreachable!() };
+	let Value::Number(versionstamp4) = a.get("versionstamp").unwrap() else { unreachable!() };
+	assert!(versionstamp3 < versionstamp4);
+	let changes = a.get("changes").unwrap().to_owned();
+	assert_eq!(
+		changes,
+		surrealdb::sql::value(
+			"[
+		{
+			update: {
+				id: user:amos,
+				name: 'Doe'
+			}
+		},
+		{
+			update: {
+				id: user:jane,
+				name: 'Doe'
+			}
+		}
+	]"
+		)
+		.unwrap()
+	);
+}
+
+#[tokio::test]
 async fn version() {
 	let db = new_db().await;
 	db.version().await.unwrap();

--- a/lib/tests/changefeeds.rs
+++ b/lib/tests/changefeeds.rs
@@ -1,0 +1,159 @@
+mod parse;
+use parse::Parse;
+use surrealdb::dbs::Session;
+use surrealdb::err::Error;
+use surrealdb::kvs::Datastore;
+use surrealdb::sql::Value;
+
+#[tokio::test]
+async fn table_change_feeds() -> Result<(), Error> {
+	let sql = "
+        DEFINE TABLE person CHANGEFEED 1h;
+		DEFINE FIELD name ON TABLE person
+			ASSERT
+				IF $input THEN
+					$input = /^[A-Z]{1}[a-z]+$/
+				ELSE
+					true
+				END
+			VALUE
+				IF $input THEN
+					'Name: ' + $input
+				ELSE
+					$value
+				END
+		;
+		UPDATE person:test CONTENT { name: 'Tobie' };
+		UPDATE person:test REPLACE { name: 'jaime' };
+		UPDATE person:test MERGE { name: 'Jaime' };
+		UPDATE person:test SET name = 'tobie';
+		UPDATE person:test SET name = 'Tobie';
+		DELETE person:test;
+		CREATE person:1000 SET name = 'Yusuke';
+        SHOW CHANGES FOR TABLE person SINCE 0;
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	assert_eq!(res.len(), 10);
+	// DEFINE TABLE
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	// DEFINE FIELD
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	// UPDATE CONTENT
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:test,
+				name: 'Name: Tobie',
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	// UPDATE REPLACE
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == r#"Found 'Name: jaime' for field `name`, with record `person:test`, but field must conform to: IF $input THEN $input = /^[A-Z]{1}[a-z]+$/ ELSE true END"#
+	));
+	// UPDATE MERGE
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:test,
+				name: 'Name: Jaime',
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	// UPDATE SET
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == r#"Found 'Name: tobie' for field `name`, with record `person:test`, but field must conform to: IF $input THEN $input = /^[A-Z]{1}[a-z]+$/ ELSE true END"#
+	));
+	// UPDATE SET
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:test,
+				name: 'Name: Tobie',
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	// DELETE
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[]");
+	assert_eq!(tmp, val);
+	// CREATE
+	let _tmp = res.remove(0).result?;
+	// SHOW CHANGES
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				versionstamp: 65536,
+				changes: [
+					{
+						update: {
+							id: person:test,
+							name: 'Name: Tobie'
+						}
+					}
+				]
+			},
+			{
+				versionstamp: 131072,
+				changes: [
+					{
+						update: {
+							id: person:test,
+							name: 'Name: Jaime'
+						}
+					}
+				]
+			},
+			{
+				versionstamp: 196608,
+				changes: [
+					{
+						update: {
+							id: person:test,
+							name: 'Name: Tobie'
+						}
+					}
+				]
+			},
+			{
+				versionstamp: 262144,
+				changes: [
+					{
+						delete: {
+							id: person:test
+						}
+					}
+				]
+			},
+			{
+				versionstamp: 327680,
+				changes: [
+					{
+						update: {
+							id: person:1000,
+							name: 'Name: Yusuke'
+						}
+					}
+				]
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
## What is the motivation?

We want a feature that serves all kinds of "CDC" use-cases.

## What does this change do?

This pull request adds the initial version of the so-called "Change Feeds" feature which almost provides a way
to reliably read the change history of a SurrealDB table (not the instance/cluster or the namespace. Database change feeds is WIP though).

Note that this initial version uses the "sound" variant of Versionstamps for Tikv, RocksDB, InMem, IndexedDB and SpeeDB. It wraps incrementing the per-database counter within the transaction to provide a monotonic Versionstamp for those backends.

We know this causes a lot of contention on the counter backed by the underlying KVS and our plan is to have unsound Versionstamp implementations in case the user wants to have more performance than the correctness of change feeds.

The good(I suppose) news is that the FoudnationDB backend uses the `set versionstamped key` atomic operation provided natively by the FoundationDB for Versionstamps. It's lockless and mostly contention-less (in terms of we don't need to "guard" the counter using the transaction by ourselves) and supposed to be more performance than other distributed SurrealDB backends.

## What is your testing strategy?

I've written a unit and integration (API) tests that checks the behavior of Change Feeds for the following backends:

- RocksDB
- InMem
- TiKV
- FoundationDB
- SpeeDB

Honestly speaking, I'm not sure how I can test the IndexedDB in an automated way!
Suggestions on how we test it are much appreciated.

## Is this related to any issues?

N/A

Probably we'd better have a discussion/issue for any design/usage/implmenetation/etc discussions once the first implementation turned out to work.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
