### PR TITLE
ci: Shorten coverage report upload timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,7 @@ jobs:
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
         timeout-minutes: 1
+        continue-on-error: true
         with:
           name: code-coverage-report
           path: target/llvm-cov/html/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,7 @@ jobs:
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v3
+        timeout-minutes: 1
         with:
           name: code-coverage-report
           path: target/llvm-cov/html/


### PR DESCRIPTION
## What is the motivation?

Let CI workflows flow smoothly even when there are issues in GHA artifact uploading.

## What does this change do?

Shorten the timeout for the coverage report upload step from the 360 minutes (default) to 1 minute.

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes

## What is your testing strategy?

Let's merge and see it works!

Note that the new setting won't affect the workflow jobs triggered for this pull request as it's main branch's ci.yml which is used for PR builds.

## Is this related to any issues?

We don't have issues in this repository but here are seemingly related issues in the wild:

https://github.com/actions/upload-artifact/issues/427
https://github.com/actions/upload-artifact/issues/428
https://github.com/actions/upload-artifact/issues/429

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
