### PR TITLE
Update dependency and fix build

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -127,14 +127,14 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pharos = "0.5.3"
-tokio = { version = "1.29.1", default-features = false, features = ["rt"] }
+tokio = { version = "1.29.1", default-features = false, features = ["rt", "sync"] }
 uuid = { version = "1.4.0", features = ["serde", "js", "v4", "v7"] }
 wasmtimer = { version = "0.2.0", default-features = false, features = ["tokio"] }
 wasm-bindgen-futures = "0.4.37"
 ws_stream_wasm = "0.7.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.29.1", default-features = false, features = ["macros", "io-util", "io-std", "fs", "rt-multi-thread", "time"] }
+tokio = { version = "1.29.1", default-features = false, features = ["macros", "io-util", "io-std", "fs", "rt-multi-thread", "time", "sync"] }
 tokio-tungstenite = { version = "0.18.0", optional = true }
 uuid = { version = "1.4.0", features = ["serde", "v4", "v7"] }
 


### PR DESCRIPTION
## What is the motivation?

After the changes made on PR #2240, compilation fails when trying to build without any storage engine features enabled.
```
cargo build -p surrealdb // this fails
cargo build -p surrealdb --features kv-mem // This works
```
I guess this is due to the usage of `tokio::sync` without enabling the required tokio features flags.

## What does this change do?

Added `sync` feature flag to tokio dependency.

## What is your testing strategy?

Ran a build and it worked.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
