### PR TITLE
Remove unnecessary `impl From<Jwt> for Value`

### DIFF
--- a/lib/src/api/method/authenticate.rs
+++ b/lib/src/api/method/authenticate.rs
@@ -27,7 +27,7 @@ where
 		Box::pin(async move {
 			let router = self.router?;
 			let mut conn = Client::new(Method::Authenticate);
-			conn.execute_unit(router, Param::new(vec![self.token.into()])).await
+			conn.execute_unit(router, Param::new(vec![self.token.0.into()])).await
 		})
 	}
 }

--- a/lib/src/api/opt/auth.rs
+++ b/lib/src/api/opt/auth.rs
@@ -1,6 +1,5 @@
 //! Authentication types
 
-use crate::sql::Value;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;
@@ -132,12 +131,6 @@ impl<'a> From<&'a String> for Jwt {
 impl<'a> From<&'a str> for Jwt {
 	fn from(jwt: &'a str) -> Self {
 		Jwt(jwt.to_owned())
-	}
-}
-
-impl From<Jwt> for Value {
-	fn from(Jwt(jwt): Jwt) -> Self {
-		jwt.into()
 	}
 }
 


### PR DESCRIPTION
## What is the motivation?

We now have `as_insecure_token` and `into_insecure_token` methods which can be used when one wants to convert the token into a string. Those methods are preferred because they make it clear that such a conversion is not secure as it can lead to the token leaking if one is not careful when handling it.

## What does this change do?

It removes the implementation.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
