### PR TITLE
Add `insert` method to WebSocket RPC endpoint

### DIFF
--- a/lib/src/sql/value/serde/ser/statement/insert.rs
+++ b/lib/src/sql/value/serde/ser/statement/insert.rs
@@ -3,8 +3,8 @@ use crate::sql::statements::InsertStatement;
 use crate::sql::value::serde::ser;
 use crate::sql::Data;
 use crate::sql::Output;
-use crate::sql::Table;
 use crate::sql::Timeout;
+use crate::sql::Value;
 use ser::Serializer as _;
 use serde::ser::Error as _;
 use serde::ser::Impossible;
@@ -38,7 +38,7 @@ impl ser::Serializer for Serializer {
 
 #[derive(Default)]
 pub struct SerializeInsertStatement {
-	into: Option<Table>,
+	into: Option<Value>,
 	data: Option<Data>,
 	ignore: Option<bool>,
 	update: Option<Data>,
@@ -57,7 +57,7 @@ impl serde::ser::SerializeStruct for SerializeInsertStatement {
 	{
 		match key {
 			"into" => {
-				self.into = Some(Table(value.serialize(ser::string::Serializer.wrap())?));
+				self.into = Some(value.serialize(ser::value::Serializer.wrap())?);
 			}
 			"data" => {
 				self.data = Some(value.serialize(ser::data::Serializer.wrap())?);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

It is currently not possible to batch insert data into SurrealDB through the WebSocket RPC layer, unless using the raw SurrealQL `query` method.

## What does this change do?

This pull request improves the `INSERT` statement so that it supports a parameter for the table name (`INSERT INTO $table $data`), and adds an `insert` method to the WebSocket RPC layer. The `insert` method accepts two arguments: `table` (the name of the table into which to insert the data as a string), and `data` (the data itself, which can be an object for a single record to insert, or an array of multiple records to insert).

## What is your testing strategy?

Tests coming in the future.

## Is this related to any issues?

Closes #2052.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
