### PR TITLE
Add thing as scalar node for indexing

### DIFF
--- a/lib/src/idx/planner/tree.rs
+++ b/lib/src/idx/planner/tree.rs
@@ -77,6 +77,7 @@ impl<'a> TreeBuilder<'a> {
 			Value::Strand(_) => Node::Scalar(v.to_owned()),
 			Value::Number(_) => Node::Scalar(v.to_owned()),
 			Value::Bool(_) => Node::Scalar(v.to_owned()),
+			Value::Thing(_) => Node::Scalar(v.to_owned()),
 			Value::Subquery(s) => self.eval_subquery(s).await?,
 			Value::Param(p) => {
 				let v = p.compute(self.ctx, self.opt, self.txn, None).await?;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently query planner doesn't consider `thing` value as a tree node. It only supports `strand`, `Number`, `bool` as scalar nodes. I'm not sure why values like (`datetime`, `thing`, e.t.c) are not considered as scalar nodes. Or Is there any special way of implementing those in future iteration on indexes

## What does this change do?

This PR adds `thing` value as a scalar node and ready to add more value types if needed.

## What is your testing strategy?

Ran  a build & tested manually. it works.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
