### PR TITLE
Use monotonic versionstamps with TiKV for now

### DIFF
--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -413,21 +413,6 @@ impl Transaction {
 	{
 		#[cfg(debug_assertions)]
 		trace!("Get Timestamp {:?}", key);
-		let use_nonmonontonic = match self {
-			#[cfg(feature = "kv-tikv")]
-			Transaction {
-				inner: Inner::TiKV(v),
-				..
-			} => true,
-			_ => false,
-		};
-		let nonmonotonic_vs = if use_nonmonontonic {
-			self.get_non_monotonic_versionstamp().await
-		} else {
-			Err(Error::Internal(
-				"Non-monotonic versionstamps are only supported on TiKV".to_string(),
-			))
-		};
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -448,11 +433,7 @@ impl Transaction {
 			Transaction {
 				inner: Inner::TiKV(v),
 				..
-			} => {
-				// TODO Make it configurable to use monotonic or non-monotonic versionstamps
-				// v.get_timestamp(key, lock).await
-				nonmonotonic_vs
-			}
+			} => v.get_timestamp(key, lock).await,
 			#[cfg(feature = "kv-fdb")]
 			Transaction {
 				inner: Inner::FoundationDB(v),
@@ -506,20 +487,6 @@ impl Transaction {
 	{
 		#[cfg(debug_assertions)]
 		trace!("Set {:?} <ts> {:?} => {:?}", prefix, suffix, val);
-		let nonmonotonic_key: Result<Vec<u8>, Error> = match self {
-			#[cfg(feature = "kv-tikv")]
-			Transaction {
-				inner: Inner::TiKV(v),
-				..
-			} => self.get_non_monotonic_versionstamped_key(prefix.clone(), suffix.clone()).await,
-			// We need this to make the compiler happy.
-			// The below is unreachable only when only the tikv feature is enabled.
-			// It's still reachable if we enabled more than one kv feature.
-			#[allow(unreachable_patterns)]
-			_ => Err(Error::Internal(
-				"Non-monotonic versionstamps are only supported on TiKV".to_string(),
-			)),
-		};
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -550,10 +517,7 @@ impl Transaction {
 				inner: Inner::TiKV(v),
 				..
 			} => {
-				// TODO Maybe make it configurable to use monotonic or non-monotonic versionstamps
-				// at the database definition time?
-				// let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
-				let k = nonmonotonic_key?;
+				let k = v.get_versionstamped_key(ts_key, prefix, suffix).await?;
 				v.set(k, val).await
 			}
 			#[cfg(feature = "kv-fdb")]


### PR DESCRIPTION
## What is the motivation?

Keep versionstamps and change feed guarantees simple and easy to understand/use for TiKV.

## What does this change do?

This partially reverts #2343 so that our TiKV datastore use the monotonic versionstamps, same as other datastores.

## What is your testing strategy?

Our existing tests are written in versionstamp monotonicy in mind so as long as the all unit and integration tests pass, it should be good.

Also, note that we don't currently have api/cli integration tests that cover versionstamp nonmonotonicity so no changes in tests.

## Is this related to any issues?

#2343

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
