### PR TITLE
Support whitespace in JavaScript function definition

### DIFF
--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -651,6 +651,44 @@ mod tests {
 	}
 
 	#[test]
+	fn function_simple_together() {
+		let sql = "function() { return 'test'; }";
+		let res = function(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(
+			"function() { return 'test'; }",
+			format!("{}", out)
+		);
+		assert_eq!(
+			out,
+			Function::Script(
+				Script::parse(" return 'test'; "),
+				vec![]
+			)
+		);
+	}
+
+	#[test]
+	fn function_simple_whitespace() {
+		let sql = "function () { return 'test'; }";
+		let res = function(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(
+			"function() { return 'test'; }",
+			format!("{}", out)
+		);
+		assert_eq!(
+			out,
+			Function::Script(
+				Script::parse(" return 'test'; "),
+				vec![]
+			)
+		);
+	}
+
+	#[test]
 	fn function_script_expression() {
 		let sql = "function() { return this.tags.filter(t => { return t.length > 3; }); }";
 		let res = function(sql);

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -656,17 +656,8 @@ mod tests {
 		let res = function(sql);
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
-		assert_eq!(
-			"function() { return 'test'; }",
-			format!("{}", out)
-		);
-		assert_eq!(
-			out,
-			Function::Script(
-				Script::parse(" return 'test'; "),
-				vec![]
-			)
-		);
+		assert_eq!("function() { return 'test'; }", format!("{}", out));
+		assert_eq!(out, Function::Script(Script::parse(" return 'test'; "), vec![]));
 	}
 
 	#[test]
@@ -675,17 +666,8 @@ mod tests {
 		let res = function(sql);
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
-		assert_eq!(
-			"function() { return 'test'; }",
-			format!("{}", out)
-		);
-		assert_eq!(
-			out,
-			Function::Script(
-				Script::parse(" return 'test'; "),
-				vec![]
-			)
-		);
+		assert_eq!("function() { return 'test'; }", format!("{}", out));
+		assert_eq!(out, Function::Script(Script::parse(" return 'test'; "), vec![]));
 	}
 
 	#[test]

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -239,6 +239,7 @@ pub fn normal(i: &str) -> IResult<&str, Function> {
 pub fn custom(i: &str) -> IResult<&str, Function> {
 	let (i, _) = tag("fn::")(i)?;
 	let (i, s) = recognize(separated_list1(tag("::"), take_while1(val_char)))(i)?;
+	let (i, _) = mightbespace(i)?;
 	let (i, _) = char('(')(i)?;
 	let (i, _) = mightbespace(i)?;
 	let (i, a) = separated_list0(commas, value)(i)?;
@@ -249,6 +250,7 @@ pub fn custom(i: &str) -> IResult<&str, Function> {
 
 fn script(i: &str) -> IResult<&str, Function> {
 	let (i, _) = tag("function")(i)?;
+	let (i, _) = mightbespace(i)?;
 	let (i, _) = openparentheses(i)?;
 	let (i, _) = mightbespace(i)?;
 	let (i, a) = separated_list0(commas, value)(i)?;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently `RETURN function() { return 'test'; };` parses correctly, but `RETURN function () { return 'test'; };` fails.

## What does this change do?

Adds support for whitespace between `function` and `()` brackets.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2419.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
