### PR TITLE
Lower parsing complexity for binary values and idioms

### DIFF
--- a/lib/src/sql/expression.rs
+++ b/lib/src/sql/expression.rs
@@ -50,7 +50,7 @@ impl Expression {
 		}
 	}
 	/// Augment an existing expression
-	fn augment(mut self, l: Value, o: Operator) -> Self {
+	pub(crate) fn augment(mut self, l: Value, o: Operator) -> Self {
 		match &mut self {
 			Self::Binary {
 				l: left,

--- a/lib/src/sql/idiom.rs
+++ b/lib/src/sql/idiom.rs
@@ -252,26 +252,20 @@ pub fn path(i: &str) -> IResult<&str, Idiom> {
 /// A full complex idiom with any number of parts
 #[cfg(test)]
 pub fn idiom(i: &str) -> IResult<&str, Idiom> {
-	alt((plain, multi))(i)
-}
+	use nom::combinator::fail;
 
-/// A complex idiom with graph or many parts
-#[cfg(test)]
-pub fn multi(i: &str) -> IResult<&str, Idiom> {
-	use crate::sql::part::start;
+	use crate::sql::value::value;
+
 	alt((
-		|i| {
-			let (i, p) = graph(i)?;
-			let (i, mut v) = many0(part)(i)?;
-			v.insert(0, p);
-			Ok((i, Idiom::from(v)))
-		},
-		|i| {
-			let (i, p) = alt((first, start))(i)?;
-			let (i, mut v) = many1(part)(i)?;
-			v.insert(0, p);
-			Ok((i, Idiom::from(v)))
-		},
+		plain,
+		alt((multi_without_start, |i| {
+			let (i, v) = value(i)?;
+			let (i, v) = reparse_idiom_start(v, i)?;
+			if let Value::Idiom(x) = v {
+				return Ok((i, x));
+			}
+			fail(i)
+		})),
 	))(i)
 }
 

--- a/lib/src/sql/part.rs
+++ b/lib/src/sql/part.rs
@@ -223,12 +223,6 @@ pub fn graph(i: &str) -> IResult<&str, Part> {
 }
 
 #[cfg(test)]
-pub fn start(i: &str) -> IResult<&str, Part> {
-	let (i, v) = value::start(i)?;
-	Ok((i, Part::Start(v)))
-}
-
-#[cfg(test)]
 mod tests {
 
 	use super::*;

--- a/lib/src/sql/part.rs
+++ b/lib/src/sql/part.rs
@@ -217,14 +217,15 @@ pub fn value(i: &str) -> IResult<&str, Part> {
 	Ok((i, Part::Value(v)))
 }
 
-pub fn start(i: &str) -> IResult<&str, Part> {
-	let (i, v) = value::start(i)?;
-	Ok((i, Part::Start(v)))
-}
-
 pub fn graph(i: &str) -> IResult<&str, Part> {
 	let (i, v) = graph::graph(i)?;
 	Ok((i, Part::Graph(v)))
+}
+
+#[cfg(test)]
+pub fn start(i: &str) -> IResult<&str, Part> {
+	let (i, v) = value::start(i)?;
+	Ok((i, Part::Start(v)))
 }
 
 #[cfg(test)]

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2829,28 +2829,6 @@ pub fn select(i: &str) -> IResult<&str, Value> {
 	reparse_idiom_start(v, i)
 }
 
-#[cfg(test)]
-/// Used as the starting part of a complex Idiom
-pub fn start(i: &str) -> IResult<&str, Value> {
-	use crate::sql::function;
-	alt((
-		map(function::normal, Value::from),
-		map(function::custom, Value::from),
-		map(subquery, Value::from),
-		map(constant, Value::from),
-		map(datetime, Value::from),
-		map(duration, Value::from),
-		map(unique, Value::from),
-		map(number, Value::from),
-		map(strand, Value::from),
-		map(object, Value::from),
-		map(array, Value::from),
-		map(param, Value::from),
-		map(edges, Value::from),
-		map(thing, Value::from),
-	))(i)
-}
-
 /// Used in CREATE, UPDATE, and DELETE clauses
 pub fn what(i: &str) -> IResult<&str, Value> {
 	let (i, v) = alt((


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The surrealql parser has O(2^n) complexity when parsing nested objects and blocks resulting in poor performance when inserting deeply nested objects or blocks.

This PR makes changes to the parser to lower the complexity from O(2^n) to O(n).

## What does this change do?

This PR changes how expression values and idioms are parsed.
 
For expressions it first parses a value without operators and then looks if an the next value is an operator, if it is then it parses the value as a binary operator, else it just returns the parsed value.

For idioms it restructures how idioms which start with a value are parsed. It first tries to parse a value, including idiom which don't start with a value, then if the value could be the start of a idiom it tries to parse the next text as a idiom and otherwise just returns the first parsed value.

This results in a drastic increase in parser performance. The following is the before and after of running the code provided by issue #1810.

before:
```
❯ python test.py
match retrieved
576382
Done in 426.3473689556122 seconds
```


after: 
```
❯ python test.py
match retrieved
576382
Done in 0.11635613441467285 seconds
```

## What is your testing strategy?

## Is this related to any issues?

Fixes #1810.
Fixes #1956.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
