### PR TITLE
Increase stack size for complex parser tests

### DIFF
--- a/lib/tests/complex.rs
+++ b/lib/tests/complex.rs
@@ -221,7 +221,7 @@ fn with_enough_stack(
 	// Same for debug mode
 	#[cfg(debug_assertions)]
 	{
-		builder = builder.stack_size(16_000_000);
+		builder = builder.stack_size(24_000_000);
 	}
 
 	builder


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The tests and nightly build are currently failing, because the complex parser tests are failing when running in debug mode with 16MB of stack memory.

## What does this change do?

Increases the debug testing mode stack memory to 24MB from 16MB.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
