### PR TITLE
feat(auth): add ability to read jwt value

### DIFF
--- a/lib/src/api/opt/auth.rs
+++ b/lib/src/api/opt/auth.rs
@@ -85,7 +85,7 @@ impl<T, P> Credentials<T, Jwt> for Scope<'_, P> where P: Serialize {}
 
 /// A JSON Web Token for authenticating with the server
 #[derive(Clone, Serialize, Deserialize)]
-pub struct Jwt(pub(crate) String);
+pub struct Jwt(pub String);
 
 impl From<String> for Jwt {
 	fn from(jwt: String) -> Self {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

```rust
let token: Jwt = db
        .signup(Scope {
            namespace: "test",
            database: "test",
            scope: "user_scope",
            params: SignUpAuthParams {
                username,
                email,
                password,
            },
        })
        .await
        .map_err(|_| ServerFnError::ServerError("Cannot signup to SurrealDB".to_string()))?;
```

When using `token`, I cannot read the value of the JWT to use it.

## What does this change do?

```rust
let token: Jwt = db
        .signup(Scope {
            namespace: "test",
            database: "test",
            scope: "user_scope",
            params: SignUpAuthParams {
                username,
                email,
                password,
            },
        })
        .await
        .map_err(|_| ServerFnError::ServerError("Cannot signup to SurrealDB".to_string()))?;

let token = token.0; // this works and contains the String value
```

## What is your testing strategy?

N/A

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
