### PR TITLE
Refactored ds.rs to re-use and close write transaction

### DIFF
--- a/lib/src/sql/statements/define.rs
+++ b/lib/src/sql/statements/define.rs
@@ -502,6 +502,25 @@ pub struct DefineUserStatement {
 	pub roles: Vec<Ident>,
 }
 
+impl From<(Base, &str, &str)> for DefineUserStatement {
+	fn from((base, user, pass): (Base, &str, &str)) -> Self {
+		DefineUserStatement {
+			base,
+			name: user.into(),
+			hash: Argon2::default()
+				.hash_password(pass.as_ref(), &SaltString::generate(&mut OsRng))
+				.unwrap()
+				.to_string(),
+			code: rand::thread_rng()
+				.sample_iter(&Alphanumeric)
+				.take(128)
+				.map(char::from)
+				.collect::<String>(),
+			roles: vec!["owner".into()],
+		}
+	}
+}
+
 impl DefineUserStatement {
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(


### PR DESCRIPTION
## What is the motivation?

We had a db operation that wasn't closing a transaction.
This change fixes that.

## What does this change do?

Change a read transaction to write.
Provide access to the transaction via a mutex.
Close the transaction in all cases.

## What is your testing strategy?

`make serve && make test`

## Is this related to any issues?

Failing builds

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
