### PR TITLE
Script function fixes

### DIFF
--- a/lib/src/fnc/script/modules/surrealdb/functions/crypto/argon2.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/crypto/argon2.rs
@@ -1,11 +1,12 @@
-use super::super::run;
+use super::super::fut;
 use crate::fnc::script::modules::impl_module_def;
+use js::prelude::Async;
 
 pub struct Package;
 
 impl_module_def!(
 	Package,
 	"crypto::argon2",
-	"compare" => run,
-	"generate" => run
+	"compare" => fut Async,
+	"generate" => fut Async
 );

--- a/lib/src/fnc/script/modules/surrealdb/functions/crypto/bcrypt.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/crypto/bcrypt.rs
@@ -1,11 +1,12 @@
-use super::super::run;
+use super::super::fut;
 use crate::fnc::script::modules::impl_module_def;
+use js::prelude::Async;
 
 pub struct Package;
 
 impl_module_def!(
 	Package,
 	"crypto::bcrypt",
-	"compare" => run,
-	"generate" => run
+	"compare" => fut Async,
+	"generate" => fut Async
 );

--- a/lib/src/fnc/script/modules/surrealdb/functions/crypto/pbkdf2.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/crypto/pbkdf2.rs
@@ -1,11 +1,12 @@
-use super::super::run;
+use super::super::fut;
 use crate::fnc::script::modules::impl_module_def;
+use js::prelude::Async;
 
 pub struct Package;
 
 impl_module_def!(
 	Package,
 	"crypto::pbkdf2",
-	"compare" => run,
-	"generate" => run
+	"compare" => fut Async,
+	"generate" => fut Async
 );

--- a/lib/src/fnc/script/modules/surrealdb/functions/crypto/scrypt.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/crypto/scrypt.rs
@@ -1,11 +1,12 @@
-use super::super::run;
+use super::super::fut;
 use crate::fnc::script::modules::impl_module_def;
+use js::prelude::Async;
 
 pub struct Package;
 
 impl_module_def!(
 	Package,
 	"crypto::scrypt",
-	"compare" => run,
-	"generate" => run
+	"compare" => fut Async,
+	"generate" => fut Async
 );

--- a/lib/src/fnc/script/modules/surrealdb/functions/rand.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/rand.rs
@@ -1,20 +1,64 @@
+use js::{
+	function::Params,
+	prelude::{Func, Rest},
+	Ctx,
+};
+
 use super::run;
-use crate::fnc::script::modules::impl_module_def;
+use crate::{fnc::script::modules::impl_module_def, sql::value::Value};
 
 mod uuid;
 
 pub struct Package;
 
-impl_module_def!(
-	Package,
-	"rand",
-	"bool" => run,
-	"enum" => run,
-	"float" => run,
-	"guid" => run,
-	"int" => run,
-	"string" => run,
-	"time" => run,
-	"ulid" => run,
-	"uuid" => (uuid::Package)
-);
+impl js::module::ModuleDef for Package {
+	fn declare(decls: &mut js::module::Declarations) -> js::Result<()> {
+		decls.declare("default")?;
+		decls.declare("bool")?;
+		decls.declare("enum")?;
+		decls.declare("float")?;
+		decls.declare("guid")?;
+		decls.declare("int")?;
+		decls.declare("string")?;
+		decls.declare("time")?;
+		decls.declare("ulid")?;
+		decls.declare("uuid")?;
+		Ok(())
+	}
+	fn evaluate<'js>(ctx: &js::Ctx<'js>, exports: &mut js::module::Exports<'js>) -> js::Result<()> {
+		let default = js::Function::new(
+			ctx.clone(),
+			Func::new(|ctx: Ctx<'js>, args: Rest<Value>| run(ctx, "rand", args.0)),
+		)?;
+		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand", "bool", run,);
+		exports.export("bool", value.clone())?;
+		default.set("bool", value)?;
+		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand", "enum", run,);
+		exports.export("enum", value.clone())?;
+		default.set("enum", value)?;
+		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand", "float", run,);
+		exports.export("float", value.clone())?;
+		default.set("float", value)?;
+		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand", "guid", run,);
+		exports.export("guid", value.clone())?;
+		default.set("guid", value)?;
+		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand", "int", run,);
+		exports.export("int", value.clone())?;
+		default.set("int", value)?;
+		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand", "string", run,);
+		exports.export("string", value.clone())?;
+		default.set("string", value)?;
+		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand", "time", run,);
+		exports.export("time", value.clone())?;
+		default.set("time", value)?;
+		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand", "ulid", run,);
+		exports.export("ulid", value.clone())?;
+		default.set("ulid", value)?;
+		let value =
+			crate::fnc::script::modules::impl_module_def!(ctx, "rand", "uuid", (uuid::Package),);
+		exports.export("uuid", value.clone())?;
+		default.set("uuid", value)?;
+		exports.export("default", default)?;
+		Ok(())
+	}
+}

--- a/lib/src/fnc/script/modules/surrealdb/functions/rand.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/rand.rs
@@ -1,11 +1,7 @@
-use js::{
-	function::Params,
-	prelude::{Func, Rest},
-	Ctx,
-};
+use js::{prelude::Rest, Ctx};
 
 use super::run;
-use crate::{fnc::script::modules::impl_module_def, sql::value::Value};
+use crate::sql::value::Value;
 
 mod uuid;
 
@@ -26,10 +22,10 @@ impl js::module::ModuleDef for Package {
 		Ok(())
 	}
 	fn evaluate<'js>(ctx: &js::Ctx<'js>, exports: &mut js::module::Exports<'js>) -> js::Result<()> {
-		let default = js::Function::new(
-			ctx.clone(),
-			Func::new(|ctx: Ctx<'js>, args: Rest<Value>| run(ctx, "rand", args.0)),
-		)?;
+		let default = js::Function::new(ctx.clone(), |ctx: Ctx<'js>, args: Rest<Value>| {
+			run(ctx, "rand", args.0)
+		})?
+		.with_name("rand")?;
 		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand", "bool", run,);
 		exports.export("bool", value.clone())?;
 		default.set("bool", value)?;

--- a/lib/src/fnc/script/modules/surrealdb/functions/rand/uuid.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/rand/uuid.rs
@@ -1,11 +1,29 @@
+use js::{prelude::Rest, Ctx};
+
 use super::super::run;
-use crate::fnc::script::modules::impl_module_def;
+use crate::sql::value::Value;
 
 pub struct Package;
 
-impl_module_def!(
-	Package,
-	"rand::uuid",
-	"v4" => run,
-	"v7" => run
-);
+impl js::module::ModuleDef for Package {
+	fn declare(decls: &mut js::module::Declarations) -> js::Result<()> {
+		decls.declare("default")?;
+		decls.declare("v4")?;
+		decls.declare("v7")?;
+		Ok(())
+	}
+	fn evaluate<'js>(ctx: &js::Ctx<'js>, exports: &mut js::module::Exports<'js>) -> js::Result<()> {
+		let default = js::Function::new(ctx.clone(), |ctx: Ctx<'js>, args: Rest<Value>| {
+			run(ctx, "rand::uuid", args.0)
+		})?
+		.with_name("uuid")?;
+		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand::uuid", "v4", run,);
+		exports.export("v4", value.clone())?;
+		default.set("v4", value)?;
+		let value = crate::fnc::script::modules::impl_module_def!(ctx, "rand::uuid", "v7", run,);
+		exports.export("v7", value.clone())?;
+		default.set("v7", value)?;
+		exports.export("default", default)?;
+		Ok(())
+	}
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Both the rand function and the uuid function where not accessible from JavaScript, they are now the default returned object from those modules.

A bunch of CPU intensive crypto functions where called incorrectly resulting in a panic.

## What does this change do?

This PR fixes this problem.

## What is your testing strategy?

N/A

## Is this related to any issues?

Non found

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
