### PR TITLE
Fix image paths in DOCKER.md documentation

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -69,11 +69,11 @@ SurrealDB is an end-to-end cloud native database for web, mobile, serverless, ja
 
 View the [features](https://surrealdb.com/features), the latest [releases](https://surrealdb.com/releases), the product [roadmap](https://surrealdb.com/roadmap), and [documentation](https://surrealdb.com/docs).
 
-<h2><img height="20" src="./img/documentation.svg">&nbsp;&nbsp;Documentation</h2>
+<h2><img height="20" src="https://github.com/surrealdb/surrealdb/blob/main/img/documentation.svg?raw=true">&nbsp;&nbsp;Documentation</h2>
 
 For guidance on installation, development, deployment, and administration, see our [documentation](https://surrealdb.com/docs).
 
-<h2><img height="20" src="./img/gettingstarted.svg">&nbsp;&nbsp;Run using Docker</h2>
+<h2><img height="20" src="https://github.com/surrealdb/surrealdb/blob/main/img/gettingstarted.svg?raw=true">&nbsp;&nbsp;Run using Docker</h2>
 
 Docker can be used to manage and run SurrealDB database instances without the need to install any command-line tools. The SurrealDB docker container contains the full command-line tools for importing and exporting data from a running server, or for running a server itself.
 
@@ -93,7 +93,7 @@ Access to the surrealdb CLI with:
 docker exec -it <container_name> /surreal sql -c http://localhost:8000 -u root -p root --ns test --db test --pretty
 ```
 
-<h2><img height="20" src="./img/gettingstarted.svg">&nbsp;&nbsp;Run using Docker Compose</h2>
+<h2><img height="20" src="https://github.com/surrealdb/surrealdb/blob/main/img/gettingstarted.svg?raw=true">&nbsp;&nbsp;Run using Docker Compose</h2>
 
 
 The Docker image can be used with the docker-compose tool.


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Paths in `DOCKER.md` documentation need absolute URLs.

## What does this change do?

Ensures paths in the `DOCKER.md` documentation use absolute URLs.

## What is your testing strategy?

Not applicable.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
