### PR TITLE
Return an error when the server version is incompatible with the SDK

### DIFF
--- a/lib/src/api/err/mod.rs
+++ b/lib/src/api/err/mod.rs
@@ -146,6 +146,20 @@ pub enum Error {
 	/// it's running on
 	#[error("The protocol or storage engine does not support backups on this architecture")]
 	BackupsNotSupported,
+
+	/// The version of the server is not compatible with the versions supported by this SDK
+	#[error("server version `{server_version}` does not match the range supported by the client `{supported_versions}`")]
+	VersionMismatch {
+		server_version: semver::Version,
+		supported_versions: String,
+	},
+
+	/// The build metadata of the server is older than the minimum supported by this SDK
+	#[error("server build `{server_metadata}` is older than the minimum supported build `{supported_metadata}`")]
+	BuildMetadataMismatch {
+		server_metadata: semver::BuildMetadata,
+		supported_metadata: semver::BuildMetadata,
+	},
 }
 
 #[cfg(feature = "protocol-http")]


### PR DESCRIPTION
## What is the motivation?

Incompatible servers can return data that the SDK doesn't know how to deserialise. The resulting error messages can be confusing to a user.

## What does this change do?

Makes the SDK return an error when a user connects to a server with an incompatible version.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
