### PR TITLE
Allow for DIFFs in notifications for simple live queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "febf23ab04509bd7672e6abe76bd8277af31b679e89fa5ffc6087dc289a448a3"
+checksum = "cebbcd90f811f93fc2a993024caecc1e8270d9d1eb9d3359edb3069c2096ea6f"
 dependencies = [
  "axum",
  "axum-core",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb524613be645939e280b7279f7b017f98cf7f5ef084ec374df373530e73277"
+checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -676,12 +676,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -1116,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.12"
+version = "4.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eab9e8ceb9afdade1ab3f0fd8dbce5b1b2f468ad653baf10e771781b2b67b73"
+checksum = "74bb1b4028935821b2d6b439bba2e970bdcf740832732437ead910c632e30d7d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1127,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.12"
+version = "4.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2763db829349bf00cfc06251268865ed4363b93a943174f638daf3ecdba2cd"
+checksum = "5ae467cbb0111869b765e13882a1dbbd6cb52f58203d8b80c44f667d4dd19843"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4696,7 +4690,7 @@ dependencies = [
  "axum-server",
  "base64 0.21.2",
  "bytes",
- "clap 4.3.12",
+ "clap 4.3.16",
  "futures 0.3.28",
  "futures-util",
  "glob",
@@ -5344,11 +5338,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8bd22a874a2d0b70452d5597b12c537331d49060824a95f49f108994f94aa4c"
+checksum = "7ac8060a61f8758a61562f6fb53ba3cbe1ca906f001df2e53cccddcdbee91e7c"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.2",
  "bitflags 2.3.3",
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,13 @@ strip = false
 
 [dependencies]
 argon2 = "0.5.1"
-axum = { version = "0.6.18", features = ["tracing", "ws", "headers"] }
+axum = { version = "0.6.19", features = ["tracing", "ws", "headers"] }
 axum-client-ip = "0.4.1"
-axum-extra = { version = "0.7.4", features = ["typed-routing"] }
+axum-extra = { version = "0.7.5", features = ["typed-routing"] }
 axum-server = { version = "0.5.1", features = ["tls-rustls"] }
 base64 = "0.21.2"
 bytes = "1.4.0"
-clap = { version = "4.3.12", features = ["env", "derive", "wrap_help", "unicode"] }
+clap = { version = "4.3.16", features = ["env", "derive", "wrap_help", "unicode"] }
 futures = "0.3.28"
 futures-util = "0.3.28"
 glob = "0.3.1"
@@ -51,13 +51,13 @@ ipnet = "2.8.0"
 once_cell = "1.18.0"
 opentelemetry = { version = "0.19", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.12.0", features = ["metrics"] }
-pin-project-lite = "0.2.9"
+pin-project-lite = "0.2.10"
 rand = "0.8.5"
 reqwest = { version = "0.11.18", features = ["blocking"] }
 rustyline = { version = "11.0.0", features = ["derive"] }
 serde = { version = "1.0.171", features = ["derive"] }
 serde_cbor = "0.11.2"
-serde_json = "1.0.102"
+serde_json = "1.0.103"
 serde_pack = { version = "1.1.1", package = "rmp-serde" }
 surrealdb = { path = "lib", features = ["protocol-http", "protocol-ws", "rustls"] }
 tempfile = "3.6.0"
@@ -65,12 +65,12 @@ thiserror = "1.0.43"
 tokio = { version = "1.29.1", features = ["macros", "signal"] }
 tokio-util = { version = "0.7.8", features = ["io"] }
 tower = "0.4.13"
-tower-http = { version = "0.4.1", features = ["trace", "sensitive-headers", "auth", "request-id", "util", "catch-panic", "cors", "set-header", "limit", "add-extension"] }
+tower-http = { version = "0.4.2", features = ["trace", "sensitive-headers", "auth", "request-id", "util", "catch-panic", "cors", "set-header", "limit", "add-extension"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.19.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 urlencoding = "2.1.2"
-uuid = { version = "1.4.0", features = ["serde", "js", "v4", "v7"] }
+uuid = { version = "1.4.1", features = ["serde", "js", "v4", "v7"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.26.2"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -97,9 +97,9 @@ rust-stemmers = "1.2.0"
 rustls = { version = "0.20.8", optional = true }
 snap = "1.1.0"
 scrypt = "0.11.0"
-semver = { version = "1.0.17", features = ["serde"] }
+semver = { version = "1.0.18", features = ["serde"] }
 serde = { version = "1.0.171", features = ["derive"] }
-serde_json = "1.0.102"
+serde_json = "1.0.103"
 sha-1 = "0.10.1"
 sha2 = "0.10.7"
 speedb = { version = "0.0.2", optional = true }
@@ -128,7 +128,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pharos = "0.5.3"
 tokio = { version = "1.29.1", default-features = false, features = ["rt", "sync"] }
-uuid = { version = "1.4.0", features = ["serde", "js", "v4", "v7"] }
+uuid = { version = "1.4.1", features = ["serde", "js", "v4", "v7"] }
 wasmtimer = { version = "0.2.0", default-features = false, features = ["tokio"] }
 wasm-bindgen-futures = "0.4.37"
 ws_stream_wasm = "0.7.4"
@@ -136,7 +136,7 @@ ws_stream_wasm = "0.7.4"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.29.1", default-features = false, features = ["macros", "io-util", "io-std", "fs", "rt-multi-thread", "time", "sync"] }
 tokio-tungstenite = { version = "0.18.0", optional = true }
-uuid = { version = "1.4.0", features = ["serde", "v4", "v7"] }
+uuid = { version = "1.4.1", features = ["serde", "v4", "v7"] }
 
 [lib]
 bench = false

--- a/lib/examples/axum/Cargo.toml
+++ b/lib/examples/axum/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = "0.6.18"
+axum = "0.6.19"
 serde = { version = "1.0.171", features = ["derive"] }
 surrealdb = { path = "../.." }
 thiserror = "1.0.43"


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently it is possible to perform a live query by calling the `live()` method on the WebSocket RPC layer, and passing in a table name. But it is not possible to specify whether the full record or the change DIFF should be returned for each notification.

## What does this change do?

This change adds a second, optional argument to the `live()` method on the WebSocket RPC layer. If this second argument is `true`, then the live query notifications sent to the client contain only the DIFFs of the record changes. If not entered, or `false`, then the full record will be returned for each notification.

## What is your testing strategy?

Coming in a future live query testing PR.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
