### PR TITLE
Improve code blocks, foreach statements, and throw statements

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 
 [features]
 # Public features
-default = ["protocol-ws", "rustls", "kv-mem"]
+default = ["protocol-ws", "rustls"]
 protocol-http = ["dep:reqwest", "dep:tokio-util"]
 protocol-ws = ["dep:tokio-tungstenite", "tokio/time"]
 kv-mem = ["dep:echodb", "tokio/time"]

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -24,6 +24,16 @@ pub enum Error {
 	#[error("Conditional clause is not truthy")]
 	Ignore,
 
+	/// This error is used for breaking a loop in a foreach statement
+	#[doc(hidden)]
+	#[error("Break statement has been reached")]
+	Break,
+
+	/// This error is used for skipping a loop in a foreach statement
+	#[doc(hidden)]
+	#[error("Continue statement has been reached")]
+	Continue,
+
 	/// The database encountered unreachable logic
 	#[error("The database encountered unreachable logic")]
 	Unreachable,

--- a/lib/src/sql/block.rs
+++ b/lib/src/sql/block.rs
@@ -74,6 +74,18 @@ impl Block {
 					let val = v.compute(&ctx, opt, txn, doc).await?;
 					ctx.add_value(v.name.to_owned(), val);
 				}
+				Entry::Throw(v) => {
+					// Always errors immediately
+					v.compute(&ctx, opt, txn, doc).await?;
+				}
+				Entry::Break(v) => {
+					// Always errors immediately
+					v.compute(&ctx, opt, txn, doc).await?;
+				}
+				Entry::Continue(v) => {
+					// Always errors immediately
+					v.compute(&ctx, opt, txn, doc).await?;
+				}
 				Entry::Ifelse(v) => {
 					v.compute(&ctx, opt, txn, doc).await?;
 				}
@@ -102,21 +114,15 @@ impl Block {
 					v.compute(&ctx, opt, txn, doc).await?;
 				}
 				Entry::Output(v) => {
-					return v.compute(&ctx, opt, txn, doc).await;
-				}
-				Entry::Throw(v) => {
-					return v.compute(&ctx, opt, txn, doc).await;
-				}
-				Entry::Break(v) => {
-					return v.compute(&ctx, opt, txn, doc).await;
-				}
-				Entry::Continue(v) => {
+					// Return the RETURN value
 					return v.compute(&ctx, opt, txn, doc).await;
 				}
 				Entry::Value(v) => {
 					if i == self.len() - 1 {
+						// If the last entry then return the value
 						return v.compute(&ctx, opt, txn, doc).await;
 					} else {
+						// Otherwise just process the value
 						v.compute(&ctx, opt, txn, doc).await?;
 					}
 				}

--- a/lib/src/sql/statements/break.rs
+++ b/lib/src/sql/statements/break.rs
@@ -15,6 +15,10 @@ use std::fmt;
 pub struct BreakStatement;
 
 impl BreakStatement {
+	/// Check if we require a writeable transaction
+	pub(crate) fn writeable(&self) -> bool {
+		false
+	}
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,

--- a/lib/src/sql/statements/break.rs
+++ b/lib/src/sql/statements/break.rs
@@ -23,9 +23,7 @@ impl BreakStatement {
 		_txn: &Transaction,
 		_doc: Option<&CursorDoc<'_>>,
 	) -> Result<Value, Error> {
-		Err(Error::FeatureNotYetImplemented {
-			feature: "BREAK statements",
-		})
+		Err(Error::Break)
 	}
 }
 

--- a/lib/src/sql/statements/continue.rs
+++ b/lib/src/sql/statements/continue.rs
@@ -15,6 +15,10 @@ use std::fmt;
 pub struct ContinueStatement;
 
 impl ContinueStatement {
+	/// Check if we require a writeable transaction
+	pub(crate) fn writeable(&self) -> bool {
+		false
+	}
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,

--- a/lib/src/sql/statements/continue.rs
+++ b/lib/src/sql/statements/continue.rs
@@ -23,9 +23,7 @@ impl ContinueStatement {
 		_txn: &Transaction,
 		_doc: Option<&CursorDoc<'_>>,
 	) -> Result<Value, Error> {
-		Err(Error::FeatureNotYetImplemented {
-			feature: "CONTINUE statements",
-		})
+		Err(Error::Continue)
 	}
 }
 

--- a/lib/src/sql/statements/define/mod.rs
+++ b/lib/src/sql/statements/define/mod.rs
@@ -56,6 +56,10 @@ pub enum DefineStatement {
 }
 
 impl DefineStatement {
+	/// Check if we require a writeable transaction
+	pub(crate) fn writeable(&self) -> bool {
+		true
+	}
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,

--- a/lib/src/sql/statements/ifelse.rs
+++ b/lib/src/sql/statements/ifelse.rs
@@ -2,14 +2,17 @@ use crate::ctx::Context;
 use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
+use crate::sql::block::block;
 use crate::sql::comment::shouldbespace;
 use crate::sql::error::IResult;
 use crate::sql::fmt::{fmt_separated_by, is_pretty, pretty_indent, Fmt, Pretty};
 use crate::sql::value::{value, Value};
 use derive::Store;
+use nom::branch::alt;
 use nom::bytes::complete::tag_no_case;
+use nom::combinator::map;
 use nom::combinator::opt;
-use nom::multi::separated_list0;
+use nom::multi::separated_list1;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Write};
@@ -30,6 +33,12 @@ impl IfelseStatement {
 			}
 		}
 		self.close.as_ref().map_or(false, |v| v.writeable())
+	}
+	/// Check if we require a writeable transaction
+	pub(crate) fn bracketed(&self) -> bool {
+		self.exprs.iter().all(|(_, v)| matches!(v, Value::Block(_)))
+			&& (self.close.as_ref().is_none()
+				|| self.close.as_ref().is_some_and(|v| matches!(v, Value::Block(_))))
 	}
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
@@ -55,51 +64,123 @@ impl IfelseStatement {
 impl Display for IfelseStatement {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		let mut f = Pretty::from(f);
-		write!(
-			f,
-			"{}",
-			&Fmt::new(
-				self.exprs.iter().map(|args| {
-					Fmt::new(args, |(cond, then), f| {
+		match self.bracketed() {
+			true => {
+				write!(
+					f,
+					"{}",
+					&Fmt::new(
+						self.exprs.iter().map(|args| {
+							Fmt::new(args, |(cond, then), f| {
+								if is_pretty() {
+									write!(f, "IF {cond}")?;
+									let indent = pretty_indent();
+									write!(f, "{then}")?;
+									drop(indent);
+								} else {
+									write!(f, "IF {cond} {then}")?;
+								}
+								Ok(())
+							})
+						}),
 						if is_pretty() {
-							write!(f, "IF {cond} THEN")?;
-							let indent = pretty_indent();
-							write!(f, "{then}")?;
-							drop(indent);
+							fmt_separated_by("ELSE")
 						} else {
-							write!(f, "IF {cond} THEN {then}")?;
-						}
-						Ok(())
-					})
-				}),
+							fmt_separated_by(" ELSE ")
+						},
+					),
+				)?;
+				if let Some(ref v) = self.close {
+					if is_pretty() {
+						write!(f, "ELSE")?;
+						let indent = pretty_indent();
+						write!(f, "{v}")?;
+						drop(indent);
+					} else {
+						write!(f, " ELSE {v}")?;
+					}
+				}
+				Ok(())
+			}
+			false => {
+				write!(
+					f,
+					"{}",
+					&Fmt::new(
+						self.exprs.iter().map(|args| {
+							Fmt::new(args, |(cond, then), f| {
+								if is_pretty() {
+									write!(f, "IF {cond} THEN")?;
+									let indent = pretty_indent();
+									write!(f, "{then}")?;
+									drop(indent);
+								} else {
+									write!(f, "IF {cond} THEN {then}")?;
+								}
+								Ok(())
+							})
+						}),
+						if is_pretty() {
+							fmt_separated_by("ELSE")
+						} else {
+							fmt_separated_by(" ELSE ")
+						},
+					),
+				)?;
+				if let Some(ref v) = self.close {
+					if is_pretty() {
+						write!(f, "ELSE")?;
+						let indent = pretty_indent();
+						write!(f, "{v}")?;
+						drop(indent);
+					} else {
+						write!(f, " ELSE {v}")?;
+					}
+				}
 				if is_pretty() {
-					fmt_separated_by("ELSE")
+					f.write_str("END")?;
 				} else {
-					fmt_separated_by(" ELSE ")
-				},
-			),
-		)?;
-		if let Some(ref v) = self.close {
-			if is_pretty() {
-				write!(f, "ELSE")?;
-				let indent = pretty_indent();
-				write!(f, "{v}")?;
-				drop(indent);
-			} else {
-				write!(f, " ELSE {v}")?;
+					f.write_str(" END")?;
+				}
+				Ok(())
 			}
 		}
-		if is_pretty() {
-			f.write_str("END")?;
-		} else {
-			f.write_str(" END")?;
-		}
-		Ok(())
 	}
 }
 
 pub fn ifelse(i: &str) -> IResult<&str, IfelseStatement> {
-	let (i, exprs) = separated_list0(split, exprs)(i)?;
+	alt((worded, bracketed))(i)
+}
+
+fn worded(i: &str) -> IResult<&str, IfelseStatement> {
+	//
+	fn exprs(i: &str) -> IResult<&str, (Value, Value)> {
+		let (i, _) = tag_no_case("IF")(i)?;
+		let (i, _) = shouldbespace(i)?;
+		let (i, cond) = value(i)?;
+		let (i, _) = shouldbespace(i)?;
+		let (i, _) = tag_no_case("THEN")(i)?;
+		let (i, _) = shouldbespace(i)?;
+		let (i, then) = value(i)?;
+		Ok((i, (cond, then)))
+	}
+	//
+	fn close(i: &str) -> IResult<&str, Value> {
+		let (i, _) = shouldbespace(i)?;
+		let (i, _) = tag_no_case("ELSE")(i)?;
+		let (i, _) = shouldbespace(i)?;
+		let (i, then) = value(i)?;
+		Ok((i, then))
+	}
+	//
+	fn split(i: &str) -> IResult<&str, ()> {
+		let (i, _) = shouldbespace(i)?;
+		let (i, _) = tag_no_case("ELSE")(i)?;
+		let (i, _) = shouldbespace(i)?;
+		Ok((i, ()))
+	}
+	//
+	let (i, exprs) = separated_list1(split, exprs)(i)?;
 	let (i, close) = opt(close)(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, _) = tag_no_case("END")(i)?;
@@ -112,30 +193,41 @@ pub fn ifelse(i: &str) -> IResult<&str, IfelseStatement> {
 	))
 }
 
-fn exprs(i: &str) -> IResult<&str, (Value, Value)> {
-	let (i, _) = tag_no_case("IF")(i)?;
-	let (i, _) = shouldbespace(i)?;
-	let (i, cond) = value(i)?;
-	let (i, _) = shouldbespace(i)?;
-	let (i, _) = tag_no_case("THEN")(i)?;
-	let (i, _) = shouldbespace(i)?;
-	let (i, then) = value(i)?;
-	Ok((i, (cond, then)))
-}
-
-fn close(i: &str) -> IResult<&str, Value> {
-	let (i, _) = shouldbespace(i)?;
-	let (i, _) = tag_no_case("ELSE")(i)?;
-	let (i, _) = shouldbespace(i)?;
-	let (i, then) = value(i)?;
-	Ok((i, then))
-}
-
-fn split(i: &str) -> IResult<&str, ()> {
-	let (i, _) = shouldbespace(i)?;
-	let (i, _) = tag_no_case("ELSE")(i)?;
-	let (i, _) = shouldbespace(i)?;
-	Ok((i, ()))
+fn bracketed(i: &str) -> IResult<&str, IfelseStatement> {
+	//
+	fn exprs(i: &str) -> IResult<&str, (Value, Value)> {
+		let (i, _) = tag_no_case("IF")(i)?;
+		let (i, _) = shouldbespace(i)?;
+		let (i, cond) = value(i)?;
+		let (i, _) = shouldbespace(i)?;
+		let (i, then) = map(block, Value::from)(i)?;
+		Ok((i, (cond, then)))
+	}
+	//
+	fn close(i: &str) -> IResult<&str, Value> {
+		let (i, _) = shouldbespace(i)?;
+		let (i, _) = tag_no_case("ELSE")(i)?;
+		let (i, _) = shouldbespace(i)?;
+		let (i, then) = map(block, Value::from)(i)?;
+		Ok((i, then))
+	}
+	//
+	fn split(i: &str) -> IResult<&str, ()> {
+		let (i, _) = shouldbespace(i)?;
+		let (i, _) = tag_no_case("ELSE")(i)?;
+		let (i, _) = shouldbespace(i)?;
+		Ok((i, ()))
+	}
+	//
+	let (i, exprs) = separated_list1(split, exprs)(i)?;
+	let (i, close) = opt(close)(i)?;
+	Ok((
+		i,
+		IfelseStatement {
+			exprs,
+			close,
+		},
+	))
 }
 
 #[cfg(test)]
@@ -144,7 +236,7 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn ifelse_statement_first() {
+	fn ifelse_worded_statement_first() {
 		let sql = "IF this THEN that END";
 		let res = ifelse(sql);
 		assert!(res.is_ok());
@@ -153,7 +245,7 @@ mod tests {
 	}
 
 	#[test]
-	fn ifelse_statement_close() {
+	fn ifelse_worded_statement_close() {
 		let sql = "IF this THEN that ELSE that END";
 		let res = ifelse(sql);
 		assert!(res.is_ok());
@@ -162,7 +254,7 @@ mod tests {
 	}
 
 	#[test]
-	fn ifelse_statement_other() {
+	fn ifelse_worded_statement_other() {
 		let sql = "IF this THEN that ELSE IF this THEN that END";
 		let res = ifelse(sql);
 		assert!(res.is_ok());
@@ -171,8 +263,44 @@ mod tests {
 	}
 
 	#[test]
-	fn ifelse_statement_other_close() {
+	fn ifelse_worded_statement_other_close() {
 		let sql = "IF this THEN that ELSE IF this THEN that ELSE that END";
+		let res = ifelse(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(sql, format!("{}", out))
+	}
+
+	#[test]
+	fn ifelse_bracketed_statement_first() {
+		let sql = "IF this { that }";
+		let res = ifelse(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(sql, format!("{}", out))
+	}
+
+	#[test]
+	fn ifelse_bracketed_statement_close() {
+		let sql = "IF this { that } ELSE { that }";
+		let res = ifelse(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(sql, format!("{}", out))
+	}
+
+	#[test]
+	fn ifelse_bracketed_statement_other() {
+		let sql = "IF this { that } ELSE IF this { that }";
+		let res = ifelse(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(sql, format!("{}", out))
+	}
+
+	#[test]
+	fn ifelse_bracketed_statement_other_close() {
+		let sql = "IF this { that } ELSE IF this { that } ELSE { that }";
 		let res = ifelse(sql);
 		assert!(res.is_ok());
 		let out = res.unwrap().1;

--- a/lib/src/sql/statements/remove/mod.rs
+++ b/lib/src/sql/statements/remove/mod.rs
@@ -56,6 +56,10 @@ pub enum RemoveStatement {
 }
 
 impl RemoveStatement {
+	/// Check if we require a writeable transaction
+	pub(crate) fn writeable(&self) -> bool {
+		true
+	}
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,

--- a/lib/src/sql/value/serde/ser/block/entry/mod.rs
+++ b/lib/src/sql/value/serde/ser/block/entry/mod.rs
@@ -37,6 +37,10 @@ impl ser::Serializer for Serializer {
 		match variant {
 			"Value" => Ok(Entry::Value(value.serialize(ser::value::Serializer.wrap())?)),
 			"Set" => Ok(Entry::Set(value.serialize(ser::statement::set::Serializer.wrap())?)),
+			"Throw" => Ok(Entry::Throw(value.serialize(ser::statement::throw::Serializer.wrap())?)),
+			"Break" => {
+				Ok(Entry::Break(value.serialize(ser::statement::r#break::Serializer.wrap())?))
+			}
 			"Ifelse" => {
 				Ok(Entry::Ifelse(value.serialize(ser::statement::ifelse::Serializer.wrap())?))
 			}
@@ -60,6 +64,15 @@ impl ser::Serializer for Serializer {
 			}
 			"Output" => {
 				Ok(Entry::Output(value.serialize(ser::statement::output::Serializer.wrap())?))
+			}
+			"Define" => {
+				Ok(Entry::Define(value.serialize(ser::statement::define::Serializer.wrap())?))
+			}
+			"Remove" => {
+				Ok(Entry::Remove(value.serialize(ser::statement::remove::Serializer.wrap())?))
+			}
+			"Continue" => {
+				Ok(Entry::Continue(value.serialize(ser::statement::r#continue::Serializer.wrap())?))
 			}
 			variant => Err(Error::custom(format!("unexpected variant `{name}::{variant}`"))),
 		}

--- a/lib/src/sql/value/serde/ser/statement/break.rs
+++ b/lib/src/sql/value/serde/ser/statement/break.rs
@@ -1,0 +1,44 @@
+use crate::err::Error;
+use crate::sql::statements::BreakStatement;
+use crate::sql::value::serde::ser;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = BreakStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<BreakStatement, Error>;
+	type SerializeTuple = Impossible<BreakStatement, Error>;
+	type SerializeTupleStruct = Impossible<BreakStatement, Error>;
+	type SerializeTupleVariant = Impossible<BreakStatement, Error>;
+	type SerializeMap = Impossible<BreakStatement, Error>;
+	type SerializeStruct = Impossible<BreakStatement, Error>;
+	type SerializeStructVariant = Impossible<BreakStatement, Error>;
+
+	const EXPECTED: &'static str = "a unit struct `BreakStatement`";
+
+	#[inline]
+	fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Error> {
+		match name {
+			"BreakStatement" => Ok(BreakStatement),
+			name => Err(Error::custom(format!("unexpected unit struct `{name}`"))),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn default() {
+		let stmt = BreakStatement::default();
+		let value: BreakStatement = stmt.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/continue.rs
+++ b/lib/src/sql/value/serde/ser/statement/continue.rs
@@ -1,0 +1,44 @@
+use crate::err::Error;
+use crate::sql::statements::ContinueStatement;
+use crate::sql::value::serde::ser;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = ContinueStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<ContinueStatement, Error>;
+	type SerializeTuple = Impossible<ContinueStatement, Error>;
+	type SerializeTupleStruct = Impossible<ContinueStatement, Error>;
+	type SerializeTupleVariant = Impossible<ContinueStatement, Error>;
+	type SerializeMap = Impossible<ContinueStatement, Error>;
+	type SerializeStruct = Impossible<ContinueStatement, Error>;
+	type SerializeStructVariant = Impossible<ContinueStatement, Error>;
+
+	const EXPECTED: &'static str = "a unit struct `ContinueStatement`";
+
+	#[inline]
+	fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Error> {
+		match name {
+			"ContinueStatement" => Ok(ContinueStatement),
+			name => Err(Error::custom(format!("unexpected unit struct `{name}`"))),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ser::Serializer as _;
+	use serde::Serialize;
+
+	#[test]
+	fn default() {
+		let stmt = ContinueStatement::default();
+		let value: ContinueStatement = stmt.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/define/mod.rs
+++ b/lib/src/sql/value/serde/ser/statement/define/mod.rs
@@ -18,7 +18,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
-pub(super) struct Serializer;
+pub struct Serializer;
 
 impl ser::Serializer for Serializer {
 	type Ok = DefineStatement;

--- a/lib/src/sql/value/serde/ser/statement/mod.rs
+++ b/lib/src/sql/value/serde/ser/statement/mod.rs
@@ -1,7 +1,9 @@
 pub mod analyze;
 pub mod begin;
+pub mod r#break;
 pub mod cancel;
 pub mod commit;
+pub mod r#continue;
 pub mod create;
 pub mod define;
 pub mod delete;
@@ -18,6 +20,7 @@ pub mod select;
 pub mod set;
 pub mod show;
 pub mod sleep;
+pub mod throw;
 pub mod update;
 pub mod vec;
 pub mod yuse;
@@ -59,8 +62,10 @@ impl ser::Serializer for Serializer {
 		match variant {
 			"Analyze" => Ok(Statement::Analyze(value.serialize(analyze::Serializer.wrap())?)),
 			"Begin" => Ok(Statement::Begin(value.serialize(begin::Serializer.wrap())?)),
+			"Break" => Ok(Statement::Break(value.serialize(r#break::Serializer.wrap())?)),
 			"Cancel" => Ok(Statement::Cancel(value.serialize(cancel::Serializer.wrap())?)),
 			"Commit" => Ok(Statement::Commit(value.serialize(commit::Serializer.wrap())?)),
+			"Continue" => Ok(Statement::Continue(value.serialize(r#continue::Serializer.wrap())?)),
 			"Create" => Ok(Statement::Create(value.serialize(create::Serializer.wrap())?)),
 			"Define" => Ok(Statement::Define(value.serialize(define::Serializer.wrap())?)),
 			"Delete" => Ok(Statement::Delete(value.serialize(delete::Serializer.wrap())?)),
@@ -77,6 +82,7 @@ impl ser::Serializer for Serializer {
 			"Set" => Ok(Statement::Set(value.serialize(set::Serializer.wrap())?)),
 			"Show" => Ok(Statement::Show(value.serialize(show::Serializer.wrap())?)),
 			"Sleep" => Ok(Statement::Sleep(value.serialize(sleep::Serializer.wrap())?)),
+			"Throw" => Ok(Statement::Throw(value.serialize(throw::Serializer.wrap())?)),
 			"Update" => Ok(Statement::Update(value.serialize(update::Serializer.wrap())?)),
 			"Use" => Ok(Statement::Use(value.serialize(yuse::Serializer.wrap())?)),
 			variant => {

--- a/lib/src/sql/value/serde/ser/statement/remove/mod.rs
+++ b/lib/src/sql/value/serde/ser/statement/remove/mod.rs
@@ -18,7 +18,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
-pub(super) struct Serializer;
+pub struct Serializer;
 
 impl ser::Serializer for Serializer {
 	type Ok = RemoveStatement;

--- a/lib/src/sql/value/serde/ser/statement/throw.rs
+++ b/lib/src/sql/value/serde/ser/statement/throw.rs
@@ -1,0 +1,77 @@
+use crate::err::Error;
+use crate::sql::statements::ThrowStatement;
+use crate::sql::value::serde::ser;
+use crate::sql::Strand;
+use ser::Serializer as _;
+use serde::ser::Error as _;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = ThrowStatement;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<ThrowStatement, Error>;
+	type SerializeTuple = Impossible<ThrowStatement, Error>;
+	type SerializeTupleStruct = Impossible<ThrowStatement, Error>;
+	type SerializeTupleVariant = Impossible<ThrowStatement, Error>;
+	type SerializeMap = Impossible<ThrowStatement, Error>;
+	type SerializeStruct = SerializeThrowStatement;
+	type SerializeStructVariant = Impossible<ThrowStatement, Error>;
+
+	const EXPECTED: &'static str = "a struct `ThrowStatement`";
+
+	#[inline]
+	fn serialize_struct(
+		self,
+		_name: &'static str,
+		_len: usize,
+	) -> Result<Self::SerializeStruct, Error> {
+		Ok(SerializeThrowStatement::default())
+	}
+}
+
+#[derive(Default)]
+pub struct SerializeThrowStatement {
+	error: Strand,
+}
+
+impl serde::ser::SerializeStruct for SerializeThrowStatement {
+	type Ok = ThrowStatement;
+	type Error = Error;
+
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match key {
+			"error" => {
+				self.error = Strand(value.serialize(ser::string::Serializer.wrap())?);
+			}
+			key => {
+				return Err(Error::custom(format!("unexpected field `ThrowStatement::{key}`")));
+			}
+		}
+		Ok(())
+	}
+
+	fn end(self) -> Result<Self::Ok, Error> {
+		Ok(ThrowStatement {
+			error: self.error,
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn default() {
+		let stmt = ThrowStatement::default();
+		let value: ThrowStatement = stmt.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(value, stmt);
+	}
+}

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2865,9 +2865,8 @@ pub fn what(i: &str) -> IResult<&str, Value> {
 /// Used to parse any simple JSON-like value
 pub fn json(i: &str) -> IResult<&str, Value> {
 	let _diving = crate::sql::parser::depth::dive()?;
-
 	// Use a specific parser for JSON objects
-	pub fn object(i: &str) -> IResult<&str, Object> {
+	fn object(i: &str) -> IResult<&str, Object> {
 		let (i, _) = char('{')(i)?;
 		let (i, _) = mightbespace(i)?;
 		let (i, v) = separated_list0(commas, |i| {
@@ -2885,7 +2884,7 @@ pub fn json(i: &str) -> IResult<&str, Value> {
 		Ok((i, Object(v.into_iter().collect())))
 	}
 	// Use a specific parser for JSON arrays
-	pub fn array(i: &str) -> IResult<&str, Array> {
+	fn array(i: &str) -> IResult<&str, Array> {
 		let (i, _) = char('[')(i)?;
 		let (i, _) = mightbespace(i)?;
 		let (i, v) = separated_list0(commas, json)(i)?;

--- a/lib/tests/foreach.rs
+++ b/lib/tests/foreach.rs
@@ -1,0 +1,89 @@
+mod parse;
+use parse::Parse;
+use surrealdb::dbs::Session;
+use surrealdb::err::Error;
+use surrealdb::kvs::Datastore;
+use surrealdb::sql::Value;
+
+#[tokio::test]
+async fn foreach() -> Result<(), Error> {
+	let sql = "
+		FOR $test in [1, 2, 3] {
+			IF $test == 2 {
+				BREAK;
+			};
+			UPDATE type::thing('person', $test) SET test = $test;
+		};
+		SELECT * FROM person;
+		FOR $test in [4, 5, 6] {
+			IF $test >= 5 {
+				CONTINUE;
+			};
+			UPDATE type::thing('person', $test) SET test = $test;
+		};
+		SELECT * FROM person;
+		FOR $test in [7, 8, 9] {
+			IF $test > 8 {
+				THROW 'This is an error';
+			};
+			UPDATE type::thing('person', $test) SET test = $test;
+		};
+		SELECT * FROM person;
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 6);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:1,
+				test: 1,
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:1,
+				test: 1,
+			},
+			{
+				id: person:4,
+				test: 4,
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_err());
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:1,
+				test: 1,
+			},
+			{
+				id: person:4,
+				test: 4,
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`FOREACH`, `BREAK`, and `CONTINUE` statements were included, but not fully implemented. In addition, there was no support for `THROW` statements, or `DEFINE` and `REMOVE` statements within code blocks.

## What does this change do?

This pull request adds support for `FOREACH`, `BREAK`, and `CONTINUE ` statements, in addition to allowing `THROW`, `DEFINE`, and `REMOVE` statements inside code blocks.

This pull request also enables code-like `IF ELSE` statements:
```sql
if this {
    "this was true"
} else {
    "this wasn't true"
}
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2471.
Closes #2459.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
