### PR TITLE
feat: the query planner should support params

### DIFF
--- a/lib/src/idx/planner/mod.rs
+++ b/lib/src/idx/planner/mod.rs
@@ -30,18 +30,17 @@ impl<'a> QueryPlanner<'a> {
 	pub(crate) async fn get_iterable(
 		&mut self,
 		ctx: &Context<'_>,
-		opt: &Options,
 		t: Table,
 	) -> Result<Iterable, Error> {
 		let txn = ctx.try_clone_transaction()?;
-		let res = Tree::build(self.opt, &txn, &t, self.cond).await?;
+		let res = Tree::build(ctx, self.opt, &txn, &t, self.cond).await?;
 		if let Some((node, im)) = res {
 			if let Some(plan) = AllAndStrategy::build(&node)? {
-				let e = QueryExecutor::new(opt, &txn, &t, im, Some(plan.e.clone())).await?;
+				let e = QueryExecutor::new(self.opt, &txn, &t, im, Some(plan.e.clone())).await?;
 				self.executors.insert(t.0.clone(), e);
 				return Ok(Iterable::Index(t, plan));
 			}
-			let e = QueryExecutor::new(opt, &txn, &t, im, None).await?;
+			let e = QueryExecutor::new(self.opt, &txn, &t, im, None).await?;
 			self.executors.insert(t.0.clone(), e);
 		}
 		Ok(Iterable::Table(t))

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -89,7 +89,7 @@ impl SelectStatement {
 			let v = w.compute(ctx, opt).await?;
 			match v {
 				Value::Table(t) => {
-					i.ingest(planner.get_iterable(ctx, opt, t).await?);
+					i.ingest(planner.get_iterable(ctx, t).await?);
 				}
 				Value::Thing(v) => i.ingest(Iterable::Thing(v)),
 				Value::Range(v) => i.ingest(Iterable::Range(*v)),

--- a/lib/tests/matches.rs
+++ b/lib/tests/matches.rs
@@ -234,15 +234,16 @@ async fn select_where_matches_without_using_index_and_score() -> Result<(), Erro
 		CREATE blog:4 SET title = 'the dog sat there and did nothing';
 		DEFINE ANALYZER simple TOKENIZERS blank,class;
 		DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25 HIGHLIGHTS;
- 		SELECT id,search::score(1) AS score FROM blog WHERE (title @1@ 'animals' AND id>0) OR (title @1@ 'animals' AND id<99);
+		LET $keywords = 'animals';
+ 		SELECT id,search::score(1) AS score FROM blog WHERE (title @1@ $keywords AND id>0) OR (title @1@ $keywords AND id<99);
 		SELECT id,search::score(1) + search::score(2) AS score FROM blog WHERE title @1@ 'dummy1' OR title @2@ 'dummy2';
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(&sql, &ses, None, false).await?;
-	assert_eq!(res.len(), 8);
+	assert_eq!(res.len(), 9);
 	//
-	for _ in 0..6 {
+	for _ in 0..7 {
 		let _ = res.remove(0).result?;
 	}
 


### PR DESCRIPTION
## What is the motivation?

Actually the query planner does not consider predicates that include a param.

Eg.:

```sql
LET $keywords = 'animals';
SELECT * FROM blog WHERE title @@ $keywords
```

## What does this change do?

This PR allows the query planner to resolve the scalar value generated by a param, and include the predicate as a possible candidate for the execution plan.

## What is your testing strategy?

A test has been written.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
