### PR TITLE
Add `null` as a specific field type

### DIFF
--- a/lib/src/sql/kind.rs
+++ b/lib/src/sql/kind.rs
@@ -19,6 +19,7 @@ use std::fmt::{self, Display, Formatter};
 #[revisioned(revision = 1)]
 pub enum Kind {
 	Any,
+	Null,
 	Bool,
 	Bytes,
 	Datetime,
@@ -62,6 +63,7 @@ impl Display for Kind {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Kind::Any => f.write_str("any"),
+			Kind::Null => f.write_str("null"),
 			Kind::Bool => f.write_str("bool"),
 			Kind::Bytes => f.write_str("bytes"),
 			Kind::Datetime => f.write_str("datetime"),
@@ -109,6 +111,7 @@ pub fn any(i: &str) -> IResult<&str, Kind> {
 pub fn simple(i: &str) -> IResult<&str, Kind> {
 	alt((
 		map(tag("bool"), |_| Kind::Bool),
+		map(tag("null"), |_| Kind::Null),
 		map(tag("bytes"), |_| Kind::Bytes),
 		map(tag("datetime"), |_| Kind::Datetime),
 		map(tag("decimal"), |_| Kind::Decimal),
@@ -264,6 +267,16 @@ mod tests {
 		let out = res.unwrap().1;
 		assert_eq!("any", format!("{}", out));
 		assert_eq!(out, Kind::Any);
+	}
+
+	#[test]
+	fn kind_null() {
+		let sql = "null";
+		let res = kind(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!("null", format!("{}", out));
+		assert_eq!(out, Kind::Null);
 	}
 
 	#[test]

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -1149,6 +1149,7 @@ impl Value {
 		// Attempt to convert to the desired type
 		let res = match kind {
 			Kind::Any => Ok(self),
+			Kind::Null => self.coerce_to_null(),
 			Kind::Bool => self.coerce_to_bool().map(Value::from),
 			Kind::Int => self.coerce_to_int().map(Value::from),
 			Kind::Float => self.coerce_to_float().map(Value::from),
@@ -1179,7 +1180,6 @@ impl Value {
 			},
 			Kind::Option(k) => match self {
 				Self::None => Ok(Self::None),
-				Self::Null => Ok(Self::None),
 				v => v.coerce_to(k),
 			},
 			Kind::Either(k) => {
@@ -1288,6 +1288,19 @@ impl Value {
 			_ => Err(Error::CoerceTo {
 				from: self,
 				into: "f64".into(),
+			}),
+		}
+	}
+
+	/// Try to coerce this value to a `null`
+	pub(crate) fn coerce_to_null(self) -> Result<Value, Error> {
+		match self {
+			// Allow any null value
+			Value::Null => Ok(Value::Null),
+			// Anything else raises an error
+			_ => Err(Error::CoerceTo {
+				from: self,
+				into: "null".into(),
 			}),
 		}
 	}
@@ -1675,6 +1688,7 @@ impl Value {
 		// Attempt to convert to the desired type
 		let res = match kind {
 			Kind::Any => Ok(self),
+			Kind::Null => self.convert_to_null(),
 			Kind::Bool => self.convert_to_bool().map(Value::from),
 			Kind::Int => self.convert_to_int().map(Value::from),
 			Kind::Float => self.convert_to_float().map(Value::from),
@@ -1705,7 +1719,6 @@ impl Value {
 			},
 			Kind::Option(k) => match self {
 				Self::None => Ok(Self::None),
-				Self::Null => Ok(Self::None),
 				v => v.convert_to(k),
 			},
 			Kind::Either(k) => {
@@ -1740,6 +1753,19 @@ impl Value {
 			Err(e) => Err(e),
 			// Everything converted ok
 			Ok(v) => Ok(v),
+		}
+	}
+
+	/// Try to convert this value to a `null`
+	pub(crate) fn convert_to_null(self) -> Result<Value, Error> {
+		match self {
+			// Allow any boolean value
+			Value::Null => Ok(Value::Null),
+			// Anything else raises an error
+			_ => Err(Error::ConvertTo {
+				from: self,
+				into: "null".into(),
+			}),
 		}
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently, if we have a field which is defined as `option<T>`, and we wish to set it to `NULL` then the field is removed (and is effectively set to `NONE`). This means that we can't use `NULL` as a specific value in an optional field. So for example the following query fails:

```sql
DEFINE TABLE person SCHEMAFULL;
DEFINE FIELD name ON TABLE person TYPE option<string>;
UPDATE person:test SET name = "Tobie"; -- This works
UPDATE person:test SET name = NULL; -- This fails
UPDATE person:test SET name = NONE; -- This works
```

## What does this change do?

This pull request adds `null` as a new field type, allowing us specify precisely whether we want to allow `null` values on a field. So we could now use the following SurrealQL to allow this behaviour:

```sql
DEFINE TABLE person SCHEMAFULL;
DEFINE FIELD name ON TABLE person TYPE option<string | null>;
UPDATE person:test SET name = "Tobie"; -- This works
UPDATE person:test SET name = NULL; -- This works
UPDATE person:test SET name = NONE; -- This works
```

Alternatively, if we wanted to ensure that the field is always present, but is allowed to be a string or a `null` value, then we could do:

```sql
DEFINE TABLE person SCHEMAFULL;
DEFINE FIELD name ON TABLE person TYPE string | null;
UPDATE person:test SET name = "Tobie"; -- This works
UPDATE person:test SET name = NULL; -- This works
UPDATE person:test SET name = NONE; -- This fails
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2149.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
