### PR TITLE
[cli/server] Add tests for signal handling

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -43,6 +43,17 @@ impl Child {
 		self
 	}
 
+	pub fn send_signal(&self, signal: nix::sys::signal::Signal) -> nix::Result<()> {
+		nix::sys::signal::kill(
+			nix::unistd::Pid::from_raw(self.inner.as_ref().unwrap().id() as i32),
+			signal,
+		)
+	}
+
+	pub fn status(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+		self.inner.as_mut().unwrap().try_wait()
+	}
+
 	/// Read the child's stdout concatenated with its stderr. Returns Ok if the child
 	/// returns successfully, Err otherwise.
 	pub fn output(mut self) -> Result<String, String> {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The signal handling for graceful and immediate shutdown broke unexpectedly. Add test cases to make sure it doesn't break in the future.

## What does this change do?

Add 2 test cases: one for graceful shutdown and another for immediate shutdown after the 2nd signal.

## What is your testing strategy?

Github Actions

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
