### PR TITLE
Bugfix - Fixed having to include order attribute in select (#1809)

### DIFF
--- a/lib/src/sql/special.rs
+++ b/lib/src/sql/special.rs
@@ -1,7 +1,6 @@
 use crate::sql::error::Error;
 use crate::sql::field::{Field, Fields};
 use crate::sql::group::Groups;
-use crate::sql::order::Orders;
 use crate::sql::split::Splits;
 use crate::sql::value::Value;
 use crate::sql::Idiom;
@@ -48,25 +47,6 @@ pub fn check_split_on_fields<'a>(
 			if !contains_idiom(fields, &split.0) {
 				// If the expression isn't specified in the SELECT clause, then error
 				return Err(Failure(Error::Split(i, split.to_string())));
-			}
-		}
-	}
-	// This query is ok to run
-	Ok(())
-}
-
-pub fn check_order_by_fields<'a>(
-	i: &'a str,
-	fields: &Fields,
-	orders: &Option<Orders>,
-) -> Result<(), Err<Error<&'a str>>> {
-	// Check to see if a ORDER BY clause has been defined
-	if let Some(orders) = orders {
-		// Loop over each of the expressions in the ORDER BY clause
-		for order in orders.iter() {
-			if !contains_idiom(fields, order) {
-				// If the expression isn't specified in the SELECT clause, then error
-				return Err(Failure(Error::Order(i, order.to_string())));
 			}
 		}
 	}

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -17,7 +17,6 @@ use crate::sql::group::{group, Groups};
 use crate::sql::limit::{limit, Limit};
 use crate::sql::order::{order, Orders};
 use crate::sql::special::check_group_by_fields;
-use crate::sql::special::check_order_by_fields;
 use crate::sql::special::check_split_on_fields;
 use crate::sql::split::{split, Splits};
 use crate::sql::start::{start, Start};
@@ -194,7 +193,6 @@ pub fn select(i: &str) -> IResult<&str, SelectStatement> {
 	let (i, group) = opt(preceded(shouldbespace, group))(i)?;
 	check_group_by_fields(i, &expr, &group)?;
 	let (i, order) = opt(preceded(shouldbespace, order))(i)?;
-	check_order_by_fields(i, &expr, &order)?;
 	let (i, limit) = opt(preceded(shouldbespace, limit))(i)?;
 	let (i, start) = opt(preceded(shouldbespace, start))(i)?;
 	let (i, fetch) = opt(preceded(shouldbespace, fetch))(i)?;
@@ -248,6 +246,15 @@ mod tests {
 	#[test]
 	fn select_statement_thing() {
 		let sql = "SELECT * FROM test:thingy ORDER BY name";
+		let res = select(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(sql, format!("{}", out))
+	}
+
+	#[test]
+	fn select_without_including_order_attribute() {
+		let sql = "SELECT field FROM test:thingy ORDER BY name";
 		let res = select(sql);
 		assert!(res.is_ok());
 		let out = res.unwrap().1;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

This PR is for fixing issue #1809 

## What does this change do?


It allows running select statements without including the attribute that is being used to order by e.g.

`select id from table order by created_at;`

## What is your testing strategy?

I've tested it manually using the in memory database and I've also added an additional unit test

## Is this related to any issues?

https://github.com/surrealdb/surrealdb/issues/1809

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
