### PR TITLE
feat: Change Feeds Enabling/Writing/Reading

### DIFF
--- a/lib/src/cf/gc.rs
+++ b/lib/src/cf/gc.rs
@@ -39,8 +39,8 @@ pub async fn gc_db(
 	watermark: u64,
 	limit: Option<u32>,
 ) -> Result<(), Error> {
-	let beg: Vec<u8> = change::ts_prefix(ns, db, vs::u64_to_versionstamp(0));
-	let end = change::ts_prefix(ns, db, vs::u64_to_versionstamp(watermark));
+	let beg: Vec<u8> = change::prefix_ts(ns, db, vs::u64_to_versionstamp(0));
+	let end = change::prefix_ts(ns, db, vs::u64_to_versionstamp(watermark));
 
 	let limit = limit.unwrap_or(100);
 

--- a/lib/src/cf/gc.rs
+++ b/lib/src/cf/gc.rs
@@ -1,0 +1,50 @@
+use crate::err::Error;
+use crate::key::change;
+use crate::kvs::Transaction;
+use crate::vs;
+use std::str;
+
+// gc_all deletes all change feed entries that are older than the given watermark.
+#[allow(unused)]
+pub async fn gc_all(tx: &mut Transaction, watermark: u64, limit: Option<u32>) -> Result<(), Error> {
+	let nses = tx.all_ns().await?;
+	let nses = nses.as_ref();
+	for ns in nses {
+		gc_ns(tx, ns.name.as_str(), watermark, limit).await?;
+	}
+	Ok(())
+}
+
+// gc_ns deletes all change feed entries in the given namespace that are older than the given watermark.
+#[allow(unused)]
+pub async fn gc_ns(
+	tx: &mut Transaction,
+	ns: &str,
+	watermark: u64,
+	limit: Option<u32>,
+) -> Result<(), Error> {
+	let dbs = tx.all_db(ns).await?;
+	let dbs = dbs.as_ref();
+	for db in dbs {
+		gc_db(tx, ns, db.name.as_str(), watermark, limit).await?;
+	}
+	Ok(())
+}
+
+// gc_db deletes all change feed entries in the given database that are older than the given watermark.
+pub async fn gc_db(
+	tx: &mut Transaction,
+	ns: &str,
+	db: &str,
+	watermark: u64,
+	limit: Option<u32>,
+) -> Result<(), Error> {
+	let beg: Vec<u8> = change::ts_prefix(ns, db, vs::u64_to_versionstamp(0));
+	let end = change::ts_prefix(ns, db, vs::u64_to_versionstamp(watermark));
+
+	let limit = limit.unwrap_or(100);
+
+	tx.delr(beg..end, limit).await?;
+
+	Ok(())
+}

--- a/lib/src/cf/mod.rs
+++ b/lib/src/cf/mod.rs
@@ -1,1 +1,9 @@
+pub(crate) mod gc;
 pub(crate) mod mutations;
+pub(crate) mod reader;
+pub(crate) mod writer;
+
+pub use self::gc::*;
+pub use self::mutations::*;
+pub use self::reader::read;
+pub use self::writer::Writer;

--- a/lib/src/cf/reader.rs
+++ b/lib/src/cf/reader.rs
@@ -25,10 +25,10 @@ pub async fn read(
 	let seq = database::vs::new(ns, db);
 
 	let beg = match start {
-		Some(x) => change::ts_prefix(ns, db, vs::u64_to_versionstamp(x)),
+		Some(x) => change::prefix_ts(ns, db, vs::u64_to_versionstamp(x)),
 		None => {
 			let ts = tx.get_timestamp(seq, false).await?;
-			change::ts_prefix(ns, db, ts)
+			change::prefix_ts(ns, db, ts)
 		} // None => dc::prefix(ns, db),
 	};
 	let end = change::suffix(ns, db);

--- a/lib/src/cf/reader.rs
+++ b/lib/src/cf/reader.rs
@@ -1,0 +1,96 @@
+use crate::cf::{ChangeSet, DatabaseMutation, TableMutations};
+use crate::err::Error;
+use crate::key::change;
+use crate::key::database;
+use crate::kvs::Transaction;
+use crate::vs;
+
+use std::ascii::escape_default;
+use std::str;
+
+fn show(bs: &[u8]) -> String {
+	let mut visible = String::new();
+	for &b in bs {
+		let part: Vec<u8> = escape_default(b).collect();
+		visible.push_str(str::from_utf8(&part).unwrap());
+	}
+	visible
+}
+
+// Reads the change feed for a specific database or a table,
+// starting from a specific versionstamp.
+//
+// The limit parameter is the maximum number of change sets to return.
+// If the limit is not specified, the default is 100.
+//
+// You can use this to read the change feed in chunks.
+// The second call would start from the last versionstamp + 1 of the first call.
+pub async fn read(
+	tx: &mut Transaction,
+	ns: &str,
+	db: &str,
+	tb: Option<&str>,
+	start: Option<u64>,
+	limit: Option<u32>,
+) -> Result<Vec<ChangeSet>, Error> {
+	// Get the current timestamp
+	let seq = database::vs::new(ns, db);
+
+	let beg = match start {
+		Some(x) => change::ts_prefix(ns, db, vs::u64_to_versionstamp(x)),
+		None => {
+			let ts = tx.get_timestamp(seq, false).await?;
+			change::ts_prefix(ns, db, ts)
+		} // None => dc::prefix(ns, db),
+	};
+	let end = change::suffix(ns, db);
+
+	let limit = limit.unwrap_or(100);
+
+	let _x = tx.scan(beg..end, limit).await?;
+
+	let mut vs: Option<[u8; 10]> = None;
+	let mut buf: Vec<TableMutations> = Vec::new();
+
+	let mut r = Vec::<ChangeSet>::new();
+	// iterate over _x and put decoded elements to r
+	for (k, v) in _x {
+		println!("read: k={}", show(k.as_slice()));
+
+		let dec = crate::key::change::Cf::decode(&k).unwrap();
+
+		if let Some(tb) = tb {
+			if dec.tb != tb {
+				continue;
+			}
+		}
+
+		let _tb = dec.tb;
+		let ts = dec.vs;
+
+		// Decode the byte array into a vector of operations
+		let tb_muts: TableMutations = v.into();
+
+		match vs {
+			Some(x) => {
+				if ts != x {
+					let db_mut = DatabaseMutation(buf);
+					r.push(ChangeSet(x, db_mut));
+					buf = Vec::new();
+					vs = Some(ts)
+				}
+			}
+			None => {
+				vs = Some(ts);
+			}
+		}
+		buf.push(tb_muts);
+	}
+
+	if !buf.is_empty() {
+		let db_mut = DatabaseMutation(buf);
+		r.push(ChangeSet(vs.unwrap(), db_mut));
+	}
+
+	Ok(r)
+}

--- a/lib/src/cf/reader.rs
+++ b/lib/src/cf/reader.rs
@@ -5,18 +5,6 @@ use crate::key::database;
 use crate::kvs::Transaction;
 use crate::vs;
 
-use std::ascii::escape_default;
-use std::str;
-
-fn show(bs: &[u8]) -> String {
-	let mut visible = String::new();
-	for &b in bs {
-		let part: Vec<u8> = escape_default(b).collect();
-		visible.push_str(str::from_utf8(&part).unwrap());
-	}
-	visible
-}
-
 // Reads the change feed for a specific database or a table,
 // starting from a specific versionstamp.
 //
@@ -55,7 +43,7 @@ pub async fn read(
 	let mut r = Vec::<ChangeSet>::new();
 	// iterate over _x and put decoded elements to r
 	for (k, v) in _x {
-		println!("read: k={}", show(k.as_slice()));
+		trace!("read change feed; {k:?}");
 
 		let dec = crate::key::change::Cf::decode(&k).unwrap();
 

--- a/lib/src/cf/writer.rs
+++ b/lib/src/cf/writer.rs
@@ -96,8 +96,6 @@ impl Writer {
 	}
 }
 
-// fn tb_mutations(ts: u64, tb: &str, changes: Vec<(ID, Patch))
-
 #[cfg(test)]
 mod tests {
 	use std::borrow::Cow;

--- a/lib/src/cf/writer.rs
+++ b/lib/src/cf/writer.rs
@@ -1,0 +1,247 @@
+use crate::cf::{TableMutation, TableMutations};
+use crate::kvs::Key;
+use crate::sql::ident::Ident;
+use crate::sql::thing::Thing;
+use crate::sql::value::Value;
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+// PreparedWrite is a tuple of (versionstamp key, key prefix, key suffix, serialized table mutations).
+// The versionstamp key is the key that contains the current versionstamp and might be used by the
+// specific transaction implementation to make the versionstamp unique and monotonic.
+// The key prefix and key suffix are used to construct the key for the table mutations.
+// The consumer of this library should write KV pairs with the following format:
+// key = key_prefix + versionstamp + key_suffix
+// value = serialized table mutations
+type PreparedWrite = (Vec<u8>, Vec<u8>, Vec<u8>, crate::kvs::Val);
+
+pub struct Writer {
+	buf: Buffer,
+}
+
+pub struct Buffer {
+	pub b: HashMap<ChangeKey, TableMutations>,
+}
+
+#[derive(Hash, Eq, PartialEq, Debug)]
+pub struct ChangeKey {
+	pub ns: String,
+	pub db: String,
+	pub tb: String,
+}
+
+impl Buffer {
+	pub fn new() -> Self {
+		Self {
+			b: HashMap::new(),
+		}
+	}
+
+	pub fn push(&mut self, ns: String, db: String, tb: String, m: TableMutation) {
+		let tb2 = tb.clone();
+		let ms = self
+			.b
+			.entry(ChangeKey {
+				ns,
+				db,
+				tb,
+			})
+			.or_insert(TableMutations::new(tb2));
+		ms.1.push(m);
+	}
+}
+
+// Writer is a helper for writing table mutations to a transaction.
+impl Writer {
+	pub(crate) fn new() -> Self {
+		Self {
+			buf: Buffer::new(),
+		}
+	}
+
+	pub(crate) fn update(&mut self, ns: &str, db: &str, tb: Ident, id: Thing, v: Cow<'_, Value>) {
+		if v.is_some() {
+			self.buf.push(
+				ns.to_string(),
+				db.to_string(),
+				tb.0,
+				TableMutation::Set(id, v.into_owned()),
+			);
+		} else {
+			self.buf.push(ns.to_string(), db.to_string(), tb.0, TableMutation::Del(id));
+		}
+	}
+
+	// get returns all the mutations buffered for this transaction,
+	// that are to be written onto the key composed of the specified prefix + the current timestamp + the specified suffix.
+	pub(crate) fn get(&self) -> Vec<PreparedWrite> {
+		let mut r = Vec::<(Vec<u8>, Vec<u8>, Vec<u8>, crate::kvs::Val)>::new();
+		// Get the current timestamp
+		for (
+			ChangeKey {
+				ns,
+				db,
+				tb,
+			},
+			mutations,
+		) in self.buf.b.iter()
+		{
+			let ts_key: Key = crate::key::database::vs::new(ns, db).into();
+			let tc_key_prefix: Key = crate::key::change::versionstamped_key_prefix(ns, db);
+			let tc_key_suffix: Key = crate::key::change::versionstamped_key_suffix(tb.as_str());
+
+			r.push((ts_key, tc_key_prefix, tc_key_suffix, mutations.into()))
+		}
+		r
+	}
+}
+
+// fn tb_mutations(ts: u64, tb: &str, changes: Vec<(ID, Patch))
+
+#[cfg(test)]
+mod tests {
+	use std::borrow::Cow;
+	use std::time::Duration;
+
+	use crate::cf::{ChangeSet, DatabaseMutation, TableMutation, TableMutations};
+	use crate::kvs::Datastore;
+	use crate::sql::changefeed::ChangeFeed;
+	use crate::sql::id::Id;
+	use crate::sql::statements::DefineTableStatement;
+	use crate::sql::thing::Thing;
+	use crate::sql::value::Value;
+	use crate::vs;
+
+	#[tokio::test]
+	async fn test_changefeed_read_write() {
+		let ns = "myns";
+		let db = "mydb";
+		let tb = super::Ident("mytb".to_string());
+		let mut dtb = DefineTableStatement::default();
+		dtb.name = tb.clone();
+		dtb.changefeed = Some(ChangeFeed {
+			expiry: Duration::from_secs(0),
+		});
+
+		let ds = Datastore::new("memory").await.unwrap();
+
+		let mut tx1 = ds.transaction(true, false).await.unwrap();
+		let thing_a = Thing {
+			tb: tb.clone().0,
+			id: Id::String("A".to_string()),
+		};
+		let value_a: super::Value = "a".into();
+		tx1.record_change(ns, db, &dtb, &thing_a, Cow::Borrowed(&value_a));
+		tx1.complete_changes(true).await.unwrap();
+		let _r1 = tx1.commit().await.unwrap();
+
+		let mut tx2 = ds.transaction(true, false).await.unwrap();
+		let thing_c = Thing {
+			tb: tb.clone().0,
+			id: Id::String("C".to_string()),
+		};
+		let value_c: Value = "c".into();
+		tx2.record_change(ns, db, &dtb, &thing_c, Cow::Borrowed(&value_c));
+		tx2.complete_changes(true).await.unwrap();
+		let _r2 = tx2.commit().await.unwrap();
+
+		let x = ds.transaction(true, false).await;
+		let mut tx3 = x.unwrap();
+		let thing_b = Thing {
+			tb: tb.clone().0,
+			id: Id::String("B".to_string()),
+		};
+		let value_b: Value = "b".into();
+		tx3.record_change(ns, db, &dtb, &thing_b, Cow::Borrowed(&value_b));
+		let thing_c2 = Thing {
+			tb: tb.clone().0,
+			id: Id::String("C".to_string()),
+		};
+		let value_c2: Value = "c2".into();
+		tx3.record_change(ns, db, &dtb, &thing_c2, Cow::Borrowed(&value_c2));
+		tx3.complete_changes(true).await.unwrap();
+		tx3.commit().await.unwrap();
+
+		// Note that we committed tx1, tx2, and tx3 in this order so far.
+		// Therfore, the change feeds should give us
+		// the mutations in the commit order, which is tx1, tx3, then tx2.
+
+		let start: u64 = 0;
+
+		let mut tx4 = ds.transaction(true, false).await.unwrap();
+		let tb = tb.clone();
+		let tb = Some(tb.0.as_ref());
+		let r = crate::cf::read(&mut tx4, ns, db, tb, Some(start), Some(10)).await.unwrap();
+		tx4.commit().await.unwrap();
+
+		let mut want: Vec<ChangeSet> = Vec::new();
+		want.push(ChangeSet(
+			vs::u64_to_versionstamp(1),
+			DatabaseMutation(vec![TableMutations(
+				"mytb".to_string(),
+				vec![TableMutation::Set(
+					Thing::from(("mytb".to_string(), "A".to_string())),
+					Value::from("a"),
+				)],
+			)]),
+		));
+		want.push(ChangeSet(
+			vs::u64_to_versionstamp(2),
+			DatabaseMutation(vec![TableMutations(
+				"mytb".to_string(),
+				vec![TableMutation::Set(
+					Thing::from(("mytb".to_string(), "C".to_string())),
+					Value::from("c"),
+				)],
+			)]),
+		));
+		want.push(ChangeSet(
+			vs::u64_to_versionstamp(3),
+			DatabaseMutation(vec![TableMutations(
+				"mytb".to_string(),
+				vec![
+					TableMutation::Set(
+						Thing::from(("mytb".to_string(), "B".to_string())),
+						Value::from("b"),
+					),
+					TableMutation::Set(
+						Thing::from(("mytb".to_string(), "C".to_string())),
+						Value::from("c2"),
+					),
+				],
+			)]),
+		));
+
+		assert_eq!(r, want);
+
+		let mut tx5 = ds.transaction(true, false).await.unwrap();
+		// gc_all needs to be committed before we can read the changes
+		crate::cf::gc_db(&mut tx5, ns, db, 3, Some(10)).await.unwrap();
+		// We now commit tx5, which should persist the gc_all resullts
+		tx5.commit().await.unwrap();
+
+		// Now we should see the gc_all results
+		let mut tx6 = ds.transaction(true, false).await.unwrap();
+		let r = crate::cf::read(&mut tx6, ns, db, tb, Some(start), Some(10)).await.unwrap();
+		tx6.commit().await.unwrap();
+
+		let mut want: Vec<ChangeSet> = Vec::new();
+		want.push(ChangeSet(
+			vs::u64_to_versionstamp(3),
+			DatabaseMutation(vec![TableMutations(
+				"mytb".to_string(),
+				vec![
+					TableMutation::Set(
+						Thing::from(("mytb".to_string(), "B".to_string())),
+						Value::from("b"),
+					),
+					TableMutation::Set(
+						Thing::from(("mytb".to_string(), "C".to_string())),
+						Value::from("c2"),
+					),
+				],
+			)]),
+		));
+		assert_eq!(r, want);
+	}
+}

--- a/lib/src/doc/changefeeds.rs
+++ b/lib/src/doc/changefeeds.rs
@@ -21,7 +21,7 @@ impl<'a> Document<'a> {
 		let _ = self.id.as_ref().unwrap();
 		let ns = opt.ns();
 		let db = opt.db();
-		let tb = self.tb(opt, &txn).await?;
+		let tb = self.tb(opt, txn).await?;
 		let tb = tb.as_ref();
 		if tb.changefeed.is_some() {
 			// Clone transaction

--- a/lib/src/doc/changefeeds.rs
+++ b/lib/src/doc/changefeeds.rs
@@ -1,0 +1,38 @@
+use crate::ctx::Context;
+use crate::dbs::Options;
+use crate::dbs::Statement;
+use crate::dbs::Transaction;
+use crate::doc::Document;
+use crate::err::Error;
+
+impl<'a> Document<'a> {
+	pub async fn changefeeds(
+		&self,
+		_ctx: &Context<'_>,
+		opt: &Options,
+		txn: &Transaction,
+		_stm: &Statement<'_>,
+	) -> Result<(), Error> {
+		// Check if forced
+		if !opt.force && !self.changed() {
+			return Ok(());
+		}
+		// Get the record id
+		let _ = self.id.as_ref().unwrap();
+		let ns = opt.ns();
+		let db = opt.db();
+		let tb = self.tb(opt, &txn).await?;
+		let tb = tb.as_ref();
+		if tb.changefeed.is_some() {
+			// Clone transaction
+			let txn = txn.clone();
+			let mut txn = txn.lock().await;
+
+			let id = &(*self.id.as_ref().unwrap()).clone();
+			// Create the changefeed entry
+			txn.record_change(ns, db, tb, id, self.current.doc.clone());
+		}
+		// Carry on
+		Ok(())
+	}
+}

--- a/lib/src/doc/create.rs
+++ b/lib/src/doc/create.rs
@@ -33,6 +33,8 @@ impl<'a> Document<'a> {
 		self.table(ctx, opt, txn, stm).await?;
 		// Run lives queries
 		self.lives(ctx, opt, txn, stm).await?;
+		// Run change feeds queries
+		self.changefeeds(ctx, opt, txn, stm).await?;
 		// Run event queries
 		self.event(ctx, opt, txn, stm).await?;
 		// Yield document

--- a/lib/src/doc/delete.rs
+++ b/lib/src/doc/delete.rs
@@ -27,6 +27,8 @@ impl<'a> Document<'a> {
 		self.table(ctx, opt, txn, stm).await?;
 		// Run lives queries
 		self.lives(ctx, opt, txn, stm).await?;
+		// Run change feeds queries
+		self.changefeeds(ctx, opt, txn, stm).await?;
 		// Run event queries
 		self.event(ctx, opt, txn, stm).await?;
 		// Yield document

--- a/lib/src/doc/insert.rs
+++ b/lib/src/doc/insert.rs
@@ -37,6 +37,8 @@ impl<'a> Document<'a> {
 				self.table(ctx, opt, txn, stm).await?;
 				// Run lives queries
 				self.lives(ctx, opt, txn, stm).await?;
+				// Run change feeds queries
+				self.changefeeds(ctx, opt, txn, stm).await?;
 				// Run event queries
 				self.event(ctx, opt, txn, stm).await?;
 				// Yield document
@@ -64,6 +66,8 @@ impl<'a> Document<'a> {
 				self.table(ctx, opt, txn, stm).await?;
 				// Run lives queries
 				self.lives(ctx, opt, txn, stm).await?;
+				// Run change feeds queries
+				self.changefeeds(ctx, opt, txn, stm).await?;
 				// Run event queries
 				self.event(ctx, opt, txn, stm).await?;
 				// Yield document

--- a/lib/src/doc/mod.rs
+++ b/lib/src/doc/mod.rs
@@ -20,6 +20,7 @@ mod update; // Processes a UPDATE statement for this document
 
 mod allow; // Checks whether the query can access this document
 mod alter; // Modifies and updates the fields in this document
+mod changefeeds; // Processes any change feeds relevant for this document
 mod check; // Checks whether the WHERE clauses matches this document
 mod clean; // Ensures records adhere to the table schema
 mod edges; // Attempts to store the edge data for this document

--- a/lib/src/doc/update.rs
+++ b/lib/src/doc/update.rs
@@ -35,6 +35,8 @@ impl<'a> Document<'a> {
 		self.table(ctx, opt, txn, stm).await?;
 		// Run lives queries
 		self.lives(ctx, opt, txn, stm).await?;
+		// Run change feeds queries
+		self.changefeeds(ctx, opt, txn, stm).await?;
 		// Run event queries
 		self.event(ctx, opt, txn, stm).await?;
 		// Yield document

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -1,6 +1,7 @@
 use crate::idx::ft::MatchRef;
 use crate::sql::idiom::Idiom;
 use crate::sql::value::Value;
+use crate::vs::Error as VersionstampError;
 use base64_lib::DecodeError as Base64Error;
 use bincode::Error as BincodeError;
 use bung::encode::Error as SerdeError;
@@ -530,6 +531,9 @@ pub enum Error {
 	/// Unimplemented functionality
 	#[error("Unimplemented functionality: {0}")]
 	Unimplemented(String),
+
+	#[error("Versionstamp in key is corrupted: {0}")]
+	CorruptedVersionstampInKey(#[from] VersionstampError),
 }
 
 impl From<Error> for String {

--- a/lib/src/key/change/mod.rs
+++ b/lib/src/key/change/mod.rs
@@ -47,7 +47,7 @@ pub fn versionstamped_key_suffix(tb: &str) -> Vec<u8> {
 /// Returns the prefix for the whole database change feeds since the
 /// specified versionstamp.
 #[allow(unused)]
-pub fn ts_prefix(ns: &str, db: &str, vs: vs::Versionstamp) -> Vec<u8> {
+pub fn prefix_ts(ns: &str, db: &str, vs: vs::Versionstamp) -> Vec<u8> {
 	let mut k = crate::key::database::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'#']);
 	k.extend_from_slice(&vs);

--- a/lib/src/key/change/mod.rs
+++ b/lib/src/key/change/mod.rs
@@ -15,8 +15,6 @@ pub struct Cf<'a> {
 	_b: u8,
 	pub db: &'a str,
 	_d: u8,
-	_e: u8,
-	_f: u8,
 	// vs is the versionstamp of the change feed entry that is encoded in big-endian.
 	// Use the to_u64_be function to convert it to a u128.
 	pub vs: [u8; 10],
@@ -60,7 +58,7 @@ pub fn ts_prefix(ns: &str, db: &str, vs: vs::Versionstamp) -> Vec<u8> {
 #[allow(unused)]
 pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
 	let mut k = crate::key::database::all::new(ns, db).encode().unwrap();
-	k.extend_from_slice(&[b'#', 0x00]);
+	k.extend_from_slice(&[b'#']);
 	k
 }
 
@@ -80,9 +78,7 @@ impl<'a> Cf<'a> {
 			ns,
 			_b: b'*',
 			db,
-			_d: b'!',
-			_e: b'c',
-			_f: b'f',
+			_d: b'#',
 			vs,
 			_c: b'*',
 			tb,

--- a/lib/src/key/database/vs.rs
+++ b/lib/src/key/database/vs.rs
@@ -10,7 +10,9 @@ pub struct Vs<'a> {
 	pub ns: &'a str,
 	_b: u8,
 	pub db: &'a str,
+	_c: u8,
 	_d: u8,
+	_e: u8,
 }
 
 #[allow(unused)]
@@ -26,7 +28,9 @@ impl<'a> Vs<'a> {
 			ns,
 			_b: b'*',
 			db,
-			_d: b'*',
+			_c: b'!',
+			_d: b'v',
+			_e: b's',
 		}
 	}
 }

--- a/lib/src/key/database/vs.rs
+++ b/lib/src/key/database/vs.rs
@@ -11,8 +11,6 @@ pub struct Vs<'a> {
 	_b: u8,
 	pub db: &'a str,
 	_d: u8,
-	_e: u8,
-	_f: u8,
 }
 
 #[allow(unused)]
@@ -28,9 +26,7 @@ impl<'a> Vs<'a> {
 			ns,
 			_b: b'*',
 			db,
-			_d: b'!',
-			_e: b'v',
-			_f: b's',
+			_d: b'*',
 		}
 	}
 }

--- a/lib/src/key/mod.rs
+++ b/lib/src/key/mod.rs
@@ -15,7 +15,7 @@
 ///
 /// crate::key::database::all            /*{ns}*{db}
 /// crate::key::database::az             /*{ns}*{db}!az{az}
-/// crate::key::database::cf             /*{ns}*{db}!cf{ts}
+/// crate::key::database::cf             /*{ns}*{db}#{ts}
 /// crate::key::database::fc             /*{ns}*{db}!fn{fc}
 /// crate::key::database::lg             /*{ns}*{db}!lg{lg}
 /// crate::key::database::pa             /*{ns}*{db}!pa{pa}

--- a/lib/src/key/mod.rs
+++ b/lib/src/key/mod.rs
@@ -15,7 +15,6 @@
 ///
 /// crate::key::database::all            /*{ns}*{db}
 /// crate::key::database::az             /*{ns}*{db}!az{az}
-/// crate::key::database::cf             /*{ns}*{db}#{ts}
 /// crate::key::database::fc             /*{ns}*{db}!fn{fc}
 /// crate::key::database::lg             /*{ns}*{db}!lg{lg}
 /// crate::key::database::pa             /*{ns}*{db}!pa{pa}

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -1,3 +1,5 @@
+use super::tx::Transaction;
+use crate::cf;
 use crate::ctx::Context;
 use crate::dbs::node::Timestamp;
 use crate::dbs::Attach;
@@ -21,8 +23,6 @@ use std::time::Duration;
 use tracing::instrument;
 use tracing::trace;
 use uuid::Uuid;
-
-use super::tx::Transaction;
 
 /// Used for cluster logic to move LQ data to LQ cleanup code
 /// Not a stored struct; Used only in this module
@@ -528,6 +528,7 @@ impl Datastore {
 		Ok(Transaction {
 			inner,
 			cache: super::cache::Cache::default(),
+			cf: cf::Writer::new(),
 		})
 	}
 

--- a/lib/src/kvs/indxdb/mod.rs
+++ b/lib/src/kvs/indxdb/mod.rs
@@ -3,6 +3,7 @@
 use crate::err::Error;
 use crate::kvs::Key;
 use crate::kvs::Val;
+use crate::vs::{try_to_u64_be, u64_to_versionstamp, Versionstamp};
 use std::ops::Range;
 
 pub struct Datastore {
@@ -103,6 +104,68 @@ impl Transaction {
 		let res = self.tx.get(key.into()).await?;
 		// Return result
 		Ok(res)
+	}
+	/// Obtain a new change timestamp for a key
+	/// which is replaced with the current timestamp when the transaction is committed.
+	/// NOTE: This should be called when composing the change feed entries for this transaction,
+	/// which should be done immediately before the transaction commit.
+	/// That is to keep other transactions commit delay(pessimistic) or conflict(optimistic) as less as possible.
+	#[allow(unused)]
+	pub async fn get_timestamp<K>(&mut self, key: K) -> Result<Versionstamp, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Write the timestamp to the "last-write-timestamp" key
+		// to ensure that no other transactions can commit with older timestamps.
+		let k: Key = key.into();
+		let prev = self.tx.get(k.clone()).await?;
+		let ver = match prev {
+			Some(prev) => {
+				let slice = prev.as_slice();
+				let res: Result<[u8; 10], Error> = match slice.try_into() {
+					Ok(ba) => Ok(ba),
+					Err(e) => Err(Error::Ds(e.to_string())),
+				};
+				let array = res?;
+				let prev: u64 = try_to_u64_be(array)?;
+				prev + 1
+			}
+			None => 1,
+		};
+
+		let verbytes = u64_to_versionstamp(ver);
+
+		self.tx.put(k, verbytes.to_vec()).await?;
+		// Return the uint64 representation of the timestamp as the result
+		Ok(verbytes)
+	}
+	/// Obtain a new key that is suffixed with the change timestamp
+	pub async fn get_versionstamped_key<K>(
+		&mut self,
+		ts_key: K,
+		prefix: K,
+		suffix: K,
+	) -> Result<Vec<u8>, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Check to see if transaction is writable
+		if !self.rw {
+			return Err(Error::TxReadonly);
+		}
+		let ts = self.get_timestamp(ts_key).await?;
+		let mut k: Vec<u8> = prefix.into();
+		k.append(&mut ts.to_vec());
+		k.append(&mut suffix.into());
+		Ok(k)
 	}
 	/// Insert or update a key in the database
 	pub async fn set<K, V>(&mut self, key: K, val: V) -> Result<(), Error>

--- a/lib/src/kvs/mem/mod.rs
+++ b/lib/src/kvs/mem/mod.rs
@@ -3,7 +3,20 @@
 use crate::err::Error;
 use crate::kvs::Key;
 use crate::kvs::Val;
+use crate::vs::{try_to_u64_be, u64_to_versionstamp, Versionstamp};
 use std::ops::Range;
+
+use std::ascii::escape_default;
+use std::str;
+
+fn show(bs: &[u8]) -> String {
+	let mut visible = String::new();
+	for &b in bs {
+		let part: Vec<u8> = escape_default(b).collect();
+		visible.push_str(str::from_utf8(&part).unwrap());
+	}
+	visible
+}
 
 pub struct Datastore {
 	db: echodb::Db<Key, Val>,
@@ -101,6 +114,84 @@ impl Transaction {
 		// Return result
 		Ok(res)
 	}
+	/// Obtain a new change timestamp for a key
+	/// which is replaced with the current timestamp when the transaction is committed.
+	/// NOTE: This should be called when composing the change feed entries for this transaction,
+	/// which should be done immediately before the transaction commit.
+	/// That is to keep other transactions commit delay(pessimistic) or conflict(optimistic) as less as possible.
+	#[allow(unused)]
+	pub fn get_timestamp<K>(&mut self, key: K) -> Result<Versionstamp, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Write the timestamp to the "last-write-timestamp" key
+		// to ensure that no other transactions can commit with older timestamps.
+		let k: Key = key.into();
+		let prev = self.tx.get(k.clone())?;
+		let ver = match prev {
+			Some(prev) => {
+				let slice = prev.as_slice();
+				let res: Result<[u8; 10], Error> = match slice.try_into() {
+					Ok(ba) => Ok(ba),
+					Err(e) => Err(Error::Ds(e.to_string())),
+				};
+				let array = res?;
+				let prev = try_to_u64_be(array)?;
+				prev + 1
+			}
+			None => 1,
+		};
+
+		let verbytes = u64_to_versionstamp(ver);
+
+		self.tx.set(k, verbytes.to_vec())?;
+		// Return the uint64 representation of the timestamp as the result
+		Ok(verbytes)
+	}
+	/// Obtain a new key that is suffixed with the change timestamp
+	pub async fn get_versionstamped_key<K>(
+		&mut self,
+		ts_key: K,
+		prefix: K,
+		suffix: K,
+	) -> Result<Vec<u8>, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Check to see if transaction is writable
+		if !self.rw {
+			return Err(Error::TxReadonly);
+		}
+
+		let ts_key: Key = ts_key.into();
+		let prefix: Key = prefix.into();
+		let suffix: Key = suffix.into();
+
+		let ts = self.get_timestamp(ts_key.clone())?;
+		let mut k: Vec<u8> = prefix.clone();
+		k.append(&mut ts.to_vec());
+		k.append(&mut suffix.clone());
+
+		println!(
+			"get_versionstamped_key: ts_key={} prefix={} r={} suffix={} k={}",
+			show(ts_key.as_slice()),
+			show(prefix.as_slice()),
+			show(ts.as_slice()),
+			show(suffix.as_slice()),
+			show(k.as_slice())
+		);
+
+		Ok(k)
+	}
+
 	/// Insert or update a key in the database
 	pub fn set<K, V>(&mut self, key: K, val: V) -> Result<(), Error>
 	where

--- a/lib/src/kvs/mem/mod.rs
+++ b/lib/src/kvs/mem/mod.rs
@@ -6,18 +6,6 @@ use crate::kvs::Val;
 use crate::vs::{try_to_u64_be, u64_to_versionstamp, Versionstamp};
 use std::ops::Range;
 
-use std::ascii::escape_default;
-use std::str;
-
-fn show(bs: &[u8]) -> String {
-	let mut visible = String::new();
-	for &b in bs {
-		let part: Vec<u8> = escape_default(b).collect();
-		visible.push_str(str::from_utf8(&part).unwrap());
-	}
-	visible
-}
-
 pub struct Datastore {
 	db: echodb::Db<Key, Val>,
 }
@@ -180,13 +168,8 @@ impl Transaction {
 		k.append(&mut ts.to_vec());
 		k.append(&mut suffix.clone());
 
-		println!(
-			"get_versionstamped_key: ts_key={} prefix={} r={} suffix={} k={}",
-			show(ts_key.as_slice()),
-			show(prefix.as_slice()),
-			show(ts.as_slice()),
-			show(suffix.as_slice()),
-			show(k.as_slice())
+		trace!(
+			"get_versionstamped_key; {ts_key:?} {prefix:?} {ts:?} {suffix:?} {k:?}",
 		);
 
 		Ok(k)

--- a/lib/src/kvs/mem/mod.rs
+++ b/lib/src/kvs/mem/mod.rs
@@ -168,9 +168,7 @@ impl Transaction {
 		k.append(&mut ts.to_vec());
 		k.append(&mut suffix.clone());
 
-		trace!(
-			"get_versionstamped_key; {ts_key:?} {prefix:?} {ts:?} {suffix:?} {k:?}",
-		);
+		trace!("get_versionstamped_key; {ts_key:?} {prefix:?} {ts:?} {suffix:?} {k:?}",);
 
 		Ok(k)
 	}

--- a/lib/src/kvs/speedb/mod.rs
+++ b/lib/src/kvs/speedb/mod.rs
@@ -3,6 +3,7 @@
 use crate::err::Error;
 use crate::kvs::Key;
 use crate::kvs::Val;
+use crate::vs::{try_to_u64_be, u64_to_versionstamp, Versionstamp};
 use futures::lock::Mutex;
 use speedb::{OptimisticTransactionDB, OptimisticTransactionOptions, ReadOptions, WriteOptions};
 use std::ops::Range;
@@ -135,6 +136,68 @@ impl Transaction {
 		let res = self.tx.lock().await.as_ref().unwrap().get_opt(key.into(), &self.ro)?;
 		// Return result
 		Ok(res)
+	}
+	/// Obtain a new change timestamp for a key
+	/// which is replaced with the current timestamp when the transaction is committed.
+	/// NOTE: This should be called when composing the change feed entries for this transaction,
+	/// which should be done immediately before the transaction commit.
+	/// That is to keep other transactions commit delay(pessimistic) or conflict(optimistic) as less as possible.
+	#[allow(unused)]
+	pub async fn get_timestamp<K>(&mut self, key: K) -> Result<Versionstamp, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Write the timestamp to the "last-write-timestamp" key
+		// to ensure that no other transactions can commit with older timestamps.
+		let k: Key = key.into();
+		let prev = self.tx.lock().await.as_ref().unwrap().get_opt(k.clone(), &self.ro)?;
+		let ver = match prev {
+			Some(prev) => {
+				let slice = prev.as_slice();
+				let res: Result<[u8; 10], Error> = match slice.try_into() {
+					Ok(ba) => Ok(ba),
+					Err(e) => Err(Error::Ds(e.to_string())),
+				};
+				let array = res?;
+				let prev = try_to_u64_be(array)?;
+				prev + 1
+			}
+			None => 1,
+		};
+
+		let verbytes = u64_to_versionstamp(ver);
+
+		self.tx.lock().await.as_ref().unwrap().put(k, verbytes)?;
+		// Return the uint64 representation of the timestamp as the result
+		Ok(verbytes)
+	}
+	/// Obtain a new key that is suffixed with the change timestamp
+	pub async fn get_versionstamped_key<K>(
+		&mut self,
+		ts_key: K,
+		prefix: K,
+		suffix: K,
+	) -> Result<Vec<u8>, Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.ok {
+			return Err(Error::TxFinished);
+		}
+		// Check to see if transaction is writable
+		if !self.rw {
+			return Err(Error::TxReadonly);
+		}
+		let ts = self.get_timestamp(ts_key).await?;
+		let mut k: Vec<u8> = prefix.into();
+		k.append(&mut ts.to_vec());
+		k.append(&mut suffix.into());
+		Ok(k)
 	}
 	/// Insert or update a key in the database
 	pub async fn set<K, V>(&mut self, key: K, val: V) -> Result<(), Error>

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -2,6 +2,7 @@ use super::kv::Add;
 use super::kv::Convert;
 use super::Key;
 use super::Val;
+use crate::cf;
 use crate::dbs::node::ClusterMembership;
 use crate::dbs::node::Timestamp;
 use crate::err::Error;
@@ -13,8 +14,9 @@ use crate::sql::paths::EDGE;
 use crate::sql::paths::IN;
 use crate::sql::paths::OUT;
 use crate::sql::thing::Thing;
-use crate::sql::value::Value;
 use crate::sql::Strand;
+use crate::sql::Value;
+use crate::vs::Versionstamp;
 use channel::Sender;
 use sql::permission::Permissions;
 use sql::statements::DefineAnalyzerStatement;
@@ -30,6 +32,7 @@ use sql::statements::DefineScopeStatement;
 use sql::statements::DefineTableStatement;
 use sql::statements::DefineTokenStatement;
 use sql::statements::LiveStatement;
+use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
 use std::ops::Range;
@@ -42,6 +45,7 @@ use uuid::Uuid;
 pub struct Transaction {
 	pub(super) inner: Inner,
 	pub(super) cache: Cache,
+	pub(super) cf: cf::Writer,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -388,6 +392,120 @@ impl Transaction {
 				inner: Inner::FoundationDB(v),
 				..
 			} => v.set(key, val).await,
+			#[allow(unreachable_patterns)]
+			_ => unreachable!(),
+		}
+	}
+
+	/// Obtain a new change timestamp for a key
+	/// which is replaced with the current timestamp when the transaction is committed.
+	/// NOTE: This should be called when composing the change feed entries for this transaction,
+	/// which should be done immediately before the transaction commit.
+	/// That is to keep other transactions commit delay(pessimistic) or conflict(optimistic) as less as possible.
+	#[allow(unused)]
+	pub async fn get_timestamp<K>(&mut self, key: K, lock: bool) -> Result<Versionstamp, Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		#[cfg(debug_assertions)]
+		trace!("Get Timestamp {:?}", key);
+		match self {
+			#[cfg(feature = "kv-mem")]
+			Transaction {
+				inner: Inner::Mem(v),
+				..
+			} => v.get_timestamp(key),
+			#[cfg(feature = "kv-rocksdb")]
+			Transaction {
+				inner: Inner::RocksDB(v),
+				..
+			} => v.get_timestamp(key).await,
+			#[cfg(feature = "kv-indxdb")]
+			Transaction {
+				inner: Inner::IndxDB(v),
+				..
+			} => v.get_timestamp(key).await,
+			#[cfg(feature = "kv-tikv")]
+			Transaction {
+				inner: Inner::TiKV(v),
+				..
+			} => v.get_timestamp(key, lock).await,
+			#[cfg(feature = "kv-fdb")]
+			Transaction {
+				inner: Inner::FoundationDB(v),
+				..
+			} => v.get_timestamp().await,
+			#[cfg(feature = "kv-speedb")]
+			Transaction {
+				inner: Inner::SpeeDB(v),
+				..
+			} => v.get_timestamp(key).await,
+			#[allow(unreachable_patterns)]
+			_ => unreachable!(),
+		}
+	}
+
+	/// Insert or update a key in the datastore.
+	#[allow(unused_variables)]
+	pub async fn set_versionstamped_key<K, V>(
+		&mut self,
+		ts_key: K,
+		prefix: K,
+		suffix: K,
+		val: V,
+	) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+		V: Into<Val> + Debug,
+	{
+		#[cfg(debug_assertions)]
+		trace!("Set {:?} <ts> {:?} => {:?}", prefix, suffix, val);
+		match self {
+			#[cfg(feature = "kv-mem")]
+			Transaction {
+				inner: Inner::Mem(v),
+				..
+			} => {
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
+				v.set(k, val)
+			}
+			#[cfg(feature = "kv-rocksdb")]
+			Transaction {
+				inner: Inner::RocksDB(v),
+				..
+			} => {
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
+				v.set(k, val).await
+			}
+			#[cfg(feature = "kv-indxdb")]
+			Transaction {
+				inner: Inner::IndxDB(v),
+				..
+			} => {
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
+				v.set(k, val).await
+			}
+			#[cfg(feature = "kv-tikv")]
+			Transaction {
+				inner: Inner::TiKV(v),
+				..
+			} => {
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
+				v.set(k, val).await
+			}
+			#[cfg(feature = "kv-fdb")]
+			Transaction {
+				inner: Inner::FoundationDB(v),
+				..
+			} => v.set_versionstamped_key(prefix, suffix, val).await,
+			#[cfg(feature = "kv-speedb")]
+			Transaction {
+				inner: Inner::SpeeDB(v),
+				..
+			} => {
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
+				v.set(k, val).await
+			}
 			#[allow(unreachable_patterns)]
 			_ => unreachable!(),
 		}
@@ -1717,6 +1835,7 @@ impl Transaction {
 					let val = DefineTableStatement {
 						name: tb.to_owned().into(),
 						permissions: Permissions::none(),
+						changefeed: None,
 						..DefineTableStatement::default()
 					};
 					self.put(key, &val).await?;
@@ -1873,6 +1992,7 @@ impl Transaction {
 					let val = DefineTableStatement {
 						name: tb.to_owned().into(),
 						permissions: Permissions::none(),
+						changefeed: None,
 						..DefineTableStatement::default()
 					};
 					self.put(key, &val).await?;
@@ -2136,6 +2256,46 @@ impl Transaction {
 			}
 		}
 		// Everything exported
+		Ok(())
+	}
+
+	// change will record the change in the changefeed if enabled.
+	// To actually persist the record changes into the underlying kvs,
+	// you must call the `complete_changes` function and then commit the transaction.
+	pub(crate) fn record_change(
+		&mut self,
+		ns: &str,
+		db: &str,
+		tb: &DefineTableStatement,
+		id: &Thing,
+		v: Cow<'_, Value>,
+	) {
+		if tb.changefeed.is_some() {
+			self.cf.update(ns, db, tb.name.to_owned(), id.clone(), v)
+		}
+	}
+
+	// complete_changes will complete the changefeed recording for the given namespace and database.
+	//
+	// Under the hood, this function calls the transaction's `set_versionstamped_key` for each change.
+	// Every change must be recorded by calling this struct's `record_change` function beforehand.
+	// If there was no preceeding `record_change` function calls for this transaction, this function will do nothing.
+	//
+	// This function should be called only after all the changes have been made to the transaction.
+	// Otherwise, changes are missed in the change feed.
+	//
+	// This function should be called immediately before calling the commit function to guarantee that
+	// the lock, if needed by lock=true, is held only for the duration of the commit, not the entire transaction.
+	//
+	// This function is here because it needs access to mutably borrow the transaction.
+	//
+	// Lastly, you should set lock=true if you want the changefeed to be correctly ordered for
+	// non-FDB backends.
+	pub(crate) async fn complete_changes(&mut self, _lock: bool) -> Result<(), Error> {
+		let changes = self.cf.get();
+		for (tskey, prefix, suffix, v) in changes {
+			self.set_versionstamped_key(tskey, prefix, suffix, v).await?
+		}
 		Ok(())
 	}
 }

--- a/lib/src/sql/statement.rs
+++ b/lib/src/sql/statement.rs
@@ -161,7 +161,7 @@ impl Statement {
 			Self::Remove(v) => v.compute(ctx, opt, txn, doc).await,
 			Self::Select(v) => v.compute(ctx, opt, txn, doc).await,
 			Self::Set(v) => v.compute(ctx, opt, txn, doc).await,
-			Self::Show(v) => v.compute(ctx, opt, doc).await,
+			Self::Show(v) => v.compute(ctx, opt, txn, doc).await,
 			Self::Sleep(v) => v.compute(ctx, opt, doc).await,
 			Self::Update(v) => v.compute(ctx, opt, txn, doc).await,
 			_ => unreachable!(),

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -672,6 +672,139 @@ async fn delete_record_range() {
 }
 
 #[tokio::test]
+async fn changefeed() {
+	let db = new_db().await;
+	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+	// Enable change feeds
+	let sql = "
+	DEFINE TABLE user CHANGEFEED 1h;
+	";
+	let response = db.query(sql).await.unwrap();
+	response.check().unwrap();
+	// Create and update users
+	let sql = "
+        CREATE user:amos SET name = 'Amos';
+        CREATE user:jane SET name = 'Jane';
+        UPDATE user:amos SET name = 'AMOS';
+    ";
+	let table = "user";
+	let response = db.query(sql).await.unwrap();
+	response.check().unwrap();
+	let users: Vec<RecordBuf> = db
+		.update(table)
+		.content(Record {
+			name: "Doe",
+		})
+		.await
+		.unwrap();
+	let expected = &[
+		RecordBuf {
+			id: thing("user:amos").unwrap(),
+			name: "Doe".to_owned(),
+		},
+		RecordBuf {
+			id: thing("user:jane").unwrap(),
+			name: "Doe".to_owned(),
+		},
+	];
+	assert_eq!(users, expected);
+	let users: Vec<RecordBuf> = db.select(table).await.unwrap();
+	assert_eq!(users, expected);
+	let sql = "
+        SHOW CHANGES FOR TABLE user SINCE 0 LIMIT 10;
+    ";
+	let mut response = db.query(sql).await.unwrap();
+	let value: Value = response.take(0).unwrap();
+	let Value::Array(array) = value.clone() else { unreachable!() };
+	assert_eq!(array.len(), 4);
+	// UPDATE user:amos
+	let a = array.get(0).unwrap();
+	let Value::Object(a) = a else { unreachable!() };
+	let Value::Number(versionstamp1) = a.get("versionstamp").unwrap() else { unreachable!() };
+	let changes = a.get("changes").unwrap().to_owned();
+	assert_eq!(
+		changes,
+		surrealdb::sql::value(
+			"[
+		{
+			update: {
+				id: user:amos,
+				name: 'Amos'
+			}
+		}
+	]"
+		)
+		.unwrap()
+	);
+	// UPDATE user:jane
+	let a = array.get(1).unwrap();
+	let Value::Object(a) = a else { unreachable!() };
+	let Value::Number(versionstamp2) = a.get("versionstamp").unwrap() else { unreachable!() };
+	assert!(versionstamp1 < versionstamp2);
+	let changes = a.get("changes").unwrap().to_owned();
+	assert_eq!(
+		changes,
+		surrealdb::sql::value(
+			"[
+		{
+			update: {
+				id: user:jane,
+				name: 'Jane'
+			}
+		}
+	]"
+		)
+		.unwrap()
+	);
+	// UPDATE user:amos
+	let a = array.get(2).unwrap();
+	let Value::Object(a) = a else { unreachable!() };
+	let Value::Number(versionstamp3) = a.get("versionstamp").unwrap() else { unreachable!() };
+	assert!(versionstamp2 < versionstamp3);
+	let changes = a.get("changes").unwrap().to_owned();
+	assert_eq!(
+		changes,
+		surrealdb::sql::value(
+			"[
+		{
+			update: {
+				id: user:amos,
+				name: 'AMOS'
+			}
+		}
+	]"
+		)
+		.unwrap()
+	);
+	// UPDATE table
+	let a = array.get(3).unwrap();
+	let Value::Object(a) = a else { unreachable!() };
+	let Value::Number(versionstamp4) = a.get("versionstamp").unwrap() else { unreachable!() };
+	assert!(versionstamp3 < versionstamp4);
+	let changes = a.get("changes").unwrap().to_owned();
+	assert_eq!(
+		changes,
+		surrealdb::sql::value(
+			"[
+		{
+			update: {
+				id: user:amos,
+				name: 'Doe'
+			}
+		},
+		{
+			update: {
+				id: user:jane,
+				name: 'Doe'
+			}
+		}
+	]"
+		)
+		.unwrap()
+	);
+}
+
+#[tokio::test]
 async fn version() {
 	let db = new_db().await;
 	db.version().await.unwrap();

--- a/lib/tests/changefeeds.rs
+++ b/lib/tests/changefeeds.rs
@@ -1,0 +1,159 @@
+mod parse;
+use parse::Parse;
+use surrealdb::dbs::Session;
+use surrealdb::err::Error;
+use surrealdb::kvs::Datastore;
+use surrealdb::sql::Value;
+
+#[tokio::test]
+async fn table_change_feeds() -> Result<(), Error> {
+	let sql = "
+        DEFINE TABLE person CHANGEFEED 1h;
+		DEFINE FIELD name ON TABLE person
+			ASSERT
+				IF $input THEN
+					$input = /^[A-Z]{1}[a-z]+$/
+				ELSE
+					true
+				END
+			VALUE
+				IF $input THEN
+					'Name: ' + $input
+				ELSE
+					$value
+				END
+		;
+		UPDATE person:test CONTENT { name: 'Tobie' };
+		UPDATE person:test REPLACE { name: 'jaime' };
+		UPDATE person:test MERGE { name: 'Jaime' };
+		UPDATE person:test SET name = 'tobie';
+		UPDATE person:test SET name = 'Tobie';
+		DELETE person:test;
+		CREATE person:1000 SET name = 'Yusuke';
+        SHOW CHANGES FOR TABLE person SINCE 0;
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	assert_eq!(res.len(), 10);
+	// DEFINE TABLE
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	// DEFINE FIELD
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	// UPDATE CONTENT
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:test,
+				name: 'Name: Tobie',
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	// UPDATE REPLACE
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == r#"Found 'Name: jaime' for field `name`, with record `person:test`, but field must conform to: IF $input THEN $input = /^[A-Z]{1}[a-z]+$/ ELSE true END"#
+	));
+	// UPDATE MERGE
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:test,
+				name: 'Name: Jaime',
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	// UPDATE SET
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == r#"Found 'Name: tobie' for field `name`, with record `person:test`, but field must conform to: IF $input THEN $input = /^[A-Z]{1}[a-z]+$/ ELSE true END"#
+	));
+	// UPDATE SET
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:test,
+				name: 'Name: Tobie',
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	// DELETE
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[]");
+	assert_eq!(tmp, val);
+	// CREATE
+	let _tmp = res.remove(0).result?;
+	// SHOW CHANGES
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				versionstamp: 65536,
+				changes: [
+					{
+						update: {
+							id: person:test,
+							name: 'Name: Tobie'
+						}
+					}
+				]
+			},
+			{
+				versionstamp: 131072,
+				changes: [
+					{
+						update: {
+							id: person:test,
+							name: 'Name: Jaime'
+						}
+					}
+				]
+			},
+			{
+				versionstamp: 196608,
+				changes: [
+					{
+						update: {
+							id: person:test,
+							name: 'Name: Tobie'
+						}
+					}
+				]
+			},
+			{
+				versionstamp: 262144,
+				changes: [
+					{
+						delete: {
+							id: person:test
+						}
+					}
+				]
+			},
+			{
+				versionstamp: 327680,
+				changes: [
+					{
+						update: {
+							id: person:1000,
+							name: 'Name: Yusuke'
+						}
+					}
+				]
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
This is a successor of #2157. This one addresses many merge conflicts and also reverts the signature of the `commit` function and uses memorized `ns` and `db` of affected tables when committing change feed entries.

## What is the motivation?

We want a feature that serves all kinds of "CDC" use-cases.

## What does this change do?

This pull request adds the initial version of the so-called "Change Feeds" feature which almost provides a way
to reliably read the change history of a SurrealDB table (not the instance/cluster or the namespace. Database change feeds is WIP though).

Note that this initial version uses the "sound" variant of Versionstamps for Tikv, RocksDB, InMem, IndexedDB and SpeeDB. It wraps incrementing the per-database counter within the transaction to provide a monotonic Versionstamp for those backends.

We know this causes a lot of contention on the counter backed by the underlying KVS and our plan is to have unsound Versionstamp implementations in case the user wants to have more performance than the correctness of change feeds.

The good(I suppose) news is that the FoudnationDB backend uses the `set versionstamped key` atomic operation provided natively by the FoundationDB for Versionstamps. It's lockless and mostly contention-less (in terms of we don't need to "guard" the counter using the transaction by ourselves) and supposed to be more performance than other distributed SurrealDB backends.

## What is your testing strategy?

I've written a unit and integration (API) tests that checks the behavior of Change Feeds for the following backends:

- RocksDB
- InMem
- TiKV
- FoundationDB
- SpeeDB

Honestly speaking, I'm not sure how I can test the IndexedDB in an automated way!
Suggestions on how we test it are much appreciated.

## Is this related to any issues?

N/A

Probably we'd better have a discussion/issue for any design/usage/implmenetation/etc discussions once the first implementation turned out to work.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
