### PR TITLE
Fix random tikv tests after ts_to_vs test to not fail anymore

### DIFF
--- a/lib/src/kvs/tests/timestamp_to_versionstamp.rs
+++ b/lib/src/kvs/tests/timestamp_to_versionstamp.rs
@@ -11,23 +11,31 @@
 //    We need to translate the timestamp to the versionstamp due to that; `now - 1h` to a key suffixed by the versionstamp.
 #[tokio::test]
 #[serial]
-#[ignore]
 async fn timestamp_to_versionstamp() {
 	// Create a new datastore
 	let ds = new_ds(Uuid::parse_str("A905CA25-56ED-49FB-B759-696AEA87C342").unwrap()).await;
 	// Give the current versionstamp a timestamp of 0
 	let mut tx = ds.transaction(true, false).await.unwrap();
 	tx.set_timestamp_for_versionstamp(0, "myns", "mydb", true).await.unwrap();
+	tx.commit().await.unwrap();
+	// Get the versionstamp for timestamp 0
+	let mut tx = ds.transaction(true, false).await.unwrap();
 	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb", true).await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 	// Give the current versionstamp a timestamp of 1
 	let mut tx = ds.transaction(true, false).await.unwrap();
 	tx.set_timestamp_for_versionstamp(1, "myns", "mydb", true).await.unwrap();
+	tx.commit().await.unwrap();
+	// Get the versionstamp for timestamp 1
+	let mut tx = ds.transaction(true, false).await.unwrap();
 	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb", true).await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 	// Give the current versionstamp a timestamp of 2
 	let mut tx = ds.transaction(true, false).await.unwrap();
 	tx.set_timestamp_for_versionstamp(2, "myns", "mydb", true).await.unwrap();
+	tx.commit().await.unwrap();
+	// Get the versionstamp for timestamp 2
+	let mut tx = ds.transaction(true, false).await.unwrap();
 	let vs3 = tx.get_versionstamp_from_timestamp(2, "myns", "mydb", true).await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 	assert!(vs1 < vs2);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Fix and re-enable the temporarily ignored timestamp_to_versionstamp tests!

See #2470 for context

## What does this change do?

Stop mixing read and write to the same key in each transaction.

## What is your testing strategy?

Ran the kvs tests using the same script shared by @tobiemh in #2470 locally. So far it's consistently faster than before (as the tikv transaction in the ts_to_vs test and the next test never need to wait lock timeouts) and never fails after the fix.

```
for i in {1..100}; do cargo test --locked --package surrealdb --no-default-features --features kv-tikv --lib kvs; done
```

## Is this related to any issues?

#2470

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
