### PR TITLE
Change kill id type to value

### DIFF
--- a/lib/src/sql/parser.rs
+++ b/lib/src/sql/parser.rs
@@ -52,44 +52,41 @@ fn parse_impl<O>(input: &str, parser: impl Fn(&str) -> IResult<&str, O>) -> Resu
 			// There was unparsed SQL remaining
 			Ok((_, _)) => Err(Error::QueryRemaining),
 			// There was an error when parsing the query
-			Err(Err::Error(e)) | Err(Err::Failure(e)) => {
-				error!("parser error: {:?}", e);
-				Err(match e {
-					// There was a parsing error
-					Parser(e) => {
-						// Locate the parser position
-						let (s, l, c) = locate(input, e);
-						// Return the parser error
-						Error::InvalidQuery {
-							line: l,
-							char: c,
-							sql: s.to_string(),
-						}
+			Err(Err::Error(e)) | Err(Err::Failure(e)) => Err(match e {
+				// There was a parsing error
+				Parser(e) => {
+					// Locate the parser position
+					let (s, l, c) = locate(input, e);
+					// Return the parser error
+					Error::InvalidQuery {
+						line: l,
+						char: c,
+						sql: s.to_string(),
 					}
-					// There was a SPLIT ON error
-					Field(e, f) => Error::InvalidField {
-						line: locate(input, e).1,
-						field: f,
-					},
-					// There was a SPLIT ON error
-					Split(e, f) => Error::InvalidSplit {
-						line: locate(input, e).1,
-						field: f,
-					},
-					// There was a ORDER BY error
-					Order(e, f) => Error::InvalidOrder {
-						line: locate(input, e).1,
-						field: f,
-					},
-					// There was a GROUP BY error
-					Group(e, f) => Error::InvalidGroup {
-						line: locate(input, e).1,
-						field: f,
-					},
-					// There was an error parsing the ROLE
-					Role(_, role) => Error::IamError(IamError::InvalidRole(role)),
-				})
-			}
+				}
+				// There was a SPLIT ON error
+				Field(e, f) => Error::InvalidField {
+					line: locate(input, e).1,
+					field: f,
+				},
+				// There was a SPLIT ON error
+				Split(e, f) => Error::InvalidSplit {
+					line: locate(input, e).1,
+					field: f,
+				},
+				// There was a ORDER BY error
+				Order(e, f) => Error::InvalidOrder {
+					line: locate(input, e).1,
+					field: f,
+				},
+				// There was a GROUP BY error
+				Group(e, f) => Error::InvalidGroup {
+					line: locate(input, e).1,
+					field: f,
+				},
+				// There was an error parsing the ROLE
+				Role(_, role) => Error::IamError(IamError::InvalidRole(role)),
+			}),
 			_ => unreachable!(),
 		},
 	}

--- a/lib/src/sql/parser.rs
+++ b/lib/src/sql/parser.rs
@@ -52,41 +52,44 @@ fn parse_impl<O>(input: &str, parser: impl Fn(&str) -> IResult<&str, O>) -> Resu
 			// There was unparsed SQL remaining
 			Ok((_, _)) => Err(Error::QueryRemaining),
 			// There was an error when parsing the query
-			Err(Err::Error(e)) | Err(Err::Failure(e)) => Err(match e {
-				// There was a parsing error
-				Parser(e) => {
-					// Locate the parser position
-					let (s, l, c) = locate(input, e);
-					// Return the parser error
-					Error::InvalidQuery {
-						line: l,
-						char: c,
-						sql: s.to_string(),
+			Err(Err::Error(e)) | Err(Err::Failure(e)) => {
+				error!("parser error: {:?}", e);
+				Err(match e {
+					// There was a parsing error
+					Parser(e) => {
+						// Locate the parser position
+						let (s, l, c) = locate(input, e);
+						// Return the parser error
+						Error::InvalidQuery {
+							line: l,
+							char: c,
+							sql: s.to_string(),
+						}
 					}
-				}
-				// There was a SPLIT ON error
-				Field(e, f) => Error::InvalidField {
-					line: locate(input, e).1,
-					field: f,
-				},
-				// There was a SPLIT ON error
-				Split(e, f) => Error::InvalidSplit {
-					line: locate(input, e).1,
-					field: f,
-				},
-				// There was a ORDER BY error
-				Order(e, f) => Error::InvalidOrder {
-					line: locate(input, e).1,
-					field: f,
-				},
-				// There was a GROUP BY error
-				Group(e, f) => Error::InvalidGroup {
-					line: locate(input, e).1,
-					field: f,
-				},
-				// There was an error parsing the ROLE
-				Role(_, role) => Error::IamError(IamError::InvalidRole(role)),
-			}),
+					// There was a SPLIT ON error
+					Field(e, f) => Error::InvalidField {
+						line: locate(input, e).1,
+						field: f,
+					},
+					// There was a SPLIT ON error
+					Split(e, f) => Error::InvalidSplit {
+						line: locate(input, e).1,
+						field: f,
+					},
+					// There was a ORDER BY error
+					Order(e, f) => Error::InvalidOrder {
+						line: locate(input, e).1,
+						field: f,
+					},
+					// There was a GROUP BY error
+					Group(e, f) => Error::InvalidGroup {
+						line: locate(input, e).1,
+						field: f,
+					},
+					// There was an error parsing the ROLE
+					Role(_, role) => Error::IamError(IamError::InvalidRole(role)),
+				})
+			}
 			_ => unreachable!(),
 		},
 	}

--- a/lib/src/sql/statements/kill.rs
+++ b/lib/src/sql/statements/kill.rs
@@ -14,8 +14,6 @@ use nom::bytes::complete::tag_no_case;
 use nom::combinator::map;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::ops::Deref;
-use std::pin::Pin;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
 pub struct KillStatement {
@@ -109,14 +107,38 @@ pub fn kill(i: &str) -> IResult<&str, KillStatement> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::sql::{Ident, Param, Uuid};
 
 	#[test]
 	fn kill_uuid() {
-		let sql = "kill c005b8da-63a4-48bc-a371-07e95b39d58e";
+		// let uuid_str = Uuid::new_v4().to_string();
+		let uuid_str = "c005b8da-63a4-48bc-a371-07e95b39d58e";
+		let uuid_str_wrapped = format!("'{}'", uuid_str);
+		let sql = format!("kill {}", uuid_str_wrapped);
+		let res = kill(&sql);
+		assert!(res.is_ok(), "{:?}", res);
+		let out = res.unwrap().1;
+		assert_eq!(
+			out,
+			KillStatement {
+				id: Value::Uuid(Uuid::from(uuid::Uuid::parse_str(uuid_str).unwrap()))
+			}
+		);
+		assert_eq!("KILL 'c005b8da-63a4-48bc-a371-07e95b39d58e'", format!("{}", out));
+	}
+
+	#[test]
+	fn kill_param() {
+		let sql = "kill $id";
 		let res = kill(sql);
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
-		assert_eq!(out, KillStatement::Root);
-		assert_eq!("KILL c005b8da-63a4-48bc-a371-07e95b39d58e", format!("{}", out));
+		assert_eq!(
+			out,
+			KillStatement {
+				id: Value::Param(Param(Ident("id".to_string()))),
+			}
+		);
+		assert_eq!("KILL $id", format!("{}", out));
 	}
 }

--- a/lib/src/sql/statements/kill.rs
+++ b/lib/src/sql/statements/kill.rs
@@ -111,7 +111,6 @@ mod tests {
 
 	#[test]
 	fn kill_uuid() {
-		// let uuid_str = Uuid::new_v4().to_string();
 		let uuid_str = "c005b8da-63a4-48bc-a371-07e95b39d58e";
 		let uuid_str_wrapped = format!("'{}'", uuid_str);
 		let sql = format!("kill {}", uuid_str_wrapped);

--- a/lib/src/sql/statements/kill.rs
+++ b/lib/src/sql/statements/kill.rs
@@ -5,23 +5,30 @@ use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::sql::comment::shouldbespace;
 use crate::sql::error::IResult;
-use crate::sql::uuid::{uuid, Uuid};
+use crate::sql::param::param;
+use crate::sql::uuid::uuid;
 use crate::sql::value::Value;
 use derive::Store;
+use nom::branch::alt;
 use nom::bytes::complete::tag_no_case;
+use nom::combinator::map;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::ops::Deref;
+use std::pin::Pin;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Store, Hash)]
 pub struct KillStatement {
-	pub id: Uuid,
+	// Uuid of Live Query
+	// or Param resolving to Uuid of Live Query
+	pub id: Value,
 }
 
 impl KillStatement {
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,
-		_ctx: &Context<'_>,
+		ctx: &Context<'_>,
 		opt: &Options,
 		txn: &Transaction,
 		_doc: Option<&CursorDoc<'_>>,
@@ -30,19 +37,37 @@ impl KillStatement {
 		opt.realtime()?;
 		// Valid options?
 		opt.valid_for_db()?;
+		// Resolve live query id
+		let live_query_id = match &self.id {
+			Value::Uuid(id) => id.clone(),
+			Value::Param(param) => *match param.compute(ctx, opt, txn, None).await? {
+				Value::Uuid(id) => Box::new(id),
+				_ => {
+					return Err(Error::KillStatement {
+						value: self.id.to_string(),
+					})
+				}
+			},
+			_ => {
+				return Err(Error::KillStatement {
+					value: self.id.to_string(),
+				})
+			}
+		};
 		// Claim transaction
 		let mut run = txn.lock().await;
 		// Fetch the live query key
-		let key = crate::key::node::lq::new(opt.id()?, self.id.0, opt.ns(), opt.db());
+		let key = crate::key::node::lq::new(opt.id()?, live_query_id.0, opt.ns(), opt.db());
 		// Fetch the live query key if it exists
 		match run.get(key).await? {
 			Some(val) => match std::str::from_utf8(&val) {
 				Ok(tb) => {
 					// Delete the node live query
-					let key = crate::key::node::lq::new(opt.id()?, self.id.0, opt.ns(), opt.db());
+					let key =
+						crate::key::node::lq::new(opt.id()?, live_query_id.0, opt.ns(), opt.db());
 					run.del(key).await?;
 					// Delete the table live query
-					let key = crate::key::table::lq::new(opt.ns(), opt.db(), tb, self.id.0);
+					let key = crate::key::table::lq::new(opt.ns(), opt.db(), tb, live_query_id.0);
 					run.del(key).await?;
 				}
 				_ => {
@@ -71,11 +96,27 @@ impl fmt::Display for KillStatement {
 pub fn kill(i: &str) -> IResult<&str, KillStatement> {
 	let (i, _) = tag_no_case("KILL")(i)?;
 	let (i, _) = shouldbespace(i)?;
-	let (i, v) = uuid(i)?;
+	trace!("kill stm eval {} uuid = {:?}", i, uuid(i));
+	let (i, v) = alt((map(uuid, Value::from), map(param, Value::from)))(i)?;
 	Ok((
 		i,
 		KillStatement {
-			id: v,
+			id: v, // TODO change to value
 		},
 	))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn kill_uuid() {
+		let sql = "kill c005b8da-63a4-48bc-a371-07e95b39d58e";
+		let res = kill(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(out, KillStatement::Root);
+		assert_eq!("KILL c005b8da-63a4-48bc-a371-07e95b39d58e", format!("{}", out));
+	}
 }

--- a/lib/src/sql/statements/kill.rs
+++ b/lib/src/sql/statements/kill.rs
@@ -94,7 +94,6 @@ impl fmt::Display for KillStatement {
 pub fn kill(i: &str) -> IResult<&str, KillStatement> {
 	let (i, _) = tag_no_case("KILL")(i)?;
 	let (i, _) = shouldbespace(i)?;
-	trace!("kill stm eval {} uuid = {:?}", i, uuid(i));
 	let (i, v) = alt((map(uuid, Value::from), map(param, Value::from)))(i)?;
 	Ok((
 		i,

--- a/lib/src/sql/statements/kill.rs
+++ b/lib/src/sql/statements/kill.rs
@@ -99,7 +99,7 @@ pub fn kill(i: &str) -> IResult<&str, KillStatement> {
 	Ok((
 		i,
 		KillStatement {
-			id: v, // TODO change to value
+			id: v,
 		},
 	))
 }

--- a/lib/src/sql/statements/kill.rs
+++ b/lib/src/sql/statements/kill.rs
@@ -38,8 +38,8 @@ impl KillStatement {
 		// Resolve live query id
 		let live_query_id = match &self.id {
 			Value::Uuid(id) => id.clone(),
-			Value::Param(param) => *match param.compute(ctx, opt, txn, None).await? {
-				Value::Uuid(id) => Box::new(id),
+			Value::Param(param) => match param.compute(ctx, opt, txn, None).await? {
+				Value::Uuid(id) => id,
 				_ => {
 					return Err(Error::KillStatement {
 						value: self.id.to_string(),

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -442,9 +442,7 @@ impl Rpc {
 			},
 			// Kill a live query using a query id
 			"kill" => match params.needs_one() {
-				Ok(v) if v.is_uuid() => {
-					rpc.read().await.kill(v).await.map(Into::into).map_err(Into::into)
-				}
+				Ok(v) => rpc.read().await.kill(v).await.map(Into::into).map_err(Into::into),
 				_ => Err(Failure::INVALID_PARAMS),
 			},
 			// Setup a live query on a specific table
@@ -637,7 +635,7 @@ impl Rpc {
 		let sql = "KILL $id";
 		// Specify the query parameters
 		let var = map! {
-			String::from("id") => id,
+			String::from("id") => id, // NOTE: id can be parameter
 			=> &self.vars
 		};
 		// Execute the query on the database


### PR DESCRIPTION
## What is the motivation?

Change the "id" type of the KILL statement to allow non-`Uuid` values such as `Param`.

## What does this change do?

Changes the type in the KILL statement.
Evaluates (resolves) the ID for KILL in the KILL compute part.
Remove requirement for web ID of KILL to be uuid (as the UUID provided will be a Param and the UUID injected).

## What is your testing strategy?

Adding tests for KILL

## Is this related to any issues?

KILL testing from web.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
