### PR TITLE
[ci] Fixes for cli_integration. Debugging for websocket tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,131 +14,131 @@ defaults:
 
 jobs:
 
-  format:
-    name: Check format
-    runs-on: ubuntu-latest
-    steps:
+  # format:
+  #   name: Check format
+  #   runs-on: ubuntu-latest
+  #   steps:
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         components: rustfmt
 
-      - name: Checkout sources
-        uses: actions/checkout@v3
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
 
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
 
-      - name: Check format
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-format
+  #     - name: Check format
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-format
 
-  check:
-    name: Check workspace
-    runs-on: ubuntu-latest
-    steps:
+  # check:
+  #   name: Check workspace
+  #   runs-on: ubuntu-latest
+  #   steps:
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
 
-      - name: Checkout sources
-        uses: actions/checkout@v3
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
 
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get -y update
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt-get -y update
 
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
 
-      - name: Check workspace
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-check
+  #     - name: Check workspace
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-check
 
-  check-wasm:
-    name: Check Wasm
-    runs-on: ubuntu-latest
-    steps:
+  # check-wasm:
+  #   name: Check Wasm
+  #   runs-on: ubuntu-latest
+  #   steps:
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         targets: wasm32-unknown-unknown
 
-      - name: Checkout sources
-        uses: actions/checkout@v3
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
 
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
 
-      - name: Check wasm
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-check-wasm
+  #     - name: Check wasm
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-check-wasm
 
-  clippy:
-    name: Check clippy
-    runs-on: ubuntu-latest
-    steps:
+  # clippy:
+  #   name: Check clippy
+  #   runs-on: ubuntu-latest
+  #   steps:
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         components: clippy
 
-      - name: Checkout sources
-        uses: actions/checkout@v3
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
 
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get -y update
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt-get -y update
 
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
 
-      - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-clippy
+  #     - name: Run clippy
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-clippy
 
   cli:
     name: CLI integration tests
@@ -167,127 +167,137 @@ jobs:
           args: --debug cargo-make
 
       - name: Run CLI integration tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-cli-integration
-
-  http-server:
-    name: HTTP integration tests
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install dependencies
         run: |
-          sudo apt-get -y update
-
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
-
-      - name: Run HTTP integration tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-http-integration
-
-  ws-server:
-    name: WebSocket integration tests
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install dependencies
+          while true; do
+            cargo make ci-cli-integration
+          done
+      
+      - name: Debug info
+        if: always()
         run: |
-          sudo apt-get -y update
+          set -x
+          free -m
+          df -h
+          ps auxf
+          cat /tmp/surrealdb.log
+          
 
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+  # http-server:
+  #   name: HTTP integration tests
+  #   runs-on: ubuntu-latest
+  #   steps:
 
-      - name: Run WS integration tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-ws-integration
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
 
-  test:
-    name: Test workspace
-    runs-on: ubuntu-latest
-    steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Checkout sources
-        uses: actions/checkout@v3
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt-get -y update
 
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get -y update
+  #     - name: Run HTTP integration tests
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-http-integration
 
-      - name: Free up some disk space
-        run: |
-          (set -x; df -h)
-          # Free up some disk space by removing unused files
-          (set -x; sudo rm -rf /imagegeneration || true)
-          (set -x; sudo rm -rf /opt/az || true)
-          (set -x; sudo rm -rf /opt/hostedtoolcache || true)
-          (set -x; sudo rm -rf /opt/google || true)
-          (set -x; sudo rm -rf /opt/pipx || true)
-          (set -x; df -h)
+  # ws-server:
+  #   name: WebSocket integration tests
+  #   runs-on: ubuntu-latest
+  #   steps:
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
 
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
 
-      - name: Test workspace + coverage
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-workspace-coverage
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v3
-        with:
-          name: code-coverage-report
-          path: target/llvm-cov/html/
-          retention-days: 5
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt-get -y update
+
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
+
+  #     - name: Run WS integration tests
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-ws-integration
+
+  # test:
+  #   name: Test workspace
+  #   runs-on: ubuntu-latest
+  #   steps:
+
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt-get -y update
+
+  #     - name: Free up some disk space
+  #       run: |
+  #         (set -x; df -h)
+  #         # Free up some disk space by removing unused files
+  #         (set -x; sudo rm -rf /imagegeneration || true)
+  #         (set -x; sudo rm -rf /opt/az || true)
+  #         (set -x; sudo rm -rf /opt/hostedtoolcache || true)
+  #         (set -x; sudo rm -rf /opt/google || true)
+  #         (set -x; sudo rm -rf /opt/pipx || true)
+  #         (set -x; df -h)
+
+  #     - name: Install cargo-llvm-cov
+  #       uses: taiki-e/install-action@cargo-llvm-cov
+
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
+
+  #     - name: Test workspace + coverage
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-workspace-coverage
+
+  #     - name: Upload coverage report
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: code-coverage-report
+  #         path: target/llvm-cov/html/
+  #         retention-days: 5
 
   ws-engine:
     name: WebSocket engine
@@ -321,10 +331,19 @@ jobs:
           args: --debug cargo-make
 
       - name: Test ws engine
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-api-integration-ws
+        run: |
+          while true; do
+            cargo make ci-api-integration-ws
+          done
+      
+      - name: Debug info
+        if: always()
+        run: |
+          set -x
+          free -m
+          df -h
+          ps auxf
+          cat /tmp/surrealdb.log
 
   http-engine:
     name: HTTP engine
@@ -358,226 +377,235 @@ jobs:
           args: --debug cargo-make
 
       - name: Test http engine
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-api-integration-http
-
-  any-engine:
-      name: Any engine
-      runs-on: ubuntu-latest
-      steps:
-
-        - name: Install stable toolchain
-          uses: dtolnay/rust-toolchain@stable
-
-        - name: Checkout sources
-          uses: actions/checkout@v3
-
-        - name: Setup cache
-          uses: Swatinem/rust-cache@v2
-          with:
-            save-if: ${{ github.ref == 'refs/heads/main' }}
-
-        - name: Install dependencies
-          run: |
-            sudo apt-get -y update
-
-        - name: Setup FoundationDB
-          uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
-          with:
-            version: "7.1.30"
-
-        - name: Install cargo-make
-          uses: actions-rs/cargo@v1
-          with:
-            command: install
-            args: --debug cargo-make
-
-        - name: Test any engine
-          uses: actions-rs/cargo@v1
-          with:
-            command: make
-            args: ci-api-integration-any
-
-  mem-engine:
-    name: Memory engine
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
-
-      - name: Test mem engine
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-api-integration-mem
-
-  file-engine:
-    name: File engine
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
-
-      - name: Test file engine
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-api-integration-file
-
-  rocksdb-engine:
-    name: RocksDB engine
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
-
-      - name: Test rocksdb engine
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-api-integration-rocksdb
-
-  speedb-engine:
-    name: SpeeDB engine
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
-
-      - name: Test speedb engine
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-api-integration-speedb
-
-  tikv-engine:
-     name: TiKV engine
-     runs-on: ubuntu-latest
-     steps:
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install dependencies
         run: |
-          sudo apt-get -y update
-
-      - name: Install TiUP
+          while true; do
+            cargo make ci-api-integration-http
+          done
+      
+      - name: Debug info
+        if: always()
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
-          ~/.tiup/bin/tiup -v
+          set -x
+          free -m
+          df -h
+          ps auxf
+          cat /tmp/surrealdb.log
 
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+  # any-engine:
+  #     name: Any engine
+  #     runs-on: ubuntu-latest
+  #     steps:
 
-      - name: Test tikv engine
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-api-integration-tikv
+  #       - name: Install stable toolchain
+  #         uses: dtolnay/rust-toolchain@stable
 
-  fdb-engine:
-    name: FoundationDB engine
-    runs-on: ubuntu-latest
-    steps:
+  #       - name: Checkout sources
+  #         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+  #       - name: Setup cache
+  #         uses: Swatinem/rust-cache@v2
+  #         with:
+  #           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Checkout sources
-        uses: actions/checkout@v3
+  #       - name: Install dependencies
+  #         run: |
+  #           sudo apt-get -y update
 
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+  #       - name: Setup FoundationDB
+  #         uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+  #         with:
+  #           version: "7.1.30"
 
-      - name: Setup FoundationDB
-        uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
-        with:
-          version: "7.1.30"
+  #       - name: Install cargo-make
+  #         uses: actions-rs/cargo@v1
+  #         with:
+  #           command: install
+  #           args: --debug cargo-make
 
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+  #       - name: Test any engine
+  #         uses: actions-rs/cargo@v1
+  #         with:
+  #           command: make
+  #           args: ci-api-integration-any
 
-      - name: Test fdb engine
-        uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: ci-api-integration-fdb
+  # mem-engine:
+  #   name: Memory engine
+  #   runs-on: ubuntu-latest
+  #   steps:
+
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
+
+  #     - name: Test mem engine
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-api-integration-mem
+
+  # file-engine:
+  #   name: File engine
+  #   runs-on: ubuntu-latest
+  #   steps:
+
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
+
+  #     - name: Test file engine
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-api-integration-file
+
+  # rocksdb-engine:
+  #   name: RocksDB engine
+  #   runs-on: ubuntu-latest
+  #   steps:
+
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
+
+  #     - name: Test rocksdb engine
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-api-integration-rocksdb
+
+  # speedb-engine:
+  #   name: SpeeDB engine
+  #   runs-on: ubuntu-latest
+  #   steps:
+
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
+
+  #     - name: Test speedb engine
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-api-integration-speedb
+
+  # tikv-engine:
+  #    name: TiKV engine
+  #    runs-on: ubuntu-latest
+  #    steps:
+
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt-get -y update
+
+  #     - name: Install TiUP
+  #       run: |
+  #         curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
+  #         ~/.tiup/bin/tiup -v
+
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
+
+  #     - name: Test tikv engine
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-api-integration-tikv
+
+  # fdb-engine:
+  #   name: FoundationDB engine
+  #   runs-on: ubuntu-latest
+  #   steps:
+
+  #     - name: Install stable toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
+
+  #     - name: Setup cache
+  #       uses: Swatinem/rust-cache@v2
+  #       with:
+  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+
+  #     - name: Setup FoundationDB
+  #       uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+  #       with:
+  #         version: "7.1.30"
+
+  #     - name: Install cargo-make
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: install
+  #         args: --debug cargo-make
+
+  #     - name: Test fdb engine
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: make
+  #         args: ci-api-integration-fdb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,131 +14,131 @@ defaults:
 
 jobs:
 
-  # format:
-  #   name: Check format
-  #   runs-on: ubuntu-latest
-  #   steps:
+  format:
+    name: Check format
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         components: rustfmt
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  #     - name: Check format
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-format
+      - name: Check format
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-format
 
-  # check:
-  #   name: Check workspace
-  #   runs-on: ubuntu-latest
-  #   steps:
+  check:
+    name: Check workspace
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt-get -y update
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  #     - name: Check workspace
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-check
+      - name: Check workspace
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-check
 
-  # check-wasm:
-  #   name: Check Wasm
-  #   runs-on: ubuntu-latest
-  #   steps:
+  check-wasm:
+    name: Check Wasm
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         targets: wasm32-unknown-unknown
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  #     - name: Check wasm
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-check-wasm
+      - name: Check wasm
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-check-wasm
 
-  # clippy:
-  #   name: Check clippy
-  #   runs-on: ubuntu-latest
-  #   steps:
+  clippy:
+    name: Check clippy
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         components: clippy
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt-get -y update
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  #     - name: Run clippy
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-clippy
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-clippy
 
   cli:
     name: CLI integration tests
@@ -179,125 +179,125 @@ jobs:
           free -m
           df -h
           ps auxf
-          cat /tmp/surrealdb.log
+          cat /tmp/surrealdb.log || true
           
 
-  # http-server:
-  #   name: HTTP integration tests
-  #   runs-on: ubuntu-latest
-  #   steps:
+  http-server:
+    name: HTTP integration tests
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt-get -y update
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  #     - name: Run HTTP integration tests
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-http-integration
+      - name: Run HTTP integration tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-http-integration
 
-  # ws-server:
-  #   name: WebSocket integration tests
-  #   runs-on: ubuntu-latest
-  #   steps:
+  ws-server:
+    name: WebSocket integration tests
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt-get -y update
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  #     - name: Run WS integration tests
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-ws-integration
+      - name: Run WS integration tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-ws-integration
 
-  # test:
-  #   name: Test workspace
-  #   runs-on: ubuntu-latest
-  #   steps:
+  test:
+    name: Test workspace
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt-get -y update
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
 
-  #     - name: Free up some disk space
-  #       run: |
-  #         (set -x; df -h)
-  #         # Free up some disk space by removing unused files
-  #         (set -x; sudo rm -rf /imagegeneration || true)
-  #         (set -x; sudo rm -rf /opt/az || true)
-  #         (set -x; sudo rm -rf /opt/hostedtoolcache || true)
-  #         (set -x; sudo rm -rf /opt/google || true)
-  #         (set -x; sudo rm -rf /opt/pipx || true)
-  #         (set -x; df -h)
+      - name: Free up some disk space
+        run: |
+          (set -x; df -h)
+          # Free up some disk space by removing unused files
+          (set -x; sudo rm -rf /imagegeneration || true)
+          (set -x; sudo rm -rf /opt/az || true)
+          (set -x; sudo rm -rf /opt/hostedtoolcache || true)
+          (set -x; sudo rm -rf /opt/google || true)
+          (set -x; sudo rm -rf /opt/pipx || true)
+          (set -x; df -h)
 
-  #     - name: Install cargo-llvm-cov
-  #       uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  #     - name: Test workspace + coverage
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-workspace-coverage
+      - name: Test workspace + coverage
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-workspace-coverage
 
-  #     - name: Upload coverage report
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: code-coverage-report
-  #         path: target/llvm-cov/html/
-  #         retention-days: 5
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: target/llvm-cov/html/
+          retention-days: 5
 
   ws-engine:
     name: WebSocket engine
@@ -331,11 +331,11 @@ jobs:
           args: --debug cargo-make
 
       - name: Test ws engine
-        run: |
-          while true; do
-            cargo make ci-api-integration-ws
-          done
-      
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-ws
+
       - name: Debug info
         if: always()
         run: |
@@ -343,7 +343,7 @@ jobs:
           free -m
           df -h
           ps auxf
-          cat /tmp/surrealdb.log
+          cat /tmp/surrealdb.log || true
 
   http-engine:
     name: HTTP engine
@@ -377,11 +377,11 @@ jobs:
           args: --debug cargo-make
 
       - name: Test http engine
-        run: |
-          while true; do
-            cargo make ci-api-integration-http
-          done
-      
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-http
+
       - name: Debug info
         if: always()
         run: |
@@ -389,223 +389,250 @@ jobs:
           free -m
           df -h
           ps auxf
-          cat /tmp/surrealdb.log
+          cat /tmp/surrealdb.log || true
 
-  # any-engine:
-  #     name: Any engine
-  #     runs-on: ubuntu-latest
-  #     steps:
+  any-engine:
+    name: Any engine
+    runs-on: ubuntu-latest
+    steps:
 
-  #       - name: Install stable toolchain
-  #         uses: dtolnay/rust-toolchain@stable
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #       - name: Checkout sources
-  #         uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #       - name: Setup cache
-  #         uses: Swatinem/rust-cache@v2
-  #         with:
-  #           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #       - name: Install dependencies
-  #         run: |
-  #           sudo apt-get -y update
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
 
-  #       - name: Setup FoundationDB
-  #         uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
-  #         with:
-  #           version: "7.1.30"
+      - name: Setup FoundationDB
+        uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+        with:
+          version: "7.1.30"
 
-  #       - name: Install cargo-make
-  #         uses: actions-rs/cargo@v1
-  #         with:
-  #           command: install
-  #           args: --debug cargo-make
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  #       - name: Test any engine
-  #         uses: actions-rs/cargo@v1
-  #         with:
-  #           command: make
-  #           args: ci-api-integration-any
+      - name: Test any engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-any
 
-  # mem-engine:
-  #   name: Memory engine
-  #   runs-on: ubuntu-latest
-  #   steps:
+      - name: Debug info
+        if: always()
+        run: |
+          set -x
+          free -m
+          df -h
+          ps auxf
+          cat /tmp/surrealdb.log || true
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  mem-engine:
+    name: Memory engine
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Test mem engine
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-api-integration-mem
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  # file-engine:
-  #   name: File engine
-  #   runs-on: ubuntu-latest
-  #   steps:
+      - name: Test mem engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-mem
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  file-engine:
+    name: File engine
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Test file engine
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-api-integration-file
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  # rocksdb-engine:
-  #   name: RocksDB engine
-  #   runs-on: ubuntu-latest
-  #   steps:
+      - name: Test file engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-file
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  rocksdb-engine:
+    name: RocksDB engine
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Test rocksdb engine
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-api-integration-rocksdb
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  # speedb-engine:
-  #   name: SpeeDB engine
-  #   runs-on: ubuntu-latest
-  #   steps:
+      - name: Test rocksdb engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-rocksdb
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  speedb-engine:
+    name: SpeeDB engine
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Test speedb engine
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-api-integration-speedb
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  # tikv-engine:
-  #    name: TiKV engine
-  #    runs-on: ubuntu-latest
-  #    steps:
+      - name: Test speedb engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-speedb
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+  tikv-engine:
+     name: TiKV engine
+     runs-on: ubuntu-latest
+     steps:
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt-get -y update
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Install TiUP
-  #       run: |
-  #         curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
-  #         ~/.tiup/bin/tiup -v
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Install TiUP
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
+          ~/.tiup/bin/tiup -v
 
-  #     - name: Test tikv engine
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-api-integration-tikv
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-  # fdb-engine:
-  #   name: FoundationDB engine
-  #   runs-on: ubuntu-latest
-  #   steps:
+      - name: Test tikv engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-tikv
 
-  #     - name: Install stable toolchain
-  #       uses: dtolnay/rust-toolchain@stable
+      - name: Debug info
+        if: always()
+        run: |
+          set -x
+          free -m
+          df -h
+          ps auxf
+          cat /tmp/surrealdb.log || true
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+  fdb-engine:
+    name: FoundationDB engine
+    runs-on: ubuntu-latest
+    steps:
 
-  #     - name: Setup cache
-  #       uses: Swatinem/rust-cache@v2
-  #       with:
-  #         save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-  #     - name: Setup FoundationDB
-  #       uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
-  #       with:
-  #         version: "7.1.30"
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Install cargo-make
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: install
-  #         args: --debug cargo-make
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-  #     - name: Test fdb engine
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: make
-  #         args: ci-api-integration-fdb
+      - name: Setup FoundationDB
+        uses: foundationdb-rs/foundationdb-actions-install@v2.0.0
+        with:
+          version: "7.1.30"
+
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
+
+      - name: Test fdb engine
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-api-integration-fdb
+
+      - name: Debug info
+        if: always()
+        run: |
+          set -x
+          free -m
+          df -h
+          ps auxf
+          cat /tmp/surrealdb.log || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,10 +167,10 @@ jobs:
           args: --debug cargo-make
 
       - name: Run CLI integration tests
-        run: |
-          while true; do
-            cargo make ci-cli-integration
-          done
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: ci-cli-integration
       
       - name: Debug info
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,6 +57,15 @@ jobs:
           command: make
           args: ci-workspace-coverage
 
+      - name: Debug info
+        if: always()
+        run: |
+          set -x
+          free -m
+          df -h
+          ps auxf
+          cat /tmp/surrealdb.log || true
+
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,15 @@ jobs:
           command: make
           args: ci-workspace-coverage-complete
 
+      - name: Debug info
+        if: always()
+        run: |
+          set -x
+          free -m
+          df -h
+          ps auxf
+          cat /tmp/surrealdb.log || true
+
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
         with:

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -143,7 +143,7 @@ run_task = { name = ["start-tikv", "ci-api-integration-tikv-tests", "stop-tikv"]
 category = "CI - SERVICES"
 dependencies = ["build-surrealdb"]
 script = """
-   #!/bin/bash
+   #!/bin/bash -ex
 
    target/debug/surreal start ${_START_SURREALDB_PATH} &>/tmp/surrealdb.log &
 
@@ -172,13 +172,11 @@ script = """
 [tasks.start-tikv]
 category = "CI - SERVICES"
 script = """
-   #!/bin/bash
+   #!/bin/bash -ex
 
    ${HOME}/.tiup/bin/tiup install pd tikv playground
 
    ${HOME}/.tiup/bin/tiup playground --mode tikv-slim --kv 3 --without-monitor &>/tmp/tiup.log &
-
-   ${HOME}/.tiup/bin/tiup clean --all
 
    echo $! > /tmp/tiup.pid
 

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -163,7 +163,11 @@ script = """
 
 [tasks.stop-surrealdb]
 category = "CI - SERVICES"
-script = "kill $(cat /tmp/surreal.pid) || true"
+script = """
+        kill $(cat /tmp/surreal.pid) || true
+        sleep 5
+        kill -9 $(cat /tmp/surreal.pid) || true
+"""
 
 [tasks.start-tikv]
 category = "CI - SERVICES"

--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1690179764,
-        "narHash": "sha256-Sgszrn/3KnemTBYHnJBwdCcY/u6Gc8FMGHAB+VpPH6I=",
+        "lastModified": 1692253212,
+        "narHash": "sha256-vLwYUD/TjjVx9dkuQMIL0la+VpuqwFohzGFn+3AGq+k=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "dce10f32abcc7740e5090e021b2c83a6b2ddb614",
+        "rev": "5d85dc369f8ee47f1cef83999d0de4bb18def5d2",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690176526,
-        "narHash": "sha256-SHdHTRu1RMLhIkTlFMSSyUJYsPNWw50Ky9W6znxGN9A=",
+        "lastModified": 1692232013,
+        "narHash": "sha256-a5hct9pN+RSxLclPBsWCg9zOCG9c0Uf1cq3XlntQpDQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a58eb89c7fcb703554aa53b4d25b50bd62e16786",
+        "rev": "edf586f399ddb6aef26edc2df3aa843e97a2ddc1",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1690057540,
-        "narHash": "sha256-MKGhZsFTpJH3Sq+9dGFGqOje3A6PD6fKGO92tM23zuY=",
+        "lastModified": 1692173342,
+        "narHash": "sha256-0JgH5lhg0AaUYeEqVAfWnVJPwOFu0dbvDVGIb0F9kUA=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "99718d0c8bc5aadd993acdcabc1778fc7b5cc572",
+        "rev": "e69b96bd40a47d7919894e3220f9d43698888a84",
         "type": "github"
       },
       "original": {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -175,30 +175,20 @@ async fn all_commands() {
 
 #[test(tokio::test)]
 async fn start_tls() {
-	// Capute the server's stdout/stderr
-	temp_env::async_with_vars(
-		[
-			("SURREAL_TEST_SERVER_STDOUT", Some("piped")),
-			("SURREAL_TEST_SERVER_STDERR", Some("piped")),
-		],
-		async {
-			let (_, server) = common::start_server(StartServerArguments {
-				auth: false,
-				tls: true,
-				wait_is_ready: false,
-				tick_interval: ONE_SEC,
-			})
-			.await
-			.unwrap();
+	let (_, server) = common::start_server(StartServerArguments {
+		auth: false,
+		tls: true,
+		wait_is_ready: false,
+		tick_interval: ONE_SEC,
+	})
+	.await
+	.unwrap();
 
-			std::thread::sleep(std::time::Duration::from_millis(2000));
-			let output = server.kill().output().err().unwrap();
+	std::thread::sleep(std::time::Duration::from_millis(2000));
+	let output = server.kill().output().err().unwrap();
 
-			// Test the crt/key args but the keys are self signed so don't actually connect.
-			assert!(output.contains("Started web server"), "couldn't start web server: {output}");
-		},
-	)
-	.await;
+	// Test the crt/key args but the keys are self signed so don't actually connect.
+	assert!(output.contains("Started web server"), "couldn't start web server: {output}");
 }
 
 #[test(tokio::test)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,6 +16,7 @@ use tokio::net::TcpStream;
 use tokio::time;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tracing::log::warn;
 use tracing::{debug, error, info};
 
 pub const USER: &str = "root";
@@ -24,6 +25,8 @@ pub const PASS: &str = "root";
 /// Child is a (maybe running) CLI process. It can be killed by dropping it
 pub struct Child {
 	inner: Option<std::process::Child>,
+	stdout_path: String,
+	stderr_path: String,
 }
 
 impl Child {
@@ -43,12 +46,19 @@ impl Child {
 	/// Read the child's stdout concatenated with its stderr. Returns Ok if the child
 	/// returns successfully, Err otherwise.
 	pub fn output(mut self) -> Result<String, String> {
-		let output = self.inner.take().unwrap().wait_with_output().unwrap();
+		let status = self.inner.take().unwrap().wait().unwrap();
 
-		let mut buf = String::from_utf8(output.stdout).unwrap();
-		buf.push_str(&String::from_utf8(output.stderr).unwrap());
+		let mut buf =
+			std::fs::read_to_string(&self.stdout_path).expect("Failed to read the stdout file");
+		buf.push_str(
+			&std::fs::read_to_string(&self.stderr_path).expect("Failed to read the stderr file"),
+		);
 
-		if output.status.success() {
+		// Cleanup files after reading them
+		std::fs::remove_file(self.stdout_path.as_str()).unwrap();
+		std::fs::remove_file(self.stderr_path.as_str()).unwrap();
+
+		if status.success() {
 			Ok(buf)
 		} else {
 			Err(buf)
@@ -64,12 +74,7 @@ impl Drop for Child {
 	}
 }
 
-pub fn run_internal<P: AsRef<Path>>(
-	args: &str,
-	current_dir: Option<P>,
-	stdout: Stdio,
-	stderr: Stdio,
-) -> Child {
+pub fn run_internal<P: AsRef<Path>>(args: &str, current_dir: Option<P>) -> Child {
 	let mut path = std::env::current_exe().unwrap();
 	assert!(path.pop());
 	if path.ends_with("deps") {
@@ -83,42 +88,40 @@ pub fn run_internal<P: AsRef<Path>>(
 	if let Some(dir) = current_dir {
 		cmd.current_dir(&dir);
 	}
+
+	// Use local files instead of pipes to avoid deadlocks. See https://github.com/rust-lang/rust/issues/45572
+	let stdout_path = tmp_file(format!("server-stdout-{}.log", rand::random::<u32>()).as_str());
+	let stderr_path = tmp_file(format!("server-stderr-{}.log", rand::random::<u32>()).as_str());
+	info!("Logging server output to: ({}, {})", stdout_path, stderr_path);
+	let stdout = Stdio::from(File::create(&stdout_path).unwrap());
+	let stderr = Stdio::from(File::create(&stderr_path).unwrap());
+
 	cmd.env_clear();
 	cmd.stdin(Stdio::piped());
 	cmd.stdout(stdout);
 	cmd.stderr(stderr);
 	cmd.args(args.split_ascii_whitespace());
+
 	Child {
 		inner: Some(cmd.spawn().unwrap()),
+		stdout_path,
+		stderr_path,
 	}
 }
 
 /// Run the CLI with the given args
 pub fn run(args: &str) -> Child {
-	run_internal::<String>(args, None, Stdio::piped(), Stdio::piped())
+	run_internal::<String>(args, None)
 }
 
 /// Run the CLI with the given args inside a temporary directory
 pub fn run_in_dir<P: AsRef<Path>>(args: &str, current_dir: P) -> Child {
-	run_internal(args, Some(current_dir), Stdio::piped(), Stdio::piped())
+	run_internal(args, Some(current_dir))
 }
 
 pub fn tmp_file(name: &str) -> String {
 	let path = Path::new(env!("OUT_DIR")).join(name);
 	path.to_string_lossy().into_owned()
-}
-
-fn parse_server_stdio_from_var(var: &str) -> Result<Stdio, Box<dyn Error>> {
-	match env::var(var).as_deref() {
-		Ok("inherit") => Ok(Stdio::inherit()),
-		Ok("null") => Ok(Stdio::null()),
-		Ok("piped") => Ok(Stdio::piped()),
-		Ok(val) if val.starts_with("file://") => {
-			Ok(Stdio::from(File::create(val.trim_start_matches("file://"))?))
-		}
-		Ok(val) => Err(format!("Unsupported stdio value: {val:?}").into()),
-		_ => Ok(Stdio::null()),
-	}
 }
 
 pub struct StartServerArguments {
@@ -191,9 +194,7 @@ pub async fn start_server(
 	info!("starting server with args: {start_args}");
 
 	// Configure where the logs go when running the test
-	let stdout = parse_server_stdio_from_var("SURREAL_TEST_SERVER_STDOUT")?;
-	let stderr = parse_server_stdio_from_var("SURREAL_TEST_SERVER_STDERR")?;
-	let server = run_internal::<String>(&start_args, None, stdout, stderr);
+	let server = run_internal::<String>(&start_args, None);
 
 	if !wait_is_ready {
 		return Ok((addr, server));
@@ -328,9 +329,16 @@ pub async fn ws_signin(
 		Some(obj) if obj.keys().all(|k| ["id", "error"].contains(&k.as_str())) => {
 			Err(format!("unexpected error from query request: {:?}", obj.get("error")).into())
 		}
-		Some(obj) if obj.keys().all(|k| ["id", "result"].contains(&k.as_str())) => {
-			Ok(obj.get("result").unwrap().as_str().unwrap_or_default().to_owned())
-		}
+		Some(obj) if obj.keys().all(|k| ["id", "result"].contains(&k.as_str())) => Ok(obj
+			.get("result")
+			.ok_or(TestError::AssertionError {
+				message: format!("expected a result from the received object, got this instead: {:?}", obj),
+			})?
+			.as_str()
+			.ok_or(TestError::AssertionError {
+				message: format!("expected the result object to be a string for the received ws message, got this instead: {:?}", obj.get("result")).to_string(),
+			})?
+			.to_owned()),
 		_ => {
 			error!("{:?}", msg.as_object().unwrap().keys().collect::<Vec<_>>());
 			Err(format!("unexpected response: {:?}", msg).into())
@@ -358,12 +366,11 @@ pub async fn ws_query(
 		Some(obj) if obj.keys().all(|k| ["id", "result"].contains(&k.as_str())) => Ok(obj
 			.get("result")
 			.ok_or(TestError::AssertionError {
-				message: "expected a result from the received object".to_string(),
+				message: format!("expected a result from the received object, got this instead: {:?}", obj),
 			})?
 			.as_array()
 			.ok_or(TestError::AssertionError {
-				message: "expected the result object to be an array for the received ws message"
-					.to_string(),
+				message: format!("expected the result object to be an array for the received ws message, got this instead: {:?}", obj.get("result")).to_string(),
 			})?
 			.to_owned()),
 		_ => {
@@ -393,9 +400,15 @@ pub async fn ws_use(
 		Some(obj) if obj.keys().all(|k| ["id", "error"].contains(&k.as_str())) => {
 			Err(format!("unexpected error from query request: {:?}", obj.get("error")).into())
 		}
-		Some(obj) if obj.keys().all(|k| ["id", "result"].contains(&k.as_str())) => {
-			Ok(obj.get("result").unwrap().to_owned())
-		}
+		Some(obj) if obj.keys().all(|k| ["id", "result"].contains(&k.as_str())) => Ok(obj
+			.get("result")
+			.ok_or(TestError::AssertionError {
+				message: format!(
+					"expected a result from the received object, got this instead: {:?}",
+					obj
+				),
+			})?
+			.to_owned()),
 		_ => {
 			error!("{:?}", msg.as_object().unwrap().keys().collect::<Vec<_>>());
 			Err(format!("unexpected response: {:?}", msg).into())

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,7 +16,6 @@ use tokio::net::TcpStream;
 use tokio::time;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
-use tracing::log::warn;
 use tracing::{debug, error, info};
 
 pub const USER: &str = "root";
@@ -92,7 +91,7 @@ pub fn run_internal<P: AsRef<Path>>(args: &str, current_dir: Option<P>) -> Child
 	// Use local files instead of pipes to avoid deadlocks. See https://github.com/rust-lang/rust/issues/45572
 	let stdout_path = tmp_file(format!("server-stdout-{}.log", rand::random::<u32>()).as_str());
 	let stderr_path = tmp_file(format!("server-stderr-{}.log", rand::random::<u32>()).as_str());
-	info!("Logging server output to: ({}, {})", stdout_path, stderr_path);
+	debug!("Logging server output to: ({}, {})", stdout_path, stderr_path);
 	let stdout = Stdio::from(File::create(&stdout_path).unwrap());
 	let stderr = Stdio::from(File::create(&stderr_path).unwrap());
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Fix some of the random failures we have been seeing and add more debugging information to the WS tests to understand why they fail
## What does this change do?

* Use `files` instead of `pipes` to capture the stdout/stderr from the server we spawn during the integration tests. When using pipes, if the output is too big, it causes a deadlock: https://github.com/rust-lang/rust/issues/45572

## What is your testing strategy?

I ran `http-engine`, `ws-engine` and `cli_integration` tests in loop. Specially the `cli_integration`, I was able to consistently hang it locally. After it stopped using pipes, it didn't hang anymore.

## Is this related to any issues?

Failing tests

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
