### PR TITLE
Bump supported versions

### DIFF
--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -30,7 +30,7 @@ use wasm_bindgen_futures::spawn_local as spawn;
 /// A specialized `Result` type
 pub type Result<T> = std::result::Result<T, crate::Error>;
 
-const SUPPORTED_VERSIONS: (&str, &str) = (">=1.0.0-beta.8, <2.0.0", "20221030.c12a1cc");
+const SUPPORTED_VERSIONS: (&str, &str) = (">=1.0.0-beta.9, <2.0.0", "20230701.55918b7c");
 const LOG: &str = "surrealdb::api";
 
 /// Connection trait implemented by supported engines


### PR DESCRIPTION
## What is the motivation?

https://github.com/surrealdb/surrealdb/pull/2134 introduced some breaking changes on the protocol.

## What does this change do?

Bumps the minimum supported version to the commit of that PR.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
