### PR TITLE
Unique index should ignore `none` or `null` values

### DIFF
--- a/lib/src/doc/index.rs
+++ b/lib/src/doc/index.rs
@@ -164,9 +164,11 @@ impl<'a> IndexOperation<'a> {
 		}
 		// Create the new index data
 		if let Some(n) = &self.n {
-			let key = self.get_unique_index_key(n);
-			if run.putc(key, self.rid, None).await.is_err() {
-				return self.err_index_exists(n);
+			if !n.is_all_none_or_null() {
+				let key = self.get_unique_index_key(n);
+				if run.putc(key, self.rid, None).await.is_err() {
+					return self.err_index_exists(n);
+				}
 			}
 		}
 		Ok(())

--- a/lib/src/sql/array.rs
+++ b/lib/src/sql/array.rs
@@ -134,6 +134,10 @@ impl Array {
 		}
 		Ok(Value::Array(x))
 	}
+
+	pub(crate) fn is_all_none_or_null(&self) -> bool {
+		self.0.iter().all(|v| v.is_none_or_null())
+	}
 }
 
 impl Display for Array {

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -100,3 +100,22 @@ async fn create_with_id() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn create_on_non_values_with_unique_index() -> Result<(), Error> {
+	let sql = "
+		DEFINE INDEX national_id_idx ON foo FIELDS national_id UNIQUE;
+		CREATE foo SET name = 'John Doe';
+		CREATE foo SET name = 'Jane Doe';
+	";
+
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 3);
+	//
+	for _ in 0..3 {
+		let _ = res.remove(0).result?;
+	}
+	Ok(())
+}


### PR DESCRIPTION
## What is the motivation?

Creating two records with a field containing no values indexed by a unique indexes...

```sql
DEFINE INDEX national_id_idx ON foo FIELDS national_id UNIQUE;
CREATE foo SET name = 'John Doe';
CREATE foo SET name = 'Jane Doe';
```
...generates the following error

```js
Error: IndexExists { thing: "foo:whhec4cih1v4t68zzx7d", index: "national_id_idx", value: "NONE" }
```

## What does this change do?

The `null` and `none` values should be ignored by the unique index.


## What is your testing strategy?

A dedicated test has been added

## Is this related to any issues?

Bug #74

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
