### PR TITLE
Fix Ctrl-C to work for node and telemetry

### DIFF
--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -15,6 +15,7 @@ use opentelemetry::Context as TelemetryContext;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 
 #[derive(Args, Debug)]
 pub struct StartCommandArguments {
@@ -144,15 +145,24 @@ pub async fn init(
 		crt: web.as_ref().and_then(|x| x.web_crt.clone()),
 		key: web.as_ref().and_then(|x| x.web_key.clone()),
 	});
+	// This is the cancellation token propagated down to
+	// all the async functions that needs to be stopped gracefully.
+	let ct = CancellationToken::new();
 	// Initiate environment
 	env::init().await?;
 	// Start the kvs server
 	dbs::init(dbs).await?;
 	// Start the node agent
 	#[cfg(feature = "has-storage")]
-	node::init().await?;
+	let nd = node::init(ct.clone());
 	// Start the web server
-	net::init().await?;
+	net::init(ct).await?;
+	// Wait for the node agent to stop
+	#[cfg(feature = "has-storage")]
+	if let Err(e) = nd.await {
+		error!("Node agent failed while running: {}", e);
+		return Err(Error::NodeAgent);
+	}
 	// All ok
 	Ok(())
 }

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -54,6 +54,9 @@ pub enum Error {
 
 	#[error("There was an error with the remote request: {0}")]
 	Remote(#[from] ReqwestError),
+
+	#[error("There was an error with the node agent")]
+	NodeAgent,
 }
 
 impl From<Error> for String {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -25,6 +25,7 @@ use http::header;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
 use tower_http::add_extension::AddExtensionLayer;
 use tower_http::auth::AsyncRequireAuthorizationLayer;
@@ -53,7 +54,7 @@ struct AppState {
 	client_ip: client_ip::ClientIp,
 }
 
-pub async fn init() -> Result<(), Error> {
+pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 
@@ -131,7 +132,7 @@ pub async fn init() -> Result<(), Error> {
 
 	// Setup the graceful shutdown
 	let handle = Handle::new();
-	let shutdown_handler = graceful_shutdown(handle.clone());
+	let shutdown_handler = graceful_shutdown(ct, handle.clone());
 
 	if let (Some(cert), Some(key)) = (&opt.crt, &opt.key) {
 		// configure certificate and private key used by https

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,5 +1,7 @@
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
 use crate::cli::CF;
-use crate::err::Error;
 
 const LOG: &str = "surrealdb::node";
 
@@ -9,25 +11,28 @@ const LOG: &str = "surrealdb::node";
 //
 // This function needs to be called before after the dbs::init and before the net::init functions.
 // It needs to be before net::init because the net::init function blocks until the web server stops.
-pub async fn init() -> Result<(), Error> {
+pub fn init(ct: CancellationToken) -> JoinHandle<()> {
 	let opt = CF.get().unwrap();
 	let tick_interval = opt.tick_interval;
-	info!(target: LOG, "Node agent starting.");
+	info!(target: LOG, "Started node agent");
 
 	// This requires the nodes::init function to be called after the dbs::init function.
 	let dbs = crate::dbs::DB.get().unwrap();
+
 	tokio::spawn(async move {
 		loop {
 			if let Err(e) = dbs.tick().await {
 				error!("Error running node agent tick: {}", e);
 			}
-			tokio::time::sleep(tick_interval).await;
+			tokio::select! {
+				_ = ct.cancelled() => {
+					info!(target: LOG, "Gracefully stopping node agent");
+					break;
+				}
+				_ = tokio::time::sleep(tick_interval) => {}
+			}
 		}
 
-		// TODO Do we need to add support for graceful stop?
-	});
-
-	info!(target: LOG, "Node agent started.");
-
-	Ok(())
+		info!(target: LOG, "Stopped node agent");
+	})
 }

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -87,11 +87,10 @@ pub fn init(cx: &TelemetryContext) -> Result<(), MetricsError> {
 //
 // Shutdown the metrics providers
 //
-pub fn shutdown(cx: &TelemetryContext) -> Result<(), MetricsError> {
-	METER_PROVIDER_DURATION.stop(cx)?;
-	METER_PROVIDER_DURATION.collect(cx)?;
-	METER_PROVIDER_SIZE.stop(cx)?;
-	METER_PROVIDER_SIZE.collect(cx)?;
+pub fn shutdown(_cx: &TelemetryContext) -> Result<(), MetricsError> {
+	// TODO(sgirones): The stop method hangs forever, so we are not calling it until we figure out why
+	// METER_PROVIDER_DURATION.stop(cx)?;
+	// METER_PROVIDER_SIZE.stop(cx)?;
 
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

Make Ctrl-C to work on `surreal start` command once again.

## What does this change do?

Implement the signal handling to the node agent and fix the telemetry agent to not block forever on cancellation!

## What is your testing strategy?

Tested manually. I'd like to delegate adding the Ctrl-C test to @sgirones if possible ☺️ 

## Is this related to any issues?

#2403 for the node agent and #2413 for the telemetry

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
