### PR TITLE
Add a `has-storage` private feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,17 @@ license-file = "LICENSE"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 
 [features]
+# Public features
 default = ["storage-mem", "storage-rocksdb", "scripting", "http"]
-storage-mem = ["surrealdb/kv-mem"]
-storage-rocksdb = ["surrealdb/kv-rocksdb"]
-storage-speedb = ["surrealdb/kv-speedb"]
-storage-tikv = ["surrealdb/kv-tikv"]
-storage-fdb = ["surrealdb/kv-fdb-7_1"]
+storage-mem = ["surrealdb/kv-mem", "has-storage"]
+storage-rocksdb = ["surrealdb/kv-rocksdb", "has-storage"]
+storage-speedb = ["surrealdb/kv-speedb", "has-storage"]
+storage-tikv = ["surrealdb/kv-tikv", "has-storage"]
+storage-fdb = ["surrealdb/kv-fdb-7_1", "has-storage"]
 scripting = ["surrealdb/scripting"]
 http = ["surrealdb/http"]
+# Private features
+has-storage = []
 
 [workspace]
 members = ["lib", "lib/examples/actix", "lib/examples/axum"]

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,28 +1,10 @@
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 use crate::net::client_ip::ClientIp;
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 use once_cell::sync::OnceCell;
 use std::{net::SocketAddr, path::PathBuf};
 
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub static CF: OnceCell<Config> = OnceCell::new();
 
 #[derive(Clone, Debug)]
@@ -30,13 +12,7 @@ pub struct Config {
 	pub strict: bool,
 	pub bind: SocketAddr,
 	pub path: String,
-	#[cfg(any(
-		feature = "storage-mem",
-		feature = "storage-tikv",
-		feature = "storage-rocksdb",
-		feature = "storage-speedb",
-		feature = "storage-fdb",
-	))]
+	#[cfg(feature = "has-storage")]
 	pub client_ip: ClientIp,
 	pub user: String,
 	pub pass: Option<String>,

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -46,21 +46,9 @@ pub async fn init(
 		password: &password,
 	};
 	// Connect to the database engine
-	#[cfg(any(
-		feature = "storage-mem",
-		feature = "storage-tikv",
-		feature = "storage-rocksdb",
-		feature = "storage-speedb",
-		feature = "storage-fdb",
-	))]
+	#[cfg(feature = "has-storage")]
 	let address = (endpoint, root);
-	#[cfg(not(any(
-		feature = "storage-mem",
-		feature = "storage-tikv",
-		feature = "storage-rocksdb",
-		feature = "storage-speedb",
-		feature = "storage-fdb",
-	)))]
+	#[cfg(not(feature = "has-storage"))]
 	let address = endpoint;
 	let client = connect(address).await?;
 	// Sign in to the server

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -44,21 +44,9 @@ pub async fn init(
 		password: &password,
 	};
 	// Connect to the database engine
-	#[cfg(any(
-		feature = "storage-mem",
-		feature = "storage-tikv",
-		feature = "storage-rocksdb",
-		feature = "storage-speedb",
-		feature = "storage-fdb",
-	))]
+	#[cfg(feature = "has-storage")]
 	let address = (endpoint, root);
-	#[cfg(not(any(
-		feature = "storage-mem",
-		feature = "storage-tikv",
-		feature = "storage-rocksdb",
-		feature = "storage-speedb",
-		feature = "storage-fdb",
-	)))]
+	#[cfg(not(feature = "has-storage"))]
 	let address = endpoint;
 	let client = connect(address).await?;
 	// Sign in to the server

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,13 +5,7 @@ mod export;
 mod import;
 mod isready;
 mod sql;
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 mod start;
 mod upgrade;
 pub(crate) mod validator;
@@ -21,25 +15,13 @@ use self::upgrade::UpgradeCommandArguments;
 use crate::cnf::LOGO;
 use backup::BackupCommandArguments;
 use clap::{Parser, Subcommand};
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub use config::CF;
 use export::ExportCommandArguments;
 use import::ImportCommandArguments;
 use isready::IsReadyCommandArguments;
 use sql::SqlCommandArguments;
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 use start::StartCommandArguments;
 use std::process::ExitCode;
 
@@ -70,13 +52,7 @@ struct Cli {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
 enum Commands {
-	#[cfg(any(
-		feature = "storage-mem",
-		feature = "storage-tikv",
-		feature = "storage-rocksdb",
-		feature = "storage-speedb",
-		feature = "storage-fdb",
-	))]
+	#[cfg(feature = "has-storage")]
 	#[command(about = "Start the database server")]
 	Start(StartCommandArguments),
 	#[command(about = "Backup data to or from an existing database")]
@@ -101,13 +77,7 @@ enum Commands {
 pub async fn init() -> ExitCode {
 	let args = Cli::parse();
 	let output = match args.command {
-		#[cfg(any(
-			feature = "storage-mem",
-			feature = "storage-tikv",
-			feature = "storage-rocksdb",
-			feature = "storage-speedb",
-			feature = "storage-fdb",
-		))]
+		#[cfg(feature = "has-storage")]
 		Commands::Start(args) => start::init(args).await,
 		Commands::Backup(args) => backup::init(args).await,
 		Commands::Import(args) => import::init(args).await,

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -56,21 +56,9 @@ pub async fn init(
 		password: &password,
 	};
 	// Connect to the database engine
-	#[cfg(any(
-		feature = "storage-mem",
-		feature = "storage-tikv",
-		feature = "storage-rocksdb",
-		feature = "storage-speedb",
-		feature = "storage-fdb",
-	))]
+	#[cfg(feature = "has-storage")]
 	let address = (endpoint, root);
-	#[cfg(not(any(
-		feature = "storage-mem",
-		feature = "storage-tikv",
-		feature = "storage-rocksdb",
-		feature = "storage-speedb",
-		feature = "storage-fdb",
-	)))]
+	#[cfg(not(feature = "has-storage"))]
 	let address = endpoint;
 	let client = connect(address).await?;
 	// Sign in to the server

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -1,10 +1,4 @@
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 use std::{
 	path::{Path, PathBuf},
 	str::FromStr,
@@ -13,13 +7,7 @@ use std::{
 
 pub(crate) mod parser;
 
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub(crate) fn path_valid(v: &str) -> Result<String, String> {
 	match v {
 		"memory" => Ok(v.to_string()),
@@ -32,13 +20,7 @@ pub(crate) fn path_valid(v: &str) -> Result<String, String> {
 	}
 }
 
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub(crate) fn file_exists(path: &str) -> Result<PathBuf, String> {
 	let path = Path::new(path);
 	if !*path.try_exists().as_ref().map_err(ToString::to_string)? {
@@ -80,13 +62,7 @@ pub(crate) fn into_valid(v: &str) -> Result<String, String> {
 	}
 }
 
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub(crate) fn key_valid(v: &str) -> Result<String, String> {
 	match v.len() {
 		16 => Ok(v.to_string()),
@@ -96,13 +72,7 @@ pub(crate) fn key_valid(v: &str) -> Result<String, String> {
 	}
 }
 
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub(crate) fn duration(v: &str) -> Result<Duration, String> {
 	surrealdb::sql::Duration::from_str(v).map(|d| d.0).map_err(|_| String::from("invalid duration"))
 }

--- a/src/cli/validator/parser/env_filter.rs
+++ b/src/cli/validator/parser/env_filter.rs
@@ -16,13 +16,7 @@ impl Clone for CustomEnvFilter {
 pub struct CustomEnvFilterParser;
 
 impl CustomEnvFilterParser {
-	#[cfg(any(
-		feature = "storage-mem",
-		feature = "storage-tikv",
-		feature = "storage-rocksdb",
-		feature = "storage-speedb",
-		feature = "storage-fdb",
-	))]
+	#[cfg(feature = "has-storage")]
 	pub fn new() -> CustomEnvFilterParser {
 		Self
 	}

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -1,11 +1,5 @@
 use once_cell::sync::Lazy;
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 use std::time::Duration;
 
 pub const LOGO: &str = "
@@ -21,46 +15,22 @@ Y88b  d88P Y88b 888 888     888     Y8b.     888  888 888 888  .d88P 888   d88P
 ";
 
 /// The publicly visible name of the server
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub const PKG_NAME: &str = "surrealdb";
 
 /// The publicly visible user-agent of the command-line tool
 pub const SERVER_AGENT: &str = concat!("SurrealDB ", env!("CARGO_PKG_VERSION"));
 
 /// The public endpoint for the administration interface
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub const APP_ENDPOINT: &str = "https://surrealdb.com/app";
 
 /// How many concurrent tasks can be handled in a WebSocket
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub const MAX_CONCURRENT_CALLS: usize = 24;
 
 /// Specifies the frequency with which ping messages should be sent to the client
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub const WEBSOCKET_PING_FREQUENCY: Duration = Duration::from_secs(5);
 
 /// The version identifier of this build

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,30 +1,12 @@
 use crate::cnf::PKG_VERSION;
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 use crate::err::Error;
 use surrealdb::env::{arch, os};
 
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 const LOG: &str = "surrealdb::env";
 
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 pub async fn init() -> Result<(), Error> {
 	// Log version
 	info!(target: LOG, "Running {}", release());

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,52 +13,22 @@
 #[macro_use]
 extern crate tracing;
 
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 #[macro_use]
 mod mac;
 
 mod cli;
 mod cnf;
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 mod dbs;
 mod env;
 mod err;
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 mod iam;
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 mod net;
 mod o11y;
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 mod rpc;
 
 use std::future::Future;

--- a/src/o11y/mod.rs
+++ b/src/o11y/mod.rs
@@ -6,13 +6,7 @@ use tracing::Subscriber;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::util::SubscriberInitExt;
-#[cfg(any(
-	feature = "storage-mem",
-	feature = "storage-tikv",
-	feature = "storage-rocksdb",
-	feature = "storage-speedb",
-	feature = "storage-fdb",
-))]
+#[cfg(feature = "has-storage")]
 use tracing_subscriber::EnvFilter;
 
 #[derive(Default, Debug, Clone)]
@@ -33,13 +27,7 @@ impl Builder {
 	}
 
 	/// Set the filter on the builder
-	#[cfg(any(
-		feature = "storage-mem",
-		feature = "storage-tikv",
-		feature = "storage-rocksdb",
-		feature = "storage-speedb",
-		feature = "storage-fdb",
-	))]
+	#[cfg(feature = "has-storage")]
 	pub fn with_filter(mut self, filter: EnvFilter) -> Self {
 		self.filter = Some(CustomEnvFilter(filter));
 		self


### PR DESCRIPTION
## What is the motivation?

Feature-gating storage engines by enumerating all the engines is cumbersome and error-prone.

## What does this change do?

It adds a private feature named `has-storage` and uses that instead.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

It's a followup PR for https://github.com/surrealdb/surrealdb/pull/2210.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
