### PR TITLE
Default to `true` if a `WHEN` clause is omitted on `DEFINE EVENT` statements

### DIFF
--- a/lib/src/sql/statements/define/event.rs
+++ b/lib/src/sql/statements/define/event.rs
@@ -86,6 +86,7 @@ pub fn event(i: &str) -> IResult<&str, DefineEventStatement> {
 	let mut res = DefineEventStatement {
 		name,
 		what,
+		when: Value::Bool(true),
 		..Default::default()
 	};
 	// Assign any defined options


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Now that it is possible to omit the `WHEN` clause in a `DEFINE EVENT` statement, we should default to true, so that the event is actually run.

## What does this change do?

Ensures that an event is run when the `WHEN` clause is omitted.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2499.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
