### PR TITLE
Enable parsing raw values at base of query

### DIFF
--- a/lib/tests/query.rs
+++ b/lib/tests/query.rs
@@ -1,0 +1,162 @@
+mod parse;
+use parse::Parse;
+use surrealdb::dbs::Session;
+use surrealdb::err::Error;
+use surrealdb::kvs::Datastore;
+use surrealdb::sql::Value;
+
+#[tokio::test]
+async fn query_basic() -> Result<(), Error> {
+	let sql = "
+		LET $test = 'Tobie';
+		SELECT * FROM $test;
+		RETURN $test;
+		$test;
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 4);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::None;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("['Tobie']");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from("Tobie");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from("Tobie");
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
+async fn query_basic_with_modification() -> Result<(), Error> {
+	let sql = "
+		LET $test = 33693;
+		SELECT * FROM $test + 11369;
+		RETURN $test + 11369;
+		$test + 11369;
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 4);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::None;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[45062]");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from(45062);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from(45062);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
+async fn query_root_function() -> Result<(), Error> {
+	let sql = "
+		LET $test = 'This is a test';
+		string::uppercase($test);
+		string::lowercase($test);
+		string::slug($test);
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 4);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::None;
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from("THIS IS A TEST");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from("this is a test");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from("this-is-a-test");
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
+async fn query_root_record() -> Result<(), Error> {
+	let sql = "
+		UPDATE person:tobie SET name = 'Tobie';
+		UPDATE person:jaime SET name = 'Jaime';
+		RELATE person:tobie->knows->person:jaime SET id = 'test', brother = true;
+		<future> { person:tobie->knows->person.name };
+		person:tobie->knows->person.name;
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 5);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:tobie,
+				name: 'Tobie'
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:jaime,
+				name: 'Jaime'
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: knows:test,
+				in: person:tobie,
+				out: person:jaime,
+				brother: true,
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("['Jaime']");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("['Jaime']");
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently in order to execute arbitrary SurrealQL one must use a `RETURN` statement, or `SELECT` statement. This shouldn't be strictly necessary, and adds some bloat to the SurrealQL queries. In addition, code blocks and subqueries already allow specifying a SurrealQL value without being part of a statement, but at the base of a SurrealQL query, this is not possible.

## What does this change do?

Enables parsing and executing SurrealQL values at the base of a SurrealQL query, meaning that a `RETURN` statement does not need to be used to execute values. This enables more programming-like behaviour in SurrealQL if desired, and is perfect for data composition and data-science related use cases.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #1776.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
