### PR TITLE
Implement all JSON Patch operations

### DIFF
--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -109,7 +109,7 @@ pub enum Error {
 
 	/// Given test operation failed for JSON Patch
 	#[error("Given test operation failed for JSON Patch. Expected `{expected}`, but got `{got}` instead.")]
-	PatchTestFail {
+	PatchTestFailure {
 		expected: Value,
 		got: Value,
 	},

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -109,9 +109,9 @@ pub enum Error {
 
 	/// Given test operation failed for JSON Patch
 	#[error("Given test operation failed for JSON Patch. Expected `{expected}`, but got `{got}` instead.")]
-	PatchTestFailure {
-		expected: Value,
-		got: Value,
+	PatchTest {
+		expected: String,
+		got: String,
 	},
 
 	/// Remote HTTP request functions are not enabled

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -107,6 +107,13 @@ pub enum Error {
 		message: String,
 	},
 
+	/// Given test operation failed for JSON Patch
+	#[error("Given test operation failed for JSON Patch. Expected `{expected}`, but got `{got}` instead.")]
+	PatchTestFail {
+		expected: Value,
+		got: Value,
+	},
+
 	/// Remote HTTP request functions are not enabled
 	#[error("Remote HTTP request functions are not enabled")]
 	HttpDisabled,

--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -112,7 +112,6 @@ pub use self::limit::Limit;
 pub use self::model::Model;
 pub use self::number::Number;
 pub use self::object::Object;
-pub use self::operation::Op;
 pub use self::operation::Operation;
 pub use self::operator::Operator;
 pub use self::order::Order;

--- a/lib/src/sql/object.rs
+++ b/lib/src/sql/object.rs
@@ -96,6 +96,14 @@ impl From<Operation> for Object {
 				String::from("path") => path.to_path().into(),
 				String::from("from") => from.to_path().into()
 			},
+			Operation::Move {
+				path,
+				from,
+			} => map! {
+				String::from("op") => Value::from("move"),
+				String::from("path") => path.to_path().into(),
+				String::from("from") => from.to_path().into()
+			},
 			Operation::Test {
 				path,
 				value,
@@ -176,6 +184,11 @@ impl Object {
 						}),
 						// Copy operation
 						"copy" => Ok(Operation::Copy {
+							path,
+							from: from?,
+						}),
+						// Copy operation
+						"move" => Ok(Operation::Move {
 							path,
 							from: from?,
 						}),

--- a/lib/src/sql/object.rs
+++ b/lib/src/sql/object.rs
@@ -64,6 +64,7 @@ impl From<Operation> for Object {
 				Op::Remove => "remove",
 				Op::Replace => "replace",
 				Op::Change => "change",
+				Op::Test => "test"
 			}),
 			String::from("path") => v.path.to_path().into(),
 			String::from("value") => v.value,

--- a/lib/src/sql/object.rs
+++ b/lib/src/sql/object.rs
@@ -157,10 +157,9 @@ impl Object {
 							message: String::from("'from' key missing"),
 						});
 
-					let value =
-						self.get("value").map(|value| value.clone()).ok_or(Error::InvalidPatch {
-							message: String::from("'value' key missing"),
-						});
+					let value = self.get("value").cloned().ok_or(Error::InvalidPatch {
+						message: String::from("'value' key missing"),
+					});
 
 					match op_val.clone().as_string().as_str() {
 						// Add operation

--- a/lib/src/sql/object.rs
+++ b/lib/src/sql/object.rs
@@ -186,7 +186,7 @@ impl Object {
 							path,
 							from: from?,
 						}),
-						// Copy operation
+						// Move operation
 						"move" => Ok(Operation::Move {
 							path,
 							from: from?,

--- a/lib/src/sql/operation.rs
+++ b/lib/src/sql/operation.rs
@@ -2,33 +2,27 @@ use crate::sql::idiom::Idiom;
 use crate::sql::value::Value;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
-pub struct Operation {
-	pub op: Op,
-	pub path: Idiom,
-	pub value: Value,
-}
-
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
-pub enum Op {
-	None,
-	#[default]
-	Add,
-	Remove,
-	Replace,
-	Change,
-	Test,
-}
-
-impl From<&Value> for Op {
-	fn from(v: &Value) -> Self {
-		match v.to_raw_string().as_str() {
-			"add" => Op::Add,
-			"remove" => Op::Remove,
-			"replace" => Op::Replace,
-			"change" => Op::Change,
-			"test" => Op::Test,
-			_ => Op::None,
-		}
-	}
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[serde(tag = "op")]
+#[serde(rename_all = "lowercase")]
+pub enum Operation {
+	Add {
+		path: Idiom,
+		value: Value,
+	},
+	Remove {
+		path: Idiom,
+	},
+	Replace {
+		path: Idiom,
+		value: Value,
+	},
+	Change {
+		path: Idiom,
+		value: Value,
+	},
+	Test {
+		path: Idiom,
+		value: Value,
+	},
 }

--- a/lib/src/sql/operation.rs
+++ b/lib/src/sql/operation.rs
@@ -21,6 +21,10 @@ pub enum Operation {
 		path: Idiom,
 		value: Value,
 	},
+	Copy {
+		path: Idiom,
+		from: Idiom,
+	},
 	Test {
 		path: Idiom,
 		value: Value,

--- a/lib/src/sql/operation.rs
+++ b/lib/src/sql/operation.rs
@@ -25,6 +25,10 @@ pub enum Operation {
 		path: Idiom,
 		from: Idiom,
 	},
+	Move {
+		path: Idiom,
+		from: Idiom,
+	},
 	Test {
 		path: Idiom,
 		value: Value,

--- a/lib/src/sql/operation.rs
+++ b/lib/src/sql/operation.rs
@@ -17,6 +17,7 @@ pub enum Op {
 	Remove,
 	Replace,
 	Change,
+	Test,
 }
 
 impl From<&Value> for Op {
@@ -26,6 +27,7 @@ impl From<&Value> for Op {
 			"remove" => Op::Remove,
 			"replace" => Op::Replace,
 			"change" => Op::Change,
+			"test" => Op::Test,
 			_ => Op::None,
 		}
 	}

--- a/lib/src/sql/value/diff.rs
+++ b/lib/src/sql/value/diff.rs
@@ -1,5 +1,5 @@
 use crate::sql::idiom::Idiom;
-use crate::sql::operation::{Op, Operation};
+use crate::sql::operation::Operation;
 use crate::sql::value::Value;
 use std::cmp::min;
 
@@ -11,18 +11,15 @@ impl Value {
 				// Loop over old keys
 				for (key, _) in a.iter() {
 					if !b.contains_key(key) {
-						ops.push(Operation {
-							op: Op::Remove,
+						ops.push(Operation::Remove {
 							path: path.clone().push(key.clone().into()),
-							value: Value::Null,
 						})
 					}
 				}
 				// Loop over new keys
 				for (key, val) in b.iter() {
 					match a.get(key) {
-						None => ops.push(Operation {
-							op: Op::Add,
+						None => ops.push(Operation::Add {
 							path: path.clone().push(key.clone().into()),
 							value: val.clone(),
 						}),
@@ -42,8 +39,7 @@ impl Value {
 				}
 				while n < b.len() {
 					if n >= a.len() {
-						ops.push(Operation {
-							op: Op::Add,
+						ops.push(Operation::Add {
 							path: path.clone().push(n.into()),
 							value: b[n].clone(),
 						})
@@ -52,17 +48,14 @@ impl Value {
 				}
 				while n < a.len() {
 					if n >= b.len() {
-						ops.push(Operation {
-							op: Op::Remove,
+						ops.push(Operation::Remove {
 							path: path.clone().push(n.into()),
-							value: Value::Null,
 						})
 					}
 					n += 1;
 				}
 			}
-			(Value::Strand(a), Value::Strand(b)) if a != b => ops.push(Operation {
-				op: Op::Change,
+			(Value::Strand(a), Value::Strand(b)) if a != b => ops.push(Operation::Change {
 				path,
 				value: {
 					let dmp = dmp::new();
@@ -71,8 +64,7 @@ impl Value {
 					txt.into()
 				},
 			}),
-			(a, b) if a != b => ops.push(Operation {
-				op: Op::Replace,
+			(a, b) if a != b => ops.push(Operation::Replace {
 				path,
 				value: val.clone(),
 			}),

--- a/lib/src/sql/value/patch.rs
+++ b/lib/src/sql/value/patch.rs
@@ -68,9 +68,9 @@ impl Value {
 					let found_val = tmp_val.pick(&path);
 
 					if value != found_val {
-						return Err(Error::PatchTestFailure {
-							expected: value,
-							got: found_val,
+						return Err(Error::PatchTest {
+							expected: value.to_string(),
+							got: found_val.to_string(),
 						});
 					}
 				}

--- a/lib/src/sql/value/patch.rs
+++ b/lib/src/sql/value/patch.rs
@@ -67,8 +67,8 @@ impl Value {
 				} => {
 					let found_val = tmp_val.pick(&path);
 
-					if value != tmp_val.pick(&path) {
-						return Err(Error::PatchTestFail {
+					if value != found_val {
+						return Err(Error::PatchTestFailure {
 							expected: value,
 							got: found_val,
 						});

--- a/lib/src/sql/value/patch.rs
+++ b/lib/src/sql/value/patch.rs
@@ -4,6 +4,8 @@ use crate::sql::value::Value;
 
 impl Value {
 	pub(crate) fn patch(&mut self, ops: Value) -> Result<(), Error> {
+		// This value is for test operation, value itself shouldn't change until all operations done.
+		// If test operations fails, nothing in value will be changed.
 		let mut tmp_val = self.clone();
 
 		for operation in ops.to_operations()?.into_iter() {

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2940,8 +2940,8 @@ mod tests {
 	#[test]
 	fn check_size() {
 		assert_eq!(64, std::mem::size_of::<Value>());
-		assert_eq!(136, std::mem::size_of::<Error>());
-		assert_eq!(136, std::mem::size_of::<Result<Value, Error>>());
+		assert_eq!(104, std::mem::size_of::<Error>());
+		assert_eq!(104, std::mem::size_of::<Result<Value, Error>>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::number::Number>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::strand::Strand>());
 		assert_eq!(16, std::mem::size_of::<crate::sql::duration::Duration>());

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2940,8 +2940,8 @@ mod tests {
 	#[test]
 	fn check_size() {
 		assert_eq!(64, std::mem::size_of::<Value>());
-		assert_eq!(104, std::mem::size_of::<Error>());
-		assert_eq!(104, std::mem::size_of::<Result<Value, Error>>());
+		assert_eq!(136, std::mem::size_of::<Error>());
+		assert_eq!(136, std::mem::size_of::<Result<Value, Error>>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::number::Number>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::strand::Strand>());
 		assert_eq!(16, std::mem::size_of::<crate::sql::duration::Duration>());


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently SurrealDB supports `add`, `remove`, and `replace` operations for JSON Patch. This pull request aims to implement the missing operations.

## What does this change do?

This PR introduces the `move`, `copy`, and `test` JSON Patch operations to SurrealDB.

It's important to note that there have been structural changes: the `Op` struct has been removed, and `Operation` is now an enum. Depending on usage, this change may be considered as a breaking change (though im not sure if these are exposed for public usage).

Additionally, I've added the `PatchTestFailure` error for test operations, intended for situations where a test operation fails for JSON Patch. I am open to any suggestions for refining the definition of this error.

## What is your testing strategy?

I added tests for new operations which is pretty much similar to existing ones.

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
