### PR TITLE
Refactor `Lazy::new(|| Surreal::init())` to `Lazy::new(Surreal::init)`

### DIFF
--- a/lib/examples/actix/src/main.rs
+++ b/lib/examples/actix/src/main.rs
@@ -8,7 +8,7 @@ use surrealdb::engine::remote::ws::Ws;
 use surrealdb::opt::auth::Root;
 use surrealdb::Surreal;
 
-static DB: Lazy<Surreal<Client>> = Lazy::new(|| Surreal::init());
+static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
 
 #[actix_web::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/lib/examples/concurrency/main.rs
+++ b/lib/examples/concurrency/main.rs
@@ -4,7 +4,7 @@ use surrealdb::engine::remote::ws::Ws;
 use surrealdb::Surreal;
 use tokio::sync::mpsc;
 
-static DB: Lazy<Surreal<Client>> = Lazy::new(|| Surreal::init());
+static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
 
 const NUM: usize = 100_000;
 

--- a/lib/src/api/engine/any/mod.rs
+++ b/lib/src/api/engine/any/mod.rs
@@ -589,7 +589,7 @@ impl Surreal<Any> {
 	/// use surrealdb::Surreal;
 	/// use surrealdb::engine::any::Any;
 	///
-	/// static DB: Lazy<Surreal<Any>> = Lazy::new(|| Surreal::init());
+	/// static DB: Lazy<Surreal<Any>> = Lazy::new(Surreal::init);
 	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -82,7 +82,7 @@ use tokio::io::AsyncWriteExt;
 /// use surrealdb::engine::local::Db;
 /// use surrealdb::engine::local::Mem;
 ///
-/// static DB: Lazy<Surreal<Db>> = Lazy::new(|| Surreal::init());
+/// static DB: Lazy<Surreal<Db>> = Lazy::new(Surreal::init);
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<()> {

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -81,7 +81,7 @@ impl Surreal<Client> {
 	/// use surrealdb::engine::remote::http::Client;
 	/// use surrealdb::engine::remote::http::Http;
 	///
-	/// static DB: Lazy<Surreal<Client>> = Lazy::new(|| Surreal::init());
+	/// static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
 	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {

--- a/lib/src/api/engine/remote/ws/mod.rs
+++ b/lib/src/api/engine/remote/ws/mod.rs
@@ -63,7 +63,7 @@ impl Surreal<Client> {
 	/// use surrealdb::engine::remote::ws::Client;
 	/// use surrealdb::engine::remote::ws::Ws;
 	///
-	/// static DB: Lazy<Surreal<Client>> = Lazy::new(|| Surreal::init());
+	/// static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
 	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -136,7 +136,7 @@ where
 	/// use surrealdb::engine::remote::ws::Client;
 	///
 	/// // Creates a new static instance of the client
-	/// static DB: Lazy<Surreal<Client>> = Lazy::new(|| Surreal::init());
+	/// static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
 	///
 	/// #[derive(Serialize, Deserialize)]
 	/// struct Person {
@@ -178,7 +178,7 @@ where
 	/// use surrealdb::opt::auth::Root;
 	///
 	/// // Creates a new static instance of the client
-	/// static DB: Lazy<Surreal<Any>> = Lazy::new(|| Surreal::init());
+	/// static DB: Lazy<Surreal<Any>> = Lazy::new(Surreal::init);
 	///
 	/// #[derive(Serialize, Deserialize)]
 	/// struct Person {

--- a/lib/src/api/method/tests/mod.rs
+++ b/lib/src/api/method/tests/mod.rs
@@ -24,7 +24,7 @@ use std::ops::Bound;
 use types::User;
 use types::USER;
 
-static DB: Lazy<Surreal<Client>> = Lazy::new(|| Surreal::init());
+static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
 
 #[tokio::test]
 async fn api() {


### PR DESCRIPTION
## What is the motivation?

Minor refactor to make code a little easier to read. 

## What does this change do?

Use a function pointer instead of a closure. Not sure why clippy didn't catch this.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
