### PR TITLE
[import] Provide descriptive error messages

### DIFF
--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -291,7 +291,7 @@ async fn import(request: RequestBuilder, path: PathBuf) -> Result<Value> {
 		.send()
 		.await?;
 
-	if let Err(_) = res.error_for_status_ref() {
+	if res.error_for_status_ref().is_err() {
 		let body: serde_json::Value = res.json().await?;
 		let error_msg =
 			format!("\n{}", serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".into()));

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -166,7 +166,6 @@ async fn submit_auth(request: RequestBuilder) -> Result<Value> {
 }
 
 async fn query(request: RequestBuilder) -> Result<QueryResponse> {
-	info!("{request:?}");
 	let response = request.send().await?.error_for_status()?;
 	let bytes = response.bytes().await?;
 	let responses = deserialize::<Vec<HttpQueryResponse>>(&bytes).map_err(|error| {
@@ -283,15 +282,22 @@ async fn import(request: RequestBuilder, path: PathBuf) -> Result<Value> {
 		}
 		.into());
 	}
-	request
+	let res = request
 		.header(ACCEPT, "application/octet-stream")
 		// ideally we should pass `file` directly into the body
 		// but currently that results in
 		// "HTTP status client error (405 Method Not Allowed) for url"
 		.body(contents)
 		.send()
-		.await?
-		.error_for_status()?;
+		.await?;
+
+	if let Err(_) = res.error_for_status_ref() {
+		let body: serde_json::Value = res.json().await?;
+		let error_msg =
+			format!("\n{}", serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".into()));
+
+		return Err(Error::Http(error_msg).into());
+	}
 	Ok(Value::None)
 }
 

--- a/lib/src/api/err/mod.rs
+++ b/lib/src/api/err/mod.rs
@@ -109,8 +109,8 @@ pub enum Error {
 		error: String,
 	},
 
-	/// Failed to serialize `sql::Value` to JSON string
-	#[error("Failed to serialize `{string}` to JSON string: {error}")]
+	/// Failed to deserialize from JSON string to `sql::Value`
+	#[error("Failed to deserialize `{string}` to sql::Value: {error}")]
 	FromJsonString {
 		string: String,
 		error: String,

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -36,7 +36,7 @@ pub async fn init(
 	}: ImportCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_log_level("error").init();
+	crate::telemetry::builder().with_log_level("info").init();
 
 	let client = if let Some((username, password)) = username.zip(password) {
 		let root = Root {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When using the import command, the response body returned by the server is not printed, so the user doesn't know why it failed.

This PR solves this situation, as pointed out by #2314

## What does this change do?

Prints the body of the server response

## What is your testing strategy?

Run it locally using the steps to reproduced provided in the issue above:

* Before:
```
2023-08-03T12:42:16.548973Z ERROR surreal::cli: There was a problem with the database: There was an error processing a remote HTTP request: HTTP status client error (400 Bad Request) for url (http://localhost:8000/import)
```
* After:
```
2023-08-03T13:20:33.742460Z ERROR surreal::cli: There was a problem with the database: There was an error processing a remote HTTP request: 
{
  "code": 400,
  "details": "Request problems detected",
  "description": "There is a problem with your request. Refer to the documentation for further information.",
  "information": "There was a problem with the database: Parse error on line 2 at character 48 when parsing '\\n ASSERT $value != NONE;\nDEFINE INDEX userName ON TABLE user COLUMNS firstName UNIQUE;\nCREATE user '"
}
```

## Is this related to any issues?

Yes, this PR fixes #2314 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
