### PR TITLE
Bugfix #2345 - allow keyword as ident prefix.

### DIFF
--- a/lib/src/sql/ending.rs
+++ b/lib/src/sql/ending.rs
@@ -14,37 +14,51 @@ use nom::sequence::preceded;
 
 pub fn number(i: &str) -> IResult<&str, ()> {
 	peek(alt((
-		map(multispace1, |_| ()),
-		map(binary, |_| ()),
-		map(assigner, |_| ()),
-		map(comment, |_| ()),
-		map(char(')'), |_| ()),
-		map(char(']'), |_| ()),
-		map(char('}'), |_| ()),
+		map(multispace1, |_| ()), // 1 + 1
+		map(binary, |_| ()),      // 1+1
+		map(assigner, |_| ()),    // 1=1
+		map(comment, |_| ()),     // 1/*comment*/
+		map(char(')'), |_| ()),   // (1)
+		map(char(']'), |_| ()),   // a[1]
+		map(char('}'), |_| ()),   // {k: 1}
 		map(char('"'), |_| ()),
 		map(char('\''), |_| ()),
-		map(char(';'), |_| ()),
-		map(char(','), |_| ()),
-		map(tag(".."), |_| ()),
-		map(eof, |_| ()),
+		map(char(';'), |_| ()), // SET a = 1;
+		map(char(','), |_| ()), // [1, 2]
+		map(tag(".."), |_| ()), // thing:1..2
+		map(eof, |_| ()),       // SET a = 1
 	)))(i)
 }
 
 pub fn ident(i: &str) -> IResult<&str, ()> {
 	peek(alt((
-		map(multispace1, |_| ()),
-		map(binary, |_| ()),
-		map(assigner, |_| ()),
-		map(comment, |_| ()),
-		map(char(')'), |_| ()),
-		map(char(']'), |_| ()),
-		map(char('}'), |_| ()),
-		map(char(';'), |_| ()),
-		map(char(','), |_| ()),
-		map(char('.'), |_| ()),
-		map(char('['), |_| ()),
-		map(char('-'), |_| ()),
-		map(eof, |_| ()),
+		map(multispace1, |_| ()), // a + 1
+		map(binary, |_| ()),      // a+1
+		map(assigner, |_| ()),    // a+=1
+		map(comment, |_| ()),     // a/*comment*/
+		map(char(')'), |_| ()),   // (a)
+		map(char(']'), |_| ()),   // foo[a]
+		map(char('}'), |_| ()),   // {k: a}
+		map(char(';'), |_| ()),   // SET k = a;
+		map(char(','), |_| ()),   // [a, b]
+		map(char('.'), |_| ()),   // a.k
+		map(char('['), |_| ()),   // a[0]
+		map(eof, |_| ()),         // SET k = a
+	)))(i)
+}
+
+/// none, false, etc.
+pub fn keyword(i: &str) -> IResult<&str, ()> {
+	peek(alt((
+		map(multispace1, |_| ()), // false || true
+		map(binary, |_| ()),      // false||true
+		map(comment, |_| ()),     // false/*comment*/
+		map(char(')'), |_| ()),   // (false)
+		map(char(']'), |_| ()),   // [WHERE k = false]
+		map(char('}'), |_| ()),   // {k: false}
+		map(char(';'), |_| ()),   // SET a = false;
+		map(char(','), |_| ()),   // [false, true]
+		map(eof, |_| ()),         // SET a = false
 	)))(i)
 }
 
@@ -60,7 +74,6 @@ pub fn duration(i: &str) -> IResult<&str, ()> {
 		map(char(';'), |_| ()),
 		map(char(','), |_| ()),
 		map(char('.'), |_| ()),
-		map(char('-'), |_| ()),
 		map(eof, |_| ()),
 	)))(i)
 }

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -16,6 +16,7 @@ use crate::sql::constant::{constant, Constant};
 use crate::sql::datetime::{datetime, Datetime};
 use crate::sql::duration::{duration, Duration};
 use crate::sql::edges::{edges, Edges};
+use crate::sql::ending::keyword;
 use crate::sql::error::IResult;
 use crate::sql::expression::{binary, unary, Expression};
 use crate::sql::fmt::{Fmt, Pretty};
@@ -49,6 +50,7 @@ use nom::character::complete::char;
 use nom::combinator::{map, opt};
 use nom::multi::separated_list0;
 use nom::multi::separated_list1;
+use nom::sequence::terminated;
 use rust_decimal::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as Json;
@@ -2695,10 +2697,15 @@ pub fn value(i: &str) -> IResult<&str, Value> {
 pub fn single(i: &str) -> IResult<&str, Value> {
 	alt((
 		alt((
-			map(tag_no_case("NONE"), |_| Value::None),
-			map(tag_no_case("NULL"), |_| Value::Null),
-			map(tag_no_case("true"), |_| Value::Bool(true)),
-			map(tag_no_case("false"), |_| Value::Bool(false)),
+			terminated(
+				alt((
+					map(tag_no_case("NONE"), |_| Value::None),
+					map(tag_no_case("NULL"), |_| Value::Null),
+					map(tag_no_case("true"), |_| Value::Bool(true)),
+					map(tag_no_case("false"), |_| Value::Bool(false)),
+				)),
+				keyword,
+			),
 			map(idiom::multi, Value::from),
 		)),
 		alt((
@@ -2967,10 +2974,10 @@ mod tests {
 	#[test]
 	fn serialize_deserialize() {
 		let val = Value::parse(
-			"{ test: { something: [1, 'two', null, test:tobie, { something: false }] } }",
+			"{ test: { something: [1, 'two', null, test:tobie, { trueee: false, noneee: nulll }] } }",
 		);
 		let res = Value::parse(
-			"{ test: { something: [1, 'two', null, test:tobie, { something: false }] } }",
+			"{ test: { something: [1, 'two', null, test:tobie, { trueee: false, noneee: nulll }] } }",
 		);
 		let enc: Vec<u8> = val.into();
 		let dec: Value = enc.into();


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Idents like `trueeeee` resulted in a parser error.

## What does this change do?

- Adds new type of `ending` for keywords
- Adds some comments revealing the intuition behind certain `ending`'s
- Removes redundant `-` endings when `binary` (binary operator) already was present

## What is your testing strategy?

Edits a test.

## Is this related to any issues?

Fixes #2345

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
