### PR TITLE
feat: WITH clause on SELECT statement

### DIFF
--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -507,10 +507,6 @@ pub enum Error {
 		feature: &'static str,
 	},
 
-	#[doc(hidden)]
-	#[error("Bypass the query planner")]
-	BypassQueryPlanner,
-
 	/// Duplicated match references are not allowed
 	#[error("Duplicated Match reference: {mr}")]
 	DuplicatedMatchRef {

--- a/lib/src/idx/planner/mod.rs
+++ b/lib/src/idx/planner/mod.rs
@@ -40,10 +40,10 @@ impl<'a> QueryPlanner<'a> {
 		t: Table,
 		it: &mut Iterator,
 	) -> Result<(), Error> {
-		let res = Tree::build(ctx, self.opt, txn, &t, self.with, self.cond).await?;
+		let res = Tree::build(ctx, self.opt, txn, &t, self.cond).await?;
 		if let Some((node, im)) = res {
 			let mut exe = QueryExecutor::new(self.opt, txn, &t, im).await?;
-			let ok = match PlanBuilder::build(node) {
+			let ok = match PlanBuilder::build(node, self.with) {
 				Ok(plan) => match plan {
 					Plan::SingleIndex(exp, io) => {
 						let ir = exe.add_iterator(exp);

--- a/lib/src/idx/planner/tree.rs
+++ b/lib/src/idx/planner/tree.rs
@@ -4,7 +4,6 @@ use crate::err::Error;
 use crate::idx::planner::plan::IndexOption;
 use crate::sql::index::Index;
 use crate::sql::statements::DefineIndexStatement;
-use crate::sql::with::With;
 use crate::sql::{Cond, Expression, Idiom, Operator, Subquery, Table, Value};
 use async_recursion::async_recursion;
 use std::collections::HashMap;
@@ -20,7 +19,6 @@ impl Tree {
 		opt: &'a Options,
 		txn: &'a Transaction,
 		table: &'a Table,
-		with: &'a Option<With>,
 		cond: &'a Option<Cond>,
 	) -> Result<Option<(Node, IndexMap)>, Error> {
 		let mut b = TreeBuilder {
@@ -28,7 +26,6 @@ impl Tree {
 			opt,
 			txn,
 			table,
-			with,
 			indexes: None,
 			index_map: IndexMap::default(),
 		};
@@ -44,7 +41,6 @@ struct TreeBuilder<'a> {
 	ctx: &'a Context<'a>,
 	opt: &'a Options,
 	txn: &'a Transaction,
-	with: &'a Option<With>,
 	table: &'a Table,
 	indexes: Option<Arc<[DefineIndexStatement]>>,
 	index_map: IndexMap,
@@ -52,11 +48,6 @@ struct TreeBuilder<'a> {
 
 impl<'a> TreeBuilder<'a> {
 	async fn find_index(&mut self, i: &Idiom) -> Result<Option<DefineIndexStatement>, Error> {
-		if let Some(with) = self.with {
-			if matches!(with, With::NoIndex) {
-				return Ok(None);
-			}
-		}
 		if self.indexes.is_none() {
 			let indexes = self
 				.txn
@@ -70,12 +61,6 @@ impl<'a> TreeBuilder<'a> {
 		if let Some(indexes) = &self.indexes {
 			for ix in indexes.as_ref() {
 				if ix.cols.len() == 1 && ix.cols[0].eq(i) {
-					// Check if we have an explicit list of index we can use
-					if let Some(With::Index(ixs)) = self.with {
-						if !ixs.contains(&ix.name.0) {
-							continue;
-						}
-					}
 					return Ok(Some(ix.clone()));
 				}
 			}

--- a/lib/src/idx/planner/tree.rs
+++ b/lib/src/idx/planner/tree.rs
@@ -71,11 +71,9 @@ impl<'a> TreeBuilder<'a> {
 			for ix in indexes.as_ref() {
 				if ix.cols.len() == 1 && ix.cols[0].eq(i) {
 					// Check if we have an explicit list of index we can use
-					if let Some(with) = self.with {
-						if let With::Index(ixs) = with {
-							if !ixs.contains(&ix.name.0) {
-								continue;
-							}
+					if let Some(With::Index(ixs)) = self.with {
+						if !ixs.contains(&ix.name.0) {
+							continue;
 						}
 					}
 					return Ok(Some(ix.clone()));

--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -68,6 +68,7 @@ pub(crate) mod uuid;
 pub(crate) mod value;
 pub(crate) mod version;
 pub(crate) mod view;
+pub(crate) mod with;
 
 #[cfg(test)]
 pub(crate) mod test;

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -93,7 +93,7 @@ impl SelectStatement {
 		let opt = &opt.new_with_futures(false);
 
 		// Get a query planner
-		let mut planner = QueryPlanner::new(opt, &self.cond);
+		let mut planner = QueryPlanner::new(opt, &self.with, &self.cond);
 		// Loop over the select targets
 		for w in self.what.0.iter() {
 			let v = w.compute(ctx, opt, txn, doc).await?;

--- a/lib/src/sql/value/serde/ser/mod.rs
+++ b/lib/src/sql/value/serde/ser/mod.rs
@@ -39,6 +39,7 @@ mod timeout;
 mod uuid;
 mod value;
 mod version;
+mod with;
 
 use serde::ser::Error;
 use serde::ser::Serialize;

--- a/lib/src/sql/value/serde/ser/with/mod.rs
+++ b/lib/src/sql/value/serde/ser/with/mod.rs
@@ -1,0 +1,78 @@
+pub(super) mod opt;
+
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::with::With;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub(super) struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = With;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<With, Error>;
+	type SerializeTuple = Impossible<With, Error>;
+	type SerializeTupleStruct = Impossible<With, Error>;
+	type SerializeTupleVariant = Impossible<With, Error>;
+	type SerializeMap = Impossible<With, Error>;
+	type SerializeStruct = Impossible<With, Error>;
+	type SerializeStructVariant = Impossible<With, Error>;
+
+	const EXPECTED: &'static str = "an enum `With`";
+
+	#[inline]
+	fn serialize_unit_variant(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+	) -> Result<Self::Ok, Error> {
+		match variant {
+			"NoIndex" => Ok(With::NoIndex),
+			variant => Err(Error::custom(format!("unexpected unit variant `{name}::{variant}`"))),
+		}
+	}
+
+	#[inline]
+	fn serialize_newtype_variant<T>(
+		self,
+		name: &'static str,
+		_variant_index: u32,
+		variant: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match variant {
+			"Index" => Ok(With::Index(value.serialize(ser::string::vec::Serializer.wrap())?)),
+			variant => {
+				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn with_noindex() {
+		let with = With::NoIndex;
+		let serialized = with.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(with, serialized);
+	}
+
+	#[test]
+	fn with_index() {
+		let with = With::Index(vec!["idx".to_string(), "uniq".to_string()]);
+		let serialized = with.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(with, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/with/opt.rs
+++ b/lib/src/sql/value/serde/ser/with/opt.rs
@@ -1,0 +1,55 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::with::With;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<With>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<With>, Error>;
+	type SerializeTuple = Impossible<Option<With>, Error>;
+	type SerializeTupleStruct = Impossible<Option<With>, Error>;
+	type SerializeTupleVariant = Impossible<Option<With>, Error>;
+	type SerializeMap = Impossible<Option<With>, Error>;
+	type SerializeStruct = Impossible<Option<With>, Error>;
+	type SerializeStructVariant = Impossible<Option<With>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<With>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(ser::with::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<With> = None;
+		let serialized = option.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(With::NoIndex);
+		let serialized = option.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/with.rs
+++ b/lib/src/sql/with.rs
@@ -1,0 +1,73 @@
+use crate::sql::comment::shouldbespace;
+use crate::sql::common::commas;
+use crate::sql::error::IResult;
+use crate::sql::ident::ident_raw;
+use derive::Store;
+use nom::branch::alt;
+use nom::bytes::complete::tag_no_case;
+use nom::multi::separated_list1;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter, Result};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
+pub enum With {
+	NoIndex,
+	Index(Vec<String>),
+}
+
+impl Display for With {
+	fn fmt(&self, f: &mut Formatter) -> Result {
+		f.write_str("WITH")?;
+		match self {
+			With::NoIndex => f.write_str(" NOINDEX"),
+			With::Index(i) => {
+				f.write_str(" INDEX ")?;
+				f.write_str(&i.join(","))
+			}
+		}
+	}
+}
+
+fn no_index(i: &str) -> IResult<&str, With> {
+	let (i, _) = tag_no_case("NOINDEX")(i)?;
+	Ok((i, With::NoIndex))
+}
+
+fn index(i: &str) -> IResult<&str, With> {
+	let (i, _) = tag_no_case("INDEX")(i)?;
+	let (i, _) = shouldbespace(i)?;
+	let (i, v) = separated_list1(commas, ident_raw)(i)?;
+	Ok((i, With::Index(v)))
+}
+
+pub fn with(i: &str) -> IResult<&str, With> {
+	let (i, _) = tag_no_case("WITH")(i)?;
+	let (i, _) = shouldbespace(i)?;
+	alt((no_index, index))(i)
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+
+	#[test]
+	fn with_no_index() {
+		let sql = "WITH NOINDEX";
+		let res = with(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(out, With::NoIndex);
+		assert_eq!("WITH NOINDEX", format!("{}", out));
+	}
+
+	#[test]
+	fn with_index() {
+		let sql = "WITH INDEX idx,uniq";
+		let res = with(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(out, With::Index(vec!["idx".to_string(), "uniq".to_string()]));
+		assert_eq!("WITH INDEX idx,uniq", format!("{}", out));
+	}
+}

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -1,19 +1,28 @@
 mod parse;
 
 use parse::Parse;
-use surrealdb::dbs::Session;
+use surrealdb::dbs::{Response, Session};
 use surrealdb::err::Error;
 use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
-async fn test_select_where_iterate_multi_index(parallel: bool) -> Result<(), Error> {
-	let parallel = if parallel {
-		"PARALLEL"
-	} else {
-		""
-	};
-	let sql = format!(
-		"
+const TABLE_ITERATOR: &str = "[
+	{
+		detail: {
+			table: 'person'
+		},
+		operation: 'Iterate Table'
+	},
+	{
+		detail: {
+			count: 2
+		},
+		operation: 'Fetch'
+	}
+]";
+
+fn three_multi_index_query(with: &str, parallel: &str) -> String {
+	format!("
 		CREATE person:tobie SET name = 'Tobie', genre='m', company='SurrealDB';
 		CREATE person:jaime SET name = 'Jaime', genre='m', company='SurrealDB';
 		CREATE person:lizzie SET name = 'Lizzie', genre='f', company='SurrealDB';
@@ -22,21 +31,11 @@ async fn test_select_where_iterate_multi_index(parallel: bool) -> Result<(), Err
 		DEFINE INDEX ft_company ON person FIELDS company SEARCH ANALYZER simple BM25;
 		DEFINE INDEX uniq_name ON TABLE person COLUMNS name UNIQUE;
 		DEFINE INDEX idx_genre ON TABLE person COLUMNS genre;
-		SELECT name FROM person WHERE name = 'Jaime' OR genre = 'm' OR company @@ 'surrealdb' {parallel};
-	    SELECT name FROM person WHERE name = 'Jaime' OR genre = 'm' OR company @@ 'surrealdb' {parallel} EXPLAIN FULL;"
-	);
-	let dbs = Datastore::new("memory").await?;
-	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
-	assert_eq!(res.len(), 10);
-	//
-	for _ in 0..8 {
-		let _ = res.remove(0).result?;
-	}
-	//
-	let tmp = res.remove(0).result?;
-	let val = Value::parse(
-		"[
+		SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' OR company @@ 'surrealdb' {parallel};
+	    SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' OR company @@ 'surrealdb' {parallel} EXPLAIN FULL;")
+}
+
+const THREE_MULTI_INDEX_RESULT: &str = "[
 			{
 				name: 'Jaime'
 			},
@@ -46,13 +45,9 @@ async fn test_select_where_iterate_multi_index(parallel: bool) -> Result<(), Err
 			{
 				name: 'Lizzie'
 			}
-		]",
-	);
-	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
-	//
-	let tmp = res.remove(0).result?;
-	let val = Value::parse(
-		"[
+		]";
+
+const THREE_MULTI_INDEX_ITERATORS: &str = "[
 				{
 					detail: {
 						plan: {
@@ -92,18 +87,134 @@ async fn test_select_where_iterate_multi_index(parallel: bool) -> Result<(), Err
 					},
 					operation: 'Fetch'
 				}
-			]",
-	);
+			]";
+
+fn two_multi_index_query(with: &str, parallel: &str) -> String {
+	format!(
+		"CREATE person:tobie SET name = 'Tobie', genre='m', company='SurrealDB';
+		CREATE person:jaime SET name = 'Jaime', genre='m', company='SurrealDB';
+		CREATE person:lizzie SET name = 'Lizzie', genre='f', company='SurrealDB';
+		DEFINE INDEX uniq_name ON TABLE person COLUMNS name UNIQUE;
+		DEFINE INDEX idx_genre ON TABLE person COLUMNS genre;
+		SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' {parallel};
+	    SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' {parallel} EXPLAIN FULL;"
+	)
+}
+
+const TWO_MULTI_INDEX_RESULT: &str = "[
+			{
+				name: 'Jaime'
+			},
+            {
+				name: 'Tobie'
+			}
+		]";
+
+const TWO_MULTI_INDEX_ITERATORS: &str = "[
+				{
+					detail: {
+						plan: {
+							index: 'uniq_name',
+							operator: '=',
+							value: 'Jaime'
+						},
+						table: 'person',
+					},
+					operation: 'Iterate Index'
+				},
+                {
+					detail: {
+						plan: {
+							index: 'idx_genre',
+							operator: '=',
+							value: 'm'
+						},
+						table: 'person',
+					},
+					operation: 'Iterate Index'
+				},
+				{
+					detail: {
+						count: 2
+					},
+					operation: 'Fetch'
+				}
+			]";
+
+async fn execute_test(sql: &str, expected_result: usize) -> Result<Vec<Response>, Error> {
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let mut res = dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), expected_result);
+	//
+	for _ in 0..(expected_result - 2) {
+		let _ = res.remove(0).result?;
+	}
+	Ok(res)
+}
+
+fn check_result(res: &mut Vec<Response>, expected: &str) -> Result<(), Error> {
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(expected);
 	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
 	Ok(())
 }
 
 #[tokio::test]
-async fn select_where_iterate_multi_index() -> Result<(), Error> {
-	test_select_where_iterate_multi_index(false).await
+async fn select_where_iterate_two_multi_index() -> Result<(), Error> {
+	let mut res = execute_test(&two_multi_index_query("", ""), 7).await?;
+	check_result(&mut res, TWO_MULTI_INDEX_RESULT)?;
+	check_result(&mut res, TWO_MULTI_INDEX_ITERATORS)?;
+	Ok(())
 }
 
 #[tokio::test]
-async fn select_where_iterate_multi_index_parallel() -> Result<(), Error> {
-	test_select_where_iterate_multi_index(true).await
+async fn select_where_iterate_two_multi_index_with_two_index() -> Result<(), Error> {
+	let mut res =
+		execute_test(&two_multi_index_query("WITH INDEX idx_genre,uniq_name", ""), 7).await?;
+	check_result(&mut res, TWO_MULTI_INDEX_RESULT)?;
+	check_result(&mut res, TWO_MULTI_INDEX_ITERATORS)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_two_no_index() -> Result<(), Error> {
+	let mut res = execute_test(&two_multi_index_query("WITH NOINDEX", ""), 7).await?;
+	check_result(&mut res, TWO_MULTI_INDEX_RESULT)?;
+	check_result(&mut res, TABLE_ITERATOR)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_two_multi_index_with_one_index() -> Result<(), Error> {
+	let mut res = execute_test(&two_multi_index_query("WITH INDEX idx_genre", ""), 7).await?;
+	check_result(&mut res, TWO_MULTI_INDEX_RESULT)?;
+	check_result(&mut res, TABLE_ITERATOR)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_three_multi_index() -> Result<(), Error> {
+	let mut res = execute_test(&three_multi_index_query("", ""), 10).await?;
+	check_result(&mut res, THREE_MULTI_INDEX_RESULT)?;
+	check_result(&mut res, THREE_MULTI_INDEX_ITERATORS)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_three_multi_index_with_all_index() -> Result<(), Error> {
+	let mut res =
+		execute_test(&three_multi_index_query("WITH INDEX uniq_name,idx_genre,ft_company", ""), 10)
+			.await?;
+	check_result(&mut res, THREE_MULTI_INDEX_RESULT)?;
+	check_result(&mut res, THREE_MULTI_INDEX_ITERATORS)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_three_multi_index_parallel() -> Result<(), Error> {
+	let mut res = execute_test(&three_multi_index_query("", "PARALLEL"), 10).await?;
+	check_result(&mut res, THREE_MULTI_INDEX_RESULT)?;
+	check_result(&mut res, THREE_MULTI_INDEX_ITERATORS)?;
+	Ok(())
 }

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -6,7 +6,7 @@ use surrealdb::err::Error;
 use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
-const TABLE_ITERATOR: &str = "[
+const TWO_TABLE_ITERATOR: &str = "[
 	{
 		detail: {
 			table: 'person'
@@ -16,6 +16,21 @@ const TABLE_ITERATOR: &str = "[
 	{
 		detail: {
 			count: 2
+		},
+		operation: 'Fetch'
+	}
+]";
+
+const THREE_TABLE_ITERATOR: &str = "[
+	{
+		detail: {
+			table: 'person'
+		},
+		operation: 'Iterate Table'
+	},
+	{
+		detail: {
+			count: 3
 		},
 		operation: 'Fetch'
 	}
@@ -181,7 +196,7 @@ async fn select_where_iterate_two_multi_index_with_two_index() -> Result<(), Err
 async fn select_where_iterate_two_no_index() -> Result<(), Error> {
 	let mut res = execute_test(&two_multi_index_query("WITH NOINDEX", ""), 7).await?;
 	check_result(&mut res, TWO_MULTI_INDEX_RESULT)?;
-	check_result(&mut res, TABLE_ITERATOR)?;
+	check_result(&mut res, TWO_TABLE_ITERATOR)?;
 	Ok(())
 }
 
@@ -189,7 +204,7 @@ async fn select_where_iterate_two_no_index() -> Result<(), Error> {
 async fn select_where_iterate_two_multi_index_with_one_index() -> Result<(), Error> {
 	let mut res = execute_test(&two_multi_index_query("WITH INDEX idx_genre", ""), 7).await?;
 	check_result(&mut res, TWO_MULTI_INDEX_RESULT)?;
-	check_result(&mut res, TABLE_ITERATOR)?;
+	check_result(&mut res, TWO_TABLE_ITERATOR)?;
 	Ok(())
 }
 
@@ -198,6 +213,27 @@ async fn select_where_iterate_three_multi_index() -> Result<(), Error> {
 	let mut res = execute_test(&three_multi_index_query("", ""), 10).await?;
 	check_result(&mut res, THREE_MULTI_INDEX_RESULT)?;
 	check_result(&mut res, THREE_MULTI_INDEX_ITERATORS)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_three_multi_index_with_one_index() -> Result<(), Error> {
+	let mut res = execute_test(&three_multi_index_query("WITH INDEX ft_company", ""), 10).await?;
+	check_result(
+		&mut res,
+		"[
+			{
+				name: 'Jaime'
+			},
+			{
+				name: 'Lizzie'
+			},
+			{
+				name: 'Tobie'
+			}
+		]",
+	)?;
+	check_result(&mut res, THREE_TABLE_ITERATOR)?;
 	Ok(())
 }
 

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -6,22 +6,186 @@ use surrealdb::err::Error;
 use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
-const TWO_TABLE_ITERATOR: &str = "[
-	{
-		detail: {
-			table: 'person'
-		},
-		operation: 'Iterate Table'
-	},
-	{
-		detail: {
-			count: 2
-		},
-		operation: 'Fetch'
-	}
-]";
+#[tokio::test]
+async fn select_where_iterate_three_multi_index() -> Result<(), Error> {
+	let mut res = execute_test(&three_multi_index_query("", ""), 12).await?;
+	check_result(&mut res, "[{ name: 'Jaime' }, { name: 'Tobie' }, { name: 'Lizzie' }]")?;
+	// OR results
+	check_result(&mut res, THREE_MULTI_INDEX_EXPLAIN)?;
+	// AND results
+	check_result(&mut res, "[{name: 'Jaime'}]")?;
+	check_result(&mut res, SINGLE_INDEX_FT_EXPLAIN)?;
+	Ok(())
+}
 
-const THREE_TABLE_ITERATOR: &str = "[
+#[tokio::test]
+async fn select_where_iterate_three_multi_index_parallel() -> Result<(), Error> {
+	let mut res = execute_test(&three_multi_index_query("", "PARALLEL"), 12).await?;
+	// OR results
+	check_result(&mut res, "[{ name: 'Jaime' }, { name: 'Tobie' }, { name: 'Lizzie' }]")?;
+	check_result(&mut res, THREE_MULTI_INDEX_EXPLAIN)?;
+	// AND results
+	check_result(&mut res, "[{name: 'Jaime'}]")?;
+	check_result(&mut res, SINGLE_INDEX_FT_EXPLAIN)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_three_multi_index_with_all_index() -> Result<(), Error> {
+	let mut res =
+		execute_test(&three_multi_index_query("WITH INDEX uniq_name,idx_genre,ft_company", ""), 12)
+			.await?;
+	// OR results
+	check_result(&mut res, "[{ name: 'Jaime' }, { name: 'Tobie' }, { name: 'Lizzie' }]")?;
+	check_result(&mut res, THREE_MULTI_INDEX_EXPLAIN)?;
+	// AND results
+	check_result(&mut res, "[{name: 'Jaime'}]")?;
+	check_result(&mut res, SINGLE_INDEX_FT_EXPLAIN)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_three_multi_index_with_one_ft_index() -> Result<(), Error> {
+	let mut res = execute_test(&three_multi_index_query("WITH INDEX ft_company", ""), 12).await?;
+	// OR results
+	check_result(&mut res, "[{ name: 'Jaime' }, { name: 'Lizzie' }, { name: 'Tobie' } ]")?;
+	check_result(&mut res, THREE_TABLE_EXPLAIN)?;
+	// AND results
+	check_result(&mut res, "[{name: 'Jaime'}]")?;
+	check_result(&mut res, SINGLE_INDEX_FT_EXPLAIN)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_three_multi_index_with_one_index() -> Result<(), Error> {
+	let mut res = execute_test(&three_multi_index_query("WITH INDEX uniq_name", ""), 12).await?;
+	// OR results
+	check_result(&mut res, "[{ name: 'Jaime' }, { name: 'Lizzie' }, { name: 'Tobie' } ]")?;
+	check_result(&mut res, THREE_TABLE_EXPLAIN)?;
+	// AND results
+	check_result(&mut res, "[{name: 'Jaime'}]")?;
+	check_result(&mut res, SINGLE_INDEX_UNIQ_EXPLAIN)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_two_multi_index() -> Result<(), Error> {
+	let mut res = execute_test(&two_multi_index_query("", ""), 9).await?;
+	// OR results
+	check_result(&mut res, "[{ name: 'Jaime' }, { name: 'Tobie' }]")?;
+	check_result(&mut res, TWO_MULTI_INDEX_EXPLAIN)?;
+	// AND results
+	check_result(&mut res, "[{name: 'Jaime'}]")?;
+	check_result(&mut res, SINGLE_INDEX_IDX_EXPLAIN)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_two_multi_index_with_one_index() -> Result<(), Error> {
+	let mut res = execute_test(&two_multi_index_query("WITH INDEX idx_genre", ""), 9).await?;
+	// OR results
+	check_result(&mut res, "[{ name: 'Jaime' }, { name: 'Tobie' }]")?;
+	check_result(&mut res, &table_explain(2))?;
+	// AND results
+	check_result(&mut res, "[{name: 'Jaime'}]")?;
+	check_result(&mut res, SINGLE_INDEX_IDX_EXPLAIN)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_two_multi_index_with_two_index() -> Result<(), Error> {
+	let mut res =
+		execute_test(&two_multi_index_query("WITH INDEX idx_genre,uniq_name", ""), 9).await?;
+	// OR results
+	check_result(&mut res, "[{ name: 'Jaime' }, { name: 'Tobie' }]")?;
+	check_result(&mut res, TWO_MULTI_INDEX_EXPLAIN)?;
+	// AND results
+	check_result(&mut res, "[{name: 'Jaime'}]")?;
+	check_result(&mut res, SINGLE_INDEX_IDX_EXPLAIN)?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_iterate_two_no_index() -> Result<(), Error> {
+	let mut res = execute_test(&two_multi_index_query("WITH NOINDEX", ""), 9).await?;
+	// OR results
+	check_result(&mut res, "[{ name: 'Jaime' }, { name: 'Tobie' }]")?;
+	check_result(&mut res, &table_explain(2))?;
+	// AND results
+	check_result(&mut res, "[{name: 'Jaime'}]")?;
+	check_result(&mut res, &table_explain(1))?;
+	Ok(())
+}
+
+async fn execute_test(sql: &str, expected_result: usize) -> Result<Vec<Response>, Error> {
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let mut res = dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), expected_result);
+	// Check that the setup is ok
+	for _ in 0..(expected_result - 4) {
+		let _ = res.remove(0).result?;
+	}
+	Ok(res)
+}
+
+fn check_result(res: &mut Vec<Response>, expected: &str) -> Result<(), Error> {
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(expected);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	Ok(())
+}
+
+fn two_multi_index_query(with: &str, parallel: &str) -> String {
+	format!(
+		"CREATE person:tobie SET name = 'Tobie', genre='m', company='SurrealDB';
+		CREATE person:jaime SET name = 'Jaime', genre='m', company='SurrealDB';
+		CREATE person:lizzie SET name = 'Lizzie', genre='f', company='SurrealDB';
+		DEFINE INDEX uniq_name ON TABLE person COLUMNS name UNIQUE;
+		DEFINE INDEX idx_genre ON TABLE person COLUMNS genre;
+		SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' {parallel};
+	    SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' {parallel} EXPLAIN FULL;
+		SELECT name FROM person {with} WHERE name = 'Jaime' AND genre = 'm' {parallel};
+	    SELECT name FROM person {with} WHERE name = 'Jaime' AND genre = 'm' {parallel} EXPLAIN FULL;"
+	)
+}
+
+fn three_multi_index_query(with: &str, parallel: &str) -> String {
+	format!("
+		CREATE person:tobie SET name = 'Tobie', genre='m', company='SurrealDB';
+		CREATE person:jaime SET name = 'Jaime', genre='m', company='SurrealDB';
+		CREATE person:lizzie SET name = 'Lizzie', genre='f', company='SurrealDB';
+		CREATE person:neytiry SET name = 'Neytiri', genre='f', company='Metkayina';
+		DEFINE ANALYZER simple TOKENIZERS blank,class FILTERS lowercase;
+		DEFINE INDEX ft_company ON person FIELDS company SEARCH ANALYZER simple BM25;
+		DEFINE INDEX uniq_name ON TABLE person COLUMNS name UNIQUE;
+		DEFINE INDEX idx_genre ON TABLE person COLUMNS genre;
+		SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' OR company @@ 'surrealdb' {parallel};
+	    SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' OR company @@ 'surrealdb' {parallel} EXPLAIN FULL;
+		SELECT name FROM person {with} WHERE name = 'Jaime' AND genre = 'm' AND company @@ 'surrealdb' {parallel};
+	    SELECT name FROM person {with} WHERE name = 'Jaime' AND genre = 'm' AND company @@ 'surrealdb' {parallel} EXPLAIN FULL;")
+}
+
+fn table_explain(fetch_count: usize) -> String {
+	format!(
+		"[
+			{{
+				detail: {{
+					table: 'person'
+				}},
+				operation: 'Iterate Table'
+			}},
+			{{
+				detail: {{
+					count: {fetch_count}
+				}},
+				operation: 'Fetch'
+			}}
+		]"
+	)
+}
+
+const THREE_TABLE_EXPLAIN: &str = "[
 	{
 		detail: {
 			table: 'person'
@@ -36,33 +200,7 @@ const THREE_TABLE_ITERATOR: &str = "[
 	}
 ]";
 
-fn three_multi_index_query(with: &str, parallel: &str) -> String {
-	format!("
-		CREATE person:tobie SET name = 'Tobie', genre='m', company='SurrealDB';
-		CREATE person:jaime SET name = 'Jaime', genre='m', company='SurrealDB';
-		CREATE person:lizzie SET name = 'Lizzie', genre='f', company='SurrealDB';
-		CREATE person:neytiry SET name = 'Neytiri', genre='f', company='Metkayina';
-		DEFINE ANALYZER simple TOKENIZERS blank,class FILTERS lowercase;
-		DEFINE INDEX ft_company ON person FIELDS company SEARCH ANALYZER simple BM25;
-		DEFINE INDEX uniq_name ON TABLE person COLUMNS name UNIQUE;
-		DEFINE INDEX idx_genre ON TABLE person COLUMNS genre;
-		SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' OR company @@ 'surrealdb' {parallel};
-	    SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' OR company @@ 'surrealdb' {parallel} EXPLAIN FULL;")
-}
-
-const THREE_MULTI_INDEX_RESULT: &str = "[
-			{
-				name: 'Jaime'
-			},
-            {
-				name: 'Tobie'
-			},
-			{
-				name: 'Lizzie'
-			}
-		]";
-
-const THREE_MULTI_INDEX_ITERATORS: &str = "[
+const THREE_MULTI_INDEX_EXPLAIN: &str = "[
 				{
 					detail: {
 						plan: {
@@ -104,28 +242,67 @@ const THREE_MULTI_INDEX_ITERATORS: &str = "[
 				}
 			]";
 
-fn two_multi_index_query(with: &str, parallel: &str) -> String {
-	format!(
-		"CREATE person:tobie SET name = 'Tobie', genre='m', company='SurrealDB';
-		CREATE person:jaime SET name = 'Jaime', genre='m', company='SurrealDB';
-		CREATE person:lizzie SET name = 'Lizzie', genre='f', company='SurrealDB';
-		DEFINE INDEX uniq_name ON TABLE person COLUMNS name UNIQUE;
-		DEFINE INDEX idx_genre ON TABLE person COLUMNS genre;
-		SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' {parallel};
-	    SELECT name FROM person {with} WHERE name = 'Jaime' OR genre = 'm' {parallel} EXPLAIN FULL;"
-	)
-}
+const SINGLE_INDEX_FT_EXPLAIN: &str = "[
+				{
+					detail: {
+						plan: {
+							index: 'ft_company',
+							operator: '@@',
+							value: 'surrealdb'
+						},
+						table: 'person',
+					},
+					operation: 'Iterate Index'
+				},
+				{
+					detail: {
+						count: 1
+					},
+					operation: 'Fetch'
+				}
+			]";
 
-const TWO_MULTI_INDEX_RESULT: &str = "[
-			{
-				name: 'Jaime'
+const SINGLE_INDEX_UNIQ_EXPLAIN: &str = "[
+				{
+					detail: {
+						plan: {
+							index: 'uniq_name',
+							operator: '=',
+							value: 'Jaime'
+						},
+						table: 'person',
+					},
+					operation: 'Iterate Index'
+				},
+				{
+					detail: {
+						count: 1
+					},
+					operation: 'Fetch'
+				}
+			]";
+
+const SINGLE_INDEX_IDX_EXPLAIN: &str = "[
+	{
+		detail: {
+			plan: {
+				index: 'idx_genre',
+				operator: '=',
+				value: 'm'
 			},
-            {
-				name: 'Tobie'
-			}
-		]";
+			table: 'person'
+		},
+		operation: 'Iterate Index'
+	},
+	{
+		detail: {
+			count: 1
+		},
+		operation: 'Fetch'
+	}
+]";
 
-const TWO_MULTI_INDEX_ITERATORS: &str = "[
+const TWO_MULTI_INDEX_EXPLAIN: &str = "[
 				{
 					detail: {
 						plan: {
@@ -155,102 +332,3 @@ const TWO_MULTI_INDEX_ITERATORS: &str = "[
 					operation: 'Fetch'
 				}
 			]";
-
-async fn execute_test(sql: &str, expected_result: usize) -> Result<Vec<Response>, Error> {
-	let dbs = Datastore::new("memory").await?;
-	let ses = Session::for_kv().with_ns("test").with_db("test");
-	let mut res = dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), expected_result);
-	//
-	for _ in 0..(expected_result - 2) {
-		let _ = res.remove(0).result?;
-	}
-	Ok(res)
-}
-
-fn check_result(res: &mut Vec<Response>, expected: &str) -> Result<(), Error> {
-	let tmp = res.remove(0).result?;
-	let val = Value::parse(expected);
-	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
-	Ok(())
-}
-
-#[tokio::test]
-async fn select_where_iterate_two_multi_index() -> Result<(), Error> {
-	let mut res = execute_test(&two_multi_index_query("", ""), 7).await?;
-	check_result(&mut res, TWO_MULTI_INDEX_RESULT)?;
-	check_result(&mut res, TWO_MULTI_INDEX_ITERATORS)?;
-	Ok(())
-}
-
-#[tokio::test]
-async fn select_where_iterate_two_multi_index_with_two_index() -> Result<(), Error> {
-	let mut res =
-		execute_test(&two_multi_index_query("WITH INDEX idx_genre,uniq_name", ""), 7).await?;
-	check_result(&mut res, TWO_MULTI_INDEX_RESULT)?;
-	check_result(&mut res, TWO_MULTI_INDEX_ITERATORS)?;
-	Ok(())
-}
-
-#[tokio::test]
-async fn select_where_iterate_two_no_index() -> Result<(), Error> {
-	let mut res = execute_test(&two_multi_index_query("WITH NOINDEX", ""), 7).await?;
-	check_result(&mut res, TWO_MULTI_INDEX_RESULT)?;
-	check_result(&mut res, TWO_TABLE_ITERATOR)?;
-	Ok(())
-}
-
-#[tokio::test]
-async fn select_where_iterate_two_multi_index_with_one_index() -> Result<(), Error> {
-	let mut res = execute_test(&two_multi_index_query("WITH INDEX idx_genre", ""), 7).await?;
-	check_result(&mut res, TWO_MULTI_INDEX_RESULT)?;
-	check_result(&mut res, TWO_TABLE_ITERATOR)?;
-	Ok(())
-}
-
-#[tokio::test]
-async fn select_where_iterate_three_multi_index() -> Result<(), Error> {
-	let mut res = execute_test(&three_multi_index_query("", ""), 10).await?;
-	check_result(&mut res, THREE_MULTI_INDEX_RESULT)?;
-	check_result(&mut res, THREE_MULTI_INDEX_ITERATORS)?;
-	Ok(())
-}
-
-#[tokio::test]
-async fn select_where_iterate_three_multi_index_with_one_index() -> Result<(), Error> {
-	let mut res = execute_test(&three_multi_index_query("WITH INDEX ft_company", ""), 10).await?;
-	check_result(
-		&mut res,
-		"[
-			{
-				name: 'Jaime'
-			},
-			{
-				name: 'Lizzie'
-			},
-			{
-				name: 'Tobie'
-			}
-		]",
-	)?;
-	check_result(&mut res, THREE_TABLE_ITERATOR)?;
-	Ok(())
-}
-
-#[tokio::test]
-async fn select_where_iterate_three_multi_index_with_all_index() -> Result<(), Error> {
-	let mut res =
-		execute_test(&three_multi_index_query("WITH INDEX uniq_name,idx_genre,ft_company", ""), 10)
-			.await?;
-	check_result(&mut res, THREE_MULTI_INDEX_RESULT)?;
-	check_result(&mut res, THREE_MULTI_INDEX_ITERATORS)?;
-	Ok(())
-}
-
-#[tokio::test]
-async fn select_where_iterate_three_multi_index_parallel() -> Result<(), Error> {
-	let mut res = execute_test(&three_multi_index_query("", "PARALLEL"), 10).await?;
-	check_result(&mut res, THREE_MULTI_INDEX_RESULT)?;
-	check_result(&mut res, THREE_MULTI_INDEX_ITERATORS)?;
-	Ok(())
-}


### PR DESCRIPTION
## What is the motivation?

The query planner can now replace the standard table iterator with one or several index iterators depending on the query. However, there may be circumstances where we want more control over these potential optimizations.

The cardinality of an index can be high, potentially even equal to the number of records in the table. The sum of the records iterated by several indexes may end up being larger than the number of records obtained by iterating over the table. In such cases, if there are different index possibilities, the most probable optimal choice would be to use the index with the lowest cardinality.

## What does this change do?

This PR introduces the clause WITH to the SELECT statement. So it is possible to influence the query planner so it uses the suggested indexes. If it is not possible, then the execution plan falls back to the Table Iterator.

`WITH NOINDEX` forces the usage of the table iterator:

```sql
SELECT name FROM person WITH NOINDEX WHERE genre = 'm' OR company @@ 'surrealdb'
```

`WITH INDEX [index_name][,index_name]` forces the query planner to use the specified index(es):

```sql
SELECT name FROM person WITH INDEX idx_name WHERE name='jaime' AND genre = 'm'
```


## What is your testing strategy?

New tests specifically targeting the planner have been implemented.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
