### PR TITLE
Remove manual log targets

### DIFF
--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -71,9 +71,6 @@ use tokio::io::AsyncWrite;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::io::AsyncWriteExt;
 
-#[cfg(not(target_arch = "wasm32"))]
-const LOG: &str = "surrealdb::api::engine::local";
-
 /// In-memory database
 ///
 /// # Examples
@@ -528,7 +525,7 @@ async fn router(
 				chn: channel::Sender<Vec<u8>>,
 			) -> std::result::Result<(), crate::Error> {
 				kvs.export(ns, db, chn).await.map_err(|error| {
-					error!(target: LOG, "{error}");
+					error!("{error}");
 					crate::Error::Db(error)
 				})
 			}

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -55,7 +55,6 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 use url::Url;
 
 const SQL_PATH: &str = "sql";
-const LOG: &str = "surrealdb::engine::remote::http";
 
 /// The HTTP scheme used to connect to `http://` endpoints
 #[derive(Debug)]
@@ -167,7 +166,7 @@ async fn submit_auth(request: RequestBuilder) -> Result<Value> {
 }
 
 async fn query(request: RequestBuilder) -> Result<QueryResponse> {
-	info!(target: LOG, "{request:?}");
+	info!("{request:?}");
 	let response = request.send().await?.error_for_status()?;
 	let bytes = response.bytes().await?;
 	let responses = deserialize::<Vec<HttpQueryResponse>>(&bytes).map_err(|error| {

--- a/lib/src/api/engine/remote/http/wasm.rs
+++ b/lib/src/api/engine/remote/http/wasm.rs
@@ -1,5 +1,4 @@
 use super::Client;
-use super::LOG;
 use crate::api::conn::Connection;
 use crate::api::conn::DbResponse;
 use crate::api::conn::Method;
@@ -68,7 +67,7 @@ impl Connection for Client {
 	) -> Pin<Box<dyn Future<Output = Result<Receiver<Result<DbResponse>>>> + Send + Sync + 'r>> {
 		Box::pin(async move {
 			let (sender, receiver) = flume::bounded(1);
-			trace!(target: LOG, "{param:?}");
+			trace!("{param:?}");
 			let route = Route {
 				request: (0, self.method, param),
 				response: sender,

--- a/lib/src/api/engine/remote/ws/mod.rs
+++ b/lib/src/api/engine/remote/ws/mod.rs
@@ -36,7 +36,6 @@ use wasmtimer::tokio::Interval;
 pub(crate) const PATH: &str = "rpc";
 const PING_INTERVAL: Duration = Duration::from_secs(5);
 const PING_METHOD: &str = "ping";
-const LOG: &str = "surrealdb::engine::remote::ws";
 
 /// The WS scheme used to connect to `ws://` endpoints
 #[derive(Debug)]

--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -31,7 +31,6 @@ use wasm_bindgen_futures::spawn_local as spawn;
 pub type Result<T> = std::result::Result<T, crate::Error>;
 
 const SUPPORTED_VERSIONS: (&str, &str) = (">=1.0.0-beta.9, <2.0.0", "20230701.55918b7c");
-const LOG: &str = "surrealdb::api";
 
 /// Connection trait implemented by supported engines
 pub trait Connection: conn::Connection {}
@@ -153,13 +152,13 @@ where
 				Ok(version) => {
 					let server_build = &version.build;
 					if !req.matches(&version) {
-						warn!(target: LOG, "server version `{version}` does not match the range supported by the client `{versions}`");
+						warn!("server version `{version}` does not match the range supported by the client `{versions}`");
 					} else if !server_build.is_empty() && server_build < &build_meta {
-						warn!(target: LOG, "server build `{server_build}` is older than the minimum supported build `{build_meta}`");
+						warn!("server build `{server_build}` is older than the minimum supported build `{build_meta}`");
 					}
 				}
 				Err(error) => {
-					trace!(target: LOG, "failed to lookup the server version; {error:?}");
+					trace!("failed to lookup the server version; {error:?}");
 				}
 			}
 		});

--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -5,7 +5,6 @@ use crate::dbs::Level;
 use crate::dbs::Notification;
 use crate::dbs::Options;
 use crate::dbs::Transaction;
-use crate::dbs::LOG;
 use crate::dbs::{Auth, QueryType};
 use crate::err::Error;
 use crate::kvs::Datastore;
@@ -171,7 +170,7 @@ impl<'a> Executor<'a> {
 		// Process all statements in query
 		for stm in qry.into_iter() {
 			// Log the statement
-			debug!(target: LOG, "Executing: {}", stm);
+			debug!("Executing: {}", stm);
 			// Reset errors
 			if self.txn.is_none() {
 				self.err = false;

--- a/lib/src/dbs/iterator.rs
+++ b/lib/src/dbs/iterator.rs
@@ -2,7 +2,6 @@ use crate::ctx::Canceller;
 use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::dbs::Statement;
-use crate::dbs::LOG;
 use crate::doc::Document;
 use crate::err::Error;
 use crate::idx::planner::plan::Plan;
@@ -78,7 +77,7 @@ impl Iterator {
 		stm: &Statement<'_>,
 	) -> Result<Value, Error> {
 		// Log the statement
-		trace!(target: LOG, "Iterating: {}", stm);
+		trace!("Iterating: {}", stm);
 		// Enable context override
 		let mut run = Context::new(ctx);
 		self.run = run.add_cancel();

--- a/lib/src/dbs/mod.rs
+++ b/lib/src/dbs/mod.rs
@@ -36,5 +36,3 @@ pub mod cl;
 
 #[cfg(test)]
 pub(crate) mod test;
-
-pub(crate) const LOG: &str = "surrealdb::dbs";

--- a/lib/src/fnc/script/globals/console.rs
+++ b/lib/src/fnc/script/globals/console.rs
@@ -3,55 +3,30 @@
 #[allow(clippy::module_inception)]
 pub mod console {
 	// Specify the imports
-	use crate::fnc::script::LOG;
 	use crate::sql::value::Value;
 	use js::prelude::Rest;
 	/// Log the input values as INFO
 	pub fn log(args: Rest<Value>) {
-		info!(
-			target: LOG,
-			"{}",
-			args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" ")
-		);
+		info!("{}", args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" "));
 	}
 	/// Log the input values as INFO
 	pub fn info(args: Rest<Value>) {
-		info!(
-			target: LOG,
-			"{}",
-			args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" ")
-		);
+		info!("{}", args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" "));
 	}
 	/// Log the input values as WARN
 	pub fn warn(args: Rest<Value>) {
-		warn!(
-			target: LOG,
-			"{}",
-			args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" ")
-		);
+		warn!("{}", args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" "));
 	}
 	/// Log the input values as ERROR
 	pub fn error(args: Rest<Value>) {
-		error!(
-			target: LOG,
-			"{}",
-			args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" ")
-		);
+		error!("{}", args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" "));
 	}
 	/// Log the input values as DEBUG
 	pub fn debug(args: Rest<Value>) {
-		debug!(
-			target: LOG,
-			"{}",
-			args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" ")
-		);
+		debug!("{}", args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" "));
 	}
 	/// Log the input values as TRACE
 	pub fn trace(args: Rest<Value>) {
-		trace!(
-			target: LOG,
-			"{}",
-			args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" ")
-		);
+		trace!("{}", args.iter().map(|v| v.to_raw_string()).collect::<Vec<String>>().join(" "));
 	}
 }

--- a/lib/src/fnc/script/mod.rs
+++ b/lib/src/fnc/script/mod.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "scripting")]
 
-const LOG: &str = "surrealdb::jsr";
-
 pub use main::run;
 
 mod classes;

--- a/lib/src/iam/mod.rs
+++ b/lib/src/iam/mod.rs
@@ -6,5 +6,4 @@ pub mod signup;
 pub mod token;
 pub mod verify;
 
-pub const LOG: &str = "surrealdb::iam";
 pub const TOKEN: &str = "Bearer ";

--- a/lib/src/iam/verify.rs
+++ b/lib/src/iam/verify.rs
@@ -2,7 +2,6 @@ use crate::dbs::Auth;
 use crate::dbs::Session;
 use crate::err::Error;
 use crate::iam::token::Claims;
-use crate::iam::LOG;
 use crate::iam::TOKEN;
 use crate::kvs::Datastore;
 use crate::sql::Algorithm;
@@ -81,7 +80,7 @@ static DUD: Lazy<Validation> = Lazy::new(|| {
 
 pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Result<(), Error> {
 	// Log the authentication type
-	trace!(target: LOG, "Attempting token authentication");
+	trace!("Attempting token authentication");
 	// Retrieve just the auth data
 	let auth = auth.trim_start_matches(TOKEN).trim();
 	// Decode the token without verifying
@@ -91,14 +90,14 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 	// Check if the auth token can be used
 	if let Some(nbf) = token.claims.nbf {
 		if nbf > Utc::now().timestamp() {
-			trace!(target: LOG, "The 'nbf' field in the authentication token was invalid");
+			trace!("The 'nbf' field in the authentication token was invalid");
 			return Err(Error::InvalidAuth);
 		}
 	}
 	// Check if the auth token has expired
 	if let Some(exp) = token.claims.exp {
 		if exp < Utc::now().timestamp() {
-			trace!(target: LOG, "The 'exp' field in the authentication token was invalid");
+			trace!("The 'exp' field in the authentication token was invalid");
 			return Err(Error::InvalidAuth);
 		}
 	}
@@ -114,7 +113,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			..
 		} => {
 			// Log the decoded authentication claims
-			trace!(target: LOG, "Authenticating to scope `{}` with token `{}`", sc, tk);
+			trace!("Authenticating to scope `{}` with token `{}`", sc, tk);
 			// Create a new readonly transaction
 			let mut tx = kvs.transaction(false, false).await?;
 			// Parse the record id
@@ -128,7 +127,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			// Verify the token
 			decode::<Claims>(auth, &cf.0, &cf.1)?;
 			// Log the success
-			debug!(target: LOG, "Authenticated to scope `{}` with token `{}`", sc, tk);
+			debug!("Authenticated to scope `{}` with token `{}`", sc, tk);
 			// Set the session
 			session.sd = Some(id);
 			session.tk = Some(value);
@@ -147,7 +146,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			..
 		} => {
 			// Log the decoded authentication claims
-			trace!(target: LOG, "Authenticating to scope `{}`", sc);
+			trace!("Authenticating to scope `{}`", sc);
 			// Create a new readonly transaction
 			let mut tx = kvs.transaction(false, false).await?;
 			// Parse the record id
@@ -158,7 +157,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			// Verify the token
 			decode::<Claims>(auth, &cf.0, &cf.1)?;
 			// Log the success
-			debug!(target: LOG, "Authenticated to scope `{}`", sc);
+			debug!("Authenticated to scope `{}`", sc);
 			// Set the session
 			session.tk = Some(value);
 			session.ns = Some(ns.to_owned());
@@ -176,7 +175,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			..
 		} => {
 			// Log the decoded authentication claims
-			trace!(target: LOG, "Authenticating to database `{}` with token `{}`", db, tk);
+			trace!("Authenticating to database `{}` with token `{}`", db, tk);
 			// Create a new readonly transaction
 			let mut tx = kvs.transaction(false, false).await?;
 			// Get the database token
@@ -185,7 +184,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			// Verify the token
 			decode::<Claims>(auth, &cf.0, &cf.1)?;
 			// Log the success
-			debug!(target: LOG, "Authenticated to database `{}` with token `{}`", db, tk);
+			debug!("Authenticated to database `{}` with token `{}`", db, tk);
 			// Set the session
 			session.tk = Some(value);
 			session.ns = Some(ns.to_owned());
@@ -201,7 +200,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			..
 		} => {
 			// Log the decoded authentication claims
-			trace!(target: LOG, "Authenticating to database `{}` with login `{}`", db, id);
+			trace!("Authenticating to database `{}` with login `{}`", db, id);
 			// Create a new readonly transaction
 			let mut tx = kvs.transaction(false, false).await?;
 			// Get the database login
@@ -210,7 +209,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			// Verify the token
 			decode::<Claims>(auth, &cf.0, &cf.1)?;
 			// Log the success
-			debug!(target: LOG, "Authenticated to database `{}` with login `{}`", db, id);
+			debug!("Authenticated to database `{}` with login `{}`", db, id);
 			// Set the session
 			session.tk = Some(value);
 			session.ns = Some(ns.to_owned());
@@ -225,7 +224,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			..
 		} => {
 			// Log the decoded authentication claims
-			trace!(target: LOG, "Authenticating to namespace `{}` with token `{}`", ns, tk);
+			trace!("Authenticating to namespace `{}` with token `{}`", ns, tk);
 			// Create a new readonly transaction
 			let mut tx = kvs.transaction(false, false).await?;
 			// Get the namespace token
@@ -234,7 +233,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			// Verify the token
 			decode::<Claims>(auth, &cf.0, &cf.1)?;
 			// Log the success
-			trace!(target: LOG, "Authenticated to namespace `{}` with token `{}`", ns, tk);
+			trace!("Authenticated to namespace `{}` with token `{}`", ns, tk);
 			// Set the session
 			session.tk = Some(value);
 			session.ns = Some(ns.to_owned());
@@ -248,7 +247,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			..
 		} => {
 			// Log the decoded authentication claims
-			trace!(target: LOG, "Authenticating to namespace `{}` with login `{}`", ns, id);
+			trace!("Authenticating to namespace `{}` with login `{}`", ns, id);
 			// Create a new readonly transaction
 			let mut tx = kvs.transaction(false, false).await?;
 			// Get the namespace login
@@ -257,7 +256,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, auth: String) -> Resu
 			// Verify the token
 			decode::<Claims>(auth, &cf.0, &cf.1)?;
 			// Log the success
-			trace!(target: LOG, "Authenticated to namespace `{}` with login `{}`", ns, id);
+			trace!("Authenticated to namespace `{}` with login `{}`", ns, id);
 			// Set the session
 			session.tk = Some(value);
 			session.ns = Some(ns.to_owned());

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -8,7 +8,6 @@ use crate::dbs::Response;
 use crate::dbs::Session;
 use crate::dbs::Variables;
 use crate::err::Error;
-use crate::kvs::LOG;
 use crate::sql;
 use crate::sql::Query;
 use crate::sql::Value;
@@ -112,9 +111,9 @@ impl Datastore {
 			"memory" => {
 				#[cfg(feature = "kv-mem")]
 				{
-					info!(target: LOG, "Starting kvs store in {}", path);
+					info!("Starting kvs store in {}", path);
 					let v = super::mem::Datastore::new().await.map(Inner::Mem);
-					info!(target: LOG, "Started kvs store in {}", path);
+					info!("Started kvs store in {}", path);
 					v
 				}
 				#[cfg(not(feature = "kv-mem"))]
@@ -124,11 +123,11 @@ impl Datastore {
 			s if s.starts_with("file:") => {
 				#[cfg(feature = "kv-rocksdb")]
 				{
-					info!(target: LOG, "Starting kvs store at {}", path);
+					info!("Starting kvs store at {}", path);
 					let s = s.trim_start_matches("file://");
 					let s = s.trim_start_matches("file:");
 					let v = super::rocksdb::Datastore::new(s).await.map(Inner::RocksDB);
-					info!(target: LOG, "Started kvs store at {}", path);
+					info!("Started kvs store at {}", path);
 					v
 				}
 				#[cfg(not(feature = "kv-rocksdb"))]
@@ -138,11 +137,11 @@ impl Datastore {
 			s if s.starts_with("rocksdb:") => {
 				#[cfg(feature = "kv-rocksdb")]
 				{
-					info!(target: LOG, "Starting kvs store at {}", path);
+					info!("Starting kvs store at {}", path);
 					let s = s.trim_start_matches("rocksdb://");
 					let s = s.trim_start_matches("rocksdb:");
 					let v = super::rocksdb::Datastore::new(s).await.map(Inner::RocksDB);
-					info!(target: LOG, "Started kvs store at {}", path);
+					info!("Started kvs store at {}", path);
 					v
 				}
 				#[cfg(not(feature = "kv-rocksdb"))]
@@ -152,11 +151,11 @@ impl Datastore {
 			s if s.starts_with("speedb:") => {
 				#[cfg(feature = "kv-speedb")]
 				{
-					info!(target: LOG, "Starting kvs store at {}", path);
+					info!("Starting kvs store at {}", path);
 					let s = s.trim_start_matches("speedb://");
 					let s = s.trim_start_matches("speedb:");
 					let v = super::speedb::Datastore::new(s).await.map(Inner::SpeeDB);
-					info!(target: LOG, "Started kvs store at {}", path);
+					info!("Started kvs store at {}", path);
 					v
 				}
 				#[cfg(not(feature = "kv-speedb"))]
@@ -166,11 +165,11 @@ impl Datastore {
 			s if s.starts_with("indxdb:") => {
 				#[cfg(feature = "kv-indxdb")]
 				{
-					info!(target: LOG, "Starting kvs store at {}", path);
+					info!("Starting kvs store at {}", path);
 					let s = s.trim_start_matches("indxdb://");
 					let s = s.trim_start_matches("indxdb:");
 					let v = super::indxdb::Datastore::new(s).await.map(Inner::IndxDB);
-					info!(target: LOG, "Started kvs store at {}", path);
+					info!("Started kvs store at {}", path);
 					v
 				}
 				#[cfg(not(feature = "kv-indxdb"))]
@@ -180,11 +179,11 @@ impl Datastore {
 			s if s.starts_with("tikv:") => {
 				#[cfg(feature = "kv-tikv")]
 				{
-					info!(target: LOG, "Connecting to kvs store at {}", path);
+					info!("Connecting to kvs store at {}", path);
 					let s = s.trim_start_matches("tikv://");
 					let s = s.trim_start_matches("tikv:");
 					let v = super::tikv::Datastore::new(s).await.map(Inner::TiKV);
-					info!(target: LOG, "Connected to kvs store at {}", path);
+					info!("Connected to kvs store at {}", path);
 					v
 				}
 				#[cfg(not(feature = "kv-tikv"))]
@@ -194,11 +193,11 @@ impl Datastore {
 			s if s.starts_with("fdb:") => {
 				#[cfg(feature = "kv-fdb")]
 				{
-					info!(target: LOG, "Connecting to kvs store at {}", path);
+					info!("Connecting to kvs store at {}", path);
 					let s = s.trim_start_matches("fdb://");
 					let s = s.trim_start_matches("fdb:");
 					let v = super::fdb::Datastore::new(s).await.map(Inner::FoundationDB);
-					info!(target: LOG, "Connected to kvs store at {}", path);
+					info!("Connected to kvs store at {}", path);
 					v
 				}
 				#[cfg(not(feature = "kv-fdb"))]
@@ -206,7 +205,7 @@ impl Datastore {
 			}
 			// The datastore path is not valid
 			_ => {
-				info!(target: LOG, "Unable to load the specified datastore {}", path);
+				info!("Unable to load the specified datastore {}", path);
 				Err(Error::Ds("Unable to load the specified datastore".into()))
 			}
 		};

--- a/lib/src/kvs/mod.rs
+++ b/lib/src/kvs/mod.rs
@@ -29,5 +29,3 @@ mod tests;
 pub use self::ds::*;
 pub use self::kv::*;
 pub use self::tx::*;
-
-pub(crate) const LOG: &str = "surrealdb::kvs";

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -35,9 +35,6 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[cfg(debug_assertions)]
-const LOG: &str = "surrealdb::txn";
-
 /// A set of undoable updates and requests against a dataset.
 #[allow(dead_code)]
 pub struct Transaction {
@@ -96,7 +93,7 @@ impl Transaction {
 	/// in a [`Error::TxFinished`] error.
 	pub async fn closed(&self) -> bool {
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Closed");
+		trace!("Closed");
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -138,7 +135,7 @@ impl Transaction {
 	/// This reverses all changes made within the transaction.
 	pub async fn cancel(&mut self) -> Result<(), Error> {
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Cancel");
+		trace!("Cancel");
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -180,7 +177,7 @@ impl Transaction {
 	/// This attempts to commit all changes made within the transaction.
 	pub async fn commit(&mut self) -> Result<(), Error> {
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Commit");
+		trace!("Commit");
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -224,7 +221,7 @@ impl Transaction {
 		K: Into<Key> + Debug,
 	{
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Del {:?}", key);
+		trace!("Del {:?}", key);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -268,7 +265,7 @@ impl Transaction {
 		K: Into<Key> + Debug,
 	{
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Exi {:?}", key);
+		trace!("Exi {:?}", key);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -312,7 +309,7 @@ impl Transaction {
 		K: Into<Key> + Debug,
 	{
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Get {:?}", key);
+		trace!("Get {:?}", key);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -357,7 +354,7 @@ impl Transaction {
 		V: Into<Val> + Debug,
 	{
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Set {:?} => {:?}", key, val);
+		trace!("Set {:?} => {:?}", key, val);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -402,7 +399,7 @@ impl Transaction {
 		V: Into<Val> + Debug,
 	{
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Put {:?} => {:?}", key, val);
+		trace!("Put {:?} => {:?}", key, val);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -448,7 +445,7 @@ impl Transaction {
 		K: Into<Key> + Debug,
 	{
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Scan {:?} - {:?}", rng.start, rng.end);
+		trace!("Scan {:?} - {:?}", rng.start, rng.end);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -493,7 +490,7 @@ impl Transaction {
 		V: Into<Val> + Debug,
 	{
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Putc {:?} if {:?} => {:?}", key, chk, val);
+		trace!("Putc {:?} if {:?} => {:?}", key, chk, val);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -538,7 +535,7 @@ impl Transaction {
 		V: Into<Val> + Debug,
 	{
 		#[cfg(debug_assertions)]
-		trace!(target: LOG, "Delc {:?} if {:?}", key, chk);
+		trace!("Delc {:?} if {:?}", key, chk);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -1,7 +1,6 @@
 use crate::cli::abstraction::{
 	AuthArguments, DatabaseConnectionArguments, DatabaseSelectionArguments,
 };
-use crate::cli::LOG;
 use crate::err::Error;
 use clap::Args;
 use surrealdb::engine::any::connect;
@@ -57,7 +56,7 @@ pub async fn init(
 	client.use_ns(ns).use_db(db).await?;
 	// Export the data from the database
 	client.export(file).await?;
-	info!(target: LOG, "The SQL file was exported successfully");
+	info!("The SQL file was exported successfully");
 	// Everything OK
 	Ok(())
 }

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -1,7 +1,6 @@
 use crate::cli::abstraction::{
 	AuthArguments, DatabaseConnectionArguments, DatabaseSelectionArguments,
 };
-use crate::cli::LOG;
 use crate::err::Error;
 use clap::Args;
 use surrealdb::engine::any::connect;
@@ -55,7 +54,7 @@ pub async fn init(
 	client.use_ns(ns).use_db(db).await?;
 	// Import the data into the database
 	client.import(file).await?;
-	info!(target: LOG, "The SQL file was imported successfully");
+	info!("The SQL file was imported successfully");
 	// Everything OK
 	Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -25,8 +25,6 @@ use sql::SqlCommandArguments;
 use start::StartCommandArguments;
 use std::process::ExitCode;
 
-pub const LOG: &str = "surrealdb::cli";
-
 const INFO: &str = "
 To get started using SurrealDB, and for guides on connecting to and building applications
 on top of SurrealDB, check out the SurrealDB documentation (https://surrealdb.com/docs).
@@ -88,7 +86,7 @@ pub async fn init() -> ExitCode {
 		Commands::IsReady(args) => isready::init(args).await,
 	};
 	if let Err(e) = output {
-		error!(target: LOG, "{}", e);
+		error!("{}", e);
 		ExitCode::FAILURE
 	} else {
 		ExitCode::SUCCESS

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -8,8 +8,6 @@ use surrealdb::kvs::Datastore;
 
 pub static DB: OnceCell<Datastore> = OnceCell::new();
 
-const LOG: &str = "surrealdb::dbs";
-
 #[derive(Args, Debug)]
 pub struct StartCommandDbsOptions {
 	#[arg(help = "The maximum duration of any query")]
@@ -27,8 +25,8 @@ pub async fn init(
 	let opt = CF.get().unwrap();
 	// Log authentication options
 	match opt.strict {
-		true => info!(target: LOG, "Database strict mode is enabled"),
-		false => info!(target: LOG, "Database strict mode is disabled"),
+		true => info!("Database strict mode is enabled"),
+		false => info!("Database strict mode is disabled"),
 	};
 	// Parse and setup the desired kv datastore
 	let dbs = Datastore::new(&opt.path).await?.query_timeout(query_timeout);

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -4,12 +4,9 @@ use crate::err::Error;
 use surrealdb::env::{arch, os};
 
 #[cfg(feature = "has-storage")]
-const LOG: &str = "surrealdb::env";
-
-#[cfg(feature = "has-storage")]
 pub async fn init() -> Result<(), Error> {
 	// Log version
-	info!(target: LOG, "Running {}", release());
+	info!("Running {}", release());
 	// All ok
 	Ok(())
 }

--- a/src/iam/mod.rs
+++ b/src/iam/mod.rs
@@ -2,7 +2,6 @@ pub mod verify;
 
 use crate::cli::CF;
 use crate::err::Error;
-use surrealdb::iam::LOG;
 
 pub const BASIC: &str = "Basic ";
 
@@ -12,10 +11,10 @@ pub async fn init() -> Result<(), Error> {
 	// Log authentication options
 	match opt.pass {
 		Some(_) => {
-			info!(target: LOG, "Root authentication is enabled");
-			info!(target: LOG, "Root username is '{}'", opt.user);
+			info!("Root authentication is enabled");
+			info!("Root username is '{}'", opt.user);
 		}
-		None => info!(target: LOG, "Root authentication is disabled"),
+		None => info!("Root authentication is disabled"),
 	};
 	// All ok
 	Ok(())

--- a/src/iam/verify.rs
+++ b/src/iam/verify.rs
@@ -8,11 +8,10 @@ use std::sync::Arc;
 use surrealdb::dbs::Auth;
 use surrealdb::dbs::Session;
 use surrealdb::iam::base::{Engine, BASE64};
-use surrealdb::iam::LOG;
 
 pub async fn basic(session: &mut Session, auth: String) -> Result<(), Error> {
 	// Log the authentication type
-	trace!(target: LOG, "Attempting basic authentication");
+	trace!("Attempting basic authentication");
 	// Retrieve just the auth data
 	let auth = auth.trim_start_matches(BASIC).trim();
 	// Get a database reference
@@ -33,7 +32,7 @@ pub async fn basic(session: &mut Session, auth: String) -> Result<(), Error> {
 		if let Some(root) = &opts.pass {
 			if user == opts.user && pass == root {
 				// Log the authentication type
-				debug!(target: LOG, "Authenticated as super user");
+				debug!("Authenticated as super user");
 				// Store the authentication data
 				session.au = Arc::new(Auth::Kv);
 				return Ok(());
@@ -49,7 +48,7 @@ pub async fn basic(session: &mut Session, auth: String) -> Result<(), Error> {
 				let hash = PasswordHash::new(&nl.hash).unwrap();
 				if Argon2::default().verify_password(pass.as_ref(), &hash).is_ok() {
 					// Log the successful namespace authentication
-					debug!(target: LOG, "Authenticated as namespace user: {}", user);
+					debug!("Authenticated as namespace user: {}", user);
 					// Store the authentication data
 					session.au = Arc::new(Auth::Ns(ns.to_owned()));
 					return Ok(());
@@ -63,7 +62,7 @@ pub async fn basic(session: &mut Session, auth: String) -> Result<(), Error> {
 					let hash = PasswordHash::new(&dl.hash).unwrap();
 					if Argon2::default().verify_password(pass.as_ref(), &hash).is_ok() {
 						// Log the successful namespace authentication
-						debug!(target: LOG, "Authenticated as database user: {}", user);
+						debug!("Authenticated as database user: {}", user);
 						// Store the authentication data
 						session.au = Arc::new(Auth::Db(ns.to_owned(), db.to_owned()));
 						return Ok(());

--- a/src/net/log.rs
+++ b/src/net/log.rs
@@ -13,12 +13,9 @@ impl<T: fmt::Display> fmt::Display for OptFmt<T> {
 	}
 }
 
-const NAME: &str = "surrealdb::net";
-
 pub fn write() -> warp::filters::log::Log<impl Fn(warp::filters::log::Info) + Copy> {
 	warp::log::custom(|info| {
 		event!(
-			target: NAME,
 			Level::INFO,
 			"{} {} {} {:?} {} \"{}\" {:?}",
 			OptFmt(info.remote_addr()),

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -24,8 +24,6 @@ use crate::cli::CF;
 use crate::err::Error;
 use warp::Filter;
 
-const LOG: &str = "surrealdb::net";
-
 pub async fn init() -> Result<(), Error> {
 	// Setup web routes
 	let net = index::config()
@@ -69,7 +67,7 @@ pub async fn init() -> Result<(), Error> {
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 
-	info!(target: LOG, "Starting web server on {}", &opt.bind);
+	info!("Starting web server on {}", &opt.bind);
 
 	if let (Some(c), Some(k)) = (&opt.crt, &opt.key) {
 		// Bind the server to the desired port
@@ -80,27 +78,27 @@ pub async fn init() -> Result<(), Error> {
 			.bind_with_graceful_shutdown(opt.bind, async move {
 				// Capture the shutdown signals and log that the graceful shutdown has started
 				let result = signals::listen().await.expect("Failed to listen to shutdown signal");
-				info!(target: LOG, "{} received. Start graceful shutdown...", result);
+				info!("{} received. Start graceful shutdown...", result);
 			});
 		// Log the server startup status
-		info!(target: LOG, "Started web server on {}", &adr);
+		info!("Started web server on {}", &adr);
 		// Run the server forever
 		srv.await;
 		// Log the server shutdown event
-		info!(target: LOG, "Shutdown complete. Bye!")
+		info!("Shutdown complete. Bye!")
 	} else {
 		// Bind the server to the desired port
 		let (adr, srv) = warp::serve(net).bind_with_graceful_shutdown(opt.bind, async move {
 			// Capture the shutdown signals and log that the graceful shutdown has started
 			let result = signals::listen().await.expect("Failed to listen to shutdown signal");
-			info!(target: LOG, "{} received. Start graceful shutdown...", result);
+			info!("{} received. Start graceful shutdown...", result);
 		});
 		// Log the server startup status
-		info!(target: LOG, "Started web server on {}", &adr);
+		info!("Started web server on {}", &adr);
 		// Run the server forever
 		srv.await;
 		// Log the server shutdown event
-		info!(target: LOG, "Shutdown complete. Bye!")
+		info!("Shutdown complete. Bye!")
 	};
 
 	Ok(())

--- a/src/rpc/res.rs
+++ b/src/rpc/res.rs
@@ -9,8 +9,6 @@ use surrealdb::sql::Value;
 use tracing::instrument;
 use warp::ws::Message;
 
-const LOG: &str = "surrealdb::rpc::res";
-
 #[derive(Clone)]
 pub enum Output {
 	Json, // JSON
@@ -105,7 +103,7 @@ impl Response {
 			}
 		};
 		let _ = chn.send(message).await;
-		trace!(target: LOG, "Response sent");
+		trace!("Response sent");
 	}
 }
 


### PR DESCRIPTION
## What is the motivation?

The tracing crate we now use already logs the full path of the current module.

## What does this change do?

It removes all manual targets from the logging statements and lets the `tracing` crate take care of logging the full path of the current module.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

It's a follow up PR for https://github.com/surrealdb/surrealdb/pull/2209.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
