### PR TITLE
[ci] Intruduce cargo-make to dry the workflows. Get rid of unused deps

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,10 @@
 name: Benchmark
 
 on:
+  workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 defaults:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -qq -y update
-          sudo apt-get -qq -y install protobuf-compiler libprotobuf-dev
           cargo install --quiet critcmp
 
       - name: Checkout baseline
@@ -27,23 +26,32 @@ jobs:
         with:
           ref: ${{ github.base_ref }}
 
-      - name: Benchmark baseline
-        run: cargo bench --quiet --package surrealdb --no-default-features --features kv-mem,scripting,http -- --save-baseline baseline
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-      - name: Extract baseline
-        run: cp -r target/criterion /tmp/criterion
+      - name: Benchmark baseline
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: bench-baseline
 
       - name: Checkout changes
         uses: actions/checkout@v3
 
-      - name: Replace baseline
-        run: mkdir target && cp -r /tmp/criterion target/criterion
-
       - name: Benchmark changes
-        run: cargo bench --quiet --package surrealdb --no-default-features --features kv-mem,scripting,http -- --save-baseline changes
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: bench-changes
 
-      - name: Compare results
-        run: critcmp baseline changes | tee benchmark_results
+      - name: Benchmark results
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: bench-compare
 
       - name: Save results as artifact
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: Continuous integration
 
 on:
+  workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
   merge_group:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,17 @@ jobs:
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Check format of code
-        run: cargo fmt --all --check
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-      - name: Check format of unlinked tests
-        run: cargo fmt --all --check -- ./lib/tests/**/*.rs ./lib/src/kvs/tests/*.rs
+      - name: Check format
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-format
 
   check:
     name: Check workspace
@@ -50,10 +56,18 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
-      - name: Run cargo check
-        run: cargo check --locked --workspace
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Check workspace
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-check
 
   check-wasm:
     name: Check Wasm
@@ -71,8 +85,17 @@ jobs:
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Run cargo check
-        run: cargo check --locked --package surrealdb --features protocol-ws,protocol-http,kv-mem,kv-indxdb,http --target wasm32-unknown-unknown
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Check wasm
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-check-wasm
 
   clippy:
     name: Check clippy
@@ -93,10 +116,18 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
-      - name: Run cargo clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-clippy
 
   cli:
     name: Test command line
@@ -115,10 +146,18 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
-      - name: Run cargo test
-        run: cargo test --locked --no-default-features --features storage-mem --workspace --test cli_integration
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Run CLI integration tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-cli-integration
 
   http-server:
     name: Test HTTP server
@@ -137,10 +176,18 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
-      - name: Run cargo test
-        run: cargo test --locked --no-default-features --features storage-mem --workspace --test http_integration
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Run HTTP integration tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-http-integration
 
   test:
     name: Test workspace
@@ -159,12 +206,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Run cargo test (+coverage)
+      - name: Free up some disk space
         run: |
           (set -x; df -h)
           # Free up some disk space by removing unused files
@@ -175,15 +218,27 @@ jobs:
           (set -x; sudo rm -rf /opt/pipx || true)
           (set -x; df -h)
 
-          cargo llvm-cov --html --locked --no-default-features --features storage-mem,scripting,http --workspace -- --skip api_integration --skip cli_integration --skip http_integration
-          (set -x; df -h)
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test workspace + coverage
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-workspace-coverage
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
         with:
-            name: code-coverage-report
-            path: target/llvm-cov/html/
-            retention-days: 5
+          name: code-coverage-report
+          path: target/llvm-cov/html/
+          retention-days: 5
 
   ws-engine:
     name: WebSocket engine
@@ -202,18 +257,23 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
       - name: Setup FoundationDB
         uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
         with:
           version: "7.1.30"
 
-      - name: Run cargo test
-        run: |
-          cargo build --locked --no-default-features --features storage-fdb
-          (&>/dev/null ./target/debug/surreal start --auth --log trace --user root --pass root fdb:/etc/foundationdb/fdb.cluster &)
-          cargo test --locked --package surrealdb --no-default-features --features protocol-ws --test api api_integration::ws
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test ws engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-ws
 
   http-engine:
     name: HTTP engine
@@ -232,18 +292,58 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
       - name: Setup FoundationDB
         uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
         with:
           version: "7.1.30"
 
-      - name: Run cargo test
-        run: |
-          cargo build --locked --no-default-features --features storage-fdb
-          (&>/dev/null ./target/debug/surreal start --auth --log trace --user root --pass root fdb:/etc/foundationdb/fdb.cluster &)
-          cargo test --locked --package surrealdb --no-default-features --features protocol-http --test api api_integration::http
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test http engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-http
+
+  any-engine:
+      name: Any engine
+      runs-on: ubuntu-latest
+      steps:
+
+        - name: Install stable toolchain
+          uses: dtolnay/rust-toolchain@stable
+
+        - name: Checkout sources
+          uses: actions/checkout@v3
+
+        - name: Setup cache
+          uses: Swatinem/rust-cache@v2
+
+        - name: Install dependencies
+          run: |
+            sudo apt-get -y update
+
+        - name: Setup FoundationDB
+          uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+          with:
+            version: "7.1.30"
+
+        - name: Install cargo-make
+          uses: actions-rs/cargo@v1
+          with:
+            command: install
+            args: --debug cargo-make
+
+        - name: Test any engine
+          uses: actions-rs/cargo@v1
+          with:
+            command: make
+            args: ci-api-integration-any
 
   mem-engine:
     name: Memory engine
@@ -259,10 +359,17 @@ jobs:
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Run cargo test
-        run: |
-          cargo test --locked --package surrealdb --no-default-features --features kv-mem --lib kvs
-          cargo test --locked --package surrealdb --no-default-features --features kv-mem --test api api_integration::mem
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test mem engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-mem
 
   file-engine:
     name: File engine
@@ -278,10 +385,17 @@ jobs:
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Run cargo test
-        run: |
-          cargo test --locked --package surrealdb --no-default-features --features kv-rocksdb --lib kvs
-          cargo test --locked --package surrealdb --no-default-features --features kv-rocksdb --test api api_integration::file
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test file engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-file
 
   rocksdb-engine:
     name: RocksDB engine
@@ -297,10 +411,17 @@ jobs:
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Run cargo test
-        run: |
-          cargo test --locked --package surrealdb --no-default-features --features kv-rocksdb --lib kvs
-          cargo test --locked --package surrealdb --no-default-features --features kv-rocksdb --test api api_integration::rocksdb
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test rocksdb engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-rocksdb
 
   speedb-engine:
     name: SpeeDB engine
@@ -316,10 +437,17 @@ jobs:
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Run cargo test
-        run: |
-          cargo test --locked --package surrealdb --no-default-features --features kv-speedb --lib kvs
-          cargo test --locked --package surrealdb --no-default-features --features kv-speedb --test api api_integration::speedb
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test speedb engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-speedb
 
   tikv-engine:
      name: TiKV engine
@@ -338,7 +466,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
       - name: Install TiKV
         run: |
@@ -346,11 +473,17 @@ jobs:
           ~/.tiup/bin/tiup install tikv pd
           ~/.tiup/bin/tiup -v
 
-      - name: Run cargo test
-        run: |
-          (&>/dev/null ~/.tiup/bin/tiup playground --mode tikv-slim --kv 3 --without-monitor &)
-          cargo test --locked --package surrealdb --no-default-features --features kv-tikv --lib kvs
-          cargo test --locked --package surrealdb --no-default-features --features kv-tikv --test api api_integration::tikv
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test tikv engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-tikv
 
   fdb-engine:
     name: FoundationDB engine
@@ -371,37 +504,14 @@ jobs:
         with:
           version: "7.1.30"
 
-      - name: Run cargo test
-        run: |
-          cargo test --locked --package surrealdb --no-default-features --features kv-fdb-7_1 --lib kvs
-          cargo test --locked --package surrealdb --no-default-features --features kv-fdb-7_1 --test api api_integration::fdb
-
-  any-engine:
-    name: Any engine
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
-
-      - name: Setup FoundationDB
-        uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
         with:
-          version: "7.1.30"
+          command: install
+          args: --debug cargo-make
 
-      - name: Run cargo test
-        run: |
-          cargo build --locked --no-default-features --features storage-fdb
-          (&>/dev/null ./target/debug/surreal start --auth --log trace --user root --pass root fdb:/etc/foundationdb/fdb.cluster &)
-          cargo test --locked --package surrealdb --no-default-features --features protocol-http --test api api_integration::any
+      - name: Test fdb engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-fdb

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,24 +16,44 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
 
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Checkout sources
         uses: actions/checkout@v3
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Free up some disk space
+        run: |
+          (set -x; df -h)
+          # Free up some disk space by removing unused files
+          (set -x; sudo rm -rf /imagegeneration || true)
+          (set -x; sudo rm -rf /opt/az || true)
+          (set -x; sudo rm -rf /opt/hostedtoolcache || true)
+          (set -x; sudo rm -rf /opt/google || true)
+          (set -x; sudo rm -rf /opt/pipx || true)
+          (set -x; df -h)
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Run cargo test (+coverage)
-        run: |
-          (&>/dev/null cargo run --no-default-features -F storage-mem -- start --log trace --user root --pass root memory &)
-          cargo llvm-cov --html --workspace --features protocol-ws,protocol-http,kv-mem,kv-rocksdb
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test workspace + coverage
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-workspace-coverage
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
@@ -53,7 +73,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -61,20 +80,35 @@ jobs:
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 
-      - name: Run cargo check
-        run: cargo check --workspace
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-      - name: Check format of code
-        run: cargo fmt --all --check
+      - name: Check workspace
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-check
 
-      - name: Check format of unlinked tests
-        run: cargo fmt --all --check -- ./lib/tests/**/*.rs ./lib/src/kvs/tests/*.rs
+      - name: Check format
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-format
 
-      - name: Check linting with clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Check wasm
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-check-wasm
 
-      - name: Run WebAssembly check
-        run: cargo check --features kv-mem,kv-indxdb,protocol-ws,protocol-http --target wasm32-unknown-unknown --package surrealdb
+      - name: Check clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-clippy
 
   build:
     name: Build ${{ matrix.arch }}
@@ -116,10 +150,7 @@ jobs:
       - name: Install dependencies
         if: contains(matrix.arch, 'windows') && endsWith(matrix.arch, '-msvc')
         run: |
-          vcpkg upgrade
           vcpkg integrate install
-          vcpkg install openssl:x64-windows-static
-          choco install protoc
 
       - name: Install dependencies
         if: contains(matrix.arch, 'apple') && endsWith(matrix.arch, '-darwin')
@@ -132,7 +163,6 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install musl-tools qemu-user libc6-dev-arm64-cross
           sudo apt-get -y install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
       - name: Install FoundationDB
         if: contains(matrix.arch, 'linux') && startsWith(matrix.arch, 'x86_64')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,24 +16,44 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
 
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Checkout sources
         uses: actions/checkout@v3
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Free up some disk space
+        run: |
+          (set -x; df -h)
+          # Free up some disk space by removing unused files
+          (set -x; sudo rm -rf /imagegeneration || true)
+          (set -x; sudo rm -rf /opt/az || true)
+          (set -x; sudo rm -rf /opt/hostedtoolcache || true)
+          (set -x; sudo rm -rf /opt/google || true)
+          (set -x; sudo rm -rf /opt/pipx || true)
+          (set -x; df -h)
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Run cargo test (+coverage)
-        run: |
-          (&>/dev/null cargo run --no-default-features -F storage-mem -- start --log trace --user root --pass root memory &)
-          cargo llvm-cov --html --workspace --features protocol-ws,protocol-http,kv-mem,kv-rocksdb
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test workspace + coverage
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-workspace-coverage-complete
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
@@ -53,7 +73,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -61,20 +80,35 @@ jobs:
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 
-      - name: Run cargo check
-        run: cargo check --workspace
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-      - name: Check format of code
-        run: cargo fmt --all --check
+      - name: Check workspace
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-check
 
-      - name: Check format of unlinked tests
-        run: cargo fmt --all --check -- ./lib/tests/**/*.rs ./lib/src/kvs/tests/*.rs
+      - name: Check format
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-format
 
-      - name: Check linting with clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Check wasm
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-check-wasm
 
-      - name: Run WebAssembly check
-        run: cargo check --features kv-mem,kv-indxdb,protocol-ws,protocol-http --target wasm32-unknown-unknown --package surrealdb
+      - name: Check clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-clippy
 
   build:
     name: Build ${{ matrix.arch }}
@@ -116,10 +150,7 @@ jobs:
       - name: Install dependencies
         if: contains(matrix.arch, 'windows') && endsWith(matrix.arch, '-msvc')
         run: |
-          vcpkg upgrade
           vcpkg integrate install
-          vcpkg install openssl:x64-windows-static
-          choco install protoc
 
       - name: Install dependencies
         if: contains(matrix.arch, 'apple') && endsWith(matrix.arch, '-darwin')
@@ -132,7 +163,6 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install musl-tools qemu-user libc6-dev-arm64-cross
           sudo apt-get -y install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
       - name: Install FoundationDB
         if: contains(matrix.arch, 'linux') && startsWith(matrix.arch, 'x86_64')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -331,7 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1695,7 +1695,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1758,7 +1758,7 @@ checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
 dependencies = [
  "cfg-if",
  "rustix 0.38.4",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2572,7 +2572,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.2",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2589,7 +2589,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
  "rustix 0.38.4",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2764,12 +2764,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
@@ -2930,7 +2924,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3257,7 +3251,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets 0.48.1",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3530,19 +3524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "procfs"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de8dacb0873f77e6aefc6d71e044761fcc68060290f5b1089fcdf84626bb69"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "hex",
- "lazy_static",
- "rustix 0.36.15",
-]
-
-[[package]]
 name = "prometheus"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3551,12 +3532,8 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
- "libc",
  "memchr",
  "parking_lot",
- "procfs",
- "protobuf",
- "reqwest",
  "thiserror",
 ]
 
@@ -3582,12 +3559,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psl-types"
@@ -4169,20 +4140,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c37f1bd5ef1b5422177b7646cba67430579cfe2ace80f284fee876bca52ad941"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
@@ -4192,7 +4149,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4205,7 +4162,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.3",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4322,7 +4279,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4915,9 +4872,8 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-tikv-client"
-version = "0.2.0-surreal.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1720f8118e3a0289dba5d781569daa85586c634b911bc290d0217869fa214a22"
+version = "0.2.0-surreal.2"
+source = "git+https://github.com/surrealdb/tikv-client.git?tag=0.2.0-surreal.2#0af5d641eb66e2f3616c251f6be381ab79882817"
 dependencies = [
  "async-recursion 0.3.2",
  "async-trait",
@@ -5022,7 +4978,7 @@ dependencies = [
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
  "rustix 0.38.4",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5052,7 +5008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
  "rustix 0.37.23",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5197,7 +5153,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5963,16 +5919,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5981,22 +5928,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -6005,20 +5937,14 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6028,21 +5954,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6052,21 +5966,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6076,21 +5978,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ opentelemetry = { version = "0.19", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.12.0", features = ["metrics"] }
 pin-project-lite = "0.2.10"
 rand = "0.8.5"
-reqwest = { version = "0.11.18", features = ["blocking"] }
+reqwest = { version = "0.11.18", default-features = false, features = ["blocking"] }
 rustyline = { version = "11.0.0", features = ["derive"] }
 serde = { version = "1.0.171", features = ["derive"] }
 serde_cbor = "0.11.2"

--- a/Makefile
+++ b/Makefile
@@ -1,59 +1,54 @@
-DEV_FEATURES ?= storage-mem,http,scripting
-SURREAL_LOG ?= trace
-SURREAL_USER ?= root
-SURREAL_PASS ?= root
-SURREAL_AUTH ?= true
-SURREAL_PATH ?= memory
-SURREAL_NAMESPACE ?= test
-SURREAL_DATABASE ?= test
-
-SHELL := env SURREAL_PATH=$(SURREAL_PATH) SURREAL_LOG=$(SURREAL_LOG) SURREAL_AUTH=$(SURREAL_AUTH) SURREAL_USER=$(SURREAL_USER) SURREAL_PASS=$(SURREAL_PASS) $(SHELL)
-
 .PHONY: default
 default:
 	@echo "Choose a Makefile target:"
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print "  - " $$1}}' | sort
 
+.PHONY: check-deps
+check-deps:
+	@cargo make --help >/dev/null 2>&1 || { \
+		echo >&2 "ERROR: Install cargo-make to use make tasks."; \
+		echo >&2 "$ cargo install --no-default-features --force cargo-make"; \
+		echo >&2 "More info: https://sagiegurari.github.io/cargo-make"; \
+		echo >&2; \
+		exit 1; \
+	}
+
 .PHONY: setup
-setup:
-	cargo upgrade --pinned
-	cargo update
+setup: check-deps
+	cargo make setup
 
 .PHONY: docs
-docs:
-	cargo doc --open --no-deps --package surrealdb --features rustls,native-tls,protocol-ws,protocol-http,kv-mem,kv-indxdb,kv-speedb,kv-rocksdb,kv-tikv,http,scripting
+docs: check-deps
+	cargo make docs
 
 .PHONY: test
-test:
-	cargo test --workspace
+test: check-deps
+	cargo make test
 
 .PHONY: check
-check:
-	cargo check --workspace
-	cargo fmt --all --check
-	cargo fmt --all --check -- ./lib/tests/**/*.rs ./lib/src/kvs/tests/*.rs
-	cargo clippy --all-targets --all-features -- -D warnings
+check: check-deps
+	cargo make check
 
 .PHONY: clean
-clean:
-	cargo clean
+clean: check-deps
+	cargo make clean
 
 .PHONY: bench
-bench:
-	cargo bench --package surrealdb --no-default-features --features kv-mem,http,scripting
+bench: check-deps
+	cargo make bench
 
 .PHONY: serve
-serve:
-	cargo run --no-default-features --features $(DEV_FEATURES) -- start
+serve: check-deps
+	cargo make serve
 
 .PHONY: sql
-sql:
-	cargo run --no-default-features --features $(DEV_FEATURES) -- sql --conn ws://0.0.0.0:8000 --multi --pretty
+sql: check-deps
+	cargo make sql
 
 .PHONY: quick
-quick:
-	cargo build
+quick: check-deps
+	cargo make quick
 
 .PHONY: build
-build:
-	cargo build --release
+build: check-deps
+	cargo make build

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -145,7 +145,7 @@ script = """
    echo "Waiting for surreal to be ready..."
    tries=0
    while [[ $tries < 5 ]]; do
-           target/debug/surreal is-ready && echo "Ready!" && exit 0 || sleep 1
+           target/debug/surreal is-ready 2>/dev/null && echo "Ready!" && exit 0 || sleep 1
            tries=$((tries + 1))
    done
 

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -171,8 +171,8 @@ script = """
    set +e
    echo "Waiting for tiup playground to be ready..."
    tries=0
-   while [[ $tries < 15 ]]; do
-           ${HOME}/.tiup/bin/tiup playground display >/dev/null && echo "Ready!" && exit 0 || sleep 1
+   while [[ $tries < 10 ]]; do
+           ${HOME}/.tiup/bin/tiup playground display >/dev/null && echo "Ready!" && exit 0 || sleep 5
            tries=$((tries + 1))
    done
    set -e

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -1,0 +1,228 @@
+[tasks.ci-format]
+category = "CI - CHECK"
+dependencies = ["cargo-fmt", "cargo-fmt-unlinked"]
+
+[tasks.ci-check]
+category = "CI - CHECK"
+command = "cargo"
+args = ["check", "--locked", "--workspace"]
+
+[tasks.ci-check-wasm]
+category = "CI - CHECK"
+command = "cargo"
+args = ["check", "--locked", "--package", "surrealdb", "--features", "protocol-ws,protocol-http,kv-mem,kv-indxdb,http", "--target", "wasm32-unknown-unknown"]
+
+[tasks.ci-clippy]
+category = "CI - CHECK"
+command = "cargo"
+args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
+
+#
+# Integration Tests
+#
+
+[tasks.ci-cli-integration]
+category = "CI - INTEGRATION TESTS"
+command = "cargo"
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem", "--workspace", "--test", "cli_integration"]
+
+[tasks.ci-http-integration]
+category = "CI - INTEGRATION TESTS"
+command = "cargo"
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem", "--workspace", "--test", "http_integration"]
+
+[tasks.ci-workspace-coverage]
+category = "CI - INTEGRATION TESTS"
+command = "cargo"
+args = [
+	"llvm-cov", "--html", "--locked", "--no-default-features", "--features", "storage-mem,scripting,http", "--workspace", "--",
+	"--skip", "api_integration",
+	"--skip", "cli_integration",
+	"--skip", "http_integration",
+	"--skip", "ws_integration"
+]
+
+[tasks.test-workspace-coverage-complete]
+category = "CI - INTEGRATION TESTS"
+command = "cargo"
+args = ["llvm-cov", "--html", "--locked", "--no-default-features", "--features", "protocol-ws,protocol-http,kv-mem,kv-rocksdb", "--workspace"]
+
+[tasks.ci-workspace-coverage-complete]
+env = { _START_SURREALDB_PATH = "memory" }
+category = "CI - INTEGRATION TESTS"
+run_task = { name = ["start-surrealdb", "test-workspace-coverage-complete", "stop-surrealdb"], fork = true }
+
+#
+# Tests private tasks
+#
+
+[tasks.test-kvs]
+private = true
+command = "cargo"
+args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--lib", "kvs"]
+
+
+[tasks.test-api-integration]
+private = true
+command = "cargo"
+args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--test", "api", "api_integration::${_TEST_API_ENGINE}"]
+
+[tasks.ci-api-integration]
+env = { _START_SURREALDB_PATH = "fdb:/etc/foundationdb/fdb.cluster" }
+private = true
+run_task = { name = ["start-surrealdb", "test-api-integration", "stop-surrealdb"], fork = true }
+
+#
+# Integration tests with background services
+#
+
+[tasks.ci-api-integration-http]
+category = "CI - INTEGRATION TESTS"
+env = { _TEST_API_ENGINE = "http", _TEST_FEATURES = "protocol-http" }
+run_task = "ci-api-integration"
+
+[tasks.ci-api-integration-ws]
+category = "CI - INTEGRATION TESTS"
+env = { _TEST_API_ENGINE = "ws", _TEST_FEATURES = "protocol-ws" }
+run_task = "ci-api-integration"
+
+[tasks.ci-api-integration-any]
+category = "CI - INTEGRATION TESTS"
+env = { _TEST_API_ENGINE = "any", _TEST_FEATURES = "protocol-http" }
+run_task = "ci-api-integration"
+
+#
+# Integration tests without background services
+#
+[tasks.ci-api-integration-mem]
+category = "CI - INTEGRATION TESTS"
+env = { _TEST_API_ENGINE = "mem", _TEST_FEATURES = "kv-mem" }
+run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+
+[tasks.ci-api-integration-file]
+category = "CI - INTEGRATION TESTS"
+env = { _TEST_API_ENGINE = "file", _TEST_FEATURES = "kv-rocksdb" }
+run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+
+[tasks.ci-api-integration-rocksdb]
+category = "CI - INTEGRATION TESTS"
+env = { _TEST_API_ENGINE = "rocksdb", _TEST_FEATURES = "kv-rocksdb" }
+run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+
+[tasks.ci-api-integration-speedb]
+category = "CI - INTEGRATION TESTS"
+env = { _TEST_API_ENGINE = "speedb", _TEST_FEATURES = "kv-speedb" }
+run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+
+[tasks.ci-api-integration-fdb]
+category = "CI - INTEGRATION TESTS"
+env = { _TEST_API_ENGINE = "fdb", _TEST_FEATURES = "kv-fdb-7_1" }
+run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+
+[tasks.ci-api-integration-tikv-tests]
+category = "CI - INTEGRATION TESTS"
+env = { _TEST_API_ENGINE = "tikv", _TEST_FEATURES = "kv-tikv" }
+run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+
+[tasks.ci-api-integration-tikv]
+category = "CI - INTEGRATION TESTS"
+run_task = { name = ["start-tikv", "ci-api-integration-tikv-tests", "stop-tikv"], fork = true }
+
+#
+# Services
+#
+[tasks.start-surrealdb]
+category = "CI - SERVICES"
+dependencies = ["build-surrealdb"]
+script = """
+   #!/bin/bash
+
+   target/debug/surreal start ${_START_SURREALDB_PATH} &>/tmp/surrealdb.log &
+
+   echo $! > /tmp/surreal.pid
+
+   set +e
+   echo "Waiting for surreal to be ready..."
+   tries=0
+   while [[ $tries < 5 ]]; do
+           target/debug/surreal is-ready && echo "Ready!" && exit 0 || sleep 1
+           tries=$((tries + 1))
+   done
+
+   echo "ERROR: Surreal is unhealthy!"
+   exit 1
+"""
+
+[tasks.stop-surrealdb]
+category = "CI - SERVICES"
+script = "kill $(cat /tmp/surreal.pid) || true"
+
+[tasks.start-tikv]
+category = "CI - SERVICES"
+script = """
+   #!/bin/bash
+
+   ${HOME}/.tiup/bin/tiup install pd tikv playground
+
+   ${HOME}/.tiup/bin/tiup playground --mode tikv-slim --kv 3 --without-monitor &>/tmp/tiup.log &
+
+   echo $! > /tmp/tiup.pid
+
+   set +e
+   echo "Waiting for tiup playground to be ready..."
+   tries=0
+   while [[ $tries < 15 ]]; do
+           ${HOME}/.tiup/bin/tiup playground display >/dev/null && echo "Ready!" && exit 0 || sleep 1
+           tries=$((tries + 1))
+   done
+   set -e
+
+   echo "ERROR: TiUP Playground is unhealthy!"
+   exit 1
+"""
+
+[tasks.stop-tikv]
+category = "CI - SERVICES"
+script = "kill $(cat /tmp/tiup.pid) || true"
+
+#
+# Builds
+#
+
+[tasks.build-surrealdb]
+category = "CI - BUILD"
+command = "cargo"
+args = ["build", "--locked", "--no-default-features", "--features", "storage-mem,storage-fdb"]
+
+#
+# Benchmarks
+#
+[tasks.bench-run-baseline]
+category = "CI - BENCHMARK"
+command = "cargo"
+args = ["bench", "--quiet", "--package", "surrealdb", "--no-default-features", "--features", "kv-mem,scripting,http", "--", "--save-baseline", "baseline"]
+
+[tasks.bench-save-baseline]
+category = "CI - BENCHMARK"
+script = "cp -r target/criterion /tmp/criterion"
+
+[tasks.bench-restore-baseline]
+category = "CI - BENCHMARK"
+script = "mkdir -p target && cp -r /tmp/criterion target/criterion"
+
+[tasks.bench-baseline]
+category = "CI - BENCHMARK"
+run_task = { name = ["bench-run-baseline", "bench-save-baseline"] }
+
+[tasks.bench-run-changes]
+category = "CI - BENCHMARK"
+command = "cargo"
+args = ["bench", "--quiet", "--package", "surrealdb", "--no-default-features", "--features", "kv-mem,scripting,http", "--", "--save-baseline", "changes"]
+
+[tasks.bench-changes]
+category = "CI - BENCHMARK"
+run_task = { name = ["bench-restore-baseline", "bench-run-changes"] }
+
+[tasks.bench-compare]
+category = "CI - BENCHMARK"
+script = "critcmp baseline changes | tee benchmark_results"

--- a/Makefile.local.toml
+++ b/Makefile.local.toml
@@ -1,0 +1,96 @@
+# Setup
+[tasks.cargo-upgrade]
+private = true
+command = "cargo"
+args = ["upgrade", "--pinned"]
+
+[tasks.cargo-update]
+private = true
+command = "cargo"
+args = ["update"]
+
+[tasks.setup]
+category = "LOCAL USAGE"
+dependencies = ["cargo-upgrade", "cargo-update"]
+
+# Docs
+[tasks.docs]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["doc", "--open", "--no-deps", "--package", "surrealdb", "--features", "rustls,native-tls,protocol-ws,protocol-http,kv-mem,kv-indxdb,kv-speedb,kv-rocksdb,kv-tikv,http,scripting"]
+
+# Test
+[tasks.test]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["test", "--workspace"]
+
+# Check
+[tasks.cargo-check]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["check", "--workspace"]
+
+[tasks.cargo-fmt]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["fmt", "--all", "--check"]
+
+[tasks.cargo-fmt-unlinked]
+category = "LOCAL USAGE"
+script = """
+	set -e
+	cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/
+	cargo fmt --all --check -- ./lib/tests/**/*.rs ./lib/src/kvs/tests/*.rs
+"""
+
+[tasks.cargo-clippy]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
+
+[tasks.check]
+category = "LOCAL USAGE"
+dependencies = ["cargo-check", "cargo-fmt", "cargo-fmt-unlinked", "cargo-clippy"]
+
+# Clean
+[tasks.clean]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["clean"]
+
+# Bench
+[tasks.bench]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["bench", "--package", "surrealdb", "--no-default-features", "--features", "kv-mem,http,scripting"]
+
+# Serve
+[tasks.serve]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["run", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "start"]
+
+# SQL
+[tasks.sql]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["run", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "sql", "--conn", "ws://0.0.0.0:8000", "--multi", "--pretty"]
+
+# Quick
+[tasks.quick]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["build"]
+
+# Build
+[tasks.build]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["build", "--release"]
+
+# Default
+[tasks.default]
+category = "LOCAL USAGE"
+clear = true
+dependencies = ["check", "test", "quick"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,30 @@
+extend = [
+	{ path = "Makefile.local.toml" },
+	{ path = "Makefile.ci.toml" }
+]
+
+[config]
+skip_core_tasks = true
+time_summary = true
+reduce_output = true
+default_to_workspace = false
+
+[env]
+DEV_FEATURES={ value = "storage-mem,http,scripting", condition = { env_not_set = ["DEV_FEATURES"] } }
+SURREAL_LOG={ value = "trace", condition = { env_not_set = ["SURREAL_LOG"] } }
+SURREAL_USER={ value = "root", condition = { env_not_set = ["SURREAL_USER"] } }
+SURREAL_PASS={ value = "root", condition = { env_not_set = ["SURREAL_PASS"] } }
+SURREAL_AUTH={ value = "true", condition = { env_not_set = ["SURREAL_AUTH"] } }
+SURREAL_PATH={ value = "memory", condition = { env_not_set = ["SURREAL_PATH"] } }
+SURREAL_NAMESPACE={ value = "test", condition = { env_not_set = ["SURREAL_NAMESPACE"] } }
+SURREAL_DATABASE={ value = "test", condition = { env_not_set = ["SURREAL_DATABASE"] } }
+
+[tasks.empty]
+disabled = true
+private = true
+
+[tasks.init]
+private = true
+
+[tasks.end]
+private = true

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,7 @@
             hardeningDisable = [ "fortify" ];
 
             depsBuildBuild = buildSpec.depsBuildBuild or [ ]
-              ++ [ rustToolchain ] ++ (with pkgs; [ nixfmt cargo-watch wasm-pack pre-commit]);
+              ++ [ rustToolchain ] ++ (with pkgs; [ nixfmt cargo-watch wasm-pack pre-commit cargo-make]);
 
             inherit (util) SURREAL_BUILD_METADATA;
           })) util.platforms);

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -105,7 +105,9 @@ sha2 = "0.10.7"
 speedb = { version = "0.0.2", optional = true }
 storekey = "0.5.0"
 thiserror = "1.0.43"
-tikv = { version = "0.2.0-surreal.1", package = "surrealdb-tikv-client", optional = true }
+# TODO: Uncomment when surrealdb-tikv-client 0.2.0-surreal.2 is published to crates.io is published
+#tikv = { version = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }
+tikv = { git = "https://github.com/surrealdb/tikv-client.git", tag = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }
 tokio-util = { version = "0.7.8", optional = true, features = ["compat"] }
 tracing = "0.1.37"
 trice = "0.3.1"


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Nightly builds have been broken for some days now for different reasons:
* SurrealDB still needed the openssl library but it couldn't find it after updating the runners to `ubuntu-latest`
* vcpkg is unreliable and sometimes it failed to download the openssl dependency

## What does this change do?

* **SurrealDB don't need the openssl library**: Since we forked the `tikv-client` repo, I could patch it so openssl is no longer necessary (see https://github.com/surrealdb/tikv-client/pull/5)
* **Github Runners don't need system dependencies**: The dependencies installed with `apt` and `vcpkg` are no longer necessary, get rid of them
* **DRY the workflows**: Github workflows had a lot of duplicated code, and when you want to tests the workflow steps locally, you need to copy & paste the necessary parts and pray you don't need anything else. In this PR, I introduce `cargo-make` so we can define all potential development commands in TOML and then reuse them either in the Github workflows or when testing locally.
Future work: Now that we have it centralised, it should be relatively easy to support running them inside docker so it's easier to run the CI commands locally.

## What is your testing strategy?

* Wait for CI and Bench workdlows to pass and verify the executed commands match what we had before.
* Trigger a nightly build locally (slightly modified so it doesn't push anything) and verify it passes executing the expected commands: https://github.com/surrealdb/surrealdb/actions/runs/5740342164

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
