### PR TITLE
Fix model range increments

### DIFF
--- a/lib/src/sql/model.rs
+++ b/lib/src/sql/model.rs
@@ -32,7 +32,10 @@ impl Iterator for IntoIter {
 				}
 			}
 			Model::Range(tb, b, e) => {
-				if self.index + b <= *e {
+				if self.index == 0 {
+					self.index = *b - 1;
+				}
+				if self.index < *e {
 					self.index += 1;
 					Some(Thing {
 						tb: tb.to_string(),

--- a/lib/tests/model.rs
+++ b/lib/tests/model.rs
@@ -33,7 +33,7 @@ async fn model_count() -> Result<(), Error> {
 #[tokio::test]
 async fn model_range() -> Result<(), Error> {
 	let sql = "
-		CREATE |test:1..1000| SET time = time::now();
+		CREATE |test:100..1100| SET time = time::now();
 		SELECT count() FROM test GROUP ALL;
 	";
 	let dbs = Datastore::new("memory").await?;

--- a/lib/tests/model.rs
+++ b/lib/tests/model.rs
@@ -33,7 +33,7 @@ async fn model_count() -> Result<(), Error> {
 #[tokio::test]
 async fn model_range() -> Result<(), Error> {
 	let sql = "
-		CREATE |test:100..1100| SET time = time::now();
+		CREATE |test:101..1100| SET time = time::now();
 		SELECT count() FROM test GROUP ALL;
 	";
 	let dbs = Datastore::new("memory").await?;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Model ranges using increments were incorrect, always starting from 0.

## What does this change do?

This PR fixes model range increments, ensuring that the following works correctly...

```sql
CREATE |person:1..10|; -- Create 10 people starting at 1
CREATE |person:11..20|; -- Create 10 people starting at 11
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2282.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
