### PR TITLE
Use non-monotonic versionstamps with TiKV by default

### DIFF
--- a/lib/src/kvs/tikv/mod.rs
+++ b/lib/src/kvs/tikv/mod.rs
@@ -137,6 +137,7 @@ impl Transaction {
 		Ok(u64_to_versionstamp(ver))
 	}
 	/// Obtain a new key that is suffixed with the change timestamp
+	#[allow(unused)]
 	pub async fn get_versionstamped_key<K>(
 		&mut self,
 		ts_key: K,

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -511,6 +511,10 @@ impl Transaction {
 				inner: Inner::TiKV(v),
 				..
 			} => self.get_non_monotonic_versionstamped_key(prefix.clone(), suffix.clone()).await,
+			// We need this to make the compiler happy.
+			// The below is unreachable only when only the tikv feature is enabled.
+			// It's still reachable if we enabled more than one kv feature.
+			#[allow(unreachable_patterns)]
 			_ => Err(Error::Internal(
 				"Non-monotonic versionstamps are only supported on TiKV".to_string(),
 			)),

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -505,7 +505,7 @@ impl Transaction {
 	{
 		#[cfg(debug_assertions)]
 		trace!("Set {:?} <ts> {:?} => {:?}", prefix, suffix, val);
-		let nonmonotonic_key = match self {
+		let nonmonotonic_key: Result<Vec<u8>, Error> = match self {
 			#[cfg(feature = "kv-tikv")]
 			Transaction {
 				inner: Inner::TiKV(v),

--- a/lib/src/vs/oracle.rs
+++ b/lib/src/vs/oracle.rs
@@ -53,6 +53,22 @@ pub enum Oracle {
 
 impl Oracle {
 	#[allow(unused)]
+	pub fn systime_counter() -> Self {
+		Oracle::SysTimeCounter(SysTimeCounter {
+			state: Mutex::new((0, 0)),
+			stale: (0, 0),
+		})
+	}
+
+	#[allow(unused)]
+	pub fn epoch_counter() -> Self {
+		Oracle::EpochCounter(EpochCounter {
+			epoch: 0,
+			counter: AtomicU64::new(0),
+		})
+	}
+
+	#[allow(unused)]
 	pub fn now(&mut self) -> Versionstamp {
 		match self {
 			Oracle::SysTimeCounter(sys) => sys.now(),
@@ -141,10 +157,7 @@ mod tests {
 
 	#[test]
 	fn systime_counter() {
-		let mut o = Oracle::SysTimeCounter(SysTimeCounter {
-			state: Mutex::new((0, 0)),
-			stale: (0, 0),
-		});
+		let mut o = Oracle::systime_counter();
 		let a = to_u128_be(o.now());
 		let b = to_u128_be(o.now());
 		assert!(a < b, "a = {}, b = {}", a, b);
@@ -152,10 +165,7 @@ mod tests {
 
 	#[test]
 	fn epoch_counter() {
-		let mut o1 = Oracle::EpochCounter(EpochCounter {
-			epoch: 0,
-			counter: AtomicU64::new(0),
-		});
+		let mut o1 = Oracle::epoch_counter();
 		let a = to_u128_be(o1.now());
 		let b = to_u128_be(o1.now());
 		assert!(a < b, "a = {}, b = {}", a, b);


### PR DESCRIPTION
## What is the motivation?

We want to see if having our own non-monotonic fast versionstamps actually works for some backends known to be unable to provide monotonic timestamps in practical performance.

## What does this change do?

Let our tikv datastore/transaction use our own SystimeCounter versionstamp oracle added in #2306.

## What is your testing strategy?

Let's see test passes and how this works in the wild...

I'd suggest merging #2339 first and rebase this onto that, because #2339 adds more tests that depend on versionstamps.

Note though; Honestly speaking, I don't know if this, use of non-monotonic versionstamps for CDC use-cases, is really practical. There can be many edge cases we don't yet understand.

## Is this related to any issues?

This had been planned to land after #2300

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
