### PR TITLE
Add array::at function

### DIFF
--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -151,6 +151,7 @@
 "array::all("
 "array::any("
 "array::append("
+"array::at("
 "array::boolean_and("
 "array::boolean_not("
 "array::boolean_or("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -150,6 +150,7 @@
 "array::add("
 "array::all("
 "array::any("
+"array::at("
 "array::append("
 "array::boolean_and("
 "array::boolean_not("

--- a/lib/src/fnc/array.rs
+++ b/lib/src/fnc/array.rs
@@ -45,6 +45,14 @@ pub fn append((mut array, value): (Array, Value)) -> Result<Value, Error> {
 	Ok(array.into())
 }
 
+pub fn at((array, i): (Array, i64)) -> Result<Value, Error> {
+	let mut idx = i as usize;
+	if i < 0 {
+		idx = (array.len() as i64 + i) as usize;
+	}
+	Ok(array.get(idx).cloned().unwrap_or_default())
+}
+
 pub fn boolean_and((lh, rh): (Array, Array)) -> Result<Value, Error> {
 	let longest_length = lh.len().max(rh.len());
 	let mut results = Array::with_capacity(longest_length);
@@ -391,7 +399,7 @@ pub mod sort {
 
 #[cfg(test)]
 mod tests {
-	use super::{first, join, last, slice};
+	use super::{at, first, join, last, slice};
 	use crate::sql::{Array, Value};
 
 	#[test]
@@ -454,5 +462,14 @@ mod tests {
 
 		test(vec!["hello", "world"].into(), "world".into());
 		test(Array::new(), Value::None);
+	}
+
+	#[test]
+	fn array_at() {
+		fn test(arr: Array, i: i64, expected: Value) {
+			assert_eq!(at((arr, i)).unwrap(), expected);
+		}
+		test(vec!["hello", "world"].into(), -2, "hello".into());
+		test(vec!["hello", "world"].into(), -3, Value::None);
 	}
 }

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -82,6 +82,7 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"array::all" => array::all,
 		"array::any" => array::any,
 		"array::append" => array::append,
+		"array::at" => array::at,
 		"array::boolean_and" => array::boolean_and,
 		"array::boolean_not" => array::boolean_not,
 		"array::boolean_or" => array::boolean_or,

--- a/lib/src/fnc/script/modules/surrealdb/functions/array.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/array.rs
@@ -10,6 +10,7 @@ impl_module_def!(
 	"add" => run,
 	"all" => run,
 	"any" => run,
+	"at" => run,
 	"append" => run,
 	"boolean_and" => run,
 	"boolean_not" => run,

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -281,6 +281,7 @@ fn function_array(i: &str) -> IResult<&str, &str> {
 			tag("all"),
 			tag("any"),
 			tag("append"),
+			tag("at"),
 			tag("boolean_and"),
 			tag("boolean_not"),
 			tag("boolean_or"),

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -201,6 +201,38 @@ async fn function_array_append() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn function_array_at() -> Result<(), Error> {
+	let sql = r#"
+		RETURN array::at(["hello", "world"], 0);
+		RETURN array::at(["hello", "world"], 3);
+		RETURN array::at(["hello", "world"], -1);
+		RETURN array::at(["hello", "world"], -3);
+	"#;
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 4);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::Strand("hello".into());
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::None;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::Strand("world".into());
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::None;
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_array_boolean_and() -> Result<(), Error> {
 	test_queries(
 		r#"RETURN array::boolean_and([false, true, false, true], [false, false, true, true]);

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -204,21 +204,20 @@ async fn function_array_append() -> Result<(), Error> {
 async fn function_array_at() -> Result<(), Error> {
 	let sql = r#"
 		RETURN array::at(["hello", "world"], 0);
-		RETURN array::at(["hello", "world"], 3);
 		RETURN array::at(["hello", "world"], -1);
+		RETURN array::at(["hello", "world"], 3);
 		RETURN array::at(["hello", "world"], -3);
+		RETURN array::at([], 0);
+		RETURN array::at([], 3);
+		RETURN array::at([], -3);
 	"#;
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 4);
+	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::Strand("hello".into());
-	assert_eq!(tmp, val);
-	//
-	let tmp = res.remove(0).result?;
-	let val = Value::None;
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
@@ -226,8 +225,19 @@ async fn function_array_at() -> Result<(), Error> {
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::None;
-	assert_eq!(tmp, val);
+	assert_eq!(tmp, Value::None);
+	//
+	let tmp = res.remove(0).result?;
+	assert_eq!(tmp, Value::None);
+	//
+	let tmp = res.remove(0).result?;
+	assert_eq!(tmp, Value::None);
+	//
+	let tmp = res.remove(0).result?;
+	assert_eq!(tmp, Value::None);
+	//
+	let tmp = res.remove(0).result?;
+	assert_eq!(tmp, Value::None);
 	//
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?
As mentioned by @kearfy on  #2287,  It would be nicer to have the ability to pick item from an array via its index & neg index like mongodb `$arrayElemAt: [ <array>, <idx> ]`

## What does this change do?

This PR implements `at` function for Array to pick an item from an array based on given index.

```
LET $arr = ['s', 'u', 'r', 'r', 'e', 'a', 'l', 'd', 'b'];
RETURN array::at($arr, 0); -- s
RETURN array::at($arr, -1); -- b

-- // reverse counter
RETURN array::at($arr, -3); -- l
```

Note: Haven't added `array::at` as an aggregation function as i don't see it to be much useful in those cases.

## What is your testing strategy?

Have added test cases as well.

## Is this related to any issues?

closes #2287 .

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x]  I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
