### PR TITLE
Remove unused fuzz dict

### DIFF
--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -345,9 +345,6 @@
 "type::int("
 "type::number("
 "type::point("
-# Avoid regex in the fuzzer as it will just slow things down.
-# the rust regex crate is already fuzzed.
-# "type::regex("
 "type::string("
 "type::table("
 "type::thing("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -344,7 +344,6 @@
 "type::int("
 "type::number("
 "type::point("
-"type::regex("
 "type::string("
 "type::table("
 "type::thing("


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

 `type::regex` has been remove on PR #1861. So I think it won't be needed in fuzz dict as well.

## What does this change do?

This PR remove the redundant `type::thing' from fuzz dict.

## What is your testing strategy?

NA.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
