### PR TITLE
Make `patch` return the patched record

### DIFF
--- a/lib/src/api/engine/mod.rs
+++ b/lib/src/api/engine/mod.rs
@@ -98,7 +98,7 @@ fn patch_statement(params: &mut [Value]) -> (bool, UpdateStatement) {
 		UpdateStatement {
 			what,
 			data,
-			output: Some(Output::Diff),
+			output: Some(Output::After),
 			..Default::default()
 		},
 	)

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -571,6 +571,13 @@ async fn merge_record_id() {
 
 #[tokio::test]
 async fn patch_record_id() {
+	#[derive(Debug, Deserialize, Eq, PartialEq)]
+	struct Record {
+		id: Thing,
+		baz: String,
+		hello: Vec<String>,
+	}
+
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
 	let id = "john";
@@ -582,21 +589,21 @@ async fn patch_record_id() {
 		}))
 		.await
 		.unwrap();
-	let _: Option<serde_json::Value> = db
+	let _: Option<Record> = db
 		.update(("user", id))
 		.patch(PatchOp::replace("/baz", "boo"))
 		.patch(PatchOp::add("/hello", ["world"]))
 		.patch(PatchOp::remove("/foo"))
 		.await
 		.unwrap();
-	let value: Option<serde_json::Value> = db.select(("user", id)).await.unwrap();
+	let value: Option<Record> = db.select(("user", id)).await.unwrap();
 	assert_eq!(
 		value,
-		Some(json!({
-			"id": thing(&format!("user:{id}")).unwrap(),
-			"baz": "boo",
-			"hello": ["world"]
-		}))
+		Some(Record {
+			id: thing(&format!("user:{id}")).unwrap(),
+			baz: "boo".to_owned(),
+			hello: vec!["world".to_owned()],
+		})
 	);
 }
 

--- a/src/rpc/processor.rs
+++ b/src/rpc/processor.rs
@@ -441,7 +441,7 @@ impl Processor {
 		// Get a database reference
 		let kvs = DB.get().unwrap();
 		// Specify the SQL query string
-		let sql = "UPDATE $what PATCH $data RETURN DIFF";
+		let sql = "UPDATE $what PATCH $data RETURN AFTER";
 		// Specify the query parameters
 		let var = Some(map! {
 			String::from("what") => what.could_be_table(),

--- a/tests/ws_integration.rs
+++ b/tests/ws_integration.rs
@@ -1156,9 +1156,14 @@ mod ws_integration {
 		.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 		let res = res.unwrap();
-		assert!(res["result"].is_array(), "result: {:?}", res);
-		let res = res["result"].as_array().unwrap();
-		assert_eq!(res.len(), ops.as_array().unwrap().len(), "result: {:?}", res);
+		assert!(res["result"].is_object(), "result: {:?}", res);
+		let res = res["result"].as_object().unwrap();
+		assert_eq!(
+			res.get("modify_name"),
+			Some(json!("modify_value")).as_ref(),
+			"result: {:?}",
+			res
+		);
 
 		//
 		// Patch data
@@ -1185,9 +1190,9 @@ mod ws_integration {
 		.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 		let res = res.unwrap();
-		assert!(res["result"].is_array(), "result: {:?}", res);
-		let res = res["result"].as_array().unwrap();
-		assert_eq!(res.len(), ops.as_array().unwrap().len(), "result: {:?}", res);
+		assert!(res["result"].is_object(), "result: {:?}", res);
+		let res = res["result"].as_object().unwrap();
+		assert_eq!(res.get("patch_name"), Some(json!("patch_value")).as_ref(), "result: {:?}", res);
 
 		//
 		// Get the data and verify the output


### PR DESCRIPTION
## What is the motivation?

Fix https://github.com/surrealdb/surrealdb/issues/1998.

## What does this change do?

Change the `patch` method to return `AFTER` instead of `DIFF`. A future PR will add another RPC method that uses DIFF.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

It fixes https://github.com/surrealdb/surrealdb/issues/1998.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
