### PR TITLE
[release] Harden the release process. Fix the Docker image

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -184,13 +184,6 @@ jobs:
         env:
           BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu: "-I/usr/aarch64-linux-gnu/include/"
 
-      - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-region: us-east-2
-          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
-
       - name: Package binaries
         if: ${{ !contains(matrix.arch, 'windows') }}
         shell: bash
@@ -199,9 +192,6 @@ jobs:
           chmod +x surreal
           tar -zcvf ${{ matrix.file }}.tgz surreal
           echo $(shasum -a 256 ${{ matrix.file }}.tgz | cut -f1 -d' ') > ${{ matrix.file }}.txt
-          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.tgz s3://download.surrealdb.com/nightly/
-          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.txt s3://download.surrealdb.com/nightly/
-          cd -
 
       - name: Package binaries
         if: ${{ contains(matrix.arch, 'windows') }}
@@ -210,9 +200,6 @@ jobs:
           cd target/${{ matrix.arch }}/release
           cp surreal.exe ${{ matrix.file }}.exe
           echo $(shasum -a 256 ${{ matrix.file }}.exe | cut -f1 -d' ') > ${{ matrix.file }}.txt
-          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.exe s3://download.surrealdb.com/nightly/
-          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.txt s3://download.surrealdb.com/nightly/
-          cd -
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -224,75 +211,11 @@ jobs:
             target/${{ matrix.arch }}/release/${{ matrix.file }}.txt
             target/${{ matrix.arch }}/release/${{ matrix.file }}.exe
 
-  package:
-    name: Package macOS
-    needs: [build]
-    runs-on: macos-latest-xl
-    steps:
-
-      - name: Download amd64 binary
-        uses: actions/download-artifact@v3
-        with:
-          name: surreal-nightly.darwin-amd64
-          path: amd64
-
-      - name: Download arm64 binary
-        uses: actions/download-artifact@v3
-        with:
-          name: surreal-nightly.darwin-arm64
-          path: arm64
-
-      - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-region: us-east-2
-          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
-
-      - name: Package universal binary
-        shell: bash
-        run: |
-          FILE="surreal-nightly.darwin-universal"
-          lipo -create -output surreal amd64/surreal arm64/surreal
-          chmod +x surreal
-          tar -zcvf $FILE.tgz surreal
-          echo $(shasum -a 256 $FILE.tgz | cut -f1 -d' ') > $FILE.txt
-          aws s3 cp --cache-control 'no-store' $FILE.tgz s3://download.surrealdb.com/nightly/
-          aws s3 cp --cache-control 'no-store' $FILE.txt s3://download.surrealdb.com/nightly/
-
-  deploy:
-    name: Deploy
-    needs: [package]
-    runs-on: ubuntu-latest-16-cores
-    steps:
-
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-region: us-east-2
-          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-
-      - name: Distribute binaries
-        shell: bash
-        run: |
-          regions=("af-south-1" "ap-east-1" "ap-south-1" "ap-southeast-1" "ap-southeast-2" "ca-central-1" "eu-central-1" "eu-west-2" "me-south-1" "sa-east-1" "us-west-2")
-          for region in ${regions[@]}; do
-              aws s3 sync --delete --storage-class INTELLIGENT_TIERING --source-region eu-west-2 --region ${region} s3://download.surrealdb.com s3://download.${region}.surrealdb.com
-          done
-
   docker:
-    name: Docker
+    name: Build and publish Docker image
     needs: [build]
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
-
       - name: Checkout sources
         uses: actions/checkout@v3
 
@@ -329,12 +252,149 @@ jobs:
         shell: bash
         run: |
           VERSION=nightly
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
-      - name: Build and Push
-        uses: docker/build-push-action@v3
+      - name: Build the Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          load: true
+          tags: surrealdb/surrealdb:${{ env.VERSION }}
+
+      # Start the docker image as server and wait until it is ready
+      - name: Test the Docker image
+        run: |
+          docker run --net=host --rm surrealdb/surrealdb:${{ env.VERSION }} start 2>&1 >surreal.log &
+
+          retries=5
+          until docker run --net=host --rm surrealdb/surrealdb:${{ env.VERSION }} is-ready; do
+            retries=$((retries-1))
+            if [[ $retries -eq 0 ]]; then
+              echo "###"
+              echo "### The container is not ready after 5 seconds!"
+              echo "###"
+              cat surreal.log
+              echo "###"
+              echo "### ERROR: The docker image is not valid. Aborting."
+              echo "###"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      # This second build reuses the cache from the build above
+      - name: Push the Docker image
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: surrealdb/surrealdb:nightly
+          tags: surrealdb/surrealdb:${{ env.VERSION }}
+
+  publish:
+    name: Publish binaries for ${{ matrix.arch }}
+    needs: [docker]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64-apple-darwin
+            os: macos-latest
+            file: surreal-nightly.darwin-amd64
+          - arch: aarch64-apple-darwin
+            os: macos-latest
+            file: surreal-nightly.darwin-arm64
+          - arch: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            file: surreal-nightly.linux-amd64
+          - arch: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            file: surreal-nightly.linux-arm64
+          - arch: x86_64-pc-windows-msvc
+            os: windows-latest
+            file: surreal-nightly.windows-amd64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.file }}
+
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: us-east-2
+          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
+
+      - name: Publish non-windows binaries
+        if: ${{ !contains(matrix.arch, 'windows') }}
+        shell: bash
+        run: |
+          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.tgz s3://download.surrealdb.com/nightly/
+          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.txt s3://download.surrealdb.com/nightly/
+
+      - name: Publish windows binaries
+        if: ${{ contains(matrix.arch, 'windows') }}
+        shell: bash
+        run: |
+          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.exe s3://download.surrealdb.com/nightly/
+          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.txt s3://download.surrealdb.com/nightly/
+
+  package-macos:
+    name: Package macOS universal binary
+    needs: [publish]
+    runs-on: macos-latest
+    steps:
+      - name: Download amd64 binary
+        uses: actions/download-artifact@v3
+        with:
+          name: surreal-nightly.darwin-amd64
+          path: amd64
+
+      - name: Download arm64 binary
+        uses: actions/download-artifact@v3
+        with:
+          name: surreal-nightly.darwin-arm64
+          path: arm64
+
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: us-east-2
+          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
+
+      - name: Package universal MacOS binary
+        shell: bash
+        run: |
+          FILE="surreal-nightly.darwin-universal"
+          lipo -create -output surreal amd64/surreal arm64/surreal
+          chmod +x surreal
+          tar -zcvf $FILE.tgz surreal
+          echo $(shasum -a 256 $FILE.tgz | cut -f1 -d' ') > $FILE.txt
+          aws s3 cp --cache-control 'no-store' $FILE.tgz s3://download.surrealdb.com/nightly/
+          aws s3 cp --cache-control 'no-store' $FILE.txt s3://download.surrealdb.com/nightly/
+
+  deploy:
+    name: Deploy
+    needs: [publish, package-macos]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: us-east-2
+          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
+
+      - name: Distribute binaries
+        shell: bash
+        run: |
+          regions=("af-south-1" "ap-east-1" "ap-south-1" "ap-southeast-1" "ap-southeast-2" "ca-central-1" "eu-central-1" "eu-west-2" "me-south-1" "sa-east-1" "us-west-2")
+          for region in ${regions[@]}; do
+              aws s3 sync --delete --storage-class INTELLIGENT_TIERING --source-region eu-west-2 --region ${region} s3://download.surrealdb.com s3://download.${region}.surrealdb.com
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,13 +184,6 @@ jobs:
         env:
           BINDGEN_EXTRA_CLANG_ARGS_aarch64-unknown-linux-gnu: "-I/usr/aarch64-linux-gnu/include/"
 
-      - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-region: us-east-2
-          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
-
       - name: Package binaries
         if: ${{ !contains(matrix.arch, 'windows') }}
         shell: bash
@@ -199,9 +192,6 @@ jobs:
           chmod +x surreal
           tar -zcvf ${{ matrix.file }}.tgz surreal
           echo $(shasum -a 256 ${{ matrix.file }}.tgz | cut -f1 -d' ') > ${{ matrix.file }}.txt
-          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.tgz s3://download.surrealdb.com/${{ github.ref_name }}/
-          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.txt s3://download.surrealdb.com/${{ github.ref_name }}/
-          cd -
 
       - name: Package binaries
         if: ${{ contains(matrix.arch, 'windows') }}
@@ -210,9 +200,6 @@ jobs:
           cd target/${{ matrix.arch }}/release
           cp surreal.exe ${{ matrix.file }}.exe
           echo $(shasum -a 256 ${{ matrix.file }}.exe | cut -f1 -d' ') > ${{ matrix.file }}.txt
-          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.exe s3://download.surrealdb.com/${{ github.ref_name }}/
-          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.txt s3://download.surrealdb.com/${{ github.ref_name }}/
-          cd -
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -224,22 +211,151 @@ jobs:
             target/${{ matrix.arch }}/release/${{ matrix.file }}.txt
             target/${{ matrix.arch }}/release/${{ matrix.file }}.exe
 
-  package:
-    name: Package macOS
+  docker:
+    name: Build and publish Docker image
     needs: [build]
-    runs-on: macos-latest-xl
+    runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
       - name: Download amd64 binary
         uses: actions/download-artifact@v3
         with:
-          name: surreal-${{ github.ref_name }}.darwin-amd64
+          name: surreal-nightly.linux-amd64
           path: amd64
 
       - name: Download arm64 binary
         uses: actions/download-artifact@v3
         with:
-          name: surreal-${{ github.ref_name }}.darwin-arm64
+          name: surreal-nightly.linux-arm64
+          path: arm64
+
+      - name: Set file permissions
+        shell: bash
+        run: |
+          chmod +x amd64/surreal arm64/surreal
+
+      - name: Configure DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Configure tag
+        shell: bash
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" | tr + - >> $GITHUB_ENV
+
+      - name: Build the Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          load: true
+          tags: surrealdb/surrealdb:latest,surrealdb/surrealdb:${{ env.VERSION }}
+
+      # Start the docker image as server and wait until it is ready
+      - name: Test the Docker image
+        run: |
+          docker run --net=host --rm surrealdb/surrealdb:${{ env.VERSION }} start 2>&1 >surreal.log &
+
+          retries=5
+          until docker run --net=host --rm surrealdb/surrealdb:${{ env.VERSION }} is-ready; do
+            retries=$((retries-1))
+            if [[ $retries -eq 0 ]]; then
+              echo "###"
+              echo "### The container is not ready after 5 seconds!"
+              echo "###"
+              cat surreal.log
+              echo "###"
+              echo "### ERROR: The docker image is not valid. Aborting."
+              echo "###"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      # This second build reuses the cache from the build above
+      - name: Push the Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: surrealdb/surrealdb:latest,surrealdb/surrealdb:${{ env.VERSION }}
+
+  publish:
+    name: Publish binaries for ${{ matrix.arch }}
+    needs: [docker]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64-apple-darwin
+            os: macos-latest
+            file: surreal-nightly.darwin-amd64
+          - arch: aarch64-apple-darwin
+            os: macos-latest
+            file: surreal-nightly.darwin-arm64
+          - arch: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            file: surreal-nightly.linux-amd64
+          - arch: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            file: surreal-nightly.linux-arm64
+          - arch: x86_64-pc-windows-msvc
+            os: windows-latest
+            file: surreal-nightly.windows-amd64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.file }}
+
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: us-east-2
+          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
+
+      - name: Publish non-windows binaries
+        if: ${{ !contains(matrix.arch, 'windows') }}
+        shell: bash
+        run: |
+          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.tgz s3://download.surrealdb.com/nightly/
+          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.txt s3://download.surrealdb.com/nightly/
+
+      - name: Publish windows binaries
+        if: ${{ contains(matrix.arch, 'windows') }}
+        shell: bash
+        run: |
+          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.exe s3://download.surrealdb.com/nightly/
+          aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.txt s3://download.surrealdb.com/nightly/
+
+  package-macos:
+    name: Package macOS universal binary
+    needs: [publish]
+    runs-on: macos-latest
+    steps:
+      - name: Download amd64 binary
+        uses: actions/download-artifact@v3
+        with:
+          name: surreal-nightly.darwin-amd64
+          path: amd64
+
+      - name: Download arm64 binary
+        uses: actions/download-artifact@v3
+        with:
+          name: surreal-nightly.darwin-arm64
           path: arm64
 
       - name: Configure AWS
@@ -249,21 +365,21 @@ jobs:
           aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
 
-      - name: Package universal binary
+      - name: Package universal MacOS binary
         shell: bash
         run: |
-          FILE="surreal-${{ github.ref_name }}.darwin-universal"
+          FILE="surreal-nightly.darwin-universal"
           lipo -create -output surreal amd64/surreal arm64/surreal
           chmod +x surreal
           tar -zcvf $FILE.tgz surreal
           echo $(shasum -a 256 $FILE.tgz | cut -f1 -d' ') > $FILE.txt
-          aws s3 cp --cache-control 'no-store' $FILE.tgz s3://download.surrealdb.com/${{ github.ref_name }}/
-          aws s3 cp --cache-control 'no-store' $FILE.txt s3://download.surrealdb.com/${{ github.ref_name }}/
+          aws s3 cp --cache-control 'no-store' $FILE.tgz s3://download.surrealdb.com/nightly/
+          aws s3 cp --cache-control 'no-store' $FILE.txt s3://download.surrealdb.com/nightly/
 
   deploy:
     name: Deploy
-    needs: [package]
-    runs-on: ubuntu-latest-16-cores
+    needs: [publish, package-macos]
+    runs-on: ubuntu-latest
     steps:
 
       - name: Checkout sources
@@ -301,55 +417,3 @@ jobs:
           for region in ${regions[@]}; do
               aws s3 sync --delete --storage-class INTELLIGENT_TIERING --source-region eu-west-2 --region ${region} s3://download.surrealdb.com s3://download.${region}.surrealdb.com
           done
-
-  docker:
-    name: Docker
-    needs: [build]
-    runs-on: ubuntu-latest-16-cores
-    steps:
-
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Download amd64 binary
-        uses: actions/download-artifact@v3
-        with:
-          name: surreal-${{ github.ref_name }}.linux-amd64
-          path: amd64
-
-      - name: Download arm64 binary
-        uses: actions/download-artifact@v3
-        with:
-          name: surreal-${{ github.ref_name }}.linux-arm64
-          path: arm64
-
-      - name: Set file permissions
-        shell: bash
-        run: |
-          chmod +x amd64/surreal arm64/surreal
-
-      - name: Configure DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Configure tag
-        shell: bash
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "VERSION=${VERSION:1}" | tr + - >> $GITHUB_ENV
-
-      - name: Build and Push
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: surrealdb/surrealdb:latest,surrealdb/surrealdb:${{ env.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the distroless/cc:latest image as the base image
-FROM gcr.io/distroless/cc:latest
+# Use ChainGuard's glibc-dynamic image as the base image. More information about this image can be found at https://www.chainguard.dev/chainguard-images
+FROM cgr.dev/chainguard/glibc-dynamic
 
 # Declare a build-time argument for the target architecture
 ARG TARGETARCH


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The Nightly Docker image is broken because the base image is too old and doesn't contain the required libraries.

## What does this change do?

* **Updates the Docker base image**: Use `cgr.dev/chainguard/glibc-dynamic`. Chainguard builds modern secure Docker base images. More info here: https://www.chainguard.dev/chainguard-images
* **Harden the release process**: Test the binary by actually running the produced Docker image before publishing the image to Docker registry or the binaries to S3. Thew new flow looks like this:
  * Build the binaries and upload them to Github Artifacts
  * Download the linux binaries from the GH Artifacts and build the Docker image. Test it and publish it.
  * Downloads the artifacts from GH and publish them to S3


## What is your testing strategy?

- [x] Run the nightly workflow and verify it succeeds (https://github.com/surrealdb/surrealdb/actions/runs/5763283849)

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
