### PR TITLE
[auth] Support auth levels for basic auth

### DIFF
--- a/lib/src/api/engine/any/native.rs
+++ b/lib/src/api/engine/any/native.rs
@@ -9,10 +9,10 @@ use crate::api::engine::any::Any;
 #[cfg(feature = "protocol-http")]
 use crate::api::engine::remote::http;
 use crate::api::err::Error;
-use crate::api::opt::Endpoint;
 #[cfg(any(feature = "native-tls", feature = "rustls"))]
 #[cfg(feature = "protocol-http")]
 use crate::api::opt::Tls;
+use crate::api::opt::{Endpoint, EndpointKind};
 use crate::api::DbResponse;
 #[allow(unused_imports)] // used by the DB engines
 use crate::api::ExtraFeatures;
@@ -61,8 +61,8 @@ impl Connection for Any {
 			let (conn_tx, conn_rx) = flume::bounded::<Result<()>>(1);
 			let mut features = HashSet::new();
 
-			match address.endpoint.scheme() {
-				"fdb" => {
+			match EndpointKind::from(address.endpoint.scheme()) {
+				EndpointKind::FoundationDb => {
 					#[cfg(feature = "kv-fdb")]
 					{
 						features.insert(ExtraFeatures::Backup);
@@ -76,7 +76,7 @@ impl Connection for Any {
 					);
 				}
 
-				"mem" => {
+				EndpointKind::Memory => {
 					#[cfg(feature = "kv-mem")]
 					{
 						features.insert(ExtraFeatures::Backup);
@@ -90,7 +90,7 @@ impl Connection for Any {
 					);
 				}
 
-				"file" | "rocksdb" => {
+				EndpointKind::File | EndpointKind::RocksDb => {
 					#[cfg(feature = "kv-rocksdb")]
 					{
 						features.insert(ExtraFeatures::Backup);
@@ -105,7 +105,7 @@ impl Connection for Any {
 					.into());
 				}
 
-				"speedb" => {
+				EndpointKind::SpeeDb => {
 					#[cfg(feature = "kv-speedb")]
 					{
 						features.insert(ExtraFeatures::Backup);
@@ -120,7 +120,7 @@ impl Connection for Any {
 					.into());
 				}
 
-				"tikv" => {
+				EndpointKind::TiKv => {
 					#[cfg(feature = "kv-tikv")]
 					{
 						features.insert(ExtraFeatures::Backup);
@@ -134,7 +134,7 @@ impl Connection for Any {
 					);
 				}
 
-				"http" | "https" => {
+				EndpointKind::Http | EndpointKind::Https => {
 					#[cfg(feature = "protocol-http")]
 					{
 						features.insert(ExtraFeatures::Backup);
@@ -166,7 +166,7 @@ impl Connection for Any {
 					.into());
 				}
 
-				"ws" | "wss" => {
+				EndpointKind::Ws | EndpointKind::Wss => {
 					#[cfg(feature = "protocol-ws")]
 					{
 						let url = address.endpoint.join(engine::remote::ws::PATH)?;
@@ -205,10 +205,7 @@ impl Connection for Any {
 					)
 					.into());
 				}
-
-				scheme => {
-					return Err(Error::Scheme(scheme.to_owned()).into());
-				}
+				EndpointKind::Unsupported(v) => return Err(Error::Scheme(v).into()),
 			}
 
 			Ok(Surreal {

--- a/lib/src/api/engine/local/native.rs
+++ b/lib/src/api/engine/local/native.rs
@@ -7,7 +7,7 @@ use crate::api::conn::Router;
 use crate::api::engine::local::Db;
 use crate::api::engine::local::DEFAULT_TICK_INTERVAL;
 use crate::api::err::Error;
-use crate::api::opt::Endpoint;
+use crate::api::opt::{Endpoint, EndpointKind};
 use crate::api::ExtraFeatures;
 use crate::api::OnceLockExt;
 use crate::api::Result;
@@ -105,9 +105,12 @@ pub(crate) fn router(
 		};
 
 		let kvs = {
-			let path = match url.scheme() {
-				"mem" => "memory".to_owned(),
-				"fdb" | "rocksdb" | "speedb" | "file" => match url.to_file_path() {
+			let path = match EndpointKind::from(url.scheme()) {
+				EndpointKind::Memory => "memory".to_owned(),
+				EndpointKind::FoundationDb
+				| EndpointKind::RocksDb
+				| EndpointKind::File
+				| EndpointKind::SpeeDb => match url.to_file_path() {
 					Ok(path) => format!("{}://{}", url.scheme(), path.display()),
 					Err(_) => {
 						let error = Error::InvalidUrl(url.as_str().to_owned());

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -22,6 +22,10 @@ use crate::api::Response as QueryResponse;
 use crate::api::Result;
 use crate::api::Surreal;
 use crate::dbs::Status;
+use crate::headers::AUTH_DB;
+use crate::headers::AUTH_NS;
+use crate::headers::DB;
+use crate::headers::NS;
 use crate::opt::IntoEndpoint;
 use crate::sql::serde::deserialize;
 use crate::sql::Array;
@@ -114,6 +118,8 @@ enum Auth {
 	Basic {
 		user: String,
 		pass: String,
+		ns: Option<String>,
+		db: Option<String>,
 	},
 	Bearer {
 		token: String,
@@ -130,7 +136,18 @@ impl Authenticate for RequestBuilder {
 			Some(Auth::Basic {
 				user,
 				pass,
-			}) => self.basic_auth(user, Some(pass)),
+				ns,
+				db,
+			}) => {
+				let mut req = self.basic_auth(user, Some(pass));
+				if let Some(ns) = ns {
+					req = req.header(&AUTH_NS, ns);
+				}
+				if let Some(db) = db {
+					req = req.header(&AUTH_DB, db);
+				}
+				req
+			}
 			Some(Auth::Bearer {
 				token,
 			}) => self.bearer_auth(token),
@@ -142,9 +159,11 @@ impl Authenticate for RequestBuilder {
 type HttpQueryResponse = (String, Status, Value);
 
 #[derive(Debug, Serialize, Deserialize)]
-struct Root {
+struct Credentials {
 	user: String,
 	pass: String,
+	ns: Option<String>,
+	db: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -338,7 +357,7 @@ async fn router(
 			let ns = match ns {
 				Some(ns) => match HeaderValue::try_from(&ns) {
 					Ok(ns) => {
-						request = request.header("NS", &ns);
+						request = request.header(&NS, &ns);
 						Some(ns)
 					}
 					Err(_) => {
@@ -350,7 +369,7 @@ async fn router(
 			let db = match db {
 				Some(db) => match HeaderValue::try_from(&db) {
 					Ok(db) => {
-						request = request.header("DB", &db);
+						request = request.header(&DB, &db);
 						Some(db)
 					}
 					Err(_) => {
@@ -362,10 +381,10 @@ async fn router(
 			request = request.auth(auth).body("RETURN true");
 			take(true, request).await?;
 			if let Some(ns) = ns {
-				headers.insert("NS", ns);
+				headers.insert(&NS, ns);
 			}
 			if let Some(db) = db {
-				headers.insert("DB", db);
+				headers.insert(&DB, db);
 			}
 			Ok(DbResponse::Other(Value::None))
 		}
@@ -378,14 +397,18 @@ async fn router(
 			let request = client.post(path).headers(headers.clone()).auth(auth).body(credentials);
 			let value = submit_auth(request).await?;
 			if let [credentials] = &mut params[..] {
-				if let Ok(Root {
+				if let Ok(Credentials {
 					user,
 					pass,
+					ns,
+					db,
 				}) = from_value(mem::take(credentials))
 				{
 					*auth = Some(Auth::Basic {
 						user,
 						pass,
+						ns,
+						db,
 					});
 				} else {
 					*auth = Some(Auth::Bearer {

--- a/lib/src/api/headers/mod.rs
+++ b/lib/src/api/headers/mod.rs
@@ -1,0 +1,14 @@
+//! HTTP headers used by SurrealDB
+
+use reqwest::header::HeaderName;
+
+pub static ID: HeaderName = HeaderName::from_static("sur-id");
+pub static ID_LEGACY: HeaderName = HeaderName::from_static("id");
+pub static NS: HeaderName = HeaderName::from_static("sur-ns");
+pub static NS_LEGACY: HeaderName = HeaderName::from_static("ns");
+pub static DB: HeaderName = HeaderName::from_static("sur-db");
+pub static DB_LEGACY: HeaderName = HeaderName::from_static("db");
+pub static AUTH_NS: HeaderName = HeaderName::from_static("sur-auth-ns");
+pub static AUTH_DB: HeaderName = HeaderName::from_static("sur-auth-db");
+pub static VERSION: HeaderName = HeaderName::from_static("sur-version");
+pub static VERSION_LEGACY: HeaderName = HeaderName::from_static("version");

--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod engine;
 pub mod err;
+#[cfg(feature = "protocol-http")]
+pub mod headers;
 pub mod method;
 pub mod opt;
 

--- a/lib/src/api/opt/auth.rs
+++ b/lib/src/api/opt/auth.rs
@@ -3,6 +3,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;
+use thiserror::Error;
 
 /// A signup action
 #[derive(Debug)]
@@ -11,6 +12,108 @@ pub struct Signup;
 /// A signin action
 #[derive(Debug)]
 pub struct Signin;
+
+/// Credentials level
+#[derive(Debug, Clone)]
+pub enum CredentialsLevel {
+	Root,
+	Namespace,
+	Database,
+	Scope,
+}
+
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+	#[error("Username is needed for authentication but it was not provided")]
+	NoUsername,
+	#[error("Password is needed for authentication but it was not provided")]
+	NoPassword,
+	#[error("Namespace is needed for authentication but it was not provided")]
+	NoNamespace,
+	#[error("Database is needed for authentication but it was not provided")]
+	NoDatabase,
+	#[error("Scope is needed for authentication but it was not provided")]
+	NoScope,
+	#[error("Scope params are needed for authentication but they were not provided")]
+	NoScopeParams,
+}
+
+/// Construct a Credentials instance for the given auth level
+#[derive(Debug, Default)]
+pub struct CredentialsBuilder<'a> {
+	/// The auth username
+	pub username: Option<&'a str>,
+	/// The auth password
+	pub password: Option<&'a str>,
+	/// The auth namespace
+	pub namespace: Option<&'a str>,
+	/// The auth database
+	pub database: Option<&'a str>,
+	/// The auth scope
+	pub scope: Option<&'a str>,
+}
+
+impl<'a> CredentialsBuilder<'a> {
+	// Builder methods
+	pub fn with_username(mut self, username: Option<&'a str>) -> Self {
+		self.username = username;
+		self
+	}
+
+	pub fn with_password(mut self, password: Option<&'a str>) -> Self {
+		self.password = password;
+		self
+	}
+
+	pub fn with_namespace(mut self, namespace: Option<&'a str>) -> Self {
+		self.namespace = namespace;
+		self
+	}
+
+	pub fn with_database(mut self, database: Option<&'a str>) -> Self {
+		self.database = database;
+		self
+	}
+
+	pub fn with_scope(mut self, scope: Option<&'a str>) -> Self {
+		self.scope = scope;
+		self
+	}
+
+	pub fn for_root(self) -> Result<Root<'a>, Error> {
+		Ok(Root {
+			username: self.username.ok_or(Error::NoUsername)?,
+			password: self.password.ok_or(Error::NoPassword)?,
+		})
+	}
+
+	pub fn for_namespace(self) -> Result<Namespace<'a>, Error> {
+		Ok(Namespace {
+			username: self.username.ok_or(Error::NoUsername)?,
+			password: self.password.ok_or(Error::NoPassword)?,
+			namespace: self.namespace.ok_or(Error::NoNamespace)?,
+		})
+	}
+
+	pub fn for_database(self) -> Result<Database<'a>, Error> {
+		Ok(Database {
+			username: self.username.ok_or(Error::NoUsername)?,
+			password: self.password.ok_or(Error::NoPassword)?,
+			namespace: self.namespace.ok_or(Error::NoNamespace)?,
+			database: self.database.ok_or(Error::NoDatabase)?,
+		})
+	}
+
+	pub fn for_scope<P>(self, params: P) -> Result<Scope<'a, P>, Error> {
+		Ok(Scope {
+			namespace: self.namespace.ok_or(Error::NoNamespace)?,
+			database: self.database.ok_or(Error::NoDatabase)?,
+			scope: self.scope.ok_or(Error::NoScope)?,
+			params,
+		})
+	}
+}
 
 /// Credentials for authenticating with the server
 pub trait Credentials<Action, Response>: Serialize {}

--- a/lib/src/api/opt/endpoint/mod.rs
+++ b/lib/src/api/opt/endpoint/mod.rs
@@ -16,6 +16,7 @@ mod speedb;
 #[cfg(feature = "kv-tikv")]
 mod tikv;
 
+use crate::api::err::Error;
 use crate::api::Connection;
 use crate::api::Result;
 use url::Url;
@@ -30,12 +31,67 @@ pub struct Endpoint {
 	pub(crate) config: Config,
 }
 
+impl Endpoint {
+	pub fn parse_kind(&self) -> Result<EndpointKind> {
+		match EndpointKind::from(self.endpoint.scheme()) {
+			EndpointKind::Unsupported(s) => Err(Error::Scheme(s).into()),
+			kind => Ok(kind),
+		}
+	}
+}
+
 /// A trait for converting inputs to a server address object
 pub trait IntoEndpoint<Scheme> {
 	/// The client implied by this scheme and address combination
 	type Client: Connection;
 	/// Converts an input into a server address object
 	fn into_endpoint(self) -> Result<Endpoint>;
+}
+
+#[derive(Debug)]
+pub enum EndpointKind {
+	Http,
+	Https,
+	Ws,
+	Wss,
+	FoundationDb,
+	#[cfg(target_arch = "wasm32")]
+	IndxDb,
+	Memory,
+	RocksDb,
+	File,
+	SpeeDb,
+	TiKv,
+	Unsupported(String),
+}
+
+impl From<&str> for EndpointKind {
+	fn from(s: &str) -> Self {
+		match s {
+			"http" => Self::Http,
+			"https" => Self::Https,
+			"ws" => Self::Ws,
+			"wss" => Self::Wss,
+			"fdb" => Self::FoundationDb,
+			#[cfg(target_arch = "wasm32")]
+			"indxdb" => Self::IndxDb,
+			"mem" => Self::Memory,
+			"file" => Self::File,
+			"rocksdb" => Self::RocksDb,
+			"speedb" => Self::SpeeDb,
+			"tikv" => Self::TiKv,
+			_ => Self::Unsupported(s.to_owned()),
+		}
+	}
+}
+
+impl EndpointKind {
+	pub fn is_local(&self) -> bool {
+		!matches!(
+			self,
+			EndpointKind::Http | EndpointKind::Https | EndpointKind::Ws | EndpointKind::Wss
+		)
+	}
 }
 
 #[cfg(any(feature = "kv-fdb", feature = "kv-rocksdb", feature = "kv-speedb"))]

--- a/lib/src/iam/signin.rs
+++ b/lib/src/iam/signin.rs
@@ -1,4 +1,4 @@
-use super::verify::verify_creds;
+use super::verify::{verify_db_creds, verify_ns_creds, verify_root_creds};
 use super::{Actor, Level};
 use crate::cnf::SERVER_NAME;
 use crate::dbs::Session;
@@ -21,6 +21,7 @@ pub async fn signin(
 	let ns = vars.get("NS").or_else(|| vars.get("ns"));
 	let db = vars.get("DB").or_else(|| vars.get("db"));
 	let sc = vars.get("SC").or_else(|| vars.get("sc"));
+
 	// Check if the parameters exist
 	match (ns, db, sc) {
 		// SCOPE signin
@@ -86,7 +87,7 @@ pub async fn signin(
 					let user = user.to_raw_string();
 					let pass = pass.to_raw_string();
 
-					super::signin::kv(kvs, session, user, pass).await
+					super::signin::root(kvs, session, user, pass).await
 				}
 				// There is no username or password
 				_ => Err(Error::InvalidAuth),
@@ -189,8 +190,8 @@ pub async fn db(
 	user: String,
 	pass: String,
 ) -> Result<Option<String>, Error> {
-	match verify_creds(kvs, Some(&ns), Some(&db), &user, &pass).await {
-		Ok((auth, u)) => {
+	match verify_db_creds(kvs, &ns, &db, &user, &pass).await {
+		Ok(u) => {
 			// Create the authentication key
 			let key = EncodingKey::from_secret(u.code.as_ref());
 			// Create the authentication claim
@@ -210,7 +211,7 @@ pub async fn db(
 			session.tk = Some(val.into());
 			session.ns = Some(ns.to_owned());
 			session.db = Some(db.to_owned());
-			session.au = Arc::new(auth);
+			session.au = Arc::new((&u, Level::Database(ns.to_owned(), db.to_owned())).into());
 			// Check the authentication token
 			match enc {
 				// The auth token was created successfully
@@ -231,8 +232,8 @@ pub async fn ns(
 	user: String,
 	pass: String,
 ) -> Result<Option<String>, Error> {
-	match verify_creds(kvs, Some(&ns), None, &user, &pass).await {
-		Ok((auth, u)) => {
+	match verify_ns_creds(kvs, &ns, &user, &pass).await {
+		Ok(u) => {
 			// Create the authentication key
 			let key = EncodingKey::from_secret(u.code.as_ref());
 			// Create the authentication claim
@@ -250,7 +251,7 @@ pub async fn ns(
 			// Set the authentication on the session
 			session.tk = Some(val.into());
 			session.ns = Some(ns.to_owned());
-			session.au = Arc::new(auth);
+			session.au = Arc::new((&u, Level::Namespace(ns.to_owned())).into());
 			// Check the authentication token
 			match enc {
 				// The auth token was created successfully
@@ -259,18 +260,19 @@ pub async fn ns(
 				_ => Err(Error::InvalidAuth),
 			}
 		}
-		Err(e) => Err(e),
+		// The password did not verify
+		_ => Err(Error::InvalidAuth),
 	}
 }
 
-pub async fn kv(
+pub async fn root(
 	kvs: &Datastore,
 	session: &mut Session,
 	user: String,
 	pass: String,
 ) -> Result<Option<String>, Error> {
-	match verify_creds(kvs, None, None, &user, &pass).await {
-		Ok((auth, u)) => {
+	match verify_root_creds(kvs, &user, &pass).await {
+		Ok(u) => {
 			// Create the authentication key
 			let key = EncodingKey::from_secret(u.code.as_ref());
 			// Create the authentication claim
@@ -286,7 +288,7 @@ pub async fn kv(
 			let enc = encode(&HEADER, &val, &key);
 			// Set the authentication on the session
 			session.tk = Some(val.into());
-			session.au = Arc::new(auth);
+			session.au = Arc::new((&u, Level::Root).into());
 			// Check the authentication token
 			match enc {
 				// The auth token was created successfully
@@ -295,6 +297,7 @@ pub async fn kv(
 				_ => Err(Error::InvalidAuth),
 			}
 		}
-		Err(e) => Err(e),
+		// The password did not verify
+		_ => Err(Error::InvalidAuth),
 	}
 }

--- a/lib/src/iam/verify.rs
+++ b/lib/src/iam/verify.rs
@@ -92,28 +92,42 @@ pub async fn basic(
 	session: &mut Session,
 	user: &str,
 	pass: &str,
+	ns: Option<&str>,
+	db: Option<&str>,
 ) -> Result<(), Error> {
 	// Log the authentication type
 	trace!("Attempting basic authentication");
 
-	match verify_creds(kvs, session.ns.as_ref(), session.db.as_ref(), user, pass).await {
-		Ok((au, _)) if au.is_root() => {
-			debug!("Authenticated as root user '{}'", user);
-			session.au = Arc::new(au);
-			Ok(())
-		}
-		Ok((au, _)) if au.is_ns() => {
-			debug!("Authenticated as namespace user '{}'", user);
-			session.au = Arc::new(au);
-			Ok(())
-		}
-		Ok((au, _)) if au.is_db() => {
-			debug!("Authenticated as database user '{}'", user);
-			session.au = Arc::new(au);
-			Ok(())
-		}
-		Ok(_) => Err(Error::InvalidAuth),
-		Err(e) => Err(e),
+	// Check if the parameters exist
+	match (ns, db) {
+		// DB signin
+		(Some(ns), Some(db)) => match verify_db_creds(kvs, ns, db, user, pass).await {
+			Ok(u) => {
+				debug!("Authenticated as database user '{}'", user);
+				session.au = Arc::new((&u, Level::Database(ns.to_owned(), db.to_owned())).into());
+				Ok(())
+			}
+			Err(err) => Err(err),
+		},
+		// NS signin
+		(Some(ns), None) => match verify_ns_creds(kvs, ns, user, pass).await {
+			Ok(u) => {
+				debug!("Authenticated as namespace user '{}'", user);
+				session.au = Arc::new((&u, Level::Namespace(ns.to_owned())).into());
+				Ok(())
+			}
+			Err(err) => Err(err),
+		},
+		// Root signin
+		(None, None) => match verify_root_creds(kvs, user, pass).await {
+			Ok(u) => {
+				debug!("Authenticated as root user '{}'", user);
+				session.au = Arc::new((&u, Level::Root).into());
+				Ok(())
+			}
+			Err(err) => Err(err),
+		},
+		(None, Some(_)) => Err(Error::InvalidAuth),
 	}
 }
 
@@ -265,7 +279,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Create a new readonly transaction
 			let mut tx = kvs.transaction(false, false).await?;
 			// Get the database user
-			let de = tx.get_db_user(&ns, &db, &id).await?;
+			let de = tx.get_db_user(&ns, &db, &id).await.map_err(|e| {
+				trace!("Error while authenticating to database `{db}`: {e}");
+				Error::InvalidAuth
+			})?;
 			let cf = config(Algorithm::Hs512, de.code)?;
 			// Verify the token
 			decode::<Claims>(token, &cf.0, &cf.1)?;
@@ -329,7 +346,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Create a new readonly transaction
 			let mut tx = kvs.transaction(false, false).await?;
 			// Get the namespace user
-			let de = tx.get_ns_user(&ns, &id).await?;
+			let de = tx.get_ns_user(&ns, &id).await.map_err(|e| {
+				trace!("Error while authenticating to namespace `{ns}`: {e}");
+				Error::InvalidAuth
+			})?;
 			let cf = config(Algorithm::Hs512, de.code)?;
 			// Verify the token
 			decode::<Claims>(token, &cf.0, &cf.1)?;
@@ -355,7 +375,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Create a new readonly transaction
 			let mut tx = kvs.transaction(false, false).await?;
 			// Get the namespace user
-			let de = tx.get_root_user(&id).await?;
+			let de = tx.get_root_user(&id).await.map_err(|e| {
+				trace!("Error while authenticating to root: {e}");
+				Error::InvalidAuth
+			})?;
 			let cf = config(Algorithm::Hs512, de.code)?;
 			// Verify the token
 			decode::<Claims>(token, &cf.0, &cf.1)?;
@@ -386,82 +409,40 @@ pub fn parse(value: &str) -> Result<Value, Error> {
 	json(value).map_err(|_| Error::InvalidAuth)
 }
 
-pub async fn verify_creds(
-	ds: &Datastore,
-	ns: Option<&String>,
-	db: Option<&String>,
-	user: &str,
-	pass: &str,
-) -> Result<(Auth, DefineUserStatement), Error> {
-	if user.is_empty() || pass.is_empty() {
-		return Err(Error::InvalidAuth);
-	}
-
-	// TODO(sgirones): Keep the same behaviour as before, where it would try to authenticate as a KV first, then NS and then DB.
-	// In the future, we want the client to specify the type of user it wants to authenticate as, so we can remove this chain.
-
-	// Try to authenticate as a ROOT user
-	match verify_root_creds(ds, user, pass).await {
-		Ok(u) => Ok(((&u, Level::Root).into(), u)),
-		Err(_) => {
-			// Try to authenticate as a NS user
-			match ns {
-				Some(ns) => {
-					match verify_ns_creds(ds, ns, user, pass).await {
-						Ok(u) => Ok(((&u, Level::Namespace(ns.to_owned())).into(), u)),
-						Err(_) => {
-							// Try to authenticate as a DB user
-							match db {
-								Some(db) => match verify_db_creds(ds, ns, db, user, pass).await {
-									Ok(u) => Ok((
-										(&u, Level::Database(ns.to_owned(), db.to_owned())).into(),
-										u,
-									)),
-									Err(_) => Err(Error::InvalidAuth),
-								},
-								None => Err(Error::InvalidAuth),
-							}
-						}
-					}
-				}
-				None => Err(Error::InvalidAuth),
-			}
-		}
-	}
-}
-
-async fn verify_root_creds(
+pub async fn verify_root_creds(
 	ds: &Datastore,
 	user: &str,
 	pass: &str,
 ) -> Result<DefineUserStatement, Error> {
 	let mut tx = ds.transaction(false, false).await?;
-	let user_res = tx.get_root_user(user).await?;
+	let user_res = tx.get_root_user(user).await.map_err(|e| {
+		trace!("Error while authenticating to root: {e}");
+		Error::InvalidAuth
+	})?;
 
 	verify_pass(pass, user_res.hash.as_ref())?;
 
 	Ok(user_res)
 }
 
-async fn verify_ns_creds(
+pub async fn verify_ns_creds(
 	ds: &Datastore,
 	ns: &str,
 	user: &str,
 	pass: &str,
 ) -> Result<DefineUserStatement, Error> {
 	let mut tx = ds.transaction(false, false).await?;
-
-	let user_res = match tx.get_ns_user(ns, user).await {
-		Ok(u) => Ok(u),
-		Err(e) => Err(e),
-	}?;
+	let user_res = tx.get_ns_user(ns, user).await.map_err(|e| {
+		trace!("Error while authenticating to namespace `{ns}`: {e}");
+		Error::InvalidAuth
+	})?;
 
 	verify_pass(pass, user_res.hash.as_ref())?;
 
 	Ok(user_res)
 }
 
-async fn verify_db_creds(
+pub async fn verify_db_creds(
 	ds: &Datastore,
 	ns: &str,
 	db: &str,
@@ -469,11 +450,10 @@ async fn verify_db_creds(
 	pass: &str,
 ) -> Result<DefineUserStatement, Error> {
 	let mut tx = ds.transaction(false, false).await?;
-
-	let user_res = match tx.get_db_user(ns, db, user).await {
-		Ok(u) => Ok(u),
-		Err(e) => Err(e),
-	}?;
+	let user_res = tx.get_db_user(ns, db, user).await.map_err(|e| {
+		trace!("Error while authenticating to database `{ns}/{db}`: {e}");
+		Error::InvalidAuth
+	})?;
 
 	verify_pass(pass, user_res.hash.as_ref())?;
 
@@ -512,7 +492,7 @@ mod tests {
 			let mut sess = Session {
 				..Default::default()
 			};
-			let res = basic(&ds, &mut sess, "user", "pass").await;
+			let res = basic(&ds, &mut sess, "user", "pass", None, None).await;
 
 			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
 			assert_eq!(sess.ns, None);
@@ -539,7 +519,7 @@ mod tests {
 			let mut sess = Session {
 				..Default::default()
 			};
-			let res = basic(&ds, &mut sess, "user", "pass").await;
+			let res = basic(&ds, &mut sess, "user", "pass", None, None).await;
 
 			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
 			assert_eq!(sess.ns, None);
@@ -562,7 +542,7 @@ mod tests {
 			let mut sess = Session {
 				..Default::default()
 			};
-			let res = basic(&ds, &mut sess, "user", "invalid").await;
+			let res = basic(&ds, &mut sess, "user", "invalid", None, None).await;
 
 			assert!(res.is_err(), "Unexpect successful signin: {:?}", res);
 		}
@@ -582,7 +562,7 @@ mod tests {
 				ns: Some("test".to_string()),
 				..Default::default()
 			};
-			let res = basic(&ds, &mut sess, "user", "pass").await;
+			let res = basic(&ds, &mut sess, "user", "pass", Some("test"), None).await;
 
 			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
 			assert_eq!(sess.ns, Some("test".to_string()));
@@ -610,7 +590,7 @@ mod tests {
 				ns: Some("test".to_string()),
 				..Default::default()
 			};
-			let res = basic(&ds, &mut sess, "user", "pass").await;
+			let res = basic(&ds, &mut sess, "user", "pass", Some("test"), None).await;
 
 			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
 			assert_eq!(sess.ns, Some("test".to_string()));
@@ -633,7 +613,7 @@ mod tests {
 			let mut sess = Session {
 				..Default::default()
 			};
-			let res = basic(&ds, &mut sess, "user", "invalid").await;
+			let res = basic(&ds, &mut sess, "user", "invalid", Some("test"), None).await;
 
 			assert!(res.is_err(), "Unexpect successful signin: {:?}", res);
 		}
@@ -654,7 +634,7 @@ mod tests {
 				db: Some("test".to_string()),
 				..Default::default()
 			};
-			let res = basic(&ds, &mut sess, "user", "pass").await;
+			let res = basic(&ds, &mut sess, "user", "pass", Some("test"), Some("test")).await;
 
 			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
 			assert_eq!(sess.ns, Some("test".to_string()));
@@ -683,7 +663,7 @@ mod tests {
 				db: Some("test".to_string()),
 				..Default::default()
 			};
-			let res = basic(&ds, &mut sess, "user", "pass").await;
+			let res = basic(&ds, &mut sess, "user", "pass", Some("test"), Some("test")).await;
 
 			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
 			assert_eq!(sess.ns, Some("test".to_string()));
@@ -706,7 +686,7 @@ mod tests {
 			let mut sess = Session {
 				..Default::default()
 			};
-			let res = basic(&ds, &mut sess, "user", "invalid").await;
+			let res = basic(&ds, &mut sess, "user", "invalid", Some("test"), Some("test")).await;
 
 			assert!(res.is_err(), "Unexpect successful signin: {:?}", res);
 		}
@@ -943,26 +923,19 @@ mod tests {
 		let ns = "N".to_string();
 		let db = "D".to_string();
 
-		// Reject empty username or password
+		// Reject invalid ROOT credentials
 		{
-			assert!(verify_creds(&ds, None, None, "", "").await.is_err());
-			assert!(verify_creds(&ds, None, None, "test", "").await.is_err());
-			assert!(verify_creds(&ds, None, None, "", "test").await.is_err());
-		}
-
-		// Reject invalid KV credentials
-		{
-			assert!(verify_creds(&ds, None, None, "test", "test").await.is_err());
+			assert!(verify_root_creds(&ds, "test", "test").await.is_err());
 		}
 
 		// Reject invalid NS credentials
 		{
-			assert!(verify_creds(&ds, Some(&ns), None, "test", "test").await.is_err());
+			assert!(verify_ns_creds(&ds, &ns, "test", "test").await.is_err());
 		}
 
 		// Reject invalid DB credentials
 		{
-			assert!(verify_creds(&ds, Some(&ns), Some(&db), "test", "test").await.is_err());
+			assert!(verify_db_creds(&ds, &ns, &db, "test", "test").await.is_err());
 		}
 	}
 
@@ -976,7 +949,7 @@ mod tests {
 		{
 			let sess = Session::owner();
 
-			let sql = "DEFINE USER kv ON ROOT PASSWORD 'kv'";
+			let sql = "DEFINE USER root ON ROOT PASSWORD 'root'";
 			ds.execute(sql, &sess, None).await.unwrap();
 
 			let sql = "USE NS N; DEFINE USER ns ON NS PASSWORD 'ns'";
@@ -986,85 +959,22 @@ mod tests {
 			ds.execute(sql, &sess, None).await.unwrap();
 		}
 
-		// Accept KV user
+		// Accept ROOT user
 		{
-			let res = verify_creds(&ds, None, None, "kv", "kv").await;
+			let res = verify_root_creds(&ds, "root", "root").await;
 			assert!(res.is_ok());
-
-			let (auth, _) = res.unwrap();
-			assert_eq!(auth.level(), &Level::Root);
-			assert_eq!(auth.id(), "kv");
 		}
 
 		// Accept NS user
 		{
-			let res = verify_creds(&ds, Some(&ns), None, "ns", "ns").await;
+			let res = verify_ns_creds(&ds, &ns, "ns", "ns").await;
 			assert!(res.is_ok());
-
-			let (auth, _) = res.unwrap();
-			assert_eq!(auth.level(), &Level::Namespace(ns.to_owned()));
-			assert_eq!(auth.id(), "ns");
 		}
 
 		// Accept DB user
 		{
-			let res = verify_creds(&ds, Some(&ns), Some(&db), "db", "db").await;
+			let res = verify_db_creds(&ds, &ns, &db, "db", "db").await;
 			assert!(res.is_ok());
-
-			let (auth, _) = res.unwrap();
-			assert_eq!(auth.level(), &Level::Database(ns.to_owned(), db.to_owned()));
-			assert_eq!(auth.id(), "db");
-		}
-	}
-
-	#[tokio::test]
-	async fn test_verify_creds_chain() {
-		let ds = Datastore::new("memory").await.unwrap();
-		let ns = "N".to_string();
-		let db = "D".to_string();
-
-		// Define users
-		{
-			let sess = Session::owner();
-
-			let sql = "DEFINE USER kv ON ROOT PASSWORD 'kv'";
-			ds.execute(sql, &sess, None).await.unwrap();
-
-			let sql = "USE NS N; DEFINE USER ns ON NS PASSWORD 'ns'";
-			ds.execute(sql, &sess, None).await.unwrap();
-
-			let sql = "USE NS N DB D; DEFINE USER db ON DB PASSWORD 'db'";
-			ds.execute(sql, &sess, None).await.unwrap();
-		}
-
-		// Accept KV user even with NS and DB defined
-		{
-			let res = verify_creds(&ds, Some(&ns), Some(&db), "kv", "kv").await;
-			assert!(res.is_ok());
-
-			let (auth, _) = res.unwrap();
-			assert_eq!(auth.level(), &Level::Root);
-			assert_eq!(auth.id(), "kv");
-		}
-
-		// Accept NS user even with DB defined
-		{
-			let res = verify_creds(&ds, Some(&ns), Some(&db), "ns", "ns").await;
-			assert!(res.is_ok());
-
-			let (auth, _) = res.unwrap();
-			assert_eq!(auth.level(), &Level::Namespace(ns.to_owned()));
-			assert_eq!(auth.id(), "ns");
-		}
-
-		// Accept DB user
-		{
-			let res = verify_creds(&ds, Some(&ns), Some(&db), "db", "db").await;
-			assert!(res.is_ok());
-
-			let (auth, _) = res.unwrap();
-			assert_eq!(auth.level(), &Level::Database(ns.to_owned(), db.to_owned()));
-			assert_eq!(auth.id(), "db");
 		}
 	}
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -137,6 +137,9 @@ pub mod kvs;
 
 #[doc(inline)]
 pub use api::engine;
+#[cfg(feature = "protocol-http")]
+#[doc(inline)]
+pub use api::headers;
 #[doc(inline)]
 pub use api::method;
 #[doc(inline)]

--- a/src/cli/abstraction/mod.rs
+++ b/src/cli/abstraction/mod.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use surrealdb::opt::auth::CredentialsLevel;
 
 #[derive(Args, Debug)]
 pub(crate) struct AuthArguments {
@@ -20,6 +21,12 @@ pub(crate) struct AuthArguments {
 		requires = "username"
 	)]
 	pub(crate) password: Option<String>,
+	#[arg(
+		help = "Authentication level to use when connecting. It uses the values from --namespace and --database to determine the level."
+	)]
+	#[arg(env = "SURREAL_AUTH_LEVEL", long = "auth-level", default_value = "root")]
+	#[arg(value_parser = super::validator::parser::creds_level::CredentialsLevelParser::new())]
+	pub(crate) auth_level: CredentialsLevel,
 }
 
 #[derive(Args, Debug)]
@@ -33,11 +40,11 @@ pub struct DatabaseSelectionArguments {
 }
 
 #[derive(Args, Debug)]
-pub struct DatabaseSelectionOptionalArguments {
-	#[arg(help = "The namespace selected for the operation")]
+pub struct LevelSelectionArguments {
+	#[arg(help = "The selected namespace")]
 	#[arg(env = "SURREAL_NAMESPACE", long = "namespace", visible_alias = "ns")]
 	pub(crate) namespace: Option<String>,
-	#[arg(help = "The database selected for the operation")]
+	#[arg(help = "The selected database")]
 	#[arg(
 		env = "SURREAL_DATABASE",
 		long = "database",

--- a/src/cli/backup.rs
+++ b/src/cli/backup.rs
@@ -1,3 +1,4 @@
+use super::abstraction::LevelSelectionArguments;
 use crate::cli::abstraction::AuthArguments;
 use crate::cnf::SERVER_AGENT;
 use crate::err::Error;
@@ -5,8 +6,13 @@ use clap::Args;
 use futures::TryStreamExt;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::header::USER_AGENT;
+use reqwest::RequestBuilder;
 use reqwest::{Body, Client, Response};
 use std::io::ErrorKind;
+use surrealdb::headers::AUTH_DB;
+use surrealdb::headers::AUTH_NS;
+use surrealdb::opt::auth::CredentialsBuilder;
+use surrealdb::opt::auth::CredentialsLevel;
 use tokio::fs::OpenOptions;
 use tokio::io::{copy, stdin, stdout, AsyncWrite, AsyncWriteExt};
 use tokio_util::io::{ReaderStream, StreamReader};
@@ -24,16 +30,16 @@ pub struct BackupCommandArguments {
 	into: String,
 	#[command(flatten)]
 	auth: AuthArguments,
+	#[command(flatten)]
+	level: LevelSelectionArguments,
 }
 
 pub async fn init(
 	BackupCommandArguments {
 		from,
 		into,
-		auth: AuthArguments {
-			username: user,
-			password: pass,
-		},
+		auth,
+		level,
 	}: BackupCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
@@ -59,27 +65,27 @@ pub async fn init(
 		(from, into) if from_local => {
 			// Copy the data to the destination
 			let from = OpenOptions::new().read(true).open(from).await?;
-			post_http_sync_body(from, into, user.as_deref(), pass.as_deref()).await
+			post_http_sync_body(from, into, &auth, &level).await
 		}
 		// From HTTP -> Into File
 		(from, into) if into_local => {
 			// Try to open the output file
 			let into =
 				OpenOptions::new().write(true).create(true).truncate(true).open(into).await?;
-			backup_http_to_file(from, into, user.as_deref(), pass.as_deref()).await
+			backup_http_to_file(from, into, &auth, &level).await
 		}
 		// From HTTP -> Into Stdout
-		(from, "-") => backup_http_to_file(from, stdout(), user.as_deref(), pass.as_deref()).await,
+		(from, "-") => backup_http_to_file(from, stdout(), &auth, &level).await,
 		// From Stdin -> Into File
 		("-", into) => {
 			let from = Body::wrap_stream(ReaderStream::new(stdin()));
-			post_http_sync_body(from, into, user.as_deref(), pass.as_deref()).await
+			post_http_sync_body(from, into, &auth, &level).await
 		}
 		// From HTTP -> Into HTTP
 		(from, into) => {
 			// Copy the data to the destination
-			let from = get_http_sync_body(from, user.as_deref(), pass.as_deref()).await?;
-			post_http_sync_body(from, into, user.as_deref(), pass.as_deref()).await
+			let from = get_http_sync_body(from, &auth, &level).await?;
+			post_http_sync_body(from, into, &auth, &level).await
 		}
 	}
 }
@@ -87,8 +93,8 @@ pub async fn init(
 async fn post_http_sync_body<B: Into<Body>>(
 	from: B,
 	into: &str,
-	user: Option<&str>,
-	pass: Option<&str>,
+	auth: &AuthArguments,
+	level: &LevelSelectionArguments,
 ) -> Result<(), Error> {
 	let mut req = Client::new()
 		.post(format!("{into}/sync"))
@@ -97,8 +103,8 @@ async fn post_http_sync_body<B: Into<Body>>(
 		.body(from);
 
 	// Add authentication if needed
-	if let Some(user) = user {
-		req = req.basic_auth(user, pass);
+	if auth.username.is_some() {
+		req = req_with_creds(req, auth, level)?;
 	}
 
 	req.send().await?.error_for_status()?;
@@ -107,8 +113,8 @@ async fn post_http_sync_body<B: Into<Body>>(
 
 async fn get_http_sync_body(
 	from: &str,
-	user: Option<&str>,
-	pass: Option<&str>,
+	auth: &AuthArguments,
+	level: &LevelSelectionArguments,
 ) -> Result<Response, Error> {
 	let mut req = Client::new()
 		.get(format!("{from}/sync"))
@@ -116,8 +122,8 @@ async fn get_http_sync_body(
 		.header(CONTENT_TYPE, TYPE);
 
 	// Add authentication if needed
-	if let Some(user) = user {
-		req = req.basic_auth(user, pass);
+	if auth.username.is_some() {
+		req = req_with_creds(req, auth, level)?;
 	}
 
 	Ok(req.send().await?.error_for_status()?)
@@ -126,11 +132,11 @@ async fn get_http_sync_body(
 async fn backup_http_to_file<W: AsyncWrite + Unpin>(
 	from: &str,
 	mut into: W,
-	user: Option<&str>,
-	pass: Option<&str>,
+	auth: &AuthArguments,
+	level: &LevelSelectionArguments,
 ) -> Result<(), Error> {
 	let mut from = StreamReader::new(
-		get_http_sync_body(from, user, pass)
+		get_http_sync_body(from, auth, level)
 			.await?
 			.bytes_stream()
 			.map_err(|x| std::io::Error::new(ErrorKind::Other, x)),
@@ -141,4 +147,44 @@ async fn backup_http_to_file<W: AsyncWrite + Unpin>(
 	into.flush().await?;
 	// Everything OK
 	Ok(())
+}
+
+fn req_with_creds(
+	req: RequestBuilder,
+	AuthArguments {
+		username,
+		password,
+		auth_level,
+	}: &AuthArguments,
+	LevelSelectionArguments {
+		namespace,
+		database,
+	}: &LevelSelectionArguments,
+) -> Result<RequestBuilder, Error> {
+	let builder = CredentialsBuilder::default()
+		.with_username(username.as_deref())
+		.with_password(password.as_deref())
+		.with_namespace(namespace.as_deref())
+		.with_database(database.as_deref());
+
+	let req = match auth_level {
+		CredentialsLevel::Root => {
+			let creds = builder.for_root()?;
+			req.basic_auth(creds.username, Some(creds.password))
+		}
+		CredentialsLevel::Namespace => {
+			let creds = builder.for_namespace()?;
+			req.header(&AUTH_NS, creds.namespace).basic_auth(creds.username, Some(creds.password))
+		}
+		CredentialsLevel::Database => {
+			let creds = builder.for_database()?;
+			req.header(&AUTH_NS, creds.namespace)
+				.header(&AUTH_DB, creds.database)
+				.basic_auth(creds.username, Some(creds.password))
+		}
+		// Clap shouldn't allow any other credentials level
+		_ => unreachable!("Invalid auth level"),
+	};
+
+	Ok(req)
 }

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -3,9 +3,8 @@ use crate::cli::abstraction::{
 };
 use crate::err::Error;
 use clap::Args;
-use surrealdb::engine::any::connect;
-use surrealdb::opt::auth::Root;
-use surrealdb::opt::Config;
+use surrealdb::engine::any::{connect, IntoEndpoint};
+use surrealdb::opt::auth::{CredentialsBuilder, CredentialsLevel};
 
 #[derive(Args, Debug)]
 pub struct ExportCommandArguments {
@@ -31,42 +30,51 @@ pub async fn init(
 		auth: AuthArguments {
 			username,
 			password,
+			auth_level,
 		},
 		sel: DatabaseSelectionArguments {
-			namespace: ns,
-			database: db,
+			namespace,
+			database,
 		},
 	}: ExportCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
 	crate::telemetry::builder().with_log_level("error").init();
 
-	let client = if let Some((username, password)) = username.zip(password) {
-		let root = Root {
-			username: &username,
-			password: &password,
+	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
+	// If we are connecting directly to a datastore (i.e. file://local.db or tikv://...), then we don't need to authenticate because we use an embedded (local) SurrealDB instance with auth disabled.
+	let client = if username.is_some()
+		&& password.is_some()
+		&& !endpoint.clone().into_endpoint()?.parse_kind()?.is_local()
+	{
+		debug!("Connecting to the database engine with authentication");
+		let creds = CredentialsBuilder::default()
+			.with_username(username.as_deref())
+			.with_password(password.as_deref())
+			.with_namespace(Some(&namespace))
+			.with_database(Some(&database));
+
+		let client = connect(endpoint).await?;
+
+		debug!("Signing in to the database engine with {:?}", auth_level);
+		match auth_level {
+			CredentialsLevel::Root => client.signin(creds.for_root()?).await?,
+			CredentialsLevel::Namespace => client.signin(creds.for_namespace()?).await?,
+			CredentialsLevel::Database => client.signin(creds.for_database()?).await?,
+			// Clap shouldn't allow any other credentials level
+			_ => unreachable!("Invalid auth level"),
 		};
 
-		// Connect to the database engine with authentication
-		//
-		// * For local engines, here we enable authentication and in the signin below we actually authenticate.
-		// * For remote engines, we connect to the endpoint and then signin.
-		#[cfg(feature = "has-storage")]
-		let address = (endpoint, Config::new().user(root));
-		#[cfg(not(feature = "has-storage"))]
-		let address = endpoint;
-		let client = connect(address).await?;
-
-		// Sign in to the server
-		client.signin(root).await?;
 		client
 	} else {
+		debug!("Connecting to the database engine without authentication");
 		connect(endpoint).await?
 	};
 
 	// Use the specified namespace / database
-	client.use_ns(ns).use_db(db).await?;
+	client.use_ns(namespace).use_db(database).await?;
 	// Export the data from the database
+	debug!("Exporting data from the database");
 	client.export(file).await?;
 	info!("The SQL file was exported successfully");
 	// Everything OK

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -3,9 +3,8 @@ use crate::cli::abstraction::{
 };
 use crate::err::Error;
 use clap::Args;
-use surrealdb::engine::any::connect;
-use surrealdb::opt::auth::Root;
-use surrealdb::opt::Config;
+use surrealdb::engine::any::{connect, IntoEndpoint};
+use surrealdb::opt::auth::{CredentialsBuilder, CredentialsLevel};
 
 #[derive(Args, Debug)]
 pub struct ImportCommandArguments {
@@ -29,41 +28,49 @@ pub async fn init(
 		auth: AuthArguments {
 			username,
 			password,
+			auth_level,
 		},
 		sel: DatabaseSelectionArguments {
-			namespace: ns,
-			database: db,
+			namespace,
+			database,
 		},
 	}: ImportCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
 	crate::telemetry::builder().with_log_level("info").init();
 
-	let client = if let Some((username, password)) = username.zip(password) {
-		let root = Root {
-			username: &username,
-			password: &password,
+	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
+	// If we are connecting directly to a datastore (i.e. file://local.db or tikv://...), then we don't need to authenticate because we use an embedded (local) SurrealDB instance with auth disabled.
+	let client = if username.is_some()
+		&& password.is_some()
+		&& !endpoint.clone().into_endpoint()?.parse_kind()?.is_local()
+	{
+		debug!("Connecting to the database engine with authentication");
+		let creds = CredentialsBuilder::default()
+			.with_username(username.as_deref())
+			.with_password(password.as_deref())
+			.with_namespace(Some(&namespace))
+			.with_database(Some(&database));
+
+		let client = connect(endpoint).await?;
+
+		debug!("Signing in to the database engine with {:?}", auth_level);
+		match auth_level {
+			CredentialsLevel::Root => client.signin(creds.for_root()?).await?,
+			CredentialsLevel::Namespace => client.signin(creds.for_namespace()?).await?,
+			CredentialsLevel::Database => client.signin(creds.for_database()?).await?,
+			// Clap shouldn't allow any other credentials level
+			_ => unreachable!("Invalid auth level"),
 		};
 
-		// Connect to the database engine with authentication
-		//
-		// * For local engines, here we enable authentication and in the signin below we actually authenticate.
-		// * For remote engines, we connect to the endpoint and then signin.
-		#[cfg(feature = "has-storage")]
-		let address = (endpoint, Config::new().user(root));
-		#[cfg(not(feature = "has-storage"))]
-		let address = endpoint;
-		let client = connect(address).await?;
-
-		// Sign in to the server
-		client.signin(root).await?;
 		client
 	} else {
+		debug!("Connecting to the database engine without authentication");
 		connect(endpoint).await?
 	};
 
 	// Use the specified namespace / database
-	client.use_ns(ns).use_db(db).await?;
+	client.use_ns(namespace).use_db(database).await?;
 	// Import the data into the database
 	client.import(file).await?;
 	info!("The SQL file was imported successfully");

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -1,5 +1,5 @@
 use crate::cli::abstraction::{
-	AuthArguments, DatabaseConnectionArguments, DatabaseSelectionOptionalArguments,
+	AuthArguments, DatabaseConnectionArguments, LevelSelectionArguments,
 };
 use crate::err::Error;
 use clap::Args;
@@ -8,9 +8,8 @@ use rustyline::validate::{ValidationContext, ValidationResult, Validator};
 use rustyline::{Completer, Editor, Helper, Highlighter, Hinter};
 use serde::Serialize;
 use serde_json::ser::PrettyFormatter;
-use surrealdb::engine::any::connect;
-use surrealdb::opt::auth::Root;
-use surrealdb::opt::Config;
+use surrealdb::engine::any::{connect, IntoEndpoint};
+use surrealdb::opt::auth::{CredentialsBuilder, CredentialsLevel};
 use surrealdb::sql::{self, Statement, Value};
 use surrealdb::Response;
 
@@ -21,7 +20,7 @@ pub struct SqlCommandArguments {
 	#[command(flatten)]
 	auth: AuthArguments,
 	#[command(flatten)]
-	sel: Option<DatabaseSelectionOptionalArguments>,
+	level: LevelSelectionArguments,
 	/// Whether database responses should be pretty printed
 	#[arg(long)]
 	pretty: bool,
@@ -38,11 +37,15 @@ pub async fn init(
 		auth: AuthArguments {
 			username,
 			password,
+			auth_level,
 		},
 		conn: DatabaseConnectionArguments {
 			endpoint,
 		},
-		sel,
+		level: LevelSelectionArguments {
+			namespace,
+			database,
+		},
 		pretty,
 		json,
 		multi,
@@ -52,26 +55,33 @@ pub async fn init(
 	// Initialize opentelemetry and logging
 	crate::telemetry::builder().with_log_level("warn").init();
 
-	let client = if let Some((username, password)) = username.zip(password) {
-		let root = Root {
-			username: &username,
-			password: &password,
+	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
+	// If we are connecting directly to a datastore (i.e. file://local.db or tikv://...), then we don't need to authenticate because we use an embedded (local) SurrealDB instance with auth disabled.
+	let client = if username.is_some()
+		&& password.is_some()
+		&& !endpoint.clone().into_endpoint()?.parse_kind()?.is_local()
+	{
+		debug!("Connecting to the database engine with authentication");
+		let creds = CredentialsBuilder::default()
+			.with_username(username.as_deref())
+			.with_password(password.as_deref())
+			.with_namespace(namespace.as_deref())
+			.with_database(database.as_deref());
+
+		let client = connect(endpoint).await?;
+
+		debug!("Signing in to the database engine with {:?}", auth_level);
+		match auth_level {
+			CredentialsLevel::Root => client.signin(creds.for_root()?).await?,
+			CredentialsLevel::Namespace => client.signin(creds.for_namespace()?).await?,
+			CredentialsLevel::Database => client.signin(creds.for_database()?).await?,
+			// Clap shouldn't allow any other credentials level
+			_ => unreachable!("Invalid auth level"),
 		};
 
-		// Connect to the database engine with authentication
-		//
-		// * For local engines, here we enable authentication and in the signin below we actually authenticate.
-		// * For remote engines, we connect to the endpoint and then signin.
-		#[cfg(feature = "has-storage")]
-		let address = (endpoint, Config::new().user(root));
-		#[cfg(not(feature = "has-storage"))]
-		let address = endpoint;
-		let client = connect(address).await?;
-
-		// Sign in to the server
-		client.signin(root).await?;
 		client
 	} else {
+		debug!("Connecting to the database engine without authentication");
 		connect(endpoint).await?
 	};
 
@@ -85,27 +95,22 @@ pub async fn init(
 	let _ = rl.load_history("history.txt");
 	// Configure the prompt
 	let mut prompt = "> ".to_owned();
+
 	// Keep track of current namespace/database.
-	if let Some(DatabaseSelectionOptionalArguments {
-		namespace,
-		database,
-	}) = sel
-	{
-		let is_not_empty = |s: &&str| !s.is_empty();
-		let namespace = namespace.as_deref().map(str::trim).filter(is_not_empty);
-		let database = database.as_deref().map(str::trim).filter(is_not_empty);
-		match (namespace, database) {
-			(Some(namespace), Some(database)) => {
-				client.use_ns(namespace).use_db(database).await?;
-				prompt = format!("{namespace}/{database}> ");
-			}
-			(Some(namespace), None) => {
-				client.use_ns(namespace).await?;
-				prompt = format!("{namespace}> ");
-			}
-			_ => {}
+	let is_not_empty = |s: &&str| !s.is_empty();
+	let namespace = namespace.as_deref().map(str::trim).filter(is_not_empty);
+	let database = database.as_deref().map(str::trim).filter(is_not_empty);
+	match (namespace, database) {
+		(Some(namespace), Some(database)) => {
+			client.use_ns(namespace).use_db(database).await?;
+			prompt = format!("{namespace}/{database}> ");
 		}
-	};
+		(Some(namespace), None) => {
+			client.use_ns(namespace).await?;
+			prompt = format!("{namespace}> ");
+		}
+		_ => {}
+	}
 
 	// Loop over each command-line input
 	loop {

--- a/src/cli/validator/parser/creds_level.rs
+++ b/src/cli/validator/parser/creds_level.rs
@@ -1,0 +1,50 @@
+use clap::builder::{NonEmptyStringValueParser, PossibleValue, TypedValueParser};
+use clap::error::{ContextKind, ContextValue, ErrorKind};
+use surrealdb::opt::auth::CredentialsLevel;
+
+#[derive(Clone)]
+pub struct CredentialsLevelParser;
+
+impl CredentialsLevelParser {
+	pub fn new() -> CredentialsLevelParser {
+		Self
+	}
+}
+
+impl TypedValueParser for CredentialsLevelParser {
+	type Value = CredentialsLevel;
+
+	fn parse_ref(
+		&self,
+		cmd: &clap::Command,
+		arg: Option<&clap::Arg>,
+		value: &std::ffi::OsStr,
+	) -> Result<Self::Value, clap::Error> {
+		let inner = NonEmptyStringValueParser::new();
+		let v = inner.parse_ref(cmd, arg, value)?;
+
+		match v.as_str() {
+			"root" => Ok(CredentialsLevel::Root),
+			"namespace" | "ns" => Ok(CredentialsLevel::Namespace),
+			"database" | "db" => Ok(CredentialsLevel::Database),
+			v => {
+				let mut err = clap::Error::new(ErrorKind::InvalidValue);
+				err.insert(ContextKind::InvalidValue, ContextValue::String(v.to_string()));
+				Err(err)
+			}
+		}
+	}
+
+	fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
+		Some(Box::new(
+			[
+				PossibleValue::new("root"),
+				PossibleValue::new("namespace"),
+				PossibleValue::new("ns"),
+				PossibleValue::new("database"),
+				PossibleValue::new("db"),
+			]
+			.into_iter(),
+		))
+	}
+}

--- a/src/cli/validator/parser/mod.rs
+++ b/src/cli/validator/parser/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod creds_level;
 pub(crate) mod env_filter;

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -253,7 +253,7 @@ mod tests {
 	use std::str::FromStr;
 
 	use surrealdb::dbs::Session;
-	use surrealdb::iam::verify::verify_creds;
+	use surrealdb::iam::verify::verify_root_creds;
 	use surrealdb::kvs::Datastore;
 	use test_log::test;
 	use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
@@ -278,7 +278,7 @@ mod tests {
 			ds.transaction(false, false).await.unwrap().all_root_users().await.unwrap().len(),
 			1
 		);
-		verify_creds(&ds, None, None, creds.username, creds.password).await.unwrap();
+		verify_root_creds(&ds, creds.username, creds.password).await.unwrap();
 
 		// Do not setup the initial root user if there are root users:
 		// Test the scenario by making sure the custom password doesn't change.

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -1,7 +1,8 @@
+use axum::extract::rejection::TypedHeaderRejection;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use base64::DecodeError as Base64Error;
-use http::StatusCode;
+use http::{HeaderName, StatusCode};
 use reqwest::Error as ReqwestError;
 use serde::Serialize;
 use serde_cbor::error::Error as CborError;
@@ -11,6 +12,7 @@ use std::io::Error as IoError;
 use std::string::FromUtf8Error as Utf8Error;
 use surrealdb::error::Db as SurrealDbError;
 use surrealdb::iam::Error as SurrealIamError;
+use surrealdb::opt::auth::Error as SurrealAuthError;
 use surrealdb::Error as SurrealError;
 use thiserror::Error;
 
@@ -33,6 +35,9 @@ pub enum Error {
 
 	#[error("There was a problem connecting with the storage engine")]
 	InvalidStorage,
+
+	#[error("There was a problem parsing the header {0}: {1}")]
+	InvalidHeader(HeaderName, TypedHeaderRejection),
 
 	#[error("The operation is unsupported")]
 	OperationUnsupported,
@@ -57,6 +62,9 @@ pub enum Error {
 
 	#[error("There was an error with the node agent")]
 	NodeAgent,
+
+	#[error("There was an error with auth: {0}")]
+	Auth(#[from] SurrealAuthError),
 }
 
 impl From<Error> for String {

--- a/src/net/auth.rs
+++ b/src/net/auth.rs
@@ -17,7 +17,15 @@ use tower_http::auth::AsyncAuthorizeRequest;
 
 use crate::{dbs::DB, err::Error};
 
-use super::{client_ip::ExtractClientIP, AppState};
+use super::{
+	client_ip::ExtractClientIP,
+	headers::{
+		parse_typed_header, SurrealAuthDatabase, SurrealAuthNamespace, SurrealDatabase,
+		SurrealDatabaseLegacy, SurrealId, SurrealIdLegacy, SurrealNamespace,
+		SurrealNamespaceLegacy,
+	},
+	AppState,
+};
 
 ///
 /// SurrealAuth is a tower layer that implements the AsyncAuthorizeRequest trait.
@@ -80,14 +88,48 @@ async fn check_auth(parts: &mut Parts) -> Result<Session, Error> {
 		None
 	};
 
-	let id = parts.headers.get("id").map(|v| v.to_str().unwrap().to_string()); // TODO: Use a TypedHeader
-	let ns = parts.headers.get("ns").map(|v| v.to_str().unwrap().to_string()); // TODO: Use a TypedHeader
-	let db = parts.headers.get("db").map(|v| v.to_str().unwrap().to_string()); // TODO: Use a TypedHeader
+	// Extract the session id from the headers. If not found, fallback to the legacy header name.
+	let id = match parse_typed_header::<SurrealId>(parts.extract::<TypedHeader<SurrealId>>().await)
+	{
+		Ok(None) => parse_typed_header::<SurrealIdLegacy>(
+			parts.extract::<TypedHeader<SurrealIdLegacy>>().await,
+		),
+		res => res,
+	}?;
+
+	// Extract the namespace from the headers. If not found, fallback to the legacy header name.
+	let ns = match parse_typed_header::<SurrealNamespace>(
+		parts.extract::<TypedHeader<SurrealNamespace>>().await,
+	) {
+		Ok(None) => parse_typed_header::<SurrealNamespaceLegacy>(
+			parts.extract::<TypedHeader<SurrealNamespaceLegacy>>().await,
+		),
+		res => res,
+	}?;
+
+	// Extract the database from the headers. If not found, fallback to the legacy header name.
+	let db = match parse_typed_header::<SurrealDatabase>(
+		parts.extract::<TypedHeader<SurrealDatabase>>().await,
+	) {
+		Ok(None) => parse_typed_header::<SurrealDatabaseLegacy>(
+			parts.extract::<TypedHeader<SurrealDatabaseLegacy>>().await,
+		),
+		res => res,
+	}?;
+
+	// Extract the authentication namespace and database from the headers.
+	let auth_ns = parse_typed_header::<SurrealAuthNamespace>(
+		parts.extract::<TypedHeader<SurrealAuthNamespace>>().await,
+	)?;
+	let auth_db = parse_typed_header::<SurrealAuthDatabase>(
+		parts.extract::<TypedHeader<SurrealAuthDatabase>>().await,
+	)?;
 
 	let Extension(state) = parts.extract::<Extension<AppState>>().await.map_err(|err| {
 		tracing::error!("Error extracting the app state: {:?}", err);
 		Error::InvalidAuth
 	})?;
+
 	let ExtractClientIP(ip) =
 		parts.extract_with_state(&state).await.unwrap_or(ExtractClientIP(None));
 
@@ -97,7 +139,15 @@ async fn check_auth(parts: &mut Parts) -> Result<Session, Error> {
 
 	// If Basic authentication data was supplied
 	if let Ok(au) = parts.extract::<TypedHeader<Authorization<Basic>>>().await {
-		basic(kvs, &mut session, au.username(), au.password()).await?;
+		basic(
+			kvs,
+			&mut session,
+			au.username(),
+			au.password(),
+			auth_ns.as_deref(),
+			auth_db.as_deref(),
+		)
+		.await?;
 	};
 
 	// If Token authentication data was supplied

--- a/src/net/headers/accept.rs
+++ b/src/net/headers/accept.rs
@@ -1,32 +1,7 @@
-use crate::cnf::PKG_NAME;
-use crate::cnf::PKG_VERSION;
 use axum::headers;
 use axum::headers::Header;
 use http::HeaderName;
 use http::HeaderValue;
-use surrealdb::cnf::SERVER_NAME;
-use tower_http::set_header::SetResponseHeaderLayer;
-
-pub(super) const ID: &str = "ID";
-pub(super) const NS: &str = "NS";
-pub(super) const DB: &str = "DB";
-const SERVER: &str = "server";
-const VERSION: &str = "version";
-
-pub fn add_version_header() -> SetResponseHeaderLayer<HeaderValue> {
-	let val = format!("{PKG_NAME}-{}", *PKG_VERSION);
-	SetResponseHeaderLayer::if_not_present(
-		HeaderName::from_static(VERSION),
-		HeaderValue::try_from(val).unwrap(),
-	)
-}
-
-pub fn add_server_header() -> SetResponseHeaderLayer<HeaderValue> {
-	SetResponseHeaderLayer::if_not_present(
-		HeaderName::from_static(SERVER),
-		HeaderValue::try_from(SERVER_NAME).unwrap(),
-	)
-}
 
 /// Typed header implementation for the `Accept` header.
 pub enum Accept {

--- a/src/net/headers/mod.rs
+++ b/src/net/headers/mod.rs
@@ -1,0 +1,51 @@
+use crate::cnf::PKG_NAME;
+use crate::cnf::PKG_VERSION;
+use crate::err::Error;
+use axum::extract::rejection::TypedHeaderRejection;
+use axum::extract::rejection::TypedHeaderRejectionReason;
+use axum::headers::Header;
+use axum::TypedHeader;
+use http::header::SERVER;
+use http::HeaderValue;
+use surrealdb::cnf::SERVER_NAME;
+use surrealdb::headers::VERSION;
+use tower_http::set_header::SetResponseHeaderLayer;
+
+mod accept;
+mod sur_auth_db;
+mod sur_auth_ns;
+mod sur_db;
+mod sur_id;
+mod sur_ns;
+
+pub use accept::Accept;
+pub use sur_auth_db::SurrealAuthDatabase;
+pub use sur_auth_ns::SurrealAuthNamespace;
+pub use sur_db::{SurrealDatabase, SurrealDatabaseLegacy};
+pub use sur_id::{SurrealId, SurrealIdLegacy};
+pub use sur_ns::{SurrealNamespace, SurrealNamespaceLegacy};
+
+pub fn add_version_header() -> SetResponseHeaderLayer<HeaderValue> {
+	let val = format!("{PKG_NAME}-{}", *PKG_VERSION);
+	SetResponseHeaderLayer::if_not_present(VERSION.to_owned(), HeaderValue::try_from(val).unwrap())
+}
+
+pub fn add_server_header() -> SetResponseHeaderLayer<HeaderValue> {
+	SetResponseHeaderLayer::if_not_present(SERVER, HeaderValue::try_from(SERVER_NAME).unwrap())
+}
+
+// Parse a TypedHeader, returning None if the header is missing and an error if the header is invalid.
+pub fn parse_typed_header<H>(
+	header: Result<TypedHeader<H>, TypedHeaderRejection>,
+) -> Result<Option<String>, Error>
+where
+	H: std::ops::Deref<Target = String> + Header,
+{
+	match header {
+		Ok(TypedHeader(val)) => Ok(Some(val.to_string())),
+		Err(e) => match e.reason() {
+			TypedHeaderRejectionReason::Missing => Ok(None),
+			_ => Err(Error::InvalidHeader(H::name().to_owned(), e)),
+		},
+	}
+}

--- a/src/net/headers/sur_auth_db.rs
+++ b/src/net/headers/sur_auth_db.rs
@@ -1,0 +1,52 @@
+use axum::headers;
+use axum::headers::Header;
+use http::HeaderName;
+use http::HeaderValue;
+use surrealdb::headers::AUTH_DB;
+
+/// Typed header implementation for the `Sur-Auth-Db` header.
+/// It's used to specify the database to use for the basic authentication.
+pub struct SurrealAuthDatabase(String);
+
+impl Header for SurrealAuthDatabase {
+	fn name() -> &'static HeaderName {
+		&AUTH_DB
+	}
+
+	fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+	where
+		I: Iterator<Item = &'i HeaderValue>,
+	{
+		let value = values.next().ok_or_else(headers::Error::invalid)?;
+		let value = value.to_str().map_err(|_| headers::Error::invalid())?.to_string();
+
+		Ok(SurrealAuthDatabase(value))
+	}
+
+	fn encode<E>(&self, values: &mut E)
+	where
+		E: Extend<HeaderValue>,
+	{
+		values.extend(std::iter::once(self.into()));
+	}
+}
+
+impl std::ops::Deref for SurrealAuthDatabase {
+	type Target = String;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl From<SurrealAuthDatabase> for HeaderValue {
+	fn from(value: SurrealAuthDatabase) -> Self {
+		HeaderValue::from(&value)
+	}
+}
+
+impl From<&SurrealAuthDatabase> for HeaderValue {
+	fn from(value: &SurrealAuthDatabase) -> Self {
+		HeaderValue::from_str(value.0.as_str()).unwrap()
+	}
+}

--- a/src/net/headers/sur_auth_ns.rs
+++ b/src/net/headers/sur_auth_ns.rs
@@ -1,0 +1,52 @@
+use axum::headers;
+use axum::headers::Header;
+use http::HeaderName;
+use http::HeaderValue;
+use surrealdb::headers::AUTH_NS;
+
+/// Typed header implementation for the `Sur-Auth-Ns` header.
+/// It's used to specify the namespace to use for the basic authentication.
+pub struct SurrealAuthNamespace(String);
+
+impl Header for SurrealAuthNamespace {
+	fn name() -> &'static HeaderName {
+		&AUTH_NS
+	}
+
+	fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+	where
+		I: Iterator<Item = &'i HeaderValue>,
+	{
+		let value = values.next().ok_or_else(headers::Error::invalid)?;
+		let value = value.to_str().map_err(|_| headers::Error::invalid())?.to_string();
+
+		Ok(SurrealAuthNamespace(value))
+	}
+
+	fn encode<E>(&self, values: &mut E)
+	where
+		E: Extend<HeaderValue>,
+	{
+		values.extend(std::iter::once(self.into()));
+	}
+}
+
+impl std::ops::Deref for SurrealAuthNamespace {
+	type Target = String;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl From<SurrealAuthNamespace> for HeaderValue {
+	fn from(value: SurrealAuthNamespace) -> Self {
+		HeaderValue::from(&value)
+	}
+}
+
+impl From<&SurrealAuthNamespace> for HeaderValue {
+	fn from(value: &SurrealAuthNamespace) -> Self {
+		HeaderValue::from_str(value.0.as_str()).unwrap()
+	}
+}

--- a/src/net/headers/sur_db.rs
+++ b/src/net/headers/sur_db.rs
@@ -1,0 +1,102 @@
+use axum::headers;
+use axum::headers::Header;
+use http::HeaderName;
+use http::HeaderValue;
+use surrealdb::headers::DB;
+
+/// Typed header implementation for the database header.
+/// It's used to specify the database to use for database operations.
+pub struct SurrealDatabase(String);
+
+impl Header for SurrealDatabase {
+	fn name() -> &'static HeaderName {
+		&DB
+	}
+
+	fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+	where
+		I: Iterator<Item = &'i HeaderValue>,
+	{
+		let value = values.next().ok_or_else(headers::Error::invalid)?;
+		let value = value.to_str().map_err(|_| headers::Error::invalid())?.to_string();
+
+		Ok(SurrealDatabase(value))
+	}
+
+	fn encode<E>(&self, values: &mut E)
+	where
+		E: Extend<HeaderValue>,
+	{
+		values.extend(std::iter::once(self.into()));
+	}
+}
+
+impl std::ops::Deref for SurrealDatabase {
+	type Target = String;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl From<SurrealDatabase> for HeaderValue {
+	fn from(value: SurrealDatabase) -> Self {
+		HeaderValue::from(&value)
+	}
+}
+
+impl From<&SurrealDatabase> for HeaderValue {
+	fn from(value: &SurrealDatabase) -> Self {
+		HeaderValue::from_str(value.0.as_str()).unwrap()
+	}
+}
+
+//
+// Legacy header
+//
+static DB_LEGACY_HEADER: HeaderName = HeaderName::from_static("db");
+
+pub struct SurrealDatabaseLegacy(String);
+
+impl Header for SurrealDatabaseLegacy {
+	fn name() -> &'static HeaderName {
+		&DB_LEGACY_HEADER
+	}
+
+	fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+	where
+		I: Iterator<Item = &'i HeaderValue>,
+	{
+		let value = values.next().ok_or_else(headers::Error::invalid)?;
+		let value = value.to_str().map_err(|_| headers::Error::invalid())?.to_string();
+
+		Ok(SurrealDatabaseLegacy(value))
+	}
+
+	fn encode<E>(&self, values: &mut E)
+	where
+		E: Extend<HeaderValue>,
+	{
+		values.extend(std::iter::once(self.into()));
+	}
+}
+
+impl std::ops::Deref for SurrealDatabaseLegacy {
+	type Target = String;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl From<SurrealDatabaseLegacy> for HeaderValue {
+	fn from(value: SurrealDatabaseLegacy) -> Self {
+		HeaderValue::from(&value)
+	}
+}
+
+impl From<&SurrealDatabaseLegacy> for HeaderValue {
+	fn from(value: &SurrealDatabaseLegacy) -> Self {
+		HeaderValue::from_str(value.0.as_str()).unwrap()
+	}
+}

--- a/src/net/headers/sur_id.rs
+++ b/src/net/headers/sur_id.rs
@@ -1,0 +1,101 @@
+use axum::headers;
+use axum::headers::Header;
+use http::HeaderName;
+use http::HeaderValue;
+use surrealdb::headers::ID;
+
+/// Typed header implementation for the id header.
+/// It's used to specify the session id.
+pub struct SurrealId(String);
+
+impl Header for SurrealId {
+	fn name() -> &'static HeaderName {
+		&ID
+	}
+
+	fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+	where
+		I: Iterator<Item = &'i HeaderValue>,
+	{
+		let value = values.next().ok_or_else(headers::Error::invalid)?;
+		let value = value.to_str().map_err(|_| headers::Error::invalid())?.to_string();
+
+		Ok(SurrealId(value))
+	}
+
+	fn encode<E>(&self, values: &mut E)
+	where
+		E: Extend<HeaderValue>,
+	{
+		values.extend(std::iter::once(self.into()));
+	}
+}
+
+impl std::ops::Deref for SurrealId {
+	type Target = String;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl From<SurrealId> for HeaderValue {
+	fn from(value: SurrealId) -> Self {
+		HeaderValue::from(&value)
+	}
+}
+
+impl From<&SurrealId> for HeaderValue {
+	fn from(value: &SurrealId) -> Self {
+		HeaderValue::from_str(value.0.as_str()).unwrap()
+	}
+}
+
+//
+// Legacy header
+//
+static ID_LEGACY_HEADER: HeaderName = HeaderName::from_static("id");
+pub struct SurrealIdLegacy(String);
+
+impl Header for SurrealIdLegacy {
+	fn name() -> &'static HeaderName {
+		&ID_LEGACY_HEADER
+	}
+
+	fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+	where
+		I: Iterator<Item = &'i HeaderValue>,
+	{
+		let value = values.next().ok_or_else(headers::Error::invalid)?;
+		let value = value.to_str().map_err(|_| headers::Error::invalid())?.to_string();
+
+		Ok(SurrealIdLegacy(value))
+	}
+
+	fn encode<E>(&self, values: &mut E)
+	where
+		E: Extend<HeaderValue>,
+	{
+		values.extend(std::iter::once(self.into()));
+	}
+}
+
+impl std::ops::Deref for SurrealIdLegacy {
+	type Target = String;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl From<SurrealIdLegacy> for HeaderValue {
+	fn from(value: SurrealIdLegacy) -> Self {
+		HeaderValue::from(&value)
+	}
+}
+
+impl From<&SurrealIdLegacy> for HeaderValue {
+	fn from(value: &SurrealIdLegacy) -> Self {
+		HeaderValue::from_str(value.0.as_str()).unwrap()
+	}
+}

--- a/src/net/headers/sur_ns.rs
+++ b/src/net/headers/sur_ns.rs
@@ -1,0 +1,102 @@
+use axum::headers;
+use axum::headers::Header;
+use http::HeaderName;
+use http::HeaderValue;
+use surrealdb::headers::NS;
+
+/// Typed header implementation for the namespace header.
+/// It's used to specify the database to use for database operations.
+pub struct SurrealNamespace(String);
+
+impl Header for SurrealNamespace {
+	fn name() -> &'static HeaderName {
+		&NS
+	}
+
+	fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+	where
+		I: Iterator<Item = &'i HeaderValue>,
+	{
+		let value = values.next().ok_or_else(headers::Error::invalid)?;
+		let value = value.to_str().map_err(|_| headers::Error::invalid())?.to_string();
+
+		Ok(SurrealNamespace(value))
+	}
+
+	fn encode<E>(&self, values: &mut E)
+	where
+		E: Extend<HeaderValue>,
+	{
+		values.extend(std::iter::once(self.into()));
+	}
+}
+
+impl std::ops::Deref for SurrealNamespace {
+	type Target = String;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl From<SurrealNamespace> for HeaderValue {
+	fn from(value: SurrealNamespace) -> Self {
+		HeaderValue::from(&value)
+	}
+}
+
+impl From<&SurrealNamespace> for HeaderValue {
+	fn from(value: &SurrealNamespace) -> Self {
+		HeaderValue::from_str(value.0.as_str()).unwrap()
+	}
+}
+
+//
+// Legacy header
+//
+static NS_LEGACY_HEADER: HeaderName = HeaderName::from_static("ns");
+
+pub struct SurrealNamespaceLegacy(String);
+
+impl Header for SurrealNamespaceLegacy {
+	fn name() -> &'static HeaderName {
+		&NS_LEGACY_HEADER
+	}
+
+	fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+	where
+		I: Iterator<Item = &'i HeaderValue>,
+	{
+		let value = values.next().ok_or_else(headers::Error::invalid)?;
+		let value = value.to_str().map_err(|_| headers::Error::invalid())?.to_string();
+
+		Ok(SurrealNamespaceLegacy(value))
+	}
+
+	fn encode<E>(&self, values: &mut E)
+	where
+		E: Extend<HeaderValue>,
+	{
+		values.extend(std::iter::once(self.into()));
+	}
+}
+
+impl std::ops::Deref for SurrealNamespaceLegacy {
+	type Target = String;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl From<SurrealNamespaceLegacy> for HeaderValue {
+	fn from(value: SurrealNamespaceLegacy) -> Self {
+		HeaderValue::from(&value)
+	}
+}
+
+impl From<&SurrealNamespaceLegacy> for HeaderValue {
+	fn from(value: &SurrealNamespaceLegacy) -> Self {
+		HeaderValue::from_str(value.0.as_str()).unwrap()
+	}
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -25,6 +25,7 @@ use http::header;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
+use surrealdb::headers::{DB, ID, NS};
 use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
 use tower_http::add_extension::AddExtensionLayer;
@@ -105,9 +106,9 @@ pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 					http::header::AUTHORIZATION,
 					http::header::CONTENT_TYPE,
 					http::header::ORIGIN,
-					headers::NS.parse().unwrap(),
-					headers::DB.parse().unwrap(),
-					headers::ID.parse().unwrap(),
+					NS.clone(),
+					DB.clone(),
+					ID.clone(),
 				])
 				// allow requests from any origin
 				.allow_origin(Any)

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -15,7 +15,6 @@ use opentelemetry::{Context as TelemetryContext, KeyValue};
 use tracing::{Level, Subscriber};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::util::SubscriberInitExt;
-#[cfg(feature = "has-storage")]
 use tracing_subscriber::EnvFilter;
 
 pub static OTEL_DEFAULT_RESOURCE: Lazy<Resource> = Lazy::new(|| {
@@ -66,7 +65,6 @@ impl Builder {
 	}
 
 	/// Set the filter on the builder
-	#[cfg(feature = "has-storage")]
 	pub fn with_filter(mut self, filter: CustomEnvFilter) -> Self {
 		self.filter = filter;
 		self

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -212,7 +212,7 @@ mod cli_integration {
 			let exported = common::tmp_file("exported.surql");
 			let args = format!("export --conn http://{addr} {creds} --ns N --db D {exported}");
 
-			common::run(&args).output().unwrap_or_else(|_| panic!("failed to run export: {args}"));
+			common::run(&args).output().expect("failed to run export");
 			exported
 		};
 

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -7,6 +7,7 @@ mod http_integration {
 	use http::{header, Method};
 	use reqwest::Client;
 	use serde_json::json;
+	use surrealdb::headers::{DB, NS};
 	use test_log::test;
 
 	use super::common::{self, PASS, USER};
@@ -18,8 +19,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -60,8 +61,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -112,8 +113,8 @@ mod http_integration {
 			// Check the selected namespace and database
 			let res = client
 				.post(url)
-				.header("NS", "N2")
-				.header("DB", "D2")
+				.header(&NS, "N2")
+				.header(&DB, "D2")
 				.bearer_auth(&token)
 				.body("SELECT * FROM session::ns(); SELECT * FROM session::db()")
 				.send()
@@ -146,8 +147,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -200,8 +201,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -272,8 +273,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -305,8 +306,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -373,8 +374,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -435,8 +436,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -547,8 +548,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -623,8 +624,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -711,8 +712,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -776,8 +777,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -845,8 +846,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -914,8 +915,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -966,8 +967,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -1005,8 +1006,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -1102,8 +1103,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -1178,8 +1179,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -1255,8 +1256,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert(&NS, "N".parse()?);
+		headers.insert(&DB, "D".parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Before this PR, basic auth credentials were always validated against the `ROOT` level first. If the credentials were not valid for `ROOT`, it would try for the `NS` provided on the `NS` header. If they weren't valid for `NS` either, it would try for `DB`.

This caused problems when the `DB` credentials user matches the credentials for `ROOT`, because it would always auth with the `ROOT` credentials.

## What does this change do?

* CLI auth level: the `sql`, `export`, `import` and `backup` commands now have the `auth-level` argument.
* HTTP auth headers: `sur-ns` and `sur-db` are now used when doing basic auth to determine against what level the credentials need to be validated.
* It adds the `sur-` prefix to all SurrealDB headers, while still supporting the legacy headers (without the prefix).

TODO:
- [ ] Add new tests
- [ ] Decide the headers suffix. Do we use `sur-`?
- [ ] Decide whether or not to be backwards compatible at this point for the headers.

## What is your testing strategy?

Github Actions and manual testing

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
