### PR TITLE
Support `ON DUPLICATE KEY UPDATE` when a unique index entry exists

### DIFF
--- a/lib/src/doc/document.rs
+++ b/lib/src/doc/document.rs
@@ -130,13 +130,11 @@ impl<'a> Document<'a> {
 			}) => {
 				// Allowed to run?
 				opt.is_allowed(Action::Edit, ResourceKind::Table, &Base::Db)?;
-
 				// We can create the table automatically
 				run.add_and_cache_ns(opt.ns(), opt.strict).await?;
 				run.add_and_cache_db(opt.ns(), opt.db(), opt.strict).await?;
 				run.add_and_cache_tb(opt.ns(), opt.db(), &rid.tb, opt.strict).await
 			}
-
 			// There was an error
 			Err(err) => Err(err),
 			// The table exists

--- a/lib/src/doc/index.rs
+++ b/lib/src/doc/index.rs
@@ -239,8 +239,19 @@ impl<'a> IndexOperation<'a> {
 		}
 	}
 
+	fn get_unique_index_key(&self, v: &'a Array) -> key::index::Index {
+		crate::key::index::Index::new(
+			self.opt.ns(),
+			self.opt.db(),
+			&self.ix.what,
+			&self.ix.name,
+			v,
+			None,
+		)
+	}
+
 	fn get_non_unique_index_key(&self, v: &'a Array) -> key::index::Index {
-		key::index::Index::new(
+		crate::key::index::Index::new(
 			self.opt.ns(),
 			self.opt.db(),
 			&self.ix.what,
@@ -250,39 +261,17 @@ impl<'a> IndexOperation<'a> {
 		)
 	}
 
-	async fn index_non_unique(&mut self, run: &mut kvs::Transaction) -> Result<(), Error> {
-		// Delete the old index data
-		if let Some(o) = self.o.take() {
-			let i = Indexable::new(o, self.ix);
-			for o in i {
-				let key = self.get_non_unique_index_key(&o);
-				let _ = run.delc(key, Some(self.rid)).await; // Ignore this error
-			}
-		}
-		// Create the new index data
-		if let Some(n) = self.n.take() {
-			let i = Indexable::new(n, self.ix);
-			for n in i {
-				let key = self.get_non_unique_index_key(&n);
-				if run.putc(key, self.rid, None).await.is_err() {
-					return self.err_index_exists(n);
-				}
-			}
-		}
-		Ok(())
-	}
-
-	fn get_unique_index_key(&self, v: &'a Array) -> key::index::Index {
-		key::index::Index::new(self.opt.ns(), self.opt.db(), &self.ix.what, &self.ix.name, v, None)
-	}
-
 	async fn index_unique(&mut self, run: &mut kvs::Transaction) -> Result<(), Error> {
 		// Delete the old index data
 		if let Some(o) = self.o.take() {
 			let i = Indexable::new(o, self.ix);
 			for o in i {
 				let key = self.get_unique_index_key(&o);
-				let _ = run.delc(key, Some(self.rid)).await; // Ignore this error
+				match run.delc(key, Some(self.rid)).await {
+					Err(Error::TxConditionNotMet) => Ok(()),
+					Err(e) => Err(e),
+					Ok(v) => Ok(v),
+				}?
 			}
 		}
 		// Create the new index data
@@ -292,7 +281,10 @@ impl<'a> IndexOperation<'a> {
 				if !n.is_all_none_or_null() {
 					let key = self.get_unique_index_key(&n);
 					if run.putc(key, self.rid, None).await.is_err() {
-						return self.err_index_exists(n);
+						let key = self.get_unique_index_key(&n);
+						let val = run.get(key).await?.unwrap();
+						let rid: Thing = val.into();
+						return self.err_index_exists(rid, n);
 					}
 				}
 			}
@@ -300,9 +292,38 @@ impl<'a> IndexOperation<'a> {
 		Ok(())
 	}
 
-	fn err_index_exists(&self, n: Array) -> Result<(), Error> {
+	async fn index_non_unique(&mut self, run: &mut kvs::Transaction) -> Result<(), Error> {
+		// Delete the old index data
+		if let Some(o) = self.o.take() {
+			let i = Indexable::new(o, self.ix);
+			for o in i {
+				let key = self.get_non_unique_index_key(&o);
+				match run.delc(key, Some(self.rid)).await {
+					Err(Error::TxConditionNotMet) => Ok(()),
+					Err(e) => Err(e),
+					Ok(v) => Ok(v),
+				}?
+			}
+		}
+		// Create the new index data
+		if let Some(n) = self.n.take() {
+			let i = Indexable::new(n, self.ix);
+			for n in i {
+				let key = self.get_non_unique_index_key(&n);
+				if run.putc(key, self.rid, None).await.is_err() {
+					let key = self.get_non_unique_index_key(&n);
+					let val = run.get(key).await?.unwrap();
+					let rid: Thing = val.into();
+					return self.err_index_exists(rid, n);
+				}
+			}
+		}
+		Ok(())
+	}
+
+	fn err_index_exists(&self, rid: Thing, n: Array) -> Result<(), Error> {
 		Err(Error::IndexExists {
-			thing: self.rid.to_string(),
+			thing: rid,
 			index: self.ix.name.to_string(),
 			value: match n.len() {
 				1 => n.first().unwrap().to_string(),

--- a/lib/src/doc/insert.rs
+++ b/lib/src/doc/insert.rs
@@ -13,64 +13,101 @@ impl<'a> Document<'a> {
 		txn: &Transaction,
 		stm: &Statement<'_>,
 	) -> Result<Value, Error> {
-		// Check current record
+		// Check whether current record exists
 		match self.current.doc.is_some() {
-			// Run INSERT clause
+			// We attempted to INSERT a document with an ID,
+			// and this ID already exists in the database,
+			// so we need to update the record instead.
+			true => self.insert_update(ctx, opt, txn, stm).await,
+			// We attempted to INSERT a document with an ID,
+			// which does not exist in the database, or we
+			// are creating a new record with a new ID.
 			false => {
-				// Merge record data
-				self.merge(ctx, opt, txn, stm).await?;
-				// Merge fields data
-				self.field(ctx, opt, txn, stm).await?;
-				// Reset fields data
-				self.reset(ctx, opt, txn, stm).await?;
-				// Clean fields data
-				self.clean(ctx, opt, txn, stm).await?;
-				// Check if allowed
-				self.allow(ctx, opt, txn, stm).await?;
-				// Store index data
-				self.index(ctx, opt, txn, stm).await?;
-				// Store record data
-				self.store(ctx, opt, txn, stm).await?;
-				// Run table queries
-				self.table(ctx, opt, txn, stm).await?;
-				// Run lives queries
-				self.lives(ctx, opt, txn, stm).await?;
-				// Run change feeds queries
-				self.changefeeds(ctx, opt, txn, stm).await?;
-				// Run event queries
-				self.event(ctx, opt, txn, stm).await?;
-				// Yield document
-				self.pluck(ctx, opt, txn, stm).await
-			}
-			// Run UPDATE clause
-			true => {
-				// Check if allowed
-				self.allow(ctx, opt, txn, stm).await?;
-				// Alter record data
-				self.alter(ctx, opt, txn, stm).await?;
-				// Merge fields data
-				self.field(ctx, opt, txn, stm).await?;
-				// Reset fields data
-				self.reset(ctx, opt, txn, stm).await?;
-				// Clean fields data
-				self.clean(ctx, opt, txn, stm).await?;
-				// Check if allowed
-				self.allow(ctx, opt, txn, stm).await?;
-				// Store index data
-				self.index(ctx, opt, txn, stm).await?;
-				// Store record data
-				self.store(ctx, opt, txn, stm).await?;
-				// Run table queries
-				self.table(ctx, opt, txn, stm).await?;
-				// Run lives queries
-				self.lives(ctx, opt, txn, stm).await?;
-				// Run change feeds queries
-				self.changefeeds(ctx, opt, txn, stm).await?;
-				// Run event queries
-				self.event(ctx, opt, txn, stm).await?;
-				// Yield document
-				self.pluck(ctx, opt, txn, stm).await
+				// First of all let's try to create the record
+				match self.insert_create(ctx, opt, txn, stm).await {
+					// We received an index exists error, so we
+					// ignore the error, and attempt to update the
+					// record using the ON DUPLICATE KEY clause
+					// with the Record ID received in the error
+					Err(Error::IndexExists {
+						thing,
+						..
+					}) => Err(Error::RetryWithId(thing)),
+					// If any other error was received, then let's
+					// pass that error through and return an error
+					Err(e) => Err(e),
+					// Otherwise the record creation succeeded
+					Ok(v) => Ok(v),
+				}
 			}
 		}
+	}
+	// Attempt to run an INSERT clause
+	async fn insert_create(
+		&mut self,
+		ctx: &Context<'_>,
+		opt: &Options,
+		txn: &Transaction,
+		stm: &Statement<'_>,
+	) -> Result<Value, Error> {
+		// Merge record data
+		self.merge(ctx, opt, txn, stm).await?;
+		// Merge fields data
+		self.field(ctx, opt, txn, stm).await?;
+		// Reset fields data
+		self.reset(ctx, opt, txn, stm).await?;
+		// Clean fields data
+		self.clean(ctx, opt, txn, stm).await?;
+		// Check if allowed
+		self.allow(ctx, opt, txn, stm).await?;
+		// Store index data
+		self.index(ctx, opt, txn, stm).await?;
+		// Store record data
+		self.store(ctx, opt, txn, stm).await?;
+		// Run table queries
+		self.table(ctx, opt, txn, stm).await?;
+		// Run lives queries
+		self.lives(ctx, opt, txn, stm).await?;
+		// Run change feeds queries
+		self.changefeeds(ctx, opt, txn, stm).await?;
+		// Run event queries
+		self.event(ctx, opt, txn, stm).await?;
+		// Yield document
+		self.pluck(ctx, opt, txn, stm).await
+	}
+	// Attempt to run an UPDATE clause
+	async fn insert_update(
+		&mut self,
+		ctx: &Context<'_>,
+		opt: &Options,
+		txn: &Transaction,
+		stm: &Statement<'_>,
+	) -> Result<Value, Error> {
+		// Check if allowed
+		self.allow(ctx, opt, txn, stm).await?;
+		// Alter record data
+		self.alter(ctx, opt, txn, stm).await?;
+		// Merge fields data
+		self.field(ctx, opt, txn, stm).await?;
+		// Reset fields data
+		self.reset(ctx, opt, txn, stm).await?;
+		// Clean fields data
+		self.clean(ctx, opt, txn, stm).await?;
+		// Check if allowed
+		self.allow(ctx, opt, txn, stm).await?;
+		// Store index data
+		self.index(ctx, opt, txn, stm).await?;
+		// Store record data
+		self.store(ctx, opt, txn, stm).await?;
+		// Run table queries
+		self.table(ctx, opt, txn, stm).await?;
+		// Run lives queries
+		self.lives(ctx, opt, txn, stm).await?;
+		// Run change feeds queries
+		self.changefeeds(ctx, opt, txn, stm).await?;
+		// Run event queries
+		self.event(ctx, opt, txn, stm).await?;
+		// Yield document
+		self.pluck(ctx, opt, txn, stm).await
 	}
 }

--- a/lib/src/doc/mod.rs
+++ b/lib/src/doc/mod.rs
@@ -6,10 +6,11 @@
 //! - `id`: traditionally an integer but can be an object or collection such as an array
 pub(crate) use self::document::*;
 
-#[cfg(not(target_arch = "wasm32"))]
-mod compute;
-
 mod document; // The entry point for a document to be processed
+
+#[cfg(not(target_arch = "wasm32"))]
+mod compute; // The point at which a document is processed
+mod process; // The point at which a document is processed
 
 mod create; // Processes a CREATE statement for this document
 mod delete; // Processes a DELETE statement for this document

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -304,14 +304,14 @@ async fn create_with_unique_index_with_two_flattened_fields() -> Result<(), Erro
 	//
 	let tmp = res.remove(0).result;
 	if let Err(e) = tmp {
-		assert_eq!(e.to_string(), "Database index `test` already contains ['Apple', ['one', 'two'], ['a@example.com', 'b@example.com']], with record `user:3`");
+		assert_eq!(e.to_string(), "Database index `test` already contains ['Apple', ['one', 'two'], ['a@example.com', 'b@example.com']], with record `user:1`");
 	} else {
 		panic!("An error was expected.")
 	}
 	//
 	let tmp = res.remove(0).result;
 	if let Err(e) = tmp {
-		assert_eq!(e.to_string(), "Database index `test` already contains ['Apple', ['two', 'three'], ['a@example.com', 'b@example.com']], with record `user:4`");
+		assert_eq!(e.to_string(), "Database index `test` already contains ['Apple', ['two', 'three'], ['a@example.com', 'b@example.com']], with record `user:2`");
 	} else {
 		panic!("An error was expected.")
 	}
@@ -337,7 +337,7 @@ async fn create_with_unique_index_with_one_flattened_field() -> Result<(), Error
 	//
 	let tmp = res.remove(0).result;
 	if let Err(e) = tmp {
-		assert_eq!(e.to_string(), "Database index `test` already contains ['Apple', 'two', ['a@example.com', 'b@example.com']], with record `user:2`");
+		assert_eq!(e.to_string(), "Database index `test` already contains ['Apple', 'two', ['a@example.com', 'b@example.com']], with record `user:1`");
 	} else {
 		panic!("An error was expected.")
 	}
@@ -363,7 +363,7 @@ async fn create_with_unique_index_on_one_field_with_flattened_sub_values() -> Re
 	//
 	let tmp = res.remove(0).result;
 	if let Err(e) = tmp {
-		assert_eq!(e.to_string(), "Database index `test` already contains ['Apple', 'two', ['a@example.com', 'b@example.com']], with record `user:2`");
+		assert_eq!(e.to_string(), "Database index `test` already contains ['Apple', 'two', ['a@example.com', 'b@example.com']], with record `user:1`");
 	} else {
 		panic!("An error was expected.")
 	}
@@ -389,7 +389,7 @@ async fn create_with_unique_index_on_two_fields() -> Result<(), Error> {
 	let tmp = res.remove(0).result;
 	//
 	if let Err(e) = tmp {
-		assert_eq!(e.to_string(), "Database index `test` already contains ['Apple', 'two', 'b@example.com'], with record `user:2`");
+		assert_eq!(e.to_string(), "Database index `test` already contains ['Apple', 'two', 'b@example.com'], with record `user:1`");
 	} else {
 		panic!("An error was expected.")
 	}

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -827,7 +827,7 @@ async fn define_statement_index_single_unique() -> Result<(), Error> {
 	let tmp = res.remove(0).result;
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Database index `test` already contains 'test@surrealdb.com', with record `user:2`"#
+		Some(e) if e.to_string() == r#"Database index `test` already contains 'test@surrealdb.com', with record `user:1`"#
 	));
 	//
 	let tmp = res.remove(0).result;
@@ -889,13 +889,13 @@ async fn define_statement_index_multiple_unique() -> Result<(), Error> {
 	let tmp = res.remove(0).result;
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Database index `test` already contains ['apple', 'test@surrealdb.com'], with record `user:3`"#
+		Some(e) if e.to_string() == r#"Database index `test` already contains ['apple', 'test@surrealdb.com'], with record `user:1`"#
 	));
 	//
 	let tmp = res.remove(0).result;
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Database index `test` already contains ['tesla', 'test@surrealdb.com'], with record `user:4`"#
+		Some(e) if e.to_string() == r#"Database index `test` already contains ['tesla', 'test@surrealdb.com'], with record `user:2`"#
 	));
 	//
 	let tmp = res.remove(0).result;
@@ -908,7 +908,7 @@ async fn define_statement_index_multiple_unique() -> Result<(), Error> {
 	let tmp = res.remove(0).result;
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Database index `test` already contains ['tesla', 'test@surrealdb.com'], with record `user:4`"#
+		Some(e) if e.to_string() == r#"Database index `test` already contains ['tesla', 'test@surrealdb.com'], with record `user:2`"#
 	));
 	//
 	let tmp = res.remove(0).result;
@@ -944,13 +944,13 @@ async fn define_statement_index_single_unique_existing() -> Result<(), Error> {
 	let tmp = res.remove(0).result;
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Database index `test` already contains 'test@surrealdb.com', with record `user:3`"#
+		Some(e) if e.to_string() == r#"Database index `test` already contains 'test@surrealdb.com', with record `user:2`"#
 	));
 	//
 	let tmp = res.remove(0).result;
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Database index `test` already contains 'test@surrealdb.com', with record `user:3`"#
+		Some(e) if e.to_string() == r#"Database index `test` already contains 'test@surrealdb.com', with record `user:2`"#
 	));
 	//
 	let tmp = res.remove(0).result?;
@@ -991,13 +991,13 @@ async fn define_statement_index_multiple_unique_existing() -> Result<(), Error> 
 	let tmp = res.remove(0).result;
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Database index `test` already contains ['apple', 'test@surrealdb.com'], with record `user:3`"#
+		Some(e) if e.to_string() == r#"Database index `test` already contains ['apple', 'test@surrealdb.com'], with record `user:1`"#
 	));
 	//
 	let tmp = res.remove(0).result;
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Database index `test` already contains ['apple', 'test@surrealdb.com'], with record `user:3`"#
+		Some(e) if e.to_string() == r#"Database index `test` already contains ['apple', 'test@surrealdb.com'], with record `user:1`"#
 	));
 
 	let tmp = res.remove(0).result?;
@@ -1053,7 +1053,7 @@ async fn define_statement_index_single_unique_embedded_multiple() -> Result<(), 
 	if let Err(e) = tmp {
 		assert_eq!(
 			e.to_string(),
-			"Database index `test` already contains 'two', with record `user:2`"
+			"Database index `test` already contains 'two', with record `user:1`"
 		);
 	} else {
 		panic!("An error was expected.")
@@ -1107,7 +1107,7 @@ async fn define_statement_index_multiple_unique_embedded_multiple() -> Result<()
 	if let Err(e) = tmp {
 		assert_eq!(
 			e.to_string(),
-			"Database index `test` already contains ['apple', 'two'], with record `user:3`"
+			"Database index `test` already contains ['apple', 'two'], with record `user:1`"
 		);
 	} else {
 		panic!("An error was expected.")
@@ -1117,7 +1117,7 @@ async fn define_statement_index_multiple_unique_embedded_multiple() -> Result<()
 	if let Err(e) = tmp {
 		assert_eq!(
 			e.to_string(),
-			"Database index `test` already contains ['tesla', 'two'], with record `user:4`"
+			"Database index `test` already contains ['tesla', 'two'], with record `user:2`"
 		);
 	} else {
 		panic!("An error was expected.")


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently the `ON DUPLICATE KEY UPDATE` clause is only used when an `INSERT` statement is run with a specific Record ID. If a unique index exists, then this will error rather than updating the record which already exists for that unique index entry.

## What does this change do?

This pull request ensures that if an `INSERT` statement is performed with no Record ID, and an `IndexExists` error is encountered, then the statement will be retried with the Record ID of the unique indexed record.

```sql
DEFINE INDEX name ON TABLE company COLUMNS name UNIQUE;

INSERT INTO company (name, founded)
    VALUES ('SurrealDB', '2021-09-10')
    ON DUPLICATE KEY UPDATE founded = $input.founded
;

INSERT INTO company (name, founded)
    VALUES ('SurrealDB', '2021-09-11')
    ON DUPLICATE KEY UPDATE founded = $input.founded
;
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #212.
Closes #2446.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
