### PR TITLE
Add code coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,13 @@ jobs:
       - name: Run cargo test (+coverage)
         run: cargo llvm-cov --html --locked --no-default-features --features storage-mem,scripting,http --workspace -- --skip api_integration --skip cli
 
+      - name: Upload coverage report'
+        uses: actions/upload-artifact@v3
+        with:
+            name: code-coverage-report
+            path: target/llvm-cov/html/index.html
+            retention-days: 5
+
   ws-engine:
     name: WebSocket engine
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,11 @@ jobs:
       - name: Run cargo test (+coverage)
         run: cargo llvm-cov --html --locked --no-default-features --features storage-mem,scripting,http --workspace -- --skip api_integration --skip cli
 
-      - name: Upload coverage report'
+      - name: Upload coverage report
         uses: actions/upload-artifact@v3
         with:
             name: code-coverage-report
-            path: target/llvm-cov/html/index.html
+            path: target/llvm-cov/html/
             retention-days: 5
 
   ws-engine:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,11 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
-      - name: Run cargo test
-        run: cargo test --locked --no-default-features --features storage-mem,scripting,http --workspace -- --skip api_integration --skip cli
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run cargo test (+coverage)
+        run: cargo llvm-cov --html --locked --no-default-features --features storage-mem,scripting,http --workspace -- --skip api_integration --skip cli
 
   ws-engine:
     name: WebSocket engine

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,10 +27,13 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run cargo test
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run cargo test (+coverage)
         run: |
           (&>/dev/null cargo run --no-default-features -F storage-mem -- start --log trace --user root --pass root memory &)
-          cargo test --workspace --features protocol-ws,protocol-http,kv-mem,kv-rocksdb
+          cargo llvm-cov --html --workspace --features protocol-ws,protocol-http,kv-mem,kv-rocksdb
 
   lint:
     name: Lint

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,13 @@ jobs:
           (&>/dev/null cargo run --no-default-features -F storage-mem -- start --log trace --user root --pass root memory &)
           cargo llvm-cov --html --workspace --features protocol-ws,protocol-http,kv-mem,kv-rocksdb
 
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: target/llvm-cov/html/
+          retention-days: 5
+
   lint:
     name: Lint
     runs-on: ubuntu-20.04-16-cores

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Run cargo test
+      - name: Run cargo test (+coverage)
         run: |
           (&>/dev/null cargo run --no-default-features -F storage-mem -- start --log trace --user root --pass root memory &)
           cargo llvm-cov --html --workspace --features protocol-ws,protocol-http,kv-mem,kv-rocksdb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,13 @@ jobs:
           (&>/dev/null cargo run --no-default-features -F storage-mem -- start --log trace --user root --pass root memory &)
           cargo llvm-cov --html --workspace --features protocol-ws,protocol-http,kv-mem,kv-rocksdb
 
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: target/llvm-cov/html/
+          retention-days: 30
+
   lint:
     name: Lint
     runs-on: ubuntu-20.04-16-cores

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,13 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
       - name: Run cargo test
         run: |
           (&>/dev/null cargo run --no-default-features -F storage-mem -- start --log trace --user root --pass root memory &)
-          cargo test --workspace --features protocol-ws,protocol-http,kv-mem,kv-rocksdb
+          cargo llvm-cov --html --workspace --features protocol-ws,protocol-http,kv-mem,kv-rocksdb
 
   lint:
     name: Lint


### PR DESCRIPTION
## What is the motivation?

We want to track the code covered by tests.

## What does this change do?

It uses [cargo-llvm-cov](https://crates.io/crates/cargo-llvm-cov) during the test phase so that an HTML report can be generated.
The directory (`target/llmv-co/html`) is uploaded as an artifact called `code-coverage-report` attached to the workflow.

## What is your testing strategy?

N/A

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
