### PR TITLE
Feature #2168 add live query details in INFO FOR TABLE statement

### DIFF
--- a/lib/src/sql/statements/info.rs
+++ b/lib/src/sql/statements/info.rs
@@ -187,6 +187,12 @@ impl InfoStatement {
 					tmp.insert(v.name.to_string(), v.to_string().into());
 				}
 				res.insert("indexes".to_owned(), tmp.into());
+				// Process the live queries
+				let mut tmp = Object::default();
+				for v in run.all_lv(opt.ns(), opt.db(), tb).await?.iter() {
+					tmp.insert(v.id.to_string(), v.to_string().into());
+				}
+				res.insert("lives".to_owned(), tmp.into());
 				// Ok all good
 				Value::from(res).ok()
 			}

--- a/lib/tests/table.rs
+++ b/lib/tests/table.rs
@@ -44,6 +44,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 			fields: {},
 			tables: { person_by_age: 'DEFINE TABLE person_by_age SCHEMALESS AS SELECT count(), age, math::sum(age) AS total, math::mean(score) AS average FROM person GROUP BY age' },
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When users invoke INFO FOR TABLE statement they do not currently get any information about the existing live queries.

## What does this change do?

The result of INFO FOR TABLE statement to include the existing live queries being performed on it.
```
test/test> info for table some_table;
[
        {
                events: {},
                fields: {},
                indexes: {},
+              lives: { "live-query-uuid-1", "live-query-uuid-2"},
                tables: {}
        }
]
```
## What is your testing strategy?

I updated `lib/tests/table.rs` where the test failed.

## Is this related to any issues?

NO

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
