### PR TITLE
Bugfix - Fixed live queries to respect filters

### DIFF
--- a/lib/src/doc/lives.rs
+++ b/lib/src/doc/lives.rs
@@ -27,7 +27,7 @@ impl<'a> Document<'a> {
 			// Create a new statement
 			let lq = Statement::from(lv);
 			// Check LIVE SELECT where condition
-			if self.check(ctx, opt, stm).await.is_err() {
+			if self.check(ctx, opt, &lq).await.is_err() {
 				continue;
 			}
 			// Check what type of data change this is


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently live queries do not respect any where clauses set. This PR fixes #2191

## What does this change do?

There is a bug in the live query notification implementation that checks the document against the where clauses of the statement that modified/created the document instead of checking against the live query statement

## What is your testing strategy?

manually test correct behaviour

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
