### PR TITLE
Add support for `OMIT` clause in `SELECT` statements

### DIFF
--- a/lib/src/dbs/statement.rs
+++ b/lib/src/dbs/statement.rs
@@ -3,6 +3,7 @@ use crate::sql::data::Data;
 use crate::sql::fetch::Fetchs;
 use crate::sql::field::Fields;
 use crate::sql::group::Groups;
+use crate::sql::idiom::Idioms;
 use crate::sql::limit::Limit;
 use crate::sql::order::Orders;
 use crate::sql::output::Output;
@@ -111,6 +112,14 @@ impl<'a> Statement<'a> {
 		match self {
 			Statement::Select(v) => Some(&v.expr),
 			Statement::Live(v) => Some(&v.expr),
+			_ => None,
+		}
+	}
+	/// Returns any OMIT clause if specified
+	#[inline]
+	pub fn omit(&self) -> Option<&Idioms> {
+		match self {
+			Statement::Select(v) => v.omit.as_ref(),
 			_ => None,
 		}
 	}

--- a/lib/src/doc/pluck.rs
+++ b/lib/src/doc/pluck.rs
@@ -91,6 +91,12 @@ impl<'a> Document<'a> {
 				}
 			}
 		}
+		// Remove any omitted fields from output
+		if let Some(v) = stm.omit() {
+			for v in v.iter() {
+				out.del(ctx, opt, txn, v).await?;
+			}
+		}
 		// Remove metadata fields on output
 		out.del(ctx, opt, txn, &*META).await?;
 		// Output result

--- a/lib/src/sql/idiom.rs
+++ b/lib/src/sql/idiom.rs
@@ -34,6 +34,14 @@ impl Deref for Idioms {
 	}
 }
 
+impl IntoIterator for Idioms {
+	type Item = Idiom;
+	type IntoIter = std::vec::IntoIter<Self::Item>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.into_iter()
+	}
+}
+
 impl Display for Idioms {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&Fmt::comma_separated(&self.0), f)

--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod limit;
 pub(crate) mod model;
 pub(crate) mod number;
 pub(crate) mod object;
+pub(crate) mod omit;
 pub(crate) mod operation;
 pub(crate) mod operator;
 pub(crate) mod order;

--- a/lib/src/sql/omit.rs
+++ b/lib/src/sql/omit.rs
@@ -19,17 +19,15 @@ mod tests {
 	fn omit_statement() {
 		let sql = "OMIT field";
 		let res = omit(sql);
-		assert!(res.is_ok());
 		let out = res.unwrap().1;
-		assert_eq!("OMIT field", format!("{}", out));
+		assert_eq!("field", format!("{}", out));
 	}
 
 	#[test]
 	fn omit_statement_multiple() {
 		let sql = "OMIT field, other.field";
 		let res = omit(sql);
-		assert!(res.is_ok());
 		let out = res.unwrap().1;
-		assert_eq!("OMIT field, other.field", format!("{}", out));
+		assert_eq!("field, other.field", format!("{}", out));
 	}
 }

--- a/lib/src/sql/omit.rs
+++ b/lib/src/sql/omit.rs
@@ -1,0 +1,35 @@
+use crate::sql::comment::shouldbespace;
+use crate::sql::error::IResult;
+use crate::sql::idiom::{locals as idioms, Idioms};
+use nom::bytes::complete::tag_no_case;
+
+pub fn omit(i: &str) -> IResult<&str, Idioms> {
+	let (i, _) = tag_no_case("OMIT")(i)?;
+	let (i, _) = shouldbespace(i)?;
+	let (i, v) = idioms(i)?;
+	Ok((i, v))
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+
+	#[test]
+	fn omit_statement() {
+		let sql = "OMIT field";
+		let res = omit(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!("OMIT field", format!("{}", out));
+	}
+
+	#[test]
+	fn omit_statement_multiple() {
+		let sql = "OMIT field, other.field";
+		let res = omit(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!("OMIT field, other.field", format!("{}", out));
+	}
+}

--- a/lib/src/sql/value/serde/ser/idiom/vec/mod.rs
+++ b/lib/src/sql/value/serde/ser/idiom/vec/mod.rs
@@ -1,3 +1,5 @@
+pub mod opt;
+
 use crate::err::Error;
 use crate::sql::value::serde::ser;
 use crate::sql::Idiom;

--- a/lib/src/sql/value/serde/ser/idiom/vec/opt.rs
+++ b/lib/src/sql/value/serde/ser/idiom/vec/opt.rs
@@ -1,0 +1,55 @@
+use crate::err::Error;
+use crate::sql::value::serde::ser;
+use crate::sql::Idiom;
+use serde::ser::Impossible;
+use serde::ser::Serialize;
+
+pub struct Serializer;
+
+impl ser::Serializer for Serializer {
+	type Ok = Option<Vec<Idiom>>;
+	type Error = Error;
+
+	type SerializeSeq = Impossible<Option<Vec<Idiom>>, Error>;
+	type SerializeTuple = Impossible<Option<Vec<Idiom>>, Error>;
+	type SerializeTupleStruct = Impossible<Option<Vec<Idiom>>, Error>;
+	type SerializeTupleVariant = Impossible<Option<Vec<Idiom>>, Error>;
+	type SerializeMap = Impossible<Option<Vec<Idiom>>, Error>;
+	type SerializeStruct = Impossible<Option<Vec<Idiom>>, Error>;
+	type SerializeStructVariant = Impossible<Option<Vec<Idiom>>, Error>;
+
+	const EXPECTED: &'static str = "an `Option<Vec<Idiom>>`";
+
+	#[inline]
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(None)
+	}
+
+	#[inline]
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		Ok(Some(value.serialize(super::Serializer.wrap())?))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ser::Serializer as _;
+
+	#[test]
+	fn none() {
+		let option: Option<Vec<Idiom>> = None;
+		let serialized = option.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(option, serialized);
+	}
+
+	#[test]
+	fn some() {
+		let option = Some(vec![Idiom::default()]);
+		let serialized = option.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(option, serialized);
+	}
+}

--- a/lib/src/sql/value/serde/ser/statement/select.rs
+++ b/lib/src/sql/value/serde/ser/statement/select.rs
@@ -7,6 +7,7 @@ use crate::sql::Cond;
 use crate::sql::Fetchs;
 use crate::sql::Fields;
 use crate::sql::Groups;
+use crate::sql::Idioms;
 use crate::sql::Limit;
 use crate::sql::Orders;
 use crate::sql::Splits;
@@ -48,6 +49,7 @@ impl ser::Serializer for Serializer {
 #[derive(Default)]
 pub struct SerializeSelectStatement {
 	expr: Option<Fields>,
+	omit: Option<Idioms>,
 	what: Option<Values>,
 	with: Option<With>,
 	cond: Option<Cond>,
@@ -74,6 +76,9 @@ impl serde::ser::SerializeStruct for SerializeSelectStatement {
 		match key {
 			"expr" => {
 				self.expr = Some(value.serialize(ser::fields::Serializer.wrap())?);
+			}
+			"omit" => {
+				self.omit = value.serialize(ser::idiom::vec::opt::Serializer.wrap())?.map(Idioms);
 			}
 			"what" => {
 				self.what = Some(Values(value.serialize(ser::value::vec::Serializer.wrap())?));
@@ -125,6 +130,7 @@ impl serde::ser::SerializeStruct for SerializeSelectStatement {
 		match (self.expr, self.what, self.parallel) {
 			(Some(expr), Some(what), Some(parallel)) => Ok(SelectStatement {
 				expr,
+				omit: self.omit,
 				what,
 				with: self.with,
 				parallel,


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently there isn't an idiomatic way of removing field expressions from the output of a `SELECT` statement. The current method is to use `NONE` aliased to the field name, or path:

```sql
SELECT *, NONE AS password, NONE AS options.security FROM user;
```

## What does this change do?

This pull request adds support for omitting certain fields from records as they are output in a `SELECT` statement using the `OMIT` keyword:

```sql
SELECT * OMIT password, options.security FROM user;
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #1219.
Closes #2194.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
