### PR TITLE
Serialise `Kind::Null` variant

### DIFF
--- a/lib/src/sql/value/serde/ser/kind/mod.rs
+++ b/lib/src/sql/value/serde/ser/kind/mod.rs
@@ -34,6 +34,7 @@ impl ser::Serializer for Serializer {
 	) -> Result<Self::Ok, Error> {
 		match variant {
 			"Any" => Ok(Kind::Any),
+			"Null" => Ok(Kind::Null),
 			"Bool" => Ok(Kind::Bool),
 			"Bytes" => Ok(Kind::Bytes),
 			"Datetime" => Ok(Kind::Datetime),


### PR DESCRIPTION
## What is the motivation?

Noticed https://github.com/surrealdb/surrealdb/pull/2524 added this variant but did not include it in the serialiser.

## What does this change do?

Adds it to the `Kind` serialiser.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
