### PR TITLE
Add tests for `DEFINE FIELD ... VALUE` clauses with references and with futures

### DIFF
--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -303,3 +303,207 @@ async fn field_definition_empty_nested_flexible() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn field_definition_value_reference() -> Result<(), Error> {
+	let sql = "
+		DEFINE TABLE product;
+		DEFINE FIELD subproducts ON product VALUE ->contains->product;
+		CREATE product:one, product:two;
+		RELATE product:one->contains:test->product:two;
+		SELECT * FROM product;
+		UPDATE product;
+		SELECT * FROM product;
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 7);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: product:one,
+				subproducts: [],
+			},
+			{
+				id: product:two,
+				subproducts: [],
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: contains:test,
+				in: product:one,
+				out: product:two,
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: product:one,
+				subproducts: [],
+			},
+			{
+				id: product:two,
+				subproducts: [],
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: product:one,
+				subproducts: [
+					product:two,
+				],
+			},
+			{
+				id: product:two,
+				subproducts: [],
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: product:one,
+				subproducts: [
+					product:two,
+				],
+			},
+			{
+				id: product:two,
+				subproducts: [],
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
+async fn field_definition_value_reference_with_future() -> Result<(), Error> {
+	let sql = "
+		DEFINE TABLE product;
+		DEFINE FIELD subproducts ON product VALUE <future> { ->contains->product };
+		CREATE product:one, product:two;
+		RELATE product:one->contains:test->product:two;
+		SELECT * FROM product;
+		UPDATE product;
+		SELECT * FROM product;
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 7);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: product:one,
+				subproducts: [],
+			},
+			{
+				id: product:two,
+				subproducts: [],
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: contains:test,
+				in: product:one,
+				out: product:two,
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: product:one,
+				subproducts: [
+					product:two,
+				],
+			},
+			{
+				id: product:two,
+				subproducts: [],
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: product:one,
+				subproducts: [
+					product:two,
+				],
+			},
+			{
+				id: product:two,
+				subproducts: [],
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: product:one,
+				subproducts: [
+					product:two,
+				],
+			},
+			{
+				id: product:two,
+				subproducts: [],
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Selecting data and returning it inside computed `VALUE` field did not work previously.

## What does this change do?

This change adds two tests:
- A test for a normal `VALUE` field, which references graph edges on the current document.
- A test for a `VALUE` field with a future, which references graph edges on the current document.

These tests ensure that the fields extract the correct data, both as a future computed value, and once a document has been updated.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #1917.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
