### PR TITLE
[cargo] Use the surrealdb-tikv-client published to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5133,7 +5133,8 @@ dependencies = [
 [[package]]
 name = "surrealdb-tikv-client"
 version = "0.2.0-surreal.2"
-source = "git+https://github.com/surrealdb/tikv-client.git?tag=0.2.0-surreal.2#0af5d641eb66e2f3616c251f6be381ab79882817"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79f921871d6ed67c970e8499b4aca3724115c189f99ab30f51b46c77bd19819"
 dependencies = [
  "async-recursion 0.3.2",
  "async-trait",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -105,9 +105,7 @@ sha2 = "0.10.7"
 speedb = { version = "0.0.2", optional = true }
 storekey = "0.5.0"
 thiserror = "1.0.43"
-# TODO: Uncomment when surrealdb-tikv-client 0.2.0-surreal.2 is published to crates.io is published
-#tikv = { version = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }
-tikv = { git = "https://github.com/surrealdb/tikv-client.git", tag = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }
+tikv = { version = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }
 tokio-util = { version = "0.7.8", optional = true, features = ["compat"] }
 tracing = "0.1.37"
 trice = "0.3.1"


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Remove a temporary workaround in Cargo.toml

## What does this change do?

Use the crate `surrealdb-tikv-client=0.2.0-surreal.2` from crates.io

## What is your testing strategy?

Verify all tests pass

## Is this related to any issues?

Yes, this closes #2374 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
