### PR TITLE
Support arbitrary number of arrays in `array::concat()`

### DIFF
--- a/lib/src/fnc/args.rs
+++ b/lib/src/fnc/args.rs
@@ -117,6 +117,20 @@ impl FromArgs for Vec<Value> {
 	}
 }
 
+impl FromArgs for Vec<Array> {
+	fn from_args(name: &str, args: Vec<Value>) -> Result<Self, Error> {
+		args.into_iter()
+			.enumerate()
+			.map(|(i, arg)| {
+				arg.coerce_to_array_type(&Kind::Any).map_err(|e| Error::InvalidArguments {
+					name: name.to_owned(),
+					message: format!("Argument {} was the wrong type. {e}", i + 1),
+				})
+			})
+			.collect()
+	}
+}
+
 /// Some functions take a fixed number of arguments.
 /// The len must match the number of type idents that follow.
 macro_rules! impl_tuple {

--- a/lib/src/fnc/array.rs
+++ b/lib/src/fnc/array.rs
@@ -117,8 +117,8 @@ pub fn concat(mut arrays: Vec<Array>) -> Result<Value, Error> {
 		Some(l) => Ok(l),
 	}?;
 	let mut arr = Array::with_capacity(len);
-	arrays.iter_mut().for_each(|mut val| {
-		arr.append(&mut val);
+	arrays.iter_mut().for_each(|val| {
+		arr.append(val);
 	});
 	Ok(arr.into())
 }

--- a/lib/src/fnc/array.rs
+++ b/lib/src/fnc/array.rs
@@ -3,7 +3,6 @@ use crate::sql::array::Array;
 use crate::sql::array::Clump;
 use crate::sql::array::Combine;
 use crate::sql::array::Complement;
-use crate::sql::array::Concat;
 use crate::sql::array::Difference;
 use crate::sql::array::Flatten;
 use crate::sql::array::Intersect;
@@ -109,8 +108,19 @@ pub fn complement((array, other): (Array, Array)) -> Result<Value, Error> {
 	Ok(array.complement(other).into())
 }
 
-pub fn concat((array, other): (Array, Array)) -> Result<Value, Error> {
-	Ok(array.concat(other).into())
+pub fn concat(mut arrays: Vec<Array>) -> Result<Value, Error> {
+	let len = match arrays.iter().map(Array::len).reduce(|c, v| c + v) {
+		None => Err(Error::InvalidArguments {
+			name: String::from("array::concat"),
+			message: String::from("Expected at least one argument"),
+		}),
+		Some(l) => Ok(l),
+	}?;
+	let mut arr = Array::with_capacity(len);
+	arrays.iter_mut().for_each(|mut val| {
+		arr.append(&mut val);
+	});
+	Ok(arr.into())
 }
 
 pub fn difference((array, other): (Array, Array)) -> Result<Value, Error> {

--- a/lib/src/sql/array.rs
+++ b/lib/src/sql/array.rs
@@ -121,6 +121,10 @@ impl Array {
 	pub fn len(&self) -> usize {
 		self.0.len()
 	}
+	// Check if there array is empty
+	pub fn is_empty(&self) -> bool {
+		self.0.is_empty()
+	}
 }
 
 impl Array {
@@ -409,7 +413,7 @@ pub(crate) trait Transpose<T> {
 
 impl Transpose<Array> for Array {
 	fn transpose(self) -> Array {
-		if self.len() == 0 {
+		if self.is_empty() {
 			return self;
 		}
 		// I'm sure there's a way more efficient way to do this that I don't know about.

--- a/lib/src/sql/array.rs
+++ b/lib/src/sql/array.rs
@@ -109,12 +109,17 @@ impl IntoIterator for Array {
 }
 
 impl Array {
+	// Create a new empty array
 	pub fn new() -> Self {
 		Self::default()
 	}
-
+	// Create a new array with capacity
 	pub fn with_capacity(len: usize) -> Self {
 		Self(Vec::with_capacity(len))
+	}
+	// Get the length of the array
+	pub fn len(&self) -> usize {
+		self.0.len()
 	}
 }
 

--- a/src/rpc/args.rs
+++ b/src/rpc/args.rs
@@ -10,7 +10,7 @@ pub trait Take {
 impl Take for Array {
 	/// Convert the array to one argument
 	fn needs_one(self) -> Result<Value, ()> {
-		if self.len() < 1 {
+		if self.is_empty() {
 			return Err(());
 		}
 		let mut x = self.into_iter();
@@ -33,7 +33,7 @@ impl Take for Array {
 	}
 	/// Convert the array to two arguments
 	fn needs_one_or_two(self) -> Result<(Value, Value), ()> {
-		if self.len() < 1 {
+		if self.is_empty() {
 			return Err(());
 		}
 		let mut x = self.into_iter();


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently it is only possible to concatenate 2 arrays together using the `array::concat()` function:

```sql
RETURN array::concat(
    [1,2,3],
    [4,5,6],
);
```

To concatenate more arrays together in a single function it is possible to use the `array::flatten()` function, and use a surrounding array:

```sql
RETURN array::flatten([
    [1,2,3],
    [4,5,6],
    [7,8,9],
]);
```

## What does this change do?

Enables support for an arbitrary number of arrays inside the `array::concat()` function:

```sql
RETURN array::concat(
    [1,2,3],
    [4,5,6],
    [7,8,9],
);
```

## What is your testing strategy?

Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

Closes #2277.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
