### PR TITLE
Add test for delete with live query predicates

### DIFF
--- a/lib/src/dbs/session.rs
+++ b/lib/src/dbs/session.rs
@@ -40,6 +40,13 @@ impl Session {
 		self.db = Some(db.to_owned());
 		self
 	}
+
+	// Set the realtime functionality of the session
+	pub fn with_rt(mut self, rt: bool) -> Session {
+		self.rt = rt;
+		self
+	}
+
 	/// Retrieves the selected namespace
 	pub(crate) fn ns(&self) -> Option<Arc<str>> {
 		self.ns.as_deref().map(Into::into)


### PR DESCRIPTION
## What is the motivation?

Validating bug #2428 
Allegedly, notifications weren't coming in for live queries with predicates for deleted records. This may still be the case, but the test proves otherwise.

## What does this change do?

Introduce a test to verify live query notifications with a predicate are sent for a delete record that matches.

## What is your testing strategy?

Test included.

## Is this related to any issues?

#2428 
Reported bug by user

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
