### PR TITLE
Add KV tests to confirm keys are being serialised the right way

### DIFF
--- a/lib/src/key/az.rs
+++ b/lib/src/key/az.rs
@@ -58,7 +58,7 @@ mod tests {
             "test",
         );
 		let enc = Az::encode(&val).unwrap();
-		assert_eq!(enc, b"/*ns\x00*db\x00!aztest\x00");
+		assert_eq!(enc, b"/*ns\0*db\0!aztest\0");
 		let dec = Az::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}
@@ -66,12 +66,12 @@ mod tests {
 	#[test]
 	fn prefix() {
 		let val = super::prefix("namespace", "database");
-		assert_eq!(val, b"/*namespace\x00*database\x00!az\x00");
+		assert_eq!(val, b"/*namespace\0*database\0!az\0");
 	}
 
 	#[test]
 	fn suffix() {
 		let val = super::suffix("namespace", "database");
-		assert_eq!(val, b"/*namespace\x00*database\x00!az\xff");
+		assert_eq!(val, b"/*namespace\0*database\0!az\xff");
 	}
 }

--- a/lib/src/key/az.rs
+++ b/lib/src/key/az.rs
@@ -58,7 +58,20 @@ mod tests {
             "test",
         );
 		let enc = Az::encode(&val).unwrap();
+		assert_eq!(enc, b"/*ns\x00*db\x00!aztest\x00");
 		let dec = Az::decode(&enc).unwrap();
 		assert_eq!(val, dec);
+	}
+
+	#[test]
+	fn prefix() {
+		let val = super::prefix("namespace", "database");
+		assert_eq!(val, b"/*namespace\x00*database\x00!az\x00");
+	}
+
+	#[test]
+	fn suffix() {
+		let val = super::suffix("namespace", "database");
+		assert_eq!(val, b"/*namespace\x00*database\x00!az\xff");
 	}
 }

--- a/lib/src/key/bc.rs
+++ b/lib/src/key/bc.rs
@@ -41,18 +41,24 @@ impl<'a> Bc<'a> {
 
 #[cfg(test)]
 mod tests {
+
 	#[test]
 	fn key() {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Bc::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 			7
 		);
 		let enc = Bc::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\x00*testdb\x00*testtb\x00!bctestix\x00*\x00\x00\x00\x00\x00\x00\x00\x07"
+		);
+
 		let dec = Bc::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/bc.rs
+++ b/lib/src/key/bc.rs
@@ -54,10 +54,7 @@ mod tests {
 			7
 		);
 		let enc = Bc::encode(&val).unwrap();
-		assert_eq!(
-			enc,
-			b"/*testns\x00*testdb\x00*testtb\x00!bctestix\x00*\x00\x00\x00\x00\x00\x00\x00\x07"
-		);
+		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0!bctestix\0*\0\0\0\0\0\0\0\x07");
 
 		let dec = Bc::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/bd.rs
+++ b/lib/src/key/bd.rs
@@ -61,9 +61,9 @@ mod tests {
 		let enc = Bd::encode(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*testns\x00*testdb\x00*testtb\x00!bdtestix\x00*\
+			b"/*testns\0*testdb\0*testtb\0!bdtestix\0*\
 			\x01\
-			\x00\x00\x00\x00\x00\x00\x00\x07"
+			\0\0\0\0\0\0\0\x07"
 		);
 		let dec = Bd::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/bd.rs
+++ b/lib/src/key/bd.rs
@@ -52,13 +52,19 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Bd::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 			Some(7)
 		);
 		let enc = Bd::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\x00*testdb\x00*testtb\x00!bdtestix\x00*\
+			\x01\
+			\x00\x00\x00\x00\x00\x00\x00\x07"
+		);
 		let dec = Bd::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/bf.rs
+++ b/lib/src/key/bf.rs
@@ -67,9 +67,9 @@ mod tests {
 		let enc = Bf::encode(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*testns\x00*testdb\x00*testtb\x00!bftestix\x00*\
-		    \x00\x00\x00\x00\x00\x00\x00\x07\
-		    \x00\x00\x00\x00\x00\x00\x00\x0d"
+			b"/*testns\0*testdb\0*testtb\0!bftestix\0*\
+		    \0\0\0\0\0\0\0\x07\
+		    \0\0\0\0\0\0\0\x0d"
 		);
 
 		let dec = Bf::decode(&enc).unwrap();

--- a/lib/src/key/bf.rs
+++ b/lib/src/key/bf.rs
@@ -57,14 +57,21 @@ mod tests {
 	fn key() {
 		#[rustfmt::skip]
 		let val = Bf::new(
-			"test",
-			"test",
-			"test",
-			"test",
-			1,
-			2
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
+			7,
+			13
 		);
 		let enc = Bf::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\x00*testdb\x00*testtb\x00!bftestix\x00*\
+		    \x00\x00\x00\x00\x00\x00\x00\x07\
+		    \x00\x00\x00\x00\x00\x00\x00\x0d"
+		);
+
 		let dec = Bf::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/bi.rs
+++ b/lib/src/key/bi.rs
@@ -46,13 +46,19 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Bi::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 			7
 		);
 		let enc = Bi::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\x00*testdb\x00*testtb\x00!bitestix\x00*\
+			\x00\x00\x00\x00\x00\x00\x00\x07"
+		);
+
 		let dec = Bi::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/bi.rs
+++ b/lib/src/key/bi.rs
@@ -55,8 +55,8 @@ mod tests {
 		let enc = Bi::encode(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*testns\x00*testdb\x00*testtb\x00!bitestix\x00*\
-			\x00\x00\x00\x00\x00\x00\x00\x07"
+			b"/*testns\0*testdb\0*testtb\0!bitestix\0*\
+			\0\0\0\0\0\0\0\x07"
 		);
 
 		let dec = Bi::decode(&enc).unwrap();

--- a/lib/src/key/bk.rs
+++ b/lib/src/key/bk.rs
@@ -53,10 +53,7 @@ mod tests {
 			7
 		);
 		let enc = Bk::encode(&val).unwrap();
-		assert_eq!(
-			enc,
-			b"/*testns\x00*testdb\x00*testtb\x00!bktestix\x00*\x00\x00\x00\x00\x00\x00\x00\x07"
-		);
+		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0!bktestix\0*\0\0\0\0\0\0\0\x07");
 
 		let dec = Bk::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/bk.rs
+++ b/lib/src/key/bk.rs
@@ -46,13 +46,18 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Bk::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 			7
 		);
 		let enc = Bk::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\x00*testdb\x00*testtb\x00!bktestix\x00*\x00\x00\x00\x00\x00\x00\x00\x07"
+		);
+
 		let dec = Bk::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/bl.rs
+++ b/lib/src/key/bl.rs
@@ -61,9 +61,9 @@ mod tests {
 		let enc = Bl::encode(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*testns\x00*testdb\x00*testtb\x00!bltestix\x00*\
+			b"/*testns\0*testdb\0*testtb\0!bltestix\0*\
 		\x01\
-		\x00\x00\x00\x00\x00\x00\x00\x07"
+		\0\0\0\0\0\0\0\x07"
 		);
 
 		let dec = Bl::decode(&enc).unwrap();

--- a/lib/src/key/bl.rs
+++ b/lib/src/key/bl.rs
@@ -52,13 +52,20 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Bl::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 			Some(7)
 		);
 		let enc = Bl::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\x00*testdb\x00*testtb\x00!bltestix\x00*\
+		\x01\
+		\x00\x00\x00\x00\x00\x00\x00\x07"
+		);
+
 		let dec = Bl::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/bo.rs
+++ b/lib/src/key/bo.rs
@@ -56,13 +56,18 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Bo::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 			1,2
 		);
 		let enc = Bo::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\0*testdb\0*testtb\0!botestix\0*\0\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02"
+		);
+
 		let dec = Bo::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/bp.rs
+++ b/lib/src/key/bp.rs
@@ -52,13 +52,20 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Bp::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 			Some(7)
 		);
 		let enc = Bp::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\x00*testdb\x00*testtb\x00!bptestix\x00*\
+		\x01\
+		\x00\x00\x00\x00\x00\x00\x00\x07"
+		);
+
 		let dec = Bp::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/bp.rs
+++ b/lib/src/key/bp.rs
@@ -61,9 +61,9 @@ mod tests {
 		let enc = Bp::encode(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*testns\x00*testdb\x00*testtb\x00!bptestix\x00*\
+			b"/*testns\0*testdb\0*testtb\0!bptestix\0*\
 		\x01\
-		\x00\x00\x00\x00\x00\x00\x00\x07"
+		\0\0\0\0\0\0\0\x07"
 		);
 
 		let dec = Bp::decode(&enc).unwrap();

--- a/lib/src/key/bs.rs
+++ b/lib/src/key/bs.rs
@@ -41,12 +41,14 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Bs::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 		);
 		let enc = Bs::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\x00*testdb\x00*testtb\x00!bstestix\x00");
+
 		let dec = Bs::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/bs.rs
+++ b/lib/src/key/bs.rs
@@ -47,7 +47,7 @@ mod tests {
 			"testix",
 		);
 		let enc = Bs::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\x00*testdb\x00*testtb\x00!bstestix\x00");
+		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0!bstestix\0");
 
 		let dec = Bs::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/bt.rs
+++ b/lib/src/key/bt.rs
@@ -61,9 +61,9 @@ mod tests {
 		let enc = Bt::encode(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*testns\x00*testdb\x00*testtb\x00!bttestix\x00*\
+			b"/*testns\0*testdb\0*testtb\0!bttestix\0*\
 			\x01\
-			\x00\x00\x00\x00\x00\x00\x00\x07"
+			\0\0\0\0\0\0\0\x07"
 		);
 		let dec = Bt::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/bt.rs
+++ b/lib/src/key/bt.rs
@@ -52,13 +52,19 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Bt::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 			Some(7)
 		);
 		let enc = Bt::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\x00*testdb\x00*testtb\x00!bttestix\x00*\
+			\x01\
+			\x00\x00\x00\x00\x00\x00\x00\x07"
+		);
 		let dec = Bt::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/bu.rs
+++ b/lib/src/key/bu.rs
@@ -53,10 +53,7 @@ mod tests {
 			7
 		);
 		let enc = Bu::encode(&val).unwrap();
-		assert_eq!(
-			enc,
-			b"/*testns\x00*testdb\x00*testtb\x00!butestix\x00*\x00\x00\x00\x00\x00\x00\x00\x07"
-		);
+		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0!butestix\0*\0\0\0\0\0\0\0\x07");
 
 		let dec = Bu::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/bu.rs
+++ b/lib/src/key/bu.rs
@@ -46,13 +46,18 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Bu::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 			7
 		);
 		let enc = Bu::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\x00*testdb\x00*testtb\x00!butestix\x00*\x00\x00\x00\x00\x00\x00\x00\x07"
+		);
+
 		let dec = Bu::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/database.rs
+++ b/lib/src/key/database.rs
@@ -37,7 +37,7 @@ mod tests {
 			"testdb",
 		);
 		let enc = Database::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\x00*testdb");
+		assert_eq!(enc, b"/*testns\0*testdb\0");
 
 		let dec = Database::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/database.rs
+++ b/lib/src/key/database.rs
@@ -33,10 +33,12 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Database::new(
-			"test",
-			"test",
+			"testns",
+			"testdb",
 		);
 		let enc = Database::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\x00*testdb");
+
 		let dec = Database::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/db.rs
+++ b/lib/src/key/db.rs
@@ -53,7 +53,7 @@ mod tests {
 			"testdb",
 		);
 		let enc = Db::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\x00!dbtestdb\x00");
+		assert_eq!(enc, b"/*testns\0!dbtestdb\0");
 
 		let dec = Db::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -62,12 +62,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix("testns");
-		assert_eq!(val, b"/*testns\x00!db\x00")
+		assert_eq!(val, b"/*testns\0!db\0")
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix("testns");
-		assert_eq!(val, b"/*testns\x00!db\xff")
+		assert_eq!(val, b"/*testns\0!db\xff")
 	}
 }

--- a/lib/src/key/db.rs
+++ b/lib/src/key/db.rs
@@ -49,11 +49,25 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Db::new(
-			"test",
-			"test",
+			"testns",
+			"testdb",
 		);
 		let enc = Db::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\x00!dbtestdb\x00");
+
 		let dec = Db::decode(&enc).unwrap();
 		assert_eq!(val, dec);
+	}
+
+	#[test]
+	fn test_prefix() {
+		let val = super::prefix("testns");
+		assert_eq!(val, b"/*testns\x00!db\x00")
+	}
+
+	#[test]
+	fn test_suffix() {
+		let val = super::suffix("testns");
+		assert_eq!(val, b"/*testns\x00!db\xff")
 	}
 }

--- a/lib/src/key/dl.rs
+++ b/lib/src/key/dl.rs
@@ -58,7 +58,7 @@ mod tests {
 			"testdl",
 		);
 		let enc = Dl::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\x00*testdb\x00!dltestdl\x00");
+		assert_eq!(enc, b"/*testns\0*testdb\0!dltestdl\0");
 
 		let dec = Dl::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/dl.rs
+++ b/lib/src/key/dl.rs
@@ -53,11 +53,13 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Dl::new(
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testdl",
 		);
 		let enc = Dl::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\x00*testdb\x00!dltestdl\x00");
+
 		let dec = Dl::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/dt.rs
+++ b/lib/src/key/dt.rs
@@ -53,12 +53,26 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Dt::new(
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtk",
 		);
 		let enc = Dt::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\x00*testdb\x00!dttesttk\x00");
+
 		let dec = Dt::decode(&enc).unwrap();
 		assert_eq!(val, dec);
+	}
+
+	#[test]
+	fn test_prefix() {
+		let val = super::prefix("testns", "testdb");
+		assert_eq!(val, b"/*testns\x00*testdb\x00!dt\x00");
+	}
+
+	#[test]
+	fn test_suffix() {
+		let val = super::suffix("testns", "testdb");
+		assert_eq!(val, b"/*testns\x00*testdb\x00!dt\xff");
 	}
 }

--- a/lib/src/key/dt.rs
+++ b/lib/src/key/dt.rs
@@ -67,12 +67,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix("testns", "testdb");
-		assert_eq!(val, b"/*testns\x00*testdb\x00!dt\x00");
+		assert_eq!(val, b"/*testns\0*testdb\0!dt\0");
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix("testns", "testdb");
-		assert_eq!(val, b"/*testns\x00*testdb\x00!dt\xff");
+		assert_eq!(val, b"/*testns\0*testdb\0!dt\xff");
 	}
 }

--- a/lib/src/key/ev.rs
+++ b/lib/src/key/ev.rs
@@ -57,13 +57,27 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Ev::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testev",
 		);
 		let enc = Ev::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\x00*testdb\x00*testtb\x00!evtestev\x00");
+
 		let dec = Ev::decode(&enc).unwrap();
 		assert_eq!(val, dec);
+	}
+
+	#[test]
+	fn test_prefix() {
+		let val = super::prefix("testns", "testdb", "testtb");
+		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!ev\x00");
+	}
+
+	#[test]
+	fn test_suffix() {
+		let val = super::suffix("testns", "testdb", "testtb");
+		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!ev\xff");
 	}
 }

--- a/lib/src/key/ev.rs
+++ b/lib/src/key/ev.rs
@@ -72,12 +72,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix("testns", "testdb", "testtb");
-		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!ev\x00");
+		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!ev\0");
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix("testns", "testdb", "testtb");
-		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!ev\xff");
+		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!ev\xff");
 	}
 }

--- a/lib/src/key/fc.rs
+++ b/lib/src/key/fc.rs
@@ -53,12 +53,25 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Fc::new(
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testfc",
 		);
 		let enc = Fc::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\x00*testdb\x00!fntestfc\x00");
 		let dec = Fc::decode(&enc).unwrap();
 		assert_eq!(val, dec);
+	}
+
+	#[test]
+	fn test_prefix() {
+		let val = super::prefix("testns", "testdb");
+		assert_eq!(val, b"/*testns\x00*testdb\x00!fn\x00");
+	}
+
+	#[test]
+	fn test_suffix() {
+		let val = super::suffix("testns", "testdb");
+		assert_eq!(val, b"/*testns\x00*testdb\x00!fn\xff");
 	}
 }

--- a/lib/src/key/fc.rs
+++ b/lib/src/key/fc.rs
@@ -66,12 +66,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix("testns", "testdb");
-		assert_eq!(val, b"/*testns\x00*testdb\x00!fn\x00");
+		assert_eq!(val, b"/*testns\0*testdb\0!fn\0");
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix("testns", "testdb");
-		assert_eq!(val, b"/*testns\x00*testdb\x00!fn\xff");
+		assert_eq!(val, b"/*testns\0*testdb\0!fn\xff");
 	}
 }

--- a/lib/src/key/fd.rs
+++ b/lib/src/key/fd.rs
@@ -72,12 +72,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix("testns", "testdb", "testtb");
-		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!fd\x00");
+		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!fd\0");
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix("testns", "testdb", "testtb");
-		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!fd\xff");
+		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!fd\xff");
 	}
 }

--- a/lib/src/key/fd.rs
+++ b/lib/src/key/fd.rs
@@ -57,13 +57,27 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Fd::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testfd",
 		);
 		let enc = Fd::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\x00*testdb\x00*testtb\x00!fdtestfd\x00");
+
 		let dec = Fd::decode(&enc).unwrap();
 		assert_eq!(val, dec);
+	}
+
+	#[test]
+	fn test_prefix() {
+		let val = super::prefix("testns", "testdb", "testtb");
+		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!fd\x00");
+	}
+
+	#[test]
+	fn test_suffix() {
+		let val = super::suffix("testns", "testdb", "testtb");
+		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!fd\xff");
 	}
 }

--- a/lib/src/key/ft.rs
+++ b/lib/src/key/ft.rs
@@ -57,13 +57,27 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Ft::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testft",
 		);
 		let enc = Ft::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\x00*testdb\x00*testtb\x00!fttestft\x00");
+
 		let dec = Ft::decode(&enc).unwrap();
 		assert_eq!(val, dec);
+	}
+
+	#[test]
+	fn test_prefix() {
+		let val = super::prefix("testns", "testdb", "testtb");
+		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!ft\0");
+	}
+
+	#[test]
+	fn test_suffix() {
+		let val = super::suffix("testns", "testdb", "testtb");
+		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!ft\xff");
 	}
 }

--- a/lib/src/key/graph.rs
+++ b/lib/src/key/graph.rs
@@ -188,14 +188,19 @@ mod tests {
 		let fk = Thing::parse("other:test");
 		#[rustfmt::skip]
 		let val = Graph::new(
-			"test",
-			"test",
-			"test",
-			"test".into(),
+			"testns",
+			"testdb",
+			"testtb",
+			"testid".into(),
 			Dir::Out,
 			&fk,
 		);
 		let enc = Graph::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\0*testdb\0*testtb\x00~\0\0\0\x01testid\0\0\0\0\x01other\0\0\0\0\x01test\0"
+		);
+
 		let dec = Graph::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/index.rs
+++ b/lib/src/key/index.rs
@@ -146,14 +146,19 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Index::new(
-			"test",
-			"test",
-			"test",
-			"test",
-			vec!["test"].into(),
-			Some("test".into()),
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
+			vec!["testfd1", "testfd2"].into(),
+			Some("testid".into()),
 		);
 		let enc = Index::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\0*testdb\0*testtb\0\xa4testix\0\0\0\0\x04testfd1\0\0\0\0\x04testfd2\0\x01\x01\0\0\0\x01testid\0"
+		);
+
 		let dec = Index::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/ix.rs
+++ b/lib/src/key/ix.rs
@@ -57,12 +57,14 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Ix::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
+			"testix",
 		);
 		let enc = Ix::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0!ixtestix\0");
+
 		let dec = Ix::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/kv.rs
+++ b/lib/src/key/kv.rs
@@ -32,6 +32,8 @@ mod tests {
 		#[rustfmt::skip]
 		let val = Kv::new();
 		let enc = Kv::encode(&val).unwrap();
+		assert_eq!(enc, b"/");
+
 		let dec = Kv::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/namespace.rs
+++ b/lib/src/key/namespace.rs
@@ -29,9 +29,11 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Namespace::new(
-			"test",
+			"testns",
 		);
 		let enc = Namespace::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0");
+
 		let dec = Namespace::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/nl.rs
+++ b/lib/src/key/nl.rs
@@ -49,10 +49,12 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Nl::new(
-			"test",
-			"test",
+			"testns",
+			"testus",
 		);
 		let enc = Nl::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0!nltestus\0");
+
 		let dec = Nl::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/ns.rs
+++ b/lib/src/key/ns.rs
@@ -45,9 +45,11 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Ns::new(
-			"test",
+			"testns",
 		);
 		let enc = Ns::encode(&val).unwrap();
+		assert_eq!(enc, b"/!nstestns\0");
+
 		let dec = Ns::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/nt.rs
+++ b/lib/src/key/nt.rs
@@ -49,10 +49,11 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Nt::new(
-			"test",
-			"test",
+			"testns",
+			"testtk",
 		);
 		let enc = Nt::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0!nttesttk\0");
 		let dec = Nt::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/pa.rs
+++ b/lib/src/key/pa.rs
@@ -53,11 +53,13 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Pa::new(
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testpa",
 		);
 		let enc = Pa::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0!patestpa\0");
+
 		let dec = Pa::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/sc.rs
+++ b/lib/src/key/sc.rs
@@ -53,11 +53,13 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Sc::new(
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testsc",
 		);
 		let enc = Sc::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0!sctestsc\0");
+
 		let dec = Sc::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/scope.rs
+++ b/lib/src/key/scope.rs
@@ -38,11 +38,13 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Scope::new(
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testsc",
 		);
 		let enc = Scope::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0\xb1testsc\0");
+
 		let dec = Scope::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/st.rs
+++ b/lib/src/key/st.rs
@@ -58,12 +58,14 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = St::new(
-			"test",
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testsc",
+			"testtk",
 		);
 		let enc = St::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0\xb1testsc\0!sttesttk\0");
+
 		let dec = St::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/table.rs
+++ b/lib/src/key/table.rs
@@ -37,11 +37,13 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Table::new(
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
 		);
 		let enc = Table::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0");
+
 		let dec = Table::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/tb.rs
+++ b/lib/src/key/tb.rs
@@ -53,11 +53,13 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Tb::new(
-			"test",
-			"test",
-			"test",
+			"testns",
+			"testdb",
+			"testtb",
 		);
 		let enc = Tb::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0!tbtesttb\0");
+
 		let dec = Tb::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/thing.rs
+++ b/lib/src/key/thing.rs
@@ -54,12 +54,14 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Thing::new(
-			"test",
-			"test",
-			"test",
-			"test".into(),
+			"testns",
+			"testdb",
+			"testtb",
+			"testid".into(),
 		);
 		let enc = Thing::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0*\0\0\0\x01testid\0");
+
 		let dec = Thing::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}
@@ -69,16 +71,20 @@ mod tests {
 		//
 		let id1 = "['test']";
 		let (_, id1) = crate::sql::id::id(id1).expect("Failed to parse the ID");
-		let val = Thing::new("test", "test", "test", id1);
+		let val = Thing::new("testns", "testdb", "testtb", id1);
 		let enc = Thing::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0*\0\0\0\x02\0\0\0\x04test\0\x01");
+
 		let dec = Thing::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 		println!("---");
 		//
 		let id2 = "['f8e238f2-e734-47b8-9a16-476b291bd78a']";
 		let (_, id2) = crate::sql::id::id(id2).expect("Failed to parse the ID");
-		let val = Thing::new("test", "test", "test", id2);
+		let val = Thing::new("testns", "testdb", "testtb", id2);
 		let enc = Thing::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0*\0\0\0\x02\0\0\0\x07\xf8\xe2\x38\xf2\xe7\x34\x47\xb8\x9a\x16\x47\x6b\x29\x1b\xd7\x8a\x01");
+
 		let dec = Thing::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 		println!("---");


### PR DESCRIPTION
## What is the motivation?

Introduce tests to confirm keys are being serialised as expected.

This also adds tests for some of the suffix/prefix keys being generated, so that we can confirm the ranges generated are correct.

## What is your testing strategy?

#2137 , but also `make serve && make test`

## Is this related to any issues?

#2137 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
