### PR TITLE
Drop build metadata from the library version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "1.0.0-beta.9+20230402"
+version = "1.0.0-beta.9"
 dependencies = [
  "addr",
  "any_ascii",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surrealdb"
 publish = true
 edition = "2021"
-version = "1.0.0-beta.9+20230402"
+version = "1.0.0-beta.9"
 rust-version = "1.65.0"
 readme = "CARGO.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]


### PR DESCRIPTION
## What is the motivation?

The CLI currently emits a warning about the server not being compatible with the library. This is because we are still using the old build metadata in our library version.

## What does this change do?

It [drops the build metadata from from `lib/Cargo.toml`](https://github.com/surrealdb/surrealdb/pull/2259#issuecomment-1635773140).

## What is your testing strategy?

Ran `make sql`.

## Is this related to any issues?

It's an alternative take on https://github.com/surrealdb/surrealdb/pull/2259#issuecomment-1635773140.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
