### PR TITLE
Run Github Actions on `ubuntu-latest`

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   bench:
     name: Bench library
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
   format:
     name: Check format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -35,7 +35,7 @@ jobs:
 
   check:
     name: Check workspace
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -57,7 +57,7 @@ jobs:
 
   check-wasm:
     name: Check Wasm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -76,7 +76,7 @@ jobs:
 
   clippy:
     name: Check clippy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -100,7 +100,7 @@ jobs:
 
   cli:
     name: Test command line
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -122,7 +122,7 @@ jobs:
 
   http-server:
     name: Test HTTP server
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -144,7 +144,7 @@ jobs:
 
   test:
     name: Test workspace
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -176,7 +176,7 @@ jobs:
 
   ws-engine:
     name: WebSocket engine
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -206,7 +206,7 @@ jobs:
 
   http-engine:
     name: HTTP engine
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -236,7 +236,7 @@ jobs:
 
   mem-engine:
     name: Memory engine
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -255,7 +255,7 @@ jobs:
 
   file-engine:
     name: File engine
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -274,7 +274,7 @@ jobs:
 
   rocksdb-engine:
     name: RocksDB engine
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -293,7 +293,7 @@ jobs:
 
   speedb-engine:
     name: SpeeDB engine
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -312,7 +312,7 @@ jobs:
 
   tikv-engine:
      name: TiKV engine
-     runs-on: ubuntu-20.04
+     runs-on: ubuntu-latest
      steps:
 
       - name: Install stable toolchain
@@ -343,7 +343,7 @@ jobs:
 
   fdb-engine:
     name: FoundationDB engine
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -367,7 +367,7 @@ jobs:
 
   any-engine:
     name: Any engine
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
 
       - name: Checkout sources
@@ -44,7 +44,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
 
       - name: Checkout sources
@@ -92,11 +92,11 @@ jobs:
             file: surreal-nightly.darwin-arm64
             opts: --features storage-tikv
           - arch: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04-16-cores
+            os: ubuntu-latest-16-cores
             file: surreal-nightly.linux-amd64
             opts: --features storage-tikv
           - arch: aarch64-unknown-linux-gnu
-            os: ubuntu-20.04-16-cores
+            os: ubuntu-latest-16-cores
             file: surreal-nightly.linux-arm64
             opts: --features storage-tikv
           - arch: x86_64-pc-windows-msvc
@@ -233,7 +233,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [package]
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
 
       - name: Checkout sources
@@ -260,7 +260,7 @@ jobs:
   docker:
     name: Docker
     needs: [build]
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
 
       - name: Checkout sources

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [ labeled ]
 
 # Setting the shell option, it will run 'bash --noprofile --norc -eo pipefail {0}'
 defaults:
@@ -14,6 +16,7 @@ jobs:
 
   build-static:
     name: Build static Linux binary
+    if: ${{ github.event.label.name == 'nix' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +31,7 @@ jobs:
 
   build-docker:
     name: Build Docker image
+    if: ${{ github.event.label.name == 'nix' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -42,6 +46,7 @@ jobs:
 
   build-native-linux:
     name: Build native Linux binary
+    if: ${{ github.event.label.name == 'nix' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
 
       - name: Checkout sources
@@ -44,7 +44,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
 
       - name: Checkout sources
@@ -92,11 +92,11 @@ jobs:
             file: surreal-${{ github.ref_name }}.darwin-arm64
             opts: --features storage-tikv
           - arch: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04-16-cores
+            os: ubuntu-latest-16-cores
             file: surreal-${{ github.ref_name }}.linux-amd64
             opts: --features storage-tikv
           - arch: aarch64-unknown-linux-gnu
-            os: ubuntu-20.04-16-cores
+            os: ubuntu-latest-16-cores
             file: surreal-${{ github.ref_name }}.linux-arm64
             opts: --features storage-tikv
           - arch: x86_64-pc-windows-msvc
@@ -233,7 +233,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [package]
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
 
       - name: Checkout sources
@@ -275,7 +275,7 @@ jobs:
   docker:
     name: Docker
     needs: [build]
-    runs-on: ubuntu-20.04-16-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
 
       - name: Checkout sources

--- a/flake.lock
+++ b/flake.lock
@@ -10,16 +10,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1679285709,
-        "narHash": "sha256-oERwmwZPZ5BOqSv6cmcXfjIBPrFR6dp02oGE8mA+1n4=",
+        "lastModified": 1686108916,
+        "narHash": "sha256-looLH5MdY4erLiJw0XwQohGdr0fJL9y6TJY3898RA2U=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2552a2d1ccf33d43259a9e00f93dbacb9e6d6bed",
+        "rev": "8ab1a49432695bd80ff4b7f6c6515da0e926d922",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
-        "ref": "v0.12.0",
+        "ref": "v0.12.2",
         "repo": "crane",
         "type": "github"
       }
@@ -32,11 +32,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1683872481,
-        "narHash": "sha256-BLXcc6oCbv98MGn/MSUTH8C4oKdczk/C5JqZ3ZlGAXU=",
+        "lastModified": 1689920490,
+        "narHash": "sha256-u/mglflFeXa2bUlN6KJmSyKbibpIhTiPgyW1PJ1rC6E=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "dd518e99e2833bb13e25570f88f2e16cdc5f8b4e",
+        "rev": "efa52586ba0ba96e06de0c549ee2f614ac928be7",
         "type": "github"
       },
       "original": {
@@ -78,12 +78,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -110,16 +113,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683802553,
-        "narHash": "sha256-1KQfY1wJ0QgAl2hwbvzy09uhEtFlGUKqwfAzjX7NCYA=",
+        "lastModified": 1689885880,
+        "narHash": "sha256-2ikAcvHKkKh8J/eUrwMA+wy1poscC+oL1RkN1V3RmT8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1a0ffed73a73ba9527480150412982adeeeecb03",
+        "rev": "fa793b06f56896b7d1909e4b69977c7bf842b2f0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11-small",
+        "ref": "nixos-23.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -136,11 +139,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1683815219,
-        "narHash": "sha256-dC79Q2Xw8sBGz6a41H15XaT3pHQ6xP4EVY4axdxUb4E=",
+        "lastModified": 1689862834,
+        "narHash": "sha256-eoFdQ3CbzSN8xCbQEWfHlKwDS+FLZZDFrIwOvK/DDCQ=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "9b3387454d7c70ec768114871682ee2946ec88a8",
+        "rev": "994f4f6e2e45bef4bebeeabee4e3d67b87727b91",
         "type": "github"
       },
       "original": {
@@ -162,16 +165,31 @@
         ]
       },
       "locked": {
-        "lastModified": 1677812689,
-        "narHash": "sha256-EakqhgRnjVeYJv5+BJx/NZ7/eFTMBxc4AhICUNquhUg=",
+        "lastModified": 1685759304,
+        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e53e8853aa7b0688bc270e9e6a681d22e01cf299",
+        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1689920490,
-        "narHash": "sha256-u/mglflFeXa2bUlN6KJmSyKbibpIhTiPgyW1PJ1rC6E=",
+        "lastModified": 1690179764,
+        "narHash": "sha256-Sgszrn/3KnemTBYHnJBwdCcY/u6Gc8FMGHAB+VpPH6I=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "efa52586ba0ba96e06de0c549ee2f614ac928be7",
+        "rev": "dce10f32abcc7740e5090e021b2c83a6b2ddb614",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689885880,
-        "narHash": "sha256-2ikAcvHKkKh8J/eUrwMA+wy1poscC+oL1RkN1V3RmT8=",
+        "lastModified": 1690176526,
+        "narHash": "sha256-SHdHTRu1RMLhIkTlFMSSyUJYsPNWw50Ky9W6znxGN9A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa793b06f56896b7d1909e4b69977c7bf842b2f0",
+        "rev": "a58eb89c7fcb703554aa53b4d25b50bd62e16786",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1689862834,
-        "narHash": "sha256-eoFdQ3CbzSN8xCbQEWfHlKwDS+FLZZDFrIwOvK/DDCQ=",
+        "lastModified": 1690057540,
+        "narHash": "sha256-MKGhZsFTpJH3Sq+9dGFGqOje3A6PD6fKGO92tM23zuY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "994f4f6e2e45bef4bebeeabee4e3d67b87727b91",
+        "rev": "99718d0c8bc5aadd993acdcabc1778fc7b5cc572",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,10 @@
     "A scalable, distributed, collaborative, document-graph database, for the realtime web";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11-small";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05-small";
     flake-utils.url = "github:numtide/flake-utils/v1.0.0";
     crane = {
-      url = "github:ipetkov/crane/v0.12.0";
+      url = "github:ipetkov/crane/v0.12.2";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     fenix = {

--- a/pkg/nix/config.nix
+++ b/pkg/nix/config.nix
@@ -2,5 +2,5 @@
   # Set the desired FoundationDB version here
   # Specify only the major and minor parts using `major.minor` format
   # Must be supported by both the foundationdb crate and NixPkgs
-  fdbVersion = "6.1";
+  fdbVersion = "7.1";
 }

--- a/pkg/nix/spec/x86_64-unknown-linux-gnu.nix
+++ b/pkg/nix/spec/x86_64-unknown-linux-gnu.nix
@@ -11,7 +11,7 @@
   buildSpec = with pkgs;
     let crossCompiling = !util.isNative target;
     in {
-      depsBuildBuild = [ clang cmake gcc10 perl protobuf grpc llvm ]
+      depsBuildBuild = [ clang cmake gcc perl protobuf grpc llvm ]
         ++ lib.lists.optional crossCompiling qemu;
 
       nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
## What is the motivation?

We are still running our tests against `ubuntu-20.04`. This shouldn't be necessary anymore since we are now depending on our own updated fork of TiKV.

## What does this change do?

Switches Github Actions to `ubuntu-latest` and makes Nix use the default `gcc` instead of `gcc10`.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
