### PR TITLE
Select/Explain should only return the explanation

### DIFF
--- a/lib/src/dbs/iterator.rs
+++ b/lib/src/dbs/iterator.rs
@@ -89,28 +89,25 @@ impl Iterator {
 		// Process the query START clause
 		self.setup_start(&cancel_ctx, opt, txn, stm).await?;
 		// Process any EXPLAIN clause
-		let explanation = self.output_explain(&cancel_ctx, opt, txn, stm)?;
-		// Process prepared values
-		self.iterate(&cancel_ctx, opt, txn, stm).await?;
-		// Return any document errors
-		if let Some(e) = self.error.take() {
-			return Err(e);
-		}
-		// Process any SPLIT clause
-		self.output_split(ctx, opt, txn, stm).await?;
-		// Process any GROUP clause
-		self.output_group(ctx, opt, txn, stm).await?;
-		// Process any ORDER clause
-		self.output_order(ctx, opt, txn, stm).await?;
-		// Process any START clause
-		self.output_start(ctx, opt, txn, stm).await?;
-		// Process any LIMIT clause
-		self.output_limit(ctx, opt, txn, stm).await?;
-		// Process any FETCH clause
-		self.output_fetch(ctx, opt, txn, stm).await?;
-		// Add the EXPLAIN clause to the result
-		if let Some(e) = explanation {
-			self.results.push(e);
+		if !self.output_explain(&cancel_ctx, opt, txn, stm)? {
+			// Process prepared values
+			self.iterate(&cancel_ctx, opt, txn, stm).await?;
+			// Return any document errors
+			if let Some(e) = self.error.take() {
+				return Err(e);
+			}
+			// Process any SPLIT clause
+			self.output_split(ctx, opt, txn, stm).await?;
+			// Process any GROUP clause
+			self.output_group(ctx, opt, txn, stm).await?;
+			// Process any ORDER clause
+			self.output_order(ctx, opt, txn, stm).await?;
+			// Process any START clause
+			self.output_start(ctx, opt, txn, stm).await?;
+			// Process any LIMIT clause
+			self.output_limit(ctx, opt, txn, stm).await?;
+			// Process any FETCH clause
+			self.output_fetch(ctx, opt, txn, stm).await?;
 		}
 		// Output the results
 		Ok(mem::take(&mut self.results).into())
@@ -362,54 +359,49 @@ impl Iterator {
 		_opt: &Options,
 		_txn: &Transaction,
 		stm: &Statement<'_>,
-	) -> Result<Option<Value>, Error> {
-		Ok(if stm.explain() {
-			let mut explains = Vec::with_capacity(self.entries.len());
-			for iter in &self.entries {
-				let (operation, detail) = match iter {
-					Iterable::Value(v) => ("Iterate Value", vec![("value", v.to_owned())]),
-					Iterable::Table(t) => {
-						("Iterate Table", vec![("table", Value::from(t.0.to_owned()))])
-					}
-					Iterable::Thing(t) => {
-						("Iterate Thing", vec![("thing", Value::Thing(t.to_owned()))])
-					}
-					Iterable::Range(r) => {
-						("Iterate Range", vec![("table", Value::from(r.tb.to_owned()))])
-					}
-					Iterable::Edges(e) => {
-						("Iterate Edges", vec![("from", Value::Thing(e.from.to_owned()))])
-					}
-					Iterable::Mergeable(t, v) => (
-						"Iterate Mergeable",
-						vec![("thing", Value::Thing(t.to_owned())), ("value", v.to_owned())],
-					),
-					Iterable::Relatable(t1, t2, t3) => (
-						"Iterate Relatable",
-						vec![
-							("thing-1", Value::Thing(t1.to_owned())),
-							("thing-2", Value::Thing(t2.to_owned())),
-							("thing-3", Value::Thing(t3.to_owned())),
-						],
-					),
-					Iterable::Index(t, p) => (
-						"Iterate Index",
-						vec![("table", Value::from(t.0.to_owned())), ("plan", p.explain())],
-					),
-				};
-				let explain = Object::from(HashMap::from([
-					("operation", Value::from(operation)),
-					("detail", Value::Object(Object::from(HashMap::from_iter(detail)))),
-				]));
-				explains.push(Value::Object(explain));
-			}
-			Some(Value::Object(Object::from(HashMap::from([(
-				"explain",
-				Value::Array(Array::from(explains)),
-			)]))))
-		} else {
-			None
-		})
+	) -> Result<bool, Error> {
+		if !stm.explain() {
+			return Ok(false);
+		}
+		for iter in &self.entries {
+			let (operation, detail) = match iter {
+				Iterable::Value(v) => ("Iterate Value", vec![("value", v.to_owned())]),
+				Iterable::Table(t) => {
+					("Iterate Table", vec![("table", Value::from(t.0.to_owned()))])
+				}
+				Iterable::Thing(t) => {
+					("Iterate Thing", vec![("thing", Value::Thing(t.to_owned()))])
+				}
+				Iterable::Range(r) => {
+					("Iterate Range", vec![("table", Value::from(r.tb.to_owned()))])
+				}
+				Iterable::Edges(e) => {
+					("Iterate Edges", vec![("from", Value::Thing(e.from.to_owned()))])
+				}
+				Iterable::Mergeable(t, v) => (
+					"Iterate Mergeable",
+					vec![("thing", Value::Thing(t.to_owned())), ("value", v.to_owned())],
+				),
+				Iterable::Relatable(t1, t2, t3) => (
+					"Iterate Relatable",
+					vec![
+						("thing-1", Value::Thing(t1.to_owned())),
+						("thing-2", Value::Thing(t2.to_owned())),
+						("thing-3", Value::Thing(t3.to_owned())),
+					],
+				),
+				Iterable::Index(t, p) => (
+					"Iterate Index",
+					vec![("table", Value::from(t.0.to_owned())), ("plan", p.explain())],
+				),
+			};
+			let explain = Object::from(HashMap::from([
+				("operation", Value::from(operation)),
+				("detail", Value::Object(Object::from(HashMap::from_iter(detail)))),
+			]));
+			self.results.push(Value::Object(explain));
+		}
+		Ok(true)
 	}
 
 	#[cfg(target_arch = "wasm32")]

--- a/lib/tests/matches.rs
+++ b/lib/tests/matches.rs
@@ -11,12 +11,13 @@ async fn select_where_matches_using_index() -> Result<(), Error> {
 		CREATE blog:1 SET title = 'Hello World!';
 		DEFINE ANALYZER simple TOKENIZERS blank,class;
 		DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25 HIGHLIGHTS;
-		SELECT id, search::highlight('<em>', '</em>', 1) AS title FROM blog WHERE title @1@ 'Hello' EXPLAIN;
+		SELECT id FROM blog WHERE title @1@ 'Hello' EXPLAIN;
+		SELECT id, search::highlight('<em>', '</em>', 1) AS title FROM blog WHERE title @1@ 'Hello';
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 4);
+	assert_eq!(res.len(), 5);
 	//
 	let _ = res.remove(0).result?;
 	let _ = res.remove(0).result?;
@@ -24,13 +25,6 @@ async fn select_where_matches_using_index() -> Result<(), Error> {
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
-			{
-				id: blog:1,
-				title: '<em>Hello</em> World!'
-			},
-			{
-				explain:
-				[
 					{
 						detail: {
 							plan: {
@@ -42,7 +36,15 @@ async fn select_where_matches_using_index() -> Result<(), Error> {
 						},
 						operation: 'Iterate Index'
 					}
-				]
+			]",
+	);
+	assert_eq!(tmp, val);
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: blog:1,
+				title: '<em>Hello</em> World!'
 			}
 		]",
 	);
@@ -57,12 +59,13 @@ async fn select_where_matches_without_using_index_iterator() -> Result<(), Error
 		CREATE blog:2 SET title = 'Foo Bar!';
 		DEFINE ANALYZER simple TOKENIZERS blank,class FILTERS lowercase;
 		DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25(1.2,0.75) HIGHLIGHTS;
-		SELECT id,search::highlight('<em>', '</em>', 1) AS title FROM blog WHERE (title @0@ 'hello' AND identifier > 0) OR (title @1@ 'world' AND identifier < 99) EXPLAIN;
+		SELECT id FROM blog WHERE (title @0@ 'hello' AND identifier > 0) OR (title @1@ 'world' AND identifier < 99) EXPLAIN;
+		SELECT id,search::highlight('<em>', '</em>', 1) AS title FROM blog WHERE (title @0@ 'hello' AND identifier > 0) OR (title @1@ 'world' AND identifier < 99);
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 5);
+	assert_eq!(res.len(), 6);
 	//
 	let _ = res.remove(0).result?;
 	let _ = res.remove(0).result?;
@@ -71,20 +74,21 @@ async fn select_where_matches_without_using_index_iterator() -> Result<(), Error
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
+				{
+					detail: {
+						table: 'blog',
+					},
+					operation: 'Iterate Table'
+				}
+		]",
+	);
+	assert_eq!(tmp, val);
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
 			{
 				id: blog:1,
 				title: 'Hello <em>World</em>!'
-			},
-			{
-				explain:
-				[
-					{
-						detail: {
-							table: 'blog',
-						},
-						operation: 'Iterate Table'
-					}
-				]
 			}
 		]",
 	);
@@ -93,41 +97,32 @@ async fn select_where_matches_without_using_index_iterator() -> Result<(), Error
 }
 
 async fn select_where_matches_using_index_and_arrays(parallel: bool) -> Result<(), Error> {
+	let p = if parallel {
+		"PARALLEL"
+	} else {
+		""
+	};
 	let sql = format!(
 		r"
 		CREATE blog:1 SET content = ['Hello World!', 'Be Bop', 'Foo Bãr'];
 		DEFINE ANALYZER simple TOKENIZERS blank,class;
 		DEFINE INDEX blog_content ON blog FIELDS content SEARCH ANALYZER simple BM25 HIGHLIGHTS;
-		SELECT id, search::highlight('<em>', '</em>', 1) AS content FROM blog WHERE content @1@ 'Hello Bãr' {} EXPLAIN;
-	",
-		if parallel {
-			"PARALLEL"
-		} else {
-			""
-		}
+		SELECT id FROM blog WHERE content @1@ 'Hello Bãr' {p} EXPLAIN;
+		SELECT id, search::highlight('<em>', '</em>', 1) AS content FROM blog WHERE content @1@ 'Hello Bãr' {p};
+	"
 	);
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(&sql, &ses, None).await?;
-	assert_eq!(res.len(), 4);
+	assert_eq!(res.len(), 5);
 	//
 	let _ = res.remove(0).result?;
 	let _ = res.remove(0).result?;
 	let _ = res.remove(0).result?;
+	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
-			{
-				id: blog:1,
-				content: [
-					'<em>Hello</em> World!',
-					'Be Bop',
-					'Foo <em>Bãr</em>'
-				]
-			},
-			{
-				explain:
-				[
 					{
 						detail: {
 							plan: {
@@ -139,6 +134,19 @@ async fn select_where_matches_using_index_and_arrays(parallel: bool) -> Result<(
 						},
 						operation: 'Iterate Index'
 					}
+			]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: blog:1,
+				content: [
+					'<em>Hello</em> World!',
+					'Be Bop',
+					'Foo <em>Bãr</em>'
 				]
 			}
 		]",
@@ -164,7 +172,7 @@ async fn select_where_matches_using_index_offsets() -> Result<(), Error> {
 		DEFINE ANALYZER simple TOKENIZERS blank,class;
 		DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25(1.2,0.75) HIGHLIGHTS;
 		DEFINE INDEX blog_content ON blog FIELDS content SEARCH ANALYZER simple BM25 HIGHLIGHTS;
-		SELECT id, search::offsets(0) AS title, search::offsets(1) AS content FROM blog WHERE title @0@ 'title' AND content @1@ 'Hello Bãr' EXPLAIN;
+		SELECT id, search::offsets(0) AS title, search::offsets(1) AS content FROM blog WHERE title @0@ 'title' AND content @1@ 'Hello Bãr';
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
@@ -186,22 +194,6 @@ async fn select_where_matches_using_index_offsets() -> Result<(), Error> {
 					0: [{s:0, e:5}],
 					2: [{s:4, e:7}]
 				}
-			},
-			{
-				explain:
-				[
-					{
-						detail: {
-							plan: {
-								index: 'blog_content',
-								operator: '@1@',
-								value: 'Hello Bãr'
-							},
-							table: 'blog',
-						},
-						operation: 'Iterate Index'
-					}
-				]
 			}
 		]",
 	);


### PR DESCRIPTION
## What is the motivation?

In the initial implementation, the SELECT...EXPLAIN command returns both the query result and its explanation. The primary purpose of the EXPLAIN command is to allow control over the execution plan prior to its actual run.

## What does this change do?

Only the explanation is returned, bypassing the iterators. As a result, the explanation is delivered immediately.

```bash
 cargo run --no-default-features -F storage-mem -- sql --conn memory --user root --pass root --ns test --db test
```

```sql
test/test> CREATE blog:1 SET title = 'Hello World!';
[{ id: blog:1, title: 'Hello World!' }]

test/test> SELECT * FROM blog
[{ id: blog:1, title: 'Hello World!' }]

test/test> SELECT * FROM blog EXPLAIN;
[{ detail: { table: 'blog' }, operation: 'Iterate Table' }]
```

## What is your testing strategy?

Tests have been updated.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
