### PR TITLE
Print `tracing` logs for `cargo test` when `RUST_LOG` is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Temporary Items
 /target/
 /lib/target/
 .idea/
+.vscode/
 /result
 /bin/
 /docker/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,6 +4566,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "trice",
  "ulid",
  "url",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -124,6 +124,7 @@ serial_test = "2.0.0"
 temp-dir = "0.1.11"
 time = { version = "0.3.21", features = ["serde"] }
 tokio = { version = "1.28.1", features = ["macros", "sync", "rt-multi-thread"] }
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pharos = "0.5.3"


### PR DESCRIPTION
## What is the motivation?

Logs are currently not printed when running integration tests which makes debugging inconvenient.

## What does this change do?

Makes integration tests print logs when `RUST_LOG` is set.

## What is your testing strategy?

Ran `cargo test` with and without `RUST_LOG`.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
