### PR TITLE
Fix multiple `Clippy` Lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
       - name: Run cargo clippy
-        run: cargo clippy --no-deps -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   cli:
     name: Test command line

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,7 +61,7 @@ jobs:
         run: cargo fmt --all --check -- ./lib/tests/**/*.rs ./lib/src/kvs/tests/*.rs
 
       - name: Check linting with clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run WebAssembly check
         run: cargo check --features kv-mem,kv-indxdb,protocol-ws,protocol-http --target wasm32-unknown-unknown --package surrealdb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         run: cargo fmt --all --check -- ./lib/tests/**/*.rs ./lib/src/kvs/tests/*.rs
 
       - name: Check linting with clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run WebAssembly check
         run: cargo check --features kv-mem,kv-indxdb,protocol-ws,protocol-http --target wasm32-unknown-unknown --package surrealdb

--- a/lib/src/dbs/iterate.rs
+++ b/lib/src/dbs/iterate.rs
@@ -200,7 +200,7 @@ impl Iterable {
 					let rid = Thing::from((key.tb, key.id));
 					// Create a new operable value
 					let val = Operable::Value(val);
-					let mut child_ctx = Context::new(&ctx);
+					let mut child_ctx = Context::new(ctx);
 					child_ctx.add_thing(&rid);
 					// Process the record
 					ite.process(&child_ctx, opt, stm, val).await;
@@ -472,7 +472,7 @@ impl Iterable {
 				let key = thing::new(opt.ns(), opt.db(), &table.0, &thing.id);
 				let val = txn.lock().await.get(key.clone()).await?;
 				let rid = Thing::from((key.tb, key.id));
-				let mut ctx = Context::new(&ctx);
+				let mut ctx = Context::new(ctx);
 				ctx.add_thing(&rid);
 				// Parse the data from the store
 				let val = Operable::Value(match val {

--- a/lib/src/doc/alter.rs
+++ b/lib/src/doc/alter.rs
@@ -71,7 +71,7 @@ impl<'a> Document<'a> {
 				}
 				Data::UnsetExpression(i) => {
 					for i in i.iter() {
-						self.current.to_mut().del(ctx, opt, &i).await?
+						self.current.to_mut().del(ctx, opt, i).await?
 					}
 				}
 				Data::UpdateExpression(x) => {

--- a/lib/src/fnc/array.rs
+++ b/lib/src/fnc/array.rs
@@ -260,9 +260,9 @@ mod tests {
 			"true is false is true",
 		);
 		test(
-			vec![Value::from(3.14), Value::from(2.72), Value::from(1.61)].into(),
+			vec![Value::from(3.56), Value::from(2.72), Value::from(1.61)].into(),
 			" is not ",
-			"3.14f is not 2.72f is not 1.61f",
+			"3.56f is not 2.72f is not 1.61f",
 		);
 	}
 }

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -324,7 +324,7 @@ mod tests {
 			let (quote, _) = line.split_once("=>").unwrap();
 			let name = quote.trim().trim_matches('"');
 
-			if crate::sql::function::function_names(&name).is_err() {
+			if crate::sql::function::function_names(name).is_err() {
 				problems.push(format!("couldn't parse {name} function"));
 			}
 

--- a/lib/src/idx/bkeys.rs
+++ b/lib/src/idx/bkeys.rs
@@ -516,9 +516,7 @@ impl<'a> KeysIterator<'a> {
 				}
 			} else {
 				self.current_node = self.node_queue.pop_front();
-				if self.current_node.is_none() {
-					return None;
-				}
+				self.current_node.as_ref()?;
 			}
 		}
 	}

--- a/lib/src/idx/btree.rs
+++ b/lib/src/idx/btree.rs
@@ -615,6 +615,7 @@ where
 		Err(Error::CorruptedIndex)
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	async fn merge_nodes<BK>(
 		tx: &mut Transaction,
 		keys: &mut BK,

--- a/lib/src/idx/btree.rs
+++ b/lib/src/idx/btree.rs
@@ -210,7 +210,7 @@ where
 	{
 		if let Some(root_id) = self.state.root {
 			let root = self.keys.load_node::<BK>(tx, root_id).await?;
-			if root.node.keys().len() as u32 == self.full_size {
+			if root.node.keys().len() == self.full_size {
 				let new_root_id = self.new_node_id();
 				let new_root =
 					self.new_node(new_root_id, Node::Internal(BK::default(), vec![root_id]));
@@ -256,7 +256,7 @@ where
 					}
 					let child_idx = keys.get_child_idx(&key);
 					let child = self.keys.load_node::<BK>(tx, children[child_idx]).await?;
-					let next = if child.node.keys().len() as u32 == self.full_size {
+					let next = if child.node.keys().len() == self.full_size {
 						let split_result =
 							self.split_child::<BK>(tx, node, child_idx, child).await?;
 						if key.gt(&split_result.median_key) {
@@ -431,7 +431,7 @@ where
 		let left_idx = keys.get_child_idx(&key_to_delete);
 		let left_id = children[left_idx];
 		let mut left_node = self.keys.load_node::<BK>(tx, left_id).await?;
-		if left_node.node.keys().len() as u32 >= self.state.minimum_degree {
+		if left_node.node.keys().len() >= self.state.minimum_degree {
 			// CLRS: 2a -> left_node is named `y` in the book
 			if let Some((key_prim, payload_prim)) = left_node.node.keys().get_last_key() {
 				keys.remove(&key_to_delete);

--- a/lib/src/idx/ft/analyzer/filter.rs
+++ b/lib/src/idx/ft/analyzer/filter.rs
@@ -133,7 +133,7 @@ impl Filter {
 				if c.eq(n) {
 					ng.push(Term::Unchanged);
 				} else {
-					ng.push(Term::NewTerm(n.into_iter().collect()));
+					ng.push(Term::NewTerm(n.iter().collect()));
 				}
 			}
 		}
@@ -159,7 +159,7 @@ impl Filter {
 			if c.eq(n) {
 				ng.push(Term::Unchanged);
 			} else {
-				ng.push(Term::NewTerm(n.into_iter().collect()));
+				ng.push(Term::NewTerm(n.iter().collect()));
 			}
 		}
 		FilterResult::Terms(ng)

--- a/lib/src/idx/ft/analyzer/filter.rs
+++ b/lib/src/idx/ft/analyzer/filter.rs
@@ -718,7 +718,7 @@ mod tests {
 		test_analyser(
 			"DEFINE ANALYZER test TOKENIZERS blank,class FILTERS lowercase,ngram(2,3);",
 			"Ālea iacta est",
-			&vec!["āl", "āle", "le", "lea", "ia", "iac", "ac", "act", "ct", "cta", "es", "est"],
+			&["āl", "āle", "le", "lea", "ia", "iac", "ac", "act", "ct", "cta", "es", "est"],
 		);
 	}
 
@@ -727,7 +727,7 @@ mod tests {
 		test_analyser(
 			"DEFINE ANALYZER test TOKENIZERS blank,class FILTERS lowercase,edgengram(2,3);",
 			"Ālea iacta est",
-			&vec!["āl", "āle", "ia", "iac", "es", "est"],
+			&["āl", "āle", "ia", "iac", "es", "est"],
 		);
 	}
 }

--- a/lib/src/idx/ft/analyzer/mod.rs
+++ b/lib/src/idx/ft/analyzer/mod.rs
@@ -79,7 +79,7 @@ impl Analyzer {
 		for tokens in &inputs {
 			for token in tokens.list() {
 				doc_length += 1;
-				match terms.entry(tokens.get_token_string(&token)) {
+				match terms.entry(tokens.get_token_string(token)) {
 					Entry::Vacant(e) => {
 						e.insert(1);
 					}

--- a/lib/src/idx/ft/analyzer/tokenizer.rs
+++ b/lib/src/idx/ft/analyzer/tokenizer.rs
@@ -111,7 +111,7 @@ impl Tokenizer {
 		res
 	}
 
-	pub(super) fn tokenize(t: &Vec<SqlTokenizer>, i: String) -> Tokens {
+	pub(super) fn tokenize(t: &[SqlTokenizer], i: String) -> Tokens {
 		let mut w = Tokenizer::new(t);
 		let mut last_pos = 0;
 		let mut current_pos = 0;

--- a/lib/src/idx/ft/mod.rs
+++ b/lib/src/idx/ft/mod.rs
@@ -343,28 +343,24 @@ impl HitsIterator {
 		&mut self,
 		tx: &mut Transaction,
 	) -> Result<Option<(Thing, Option<Score>)>, Error> {
-		loop {
-			if let Some(doc_id) = self.iter.next() {
-				if let Some(doc_key) = self.doc_ids.get_doc_key(tx, doc_id).await? {
-					let score = if let Some(scorer) = &self.scorer {
-						let mut sc = 0.0;
-						for (term_id, docs) in &self.terms_docs {
-							if docs.contains(doc_id) {
-								if let Some(term_freq) =
-									self.postings.get_term_frequency(tx, *term_id, doc_id).await?
-								{
-									sc += scorer.score(tx, doc_id, docs.len(), term_freq).await?;
-								}
+		for doc_id in self.iter.by_ref() {
+			if let Some(doc_key) = self.doc_ids.get_doc_key(tx, doc_id).await? {
+				let score = if let Some(scorer) = &self.scorer {
+					let mut sc = 0.0;
+					for (term_id, docs) in &self.terms_docs {
+						if docs.contains(doc_id) {
+							if let Some(term_freq) =
+								self.postings.get_term_frequency(tx, *term_id, doc_id).await?
+							{
+								sc += scorer.score(tx, doc_id, docs.len(), term_freq).await?;
 							}
 						}
-						Some(sc)
-					} else {
-						None
-					};
-					return Ok(Some((doc_key.into(), score)));
-				}
-			} else {
-				break;
+					}
+					Some(sc)
+				} else {
+					None
+				};
+				return Ok(Some((doc_key.into(), score)));
 			}
 		}
 		Ok(None)

--- a/lib/src/idx/planner/plan.rs
+++ b/lib/src/idx/planner/plan.rs
@@ -225,6 +225,7 @@ struct MatchesThingIterator {
 }
 
 impl MatchesThingIterator {
+	#[allow(clippy::too_many_arguments)]
 	async fn new(
 		opt: &Options,
 		txn: &Transaction,

--- a/lib/src/idx/planner/plan.rs
+++ b/lib/src/idx/planner/plan.rs
@@ -47,18 +47,18 @@ impl Plan {
 	}
 
 	pub(crate) fn explain(&self) -> Value {
-		match &self.i {
-			IndexOption {
-				ix,
-				v,
-				op,
-				..
-			} => Value::Object(Object::from(HashMap::from([
-				("index", Value::from(ix.name.0.to_owned())),
-				("operator", Value::from(op.to_string())),
-				("value", v.clone()),
-			]))),
-		}
+		let IndexOption {
+			ix,
+			v,
+			op,
+			..
+		} = &self.i;
+
+		Value::Object(Object::from(HashMap::from([
+			("index", Value::from(ix.name.0.to_owned())),
+			("operator", Value::from(op.to_string())),
+			("value", v.clone()),
+		])))
 	}
 }
 

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -38,7 +38,7 @@ pub(super) enum Inner {
 	#[cfg(feature = "kv-tikv")]
 	TiKV(super::tikv::Datastore),
 	#[cfg(feature = "kv-fdb")]
-	FDB(super::fdb::Datastore),
+	FoundationDB(super::fdb::Datastore),
 }
 
 impl fmt::Display for Datastore {
@@ -56,7 +56,7 @@ impl fmt::Display for Datastore {
 			#[cfg(feature = "kv-tikv")]
 			Inner::TiKV(_) => write!(f, "tikv"),
 			#[cfg(feature = "kv-fdb")]
-			Inner::FDB(_) => write!(f, "fdb"),
+			Inner::FoundationDB(_) => write!(f, "fdb"),
 			#[allow(unreachable_patterns)]
 			_ => unreachable!(),
 		}
@@ -191,7 +191,7 @@ impl Datastore {
 					info!(target: LOG, "Connecting to kvs store at {}", path);
 					let s = s.trim_start_matches("fdb://");
 					let s = s.trim_start_matches("fdb:");
-					let v = super::fdb::Datastore::new(s).await.map(Inner::FDB);
+					let v = super::fdb::Datastore::new(s).await.map(Inner::FoundationDB);
 					info!(target: LOG, "Connected to kvs store at {}", path);
 					v
 				}
@@ -259,9 +259,9 @@ impl Datastore {
 				super::tx::Inner::TiKV(tx)
 			}
 			#[cfg(feature = "kv-fdb")]
-			Inner::FDB(v) => {
+			Inner::FoundationDB(v) => {
 				let tx = v.transaction(write, lock).await?;
-				super::tx::Inner::FDB(tx)
+				super::tx::Inner::FoundationDB(tx)
 			}
 			#[allow(unreachable_patterns)]
 			_ => unreachable!(),

--- a/lib/src/kvs/fdb/mod.rs
+++ b/lib/src/kvs/fdb/mod.rs
@@ -139,7 +139,7 @@ impl Transaction {
 		match r {
 			Ok(_r) => {}
 			Err(e) => {
-				return Err(Error::Tx(format!("Transaction commit error: {}", e).to_string()));
+				return Err(Error::Tx(format!("Transaction commit error: {}", e)));
 			}
 		}
 		// Continue
@@ -167,7 +167,7 @@ impl Transaction {
 		tx.get(key, self.snapshot())
 			.await
 			.map(|v| v.is_some())
-			.map_err(|e| Error::Tx(format!("Unable to get kv from FDB: {}", e)))
+			.map_err(|e| Error::Tx(format!("Unable to get kv from FoundationDB: {}", e)))
 	}
 	/// Fetch a key from the database
 	pub async fn get<K>(&mut self, key: K) -> Result<Option<Val>, Error>
@@ -188,12 +188,10 @@ impl Transaction {
 		// make the transaction serializable, we use the inverse of it to enable the snapshot isolation
 		// on the get request.
 		// See https://apple.github.io/foundationdb/api-c.html#snapshot-reads for more information on how the snapshot get is supposed to work in FDB.
-		let res = tx
-			.get(key, self.snapshot())
+		tx.get(key, self.snapshot())
 			.await
-			.map(|v| v.as_ref().map(|v| Val::from(v.to_vec())))
-			.map_err(|e| Error::Tx(format!("Unable to get kv from FDB: {}", e)));
-		res
+			.map(|v| v.as_ref().map(|v| v.to_vec()))
+			.map_err(|e| Error::Tx(format!("Unable to get kv from FoundationDB: {}", e)))
 	}
 	/// Insert or update a key in the database
 	pub async fn set<K, V>(&mut self, key: K, val: V) -> Result<(), Error>
@@ -288,9 +286,9 @@ impl Transaction {
 		// on the get request.
 		// See https://apple.github.io/foundationdb/api-c.html#snapshot-reads for more information on how the snapshot get is supposed to work in FDB.
 		let res = tx.get(key, false).await;
-		let res = res.map_err(|e| Error::Tx(format!("Unable to get kv from FDB: {}", e)));
+		let res = res.map_err(|e| Error::Tx(format!("Unable to get kv from FoundationDB: {}", e)));
 		match (res, chk) {
-			(Ok(Some(v)), Some(w)) if Val::from(v.as_ref()) == w => tx.set(key, val),
+			(Ok(Some(v)), Some(w)) if *v.as_ref() == w => tx.set(key, val),
 			(Ok(None), None) => tx.set(key, val),
 			(Err(e), _) => return Err(e),
 			_ => return Err(Error::TxConditionNotMet),
@@ -341,9 +339,12 @@ impl Transaction {
 		// Delete the key
 		let tx = self.tx.lock().await;
 		let tx = tx.as_ref().unwrap();
-		let res = tx.get(key, false).await.map_err(|e| Error::Tx(format!("FDB tx failure: {}", e)));
+		let res = tx
+			.get(key, false)
+			.await
+			.map_err(|e| Error::Tx(format!("FoundationDB tx failure: {}", e)));
 		match (res, chk) {
-			(Ok(Some(v)), Some(w)) if Val::from(v.as_ref()) == w => tx.clear(key),
+			(Ok(Some(v)), Some(w)) if *v.as_ref() == w => tx.clear(key),
 			(Ok(None), None) => tx.clear(key),
 			_ => return Err(Error::TxConditionNotMet),
 		};
@@ -365,8 +366,8 @@ impl Transaction {
 			end: rng.end.into(),
 		};
 		// Scan the keys
-		let begin: Vec<u8> = rng.start.into();
-		let end: Vec<u8> = rng.end.into();
+		let begin: Vec<u8> = rng.start;
+		let end: Vec<u8> = rng.end;
 		let opt = foundationdb::RangeOption {
 			limit: Some(limit.try_into().unwrap()),
 			..foundationdb::RangeOption::from((begin.as_slice(), end.as_slice()))
@@ -388,9 +389,9 @@ impl Transaction {
 					res.push(x)
 				}
 				Ok(None) => break,
-				Err(e) => return Err(Error::Tx(format!("GetRanges failed: {}", e).to_string())),
+				Err(e) => return Err(Error::Tx(format!("GetRanges failed: {}", e))),
 			}
 		}
-		return Ok(res);
+		Ok(res)
 	}
 }

--- a/lib/src/kvs/tests/raw.rs
+++ b/lib/src/kvs/tests/raw.rs
@@ -18,9 +18,9 @@ async fn exi() {
 	// Create a readonly transaction
 	let mut tx = ds.transaction(false, false).await.unwrap();
 	let val = tx.exi("test").await.unwrap();
-	assert_eq!(val, true);
+	assert!(val);
 	let val = tx.exi("none").await.unwrap();
-	assert_eq!(val, false);
+	assert!(!val);
 	tx.cancel().await.unwrap();
 }
 

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -55,7 +55,7 @@ pub(super) enum Inner {
 	#[cfg(feature = "kv-tikv")]
 	TiKV(super::tikv::Transaction),
 	#[cfg(feature = "kv-fdb")]
-	FDB(super::fdb::Transaction),
+	FoundationDB(super::fdb::Transaction),
 }
 
 impl fmt::Display for Transaction {
@@ -73,7 +73,7 @@ impl fmt::Display for Transaction {
 			#[cfg(feature = "kv-tikv")]
 			Inner::TiKV(_) => write!(f, "tikv"),
 			#[cfg(feature = "kv-fdb")]
-			Inner::FDB(_) => write!(f, "fdb"),
+			Inner::FoundationDB(_) => write!(f, "fdb"),
 			#[allow(unreachable_patterns)]
 			_ => unreachable!(),
 		}
@@ -122,7 +122,7 @@ impl Transaction {
 			} => v.closed(),
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.closed(),
 			#[allow(unreachable_patterns)]
@@ -164,7 +164,7 @@ impl Transaction {
 			} => v.cancel().await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.cancel().await,
 			#[allow(unreachable_patterns)]
@@ -206,7 +206,7 @@ impl Transaction {
 			} => v.commit().await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.commit().await,
 			#[allow(unreachable_patterns)]
@@ -250,7 +250,7 @@ impl Transaction {
 			} => v.del(key).await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.del(key).await,
 			#[allow(unreachable_patterns)]
@@ -294,7 +294,7 @@ impl Transaction {
 			} => v.exi(key).await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.exi(key).await,
 			#[allow(unreachable_patterns)]
@@ -338,7 +338,7 @@ impl Transaction {
 			} => v.get(key).await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.get(key).await,
 			#[allow(unreachable_patterns)]
@@ -383,7 +383,7 @@ impl Transaction {
 			} => v.set(key, val).await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.set(key, val).await,
 			#[allow(unreachable_patterns)]
@@ -428,7 +428,7 @@ impl Transaction {
 			} => v.put(key, val).await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.put(key, val).await,
 			#[allow(unreachable_patterns)]
@@ -474,7 +474,7 @@ impl Transaction {
 			} => v.scan(rng, limit).await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.scan(rng, limit).await,
 			#[allow(unreachable_patterns)]
@@ -519,7 +519,7 @@ impl Transaction {
 			} => v.putc(key, val, chk).await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.putc(key, val, chk).await,
 			#[allow(unreachable_patterns)]
@@ -564,7 +564,7 @@ impl Transaction {
 			} => v.delc(key, chk).await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
-				inner: Inner::FDB(v),
+				inner: Inner::FoundationDB(v),
 				..
 			} => v.delc(key, chk).await,
 			#[allow(unreachable_patterns)]

--- a/lib/src/sql/number.rs
+++ b/lib/src/sql/number.rs
@@ -318,7 +318,7 @@ impl Number {
 		match self {
 			Number::Int(v) => Decimal::try_from(*v).unwrap_or_default(),
 			Number::Float(v) => Decimal::try_from(*v).unwrap_or_default(),
-			Number::Decimal(v) => v.clone(),
+			Number::Decimal(v) => *v,
 		}
 	}
 

--- a/lib/src/sql/operator.rs
+++ b/lib/src/sql/operator.rs
@@ -235,7 +235,8 @@ pub fn phrases(i: &str) -> IResult<&str, Operator> {
 
 pub fn matches(i: &str) -> IResult<&str, Operator> {
 	let (i, _) = char('@')(i)?;
-	let (i, reference) = opt(|i| uint8(i))(i)?;
+	// let (i, reference) = opt(|i| uint8(i))(i)?;
+	let (i, reference) = opt(uint8)(i)?;
 	let (i, _) = char('@')(i)?;
 	Ok((i, Operator::Matches(reference)))
 }

--- a/lib/src/sql/special.rs
+++ b/lib/src/sql/special.rs
@@ -64,7 +64,7 @@ pub fn check_order_by_fields<'a>(
 	if let Some(orders) = orders {
 		// Loop over each of the expressions in the ORDER BY clause
 		for order in orders.iter() {
-			if !contains_idiom(fields, &*order) {
+			if !contains_idiom(fields, order) {
 				// If the expression isn't specified in the SELECT clause, then error
 				return Err(Failure(Error::Order(i, order.to_string())));
 			}

--- a/lib/src/sql/special.rs
+++ b/lib/src/sql/special.rs
@@ -95,31 +95,28 @@ pub fn check_group_by_fields<'a>(
 				// Loop over each of the expressions in the GROUP BY clause
 				for group in groups.iter() {
 					// Check to see whether the expression is in the GROUP BY clause or is an aggregate
-					match field {
-						Field::Single {
-							expr,
-							alias,
-						} => {
-							if alias.as_ref().map(|i| i.as_ref() == group.as_ref()).unwrap_or(false)
-							{
-								// This field is aliased, and the alias name matched
-								continue 'outer;
-							} else {
-								match expr {
-									// If the expression in the SELECT clause is a field, check to see if it exists in the GROUP BY
-									Value::Idiom(i) if i == &group.0 => continue 'outer,
-									// If the expression in the SELECT clause is a function, check to see if it is an aggregate function
-									Value::Function(f) if f.is_aggregate() => continue 'outer,
-									// Otherwise check if the expression itself exists in the GROUP BY clause
-									v if v.to_idiom() == group.0 => continue 'outer,
-									// Check if this is a static value which can be used in the GROUP BY clause
-									v if v.is_static() => continue 'outer,
-									// If not, then this query should fail
-									_ => (),
-								}
+					if let Field::Single {
+						expr,
+						alias,
+					} = field
+					{
+						if alias.as_ref().map(|i| i.as_ref() == group.as_ref()).unwrap_or(false) {
+							// This field is aliased, and the alias name matched
+							continue 'outer;
+						} else {
+							match expr {
+								// If the expression in the SELECT clause is a field, check to see if it exists in the GROUP BY
+								Value::Idiom(i) if i == &group.0 => continue 'outer,
+								// If the expression in the SELECT clause is a function, check to see if it is an aggregate function
+								Value::Function(f) if f.is_aggregate() => continue 'outer,
+								// Otherwise check if the expression itself exists in the GROUP BY clause
+								v if v.to_idiom() == group.0 => continue 'outer,
+								// Check if this is a static value which can be used in the GROUP BY clause
+								v if v.is_static() => continue 'outer,
+								// If not, then this query should fail
+								_ => (),
 							}
 						}
-						_ => (),
 					}
 				}
 				// If the expression isn't an aggregate function and isn't specified in the GROUP BY clause, then error

--- a/lib/src/sql/value/patch.rs
+++ b/lib/src/sql/value/patch.rs
@@ -16,12 +16,12 @@ impl Value {
 					if let Value::Strand(p) = o.value {
 						if let Value::Strand(v) = self.pick(&o.path) {
 							let dmp = dmp::new();
-							let mut pch = dmp.patch_from_text(p.as_string()).map_err(|e| {
+							let pch = dmp.patch_from_text(p.as_string()).map_err(|e| {
 								Error::InvalidPatch {
 									message: format!("{e:?}"),
 								}
 							})?;
-							let (txt, _) = dmp.patch_apply(&mut pch, v.as_str()).map_err(|e| {
+							let (txt, _) = dmp.patch_apply(&pch, v.as_str()).map_err(|e| {
 								Error::InvalidPatch {
 									message: format!("{e:?}"),
 								}

--- a/lib/src/sql/value/serde/ser/datetime/mod.rs
+++ b/lib/src/sql/value/serde/ser/datetime/mod.rs
@@ -63,7 +63,7 @@ impl serde::ser::SerializeTuple for SerializeDatetime {
 		} else if self.nanos.is_none() {
 			self.nanos = Some(value.serialize(ser::primitive::u32::Serializer.wrap())?);
 		} else {
-			return Err(Error::custom(format!("unexpected `Datetime` 3rd field`")));
+			return Err(Error::custom("unexpected `Datetime` 3rd field`".to_string()));
 		}
 		Ok(())
 	}

--- a/lib/src/sql/value/serde/ser/kind/mod.rs
+++ b/lib/src/sql/value/serde/ser/kind/mod.rs
@@ -260,7 +260,7 @@ mod tests {
 
 	#[test]
 	fn option() {
-		let kind = Kind::Option(Box::new(Default::default()));
+		let kind = Kind::Option(Box::default());
 		let serialized = kind.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(kind, serialized);
 	}
@@ -278,22 +278,22 @@ mod tests {
 
 	#[test]
 	fn set() {
-		let kind = Kind::Set(Box::new(Default::default()), None);
+		let kind = Kind::Set(Box::default(), None);
 		let serialized = kind.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(kind, serialized);
 
-		let kind = Kind::Set(Box::new(Default::default()), Some(Default::default()));
+		let kind = Kind::Set(Box::default(), Some(Default::default()));
 		let serialized = kind.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(kind, serialized);
 	}
 
 	#[test]
 	fn array() {
-		let kind = Kind::Array(Box::new(Default::default()), None);
+		let kind = Kind::Array(Box::default(), None);
 		let serialized = kind.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(kind, serialized);
 
-		let kind = Kind::Array(Box::new(Default::default()), Some(Default::default()));
+		let kind = Kind::Array(Box::default(), Some(Default::default()));
 		let serialized = kind.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(kind, serialized);
 	}

--- a/lib/src/sql/value/serde/ser/value/mod.rs
+++ b/lib/src/sql/value/serde/ser/value/mod.rs
@@ -563,7 +563,7 @@ mod tests {
 	#[test]
 	fn none() {
 		let expected = Value::None;
-		assert_eq!(expected, to_value(&None::<u32>).unwrap());
+		assert_eq!(expected, to_value(None::<u32>).unwrap());
 		assert_eq!(expected, to_value(&expected).unwrap());
 	}
 
@@ -576,14 +576,14 @@ mod tests {
 	#[test]
 	fn r#false() {
 		let expected = Value::Bool(false);
-		assert_eq!(expected, to_value(&false).unwrap());
+		assert_eq!(expected, to_value(false).unwrap());
 		assert_eq!(expected, to_value(&expected).unwrap());
 	}
 
 	#[test]
 	fn r#true() {
 		let expected = Value::Bool(true);
-		assert_eq!(expected, to_value(&true).unwrap());
+		assert_eq!(expected, to_value(true).unwrap());
 		assert_eq!(expected, to_value(&expected).unwrap());
 	}
 
@@ -623,7 +623,7 @@ mod tests {
 		assert_eq!(expected, to_value(&expected).unwrap());
 
 		let strand = "foobar";
-		let value = to_value(&strand).unwrap();
+		let value = to_value(strand).unwrap();
 		let expected = Value::Strand(Strand(strand.to_owned()));
 		assert_eq!(value, expected);
 		assert_eq!(expected, to_value(&expected).unwrap());
@@ -850,7 +850,7 @@ mod tests {
 			bar,
 			foo: foo.to_owned(),
 		};
-		let value = to_value(&foo_bar).unwrap();
+		let value = to_value(foo_bar).unwrap();
 		let expected = Value::Object(
 			map! {
 				"foo".to_owned() => foo.into(),

--- a/lib/src/sql/value/serde/ser/value/mod.rs
+++ b/lib/src/sql/value/serde/ser/value/mod.rs
@@ -748,7 +748,7 @@ mod tests {
 
 	#[test]
 	fn block() {
-		let block = Box::new(Block::default());
+		let block = Box::default();
 		let value = to_value(&block).unwrap();
 		let expected = Value::Block(block);
 		assert_eq!(value, expected);

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2830,52 +2830,52 @@ mod tests {
 
 	#[test]
 	fn check_none() {
-		assert_eq!(true, Value::None.is_none());
-		assert_eq!(false, Value::Null.is_none());
-		assert_eq!(false, Value::from(1).is_none());
+		assert!(Value::None.is_none());
+		assert!(!Value::None.is_none());
+		assert!(!Value::from(1).is_none());
 	}
 
 	#[test]
 	fn check_null() {
-		assert_eq!(true, Value::Null.is_null());
-		assert_eq!(false, Value::None.is_null());
-		assert_eq!(false, Value::from(1).is_null());
+		assert!(Value::Null.is_null());
+		assert!(!Value::None.is_null());
+		assert!(!Value::from(1).is_null());
 	}
 
 	#[test]
 	fn check_true() {
-		assert_eq!(false, Value::None.is_true());
-		assert_eq!(true, Value::Bool(true).is_true());
-		assert_eq!(false, Value::Bool(false).is_true());
-		assert_eq!(false, Value::from(1).is_true());
-		assert_eq!(false, Value::from("something").is_true());
+		assert!(!Value::None.is_true());
+		assert!(Value::Bool(true).is_true());
+		assert!(!Value::Bool(false).is_true());
+		assert!(!Value::from(1).is_true());
+		assert!(!Value::from("something").is_true());
 	}
 
 	#[test]
 	fn check_false() {
-		assert_eq!(false, Value::None.is_false());
-		assert_eq!(false, Value::Bool(true).is_false());
-		assert_eq!(true, Value::Bool(false).is_false());
-		assert_eq!(false, Value::from(1).is_false());
-		assert_eq!(false, Value::from("something").is_false());
+		assert!(!Value::None.is_false());
+		assert!(!Value::Bool(true).is_false());
+		assert!(Value::Bool(false).is_false());
+		assert!(!Value::from(1).is_false());
+		assert!(!Value::from("something").is_false());
 	}
 
 	#[test]
 	fn convert_truthy() {
-		assert_eq!(false, Value::None.is_truthy());
-		assert_eq!(false, Value::Null.is_truthy());
-		assert_eq!(true, Value::Bool(true).is_truthy());
-		assert_eq!(false, Value::Bool(false).is_truthy());
-		assert_eq!(false, Value::from(0).is_truthy());
-		assert_eq!(true, Value::from(1).is_truthy());
-		assert_eq!(true, Value::from(-1).is_truthy());
-		assert_eq!(true, Value::from(1.1).is_truthy());
-		assert_eq!(true, Value::from(-1.1).is_truthy());
-		assert_eq!(true, Value::from("true").is_truthy());
-		assert_eq!(false, Value::from("false").is_truthy());
-		assert_eq!(true, Value::from("falsey").is_truthy());
-		assert_eq!(true, Value::from("something").is_truthy());
-		assert_eq!(true, Value::from(Uuid::new()).is_truthy());
+		assert!(!Value::None.is_truthy());
+		assert!(!Value::Null.is_truthy());
+		assert!(Value::Bool(true).is_truthy());
+		assert!(!Value::Bool(false).is_truthy());
+		assert!(!Value::from(0).is_truthy());
+		assert!(Value::from(1).is_truthy());
+		assert!(Value::from(-1).is_truthy());
+		assert!(Value::from(1.1).is_truthy());
+		assert!(Value::from(-1.1).is_truthy());
+		assert!(Value::from("true").is_truthy());
+		assert!(!Value::from("false").is_truthy());
+		assert!(Value::from("falsey").is_truthy());
+		assert!(Value::from("something").is_truthy());
+		assert!(Value::from(Uuid::new()).is_truthy());
 	}
 
 	#[test]

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2831,7 +2831,7 @@ mod tests {
 	#[test]
 	fn check_none() {
 		assert!(Value::None.is_none());
-		assert!(!Value::None.is_none());
+		assert!(!Value::Null.is_none());
 		assert!(!Value::from(1).is_none());
 	}
 

--- a/lib/tests/cache.rs
+++ b/lib/tests/cache.rs
@@ -17,7 +17,7 @@ async fn clear_transaction_cache_table() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -73,7 +73,7 @@ async fn clear_transaction_cache_field() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/compare.rs
+++ b/lib/tests/compare.rs
@@ -19,7 +19,7 @@ async fn compare_empty() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/complex.rs
+++ b/lib/tests/complex.rs
@@ -203,7 +203,7 @@ async fn run_queries(
 > {
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	dbs.execute(&sql, &ses, None, false).await.map(|v| v.into_iter().map(|res| res.result))
+	dbs.execute(sql, &ses, None, false).await.map(|v| v.into_iter().map(|res| res.result))
 }
 
 fn with_enough_stack(

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -18,7 +18,7 @@ async fn create_with_id() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/datetimes.rs
+++ b/lib/tests/datetimes.rs
@@ -14,7 +14,7 @@ async fn datetimes_conversion() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -14,7 +14,7 @@ async fn define_statement_namespace() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -39,7 +39,7 @@ async fn define_statement_database() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -68,7 +68,7 @@ async fn define_statement_function() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -101,7 +101,7 @@ async fn define_statement_table_drop() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -132,7 +132,7 @@ async fn define_statement_table_schemaless() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -164,7 +164,7 @@ async fn define_statement_table_schemafull() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -198,7 +198,7 @@ async fn define_statement_table_schemaful() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -238,7 +238,7 @@ async fn define_statement_event() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -295,7 +295,7 @@ async fn define_statement_event_when_event() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -352,7 +352,7 @@ async fn define_statement_event_when_logic() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -401,7 +401,7 @@ async fn define_statement_field() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -433,7 +433,7 @@ async fn define_statement_field_type() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -465,7 +465,7 @@ async fn define_statement_field_value() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -497,7 +497,7 @@ async fn define_statement_field_assert() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -529,7 +529,7 @@ async fn define_statement_field_type_value_assert() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -565,7 +565,7 @@ async fn define_statement_index_single_simple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -613,7 +613,7 @@ async fn define_statement_index_single() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -657,7 +657,7 @@ async fn define_statement_index_multiple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -709,7 +709,7 @@ async fn define_statement_index_single_unique() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -767,7 +767,7 @@ async fn define_statement_index_multiple_unique() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 12);
 	//
 	let tmp = res.remove(0).result;
@@ -842,7 +842,7 @@ async fn define_statement_index_single_unique_existing() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 6);
 	//
 	for _ in 0..3 {
@@ -889,7 +889,7 @@ async fn define_statement_index_multiple_unique_existing() -> Result<(), Error> 
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	for _ in 0..4 {
@@ -933,7 +933,7 @@ async fn define_statement_analyzer() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -977,7 +977,7 @@ async fn define_statement_search_index() -> Result<(), Error> {
 
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 8);
 	//
 	for i in 0..6 {

--- a/lib/tests/escape.rs
+++ b/lib/tests/escape.rs
@@ -18,7 +18,7 @@ async fn complex_ids() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -96,7 +96,7 @@ async fn complex_strings() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/fetch.rs
+++ b/lib/tests/fetch.rs
@@ -23,7 +23,7 @@ async fn create_relate_select() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 12);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -20,7 +20,7 @@ async fn field_definition_value_assert_failure() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result;
@@ -103,7 +103,7 @@ async fn field_definition_value_assert_success() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -152,7 +152,7 @@ async fn field_definition_empty_nested_objects() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result;
@@ -206,7 +206,7 @@ async fn field_definition_empty_nested_arrays() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result;
@@ -258,7 +258,7 @@ async fn field_definition_empty_nested_flexible() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -20,7 +20,7 @@ async fn function_array_add() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;
@@ -60,7 +60,7 @@ async fn function_array_all() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -92,7 +92,7 @@ async fn function_array_any() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -124,7 +124,7 @@ async fn function_array_append() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -156,7 +156,7 @@ async fn function_array_combine() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -188,7 +188,7 @@ async fn function_array_complement() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -220,7 +220,7 @@ async fn function_array_concat() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -252,7 +252,7 @@ async fn function_array_difference() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -283,7 +283,7 @@ async fn function_array_distinct() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -316,7 +316,7 @@ async fn function_array_flatten() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -352,7 +352,7 @@ async fn function_array_group() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -385,7 +385,7 @@ async fn function_array_insert() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -416,7 +416,7 @@ async fn function_array_intersect() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -449,7 +449,7 @@ async fn function_string_join_arr() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -480,7 +480,7 @@ async fn function_array_len() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -512,7 +512,7 @@ async fn function_array_max() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -544,7 +544,7 @@ async fn function_array_min() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -576,7 +576,7 @@ async fn function_array_pop() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -608,7 +608,7 @@ async fn function_array_prepend() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -640,7 +640,7 @@ async fn function_array_push() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -673,7 +673,7 @@ async fn function_array_remove() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -704,7 +704,7 @@ async fn function_array_reverse() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -740,7 +740,7 @@ async fn function_array_slice() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -792,7 +792,7 @@ async fn function_array_sort() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -840,7 +840,7 @@ async fn function_array_sort_asc() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -872,7 +872,7 @@ async fn function_array_sort_desc() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -904,7 +904,7 @@ async fn function_array_union() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -941,7 +941,7 @@ async fn function_bytes_len() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -983,7 +983,7 @@ async fn function_count() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;
@@ -1020,7 +1020,7 @@ async fn function_crypto_md5() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1037,7 +1037,7 @@ async fn function_crypto_sha1() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1054,7 +1054,7 @@ async fn function_crypto_sha256() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1071,7 +1071,7 @@ async fn function_crypto_sha512() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1094,7 +1094,7 @@ async fn function_duration_days() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1121,7 +1121,7 @@ async fn function_duration_hours() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1148,7 +1148,7 @@ async fn function_duration_micros() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1175,7 +1175,7 @@ async fn function_duration_millis() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1202,7 +1202,7 @@ async fn function_duration_mins() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1229,7 +1229,7 @@ async fn function_duration_nanos() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1256,7 +1256,7 @@ async fn function_duration_secs() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1283,7 +1283,7 @@ async fn function_duration_weeks() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1310,7 +1310,7 @@ async fn function_duration_years() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -1336,7 +1336,7 @@ async fn function_duration_from_days() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1358,7 +1358,7 @@ async fn function_duration_from_hours() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1380,7 +1380,7 @@ async fn function_duration_from_micros() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1402,7 +1402,7 @@ async fn function_duration_from_millis() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1424,7 +1424,7 @@ async fn function_duration_from_mins() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1446,7 +1446,7 @@ async fn function_duration_from_nanos() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1468,7 +1468,7 @@ async fn function_duration_from_secs() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1490,7 +1490,7 @@ async fn function_duration_from_weeks() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1516,7 +1516,7 @@ async fn function_encoding_base64_decode() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1538,7 +1538,7 @@ async fn function_encoding_base64_encode() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1570,7 +1570,7 @@ async fn function_parse_geo_area() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1596,7 +1596,7 @@ async fn function_parse_geo_bearing() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1620,7 +1620,7 @@ async fn function_parse_geo_centroid() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1654,7 +1654,7 @@ async fn function_parse_geo_distance() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1674,7 +1674,7 @@ async fn function_parse_geo_hash_encode() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1691,7 +1691,7 @@ async fn function_parse_geo_hash_decode() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -1721,7 +1721,7 @@ async fn function_parse_is_alphanum() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1743,7 +1743,7 @@ async fn function_parse_is_alpha() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1765,7 +1765,7 @@ async fn function_parse_is_ascii() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1787,7 +1787,7 @@ async fn function_parse_is_datetime() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1809,7 +1809,7 @@ async fn function_parse_is_domain() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1831,7 +1831,7 @@ async fn function_parse_is_email() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1853,7 +1853,7 @@ async fn function_parse_is_hexadecimal() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1875,7 +1875,7 @@ async fn function_parse_is_latitude() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1897,7 +1897,7 @@ async fn function_parse_is_longitude() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1919,7 +1919,7 @@ async fn function_parse_is_numeric() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1941,7 +1941,7 @@ async fn function_parse_is_semver() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1963,7 +1963,7 @@ async fn function_parse_is_url() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -1985,7 +1985,7 @@ async fn function_parse_is_uuid() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2012,7 +2012,7 @@ async fn function_math_abs() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2039,7 +2039,7 @@ async fn function_math_bottom() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -2070,7 +2070,7 @@ async fn function_math_ceil() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2093,7 +2093,7 @@ async fn function_math_fixed() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -2124,7 +2124,7 @@ async fn function_math_floor() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2147,7 +2147,7 @@ async fn function_math_interquartile() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2173,7 +2173,7 @@ async fn function_math_max() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2200,7 +2200,7 @@ async fn function_math_mean() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2226,7 +2226,7 @@ async fn function_math_median() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2253,7 +2253,7 @@ async fn function_math_midhinge() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2279,7 +2279,7 @@ async fn function_math_min() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2306,7 +2306,7 @@ async fn function_math_mode() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2332,7 +2332,7 @@ async fn function_math_nearestrank() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2358,7 +2358,7 @@ async fn function_math_percentile() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2383,7 +2383,7 @@ async fn function_math_pow() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2406,7 +2406,7 @@ async fn function_math_product() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2432,7 +2432,7 @@ async fn function_math_round() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2455,7 +2455,7 @@ async fn function_math_spread() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2480,7 +2480,7 @@ async fn function_math_sqrt() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2503,7 +2503,7 @@ async fn function_math_stddev() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2529,7 +2529,7 @@ async fn function_math_sum() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2556,7 +2556,7 @@ async fn function_math_top() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -2588,7 +2588,7 @@ async fn function_math_trimean() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2614,7 +2614,7 @@ async fn function_math_variance() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2642,7 +2642,7 @@ async fn function_parse_meta_id() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2659,7 +2659,7 @@ async fn function_parse_meta_table() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2676,7 +2676,7 @@ async fn function_parse_meta_tb() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2703,7 +2703,7 @@ async fn function_not() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -2748,7 +2748,7 @@ async fn function_parse_email_host() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2765,7 +2765,7 @@ async fn function_parse_email_user() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2782,7 +2782,7 @@ async fn function_parse_url_domain() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2799,7 +2799,7 @@ async fn function_parse_url_fragment() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2816,7 +2816,7 @@ async fn function_parse_url_host() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2833,7 +2833,7 @@ async fn function_parse_url_path() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2850,7 +2850,7 @@ async fn function_parse_url_port() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2867,7 +2867,7 @@ async fn function_parse_url_query() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2884,7 +2884,7 @@ async fn function_parse_url_scheme() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2905,7 +2905,7 @@ async fn function_rand() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2921,7 +2921,7 @@ async fn function_rand_bool() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2937,7 +2937,7 @@ async fn function_rand_enum() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -2954,7 +2954,7 @@ async fn function_rand_float() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -2975,7 +2975,7 @@ async fn function_rand_guid() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -2998,7 +2998,7 @@ async fn function_rand_int() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3019,7 +3019,7 @@ async fn function_rand_string() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3042,7 +3042,7 @@ async fn function_rand_time() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3061,7 +3061,7 @@ async fn function_rand_ulid() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -3077,7 +3077,7 @@ async fn function_rand_uuid() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -3093,7 +3093,7 @@ async fn function_rand_uuid_v4() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -3109,7 +3109,7 @@ async fn function_rand_uuid_v7() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -3131,7 +3131,7 @@ async fn function_string_concat() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3170,7 +3170,7 @@ async fn function_string_contains() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 15);
 	// 1
 	let tmp = res.remove(0).result?;
@@ -3245,7 +3245,7 @@ async fn function_string_ends_with() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3272,7 +3272,7 @@ async fn function_string_join() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3299,7 +3299,7 @@ async fn function_string_len() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3326,7 +3326,7 @@ async fn function_string_lowercase() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3353,7 +3353,7 @@ async fn function_string_repeat() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3380,7 +3380,7 @@ async fn function_string_replace() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3407,7 +3407,7 @@ async fn function_string_reverse() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3438,7 +3438,7 @@ async fn function_string_slice() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -3481,7 +3481,7 @@ async fn function_string_slug() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3508,7 +3508,7 @@ async fn function_string_split() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3535,7 +3535,7 @@ async fn function_string_starts_with() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3562,7 +3562,7 @@ async fn function_string_trim() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3589,7 +3589,7 @@ async fn function_string_uppercase() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3616,7 +3616,7 @@ async fn function_string_words() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3647,7 +3647,7 @@ async fn function_time_ceil() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3673,7 +3673,7 @@ async fn function_time_day() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3695,7 +3695,7 @@ async fn function_time_floor() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -3721,7 +3721,7 @@ async fn function_time_format() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3743,7 +3743,7 @@ async fn function_time_group() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3765,7 +3765,7 @@ async fn function_time_hour() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3786,7 +3786,7 @@ async fn function_time_minute() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3807,7 +3807,7 @@ async fn function_time_month() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3828,7 +3828,7 @@ async fn function_time_nano() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3848,7 +3848,7 @@ async fn function_time_now() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -3865,7 +3865,7 @@ async fn function_time_round() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3887,7 +3887,7 @@ async fn function_time_second() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3908,7 +3908,7 @@ async fn function_time_unix() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3929,7 +3929,7 @@ async fn function_time_wday() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3950,7 +3950,7 @@ async fn function_time_week() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3971,7 +3971,7 @@ async fn function_time_yday() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -3992,7 +3992,7 @@ async fn function_time_year() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4013,7 +4013,7 @@ async fn function_time_from_micros() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4035,7 +4035,7 @@ async fn function_time_from_millis() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4057,7 +4057,7 @@ async fn function_time_from_secs() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4079,7 +4079,7 @@ async fn function_time_from_unix() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4105,7 +4105,7 @@ async fn function_type_bool() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4127,7 +4127,7 @@ async fn function_type_datetime() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4149,7 +4149,7 @@ async fn function_type_decimal() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4173,7 +4173,7 @@ async fn function_type_duration() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4195,7 +4195,7 @@ async fn function_type_float() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4217,7 +4217,7 @@ async fn function_type_int() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4239,7 +4239,7 @@ async fn function_type_number() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4261,7 +4261,7 @@ async fn function_type_point() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4299,7 +4299,7 @@ async fn function_type_string() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4321,7 +4321,7 @@ async fn function_type_table() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -4345,7 +4345,7 @@ async fn function_type_thing() -> Result<(), Error> {
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/future.rs
+++ b/lib/tests/future.rs
@@ -14,7 +14,7 @@ async fn future_function_simple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -46,7 +46,7 @@ async fn future_function_arguments() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/geometry.rs
+++ b/lib/tests/geometry.rs
@@ -13,7 +13,7 @@ async fn geometry_point() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -70,7 +70,7 @@ async fn geometry_polygon() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -163,7 +163,7 @@ async fn geometry_multipoint() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -241,7 +241,7 @@ async fn geometry_multipolygon() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/group.rs
+++ b/lib/tests/group.rs
@@ -22,7 +22,7 @@ async fn select_limit_fetch() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 11);
 	//
 	let tmp = res.remove(0).result?;
@@ -246,7 +246,7 @@ async fn select_multi_aggregate() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result?;
@@ -351,7 +351,7 @@ async fn select_multi_aggregate_composed() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/insert.rs
+++ b/lib/tests/insert.rs
@@ -16,7 +16,7 @@ async fn insert_statement_object_single() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -44,7 +44,7 @@ async fn insert_statement_object_multiple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -66,7 +66,7 @@ async fn insert_statement_values_single() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -83,7 +83,7 @@ async fn insert_statement_values_multiple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -105,7 +105,7 @@ async fn insert_statement_values_retable_id() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -128,7 +128,7 @@ async fn insert_statement_on_duplicate_key() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;
@@ -149,7 +149,7 @@ async fn insert_statement_output() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/limit.rs
+++ b/lib/tests/limit.rs
@@ -17,7 +17,7 @@ async fn select_limit_fetch() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/matches.rs
+++ b/lib/tests/matches.rs
@@ -15,7 +15,7 @@ async fn select_where_matches_using_index() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let _ = res.remove(0).result?;
@@ -61,7 +61,7 @@ async fn select_where_matches_without_using_index_iterator() -> Result<(), Error
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let _ = res.remove(0).result?;

--- a/lib/tests/merge.rs
+++ b/lib/tests/merge.rs
@@ -19,7 +19,7 @@ async fn merge_record() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/model.rs
+++ b/lib/tests/model.rs
@@ -13,7 +13,7 @@ async fn model_count() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -38,7 +38,7 @@ async fn model_range() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/param.rs
+++ b/lib/tests/param.rs
@@ -16,7 +16,7 @@ async fn define_global_param() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -59,7 +59,7 @@ async fn define_protected_param() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/relate.rs
+++ b/lib/tests/relate.rs
@@ -14,7 +14,7 @@ async fn relate_with_parameters() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -51,7 +51,7 @@ async fn relate_and_overwrite() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -15,7 +15,7 @@ async fn remove_statement_table() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -49,7 +49,7 @@ async fn remove_statement_analyzer() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	// Analyzer is defined
 	let tmp = res.remove(0).result;

--- a/lib/tests/script.rs
+++ b/lib/tests/script.rs
@@ -19,7 +19,7 @@ async fn script_function_error() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 2);
 	//
 	let tmp = res.remove(0).result;
@@ -46,7 +46,7 @@ async fn script_function_simple() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -75,7 +75,7 @@ async fn script_function_context() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -109,7 +109,7 @@ async fn script_function_arguments() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
@@ -152,7 +152,7 @@ async fn script_function_types() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
@@ -182,7 +182,7 @@ async fn script_function_module_os() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -15,7 +15,7 @@ async fn select_field_value() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let tmp = res.remove(0).result?;
@@ -77,7 +77,7 @@ async fn select_writeable_subqueries() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result;
@@ -121,7 +121,7 @@ async fn select_where_field_is_bool() -> Result<(), Error> {
 
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result?;
@@ -209,7 +209,7 @@ async fn select_where_and_with_index() -> Result<(), Error> {
 		SELECT name FROM person WHERE name = 'Tobie' AND genre = 'm' EXPLAIN;";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let _ = res.remove(0).result?;
@@ -253,7 +253,7 @@ async fn select_where_and_with_unique_index() -> Result<(), Error> {
 		SELECT name FROM person WHERE name = 'Jaime' AND genre = 'm' EXPLAIN;";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 4);
 	//
 	let _ = res.remove(0).result?;
@@ -298,7 +298,7 @@ async fn select_where_and_with_fulltext_index() -> Result<(), Error> {
 		SELECT name FROM person WHERE name @@ 'Jaime' AND genre = 'm' EXPLAIN;";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let _ = res.remove(0).result?;

--- a/lib/tests/strict.rs
+++ b/lib/tests/strict.rs
@@ -17,7 +17,7 @@ async fn strict_mode_no_namespace() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, true).await?;
+	let res = &mut dbs.execute(sql, &ses, None, true).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -75,7 +75,7 @@ async fn strict_mode_no_database() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, true).await?;
+	let res = &mut dbs.execute(sql, &ses, None, true).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -128,7 +128,7 @@ async fn strict_mode_no_table() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, true).await?;
+	let res = &mut dbs.execute(sql, &ses, None, true).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -176,7 +176,7 @@ async fn strict_mode_all_ok() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, true).await?;
+	let res = &mut dbs.execute(sql, &ses, None, true).await?;
 	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result;
@@ -215,7 +215,7 @@ async fn loose_mode_all_ok() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/subquery.rs
+++ b/lib/tests/subquery.rs
@@ -25,7 +25,7 @@ async fn subquery_select() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
@@ -137,7 +137,7 @@ async fn subquery_ifelse_set() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result?;
@@ -252,7 +252,7 @@ async fn subquery_ifelse_array() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/table.rs
+++ b/lib/tests/table.rs
@@ -28,7 +28,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/typing.rs
+++ b/lib/tests/typing.rs
@@ -20,7 +20,7 @@ async fn strict_typing_inline() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 9);
 	//
 	let tmp = res.remove(0).result;
@@ -136,7 +136,7 @@ async fn strict_typing_defined() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 8);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/update.rs
+++ b/lib/tests/update.rs
@@ -31,7 +31,7 @@ async fn update_simple_with_input() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -111,7 +111,7 @@ async fn update_complex_with_input() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;

--- a/lib/tests/yuse.rs
+++ b/lib/tests/yuse.rs
@@ -14,7 +14,7 @@ async fn use_statement_set_ns() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -40,7 +40,7 @@ async fn use_statement_set_db() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
@@ -66,7 +66,7 @@ async fn use_statement_set_both() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
+	let res = &mut dbs.execute(sql, &ses, None, false).await?;
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I fixed existing Clippy warnings.

## What does this change do?

Fixes the following lints:

- `needless_borrow` 
- `approx_constant` 
- `unnecessary_cast` 
- `too_many_arguments` 
- `question_mark` 
- `match_single_binding` 
- `into_iter_on_ref` 
- `useless_vec` 
- `bool_assert_comparison` 
- `box_default` 
- `ptr_arg` 
-  `borrow_deref_ref` 
-  `unnecessary_mut_passed` 
-  `redundant_closure` 
-  `clone_on_copy` 
-  `useless_format` 
-  `while_let_loop` 
-  `single_match`



## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
