### PR TITLE
Added steps to publish docker image to AWS ECR to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -212,7 +212,7 @@ jobs:
             target/${{ matrix.arch }}/release/${{ matrix.file }}.exe
 
   docker:
-    name: Build and publish Docker image
+    name: Build and publish Docker image to Docker Hub and AWS ECR
     needs: [build]
     runs-on: ubuntu-latest
     steps:
@@ -283,14 +283,40 @@ jobs:
           done
 
       # This second build reuses the cache from the build above
-      - name: Push the Docker image
+      - name: Push the Docker image to Docker Hub
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
           tags: surrealdb/surrealdb:${{ env.VERSION }}
+      
+      # The following steps publish the docker image to AWS ECR public repository
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
+          aws-region: us-east-2
 
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
+        
+      - name: tag and push the image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ env.VERSION }}
+        run: |
+          # Build a docker container and push it to ECR 
+          docker tag surrealdb/surrealdb:${{ env.VERSION }} $ECR_REGISTRY/surrealdb:$IMAGE_TAG
+          echo "Pushing image to ECR..."
+          docker push $ECR_REGISTRY/surrealdb:$IMAGE_TAG
+          echo "name=image::$ECR_REGISTRY/surrealdb:$IMAGE_TAG" >> $GITHUB_OUTPUT
+      
   publish:
     name: Publish binaries for ${{ matrix.arch }}
     needs: [docker]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently Docker Hub rate limits the amount of image pulls that can be made by services like AWS Elastic Container Service. Furthermore, to setup a private ECS cluster with no conection to the internet the Docker image must be hosted on AWS ECR

## What does this change do?

This PR added additional steps to the nightly workflow to push the docker image to a public AWS ECR registery along with Docker Hub.

Along with the PR a public registery must be created on AWS to host the image. This is must be done before merging this PR. Also any additonal permissions required by AWS ECR must be granted to the AWS credentials for github actions.

## What is your testing strategy?

Once the image is pushed confirm it can be pulled from the registery and runs correctly

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
