### PR TITLE
[integration-tests] Improvements. Increase timeout for WS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,13 +24,18 @@
 # Code and tests for the server
 /src/net/ @surrealdb/api
 /src/rpc/ @surrealdb/api
+/tests/http_integration.rs @surrealdb/api
+/tests/ws_integration.rs @surrealdb/api
 
 # Code and tests for the command-line
 /src/cli/ @surrealdb/cli
-/tests/cli.rs @surrealdb/cli
+/tests/cli_integration.rs @surrealdb/cli
 
 # Code and tests for opentelemetry
-/src/o11y/ @surrealdb/monitoring
+/src/telemetry/ @surrealdb/monitoring
 
 # Tests related to the key-value store
 /lib/src/kvs/tests/ @tobiemh @phughk
+
+# IAM
+/lib/src/iam/ @surrealdb/api @surrealdb/security

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,10 +209,18 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install protobuf-compiler libprotobuf-dev
 
-      - name: Run cargo test
-        run: cargo test --locked --no-default-features --features storage-mem --workspace --test ws_integration
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Run WS integration tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-ws-integration
 
   test:
     name: Test workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
         uses: actions-rs/cargo@v1
@@ -55,6 +57,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |
@@ -87,6 +91,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
         uses: actions-rs/cargo@v1
@@ -115,6 +121,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |
@@ -145,6 +153,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |
@@ -175,6 +185,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |
@@ -205,6 +217,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |
@@ -235,6 +249,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |
@@ -286,6 +302,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |
@@ -321,6 +339,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |
@@ -356,6 +376,8 @@ jobs:
 
         - name: Setup cache
           uses: Swatinem/rust-cache@v2
+          with:
+            save-if: ${{ github.ref == 'refs/heads/main' }}
 
         - name: Install dependencies
           run: |
@@ -391,6 +413,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
         uses: actions-rs/cargo@v1
@@ -417,6 +441,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
         uses: actions-rs/cargo@v1
@@ -443,6 +469,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
         uses: actions-rs/cargo@v1
@@ -469,6 +497,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
         uses: actions-rs/cargo@v1
@@ -495,6 +525,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |
@@ -530,6 +562,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup FoundationDB
         uses: foundationdb-rs/foundationdb-actions-install@v2.0.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: |

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -24,12 +24,20 @@ args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
 [tasks.ci-cli-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem", "--workspace", "--test", "cli_integration"]
+env = { RUST_LOG = "cli_integration=debug" }
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem", "--workspace", "--test", "cli_integration", "--", "--nocapture"]
 
 [tasks.ci-http-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem", "--workspace", "--test", "http_integration"]
+env = { RUST_LOG = "http_integration=debug" }
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem", "--workspace", "--test", "http_integration", "--", "--nocapture"]
+
+[tasks.ci-ws-integration]
+category = "CI - INTEGRATION TESTS"
+command = "cargo"
+env = { RUST_LOG = "ws_integration=debug" }
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem", "--workspace", "--test", "ws_integration", "--", "--nocapture"]
 
 [tasks.ci-workspace-coverage]
 category = "CI - INTEGRATION TESTS"

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -16,31 +16,26 @@ const ONE_SEC: time::Duration = time::Duration::new(1, 0);
 const TWO_SECS: time::Duration = time::Duration::new(2, 0);
 
 #[test]
-#[serial]
 fn version() {
 	assert!(common::run("version").output().is_ok());
 }
 
 #[test]
-#[serial]
 fn help() {
 	assert!(common::run("help").output().is_ok());
 }
 
 #[test]
-#[serial]
 fn nonexistent_subcommand() {
 	assert!(common::run("nonexistent").output().is_err());
 }
 
 #[test]
-#[serial]
 fn nonexistent_option() {
 	assert!(common::run("version --turbo").output().is_err());
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn all_commands() {
 	// Commands without credentials when auth is disabled, should succeed
 	let (addr, _server) = common::start_server(StartServerArguments {
@@ -180,7 +175,6 @@ async fn all_commands() {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn start_tls() {
 	// Capute the server's stdout/stderr
 	temp_env::async_with_vars(
@@ -209,7 +203,6 @@ async fn start_tls() {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn with_root_auth() {
 	// Commands with credentials when auth is enabled, should succeed
 	let (addr, _server) = common::start_server(StartServerArguments {
@@ -266,7 +259,6 @@ async fn with_root_auth() {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn with_anon_auth() {
 	// Commands without credentials when auth is enabled, should fail
 	let (addr, _server) = common::start_server(StartServerArguments {
@@ -334,7 +326,6 @@ async fn with_anon_auth() {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn node() {
 	// Commands without credentials when auth is disabled, should succeed
 	let (addr, _server) = common::start_server(StartServerArguments {
@@ -392,7 +383,6 @@ async fn node() {
 }
 
 #[test]
-#[serial]
 fn validate_found_no_files() {
 	let temp_dir = assert_fs::TempDir::new().unwrap();
 
@@ -402,7 +392,6 @@ fn validate_found_no_files() {
 }
 
 #[test]
-#[serial]
 fn validate_succeed_for_valid_surql_files() {
 	let temp_dir = assert_fs::TempDir::new().unwrap();
 
@@ -415,7 +404,6 @@ fn validate_succeed_for_valid_surql_files() {
 }
 
 #[test]
-#[serial]
 fn validate_failed_due_to_invalid_glob_pattern() {
 	let temp_dir = assert_fs::TempDir::new().unwrap();
 
@@ -427,7 +415,6 @@ fn validate_failed_due_to_invalid_glob_pattern() {
 }
 
 #[test]
-#[serial]
 fn validate_failed_due_to_invalid_surql_files_syntax() {
 	let temp_dir = assert_fs::TempDir::new().unwrap();
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -3,7 +3,6 @@
 mod common;
 
 use assert_fs::prelude::{FileTouch, FileWriteStr, PathChild};
-use serial_test::serial;
 use std::fs;
 use std::time;
 use test_log::test;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,9 +15,7 @@ use tokio::net::TcpStream;
 use tokio::time;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
-use tracing::{error, info};
-
-use crate::common::error::TestError;
+use tracing::{error, info, debug};
 
 pub const USER: &str = "root";
 pub const PASS: &str = "root";
@@ -228,12 +226,34 @@ pub async fn connect_ws(addr: &str) -> Result<WsStream, Box<dyn Error>> {
 pub async fn ws_send_msg(
 	socket: &mut WsStream,
 	msg_req: String,
-) -> Result<serde_json::Value, Box<dyn Error>> {
-	// Use JSON format by default
-	ws_send_msg_with_fmt(socket, msg_req, Format::Json).await
+) -> Result<(), Box<dyn Error>> {
+	let now = time::Instant::now();
+	debug!("Sending message: {msg_req}");
+	tokio::select! {
+		_ = time::sleep(time::Duration::from_millis(500)) => {
+			return Err("timeout after 500ms waiting for the request to be sent".into());
+		}
+		res = socket.send(Message::Text(msg_req)) => {
+			debug!("Message sent in {:?}", now.elapsed());
+			if let Err(err) = res {
+				return Err(format!("Error sending the message: {}", err).into());
+			}
+		}
+	}
+
+	Ok(())
 }
 
 pub async fn ws_recv_msg(socket: &mut WsStream) -> Result<serde_json::Value, Box<dyn Error>> {
+	ws_recv_msg_with_fmt(socket, Format::Json).await
+}
+
+pub async fn ws_send_msg_and_wait_response(
+	socket: &mut WsStream,
+	msg_req: String,
+) -> Result<serde_json::Value, Box<dyn Error>> {
+	// Use JSON format by default
+	ws_send_msg(socket, msg_req).await?;
 	ws_recv_msg_with_fmt(socket, Format::Json).await
 }
 
@@ -247,49 +267,21 @@ pub async fn ws_recv_msg_with_fmt(
 	socket: &mut WsStream,
 	format: Format,
 ) -> Result<serde_json::Value, Box<dyn Error>> {
+	let now = time::Instant::now();
+	debug!("Waiting for response...");
 	// Parse and return response
 	let mut f = socket.try_filter(|msg| match format {
 		Format::Json => futures_util::future::ready(msg.is_text()),
 		Format::Pack | Format::Cbor => futures_util::future::ready(msg.is_binary()),
 	});
-	let msg: serde_json::Value = tokio::select! {
-			_ = time::sleep(time::Duration::from_millis(2000)) => {
-					return Err(TestError::NetworkError{message: "timeout waiting for the response".to_string()}.into());
-			}
-			msg = f.select_next_some() => {
-					serde_json::from_str(&msg?.to_string())?
-			}
-	};
-	Ok(serde_json::from_str(&msg.to_string())?)
-}
-
-pub async fn ws_send_msg_with_fmt(
-	socket: &mut WsStream,
-	msg_req: String,
-	response_format: Format,
-) -> Result<serde_json::Value, Box<dyn Error>> {
-	tokio::select! {
-		_ = time::sleep(time::Duration::from_millis(500)) => {
-			return Err("timeout waiting for the request to be sent".into());
-		}
-		res = socket.send(Message::Text(msg_req)) => {
-			if let Err(err) = res {
-				return Err(format!("Error sending the message: {}", err).into());
-			}
-		}
-	}
-
-	let mut f = socket.try_filter(|msg| match response_format {
-		Format::Json => futures_util::future::ready(msg.is_text()),
-		Format::Pack | Format::Cbor => futures_util::future::ready(msg.is_binary()),
-	});
 
 	tokio::select! {
-		_ = time::sleep(time::Duration::from_millis(2000)) => {
-			Err("timeout waiting for the response".into())
+		_ = time::sleep(time::Duration::from_millis(5000)) => {
+			Err("timeout after 5s waiting for the response".into())
 		}
 		res = f.select_next_some() => {
-			match response_format {
+			debug!("Response received in {:?}", now.elapsed());
+			match format {
 				Format::Json => Ok(serde_json::from_str(&res?.to_string())?),
 				Format::Cbor => Ok(serde_cbor::from_slice(&res?.into_data())?),
 				Format::Pack => Ok(serde_pack::from_slice(&res?.into_data())?),
@@ -333,7 +325,8 @@ pub async fn ws_signin(
 		],
 	});
 
-	let msg = ws_send_msg(socket, serde_json::to_string(&json).unwrap()).await?;
+	ws_send_msg(socket, serde_json::to_string(&json).unwrap()).await?;
+	let msg = ws_recv_msg(socket).await?;
 	match msg.as_object() {
 		Some(obj) if obj.keys().all(|k| ["id", "error"].contains(&k.as_str())) => {
 			Err(format!("unexpected error from query request: {:?}", obj.get("error")).into())
@@ -358,7 +351,8 @@ pub async fn ws_query(
 		"params": [query],
 	});
 
-	let msg = ws_send_msg(socket, serde_json::to_string(&json).unwrap()).await?;
+	ws_send_msg(socket, serde_json::to_string(&json).unwrap()).await?;
+	let msg = ws_recv_msg(socket).await?;
 
 	match msg.as_object() {
 		Some(obj) if obj.keys().all(|k| ["id", "error"].contains(&k.as_str())) => {
@@ -387,7 +381,9 @@ pub async fn ws_use(
 		],
 	});
 
-	let msg = ws_send_msg(socket, serde_json::to_string(&json).unwrap()).await?;
+	ws_send_msg(socket, serde_json::to_string(&json).unwrap()).await?;
+	let msg = ws_recv_msg(socket).await?;
+
 	match msg.as_object() {
 		Some(obj) if obj.keys().all(|k| ["id", "error"].contains(&k.as_str())) => {
 			Err(format!("unexpected error from query request: {:?}", obj.get("error")).into())

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,7 +15,7 @@ use tokio::net::TcpStream;
 use tokio::time;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
-use tracing::{error, info, debug};
+use tracing::{debug, error, info};
 
 pub const USER: &str = "root";
 pub const PASS: &str = "root";
@@ -223,10 +223,7 @@ pub async fn connect_ws(addr: &str) -> Result<WsStream, Box<dyn Error>> {
 	Ok(ws_stream)
 }
 
-pub async fn ws_send_msg(
-	socket: &mut WsStream,
-	msg_req: String,
-) -> Result<(), Box<dyn Error>> {
+pub async fn ws_send_msg(socket: &mut WsStream, msg_req: String) -> Result<(), Box<dyn Error>> {
 	let now = time::Instant::now();
 	debug!("Sending message: {msg_req}");
 	tokio::select! {
@@ -252,7 +249,6 @@ pub async fn ws_send_msg_and_wait_response(
 	socket: &mut WsStream,
 	msg_req: String,
 ) -> Result<serde_json::Value, Box<dyn Error>> {
-	// Use JSON format by default
 	ws_send_msg(socket, msg_req).await?;
 	ws_recv_msg_with_fmt(socket, Format::Json).await
 }

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -12,7 +12,6 @@ use test_log::test;
 use crate::common::{PASS, USER};
 
 #[test(tokio::test)]
-#[serial]
 async fn basic_auth() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/sql");
@@ -54,7 +53,6 @@ async fn basic_auth() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn bearer_auth() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/sql");
@@ -135,14 +133,12 @@ async fn bearer_auth() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn client_ip_extractor() -> Result<(), Box<dyn std::error::Error>> {
 	// TODO: test the client IP extractor
 	Ok(())
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn export_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/export");
@@ -186,7 +182,6 @@ async fn export_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn health_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/health");
@@ -198,7 +193,6 @@ async fn health_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn import_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/import");
@@ -271,7 +265,6 @@ async fn import_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn rpc_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/rpc");
@@ -305,7 +298,6 @@ async fn rpc_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn signin_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/signin");
@@ -374,7 +366,6 @@ async fn signin_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn signup_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/signup");
@@ -437,7 +428,6 @@ async fn signup_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn sql_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/sql");
@@ -549,7 +539,6 @@ async fn sql_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn sync_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/sync");
@@ -583,7 +572,6 @@ async fn sync_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn version_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let url = &format!("http://{addr}/version");
@@ -625,7 +613,6 @@ async fn seed_table(
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn key_endpoint_select_all() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
@@ -702,7 +689,6 @@ async fn key_endpoint_select_all() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn key_endpoint_create_all() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 
@@ -765,7 +751,6 @@ async fn key_endpoint_create_all() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn key_endpoint_update_all() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
@@ -835,7 +820,6 @@ async fn key_endpoint_update_all() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn key_endpoint_modify_all() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
@@ -905,7 +889,6 @@ async fn key_endpoint_modify_all() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn key_endpoint_delete_all() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
@@ -959,7 +942,6 @@ async fn key_endpoint_delete_all() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn key_endpoint_select_one() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
@@ -1000,7 +982,6 @@ async fn key_endpoint_select_one() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn key_endpoint_create_one() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
@@ -1097,7 +1078,6 @@ async fn key_endpoint_create_one() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn key_endpoint_update_one() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
@@ -1170,7 +1150,6 @@ async fn key_endpoint_update_one() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn key_endpoint_modify_one() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";
@@ -1248,7 +1227,6 @@ async fn key_endpoint_modify_one() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn key_endpoint_delete_one() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let table_name = "table";

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 use http::{header, Method};
 use reqwest::Client;
 use serde_json::json;
-use serial_test::serial;
 use test_log::test;
 
 use crate::common::{PASS, USER};

--- a/tests/ws_integration.rs
+++ b/tests/ws_integration.rs
@@ -3,7 +3,6 @@
 mod common;
 
 use serde_json::json;
-use serial_test::serial;
 use test_log::test;
 
 use crate::common::error::TestError;

--- a/tests/ws_integration.rs
+++ b/tests/ws_integration.rs
@@ -10,13 +10,12 @@ use crate::common::error::TestError;
 use crate::common::{PASS, USER};
 
 #[test(tokio::test)]
-#[serial]
 async fn ping() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	// Send command
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -35,7 +34,6 @@ async fn ping() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn info() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -81,7 +79,7 @@ async fn info() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Send the info command
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -102,7 +100,6 @@ async fn info() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn signup() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -124,7 +121,7 @@ async fn signup() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Signup
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -157,7 +154,6 @@ async fn signup() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -179,7 +175,7 @@ async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Signup
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -198,7 +194,7 @@ async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Sign in
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -231,7 +227,6 @@ async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn invalidate() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -247,7 +242,7 @@ async fn invalidate() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Invalidate session
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -273,7 +268,6 @@ async fn invalidate() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn authenticate() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -294,7 +288,7 @@ async fn authenticate() -> Result<(), Box<dyn std::error::Error>> {
 	//
 
 	// Send command
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -318,14 +312,12 @@ async fn authenticate() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	// TODO: implement
 	Ok(())
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn live_live_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_without_auth().await.unwrap();
 	let table_name = "table_FD40A9A361884C56B5908A934164884A".to_string();
@@ -338,7 +330,7 @@ async fn live_live_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let _ = common::ws_use(socket, Some(ns), Some(db)).await?;
 
 	// LIVE query via live endpoint
-	let live_id = common::ws_send_msg(
+	let live_id = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 				"id": "1",
@@ -411,7 +403,6 @@ async fn live_live_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn live_query_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_without_auth().await.unwrap();
 	let table_name = "table_FD40A9A361884C56B5908A934164884A".to_string();
@@ -494,7 +485,6 @@ async fn live_query_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn let_and_set() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -506,7 +496,7 @@ async fn let_and_set() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Define variable using let
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -521,7 +511,7 @@ async fn let_and_set() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Define variable using set
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -547,7 +537,6 @@ async fn let_and_set() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn unset() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -559,7 +548,7 @@ async fn unset() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Define variable
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -583,7 +572,7 @@ async fn unset() -> Result<(), Box<dyn std::error::Error>> {
 	assert_eq!(res[0], "let_value", "result: {:?}", res);
 
 	// Unset variable
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -610,7 +599,6 @@ async fn unset() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn select() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -630,7 +618,7 @@ async fn select() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Select data
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -654,7 +642,6 @@ async fn select() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn insert() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -668,7 +655,7 @@ async fn insert() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Insert data
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -700,7 +687,6 @@ async fn insert() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn create() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -714,7 +700,7 @@ async fn create() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Insert data
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -740,7 +726,6 @@ async fn create() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn update() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -760,7 +745,7 @@ async fn update() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Insert data
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -790,7 +775,6 @@ async fn update() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn change_and_merge() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -819,7 +803,7 @@ async fn change_and_merge() -> Result<(), Box<dyn std::error::Error>> {
 	// Change / Marge data
 	//
 
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 		"id": "1",
@@ -836,7 +820,7 @@ async fn change_and_merge() -> Result<(), Box<dyn std::error::Error>> {
 	.await;
 	assert!(res.is_ok(), "result: {:?}", res);
 
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -872,7 +856,6 @@ async fn change_and_merge() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn modify_and_patch() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -912,7 +895,7 @@ async fn modify_and_patch() -> Result<(), Box<dyn std::error::Error>> {
 			"path": "original_name",
 		}
 	]);
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -941,7 +924,7 @@ async fn modify_and_patch() -> Result<(), Box<dyn std::error::Error>> {
 			"value": "patch_value"
 		}
 	]);
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -977,7 +960,6 @@ async fn modify_and_patch() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn delete() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -1010,7 +992,7 @@ async fn delete() -> Result<(), Box<dyn std::error::Error>> {
 	//
 	// Delete data
 	//
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -1039,7 +1021,6 @@ async fn delete() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn format_json() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -1070,7 +1051,7 @@ async fn format_json() -> Result<(), Box<dyn std::error::Error>> {
 			"json"
 		]
 	});
-	let res = common::ws_send_msg(socket, serde_json::to_string(&msg).unwrap()).await;
+	let res = common::ws_send_msg_and_wait_response(socket, serde_json::to_string(&msg).unwrap()).await;
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Query data
@@ -1085,7 +1066,6 @@ async fn format_json() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn format_cbor() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -1117,7 +1097,7 @@ async fn format_cbor() -> Result<(), Box<dyn std::error::Error>> {
 		]
 	}))
 	.unwrap();
-	let res = common::ws_send_msg(socket, msg).await;
+	let res = common::ws_send_msg_and_wait_response(socket, msg).await;
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Query data
@@ -1130,7 +1110,10 @@ async fn format_cbor() -> Result<(), Box<dyn std::error::Error>> {
 	}))
 	.unwrap();
 
-	let res = common::ws_send_msg_with_fmt(socket, msg, common::Format::Cbor).await;
+	let res = common::ws_send_msg(socket, msg).await;
+	assert!(res.is_ok(), "result: {:?}", res);
+
+	let res = common::ws_recv_msg_with_fmt(socket, common::Format::Cbor).await;
 	assert!(res.is_ok(), "result: {:?}", res);
 	let res = res.unwrap();
 	assert!(res["result"].is_array(), "result: {:?}", res);
@@ -1143,7 +1126,6 @@ async fn format_cbor() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn format_pack() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -1175,7 +1157,7 @@ async fn format_pack() -> Result<(), Box<dyn std::error::Error>> {
 		]
 	}))
 	.unwrap();
-	let res = common::ws_send_msg(socket, msg).await;
+	let res = common::ws_send_msg_and_wait_response(socket, msg).await;
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Query data
@@ -1188,7 +1170,9 @@ async fn format_pack() -> Result<(), Box<dyn std::error::Error>> {
 	}))
 	.unwrap();
 
-	let res = common::ws_send_msg_with_fmt(socket, msg, common::Format::Pack).await;
+	let res = common::ws_send_msg(socket, msg).await;
+	assert!(res.is_ok(), "result: {:?}", res);
+	let res = common::ws_recv_msg_with_fmt(socket, common::Format::Pack).await;
 	assert!(res.is_ok(), "result: {:?}", res);
 	let res = res.unwrap();
 	assert!(res["result"].is_array(), "result: {:?}", res);
@@ -1201,7 +1185,6 @@ async fn format_pack() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn query() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
@@ -1217,7 +1200,7 @@ async fn query() -> Result<(), Box<dyn std::error::Error>> {
 	//
 	// Run a CREATE query
 	//
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",
@@ -1245,13 +1228,12 @@ async fn query() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test(tokio::test)]
-#[serial]
 async fn version() -> Result<(), Box<dyn std::error::Error>> {
 	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 	let socket = &mut common::connect_ws(&addr).await?;
 
 	// Send command
-	let res = common::ws_send_msg(
+	let res = common::ws_send_msg_and_wait_response(
 		socket,
 		serde_json::to_string(&json!({
 			"id": "1",

--- a/tests/ws_integration.rs
+++ b/tests/ws_integration.rs
@@ -1051,7 +1051,8 @@ async fn format_json() -> Result<(), Box<dyn std::error::Error>> {
 			"json"
 		]
 	});
-	let res = common::ws_send_msg_and_wait_response(socket, serde_json::to_string(&msg).unwrap()).await;
+	let res =
+		common::ws_send_msg_and_wait_response(socket, serde_json::to_string(&msg).unwrap()).await;
 	assert!(res.is_ok(), "result: {:?}", res);
 
 	// Query data


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

WebSocket tests fail from time to time with a timeout while waiting for Live Query notifications. This is likely a consequence of a slow Github Runner.

This PR increases the timeout when waiting for WS messages and also removes the serial for tests because it's not really necessary.

## What does this change do?

* Increases the `recv_msg` timeout: `tests/common/mod.rs:279`
* Remove `#[serial]` from integration tests
* DRY the WS helpers
* Adds further logging to the integration tests for debugging purposes

## What is your testing strategy?

Github Actions

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
