### PR TITLE
[feat] query and print remote database version along with CLI version…

### DIFF
--- a/src/cli/abstraction/mod.rs
+++ b/src/cli/abstraction/mod.rs
@@ -45,3 +45,12 @@ pub struct DatabaseConnectionArguments {
 	#[arg(value_parser = super::validator::endpoint_valid)]
 	pub(crate) endpoint: String,
 }
+
+#[derive(Args, Debug)]
+pub struct OptionalDatabaseConnectionArguments {
+	// Endpoint w/o default value
+	#[arg(help = "Remote database server url to connect to")]
+	#[arg(short = 'e', long = "endpoint", visible_aliases = ["conn"])]
+	#[arg(value_parser = super::validator::endpoint_valid)]
+	pub(crate) endpoint: Option<String>,
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,6 +24,7 @@ use sql::SqlCommandArguments;
 #[cfg(feature = "has-storage")]
 use start::StartCommandArguments;
 use std::process::ExitCode;
+use version::VersionCommandArguments;
 
 const INFO: &str = "
 To get started using SurrealDB, and for guides on connecting to and building applications
@@ -59,8 +60,8 @@ enum Commands {
 	Import(ImportCommandArguments),
 	#[command(about = "Export an existing database as a SurrealQL script")]
 	Export(ExportCommandArguments),
-	#[command(about = "Output the command-line tool version information")]
-	Version,
+	#[command(about = "Output the command-line tool and remote server version information")]
+	Version(VersionCommandArguments),
 	#[command(about = "Upgrade to the latest stable version")]
 	Upgrade(UpgradeCommandArguments),
 	#[command(about = "Start an SQL REPL in your terminal with pipe support")]
@@ -80,7 +81,7 @@ pub async fn init() -> ExitCode {
 		Commands::Backup(args) => backup::init(args).await,
 		Commands::Import(args) => import::init(args).await,
 		Commands::Export(args) => export::init(args).await,
-		Commands::Version => version::init(),
+		Commands::Version(args) => version::init(args).await,
 		Commands::Upgrade(args) => upgrade::init(args).await,
 		Commands::Sql(args) => sql::init(args).await,
 		Commands::IsReady(args) => isready::init(args).await,

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -1,7 +1,40 @@
+use crate::cli::abstraction::OptionalDatabaseConnectionArguments;
 use crate::env::release;
 use crate::err::Error;
+use clap::Args;
+use surrealdb::engine::any::connect;
 
-pub fn init() -> Result<(), Error> {
-	println!("{}", release());
+#[derive(Args, Debug)]
+pub struct VersionCommandArguments {
+	#[command(flatten)]
+	conn: OptionalDatabaseConnectionArguments,
+}
+
+pub async fn init(
+	VersionCommandArguments {
+		conn: OptionalDatabaseConnectionArguments {
+			endpoint,
+		},
+	}: VersionCommandArguments,
+) -> Result<(), Error> {
+	// Initialize opentelemetry and logging
+	crate::o11y::builder().with_log_level("error").init();
+	// Print server version if endpoint supplied else CLI version
+	if let Some(e) = endpoint {
+		// Print remote server version
+		println!("{}", get_server_version_string(e).await?);
+	} else {
+		// Print local CLI version
+		println!("{}", release());
+	}
 	Ok(())
+}
+
+async fn get_server_version_string(endpoint: String) -> Result<String, Error> {
+	// Connect to the database engine
+	let client = connect(endpoint).await?;
+	// Query database version info
+	let server_version = client.version().await?;
+	// Convert version info to formatted string
+	Ok(server_version.to_string())
 }


### PR DESCRIPTION
… (#1771)

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I want to start contributing to SurrealDB and this seemed like a good simple issue to start with

## What does this change do?

It adds version info for remotes along with CLI when using the `version` sub-command. The endpoint can be specified by the user and defaults to ws://localhost:8000 when not supplied. If there's an error querying the version info from the remote and the endpoint was manually supplied by the user then the command errors, otherwise the server version info is not printed.

## What is your testing strategy?

Manually run through the 4 cases locally:

- local server running and endpoint not supplied
- local server running and endpoint manually supplied
- local server not running and endpoint manually supplied
- local server not running and endpoint not supplied

If testing on remote is necessary, I will do this per any recommendations. I'm still new to the code and the tool.

## Is this related to any issues?

Closes #1771 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
