### PR TITLE
Ensure foreign tables are deleted fully when removed

### DIFF
--- a/lib/src/sql/statements/remove/table.rs
+++ b/lib/src/sql/statements/remove/table.rs
@@ -34,12 +34,23 @@ impl RemoveTableStatement {
 		let mut run = txn.lock().await;
 		// Clear the cache
 		run.clear_cache();
+		// Get the defined table
+		let tb = run.get_tb(opt.ns(), opt.db(), &self.name).await?;
 		// Delete the definition
 		let key = crate::key::database::tb::new(opt.ns(), opt.db(), &self.name);
 		run.del(key).await?;
 		// Remove the resource data
 		let key = crate::key::table::all::new(opt.ns(), opt.db(), &self.name);
 		run.delp(key, u32::MAX).await?;
+		// Check if this is a foreign table
+		if let Some(view) = &tb.view {
+			// Process each foreign table
+			for v in view.what.0.iter() {
+				// Save the view config
+				let key = crate::key::table::ft::new(opt.ns(), opt.db(), v, &self.name);
+				run.del(key).await?;
+			}
+		}
 		// Ok all good
 		Ok(Value::None)
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Foreign tables weren't fully deleted when removed using a `REMOVE` statement. Instead, the foreign table definition would still be defined on the table on which it was attached.

## What does this change do?

This pull request ensures that all table data, and all table attachments are removed fully when removing a table using a `REMOVE` statement.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #1816.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
