### PR TITLE
Ensure TiKV cluster is clean before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,10 +492,9 @@ jobs:
         run: |
           sudo apt-get -y update
 
-      - name: Install TiKV
+      - name: Install TiUP
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
-          ~/.tiup/bin/tiup install tikv pd
           ~/.tiup/bin/tiup -v
 
       - name: Install cargo-make

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -117,12 +117,12 @@ run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel 
 [tasks.ci-api-integration-fdb]
 category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "fdb", _TEST_FEATURES = "kv-fdb-7_1" }
-run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = false }
 
 [tasks.ci-api-integration-tikv-tests]
 category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "tikv", _TEST_FEATURES = "kv-tikv" }
-run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = false }
 
 [tasks.ci-api-integration-tikv]
 category = "CI - INTEGRATION TESTS"
@@ -165,6 +165,8 @@ script = """
    ${HOME}/.tiup/bin/tiup install pd tikv playground
 
    ${HOME}/.tiup/bin/tiup playground --mode tikv-slim --kv 3 --without-monitor &>/tmp/tiup.log &
+
+   ${HOME}/.tiup/bin/tiup clean --all
 
    echo $! > /tmp/tiup.pid
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

TiKV tests don't always run consistently. This is the first step in trying to ensure the environment is clean and allows for consistent tests.

## What does this change do?

Ensures all data is cleaned up before running tests.

## What is your testing strategy?

Doesn't change any tests.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
