### PR TITLE
Ensure records can be created correctly when using `INSERT` statement

### DIFF
--- a/lib/src/doc/insert.rs
+++ b/lib/src/doc/insert.rs
@@ -17,8 +17,6 @@ impl<'a> Document<'a> {
 		match self.current.doc.is_some() {
 			// Run INSERT clause
 			false => {
-				// Check if allowed
-				self.allow(ctx, opt, txn, stm).await?;
 				// Merge record data
 				self.merge(ctx, opt, txn, stm).await?;
 				// Merge fields data

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -4,6 +4,7 @@ use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
 use surrealdb::kvs::Datastore;
+use surrealdb::sql::Thing;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -128,6 +129,64 @@ async fn create_with_id() -> Result<(), Error> {
 			{
 				id: test:⟨9223372036854775808⟩
 			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
+async fn create_or_insert_with_permissions() -> Result<(), Error> {
+	let sql = "
+		CREATE user:test;
+		DEFINE TABLE user SCHEMAFULL PERMISSIONS FULL;
+		DEFINE TABLE demo SCHEMAFULL PERMISSIONS FOR select, create, update WHERE user = $auth.id;
+		DEFINE FIELD user ON TABLE demo VALUE $auth.id;
+	";
+	let dbs = Datastore::new("memory").await?.with_auth_enabled(true);
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 4);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let sql = "
+		CREATE demo SET id = demo:one;
+		INSERT INTO demo (id) VALUES (demo:two);
+	";
+	let ses = Session::for_scope("test", "test", "test", Thing::from(("user", "test")).into());
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: demo:one,
+				user: user:test,
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: demo:two,
+				user: user:test,
+			},
 		]",
 	);
 	assert_eq!(tmp, val);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

There is a bug where records can be created using `CREATE` but not with `INSERT` when `PERMISSIONS` are defined on the table.

## What does this change do?

This pull-request ensures that records can be created successfully with an `INSERT` statement, when `PERMISSIONS` have been defined on the table. Now, when `INSERT`ing a record which does not exist, it first sets the record's fields, and checks permissions after the data has been created. When `INSERT`ing a record which already exists, it checks for permissions first, then updates the record, and then checks permissions after the data has been updated.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2440.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
