### PR TITLE
Bugfix - Non-spec behavour in `Request.prototype.text`

### DIFF
--- a/lib/src/fnc/script/fetch/classes/request.rs
+++ b/lib/src/fnc/script/fetch/classes/request.rs
@@ -556,7 +556,12 @@ mod request {
 		pub async fn text<'js>(&self, ctx: Ctx<'js>, args: Rest<()>) -> Result<String> {
 			let data = self.take_buffer(ctx).await?;
 
-			Ok(String::from_utf8(data.to_vec())?)
+			// Skip UTF-BOM
+			if data.starts_with(&[0xEF, 0xBB, 0xBF]) {
+				Ok(String::from_utf8_lossy(&data[3..]).into_owned())
+			} else {
+				Ok(String::from_utf8_lossy(&data).into_owned())
+			}
 		}
 	}
 }

--- a/lib/src/fnc/script/fetch/classes/response/mod.rs
+++ b/lib/src/fnc/script/fetch/classes/response/mod.rs
@@ -221,7 +221,12 @@ pub mod response {
 		pub async fn text<'js>(&self, ctx: Ctx<'js>, args: Rest<()>) -> Result<String> {
 			let data = self.take_buffer(ctx).await?;
 
-			Ok(String::from_utf8(data.to_vec())?)
+			// Skip UTF-BOM
+			if data.starts_with(&[0xEF, 0xBB, 0xBF]) {
+				Ok(String::from_utf8_lossy(&data[3..]).into_owned())
+			} else {
+				Ok(String::from_utf8_lossy(&data).into_owned())
+			}
 		}
 
 		// Returns a promise with the response body as text


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`Response.prototype.text` and `Request.prototype.text` has behavior which is not according to fetch spec.
When a request or a response has a non-UTF-8 body calling the text method on that request or response results in an conversion error. 
This is different from spec which dictates that all non-UTF-8 characters are replaced with the replacement character `�`. 

Furthermore, the stream from which a body is produced was bounded. 
This leads to problems when a body is made up of a greater number of chunks than the bound.
In this case teeing a body and then awaiting one of the bodies the future will block forever if the second body isn't also simultaneously awaited.

## What does this change do?

This PR fixes the spec difference and makes the body streams unbounded so that awaiting one will not block forever.

## What is your testing strategy?

Haven't yet found a good way to test request and streams.
Will introduce tests in a later PR.

## Is this related to any issues?

None found

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [*] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
