### PR TITLE
docs(auth): improve docs of Jwt struct

### DIFF
--- a/lib/src/api/opt/auth.rs
+++ b/lib/src/api/opt/auth.rs
@@ -86,10 +86,14 @@ impl<T, P> Credentials<T, Jwt> for Scope<'_, P> where P: Serialize {}
 /// A JSON Web Token for authenticating with the server.
 ///
 /// This struct represents a JSON Web Token (JWT) that can be used for authentication purposes.
-/// It is important to note that this implementation does not provide any security measures to
-/// protect the token.
+/// It is important to note that this implementation provide some security measures to
+/// protect the token:
+/// * the debug implementation just prints `Jwt(REDACTED)`,
+/// * `Display` is not implemented so you can't call `.to_string()` on it
 ///
-/// You should take care to ensure that only authorized users have access to the JWT.
+/// You can still have access to the token string using either
+/// [`as_insecure_token`](Jwt::as_insecure_token) or [`into_insecure_token`](Jwt::into_insecure_token) functions.
+/// However, you should take care to ensure that only authorized users have access to the JWT.
 /// For example:
 /// * it can be stored in a secure cookie,
 /// * stored in a database with restricted access,


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

This is missing part of the docs of `Jwt` struct.

## What does this change do?

## What is your testing strategy?

## Is this related to any issues?

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
