### PR TITLE
Ensure `ON DUPLICATE KEY UPDATE` clause is displayed on `INSERT` statement

### DIFF
--- a/lib/src/sql/statements/insert.rs
+++ b/lib/src/sql/statements/insert.rs
@@ -127,6 +127,9 @@ impl fmt::Display for InsertStatement {
 			f.write_str(" IGNORE")?
 		}
 		write!(f, " INTO {} {}", self.into, self.data)?;
+		if let Some(ref v) = self.update {
+			write!(f, " {v}")?
+		}
 		if let Some(ref v) = self.output {
 			write!(f, " {v}")?
 		}
@@ -188,5 +191,14 @@ mod tests {
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
 		assert_eq!("INSERT IGNORE INTO test (field) VALUES ($value)", format!("{}", out))
+	}
+
+	#[test]
+	fn insert_statement_ignore_update() {
+		let sql = "INSERT IGNORE INTO test (field) VALUES ($value) ON DUPLICATE KEY UPDATE field = $value";
+		let res = insert(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!("INSERT IGNORE INTO test (field) VALUES ($value) ON DUPLICATE KEY UPDATE field = $value", format!("{}", out))
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When using an `INSERT` statement, the `ON DUPLICATE KEY UPDATE ...` clause was not formatted with the statement.

## What does this change do?

This pull request ensures that the `ON DUPLICATE KEY UPDATE ...` key is output when formatting the statement, and adds a test to ensure this is correct.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2387.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
