### PR TITLE
Fix context cancellation issue

### DIFF
--- a/lib/src/dbs/iterator.rs
+++ b/lib/src/dbs/iterator.rs
@@ -79,16 +79,16 @@ impl Iterator {
 		// Log the statement
 		trace!("Iterating: {}", stm);
 		// Enable context override
-		let mut run = Context::new(ctx);
-		self.run = run.add_cancel();
+		let mut cancel_ctx = Context::new(ctx);
+		self.run = cancel_ctx.add_cancel();
 		// Process the query LIMIT clause
-		self.setup_limit(ctx, opt, stm).await?;
+		self.setup_limit(&cancel_ctx, opt, stm).await?;
 		// Process the query START clause
-		self.setup_start(ctx, opt, stm).await?;
+		self.setup_start(&cancel_ctx, opt, stm).await?;
 		// Process any EXPLAIN clause
-		let explanation = self.output_explain(ctx, opt, stm)?;
+		let explanation = self.output_explain(&cancel_ctx, opt, stm)?;
 		// Process prepared values
-		self.iterate(ctx, opt, stm).await?;
+		self.iterate(&cancel_ctx, opt, stm).await?;
 		// Return any document errors
 		if let Some(e) = self.error.take() {
 			return Err(e);

--- a/lib/src/key/index.rs
+++ b/lib/src/key/index.rs
@@ -15,7 +15,6 @@ struct Prefix<'a> {
 	pub tb: &'a str,
 	_d: u8,
 	pub ix: &'a str,
-	_e: u8,
 }
 
 impl<'a> Prefix<'a> {
@@ -30,7 +29,6 @@ impl<'a> Prefix<'a> {
 			tb,
 			_d: CHAR_INDEX,
 			ix,
-			_e: b'*',
 		}
 	}
 }
@@ -46,9 +44,7 @@ struct PrefixIds<'a> {
 	pub tb: &'a str,
 	_d: u8,
 	pub ix: &'a str,
-	_e: u8,
 	pub fd: Array,
-	_f: u8,
 }
 
 impl<'a> PrefixIds<'a> {
@@ -63,9 +59,7 @@ impl<'a> PrefixIds<'a> {
 			tb,
 			_d: CHAR_INDEX,
 			ix,
-			_e: b'*',
 			fd: fd.to_owned(),
-			_f: b'*',
 		}
 	}
 }
@@ -81,9 +75,7 @@ pub struct Index<'a> {
 	pub tb: &'a str,
 	_d: u8,
 	pub ix: &'a str,
-	_e: u8,
 	pub fd: Array,
-	_f: u8,
 	pub id: Option<Id>,
 }
 
@@ -141,9 +133,7 @@ impl<'a> Index<'a> {
 			tb,
 			_d: CHAR_INDEX,
 			ix,
-			_e: 0x2a, // *
 			fd,
-			_f: 0x2a, // *
 			id,
 		}
 	}

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -898,18 +898,17 @@ async fn define_statement_index_multiple_unique_existing() -> Result<(), Error> 
 	}
 	//
 	let tmp = res.remove(0).result;
-	println!("{:?}", tmp);
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Database index `test` already contains ['tesla', 'test@surrealdb.com'], with record `user:4`"#
+		Some(e) if e.to_string() == r#"Database index `test` already contains ['apple', 'test@surrealdb.com'], with record `user:3`"#
 	));
 	//
 	let tmp = res.remove(0).result;
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Database index `test` already contains ['tesla', 'test@surrealdb.com'], with record `user:4`"#
+		Some(e) if e.to_string() == r#"Database index `test` already contains ['apple', 'test@surrealdb.com'], with record `user:3`"#
 	));
-	//
+
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"{


### PR DESCRIPTION
## What is the motivation?

The following test broken due to a regression on context cancellation.

https://github.com/surrealdb/surrealdb/blob/3620657adba70c872829f695ea6c69c5a49a089c/lib/tests/define.rs#L900-L910

The key structure of `index.rs` has been restored to a version compatible with beta9.

## What does this change do?

Restore the expected behaviour.

## What is your testing strategy?

The wrongly modified test has been restored.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
