### PR TITLE
Fix CF GC / node::init to actuallly run on start

### DIFF
--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -144,11 +144,11 @@ pub async fn init(
 	env::init().await?;
 	// Start the kvs server
 	dbs::init(dbs).await?;
-	// Start the web server
-	net::init().await?;
 	// Start the node agent
 	#[cfg(feature = "has-storage")]
 	node::init().await?;
+	// Start the web server
+	net::init().await?;
 	// All ok
 	Ok(())
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -6,27 +6,26 @@ const LOG: &str = "surrealdb::node";
 // The init starts a long-running thread for periodically calling Datastore.tick.
 // Datastore.tick is responsible for running garbage collection and other
 // background tasks.
-// This can be a temporary solution until we have a proper background
-// task system in place.
+//
+// This function needs to be called before after the dbs::init and before the net::init functions.
+// It needs to be before net::init because the net::init function blocks until the web server stops.
 pub async fn init() -> Result<(), Error> {
 	let opt = CF.get().unwrap();
 	let tick_interval = opt.tick_interval;
 	info!(target: LOG, "Node agent starting.");
 
-	let gc = move || {
-		let dbs = crate::dbs::DB.get().unwrap();
-		tokio::spawn(async move {
-			loop {
-				tokio::time::sleep(tick_interval).await;
-				if let Err(e) = dbs.tick().await {
-					error!("Error running node agent tick: {}", e);
-				}
+	// This requires the nodes::init function to be called after the dbs::init function.
+	let dbs = crate::dbs::DB.get().unwrap();
+	tokio::spawn(async move {
+		loop {
+			if let Err(e) = dbs.tick().await {
+				error!("Error running node agent tick: {}", e);
 			}
+			tokio::time::sleep(tick_interval).await;
+		}
 
-			// TODO Do we need to add support for graceful stop?
-		});
-	};
-	std::thread::spawn(gc);
+		// TODO Do we need to add support for graceful stop?
+	});
 
 	info!(target: LOG, "Node agent started.");
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -129,6 +129,21 @@ pub struct StartServerArguments {
 	pub tick_interval: time::Duration,
 }
 
+impl Default for StartServerArguments {
+	fn default() -> Self {
+		Self {
+			auth: true,
+			tls: false,
+			wait_is_ready: true,
+			tick_interval: time::Duration::new(1, 0),
+		}
+	}
+}
+
+pub async fn start_server_with_defaults() -> Result<(String, Child), Box<dyn Error>> {
+	start_server(StartServerArguments::default()).await
+}
+
 pub async fn start_server(
 	StartServerArguments {
 		auth,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -122,10 +122,20 @@ fn parse_server_stdio_from_var(var: &str) -> Result<Stdio, Box<dyn Error>> {
 	}
 }
 
+pub struct StartServerArguments {
+	pub auth: bool,
+	pub tls: bool,
+	pub wait_is_ready: bool,
+	pub tick_interval: time::Duration,
+}
+
 pub async fn start_server(
-	auth: bool,
-	tls: bool,
-	wait_is_ready: bool,
+	StartServerArguments {
+		auth,
+		tls,
+		wait_is_ready,
+		tick_interval,
+	}: StartServerArguments,
 ) -> Result<(String, Child), Box<dyn Error>> {
 	let mut rng = thread_rng();
 
@@ -147,6 +157,11 @@ pub async fn start_server(
 
 	if auth {
 		extra_args.push_str(" --auth");
+	}
+
+	if !tick_interval.is_zero() {
+		let sec = tick_interval.as_secs();
+		extra_args.push_str(format!(" --tick-interval {sec}s").as_str());
 	}
 
 	let start_args = format!("start --bind {addr} memory --no-banner --log trace --user {USER} --pass {PASS} {extra_args}");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -140,6 +140,14 @@ impl Default for StartServerArguments {
 	}
 }
 
+pub async fn start_server_without_auth() -> Result<(String, Child), Box<dyn Error>> {
+	start_server(StartServerArguments {
+		auth: false,
+		..Default::default()
+	})
+	.await
+}
+
 pub async fn start_server_with_defaults() -> Result<(String, Child), Box<dyn Error>> {
 	start_server(StartServerArguments::default()).await
 }

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -14,7 +14,7 @@ use crate::common::{PASS, USER};
 #[test(tokio::test)]
 #[serial]
 async fn basic_auth() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/sql");
 
 	// Prepare HTTP client
@@ -56,7 +56,7 @@ async fn basic_auth() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn bearer_auth() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/sql");
 
 	// Prepare HTTP client
@@ -144,7 +144,7 @@ async fn client_ip_extractor() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn export_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/export");
 
 	// Prepare HTTP client
@@ -188,7 +188,7 @@ async fn export_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn health_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/health");
 
 	let res = Client::default().get(url).send().await?;
@@ -200,7 +200,7 @@ async fn health_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn import_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/import");
 
 	// Prepare HTTP client
@@ -273,7 +273,7 @@ async fn import_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn rpc_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/rpc");
 
 	// Prepare HTTP client
@@ -307,7 +307,7 @@ async fn rpc_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn signin_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/signin");
 
 	// Prepare HTTP client
@@ -376,7 +376,7 @@ async fn signin_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn signup_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/signup");
 
 	// Prepare HTTP client
@@ -439,7 +439,7 @@ async fn signup_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn sql_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/sql");
 
 	// Prepare HTTP client
@@ -551,7 +551,7 @@ async fn sql_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn sync_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/sync");
 
 	// Prepare HTTP client
@@ -585,7 +585,7 @@ async fn sync_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn version_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/version");
 
 	let res = Client::default().get(url).send().await?;
@@ -627,7 +627,7 @@ async fn seed_table(
 #[test(tokio::test)]
 #[serial]
 async fn key_endpoint_select_all() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
 	let num_records = 50;
 	let url = &format!("http://{addr}/key/{table_name}");
@@ -704,7 +704,7 @@ async fn key_endpoint_select_all() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn key_endpoint_create_all() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 
 	// Prepare HTTP client
 	let mut headers = reqwest::header::HeaderMap::new();
@@ -767,7 +767,7 @@ async fn key_endpoint_create_all() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn key_endpoint_update_all() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
 	let num_records = 10;
 	let url = &format!("http://{addr}/key/{table_name}");
@@ -837,7 +837,7 @@ async fn key_endpoint_update_all() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn key_endpoint_modify_all() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
 	let num_records = 10;
 	let url = &format!("http://{addr}/key/{table_name}");
@@ -907,7 +907,7 @@ async fn key_endpoint_modify_all() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn key_endpoint_delete_all() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
 	let num_records = 10;
 	let url = &format!("http://{addr}/key/{table_name}");
@@ -961,7 +961,7 @@ async fn key_endpoint_delete_all() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn key_endpoint_select_one() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
 	let url = &format!("http://{addr}/key/{table_name}/1");
 
@@ -1002,7 +1002,7 @@ async fn key_endpoint_select_one() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn key_endpoint_create_one() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
 
 	// Prepare HTTP client
@@ -1099,7 +1099,7 @@ async fn key_endpoint_create_one() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn key_endpoint_update_one() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
 	let url = &format!("http://{addr}/key/{table_name}/1");
 
@@ -1172,7 +1172,7 @@ async fn key_endpoint_update_one() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn key_endpoint_modify_one() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
 	let url = &format!("http://{addr}/key/{table_name}/1");
 
@@ -1250,7 +1250,7 @@ async fn key_endpoint_modify_one() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn key_endpoint_delete_one() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
 	let base_url = &format!("http://{addr}/key/{table_name}");
 

--- a/tests/ws_integration.rs
+++ b/tests/ws_integration.rs
@@ -327,7 +327,7 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn live_live_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(false, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_without_auth().await.unwrap();
 	let table_name = "table_FD40A9A361884C56B5908A934164884A".to_string();
 
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -413,7 +413,7 @@ async fn live_live_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn live_query_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(false, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_without_auth().await.unwrap();
 	let table_name = "table_FD40A9A361884C56B5908A934164884A".to_string();
 
 	let socket = &mut common::connect_ws(&addr).await?;

--- a/tests/ws_integration.rs
+++ b/tests/ws_integration.rs
@@ -12,7 +12,7 @@ use crate::common::{PASS, USER};
 #[test(tokio::test)]
 #[serial]
 async fn ping() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	// Send command
@@ -37,7 +37,7 @@ async fn ping() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn info() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -104,7 +104,7 @@ async fn info() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn signup() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -159,7 +159,7 @@ async fn signup() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn signin() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -233,7 +233,7 @@ async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn invalidate() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -275,7 +275,7 @@ async fn invalidate() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn authenticate() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -496,7 +496,7 @@ async fn live_query_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn let_and_set() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -549,7 +549,7 @@ async fn let_and_set() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn unset() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -612,7 +612,7 @@ async fn unset() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn select() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -656,7 +656,7 @@ async fn select() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn insert() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -702,7 +702,7 @@ async fn insert() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn create() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -742,7 +742,7 @@ async fn create() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn update() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -792,7 +792,7 @@ async fn update() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn change_and_merge() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -874,7 +874,7 @@ async fn change_and_merge() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn modify_and_patch() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -979,7 +979,7 @@ async fn modify_and_patch() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn delete() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -1041,7 +1041,7 @@ async fn delete() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn format_json() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -1087,7 +1087,7 @@ async fn format_json() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn format_cbor() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -1145,7 +1145,7 @@ async fn format_cbor() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn format_pack() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -1203,7 +1203,7 @@ async fn format_pack() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn query() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	//
@@ -1247,7 +1247,7 @@ async fn query() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 #[serial]
 async fn version() -> Result<(), Box<dyn std::error::Error>> {
-	let (addr, _server) = common::start_server(true, false, true).await.unwrap();
+	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	// Send command


### PR DESCRIPTION
## What is the motivation?

Make CF GC actually work!

## What does this change do?

Fixes a bug in the nodes::init function that resulted in the spawned async func to never correctly run.

## What is your testing strategy?

I've added a new test case to the existing cli_integration test suite. It would pass only when a CF GC is actually called once at the expected timing.

## Is this related to any issues?

#2339

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
