### PR TITLE
[iam] Restore $auth. Allow user-token signin for root users

### DIFF
--- a/lib/src/dbs/session.rs
+++ b/lib/src/dbs/session.rs
@@ -56,7 +56,7 @@ impl Session {
 	pub(crate) fn context<'a>(&self, mut ctx: Context<'a>) -> Context<'a> {
 		// Add scope auth data
 		let val: Value = self.sd.to_owned().into();
-		ctx.add_value("scope_auth", val);
+		ctx.add_value("auth", val);
 		// Add scope data
 		let val: Value = self.sc.to_owned().into();
 		ctx.add_value("scope", val);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Fix the `$auth` object, allow user-token authentication at root level using tokens

## What does this change do?

* **Restore the `$auth` object**: It broke in a previous PR. The object can be queried like `SELECT * FROM $auth`
* **Allow user-token authentication for root users**: with the PR #2176, root users now return a token after signin. With this PR, we allow that token to be used for signing in into the database.

## What is your testing strategy?

I added tests for them in #2325

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
