### PR TITLE
include define and remove statements in subquery #2459

### DIFF
--- a/lib/src/sql/subquery.rs
+++ b/lib/src/sql/subquery.rs
@@ -63,8 +63,8 @@ impl Subquery {
 			Self::Delete(v) => v.writeable(),
 			Self::Relate(v) => v.writeable(),
 			Self::Insert(v) => v.writeable(),
-			Self::Define(_) => true,
-			Self::Remove(_) => true,
+			Self::Define(v) => v.writeable(),
+			Self::Remove(v) => v.writeable(),
 		}
 	}
 	/// Process this type returning a computed simple Value

--- a/lib/src/sql/subquery.rs
+++ b/lib/src/sql/subquery.rs
@@ -322,7 +322,10 @@ mod tests {
 		let res = subquery(sql);
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
-		assert_eq!("(DEFINE EVENT foo ON bar WHEN $event = 'CREATE' THEN (CREATE x SET y = 1))", format!("{}", out))
+		assert_eq!(
+			"(DEFINE EVENT foo ON bar WHEN $event = 'CREATE' THEN (CREATE x SET y = 1))",
+			format!("{}", out)
+		)
 	}
 
 	#[test]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

It is especially useful to be able to do dynamic DEFINE and REMOVE (e.g. DEFINE EVENT) in the `THEN` statement of DEFINE EVENT, as in the following example:

```sql
BEGIN TRANSACTION;
DEFINE EVENT define_event ON event WHEN $event = 'CREATE' OR $event = 'UPDATE' THEN (function($value) {
	const value = arguments[0]
	return await surrealdb.query(`DEFINE EVENT ${value.name} ON ${value.table} WHEN ${value.condition} THEN (${value.statement})`)
});
CREATE event SET name = "foo_event", table = "foo", condition = "$event = 'CREATE'", statement = "CREATE bar SET x = 1";
CREATE foo SET a = 1;
SELECT * FROM bar;
COMMIT TRANSACTION;
```

## What does this change do?

Allows DEFINE AND REMOVE in subqueries, and therefore in a script's `surrealdb.query`.

## What is your testing strategy?

Included tests according to the existing test format in the changed file.

## Is this related to any issues?

#2459

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
