### PR TITLE
BM25 without parameters

### DIFF
--- a/lib/src/idx/ft/mod.rs
+++ b/lib/src/idx/ft/mod.rs
@@ -522,7 +522,7 @@ mod tests {
 				az.clone(),
 				IndexKeyBase::default(),
 				default_btree_order,
-				&Scoring::default(),
+				&Scoring::bm25(),
 				false,
 			)
 			.await
@@ -541,7 +541,7 @@ mod tests {
 				az.clone(),
 				IndexKeyBase::default(),
 				default_btree_order,
-				&Scoring::default(),
+				&Scoring::bm25(),
 				false,
 			)
 			.await
@@ -558,7 +558,7 @@ mod tests {
 				az.clone(),
 				IndexKeyBase::default(),
 				default_btree_order,
-				&Scoring::default(),
+				&Scoring::bm25(),
 				false,
 			)
 			.await
@@ -599,7 +599,7 @@ mod tests {
 				az.clone(),
 				IndexKeyBase::default(),
 				default_btree_order,
-				&Scoring::default(),
+				&Scoring::bm25(),
 				false,
 			)
 			.await
@@ -629,7 +629,7 @@ mod tests {
 				az.clone(),
 				IndexKeyBase::default(),
 				default_btree_order,
-				&Scoring::default(),
+				&Scoring::bm25(),
 				false,
 			)
 			.await
@@ -670,7 +670,7 @@ mod tests {
 					az.clone(),
 					IndexKeyBase::default(),
 					default_btree_order,
-					&Scoring::default(),
+					&Scoring::bm25(),
 					hl,
 				)
 				.await
@@ -713,7 +713,7 @@ mod tests {
 					az.clone(),
 					IndexKeyBase::default(),
 					default_btree_order,
-					&Scoring::default(),
+					&Scoring::bm25(),
 					hl,
 				)
 				.await

--- a/lib/tests/matches.rs
+++ b/lib/tests/matches.rs
@@ -10,7 +10,7 @@ async fn select_where_matches_using_index() -> Result<(), Error> {
 	let sql = r"
 		CREATE blog:1 SET title = 'Hello World!';
 		DEFINE ANALYZER simple TOKENIZERS blank,class;
-		DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25(1.2,0.75) HIGHLIGHTS;
+		DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25 HIGHLIGHTS;
 		SELECT id, search::highlight('<em>', '</em>', 1) AS title FROM blog WHERE title @1@ 'Hello' EXPLAIN;
 	";
 	let dbs = Datastore::new("memory").await?;
@@ -97,7 +97,7 @@ async fn select_where_matches_using_index_and_arrays() -> Result<(), Error> {
 	let sql = r"
 		CREATE blog:1 SET content = ['Hello World!', 'Be Bop', 'Foo Bãr'];
 		DEFINE ANALYZER simple TOKENIZERS blank,class;
-		DEFINE INDEX blog_content ON blog FIELDS content SEARCH ANALYZER simple BM25(1.2,0.75) HIGHLIGHTS;
+		DEFINE INDEX blog_content ON blog FIELDS content SEARCH ANALYZER simple BM25 HIGHLIGHTS;
 		SELECT id, search::highlight('<em>', '</em>', 1) AS content FROM blog WHERE content @1@ 'Hello Bãr' EXPLAIN;
 	";
 	let dbs = Datastore::new("memory").await?;
@@ -147,7 +147,7 @@ async fn select_where_matches_using_index_offsets() -> Result<(), Error> {
 		CREATE blog:1 SET title = 'Blog title!', content = ['Hello World!', 'Be Bop', 'Foo Bãr'];
 		DEFINE ANALYZER simple TOKENIZERS blank,class;
 		DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25(1.2,0.75) HIGHLIGHTS;
-		DEFINE INDEX blog_content ON blog FIELDS content SEARCH ANALYZER simple BM25(1.2,0.75) HIGHLIGHTS;
+		DEFINE INDEX blog_content ON blog FIELDS content SEARCH ANALYZER simple BM25 HIGHLIGHTS;
 		SELECT id, search::offsets(0) AS title, search::offsets(1) AS content FROM blog WHERE title @0@ 'title' AND content @1@ 'Hello Bãr' EXPLAIN;
 	";
 	let dbs = Datastore::new("memory").await?;
@@ -233,7 +233,7 @@ async fn select_where_matches_without_using_index_and_score() -> Result<(), Erro
 		CREATE blog:3 SET title = 'the other animals sat there watching';
 		CREATE blog:4 SET title = 'the dog sat there and did nothing';
 		DEFINE ANALYZER simple TOKENIZERS blank,class;
-		DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25(1.2,0.75) HIGHLIGHTS;
+		DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25 HIGHLIGHTS;
  		SELECT id,search::score(1) AS score FROM blog WHERE (title @1@ 'animals' AND id>0) OR (title @1@ 'animals' AND id<99);
 		SELECT id,search::score(1) + search::score(2) AS score FROM blog WHERE title @1@ 'dummy1' OR title @2@ 'dummy2';
 	";


### PR DESCRIPTION
## What is the motivation?

The current `DEFINE INDEX ... SEARCH` statement with the scoring `BM25` requires the parameters `k1` and `b` to be set. 

```sql
DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25(1.2,0.75)
```

However, BM25 is generally used with the default parameters.

## What does this change do?

This PR allows index definititions using BM25 to be specified with or without parameters.

Without parameters, we use the default values of 1.2 for `k1` and 0.75 for `b`.

```sql
DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25
```

## What is your testing strategy?

Tests has been created.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
