### PR TITLE
Attempt to fix Windows release builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Install dependencies
         if: contains(matrix.arch, 'windows') && endsWith(matrix.arch, '-msvc')
         run: |
+          vcpkg upgrade
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static
           choco install protoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Install dependencies
         if: contains(matrix.arch, 'windows') && endsWith(matrix.arch, '-msvc')
         run: |
+          vcpkg upgrade
           vcpkg integrate install
           vcpkg install openssl:x64-windows-static
           choco install protoc


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Windows builds are currently failing (and preventing `nightly` or `release` builds intermittently, with a `Failed to download file with error: 1   If you are using a proxy, please check your proxy setting.` error. One suggestion is to ensure `vcpkg` is up-to-date.

## What does this change do?

This ensures `vcpkg` is updated prior to installing `openssl` library filed.

## What is your testing strategy?

Not applicable.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
