### PR TITLE
[ci] Pin the Rust version

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.71.1
           components: rustfmt
 
       - name: Checkout sources
@@ -50,7 +51,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -82,8 +85,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.71.1
           targets: wasm32-unknown-unknown
 
       - name: Checkout sources
@@ -112,8 +116,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.71.1
           components: clippy
 
       - name: Checkout sources
@@ -146,7 +151,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -188,7 +195,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -220,7 +229,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -252,7 +263,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -307,7 +320,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -353,7 +368,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -399,7 +416,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -445,7 +464,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -473,7 +494,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -501,7 +524,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -529,7 +554,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -557,7 +584,9 @@ jobs:
      steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -603,7 +632,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -86,8 +88,9 @@ jobs:
           sudo apt-get -y update
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.71.1
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 
@@ -183,8 +186,9 @@ jobs:
           rm -rf foundationdb-clients_6.3.23-1_amd64.deb
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.71.1
           targets: ${{ matrix.arch }}
 
       - name: Output package versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,9 @@ jobs:
     steps:
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.71.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -86,8 +88,9 @@ jobs:
           sudo apt-get -y update
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.71.1
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 
@@ -183,8 +186,9 @@ jobs:
           rm -rf foundationdb-clients_6.3.23-1_amd64.deb
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: 1.71.1
           targets: ${{ matrix.arch }}
 
       - name: Output package versions


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The new Rust version `1.72.0` treats some warnings as errors that were not errors in `1.71.1` (see https://github.com/surrealdb/surrealdb/actions/runs/5964796701)

Also, it's a general best practice to pin versions.

## What does this change do?

Pin the Rust version for Github Actions to `1.71.1`

## What is your testing strategy?

See if CI is green

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
