### PR TITLE
Allow more export options

### DIFF
--- a/lib/src/api/conn.rs
+++ b/lib/src/api/conn.rs
@@ -8,6 +8,7 @@ use crate::api::Surreal;
 use crate::opt::from_value;
 use crate::sql::Query;
 use crate::sql::Value;
+use channel;
 use flume::Receiver;
 use flume::Sender;
 use serde::de::DeserializeOwned;
@@ -119,14 +120,16 @@ pub struct Param {
 	pub(crate) query: Option<(Query, BTreeMap<String, Value>)>,
 	pub(crate) other: Vec<Value>,
 	pub(crate) file: Option<PathBuf>,
+	pub(crate) send: Option<channel::Sender<Vec<u8>>>,
 }
 
 impl Param {
 	pub(crate) fn new(other: Vec<Value>) -> Self {
 		Self {
-			other,
 			query: None,
+			other,
 			file: None,
+			send: None,
 		}
 	}
 
@@ -135,6 +138,7 @@ impl Param {
 			query: Some((query, bindings)),
 			other: Vec::new(),
 			file: None,
+			send: None,
 		}
 	}
 
@@ -143,6 +147,16 @@ impl Param {
 			query: None,
 			other: Vec::new(),
 			file: Some(file),
+			send: None,
+		}
+	}
+
+	pub(crate) fn send(send: channel::Sender<Vec<u8>>) -> Self {
+		Self {
+			query: None,
+			other: Vec::new(),
+			file: None,
+			send: Some(send),
 		}
 	}
 }

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -527,66 +527,74 @@ async fn router(
 					crate::Error::Db(error)
 				})
 			}
+			match (param.file, param.send) {
+				(None, None) => panic!("Expected file or channel, neither found"),
+				(Some(_), Some(_)) => panic!("Expected file or channel, found both"),
+				(Some(path), None) => {
+					let export = export_with_err(kvs, session, ns, db, tx);
 
-			let export = export_with_err(kvs, session, ns, db, tx);
+					// Read from channel and write to pipe.
+					let bridge = async move {
+						while let Ok(value) = rx.recv().await {
+							if writer.write_all(&value).await.is_err() {
+								// Broken pipe. Let either side's error be propagated.
+								break;
+							}
+						}
+						Ok(())
+					};
 
-			// Read from channel and write to pipe.
-			let bridge = async move {
-				while let Ok(value) = rx.recv().await {
-					if writer.write_all(&value).await.is_err() {
-						// Broken pipe. Let either side's error be propagated.
-						break;
-					}
-				}
-				Ok(())
-			};
+					// Output to stdout or file.
+					let mut output: Box<dyn AsyncWrite + Unpin + Send> =
+						match path.to_str().unwrap() {
+							"-" => Box::new(io::stdout()),
+							_ => {
+								let file = match OpenOptions::new()
+									.write(true)
+									.create(true)
+									.truncate(true)
+									.open(&path)
+									.await
+								{
+									Ok(path) => path,
+									Err(error) => {
+										return Err(Error::FileOpen {
+											path,
+											error,
+										}
+										.into());
+									}
+								};
+								Box::new(file)
+							}
+						};
 
-			// Output to stdout or file.
-			let path = param.file.expect("file to export into");
-			let mut output: Box<dyn AsyncWrite + Unpin + Send> = match path.to_str().unwrap() {
-				"-" => Box::new(io::stdout()),
-				_ => {
-					let file = match OpenOptions::new()
-						.write(true)
-						.create(true)
-						.truncate(true)
-						.open(&path)
-						.await
+					// Copy from pipe to output.
+					async fn copy_with_err<'a, R, W>(
+						path: PathBuf,
+						reader: &'a mut R,
+						writer: &'a mut W,
+					) -> std::result::Result<(), crate::Error>
+					where
+						R: tokio::io::AsyncRead + Unpin + ?Sized,
+						W: tokio::io::AsyncWrite + Unpin + ?Sized,
 					{
-						Ok(path) => path,
-						Err(error) => {
-							return Err(Error::FileOpen {
+						io::copy(reader, writer).await.map(|_| ()).map_err(|error| {
+							crate::Error::Api(crate::error::Api::FileRead {
 								path,
 								error,
-							}
-							.into());
-						}
-					};
-					Box::new(file)
+							})
+						})
+					}
+
+					let copy = copy_with_err(path, &mut reader, &mut output);
+
+					tokio::try_join!(export, bridge, copy).map(|_| DbResponse::Other(Value::None))
 				}
-			};
-
-			// Copy from pipe to output.
-			async fn copy_with_err<'a, R, W>(
-				path: PathBuf,
-				reader: &'a mut R,
-				writer: &'a mut W,
-			) -> std::result::Result<(), crate::Error>
-			where
-				R: tokio::io::AsyncRead + Unpin + ?Sized,
-				W: tokio::io::AsyncWrite + Unpin + ?Sized,
-			{
-				io::copy(reader, writer).await.map(|_| ()).map_err(|error| {
-					crate::Error::Api(crate::error::Api::FileRead {
-						path,
-						error,
-					})
-				})
+				(None, Some(chn)) => export_with_err(kvs, session, ns, db, chn)
+					.await
+					.map(|_| DbResponse::Other(Value::None)),
 			}
-
-			let copy = copy_with_err(path, &mut reader, &mut output);
-
-			tokio::try_join!(export, bridge, copy).map(|_| DbResponse::Other(Value::None))
 		}
 		#[cfg(not(target_arch = "wasm32"))]
 		Method::Import => {

--- a/lib/src/api/method/export.rs
+++ b/lib/src/api/method/export.rs
@@ -6,8 +6,13 @@ use crate::api::Error;
 use crate::api::ExtraFeatures;
 use crate::api::Result;
 use channel::Sender;
+use std::borrow::Cow;
+use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::future::Future;
 use std::future::IntoFuture;
+use std::path::Component;
+use std::path::Components;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -49,47 +54,82 @@ pub enum Exportable {
 }
 
 pub trait IntoExportable {
-	fn into_exportable(self) -> Exportable;
+	fn into_exportable(&self) -> Exportable;
 }
 
 impl IntoExportable for &str {
-	fn into_exportable(self) -> Exportable {
+	fn into_exportable(&self) -> Exportable {
 		Exportable::File(<str as AsRef<Path>>::as_ref(self).to_owned())
 	}
 }
 
 impl IntoExportable for String {
-	fn into_exportable(self) -> Exportable {
+	fn into_exportable(&self) -> Exportable {
 		Exportable::File(<str as AsRef<Path>>::as_ref(&self).to_owned())
 	}
 }
 
 impl IntoExportable for &String {
-	fn into_exportable(self) -> Exportable {
+	fn into_exportable(&self) -> Exportable {
 		Exportable::File(<str as AsRef<Path>>::as_ref(self).to_owned())
 	}
 }
 
 impl IntoExportable for &Path {
-	fn into_exportable(self) -> Exportable {
-		Exportable::File(self.to_owned())
+	fn into_exportable(&self) -> Exportable {
+		Exportable::File((*self).to_owned())
 	}
 }
 
 impl IntoExportable for &PathBuf {
-	fn into_exportable(self) -> Exportable {
-		Exportable::File(self.to_owned())
+	fn into_exportable(&self) -> Exportable {
+		Exportable::File((*self).to_owned())
 	}
 }
 
 impl IntoExportable for PathBuf {
-	fn into_exportable(self) -> Exportable {
-		Exportable::File(self)
+	fn into_exportable(&self) -> Exportable {
+		Exportable::File(self.to_owned())
 	}
 }
 
+impl IntoExportable for Path {
+	fn into_exportable(&self) -> Exportable {
+		Exportable::File(self.to_owned())
+	}
+}
+impl IntoExportable for Component<'_> {
+	fn into_exportable(&self) -> Exportable {
+		<Component as AsRef<Path>>::as_ref(self).into_exportable()
+	}
+}
+impl IntoExportable for Components<'_> {
+	fn into_exportable(&self) -> Exportable {
+		<Components<'_> as AsRef<Path>>::as_ref(self).into_exportable()
+	}
+}
+impl IntoExportable for Cow<'_, OsStr> {
+	fn into_exportable(&self) -> Exportable {
+		<Cow<'_, OsStr> as AsRef<Path>>::as_ref(self).into_exportable()
+	}
+}
+impl IntoExportable for std::path::Iter<'_> {
+	fn into_exportable(&self) -> Exportable {
+		self.as_path().into_exportable()
+	}
+}
+impl IntoExportable for OsStr {
+	fn into_exportable(&self) -> Exportable {
+		<OsStr as AsRef<Path>>::as_ref(self).into_exportable()
+	}
+}
+impl IntoExportable for OsString {
+	fn into_exportable(&self) -> Exportable {
+		<OsString as AsRef<Path>>::as_ref(self).into_exportable()
+	}
+}
 impl IntoExportable for Sender<Vec<u8>> {
-	fn into_exportable(self) -> Exportable {
-		Exportable::Send(self)
+	fn into_exportable(&self) -> Exportable {
+		Exportable::Send(self.clone())
 	}
 }

--- a/lib/src/api/method/export.rs
+++ b/lib/src/api/method/export.rs
@@ -76,6 +76,12 @@ impl IntoExportable for &Path {
 	}
 }
 
+impl IntoExportable for &PathBuf {
+	fn into_exportable(self) -> Exportable {
+		Exportable::File(self.to_owned())
+	}
+}
+
 impl IntoExportable for PathBuf {
 	fn into_exportable(self) -> Exportable {
 		Exportable::File(self)

--- a/lib/src/api/method/export.rs
+++ b/lib/src/api/method/export.rs
@@ -5,8 +5,10 @@ use crate::api::Connection;
 use crate::api::Error;
 use crate::api::ExtraFeatures;
 use crate::api::Result;
+use channel::Sender;
 use std::future::Future;
 use std::future::IntoFuture;
+use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
 
@@ -15,7 +17,7 @@ use std::pin::Pin;
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Export<'r, C: Connection> {
 	pub(super) router: Result<&'r Router<C>>,
-	pub(super) file: PathBuf,
+	pub(super) target: Exportable,
 }
 
 impl<'r, Client> IntoFuture for Export<'r, Client>
@@ -32,7 +34,56 @@ where
 				return Err(Error::BackupsNotSupported.into());
 			}
 			let mut conn = Client::new(Method::Export);
-			conn.execute_unit(router, Param::file(self.file)).await
+			match self.target {
+				Exportable::File(f) => conn.execute_unit(router, Param::file(f)).await,
+				Exportable::Send(s) => conn.execute_unit(router, Param::send(s)).await,
+			}
 		})
+	}
+}
+
+#[derive(Debug)]
+pub enum Exportable {
+	File(PathBuf),
+	Send(Sender<Vec<u8>>),
+}
+
+pub trait IntoExportable {
+	fn into_exportable(self) -> Exportable;
+}
+
+impl IntoExportable for &str {
+	fn into_exportable(self) -> Exportable {
+		Exportable::File(<str as AsRef<Path>>::as_ref(self).to_owned())
+	}
+}
+
+impl IntoExportable for String {
+	fn into_exportable(self) -> Exportable {
+		Exportable::File(<str as AsRef<Path>>::as_ref(&self).to_owned())
+	}
+}
+
+impl IntoExportable for &String {
+	fn into_exportable(self) -> Exportable {
+		Exportable::File(<str as AsRef<Path>>::as_ref(self).to_owned())
+	}
+}
+
+impl IntoExportable for &Path {
+	fn into_exportable(self) -> Exportable {
+		Exportable::File(self.to_owned())
+	}
+}
+
+impl IntoExportable for PathBuf {
+	fn into_exportable(self) -> Exportable {
+		Exportable::File(self)
+	}
+}
+
+impl IntoExportable for Sender<Vec<u8>> {
+	fn into_exportable(self) -> Exportable {
+		Exportable::Send(self)
 	}
 }

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -64,6 +64,7 @@ pub use use_ns::UseNs;
 pub use version::Version;
 
 use crate::api::conn::Method;
+use crate::api::method::export::IntoExportable;
 use crate::api::opt;
 use crate::api::opt::auth;
 use crate::api::opt::auth::Credentials;
@@ -971,13 +972,13 @@ where
 	/// # Ok(())
 	/// # }
 	/// ```
-	pub fn export<P>(&self, file: P) -> Export<C>
+	pub fn export<E>(&self, target: E) -> Export<C>
 	where
-		P: AsRef<Path>,
+		E: IntoExportable,
 	{
 		Export {
 			router: self.router.extract(),
-			file: file.as_ref().to_owned(),
+			target: target.into_exportable(),
 		}
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently exports can only be done through the file system, this will allow exports to be done without file system access and more efficiently if the file will then be immediately read.

## What does this change do?

Adds support to pass a Sender into export which is will write the exported data into instead of a path.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
