### PR TITLE
Remove semver warnings for dirty builds

### DIFF
--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -151,7 +151,11 @@ where
 			match conn.version().await {
 				Ok(version) => {
 					let server_build = &version.build;
-					if !req.matches(&version) {
+					if version.build.contains("dirty") {
+						// don't generate output warnings for dirty builds
+						// Try to write tests that do output checking for "contains"
+						// instead of exact matches.
+					} else if !req.matches(&version) {
 						warn!("server version `{version}` does not match the range supported by the client `{versions}`");
 					} else if !server_build.is_empty() && server_build < &build_meta {
 						warn!("server build `{server_build}` is older than the minimum supported build `{build_meta}`");


### PR DESCRIPTION
## What is the motivation?

Remove semver warnings for dirty builds.

We have tests that validate output.
```
---- cli_integration::start stdout ----
starting server with args: start --bind 127.0.0.1:13276 --user root --pass 16080441548413343829 memory --no-banner --log info
thread 'cli_integration::start' panicked at 'assertion failed: `(left == right)`
  left: `Ok("[{ id: thing:one }]\n\n\u{1b}[2m2023-07-14T11:18:30.883114Z\u{1b}[0m \u{1b}[33m WARN\u{1b}[0m \u{1b}[2msurrealdb::api\u{1b}[0m\u{1b}[2m:\u{1b}[0m server build `20230
505.f860e34a.dirty` is older than the minimum supported build `20230701.55918b7c`\n")`,
 right: `Ok("[{ id: thing:one }]\n\n")`: failed to send sql: sql --conn http://127.0.0.1:13276 --user root --pass 16080441548413343829 --ns N --db D --multi', tests/cli.rs:141:13
```

The tests could use `contains`, but it is better if the output is compared strictly. In order to do that, we need the output to be predictable. So removing semver warnings from dirty builds will be useful.

## What does this change do?

Remove semver warnings for dirty builds.

## What is your testing strategy?

`cargo test -p surreal --test cli cli_integration::start`

## Is this related to any issues?

Failing local builds on `make test` after `make serve`

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
