### PR TITLE
Replaced Deserialization implementation

### DIFF
--- a/lib/src/sql/thing/de.rs
+++ b/lib/src/sql/thing/de.rs
@@ -1,0 +1,105 @@
+use std::fmt;
+
+use crate::sql::Id;
+
+use super::Thing;
+
+use serde::de::{self, MapAccess, Visitor};
+use serde::Deserialize;
+
+struct ThingVisitor;
+
+impl<'de> Visitor<'de> for ThingVisitor {
+	type Value = Thing;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		write!(formatter, "either a string following the format \"table:id\", an object of structure {{ tb: \"table\", id: \"id\" }}, or a tuple of type (String, Id)")
+	}
+
+	fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+	where
+		A: de::SeqAccess<'de>,
+	{
+		let tb =
+			seq.next_element::<String>()?.ok_or_else(|| de::Error::invalid_length(0, &self))?;
+		let id = seq.next_element::<Id>()?.ok_or_else(|| de::Error::invalid_length(1, &self))?;
+
+		Ok(Thing {
+			tb,
+			id,
+		})
+	}
+
+	fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+	where
+		V: MapAccess<'de>,
+	{
+		let mut tb = None;
+		let mut id = None;
+
+		while let Some(k) = map.next_key::<&str>()? {
+			match k {
+				"tb" => {
+					if tb.is_some() {
+						return Err(de::Error::duplicate_field("tb"));
+					}
+
+					tb = Some(map.next_value::<String>()?);
+				}
+
+				"id" => {
+					if id.is_some() {
+						return Err(de::Error::duplicate_field("id"));
+					}
+
+					id = Some(map.next_value::<Id>()?);
+				}
+
+				_ => {}
+			}
+		}
+
+		let tb: String = tb.ok_or_else(|| de::Error::missing_field("tb"))?;
+		let id: Id = id.ok_or_else(|| de::Error::missing_field("id"))?;
+
+		Ok(Thing {
+			tb,
+			id,
+		})
+	}
+
+	fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+	where
+		E: de::Error,
+	{
+		// "table:id"
+		// requires a `:` to split at
+		if !v.contains(':') {
+			return Err(de::Error::custom("str type does not contain character ':'"));
+		}
+
+		// safety: we have already check for the existence of the ':'
+		//         as such this cannot fail
+		let (tb, id) = v.split_once(':').unwrap();
+
+		Ok(Thing {
+			tb: tb.to_owned(),
+			id: Id::from(id),
+		})
+	}
+}
+
+impl<'de> Deserialize<'de> for Thing {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		// this can come in many types
+		//
+		// as such this can be considered necessary for better interop
+		//
+		// it does however, require the use of a structured / descriptive
+		// serialization method
+		deserializer.deserialize_any(ThingVisitor)
+	}
+}

--- a/lib/src/sql/thing/mod.rs
+++ b/lib/src/sql/thing/mod.rs
@@ -19,8 +19,6 @@ use std::fmt;
 use std::str::FromStr;
 
 mod de;
-// is this 100% necessary
-use de::*;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Thing";
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Being able to deserialize the `Thing` type via multiple methods

## What does this change do?

Replaces the `derive` implemented `serde::Deserialize` with a custom implementation that enables Deserialization from:
- Strings
- Sequences
- Maps

## What is your testing strategy?

I've added some extra tests to `lib/src/sql/thing/mod.rs` (moved from `lib/src/sql/thing.rs`) that test the serde deserialization from a String, a map, and a sequence.

## Is this related to any issues?

Closes https://github.com/surrealdb/surrealdb/issues/2421

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
