### PR TITLE
impl IntoResource for &Thing

### DIFF
--- a/lib/src/api/opt/resource.rs
+++ b/lib/src/api/opt/resource.rs
@@ -144,6 +144,12 @@ impl<R> IntoResource<Option<R>> for Thing {
 	}
 }
 
+impl<R> IntoResource<Option<R>> for &Thing {
+	fn into_resource(self) -> Result<Resource> {
+		Ok(Resource::RecordId(self.clone()))
+	}
+}
+
 impl<R, T, I> IntoResource<Option<R>> for (T, I)
 where
 	T: Into<String>,


### PR DESCRIPTION
## What is the motivation?

It's a requested feature.

## What does this change do?

It makes it possible to pass in a reference of a `Thing` to CRUD methods instead of cloning the `Thing` when one needs it for subsequent code. In this case, we will just clone the `Thing` ourselves.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

It closes https://github.com/surrealdb/surrealdb/issues/2378.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
