### PR TITLE
Don't skip running Nix on main

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,7 +16,7 @@ jobs:
 
   build-static:
     name: Build static Linux binary
-    if: ${{ github.event.label.name == 'nix' }}
+    if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.event.label.name == 'nix' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
 
   build-docker:
     name: Build Docker image
-    if: ${{ github.event.label.name == 'nix' }}
+    if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.event.label.name == 'nix' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
 
   build-native-linux:
     name: Build native Linux binary
-    if: ${{ github.event.label.name == 'nix' }}
+    if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.event.label.name == 'nix' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What is the motivation?

My earlier PR made Nix expressions to only be run on labelled PRs.

## What does this change do?

This is an attempt to make them be evaluated on main too.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
