### PR TITLE
Fix stub fetch functions

### DIFF
--- a/lib/src/fnc/script/fetch_stub/mod.rs
+++ b/lib/src/fnc/script/fetch_stub/mod.rs
@@ -1,6 +1,6 @@
 //! stub implementations for the fetch API when `http` is not enabled.
 
-use js::{class::Trace, Class, Ctx, Exception, Result};
+use js::{class::Trace, Class, Ctx, Exception, Function, Result};
 
 #[cfg(test)]
 mod test;
@@ -13,8 +13,7 @@ pub fn register(ctx: &Ctx<'_>) -> Result<()> {
 	Class::<blob::Blob>::define(&globals)?;
 	Class::<form_data::FormData>::define(&globals)?;
 	Class::<headers::Headers>::define(&globals)?;
-	globals.set("fetch", Function::new(ctx, js_fetch).with_name("fetch"));
-	Ok(())
+	globals.set("fetch", Function::new(ctx.clone(), js_fetch)?.with_name("fetch")?)
 }
 
 #[js::function]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The stub fetch JavaScript functions, the function the surrealdb library falls back to when the `http` feature is not enabled, aren't compiling.

## What does this change do?

This PR fixes those functions.

## Is this related to any issues?

Not yet.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [*] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
