### PR TITLE
Add Change Feeds GC

### DIFF
--- a/lib/src/cf/gc.rs
+++ b/lib/src/cf/gc.rs
@@ -45,11 +45,8 @@ pub async fn gc_ns(
 				let c = ts - cf.expiry.as_secs();
 				let watermark_vs =
 					tx.get_versionstamp_from_timestamp(ts, ns, db.name.as_str(), true).await?;
-				match watermark_vs {
-					Some(watermark_vs) => {
-						gc_db(tx, ns, db.name.as_str(), watermark_vs, limit).await?;
-					}
-					None => {}
+				if let Some(watermark_vs) = watermark_vs {
+					gc_db(tx, ns, db.name.as_str(), watermark_vs, limit).await?;
 				}
 			}
 		}

--- a/lib/src/cf/writer.rs
+++ b/lib/src/cf/writer.rs
@@ -214,7 +214,7 @@ mod tests {
 
 		let mut tx5 = ds.transaction(true, false).await.unwrap();
 		// gc_all needs to be committed before we can read the changes
-		crate::cf::gc_db(&mut tx5, ns, db, 3, Some(10)).await.unwrap();
+		crate::cf::gc_db(&mut tx5, ns, db, vs::u64_to_versionstamp(3), Some(10)).await.unwrap();
 		// We now commit tx5, which should persist the gc_all resullts
 		tx5.commit().await.unwrap();
 

--- a/lib/src/key/database/mod.rs
+++ b/lib/src/key/database/mod.rs
@@ -6,4 +6,5 @@ pub mod pa;
 pub mod sc;
 pub mod tb;
 pub mod tk;
+pub mod ts;
 pub mod vs;

--- a/lib/src/key/database/ts.rs
+++ b/lib/src/key/database/ts.rs
@@ -2,7 +2,9 @@
 use derive::Key;
 use serde::{Deserialize, Serialize};
 
-// Ts stands for Database Timestamps
+// Ts stands for Database Timestamps that corresponds to Versionstamps.
+// Each Ts key is suffixed by a timestamp.
+// The value is the versionstamp that corresponds to the timestamp.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
 pub struct Ts<'a> {
 	__: u8,

--- a/lib/src/key/database/ts.rs
+++ b/lib/src/key/database/ts.rs
@@ -1,0 +1,68 @@
+//! Stores database timestamps
+use derive::Key;
+use serde::{Deserialize, Serialize};
+
+// Ts stands for Database Timestamps
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+pub struct Ts<'a> {
+	__: u8,
+	_a: u8,
+	pub ns: &'a str,
+	_b: u8,
+	pub db: &'a str,
+	_c: u8,
+	_d: u8,
+	_e: u8,
+	pub ts: u64,
+}
+
+pub fn new<'a>(ns: &'a str, db: &'a str, ts: u64) -> Ts<'a> {
+	Ts::new(ns, db, ts)
+}
+
+/// Returns the prefix for the whole database timestamps
+pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
+	let mut k = crate::key::database::all::new(ns, db).encode().unwrap();
+	k.extend_from_slice(&[b'!', b't', b's']);
+	k
+}
+
+/// Returns the prefix for the whole database timestamps
+pub fn suffix(ns: &str, db: &str) -> Vec<u8> {
+	let mut k = prefix(ns, db);
+	k.extend_from_slice(&[0xff]);
+	k
+}
+
+impl<'a> Ts<'a> {
+	pub fn new(ns: &'a str, db: &'a str, ts: u64) -> Self {
+		Ts {
+			__: b'/',
+			_a: b'*',
+			ns,
+			_b: b'*',
+			db,
+			_c: b'!',
+			_d: b't',
+			_e: b's',
+			ts,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn key() {
+		use super::*;
+		#[rustfmt::skip]
+		let val = Ts::new(
+			"test",
+			"test",
+			123,
+		);
+		let enc = Ts::encode(&val).unwrap();
+		let dec = Ts::decode(&enc).unwrap();
+		assert_eq!(val, dec);
+	}
+}

--- a/lib/src/key/mod.rs
+++ b/lib/src/key/mod.rs
@@ -21,6 +21,7 @@
 /// crate::key::database::sc             /*{ns}*{db}!sc{sc}
 /// crate::key::database::tb             /*{ns}*{db}!tb{tb}
 /// crate::key::database::tk             /*{ns}*{db}!tk{tk}
+/// crate::key::database::ts             /*{ns}*{db}!ts{ts}
 /// crate::key::database::vs             /*{ns}*{db}!vs
 ///
 /// crate::key::scope::all               /*{ns}*{db}±{sc}

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -448,21 +448,32 @@ impl Datastore {
 		Ok::<Vec<Hb>, Error>(dead)
 	}
 
+	// tick is called periodically to perform maintenance tasks.
+	// On a linux/windows/macos system, this is called every TICK_INTERVAL.
+	// On embedded scenarios like WASM where there is no background thread,
+	// this should be called by the application.
 	pub async fn tick(&self) -> Result<(), Error> {
-		self.save_timestamp_for_versionstamp().await?;
-		self.garbage_collect_stale_change_feeds().await?;
+		let now = std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.map_err(|e| Error::Internal(e.to_string()))?;
+		let ts = now.as_secs();
+		self.tick_at(ts).await?;
+		Ok(())
+	}
+
+	// tick_at is the utility function that is called by tick.
+	// It is handy for testing, because it allows you to specify the timestamp,
+	// without depending on a system clock.
+	pub async fn tick_at(&self, ts: u64) -> Result<(), Error> {
+		self.save_timestamp_for_versionstamp(ts).await?;
+		self.garbage_collect_stale_change_feeds(ts).await?;
 		// TODO Add LQ GC
 		// TODO Add Node GC?
 		Ok(())
 	}
 
 	// save_timestamp_for_versionstamp saves the current timestamp for the each database's current versionstamp.
-	pub async fn save_timestamp_for_versionstamp(&self) -> Result<(), Error> {
-		let now = std::time::SystemTime::now()
-			.duration_since(std::time::UNIX_EPOCH)
-			.map_err(|e| Error::Internal(e.to_string()))?;
-		let ts = now.as_secs();
-
+	pub async fn save_timestamp_for_versionstamp(&self, ts: u64) -> Result<(), Error> {
 		let mut tx = self.transaction(true, false).await?;
 		let nses = tx.all_ns().await?;
 		let nses = nses.as_ref();
@@ -480,10 +491,10 @@ impl Datastore {
 	}
 
 	// garbage_collect_stale_change_feeds deletes all change feed entries that are older than the watermarks.
-	pub async fn garbage_collect_stale_change_feeds(&self) -> Result<(), Error> {
+	pub async fn garbage_collect_stale_change_feeds(&self, ts: u64) -> Result<(), Error> {
 		let mut tx = self.transaction(true, false).await?;
 		// TODO Make gc batch size/limit configurable?
-		crate::cf::gc_all(&mut tx, Some(100)).await?;
+		crate::cf::gc_all_at(&mut tx, ts, Some(100)).await?;
 		tx.commit().await?;
 		Ok(())
 	}

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -448,6 +448,46 @@ impl Datastore {
 		Ok::<Vec<Hb>, Error>(dead)
 	}
 
+	pub async fn tick(&self) -> Result<(), Error> {
+		self.save_timestamp_for_versionstamp().await?;
+		self.garbage_collect_stale_change_feeds().await?;
+		// TODO Add LQ GC
+		// TODO Add Node GC?
+		Ok(())
+	}
+
+	// save_timestamp_for_versionstamp saves the current timestamp for the each database's current versionstamp.
+	pub async fn save_timestamp_for_versionstamp(&self) -> Result<(), Error> {
+		let now = std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.map_err(|e| Error::Internal(e.to_string()))?;
+		let ts = now.as_secs();
+
+		let mut tx = self.transaction(true, false).await?;
+		let nses = tx.all_ns().await?;
+		let nses = nses.as_ref();
+		for ns in nses {
+			let ns = ns.name.as_str();
+			let dbs = tx.all_db(ns).await?;
+			let dbs = dbs.as_ref();
+			for db in dbs {
+				let db = db.name.as_str();
+				tx.set_timestamp_for_versionstamp(ts, ns, db, true).await?;
+			}
+		}
+		tx.commit().await?;
+		Ok(())
+	}
+
+	// garbage_collect_stale_change_feeds deletes all change feed entries that are older than the watermarks.
+	pub async fn garbage_collect_stale_change_feeds(&self) -> Result<(), Error> {
+		let mut tx = self.transaction(true, false).await?;
+		// TODO Make gc batch size/limit configurable?
+		crate::cf::gc_all(&mut tx, Some(100)).await?;
+		tx.commit().await?;
+		Ok(())
+	}
+
 	// Creates a heartbeat entry for the member indicating to the cluster
 	// that the node is alive.
 	// This is the preferred way of creating heartbeats inside the database, so try to use this.

--- a/lib/src/kvs/tests/mod.rs
+++ b/lib/src/kvs/tests/mod.rs
@@ -21,6 +21,7 @@ mod mem {
 	include!("snapshot.rs");
 	include!("tb.rs");
 	include!("multireader.rs");
+	include!("timestamp_to_versionstamp.rs");
 }
 
 #[cfg(feature = "kv-rocksdb")]
@@ -50,6 +51,7 @@ mod rocksdb {
 	include!("multireader.rs");
 	include!("multiwriter_different_keys.rs");
 	include!("multiwriter_same_keys_conflict.rs");
+	include!("timestamp_to_versionstamp.rs");
 }
 
 #[cfg(feature = "kv-speedb")]
@@ -79,6 +81,7 @@ mod speedb {
 	include!("multireader.rs");
 	include!("multiwriter_different_keys.rs");
 	include!("multiwriter_same_keys_conflict.rs");
+	include!("timestamp_to_versionstamp.rs");
 }
 
 #[cfg(feature = "kv-tikv")]
@@ -112,6 +115,7 @@ mod tikv {
 	include!("multireader.rs");
 	include!("multiwriter_different_keys.rs");
 	include!("multiwriter_same_keys_conflict.rs");
+	include!("timestamp_to_versionstamp.rs");
 }
 
 #[cfg(feature = "kv-fdb")]
@@ -145,4 +149,5 @@ mod fdb {
 	include!("multireader.rs");
 	include!("multiwriter_different_keys.rs");
 	include!("multiwriter_same_keys_allow.rs");
+	include!("timestamp_to_versionstamp.rs");
 }

--- a/lib/src/kvs/tests/timestamp_to_versionstamp.rs
+++ b/lib/src/kvs/tests/timestamp_to_versionstamp.rs
@@ -1,0 +1,34 @@
+// Timestamp to versionstamp tests
+// This translation mechanism is currently used by the garbage collector to determine which change feed entries to delete.
+//
+// FAQ:
+// Q: What’s the difference between database TS and database VS?
+// A: Timestamps are basically seconds since the unix epoch.
+//    Versionstamps can be anything that is provided by our TSO.
+// Q: Why do we need to translate timestamps to versionstamps?
+// A: The garbage collector needs to know which change feed entries to delete.
+//    However our SQL syntax `DEFINE DATABASE foo CHANGEFEED 1h` let the user specify the expiration in a duration, not a delta in the versionstamp.
+//    We need to translate the timestamp to the versionstamp due to that; `now - 1h` to a key suffixed by the versionstamp.
+#[tokio::test]
+#[serial]
+async fn timestamp_to_versionstamp() {
+	// Create a new datastore
+	let ds = new_ds().await;
+	// Give the current versionstamp a timestamp of 0
+	let mut tx = ds.transaction(true, false).await.unwrap();
+	tx.set_timestamp_for_versionstamp(0, "myns", "mydb", true).await.unwrap();
+	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb", true).await.unwrap().unwrap();
+	tx.commit().await.unwrap();
+	// Give the current versionstamp a timestamp of 1
+	let mut tx = ds.transaction(true, false).await.unwrap();
+	tx.set_timestamp_for_versionstamp(1, "myns", "mydb", true).await.unwrap();
+	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb", true).await.unwrap().unwrap();
+	tx.commit().await.unwrap();
+	// Give the current versionstamp a timestamp of 2
+	let mut tx = ds.transaction(true, false).await.unwrap();
+	tx.set_timestamp_for_versionstamp(2, "myns", "mydb", true).await.unwrap();
+	let vs3 = tx.get_versionstamp_from_timestamp(2, "myns", "mydb", true).await.unwrap().unwrap();
+	tx.commit().await.unwrap();
+	assert!(vs1 < vs2);
+	assert!(vs2 < vs3);
+}

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -2320,7 +2320,7 @@ impl Transaction {
 		let ts_pairs: Vec<(Vec<u8>, Vec<u8>)> = self.getr(begin..end, u32::MAX).await?;
 		let latest_ts_pair = ts_pairs.last();
 		if let Some((k, _)) = latest_ts_pair {
-			let k = crate::key::database::ts::Ts::decode(&k)?;
+			let k = crate::key::database::ts::Ts::decode(k)?;
 			let latest_ts = k.ts;
 			if latest_ts >= ts {
 				return Err(Error::Internal(

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -2340,7 +2340,7 @@ impl Transaction {
 		_lock: bool,
 	) -> Result<Option<Versionstamp>, Error> {
 		let start = crate::key::database::ts::prefix(ns, db);
-		let ts_key = crate::key::database::ts::new(ns, db, ts);
+		let ts_key = crate::key::database::ts::new(ns, db, ts + 1);
 		let end = ts_key.encode()?;
 		let ts_pairs = self.getr(start..end, u32::MAX).await?;
 		let latest_ts_pair = ts_pairs.last();

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -2298,4 +2298,67 @@ impl Transaction {
 		}
 		Ok(())
 	}
+
+	// set_timestamp_for_versionstamp correlates the given timestamp with the current versionstamp.
+	// This allows get_versionstamp_from_timestamp to obtain the versionstamp from the timestamp later.
+	pub(crate) async fn set_timestamp_for_versionstamp(
+		&mut self,
+		ts: u64,
+		ns: &str,
+		db: &str,
+		lock: bool,
+	) -> Result<(), Error> {
+		// This also works as an advisory lock on the ts keys so that there is
+		// on other concurrent transactions that can write to the ts_key or the keys after it.
+		let vs = self.get_timestamp(crate::key::database::vs::new(ns, db), lock).await?;
+
+		// Ensure there are no keys after the ts_key
+		// Otherwise we can go back in time!
+		let ts_key = crate::key::database::ts::new(ns, db, ts);
+		let begin = ts_key.encode()?;
+		let end = crate::key::database::ts::suffix(ns, db);
+		let ts_pairs: Vec<(Vec<u8>, Vec<u8>)> = self.getr(begin..end, u32::MAX).await?;
+		let latest_ts_pair = ts_pairs.last();
+		match latest_ts_pair {
+			Some((k, _)) => {
+				let k = crate::key::database::ts::Ts::decode(&k)?;
+				let latest_ts = k.ts;
+				if latest_ts >= ts {
+					return Err(Error::Internal(
+						"ts is less than or equal to the latest ts".to_string(),
+					));
+				}
+			}
+			None => {}
+		}
+		let _ = self.set(ts_key, vs).await?;
+		Ok(())
+	}
+
+	pub(crate) async fn get_versionstamp_from_timestamp(
+		&mut self,
+		ts: u64,
+		ns: &str,
+		db: &str,
+		_lock: bool,
+	) -> Result<Option<Versionstamp>, Error> {
+		let start = crate::key::database::ts::prefix(ns, db);
+		let ts_key = crate::key::database::ts::new(ns, db, ts);
+		let end = ts_key.encode()?;
+		let ts_pairs = self.getr(start..end, u32::MAX).await?;
+		let latest_ts_pair = ts_pairs.last();
+		match latest_ts_pair {
+			Some((_, v)) => {
+				if v.len() == 10 {
+					let mut sl = [0u8; 10];
+					sl.copy_from_slice(&v);
+					return Ok(Some(sl.into()));
+				} else {
+					return Err(Error::Internal("versionstamp is not 10 bytes".to_string()));
+				}
+			}
+			None => {}
+		}
+		Ok(None)
+	}
 }

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -2351,8 +2351,8 @@ impl Transaction {
 			Some((_, v)) => {
 				if v.len() == 10 {
 					let mut sl = [0u8; 10];
-					sl.copy_from_slice(&v);
-					return Ok(Some(sl.into()));
+					sl.copy_from_slice(v);
+					return Ok(Some(sl));
 				} else {
 					return Err(Error::Internal("versionstamp is not 10 bytes".to_string()));
 				}

--- a/lib/tests/changefeeds.rs
+++ b/lib/tests/changefeeds.rs
@@ -34,7 +34,11 @@ async fn table_change_feeds() -> Result<(), Error> {
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let start_ts = 0u64;
+	let end_ts = start_ts + 1;
+	dbs.tick_at(start_ts).await?;
 	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	dbs.tick_at(end_ts).await?;
 	assert_eq!(res.len(), 10);
 	// DEFINE TABLE
 	let tmp = res.remove(0).result;
@@ -153,6 +157,20 @@ async fn table_change_feeds() -> Result<(), Error> {
 			}
 		]",
 	);
+	assert_eq!(tmp, val);
+	// Retain for 1h
+	let sql = "
+        SHOW CHANGES FOR TABLE person SINCE 0;
+	";
+	dbs.tick_at(end_ts + 3599).await?;
+	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let tmp = res.remove(0).result?;
+	assert_eq!(tmp, val);
+	// GC after 1hs
+	dbs.tick_at(end_ts + 3600).await?;
+	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[]");
 	assert_eq!(tmp, val);
 	//
 	Ok(())

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -7,6 +7,8 @@ use std::{net::SocketAddr, path::PathBuf};
 #[cfg(feature = "has-storage")]
 pub static CF: OnceCell<Config> = OnceCell::new();
 
+use std::time::Duration;
+
 #[derive(Clone, Debug)]
 pub struct Config {
 	pub bind: SocketAddr,
@@ -17,4 +19,5 @@ pub struct Config {
 	pub pass: Option<String>,
 	pub crt: Option<PathBuf>,
 	pub key: Option<PathBuf>,
+	pub tick_interval: Duration,
 }

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -13,6 +13,7 @@ use clap::Args;
 use ipnet::IpNet;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 #[derive(Args, Debug)]
 pub struct StartCommandArguments {
@@ -40,6 +41,10 @@ pub struct StartCommandArguments {
 	#[arg(env = "SURREAL_BIND", short = 'b', long = "bind")]
 	#[arg(default_value = "0.0.0.0:8000")]
 	listen_addresses: Vec<SocketAddr>,
+	#[arg(help = "The interval at which to run node agent tick (including garbage collection)")]
+	#[arg(env = "SURREAL_TICK_INTERVAL", long = "tick-interval", value_parser = super::validator::duration)]
+	#[arg(default_value = "10s")]
+	tick_interval: Duration,
 	#[command(flatten)]
 	dbs: StartCommandDbsOptions,
 	#[arg(help = "Encryption key to use for on-disk encryption")]
@@ -96,6 +101,7 @@ pub async fn init(
 		dbs,
 		web,
 		log: CustomEnvFilter(log),
+		tick_interval,
 		no_banner,
 		..
 	}: StartCommandArguments,
@@ -115,6 +121,7 @@ pub async fn init(
 		path,
 		user,
 		pass,
+		tick_interval,
 		crt: web.as_ref().and_then(|x| x.web_crt.clone()),
 		key: web.as_ref().and_then(|x| x.web_key.clone()),
 	});
@@ -126,6 +133,9 @@ pub async fn init(
 	dbs::init(dbs).await?;
 	// Start the web server
 	net::init().await?;
+	// Start the node agent
+	#[cfg(feature = "has-storage")]
+	node::init().await?;
 	// All ok
 	Ok(())
 }

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -9,6 +9,7 @@ use crate::env;
 use crate::err::Error;
 use crate::iam;
 use crate::net::{self, client_ip::ClientIp};
+use crate::node;
 use clap::Args;
 use ipnet::IpNet;
 use std::net::SocketAddr;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,8 @@ mod iam;
 #[cfg(feature = "has-storage")]
 mod net;
 #[cfg(feature = "has-storage")]
+mod node;
+#[cfg(feature = "has-storage")]
 mod rpc;
 mod telemetry;
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -3,11 +3,10 @@ use crate::err::Error;
 
 const LOG: &str = "surrealdb::node";
 
-// the following init function starts a long-running process
-// that is backed by tokio.
-// It periodicall calls the Datastore's `gc` function currently.
-// This is a blocking call, so we spawn it on a separate thread.
-// This is a temporary solution until we have a proper background
+// The init starts a long-running thread for periodically calling Datastore.tick.
+// Datastore.tick is responsible for running garbage collection and other
+// background tasks.
+// This can be a temporary solution until we have a proper background
 // task system in place.
 pub async fn init() -> Result<(), Error> {
 	let opt = CF.get().unwrap();

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,0 +1,35 @@
+use crate::cli::CF;
+use crate::err::Error;
+
+const LOG: &str = "surrealdb::node";
+
+// the following init function starts a long-running process
+// that is backed by tokio.
+// It periodicall calls the Datastore's `gc` function currently.
+// This is a blocking call, so we spawn it on a separate thread.
+// This is a temporary solution until we have a proper background
+// task system in place.
+pub async fn init() -> Result<(), Error> {
+	let opt = CF.get().unwrap();
+	let tick_interval = opt.tick_interval;
+	info!(target: LOG, "Node agent starting.");
+
+	let gc = move || {
+		let dbs = crate::dbs::DB.get().unwrap();
+		tokio::spawn(async move {
+			loop {
+				tokio::time::sleep(tick_interval).await;
+				if let Err(e) = dbs.tick().await {
+					error!("Error running node agent tick: {}", e);
+				}
+			}
+
+			// TODO Do we need to add support for graceful stop?
+		});
+	};
+	std::thread::spawn(gc);
+
+	info!(target: LOG, "Node agent started.");
+
+	Ok(())
+}


### PR DESCRIPTION
## What is the motivation?

I want the baseline/foundation for CF and LQ GCs and task ownership/management systems towards SurrealDB v1 earlier!

## What does this change do?

- Enhances the surreal start command to have a new flag `--tick-interval`
- The surreal start command now starts a background thread that periodically runs Datastore.tick
- Datastore.tick currently runs the the timestamp -> versionstamp mapper and the CF GC
  - You know we version change feed entries (and probably LQ messages) by versionstamps
  - However the change feed expiration duration is written literally in a duration(i.e. delta in timestamps), instead of versionstamp delta. We need a way to translate timestamps to versionstamps so that we can obtain e.g. the versionstamp that corresponds to (the timestamp of) 60 seconds ago.
- Tests
  - **Added new timestamp_to_versionstamp kvs test**
  - **Enhanced change feed lib test to also cover GC**
- Fixes
  - Fixed table cf gc to actually work

## What is your testing strategy?

We can ensure that it doesn't break anything by seeing it passes our existing test suite.
~~I'll gradually add new tests for this feature but in the meantime, it would be great if we could merge this anyway and defer adding tests to future PRs.~~

**The new functions for Transction are unit tested by the new timestamp_to_versionstamp kvs test and the improved change feed lib test.**

## Is this related to any issues?

#2306 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
