### PR TITLE
Delay Record ID generation when using functions

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 
 [features]
 # Public features
-default = ["protocol-ws", "rustls"]
+default = ["protocol-ws", "rustls", "kv-mem"]
 protocol-http = ["dep:reqwest", "dep:tokio-util"]
 protocol-ws = ["dep:tokio-tungstenite", "tokio/time"]
 kv-mem = ["dep:echodb", "tokio/time"]

--- a/lib/src/api/opt/mod.rs
+++ b/lib/src/api/opt/mod.rs
@@ -11,6 +11,7 @@ mod tls;
 
 use crate::api::err::Error;
 use crate::sql::constant::ConstantValue;
+use crate::sql::id::Gen;
 use crate::sql::to_value;
 use crate::sql::Thing;
 use crate::sql::Value;
@@ -325,6 +326,11 @@ fn into_json(value: Value, simplify: bool) -> JsonValue {
 				sql::Id::String(s) => Id::String(s),
 				sql::Id::Array(arr) => Id::Array((arr, simplify).into()),
 				sql::Id::Object(obj) => Id::Object((obj, simplify).into()),
+				sql::Id::Generate(v) => match v {
+					Gen::Rand => Id::from((sql::Id::rand(), simplify)),
+					Gen::Ulid => Id::from((sql::Id::ulid(), simplify)),
+					Gen::Uuid => Id::from((sql::Id::uuid(), simplify)),
+				},
 			}
 		}
 	}

--- a/lib/src/sql/thing.rs
+++ b/lib/src/sql/thing.rs
@@ -4,7 +4,7 @@ use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::sql::error::IResult;
 use crate::sql::escape::escape_rid;
-use crate::sql::id::{id, Id};
+use crate::sql::id::{id, Gen, Id};
 use crate::sql::ident::ident_raw;
 use crate::sql::strand::Strand;
 use crate::sql::value::Value;
@@ -135,9 +135,9 @@ fn thing_raw(i: &str) -> IResult<&str, Thing> {
 	let (i, t) = ident_raw(i)?;
 	let (i, _) = char(':')(i)?;
 	let (i, v) = alt((
-		map(tag("rand()"), |_| Id::rand()),
-		map(tag("ulid()"), |_| Id::ulid()),
-		map(tag("uuid()"), |_| Id::uuid()),
+		map(tag("rand()"), |_| Id::Generate(Gen::Rand)),
+		map(tag("ulid()"), |_| Id::Generate(Gen::Ulid)),
+		map(tag("uuid()"), |_| Id::Generate(Gen::Uuid)),
 		id,
 	))(i)?;
 	Ok((

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -23,7 +23,7 @@ use crate::sql::fmt::{Fmt, Pretty};
 use crate::sql::function::{self, function, Function};
 use crate::sql::future::{future, Future};
 use crate::sql::geometry::{geometry, Geometry};
-use crate::sql::id::Id;
+use crate::sql::id::{Gen, Id};
 use crate::sql::idiom::{self, Idiom};
 use crate::sql::kind::Kind;
 use crate::sql::model::{model, Model};
@@ -531,8 +531,13 @@ impl From<Id> for Value {
 		match v {
 			Id::Number(v) => v.into(),
 			Id::String(v) => v.into(),
-			Id::Object(v) => v.into(),
 			Id::Array(v) => v.into(),
+			Id::Object(v) => v.into(),
+			Id::Generate(v) => match v {
+				Gen::Rand => Id::rand().into(),
+				Gen::Ulid => Id::ulid().into(),
+				Gen::Uuid => Id::uuid().into(),
+			},
 		}
 	}
 }

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -4,6 +4,7 @@ use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
 use surrealdb::kvs::Datastore;
+use surrealdb::sql::Part;
 use surrealdb::sql::Thing;
 use surrealdb::sql::Value;
 
@@ -130,6 +131,44 @@ async fn create_with_id() -> Result<(), Error> {
 				id: test:⟨9223372036854775808⟩
 			}
 		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
+async fn create_with_custom_function() -> Result<(), Error> {
+	let sql = "
+		DEFINE FUNCTION fn::record::create($data: any) {
+			RETURN CREATE person:ulid() CONTENT { data: $data } RETURN AFTER;
+		};
+		RETURN fn::record::create({ test: true, name: 'Tobie' });
+		RETURN fn::record::create({ test: true, name: 'Jaime' });
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 3);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result?.pick(&[Part::from("data")]);
+	let val = Value::parse(
+		"{
+			test: true,
+			name: 'Tobie'
+		}",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?.pick(&[Part::from("data")]);
+	let val = Value::parse(
+		"{
+			test: true,
+			name: 'Jaime'
+		}",
 	);
 	assert_eq!(tmp, val);
 	//


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Previously, Record IDs created with a function (`person:rand()`, `person:ulid()`, `person:uuid()`) were computed instantly, instead of when required. This prevented a function-based Record ID, from being specified in a custom function, or a block of code which can be called multiple times - as the initially generated Record ID would be used for every invocation.

## What does this change do?

This pull request ensures that a function-based Record ID only generates an ID when required, and not when parsed. This allows function-based Record IDs to be used anywhere.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2260.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
