### PR TITLE
Ensure comments are output with `DEFINE` statements

### DIFF
--- a/lib/src/sql/statements/define/event.rs
+++ b/lib/src/sql/statements/define/event.rs
@@ -66,7 +66,11 @@ impl Display for DefineEventStatement {
 			f,
 			"DEFINE EVENT {} ON {} WHEN {} THEN {}",
 			self.name, self.what, self.when, self.then
-		)
+		)?;
+		if let Some(ref v) = self.comment {
+			write!(f, " COMMENT {v}")?
+		}
+		Ok(())
 	}
 }
 

--- a/lib/src/sql/statements/define/field.rs
+++ b/lib/src/sql/statements/define/field.rs
@@ -84,6 +84,9 @@ impl Display for DefineFieldStatement {
 		if let Some(ref v) = self.assert {
 			write!(f, " ASSERT {v}")?
 		}
+		if let Some(ref v) = self.comment {
+			write!(f, " COMMENT {v}")?
+		}
 		if !self.permissions.is_full() {
 			write!(f, " {}", self.permissions)?;
 		}

--- a/lib/src/sql/statements/define/index.rs
+++ b/lib/src/sql/statements/define/index.rs
@@ -90,6 +90,9 @@ impl Display for DefineIndexStatement {
 		if Index::Idx != self.index {
 			write!(f, " {}", self.index)?;
 		}
+		if let Some(ref v) = self.comment {
+			write!(f, " COMMENT {v}")?
+		}
 		Ok(())
 	}
 }

--- a/lib/src/sql/statements/define/param.rs
+++ b/lib/src/sql/statements/define/param.rs
@@ -55,7 +55,11 @@ impl DefineParamStatement {
 
 impl Display for DefineParamStatement {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "DEFINE PARAM ${} VALUE {}", self.name, self.value)
+		write!(f, "DEFINE PARAM ${} VALUE {}", self.name, self.value)?;
+		if let Some(ref v) = self.comment {
+			write!(f, " COMMENT {v}")?
+		}
+		Ok(())
 	}
 }
 

--- a/lib/src/sql/statements/define/scope.rs
+++ b/lib/src/sql/statements/define/scope.rs
@@ -70,6 +70,9 @@ impl Display for DefineScopeStatement {
 		if let Some(ref v) = self.signin {
 			write!(f, " SIGNIN {v}")?
 		}
+		if let Some(ref v) = self.comment {
+			write!(f, " COMMENT {v}")?
+		}
 		Ok(())
 	}
 }

--- a/lib/src/sql/statements/define/table.rs
+++ b/lib/src/sql/statements/define/table.rs
@@ -113,6 +113,9 @@ impl Display for DefineTableStatement {
 		} else {
 			" SCHEMALESS"
 		})?;
+		if let Some(ref v) = self.comment {
+			write!(f, " COMMENT {v}")?
+		}
 		if let Some(ref v) = self.view {
 			write!(f, " {v}")?
 		}

--- a/lib/src/sql/statements/define/user.rs
+++ b/lib/src/sql/statements/define/user.rs
@@ -128,7 +128,11 @@ impl Display for DefineUserStatement {
 			Fmt::comma_separated(
 				&self.roles.iter().map(|r| r.to_string().to_uppercase()).collect::<Vec<String>>()
 			)
-		)
+		)?;
+		if let Some(ref v) = self.comment {
+			write!(f, " COMMENT {v}")?
+		}
+		Ok(())
 	}
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Some `DEFINE` statements did not display the `COMMENT` clause when being output in SurrealQL.

## What does this change do?

Ensures all `DEFINE` statement types display the `COMMENT` clause when formatted.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2498.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
