### PR TITLE
Change uuid serialisation to compact

### DIFF
--- a/lib/src/sql/uuid.rs
+++ b/lib/src/sql/uuid.rs
@@ -18,7 +18,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Uuid";
 
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Uuid")]
-pub struct Uuid(pub uuid::Uuid);
+pub struct Uuid(#[serde(with = "uuid::serde::compact")] pub uuid::Uuid);
 
 impl From<uuid::Uuid> for Uuid {
 	fn from(v: uuid::Uuid) -> Self {

--- a/lib/src/sql/value/serde/ser/primitive/mod.rs
+++ b/lib/src/sql/value/serde/ser/primitive/mod.rs
@@ -3,5 +3,6 @@ pub mod f64;
 pub mod i64;
 pub mod u32;
 pub mod u64;
+pub mod u8;
 
 mod opt;

--- a/lib/src/sql/value/serde/ser/primitive/u8.rs
+++ b/lib/src/sql/value/serde/ser/primitive/u8.rs
@@ -1,0 +1,25 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use serde::ser::Impossible;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = u8;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<u8, Error>;
+	type SerializeTuple = Impossible<u8, Error>;
+	type SerializeTupleStruct = Impossible<u8, Error>;
+	type SerializeTupleVariant = Impossible<u8, Error>;
+	type SerializeMap = Impossible<u8, Error>;
+	type SerializeStruct = Impossible<u8, Error>;
+	type SerializeStructVariant = Impossible<u8, Error>;
+
+	const EXPECTED: &'static str = "a u8";
+
+	#[inline]
+	fn serialize_u8(self, value: u8) -> Result<Self::Ok, Error> {
+		Ok(value)
+	}
+}

--- a/lib/src/sql/value/serde/ser/uuid/mod.rs
+++ b/lib/src/sql/value/serde/ser/uuid/mod.rs
@@ -1,7 +1,9 @@
 use crate::err::Error;
 use crate::sql::value::serde::ser;
+use ser::Serializer as _;
 use serde::ser::Error as _;
 use serde::ser::Impossible;
+use serde::Serialize;
 use uuid::Uuid;
 
 pub(super) struct Serializer;
@@ -11,7 +13,7 @@ impl ser::Serializer for Serializer {
 	type Error = Error;
 
 	type SerializeSeq = Impossible<Uuid, Error>;
-	type SerializeTuple = Impossible<Uuid, Error>;
+	type SerializeTuple = SerializeCompactUuidTuple;
 	type SerializeTupleStruct = Impossible<Uuid, Error>;
 	type SerializeTupleVariant = Impossible<Uuid, Error>;
 	type SerializeMap = Impossible<Uuid, Error>;
@@ -23,12 +25,39 @@ impl ser::Serializer for Serializer {
 	fn serialize_bytes(self, value: &[u8]) -> Result<Self::Ok, Self::Error> {
 		Uuid::from_slice(value).map_err(Error::custom)
 	}
+
+	fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+		Ok(SerializeCompactUuidTuple::default())
+	}
+}
+
+#[derive(Default)]
+pub(super) struct SerializeCompactUuidTuple {
+	index: usize,
+	bytes: [u8; 16],
+}
+
+impl serde::ser::SerializeTuple for SerializeCompactUuidTuple {
+	type Ok = Uuid;
+	type Error = Error;
+
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: Serialize + ?Sized,
+	{
+		self.bytes[self.index] = value.serialize(ser::primitive::u8::Serializer.wrap())?;
+		self.index += 1;
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Uuid::from_slice(&self.bytes).map_err(Error::custom)
+	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use ser::Serializer as _;
 	use serde::Serialize;
 
 	#[test]


### PR DESCRIPTION
## What is the motivation?

See https://github.com/surrealdb/surrealdb/pull/2166 for background information on this.

## What does this change do?

It implements the actual serialisation of compact UUIDs.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

It's a pre-requisite for https://github.com/surrealdb/surrealdb/pull/2166 which seeks to improve related tests.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
