### PR TITLE
impl Clone for Any

### DIFF
--- a/lib/src/api/engine/any/mod.rs
+++ b/lib/src/api/engine/any/mod.rs
@@ -416,7 +416,7 @@ where
 }
 
 /// A dynamic connection that supports any engine and allows you to pick at runtime
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Any {
 	id: i64,
 	method: Method,


### PR DESCRIPTION
## What is the motivation?

Depending on how it's defined, sometimes the naive implementation that `derive(Clone)` uses cannot tell that `Surreal<C>` is always clonable.

## What does this change do?

It derives `Clone` for `Any`.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

It would have helped avoid https://github.com/surrealdb/surrealdb/issues/2228.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
