### PR TITLE
Fix merging of empty objects & arrays

### DIFF
--- a/lib/src/sql/value/every.rs
+++ b/lib/src/sql/value/every.rs
@@ -11,8 +11,8 @@ impl Value {
 	}
 	fn _every(&self, steps: bool, arrays: bool, prev: Idiom) -> Vec<Idiom> {
 		match self {
-			// Current path part is an object
-			Value::Object(v) => match steps {
+			// Current path part is an object and is not empty
+			Value::Object(v) if !v.is_empty() => match steps {
 				// Let's log all intermediary nodes
 				true if !prev.is_empty() => Some(prev.clone())
 					.into_iter()
@@ -30,8 +30,8 @@ impl Value {
 					})
 					.collect::<Vec<_>>(),
 			},
-			// Current path part is an array
-			Value::Array(v) => match arrays {
+			// Current path part is an array and is not empty
+			Value::Array(v) if !v.is_empty() => match arrays {
 				// Let's log all individual array items
 				true => std::iter::once(prev.clone())
 					.chain(v.iter().enumerate().rev().flat_map(|(i, v)| {
@@ -54,6 +54,18 @@ mod tests {
 	use super::*;
 	use crate::sql::idiom::Idiom;
 	use crate::sql::test::Parse;
+
+	#[test]
+	fn every_with_empty_objects_arrays() {
+		let val = Value::parse("{ test: {}, status: false, something: {age: 45}, tags: []}");
+		let res = vec![
+			Idiom::parse("something.age"),
+			Idiom::parse("status"),
+			Idiom::parse("tags"),
+			Idiom::parse("test"),
+		];
+		assert_eq!(res, val.every(None, false, false));
+	}
 
 	#[test]
 	fn every_without_array_indexes() {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`create` & `insert` operations doesn't seem to work alike. Especially when using empty object & array values.

Ex:
```
DEFINE TABLE test SCHEMAFULL;
DEFINE FIELD something ON TABLE test TYPE object;

CREATE test CONTENT {  // This works as something has been provided with an {} value
	id: 'tester',
	something: {},
};

INSERT INTO test {           // This throws error as {} is considered as NONE
	id: 'tester',
	something: {},
};
```
The error occurs on value merging during `insert` where empty objects and arrays are considered as NONE.

## What does this change do?

This PR fixes the issue by slightly tweaking the current implementation of `every` method of value.

## What is your testing strategy?

Have added a small test as well.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
