### PR TITLE
feat(cli): add validate command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,15 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
@@ -377,6 +386,21 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "assert_fs"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f070617a68e5c2ed5d06ee8dd620ee18fb72b99f6c094bed34cf8ab07c875b48"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
 
 [[package]]
 name = "async-channel"
@@ -827,6 +851,16 @@ checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1363,6 +1397,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1bba4f227a4a53d12b653f50ca7bf10c9119ae2aba56aff9e0338b5c98f36a"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1442,12 @@ checksum = "bfaa1135a34d26e5cc5b4927a8935af887d4f30a5653a797c33b9a4222beb6d9"
 dependencies = [
  "urlencoding",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "earcutr"
@@ -1901,6 +1947,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick 0.7.20",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "grpcio"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,6 +2295,23 @@ checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3212,6 +3299,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "predicates"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "itertools 0.10.5",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,7 +3765,7 @@ version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.2",
  "memchr",
  "regex-syntax 0.7.2",
 ]
@@ -4477,10 +4592,12 @@ name = "surreal"
 version = "1.0.0-beta.9"
 dependencies = [
  "argon2",
+ "assert_fs",
  "base64 0.21.2",
  "bytes",
  "clap 4.3.10",
  "futures 0.3.28",
+ "glob",
  "http",
  "hyper",
  "ipnet",
@@ -4796,6 +4913,12 @@ dependencies = [
  "rustix 0.37.22",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ base64 = "0.21.2"
 bytes = "1.4.0"
 clap = { version = "4.3.10", features = ["env", "derive", "wrap_help", "unicode"] }
 futures = "0.3.28"
+glob = "0.3.1"
 http = "0.2.9"
 hyper = "0.14.27"
 ipnet = "2.8.0"
@@ -49,30 +50,31 @@ reqwest = { version = "0.11.18", features = ["blocking"] }
 rustyline = { version = "11.0.0", features = ["derive"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_cbor = "0.11.2"
-serde_pack = { version = "1.1.1", package = "rmp-serde" }
 serde_json = "1.0.99"
+serde_pack = { version = "1.1.1", package = "rmp-serde" }
 surrealdb = { path = "lib", features = ["protocol-http", "protocol-ws", "rustls"] }
 tempfile = "3.6.0"
 thiserror = "1.0.40"
 tokio = { version = "1.29.1", features = ["macros", "signal"] }
 tokio-util = { version = "0.7.8", features = ["io"] }
-uuid = { version = "1.4.0", features = ["serde", "js", "v4", "v7"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 urlencoding = "2.1.2"
+uuid = { version = "1.4.0", features = ["serde", "js", "v4", "v7"] }
 warp = { version = "0.3.5", features = ["compression", "tls", "websocket"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.26.2"
 
 [dev-dependencies]
+assert_fs = "1.0.13"
+opentelemetry-proto = { version = "0.1.0", features = ["gen-tonic", "traces", "build-server"] }
 rcgen = "0.10.0"
-tonic = "0.8.3"
-opentelemetry-proto = {version = "0.1.0", features = ["gen-tonic", "traces", "build-server"] }
 serial_test = "2.0.0"
-tokio-stream = { version = "0.1", features = ["net"] }
 temp-env = "0.3.4"
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic = "0.8.3"
 
 [package.metadata.deb]
 maintainer-scripts = "pkg/deb/"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,10 +8,10 @@ mod sql;
 #[cfg(feature = "has-storage")]
 mod start;
 mod upgrade;
+mod validate;
 pub(crate) mod validator;
 mod version;
 
-use self::upgrade::UpgradeCommandArguments;
 use crate::cnf::LOGO;
 use backup::BackupCommandArguments;
 use clap::{Parser, Subcommand};
@@ -24,6 +24,8 @@ use sql::SqlCommandArguments;
 #[cfg(feature = "has-storage")]
 use start::StartCommandArguments;
 use std::process::ExitCode;
+use upgrade::UpgradeCommandArguments;
+use validate::ValidateCommandArguments;
 use version::VersionCommandArguments;
 
 const INFO: &str = "
@@ -71,6 +73,8 @@ enum Commands {
 		visible_alias = "isready"
 	)]
 	IsReady(IsReadyCommandArguments),
+	#[command(about = "Validate SurrealQL query files")]
+	Validate(ValidateCommandArguments),
 }
 
 pub async fn init() -> ExitCode {
@@ -85,6 +89,7 @@ pub async fn init() -> ExitCode {
 		Commands::Upgrade(args) => upgrade::init(args).await,
 		Commands::Sql(args) => sql::init(args).await,
 		Commands::IsReady(args) => isready::init(args).await,
+		Commands::Validate(args) => validate::init(args).await,
 	};
 	if let Err(e) = output {
 		error!("{}", e);

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -1,0 +1,62 @@
+use crate::err::Error;
+use clap::Args;
+use glob::glob;
+use std::io::{Error as IoError, ErrorKind};
+use surrealdb::sql::parse;
+
+#[derive(Args, Debug)]
+pub struct ValidateCommandArguments {
+	#[arg(help = "Glob pattern for the files to validate")]
+	#[arg(default_value = "**/*.surql")]
+	pattern: String,
+}
+
+pub async fn init(args: ValidateCommandArguments) -> Result<(), Error> {
+	let ValidateCommandArguments {
+		pattern,
+	} = args;
+
+	let entries = match glob(&pattern) {
+		Ok(entries) => entries,
+		Err(error) => {
+			eprintln!("Error parsing glob pattern {pattern}: {error}");
+
+			return Err(Error::Io(IoError::new(
+				ErrorKind::Other,
+				format!("Error parsing glob pattern {pattern}: {error}"),
+			)));
+		}
+	};
+
+	let mut has_entries = false;
+
+	for entry in entries.flatten() {
+		let file_content = tokio::fs::read_to_string(entry.clone()).await?;
+		let parse_result = parse(&file_content);
+
+		match parse_result {
+			Ok(_) => {
+				println!("{}: OK", entry.display());
+			}
+			Err(error) => {
+				println!("{}: KO", entry.display());
+				eprintln!("{error}");
+
+				return Err(crate::err::Error::from(error));
+			}
+		}
+
+		has_entries = true;
+	}
+
+	if !has_entries {
+		eprintln!("No files found for pattern {pattern}");
+
+		return Err(Error::Io(IoError::new(
+			ErrorKind::NotFound,
+			format!("No files found for pattern {pattern}"),
+		)));
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The ultimate goal is to be able to validate *.surql files on CI (GitHub Actions, etc..). 

For that purpose, we can reuse the `parse` function offered by the `surrealdb` crate. It can be easy to provide a cli command named `validate` to the surrealdb cli that will parse SurrealDB query files.

## What does this change do?

* Provide a new cli command named `validate`. Example:

```
surreal validate
```

```
surreal validate my-file.surql
```

The default version of the command will use the following glob pattern: `**/*.surql`

* Reorder dependencies on `Cargo.toml`
* Add `glob` crate to handle glob pattern and access files that match the pattern
* Add `assert_fs` dev dependency crate that allow to isolate integration tests on temporary folders
* Add integration tests

## What is your testing strategy?

* Integration tests
* Manual tests using `cargo run --`

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
