### PR TITLE
Ensure permissions are enforced on edge `in` and `out` fields

### DIFF
--- a/lib/src/dbs/session.rs
+++ b/lib/src/dbs/session.rs
@@ -35,9 +35,16 @@ impl Session {
 		self.ns = Some(ns.to_owned());
 		self
 	}
+
 	/// Set the selected database for the session
 	pub fn with_db(mut self, db: &str) -> Session {
 		self.db = Some(db.to_owned());
+		self
+	}
+
+	/// Set the selected database for the session
+	pub fn with_sc(mut self, sc: &str) -> Session {
+		self.sc = Some(sc.to_owned());
 		self
 	}
 
@@ -51,14 +58,17 @@ impl Session {
 	pub(crate) fn ns(&self) -> Option<Arc<str>> {
 		self.ns.as_deref().map(Into::into)
 	}
+
 	/// Retrieves the selected database
 	pub(crate) fn db(&self) -> Option<Arc<str>> {
 		self.db.as_deref().map(Into::into)
 	}
+
 	/// Checks if live queries are allowed
 	pub(crate) fn live(&self) -> bool {
 		self.rt
 	}
+
 	/// Convert a session into a runtime
 	pub(crate) fn context<'a>(&self, mut ctx: Context<'a>) -> Context<'a> {
 		// Add scope auth data
@@ -88,8 +98,9 @@ impl Session {
 
 	/// Create a system session for a given level and role
 	pub fn for_level(level: Level, role: Role) -> Session {
+		// Create a new session
 		let mut sess = Session::default();
-
+		// Set the session details
 		match level {
 			Level::Root => {
 				sess.au = Arc::new(Auth::for_root(role));
@@ -106,6 +117,22 @@ impl Session {
 			_ => {}
 		}
 		sess
+	}
+
+	/// Create a scoped session for a given NS and DB
+	pub fn for_scope(ns: &str, db: &str, sc: &str, rid: Value) -> Session {
+		Session {
+			au: Arc::new(Auth::for_sc(rid.to_string(), ns, db, sc)),
+			rt: false,
+			ip: None,
+			or: None,
+			id: None,
+			ns: Some(ns.to_owned()),
+			db: Some(db.to_owned()),
+			sc: Some(sc.to_owned()),
+			tk: None,
+			sd: Some(rid),
+		}
 	}
 
 	/// Create a system session for the root level with Owner role

--- a/lib/src/doc/relate.rs
+++ b/lib/src/doc/relate.rs
@@ -17,6 +17,8 @@ impl<'a> Document<'a> {
 		self.allow(ctx, opt, txn, stm).await?;
 		// Alter record data
 		self.alter(ctx, opt, txn, stm).await?;
+		// Store record edges
+		self.edges(ctx, opt, txn, stm).await?;
 		// Merge fields data
 		self.field(ctx, opt, txn, stm).await?;
 		// Reset fields data
@@ -25,8 +27,6 @@ impl<'a> Document<'a> {
 		self.clean(ctx, opt, txn, stm).await?;
 		// Check if allowed
 		self.allow(ctx, opt, txn, stm).await?;
-		// Store record edges
-		self.edges(ctx, opt, txn, stm).await?;
 		// Store index data
 		self.index(ctx, opt, txn, stm).await?;
 		// Store record data

--- a/lib/src/doc/relate.rs
+++ b/lib/src/doc/relate.rs
@@ -13,31 +13,68 @@ impl<'a> Document<'a> {
 		txn: &Transaction,
 		stm: &Statement<'_>,
 	) -> Result<Value, Error> {
-		// Check if allowed
-		self.allow(ctx, opt, txn, stm).await?;
-		// Alter record data
-		self.alter(ctx, opt, txn, stm).await?;
-		// Store record edges
-		self.edges(ctx, opt, txn, stm).await?;
-		// Merge fields data
-		self.field(ctx, opt, txn, stm).await?;
-		// Reset fields data
-		self.reset(ctx, opt, txn, stm).await?;
-		// Clean fields data
-		self.clean(ctx, opt, txn, stm).await?;
-		// Check if allowed
-		self.allow(ctx, opt, txn, stm).await?;
-		// Store index data
-		self.index(ctx, opt, txn, stm).await?;
-		// Store record data
-		self.store(ctx, opt, txn, stm).await?;
-		// Run table queries
-		self.table(ctx, opt, txn, stm).await?;
-		// Run lives queries
-		self.lives(ctx, opt, txn, stm).await?;
-		// Run event queries
-		self.event(ctx, opt, txn, stm).await?;
-		// Yield document
-		self.pluck(ctx, opt, txn, stm).await
+		// Check current record
+		match self.current.doc.is_some() {
+			// Create new edge
+			false => {
+				// Store record edges
+				self.edges(ctx, opt, txn, stm).await?;
+				// Alter record data
+				self.alter(ctx, opt, txn, stm).await?;
+				// Merge fields data
+				self.field(ctx, opt, txn, stm).await?;
+				// Reset fields data
+				self.reset(ctx, opt, txn, stm).await?;
+				// Clean fields data
+				self.clean(ctx, opt, txn, stm).await?;
+				// Check if allowed
+				self.allow(ctx, opt, txn, stm).await?;
+				// Store index data
+				self.index(ctx, opt, txn, stm).await?;
+				// Store record data
+				self.store(ctx, opt, txn, stm).await?;
+				// Run table queries
+				self.table(ctx, opt, txn, stm).await?;
+				// Run lives queries
+				self.lives(ctx, opt, txn, stm).await?;
+				// Run change feeds queries
+				self.changefeeds(ctx, opt, txn, stm).await?;
+				// Run event queries
+				self.event(ctx, opt, txn, stm).await?;
+				// Yield document
+				self.pluck(ctx, opt, txn, stm).await
+			}
+			// Update old edge
+			true => {
+				// Check if allowed
+				self.allow(ctx, opt, txn, stm).await?;
+				// Store record edges
+				self.edges(ctx, opt, txn, stm).await?;
+				// Alter record data
+				self.alter(ctx, opt, txn, stm).await?;
+				// Merge fields data
+				self.field(ctx, opt, txn, stm).await?;
+				// Reset fields data
+				self.reset(ctx, opt, txn, stm).await?;
+				// Clean fields data
+				self.clean(ctx, opt, txn, stm).await?;
+				// Check if allowed
+				self.allow(ctx, opt, txn, stm).await?;
+				// Store index data
+				self.index(ctx, opt, txn, stm).await?;
+				// Store record data
+				self.store(ctx, opt, txn, stm).await?;
+				// Run table queries
+				self.table(ctx, opt, txn, stm).await?;
+				// Run lives queries
+				self.lives(ctx, opt, txn, stm).await?;
+				// Run change feeds queries
+				self.changefeeds(ctx, opt, txn, stm).await?;
+				// Run event queries
+				self.event(ctx, opt, txn, stm).await?;
+				// Yield document
+				self.pluck(ctx, opt, txn, stm).await
+			}
+		}
 	}
 }

--- a/lib/src/iam/auth.rs
+++ b/lib/src/iam/auth.rs
@@ -66,6 +66,10 @@ impl Auth {
 		Self::new(Actor::new("system_auth".into(), vec![role], (ns, db).into()))
 	}
 
+	pub fn for_sc(rid: String, ns: &str, db: &str, sc: &str) -> Self {
+		Self::new(Actor::new(rid, vec![], (ns, db, sc).into()))
+	}
+
 	//
 	// Permission checks
 	//

--- a/lib/src/iam/entities/resources/level.rs
+++ b/lib/src/iam/entities/resources/level.rs
@@ -123,20 +123,20 @@ impl From<()> for Level {
 }
 
 impl From<(&str,)> for Level {
-	fn from(val: (&str,)) -> Self {
-		Level::Namespace(val.0.to_owned())
+	fn from((ns,): (&str,)) -> Self {
+		Level::Namespace(ns.to_owned())
 	}
 }
 
 impl From<(&str, &str)> for Level {
-	fn from(val: (&str, &str)) -> Self {
-		Level::Database(val.0.to_owned(), val.1.to_owned())
+	fn from((ns, db): (&str, &str)) -> Self {
+		Level::Database(ns.to_owned(), db.to_owned())
 	}
 }
 
 impl From<(&str, &str, &str)> for Level {
-	fn from(val: (&str, &str, &str)) -> Self {
-		Level::Scope(val.0.to_owned(), val.1.to_owned(), val.2.to_owned())
+	fn from((ns, db, sc): (&str, &str, &str)) -> Self {
+		Level::Scope(ns.to_owned(), db.to_owned(), sc.to_owned())
 	}
 }
 

--- a/lib/src/iam/signin.rs
+++ b/lib/src/iam/signin.rs
@@ -1,3 +1,5 @@
+use super::verify::verify_creds;
+use super::{Actor, Level};
 use crate::cnf::SERVER_NAME;
 use crate::dbs::Session;
 use crate::err::Error;
@@ -9,9 +11,6 @@ use crate::sql::Value;
 use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey};
 use std::sync::Arc;
-
-use super::verify::verify_creds;
-use super::{Actor, Level};
 
 pub async fn signin(
 	kvs: &Datastore,


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

It was not possible to define `PERMISSIONS` on a `TABLE` which referenced the `in` or the `out` field, as these fields did not exist when the permissions check was run.

## What does this change do?

Now the `RELATE` statement first checks to see if a record exists or not, creating a new edge, or updating an old edge. When creating a new edge, it first sets the edges, and the fields, and checks permissions after the data has been created. When updating an old edge, it checks for permissions first, then updates the record, and then checks permissions after the data has been updated

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #1820.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
