### PR TITLE
Ensure foreach range is computed before iterating over

### DIFF
--- a/lib/src/sql/statements/foreach.rs
+++ b/lib/src/sql/statements/foreach.rs
@@ -35,7 +35,7 @@ impl ForeachStatement {
 		doc: Option<&CursorDoc<'_>>,
 	) -> Result<Value, Error> {
 		// Check the loop data
-		match &self.range {
+		match &self.range.compute(ctx, opt, txn, doc).await? {
 			Value::Array(arr) => {
 				// Loop over the values
 				'foreach: for v in arr.iter() {

--- a/lib/tests/foreach.rs
+++ b/lib/tests/foreach.rs
@@ -16,13 +16,13 @@ async fn foreach() -> Result<(), Error> {
 		};
 		SELECT * FROM person;
 		FOR $test in [4, 5, 6] {
-			IF $test >= 5 {
+			IF $test == 5 {
 				CONTINUE;
 			};
 			UPDATE type::thing('person', $test) SET test = $test;
 		};
 		SELECT * FROM person;
-		FOR $test in [7, 8, 9] {
+		FOR $test in <future> { [7, 8, 9] } {
 			IF $test > 8 {
 				THROW 'This is an error';
 			};
@@ -63,6 +63,10 @@ async fn foreach() -> Result<(), Error> {
 				id: person:4,
 				test: 4,
 			},
+			{
+				id: person:6,
+				test: 6,
+			},
 		]",
 	);
 	assert_eq!(tmp, val);
@@ -80,6 +84,10 @@ async fn foreach() -> Result<(), Error> {
 			{
 				id: person:4,
 				test: 4,
+			},
+			{
+				id: person:6,
+				test: 6,
 			},
 		]",
 	);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The range specified in a `foreach` statement is not computed before being processed. This means that any arrays within parameters can not be used as the basis of a foreach statement.

## What does this change do?

Ensures that the range in a `foreach` statement is computed before attempting to iterate over it.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
