### PR TITLE
Bugfix - JSON datetime string.

### DIFF
--- a/lib/src/api/opt/mod.rs
+++ b/lib/src/api/opt/mod.rs
@@ -341,14 +341,14 @@ fn into_json(value: Value, simplify: bool) -> JsonValue {
 		Value::Number(Number::Float(n)) => n.into(),
 		Value::Number(Number::Decimal(n)) => json!(n),
 		Value::Strand(strand) => match simplify {
-			true => strand.0.into(),
+			true => strand.to_raw().into(),
 			false => json!(strand),
 		},
 		Value::Duration(d) => match simplify {
 			true => d.to_string().into(),
 			false => json!(d),
 		},
-		Value::Datetime(d) => json!(d),
+		Value::Datetime(d) => d.to_raw().into(),
 		Value::Uuid(uuid) => json!(uuid),
 		Value::Array(arr) => JsonValue::Array(Array::from((arr, simplify)).0),
 		Value::Object(obj) => JsonValue::Object(Object::from((obj, simplify)).0),

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -91,7 +91,7 @@ impl Datetime {
 
 impl Display for Datetime {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		Display::fmt(&quote_str(&self.0.to_rfc3339_opts(SecondsFormat::AutoSi, true)), f)
+		Display::fmt(&quote_str(&self.to_raw()), f)
 	}
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

As @kearfy noticed, `Datetime`'s were erroneously serialized as an array of numbers (seconds and nanoseconds) ever since https://github.com/surrealdb/surrealdb/pull/1951.

## What does this change do?

Serialize `Datetime` as string again in JSON.

## What is your testing strategy?

```
$ surreal sql ... --json --pretty
test/test> return time::now();
[
        "2023-06-25T22:36:47.039110426Z"
]
```

## Is this related to any issues?

Fixes issue caused by https://github.com/surrealdb/surrealdb/pull/1951

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
