### PR TITLE
[tracing] Fix the WS spans

### DIFF
--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -3,6 +3,8 @@ use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use opentelemetry::trace::FutureExt;
 use opentelemetry::Context as TelemetryContext;
+use tracing::Span;
+use tracing_futures::Instrument;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use surrealdb::channel::{self, Receiver, Sender};
@@ -272,39 +274,42 @@ impl Connection {
 		let mut out_fmt = rpc.read().await.processor.format.clone();
 		// Prepare Span and Otel context
 		let span = span_for_request(&rpc.read().await.ws_id);
-		let _enter = span.enter();
-		let req_cx = RequestContext::default();
-		let otel_cx = TelemetryContext::current_with_value(req_cx.clone());
 
 		// Parse the request
-		match parse_request(msg).await {
-			Ok(req) => {
-				if let Some(_out_fmt) = req.out_fmt {
-					out_fmt = _out_fmt;
+		async move {
+			let span = Span::current();
+			let req_cx = RequestContext::default();
+			let otel_cx = TelemetryContext::new().with_value(req_cx.clone());
+
+			match parse_request(msg).await {
+				Ok(req) => {
+					if let Some(_out_fmt) = req.out_fmt {
+						out_fmt = _out_fmt;
+					}
+	
+					// Now that we know the method, we can update the span and create otel context
+					span.record("rpc.method", &req.method);
+					span.record("otel.name", format!("surrealdb.rpc/{}", req.method));
+					span.record(
+						"rpc.jsonrpc.request_id",
+						req.id.clone().map(|v| v.as_string()).unwrap_or(String::new()),
+					);
+					let otel_cx = TelemetryContext::current_with_value(
+						req_cx.with_method(&req.method).with_size(req.size),
+					);
+	
+					// Process the request
+					let res =
+						rpc.write().await.processor.process_request(&req.method, req.params).await;
+	
+					// Process the response
+					res.into_response(req.id).send(out_fmt, chn).with_context(otel_cx).await
 				}
-
-				// Now that we know the method, we can update the span and create otel context
-				span.record("rpc.method", &req.method);
-				span.record("otel.name", format!("surrealdb.rpc/{}", req.method));
-				span.record(
-					"rpc.jsonrpc.request_id",
-					req.id.clone().map(|v| v.as_string()).unwrap_or(String::new()),
-				);
-				let otel_cx = TelemetryContext::current_with_value(
-					req_cx.with_method(&req.method).with_size(req.size),
-				);
-
-				// Process the request
-				let res =
-					rpc.write().await.processor.process_request(&req.method, req.params).await;
-
-				// Process the response
-				res.into_response(req.id).send(out_fmt, chn).with_context(otel_cx).await
+				Err(err) => {
+					// Process the response
+					failure(None, err).send(out_fmt, chn).with_context(otel_cx.clone()).await
+				}
 			}
-			Err(err) => {
-				// Process the response
-				failure(None, err).send(out_fmt, chn).with_context(otel_cx.clone()).await
-			}
-		}
+		}.instrument(span).await;
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Fix the websocket spans.

`span.enter()` is not able to handle futures yielding. The Span is global to the thread and when using `enter()`, if the future yields, the span won't exit, so the new task being executed may treat the current span as a parent.

This issue was detected by logs looking like this (see the `rpc/call` chain):
> 2023-08-29T07:42:01.212963Z  INFO rpc/call:rpc/call:rpc/call:rpc/call:rpc/call:rpc/call:rpc/call: surreal::rpc::processor: Process RPC request otel.kind="server" rpc.service="surrealdb" rpc.system="jsonrpc" rpc.jsonrpc.version="2.0" ws.id=c6565b47-070a-43b6-a7c5-2fcada8aa5ef rpc.method="query" otel.name="surrealdb.rpc/query" rpc.jsonrpc.request_id="12" otel.kind="server" rpc.service="surrealdb" rpc.system="jsonrpc" rpc.jsonrpc.version="2.0" ws.id=c6565b47-070a-43b6-a7c5-2fcada8aa5ef rpc.method="query" otel.name="surrealdb.rpc/query" rpc.jsonrpc.request_id="30" otel.kind="server" rpc.service="surrealdb" rpc.system="jsonrpc" rpc.jsonrpc.version="2.0" ws.id=c6565b47-070a-43b6-a7c5-2fcada8aa5ef rpc.method="query" otel.name="surrealdb.rpc/query" rpc.jsonrpc.request_id="17" otel.kind="server" rpc.service="surrealdb" rpc.system="jsonrpc" rpc.jsonrpc.version="2.0" ws.id=c6565b47-070a-43b6-a7c5-2fcada8aa5ef rpc.method="query" otel.name="surrealdb.rpc/query" rpc.jsonrpc.request_id="40" otel.kind="server" rpc.service="surrealdb" rpc.system="jsonrpc" rpc.jsonrpc.version="2.0" ws.id=c6565b47-070a-43b6-a7c5-2fcada8aa5ef rpc.method="query" otel.name="surrealdb.rpc/query" rpc.jsonrpc.request_id="34" otel.kind="server" rpc.service="surrealdb" rpc.system="jsonrpc" rpc.jsonrpc.version="2.0" ws.id=c6565b47-070a-43b6-a7c5-2fcada8aa5ef rpc.method="query" otel.name="surrealdb.rpc/query" rpc.jsonrpc.request_id="53" otel.kind="server" rpc.service="surrealdb" rpc.system="jsonrpc" rpc.jsonrpc.version="2.0" ws.id=c6565b47-070a-43b6-a7c5-2fcada8aa5ef rpc.method="query" otel.name="surrealdb.rpc/query" rpc.jsonrpc.request_id="48"


## What does this change do?

It sets up the Span only for the instrumented future, as described here https://docs.rs/tracing/latest/tracing/span/struct.Span.html#in-asynchronous-code

## What is your testing strategy?

Tested a few scenarios where this would consistently happen, and verified it doesn't happen anymore.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
