### PR TITLE
Add lint target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,7 @@ quick: check-deps
 .PHONY: build
 build: check-deps
 	cargo make build
+
+.PHONY: lint
+lint:
+	cargo make ci-clippy


### PR DESCRIPTION
## What is the motivation?

Make linting easy with `make lint`

## What does this change do?

Add a lint goal for the Makefile that invokes the cargo-make lint goal.

## What is your testing strategy?

Terminal.

## Is this related to any issues?

General convenience.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
