### PR TITLE
feat(auth): add functions to read jwt value

### DIFF
--- a/lib/src/api/opt/auth.rs
+++ b/lib/src/api/opt/auth.rs
@@ -83,9 +83,35 @@ pub struct Scope<'a, P> {
 
 impl<T, P> Credentials<T, Jwt> for Scope<'_, P> where P: Serialize {}
 
-/// A JSON Web Token for authenticating with the server
+/// A JSON Web Token for authenticating with the server.
+///
+/// This struct represents a JSON Web Token (JWT) that can be used for authentication purposes.
+/// It is important to note that this implementation does not provide any security measures to
+/// protect the token.
+///
+/// You should take care to ensure that only authorized users have access to the JWT.
+/// For example:
+/// * it can be stored in a secure cookie,
+/// * stored in a database with restricted access,
+/// * or encrypted in conjunction with other encryption mechanisms.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Jwt(pub(crate) String);
+
+impl Jwt {
+	/// Returns the underlying token string.
+	///
+	/// ⚠️: It is important to note that the token should be handled securely and protected from unauthorized access.
+	pub fn as_insecure_token(&self) -> &str {
+		&self.0
+	}
+
+	/// Returns the underlying token string.
+	///
+	/// ⚠️: It is important to note that the token should be handled securely and protected from unauthorized access.
+	pub fn into_insecure_token(self) -> String {
+		self.0
+	}
+}
 
 impl From<String> for Jwt {
 	fn from(jwt: String) -> Self {
@@ -114,5 +140,22 @@ impl From<Jwt> for Value {
 impl fmt::Debug for Jwt {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(f, "Jwt(REDACTED)")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn as_insecure_token() {
+		let jwt = Jwt("super-long-jwt".to_owned());
+		assert_eq!(jwt.as_insecure_token(), "super-long-jwt");
+	}
+
+	#[test]
+	fn into_insecure_token() {
+		let jwt = Jwt("super-long-jwt".to_owned());
+		assert_eq!(jwt.into_insecure_token(), "super-long-jwt");
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

```rust
let token: Jwt = db
        .signup(Scope {
            namespace: "test",
            database: "test",
            scope: "user_scope",
            params: SignUpAuthParams {
                username,
                email,
                password,
            },
        })
        .await
        .map_err(|_| ServerFnError::ServerError("Cannot signup to SurrealDB".to_string()))?;
```

When using `token`, I cannot read the value of the JWT to use it.

## What does this change do?

```rust
let token: Jwt = db
        .signup(Scope {
            namespace: "test",
            database: "test",
            scope: "user_scope",
            params: SignUpAuthParams {
                username,
                email,
                password,
            },
        })
        .await
        .map_err(|_| ServerFnError::ServerError("Cannot signup to SurrealDB".to_string()))?;

let token = token.as_insecure_token(); // this works and contains the String value
```

## What is your testing strategy?

N/A

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
