### PR TITLE
Ensure edge `in` and `out` fields are not overwritten

### DIFF
--- a/lib/src/doc/document.rs
+++ b/lib/src/doc/document.rs
@@ -108,6 +108,10 @@ impl<'a> Document<'a> {
 	pub fn is_new(&self) -> bool {
 		self.initial.doc.is_none()
 	}
+	/// Check if this is a graph edge
+	pub fn is_edge(&self) -> bool {
+		matches!(self.extras, Workable::Relate(_, _))
+	}
 	/// Get the table for this document
 	pub async fn tb(
 		&self,

--- a/lib/src/doc/document.rs
+++ b/lib/src/doc/document.rs
@@ -108,10 +108,6 @@ impl<'a> Document<'a> {
 	pub fn is_new(&self) -> bool {
 		self.initial.doc.is_none()
 	}
-	/// Check if this is a graph edge
-	pub fn is_edge(&self) -> bool {
-		matches!(self.extras, Workable::Relate(_, _))
-	}
 	/// Get the table for this document
 	pub async fn tb(
 		&self,

--- a/lib/src/doc/reset.rs
+++ b/lib/src/doc/reset.rs
@@ -22,7 +22,7 @@ impl<'a> Document<'a> {
 		// Set default field values
 		self.current.doc.to_mut().def(rid);
 		// Ensure edge fields are reset
-		if self.initial.doc.pick(&*EDGE).is_true() {
+		if self.is_edge() || self.initial.doc.pick(&*EDGE).is_true() {
 			self.current.doc.to_mut().put(&*EDGE, Value::Bool(true));
 			self.current.doc.to_mut().put(&*IN, self.initial.doc.pick(&*IN));
 			self.current.doc.to_mut().put(&*OUT, self.initial.doc.pick(&*OUT));

--- a/lib/src/doc/reset.rs
+++ b/lib/src/doc/reset.rs
@@ -2,6 +2,7 @@ use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::dbs::Statement;
 use crate::dbs::Transaction;
+use crate::dbs::Workable;
 use crate::doc::Document;
 use crate::err::Error;
 use crate::sql::paths::EDGE;
@@ -21,8 +22,14 @@ impl<'a> Document<'a> {
 		let rid = self.id.as_ref().unwrap();
 		// Set default field values
 		self.current.doc.to_mut().def(rid);
-		// Ensure edge fields are reset
-		if self.is_edge() || self.initial.doc.pick(&*EDGE).is_true() {
+		// This is a RELATE statement, so reset fields
+		if let Workable::Relate(l, r) = &self.extras {
+			self.current.doc.to_mut().put(&*EDGE, Value::Bool(true));
+			self.current.doc.to_mut().put(&*IN, l.clone().into());
+			self.current.doc.to_mut().put(&*OUT, r.clone().into());
+		}
+		// This is an UPDATE of a graph edge, so reset fields
+		if self.initial.doc.pick(&*EDGE).is_true() {
 			self.current.doc.to_mut().put(&*EDGE, Value::Bool(true));
 			self.current.doc.to_mut().put(&*IN, self.initial.doc.pick(&*IN));
 			self.current.doc.to_mut().put(&*OUT, self.initial.doc.pick(&*OUT));

--- a/lib/tests/relate.rs
+++ b/lib/tests/relate.rs
@@ -10,7 +10,7 @@ async fn relate_with_parameters() -> Result<(), Error> {
 	let sql = "
 		LET $tobie = person:tobie;
 		LET $jaime = person:jaime;
-		RELATE $tobie->knows->$jaime SET id = knows:test;
+		RELATE $tobie->knows->$jaime SET id = knows:test, brother = true;
 	";
 	let dbs = Datastore::new("memory").await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
@@ -32,6 +32,7 @@ async fn relate_with_parameters() -> Result<(), Error> {
 				id: knows:test,
 				in: person:tobie,
 				out: person:jaime,
+				brother: true,
 			}
 		]",
 	);
@@ -45,7 +46,7 @@ async fn relate_and_overwrite() -> Result<(), Error> {
 	let sql = "
 		LET $tobie = person:tobie;
 		LET $jaime = person:jaime;
-		RELATE $tobie->knows->$jaime SET id = knows:test;
+		RELATE $tobie->knows->$jaime CONTENT { id: knows:test, brother: true };
 		UPDATE knows:test CONTENT { test: true };
 		SELECT * FROM knows:test;
 	";
@@ -69,6 +70,7 @@ async fn relate_and_overwrite() -> Result<(), Error> {
 				id: knows:test,
 				in: person:tobie,
 				out: person:jaime,
+				brother: true,
 			}
 		]",
 	);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When using `CONTENT` or `REPLACE` clauses on a `RELATE` statement, the `in` and `out` fields were overwritten and removed.

## What does this change do?

Ensures using `CONTENT` or `REPLACE` on an edge record does not overwrite `in` and `out` fields.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2504.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
