### PR TITLE
[security] Introduce "allow-guests". Deny all caps by default

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -145,7 +145,7 @@ dependencies = ["build-surrealdb"]
 script = """
    #!/bin/bash -ex
 
-   target/debug/surreal start --allow-all ${_START_SURREALDB_PATH} &>/tmp/surrealdb.log &
+   target/debug/surreal start ${_START_SURREALDB_PATH} --allow-all &>/tmp/surrealdb.log &
 
    echo $! > /tmp/surreal.pid
 

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -145,7 +145,7 @@ dependencies = ["build-surrealdb"]
 script = """
    #!/bin/bash -ex
 
-   target/debug/surreal start ${_START_SURREALDB_PATH} &>/tmp/surrealdb.log &
+   target/debug/surreal start --allow-all ${_START_SURREALDB_PATH} &>/tmp/surrealdb.log &
 
    echo $! > /tmp/surreal.pid
 

--- a/Makefile.local.toml
+++ b/Makefile.local.toml
@@ -65,11 +65,17 @@ category = "LOCAL USAGE"
 command = "cargo"
 args = ["bench", "--package", "surrealdb", "--no-default-features", "--features", "kv-mem,http,scripting"]
 
+# Run
+[tasks.run]
+category = "LOCAL USAGE"
+command = "cargo"
+args = ["run", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "${@}"]
+
 # Serve
 [tasks.serve]
 category = "LOCAL USAGE"
 command = "cargo"
-args = ["run", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "start", "${@}"]
+args = ["run", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "start", "--allow-all", "${@}"]
 
 # SQL
 [tasks.sql]

--- a/lib/benches/executor.rs
+++ b/lib/benches/executor.rs
@@ -15,7 +15,7 @@ macro_rules! query {
 				let dbs = Datastore::new("memory")
 					.await
 					.unwrap()
-					.with_capabilities(Capabilities::new_allow_all());
+					.with_capabilities(Capabilities::all());
 				let ses = Session::owner().with_ns("test").with_db("test");
 				let setup = $setup;
 				if !setup.is_empty() {

--- a/lib/benches/executor.rs
+++ b/lib/benches/executor.rs
@@ -12,10 +12,8 @@ macro_rules! query {
 	($c: expr, $name: ident, $setup: expr, $query: expr) => {
 		$c.bench_function(stringify!($name), |b| {
 			let (dbs, ses) = futures::executor::block_on(async {
-				let dbs = Datastore::new("memory")
-					.await
-					.unwrap()
-					.with_capabilities(Capabilities::all());
+				let dbs =
+					Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::all());
 				let ses = Session::owner().with_ns("test").with_db("test");
 				let setup = $setup;
 				if !setup.is_empty() {

--- a/lib/benches/executor.rs
+++ b/lib/benches/executor.rs
@@ -1,6 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use pprof::criterion::{Output, PProfProfiler};
-use surrealdb::{dbs::Session, kvs::Datastore};
+use surrealdb::{
+	dbs::{Capabilities, Session},
+	kvs::Datastore,
+};
 
 macro_rules! query {
 	($c: expr, $name: ident, $query: expr) => {
@@ -9,7 +12,10 @@ macro_rules! query {
 	($c: expr, $name: ident, $setup: expr, $query: expr) => {
 		$c.bench_function(stringify!($name), |b| {
 			let (dbs, ses) = futures::executor::block_on(async {
-				let dbs = Datastore::new("memory").await.unwrap();
+				let dbs = Datastore::new("memory")
+					.await
+					.unwrap()
+					.with_capabilities(Capabilities::new_allow_all());
 				let ses = Session::owner().with_ns("test").with_db("test");
 				let setup = $setup;
 				if !setup.is_empty() {

--- a/lib/src/api/engine/any/mod.rs
+++ b/lib/src/api/engine/any/mod.rs
@@ -265,12 +265,9 @@ mod tests {
 			username: "root",
 			password: "root",
 		};
-		let db = connect((
-			"memory",
-			Config::new().user(creds).capabilities(Capabilities::new_allow_all()),
-		))
-		.await
-		.unwrap();
+		let db = connect(("memory", Config::new().user(creds).capabilities(Capabilities::all())))
+			.await
+			.unwrap();
 		db.use_ns("N").use_db("D").await.unwrap();
 
 		// The client needs to sign in before it can access anything

--- a/lib/src/api/engine/any/mod.rs
+++ b/lib/src/api/engine/any/mod.rs
@@ -228,6 +228,7 @@ pub fn connect(address: impl IntoEndpoint) -> Connect<Any, Surreal<Any>> {
 #[cfg(all(test, feature = "kv-mem"))]
 mod tests {
 	use super::*;
+	use crate::dbs::Capabilities;
 	use crate::opt::auth::Root;
 	use crate::sql::{test::Parse, value::Value};
 
@@ -264,7 +265,12 @@ mod tests {
 			username: "root",
 			password: "root",
 		};
-		let db = connect(("memory", Config::new().user(creds))).await.unwrap();
+		let db = connect((
+			"memory",
+			Config::new().user(creds).capabilities(Capabilities::new_allow_all()),
+		))
+		.await
+		.unwrap();
 		db.use_ns("N").use_db("D").await.unwrap();
 
 		// The client needs to sign in before it can access anything

--- a/lib/src/api/engine/local/native.rs
+++ b/lib/src/api/engine/local/native.rs
@@ -140,7 +140,8 @@ pub(crate) fn router(
 		let kvs = kvs
 			.with_strict_mode(address.config.strict)
 			.with_query_timeout(address.config.query_timeout)
-			.with_transaction_timeout(address.config.transaction_timeout);
+			.with_transaction_timeout(address.config.transaction_timeout)
+			.with_capabilities(address.config.capabilities);
 
 		let kvs = match address.config.notifications {
 			true => kvs.with_notifications(),

--- a/lib/src/api/opt/config.rs
+++ b/lib/src/api/opt/config.rs
@@ -1,4 +1,4 @@
-use crate::iam::Level;
+use crate::{dbs::Capabilities, iam::Level};
 use std::time::Duration;
 
 /// Configuration for server connection, including: strictness, notifications, query_timeout, transaction_timeout
@@ -16,6 +16,7 @@ pub struct Config {
 	pub(crate) username: String,
 	pub(crate) password: String,
 	pub(crate) tick_interval: Option<Duration>,
+	pub(crate) capabilities: Capabilities,
 }
 
 impl Config {
@@ -87,6 +88,12 @@ impl Config {
 	/// Set the interval at which the database should run node maintenance tasks
 	pub fn tick_interval(mut self, interval: impl Into<Option<Duration>>) -> Self {
 		self.tick_interval = interval.into().filter(|x| !x.is_zero());
+		self
+	}
+
+	/// Set the capabilities for the database
+	pub fn capabilities(mut self, capabilities: Capabilities) -> Self {
+		self.capabilities = capabilities;
 		self
 	}
 }

--- a/lib/src/ctx/context.rs
+++ b/lib/src/ctx/context.rs
@@ -232,7 +232,7 @@ impl<'a> Context<'a> {
 			message: "Invalid function name".to_string(),
 		})?;
 
-		if !self.capabilities.allows_func(&func_target) {
+		if !self.capabilities.allows_function(&func_target) {
 			return Err(Error::FunctionNotAllowed(target.to_string()));
 		}
 		Ok(())

--- a/lib/src/ctx/context.rs
+++ b/lib/src/ctx/context.rs
@@ -243,7 +243,7 @@ impl<'a> Context<'a> {
 	pub fn check_allowed_net(&self, target: &Url) -> Result<(), Error> {
 		match target.host() {
 			Some(host)
-				if self.capabilities.allows_net(&NetTarget::Host(
+				if self.capabilities.allows_network_target(&NetTarget::Host(
 					host.to_owned(),
 					target.port_or_known_default(),
 				)) =>

--- a/lib/src/ctx/context.rs
+++ b/lib/src/ctx/context.rs
@@ -219,7 +219,7 @@ impl<'a> Context<'a> {
 
 	/// Check if scripting is allowed
 	pub fn check_allowed_scripting(&self) -> Result<(), Error> {
-		if !self.capabilities.is_allowed_scripting() {
+		if !self.capabilities.allows_scripting() {
 			return Err(Error::ScriptingNotAllowed);
 		}
 		Ok(())
@@ -232,7 +232,7 @@ impl<'a> Context<'a> {
 			message: "Invalid function name".to_string(),
 		})?;
 
-		if !self.capabilities.is_allowed_func(&func_target) {
+		if !self.capabilities.allows_func(&func_target) {
 			return Err(Error::FunctionNotAllowed(target.to_string()));
 		}
 		Ok(())
@@ -243,7 +243,7 @@ impl<'a> Context<'a> {
 	pub fn check_allowed_net(&self, target: &Url) -> Result<(), Error> {
 		match target.host() {
 			Some(host)
-				if self.capabilities.is_allowed_net(&NetTarget::Host(
+				if self.capabilities.allows_net(&NetTarget::Host(
 					host.to_owned(),
 					target.port_or_known_default(),
 				)) =>

--- a/lib/src/dbs/capabilities.rs
+++ b/lib/src/dbs/capabilities.rs
@@ -236,22 +236,22 @@ impl Capabilities {
 		self
 	}
 
-	pub fn with_allow_functions(mut self, allow_funcs: Targets<FuncTarget>) -> Self {
+	pub fn with_functions(mut self, allow_funcs: Targets<FuncTarget>) -> Self {
 		self.allow_funcs = Arc::new(allow_funcs);
 		self
 	}
 
-	pub fn with_deny_functions(mut self, deny_funcs: Targets<FuncTarget>) -> Self {
+	pub fn without_functions(mut self, deny_funcs: Targets<FuncTarget>) -> Self {
 		self.deny_funcs = Arc::new(deny_funcs);
 		self
 	}
 
-	pub fn with_allow_net(mut self, allow_net: Targets<NetTarget>) -> Self {
+	pub fn with_network_targets(mut self, allow_net: Targets<NetTarget>) -> Self {
 		self.allow_net = Arc::new(allow_net);
 		self
 	}
 
-	pub fn with_deny_net(mut self, deny_net: Targets<NetTarget>) -> Self {
+	pub fn without_network_targets(mut self, deny_net: Targets<NetTarget>) -> Self {
 		self.deny_net = Arc::new(deny_net);
 		self
 	}
@@ -268,7 +268,7 @@ impl Capabilities {
 		self.allow_funcs.matches(target) && !self.deny_funcs.matches(target)
 	}
 
-	pub fn allows_net(&self, target: &NetTarget) -> bool {
+	pub fn allows_network_target(&self, target: &NetTarget) -> bool {
 		self.allow_net.matches(target) && !self.deny_net.matches(target)
 	}
 }
@@ -499,40 +499,40 @@ mod tests {
 		// When all nets are allowed
 		{
 			let caps = Capabilities::default()
-				.with_allow_net(Targets::<NetTarget>::All)
-				.with_deny_net(Targets::<NetTarget>::None);
-			assert!(caps.allows_net(&NetTarget::from_str("example.com").unwrap()));
-			assert!(caps.allows_net(&NetTarget::from_str("example.com:80").unwrap()));
+				.with_network_targets(Targets::<NetTarget>::All)
+				.without_network_targets(Targets::<NetTarget>::None);
+			assert!(caps.allows_network_target(&NetTarget::from_str("example.com").unwrap()));
+			assert!(caps.allows_network_target(&NetTarget::from_str("example.com:80").unwrap()));
 		}
 
 		// When all nets are allowed and denied at the same time
 		{
 			let caps = Capabilities::default()
-				.with_allow_net(Targets::<NetTarget>::All)
-				.with_deny_net(Targets::<NetTarget>::All);
-			assert!(!caps.allows_net(&NetTarget::from_str("example.com").unwrap()));
-			assert!(!caps.allows_net(&NetTarget::from_str("example.com:80").unwrap()));
+				.with_network_targets(Targets::<NetTarget>::All)
+				.without_network_targets(Targets::<NetTarget>::All);
+			assert!(!caps.allows_network_target(&NetTarget::from_str("example.com").unwrap()));
+			assert!(!caps.allows_network_target(&NetTarget::from_str("example.com:80").unwrap()));
 		}
 
 		// When some nets are allowed and some are denied, deny overrides the allow rules
 		{
 			let caps = Capabilities::default()
-				.with_allow_net(Targets::<NetTarget>::Some(
+				.with_network_targets(Targets::<NetTarget>::Some(
 					[NetTarget::from_str("example.com").unwrap()].into(),
 				))
-				.with_deny_net(Targets::<NetTarget>::Some(
+				.without_network_targets(Targets::<NetTarget>::Some(
 					[NetTarget::from_str("example.com:80").unwrap()].into(),
 				));
-			assert!(caps.allows_net(&NetTarget::from_str("example.com").unwrap()));
-			assert!(caps.allows_net(&NetTarget::from_str("example.com:443").unwrap()));
-			assert!(!caps.allows_net(&NetTarget::from_str("example.com:80").unwrap()));
+			assert!(caps.allows_network_target(&NetTarget::from_str("example.com").unwrap()));
+			assert!(caps.allows_network_target(&NetTarget::from_str("example.com:443").unwrap()));
+			assert!(!caps.allows_network_target(&NetTarget::from_str("example.com:80").unwrap()));
 		}
 
 		// When all funcs are allowed
 		{
 			let caps = Capabilities::default()
-				.with_allow_functions(Targets::<FuncTarget>::All)
-				.with_deny_functions(Targets::<FuncTarget>::None);
+				.with_functions(Targets::<FuncTarget>::All)
+				.without_functions(Targets::<FuncTarget>::None);
 			assert!(caps.allows_function(&FuncTarget::from_str("http::get").unwrap()));
 			assert!(caps.allows_function(&FuncTarget::from_str("http::post").unwrap()));
 		}
@@ -540,8 +540,8 @@ mod tests {
 		// When all funcs are allowed and denied at the same time
 		{
 			let caps = Capabilities::default()
-				.with_allow_functions(Targets::<FuncTarget>::All)
-				.with_deny_functions(Targets::<FuncTarget>::All);
+				.with_functions(Targets::<FuncTarget>::All)
+				.without_functions(Targets::<FuncTarget>::All);
 			assert!(!caps.allows_function(&FuncTarget::from_str("http::get").unwrap()));
 			assert!(!caps.allows_function(&FuncTarget::from_str("http::post").unwrap()));
 		}
@@ -549,10 +549,10 @@ mod tests {
 		// When some funcs are allowed and some are denied, deny overrides the allow rules
 		{
 			let caps = Capabilities::default()
-				.with_allow_functions(Targets::<FuncTarget>::Some(
+				.with_functions(Targets::<FuncTarget>::Some(
 					[FuncTarget::from_str("http::*").unwrap()].into(),
 				))
-				.with_deny_functions(Targets::<FuncTarget>::Some(
+				.without_functions(Targets::<FuncTarget>::Some(
 					[FuncTarget::from_str("http::post").unwrap()].into(),
 				));
 			assert!(caps.allows_function(&FuncTarget::from_str("http::get").unwrap()));

--- a/lib/src/dbs/capabilities.rs
+++ b/lib/src/dbs/capabilities.rs
@@ -236,12 +236,12 @@ impl Capabilities {
 		self
 	}
 
-	pub fn with_allow_funcs(mut self, allow_funcs: Targets<FuncTarget>) -> Self {
+	pub fn with_allow_functions(mut self, allow_funcs: Targets<FuncTarget>) -> Self {
 		self.allow_funcs = Arc::new(allow_funcs);
 		self
 	}
 
-	pub fn with_deny_funcs(mut self, deny_funcs: Targets<FuncTarget>) -> Self {
+	pub fn with_deny_functions(mut self, deny_funcs: Targets<FuncTarget>) -> Self {
 		self.deny_funcs = Arc::new(deny_funcs);
 		self
 	}
@@ -264,7 +264,7 @@ impl Capabilities {
 		self.guest_access
 	}
 
-	pub fn allows_func(&self, target: &FuncTarget) -> bool {
+	pub fn allows_function(&self, target: &FuncTarget) -> bool {
 		self.allow_funcs.matches(target) && !self.deny_funcs.matches(target)
 	}
 
@@ -531,33 +531,33 @@ mod tests {
 		// When all funcs are allowed
 		{
 			let caps = Capabilities::default()
-				.with_allow_funcs(Targets::<FuncTarget>::All)
-				.with_deny_funcs(Targets::<FuncTarget>::None);
-			assert!(caps.allows_func(&FuncTarget::from_str("http::get").unwrap()));
-			assert!(caps.allows_func(&FuncTarget::from_str("http::post").unwrap()));
+				.with_allow_functions(Targets::<FuncTarget>::All)
+				.with_deny_functions(Targets::<FuncTarget>::None);
+			assert!(caps.allows_function(&FuncTarget::from_str("http::get").unwrap()));
+			assert!(caps.allows_function(&FuncTarget::from_str("http::post").unwrap()));
 		}
 
 		// When all funcs are allowed and denied at the same time
 		{
 			let caps = Capabilities::default()
-				.with_allow_funcs(Targets::<FuncTarget>::All)
-				.with_deny_funcs(Targets::<FuncTarget>::All);
-			assert!(!caps.allows_func(&FuncTarget::from_str("http::get").unwrap()));
-			assert!(!caps.allows_func(&FuncTarget::from_str("http::post").unwrap()));
+				.with_allow_functions(Targets::<FuncTarget>::All)
+				.with_deny_functions(Targets::<FuncTarget>::All);
+			assert!(!caps.allows_function(&FuncTarget::from_str("http::get").unwrap()));
+			assert!(!caps.allows_function(&FuncTarget::from_str("http::post").unwrap()));
 		}
 
 		// When some funcs are allowed and some are denied, deny overrides the allow rules
 		{
 			let caps = Capabilities::default()
-				.with_allow_funcs(Targets::<FuncTarget>::Some(
+				.with_allow_functions(Targets::<FuncTarget>::Some(
 					[FuncTarget::from_str("http::*").unwrap()].into(),
 				))
-				.with_deny_funcs(Targets::<FuncTarget>::Some(
+				.with_deny_functions(Targets::<FuncTarget>::Some(
 					[FuncTarget::from_str("http::post").unwrap()].into(),
 				));
-			assert!(caps.allows_func(&FuncTarget::from_str("http::get").unwrap()));
-			assert!(caps.allows_func(&FuncTarget::from_str("http::put").unwrap()));
-			assert!(!caps.allows_func(&FuncTarget::from_str("http::post").unwrap()));
+			assert!(caps.allows_function(&FuncTarget::from_str("http::get").unwrap()));
+			assert!(caps.allows_function(&FuncTarget::from_str("http::put").unwrap()));
+			assert!(!caps.allows_function(&FuncTarget::from_str("http::post").unwrap()));
 		}
 	}
 }

--- a/lib/src/dbs/capabilities.rs
+++ b/lib/src/dbs/capabilities.rs
@@ -484,6 +484,18 @@ mod tests {
 			assert!(!caps.is_allowed_scripting());
 		}
 
+		// When anonymous access is allowed
+		{
+			let caps = Capabilities::default().with_anon_access(true);
+			assert!(caps.is_allowed_anon_access());
+		}
+
+		// When anonymous access is denied
+		{
+			let caps = Capabilities::default().with_anon_access(false);
+			assert!(!caps.is_allowed_anon_access());
+		}
+
 		// When all nets are allowed
 		{
 			let caps = Capabilities::default()

--- a/lib/src/dbs/mod.rs
+++ b/lib/src/dbs/mod.rs
@@ -19,7 +19,6 @@ pub use self::options::*;
 pub use self::response::*;
 pub use self::session::*;
 
-pub(crate) use self::capabilities::Capabilities;
 pub(crate) use self::executor::*;
 pub(crate) use self::iterator::*;
 pub(crate) use self::statement::*;
@@ -27,6 +26,7 @@ pub(crate) use self::transaction::*;
 pub(crate) use self::variables::*;
 
 pub mod capabilities;
+pub use self::capabilities::Capabilities;
 pub mod node;
 
 mod processor;

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -405,7 +405,7 @@ mod tests {
 				let dbs = crate::kvs::Datastore::new("memory")
 					.await
 					.unwrap()
-					.with_capabilities(Capabilities::new_allow_all());
+					.with_capabilities(Capabilities::all());
 				let ses = crate::dbs::Session::owner().with_ns("test").with_db("test");
 				let res = &mut dbs.execute(&sql, &ses, None).await.unwrap();
 				let tmp = res.remove(0).result.unwrap();

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -370,6 +370,9 @@ pub async fn asynchronous(
 
 #[cfg(test)]
 mod tests {
+	#[cfg(all(feature = "scripting", feature = "kv-mem"))]
+	use crate::dbs::Capabilities;
+
 	#[test]
 	fn implementations_are_present() {
 		// Accumulate and display all problems at once to avoid a test -> fix -> test -> fix cycle.
@@ -399,7 +402,10 @@ mod tests {
 				let name = name.replace("::", ".");
 				let sql =
 					format!("RETURN function() {{ return typeof surrealdb.functions.{name}; }}");
-				let dbs = crate::kvs::Datastore::new("memory").await.unwrap();
+				let dbs = crate::kvs::Datastore::new("memory")
+					.await
+					.unwrap()
+					.with_capabilities(Capabilities::new_allow_all());
 				let ses = crate::dbs::Session::owner().with_ns("test").with_db("test");
 				let res = &mut dbs.execute(&sql, &ses, None).await.unwrap();
 				let tmp = res.remove(0).result.unwrap();

--- a/lib/src/fnc/script/tests/fetch.rs
+++ b/lib/src/fnc/script/tests/fetch.rs
@@ -168,7 +168,7 @@ async fn test_fetch_denied() {
 
 	// Execute test
 	let ds = Datastore::new("memory").await.unwrap().with_capabilities(
-		Capabilities::all().with_deny_net(Targets::Some(
+		Capabilities::all().without_network_targets(Targets::Some(
 			[NetTarget::from_str(&server.address().to_string()).unwrap()].into(),
 		)),
 	);

--- a/lib/src/fnc/script/tests/fetch.rs
+++ b/lib/src/fnc/script/tests/fetch.rs
@@ -26,7 +26,8 @@ async fn test_fetch_get() {
 		.await;
 
 	// Execute test
-	let ds = Datastore::new("memory").await.unwrap();
+	let ds =
+		Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::new_allow_all());
 	let sess = Session::owner();
 	let sql = format!(
 		r#"
@@ -71,7 +72,8 @@ async fn test_fetch_put() {
 		.await;
 
 	// Execute test
-	let ds = Datastore::new("memory").await.unwrap();
+	let ds =
+		Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::new_allow_all());
 	let sess = Session::owner();
 	let sql = format!(
 		r#"
@@ -121,7 +123,8 @@ async fn test_fetch_error() {
 		.await;
 
 	// Execute test
-	let ds = Datastore::new("memory").await.unwrap();
+	let ds =
+		Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::new_allow_all());
 	let sess = Session::owner();
 	let sql = format!(
 		r#"
@@ -168,7 +171,7 @@ async fn test_fetch_denied() {
 
 	// Execute test
 	let ds = Datastore::new("memory").await.unwrap().with_capabilities(
-		Capabilities::default().with_deny_net(Targets::Some(
+		Capabilities::new_allow_all().with_deny_net(Targets::Some(
 			[NetTarget::from_str(&server.address().to_string()).unwrap()].into(),
 		)),
 	);

--- a/lib/src/fnc/script/tests/fetch.rs
+++ b/lib/src/fnc/script/tests/fetch.rs
@@ -26,8 +26,7 @@ async fn test_fetch_get() {
 		.await;
 
 	// Execute test
-	let ds =
-		Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::new_allow_all());
+	let ds = Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::all());
 	let sess = Session::owner();
 	let sql = format!(
 		r#"
@@ -72,8 +71,7 @@ async fn test_fetch_put() {
 		.await;
 
 	// Execute test
-	let ds =
-		Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::new_allow_all());
+	let ds = Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::all());
 	let sess = Session::owner();
 	let sql = format!(
 		r#"
@@ -123,8 +121,7 @@ async fn test_fetch_error() {
 		.await;
 
 	// Execute test
-	let ds =
-		Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::new_allow_all());
+	let ds = Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::all());
 	let sess = Session::owner();
 	let sql = format!(
 		r#"
@@ -171,7 +168,7 @@ async fn test_fetch_denied() {
 
 	// Execute test
 	let ds = Datastore::new("memory").await.unwrap().with_capabilities(
-		Capabilities::new_allow_all().with_deny_net(Targets::Some(
+		Capabilities::all().with_deny_net(Targets::Some(
 			[NetTarget::from_str(&server.address().to_string()).unwrap()].into(),
 		)),
 	);

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -12,7 +12,7 @@ use crate::dbs::Session;
 use crate::dbs::Variables;
 use crate::err::Error;
 use crate::iam::ResourceKind;
-use crate::iam::{Action, Auth, Role};
+use crate::iam::{Action, Auth, Error as IamError, Role};
 use crate::key::root::hb::Hb;
 use crate::opt::auth::Root;
 use crate::sql;
@@ -747,6 +747,17 @@ impl Datastore {
 		sess: &Session,
 		vars: Variables,
 	) -> Result<Vec<Response>, Error> {
+		// Check if anonymous actors can execute queries when auth is enabled
+		// TODO(sgirones): Check this as part of the authoritzation layer
+		if self.auth_enabled && sess.au.is_anon() && !self.capabilities.is_allowed_anon_access() {
+			return Err(IamError::NotAllowed {
+				actor: "anonymous".to_string(),
+				action: "process".to_string(),
+				resource: "query".to_string(),
+			}
+			.into());
+		}
+
 		// Create a new query options
 		let opt = Options::default()
 			.with_id(self.id.0)
@@ -802,6 +813,17 @@ impl Datastore {
 		sess: &Session,
 		vars: Variables,
 	) -> Result<Value, Error> {
+		// Check if anonymous actors can compute values when auth is enabled
+		// TODO(sgirones): Check this as part of the authoritzation layer
+		if self.auth_enabled && !self.capabilities.is_allowed_anon_access() {
+			return Err(IamError::NotAllowed {
+				actor: "anonymous".to_string(),
+				action: "compute".to_string(),
+				resource: "value".to_string(),
+			}
+			.into());
+		}
+
 		// Create a new query options
 		let opt = Options::default()
 			.with_id(self.id.0)

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -749,7 +749,7 @@ impl Datastore {
 	) -> Result<Vec<Response>, Error> {
 		// Check if anonymous actors can execute queries when auth is enabled
 		// TODO(sgirones): Check this as part of the authoritzation layer
-		if self.auth_enabled && sess.au.is_anon() && !self.capabilities.is_allowed_anon_access() {
+		if self.auth_enabled && sess.au.is_anon() && !self.capabilities.allows_guest_access() {
 			return Err(IamError::NotAllowed {
 				actor: "anonymous".to_string(),
 				action: "process".to_string(),
@@ -815,7 +815,7 @@ impl Datastore {
 	) -> Result<Value, Error> {
 		// Check if anonymous actors can compute values when auth is enabled
 		// TODO(sgirones): Check this as part of the authoritzation layer
-		if self.auth_enabled && !self.capabilities.is_allowed_anon_access() {
+		if self.auth_enabled && !self.capabilities.allows_guest_access() {
 			return Err(IamError::NotAllowed {
 				actor: "anonymous".to_string(),
 				action: "compute".to_string(),

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -231,7 +231,7 @@ mod api_integration {
 			let config = Config::new()
 				.user(root)
 				.tick_interval(TICK_INTERVAL)
-				.capabilities(Capabilities::new_allow_all());
+				.capabilities(Capabilities::all());
 			let db = Surreal::new::<File>((path, config)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db
@@ -258,7 +258,7 @@ mod api_integration {
 			let config = Config::new()
 				.user(root)
 				.tick_interval(TICK_INTERVAL)
-				.capabilities(Capabilities::new_allow_all());
+				.capabilities(Capabilities::all());
 			let db = Surreal::new::<RocksDb>((path, config)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db
@@ -285,7 +285,7 @@ mod api_integration {
 			let config = Config::new()
 				.user(root)
 				.tick_interval(TICK_INTERVAL)
-				.capabilities(Capabilities::new_allow_all());
+				.capabilities(Capabilities::all());
 			let db = Surreal::new::<SpeeDb>((path, config)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db
@@ -311,7 +311,7 @@ mod api_integration {
 			let config = Config::new()
 				.user(root)
 				.tick_interval(TICK_INTERVAL)
-				.capabilities(Capabilities::new_allow_all());
+				.capabilities(Capabilities::all());
 			let db = Surreal::new::<TiKv>(("127.0.0.1:2379", config)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db
@@ -337,7 +337,7 @@ mod api_integration {
 			let config = Config::new()
 				.user(root)
 				.tick_interval(TICK_INTERVAL)
-				.capabilities(Capabilities::new_allow_all());
+				.capabilities(Capabilities::all());
 			let db = Surreal::new::<FDb>(("/etc/foundationdb/fdb.cluster", config)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -138,7 +138,7 @@ mod api_integration {
 			let config = Config::new()
 				.user(root)
 				.tick_interval(TICK_INTERVAL)
-				.capabilities(Capabilities::new_allow_all());
+				.capabilities(Capabilities::all());
 			let db = Surreal::new::<Mem>(config).await.unwrap();
 			db.signin(root).await.unwrap();
 			db

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -10,6 +10,7 @@ mod api_integration {
 	use std::sync::Arc;
 	use std::sync::Mutex;
 	use std::time::Duration;
+	use surrealdb::dbs::capabilities::Capabilities;
 	use surrealdb::error::Api as ApiError;
 	use surrealdb::error::Db as DbError;
 	use surrealdb::opt::auth::Database;
@@ -134,7 +135,10 @@ mod api_integration {
 				username: ROOT_USER,
 				password: ROOT_PASS,
 			};
-			let config = Config::new().user(root).tick_interval(TICK_INTERVAL);
+			let config = Config::new()
+				.user(root)
+				.tick_interval(TICK_INTERVAL)
+				.capabilities(Capabilities::new_allow_all());
 			let db = Surreal::new::<Mem>(config).await.unwrap();
 			db.signin(root).await.unwrap();
 			db
@@ -224,7 +228,10 @@ mod api_integration {
 				username: ROOT_USER,
 				password: ROOT_PASS,
 			};
-			let config = Config::new().user(root).tick_interval(TICK_INTERVAL);
+			let config = Config::new()
+				.user(root)
+				.tick_interval(TICK_INTERVAL)
+				.capabilities(Capabilities::new_allow_all());
 			let db = Surreal::new::<File>((path, config)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db
@@ -248,7 +255,10 @@ mod api_integration {
 				username: ROOT_USER,
 				password: ROOT_PASS,
 			};
-			let config = Config::new().user(root).tick_interval(TICK_INTERVAL);
+			let config = Config::new()
+				.user(root)
+				.tick_interval(TICK_INTERVAL)
+				.capabilities(Capabilities::new_allow_all());
 			let db = Surreal::new::<RocksDb>((path, config)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db
@@ -272,7 +282,10 @@ mod api_integration {
 				username: ROOT_USER,
 				password: ROOT_PASS,
 			};
-			let config = Config::new().user(root).tick_interval(TICK_INTERVAL);
+			let config = Config::new()
+				.user(root)
+				.tick_interval(TICK_INTERVAL)
+				.capabilities(Capabilities::new_allow_all());
 			let db = Surreal::new::<SpeeDb>((path, config)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db
@@ -295,7 +308,10 @@ mod api_integration {
 				username: ROOT_USER,
 				password: ROOT_PASS,
 			};
-			let config = Config::new().user(root).tick_interval(TICK_INTERVAL);
+			let config = Config::new()
+				.user(root)
+				.tick_interval(TICK_INTERVAL)
+				.capabilities(Capabilities::new_allow_all());
 			let db = Surreal::new::<TiKv>(("127.0.0.1:2379", config)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db
@@ -318,7 +334,10 @@ mod api_integration {
 				username: ROOT_USER,
 				password: ROOT_PASS,
 			};
-			let config = Config::new().user(root).tick_interval(TICK_INTERVAL);
+			let config = Config::new()
+				.user(root)
+				.tick_interval(TICK_INTERVAL)
+				.capabilities(Capabilities::new_allow_all());
 			let db = Surreal::new::<FDb>(("/etc/foundationdb/fdb.cluster", config)).await.unwrap();
 			db.signin(root).await.unwrap();
 			db

--- a/lib/tests/cache.rs
+++ b/lib/tests/cache.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -15,7 +16,7 @@ async fn clear_transaction_cache_table() -> Result<(), Error> {
 		COMMIT;
 		SELECT * FROM other;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -71,7 +72,7 @@ async fn clear_transaction_cache_field() -> Result<(), Error> {
 		SELECT * FROM person;
 		COMMIT;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 6);

--- a/lib/tests/changefeeds.rs
+++ b/lib/tests/changefeeds.rs
@@ -1,9 +1,10 @@
 mod parse;
 use chrono::DateTime;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -33,7 +34,7 @@ async fn table_change_feeds() -> Result<(), Error> {
 		CREATE person:1000 SET name = 'Yusuke';
         SHOW CHANGES FOR TABLE person SINCE 0;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let start_ts = 0u64;
 	let end_ts = start_ts + 1;
@@ -179,7 +180,7 @@ async fn table_change_feeds() -> Result<(), Error> {
 
 #[tokio::test]
 async fn changefeed_with_ts() -> Result<(), Error> {
-	let db = Datastore::new("memory").await?;
+	let db = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	// Enable change feeds
 	let sql = "

--- a/lib/tests/compare.rs
+++ b/lib/tests/compare.rs
@@ -1,7 +1,7 @@
-mod parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -17,7 +17,7 @@ async fn compare_empty() -> Result<(), Error> {
 		RETURN 0 = 0.0;
 		RETURN 0 = 0.1;
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 9);

--- a/lib/tests/complex.rs
+++ b/lib/tests/complex.rs
@@ -2,11 +2,12 @@
 
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use std::future::Future;
 use std::thread::Builder;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[test]
@@ -204,7 +205,7 @@ async fn run_queries(
 	impl Iterator<Item = Result<Value, Error>> + ExactSizeIterator + DoubleEndedIterator + 'static,
 	Error,
 > {
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	dbs.execute(sql, &ses, None).await.map(|v| v.into_iter().map(|res| res.result))
 }

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -1,9 +1,10 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Part;
 use surrealdb::sql::Thing;
 use surrealdb::sql::Value;
@@ -29,7 +30,7 @@ async fn create_with_id() -> Result<(), Error> {
 		CREATE person:other SET id = 'tobie';
 		CREATE person:other CONTENT { id: 'tobie', name: 'Tester' };
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 14);
@@ -177,7 +178,7 @@ async fn create_with_custom_function() -> Result<(), Error> {
 		RETURN fn::record::create({ test: true, name: 'Tobie' });
 		RETURN fn::record::create({ test: true, name: 'Jaime' });
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -214,7 +215,7 @@ async fn create_or_insert_with_permissions() -> Result<(), Error> {
 		DEFINE TABLE demo SCHEMAFULL PERMISSIONS FOR select, create, update WHERE user = $auth.id;
 		DEFINE FIELD user ON TABLE demo VALUE $auth.id;
 	";
-	let dbs = Datastore::new("memory").await?.with_auth_enabled(true);
+	let dbs = new_ds().await?.with_auth_enabled(true);
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -272,7 +273,7 @@ async fn create_on_none_values_with_unique_index() -> Result<(), Error> {
 		CREATE foo SET name = 'Jane Doe';
 	";
 
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -293,7 +294,7 @@ async fn create_with_unique_index_with_two_flattened_fields() -> Result<(), Erro
 		CREATE user:4 SET account = 'Apple', tags = ['two', 'three'], emails = ['a@example.com', 'b@example.com'];
 	";
 
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -326,7 +327,7 @@ async fn create_with_unique_index_with_one_flattened_field() -> Result<(), Error
 		CREATE user:2 SET account = 'Apple', tags = ['two', 'three'], emails = ['a@example.com', 'b@example.com'];
 	";
 
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -352,7 +353,7 @@ async fn create_with_unique_index_on_one_field_with_flattened_sub_values() -> Re
 		CREATE user:2 SET account = 'Apple', tags = ['two', 'three'], emails = [ { value:'a@example.com'} , { value:'b@example.com' } ];
 	";
 
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -378,7 +379,7 @@ async fn create_with_unique_index_on_two_fields() -> Result<(), Error> {
 		CREATE user:2 SET account = 'Apple', tags = ['two', 'one'], emails = ['b@example.com', 'c@example.com'];
 	";
 
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -433,7 +434,7 @@ async fn common_permissions_checks(auth_enabled: bool) {
 		let sess = Session::for_level(level, role).with_ns(ns).with_db(db);
 
 		{
-			let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+			let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 			let mut resp = ds.execute(statement, &sess, None).await.unwrap();
 			let res = resp.remove(0).output();
@@ -458,7 +459,7 @@ async fn common_permissions_checks(auth_enabled: bool) {
 
 		// Test the CREATE statement when the table already exists
 		{
-			let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+			let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 			let mut resp = ds
 				.execute("CREATE person", &Session::owner().with_ns("NS").with_db("DB"), None)
@@ -528,7 +529,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table doesn't exist
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute("CREATE person", &Session::default().with_ns("NS").with_db("DB"), None)
@@ -546,7 +547,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table exists but grants no permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -570,7 +571,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table exists and grants full permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -607,7 +608,7 @@ async fn check_permissions_auth_disabled() {
 
 	// When the table doesn't exist
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute("CREATE person", &Session::default().with_ns("NS").with_db("DB"), None)
@@ -624,7 +625,7 @@ async fn check_permissions_auth_disabled() {
 
 	// When the table exists but grants no permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -647,7 +648,7 @@ async fn check_permissions_auth_disabled() {
 	}
 
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		// When the table exists and grants full permissions
 		let mut resp = ds

--- a/lib/tests/datetimes.rs
+++ b/lib/tests/datetimes.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -12,7 +13,7 @@ async fn datetimes_conversion() -> Result<(), Error> {
 		SELECT * FROM <datetime> "2012-01-01";
 		SELECT * FROM <string> "2012-01-01T08:00:00Z" + "-test";
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -1,15 +1,14 @@
 mod parse;
+use parse::Parse;
 
 mod helpers;
 use helpers::*;
 
 use std::collections::HashMap;
 
-use parse::Parse;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Idiom;
 use surrealdb::sql::{Part, Value};
 
@@ -19,7 +18,7 @@ async fn define_statement_namespace() -> Result<(), Error> {
 		DEFINE NAMESPACE test;
 		INFO FOR ROOT;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -45,7 +44,7 @@ async fn define_statement_database() -> Result<(), Error> {
 		DEFINE DATABASE test;
 		INFO FOR NS;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -74,7 +73,7 @@ async fn define_statement_function() -> Result<(), Error> {
 		};
 		INFO FOR DB;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -107,7 +106,7 @@ async fn define_statement_table_drop() -> Result<(), Error> {
 		DEFINE TABLE test DROP;
 		INFO FOR DB;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -138,7 +137,7 @@ async fn define_statement_table_schemaless() -> Result<(), Error> {
 		DEFINE TABLE test SCHEMALESS;
 		INFO FOR DB;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -170,7 +169,7 @@ async fn define_statement_table_schemafull() -> Result<(), Error> {
 		DEFINE TABLE test SCHEMAFULL;
 		INFO FOR DB;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -204,7 +203,7 @@ async fn define_statement_table_schemaful() -> Result<(), Error> {
 		DEFINE TABLE test SCHEMAFUL;
 		INFO FOR DB;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -240,7 +239,7 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 		INFO FOR DB;
 		INFO FOR TB test;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -327,7 +326,7 @@ async fn define_statement_event() -> Result<(), Error> {
 		UPDATE user:test SET email = 'test@surrealdb.com', updated_at = time::now();
 		SELECT count() FROM activity GROUP ALL;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -384,7 +383,7 @@ async fn define_statement_event_when_event() -> Result<(), Error> {
 		UPDATE user:test SET email = 'test@surrealdb.com', updated_at = time::now();
 		SELECT count() FROM activity GROUP ALL;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -441,7 +440,7 @@ async fn define_statement_event_when_logic() -> Result<(), Error> {
 		UPDATE user:test SET email = 'test@surrealdb.com', updated_at = time::now();
 		SELECT count() FROM activity GROUP ALL;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -490,7 +489,7 @@ async fn define_statement_field() -> Result<(), Error> {
 		DEFINE FIELD test ON TABLE user;
 		INFO FOR TABLE user;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -522,7 +521,7 @@ async fn define_statement_field_type() -> Result<(), Error> {
 		DEFINE FIELD test ON TABLE user TYPE string;
 		INFO FOR TABLE user;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -554,7 +553,7 @@ async fn define_statement_field_value() -> Result<(), Error> {
 		DEFINE FIELD test ON TABLE user VALUE $value OR 'GBR';
 		INFO FOR TABLE user;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -586,7 +585,7 @@ async fn define_statement_field_assert() -> Result<(), Error> {
 		DEFINE FIELD test ON TABLE user ASSERT $value != NONE AND $value = /[A-Z]{3}/;
 		INFO FOR TABLE user;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -618,7 +617,7 @@ async fn define_statement_field_type_value_assert() -> Result<(), Error> {
 		DEFINE FIELD test ON TABLE user TYPE string VALUE $value OR 'GBR' ASSERT $value != NONE AND $value = /[A-Z]{3}/;
 		INFO FOR TABLE user;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -654,7 +653,7 @@ async fn define_statement_index_single_simple() -> Result<(), Error> {
 		UPDATE user:1 SET age = 24;
 		UPDATE user:2 SET age = 11;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -702,7 +701,7 @@ async fn define_statement_index_single() -> Result<(), Error> {
 		CREATE user:1 SET email = 'test@surrealdb.com';
 		CREATE user:2 SET email = 'test@surrealdb.com';
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -746,7 +745,7 @@ async fn define_statement_index_multiple() -> Result<(), Error> {
 		CREATE user:3 SET account = 'apple', email = 'test@surrealdb.com';
 		CREATE user:4 SET account = 'tesla', email = 'test@surrealdb.com';
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -798,7 +797,7 @@ async fn define_statement_index_single_unique() -> Result<(), Error> {
 		DELETE user:1;
 		CREATE user:2 SET email = 'test@surrealdb.com';
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -856,7 +855,7 @@ async fn define_statement_index_multiple_unique() -> Result<(), Error> {
 		DELETE user:2;
 		CREATE user:4 SET account = 'tesla', email = 'test@surrealdb.com';
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 12);
@@ -931,7 +930,7 @@ async fn define_statement_index_single_unique_existing() -> Result<(), Error> {
 		DEFINE INDEX test ON user COLUMNS email UNIQUE;
 		INFO FOR TABLE user;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 6);
@@ -978,7 +977,7 @@ async fn define_statement_index_multiple_unique_existing() -> Result<(), Error> 
 		DEFINE INDEX test ON user COLUMNS account, email UNIQUE;
 		INFO FOR TABLE user;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -1023,7 +1022,7 @@ async fn define_statement_index_single_unique_embedded_multiple() -> Result<(), 
 		CREATE user:1 SET tags = ['one', 'two'];
 		CREATE user:2 SET tags = ['two', 'three'];
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(&sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -1073,7 +1072,7 @@ async fn define_statement_index_multiple_unique_embedded_multiple() -> Result<()
 		CREATE user:3 SET account = 'apple', tags = ['two', 'three'];
 		CREATE user:4 SET account = 'tesla', tags = ['two', 'three'];
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(&sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -1133,7 +1132,7 @@ async fn define_statement_analyzer() -> Result<(), Error> {
 		DEFINE ANALYZER autocomplete FILTERS lowercase,edgengram(2,10);
 		INFO FOR DB;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1177,7 +1176,7 @@ async fn define_statement_search_index() -> Result<(), Error> {
 		ANALYZE INDEX blog_title ON blog;
 	"#;
 
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 8);
@@ -1230,7 +1229,7 @@ async fn define_statement_user_root() -> Result<(), Error> {
 
 		INFO FOR ROOT;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner();
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 
@@ -1252,7 +1251,7 @@ async fn define_statement_user_root() -> Result<(), Error> {
 
 #[tokio::test]
 async fn define_statement_user_ns() -> Result<(), Error> {
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner();
 
 	// Create a NS user and retrieve it.
@@ -1308,7 +1307,7 @@ async fn define_statement_user_ns() -> Result<(), Error> {
 
 #[tokio::test]
 async fn define_statement_user_db() -> Result<(), Error> {
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner();
 
 	// Create a NS user and retrieve it.

--- a/lib/tests/delete.rs
+++ b/lib/tests/delete.rs
@@ -1,11 +1,12 @@
 mod parse;
+use parse::Parse;
 
 use channel::{Receiver, TryRecvError};
-use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::{Action, Notification, Session};
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::{Id, Thing, Value};
 
 #[tokio::test]
@@ -15,7 +16,7 @@ async fn delete() -> Result<(), Error> {
 		DELETE person:test;
 		SELECT * FROM person;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -79,7 +80,7 @@ async fn common_permissions_checks(auth_enabled: bool) {
 		let sess = Session::for_level(level, role).with_ns(ns).with_db(db);
 
 		{
-			let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+			let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 			let mut resp = ds
 				.execute("CREATE person:test", &Session::owner().with_ns("NS").with_db("DB"), None)
@@ -191,7 +192,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table exists but grants no permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -233,7 +234,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table exists and grants full permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -290,7 +291,7 @@ async fn check_permissions_auth_disabled() {
 
 	// When the table exists but grants no permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -331,7 +332,7 @@ async fn check_permissions_auth_disabled() {
 	}
 
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		// When the table exists and grants full permissions
 		let mut resp = ds
@@ -375,7 +376,7 @@ async fn check_permissions_auth_disabled() {
 
 #[tokio::test]
 async fn delete_filtered_live_notification() -> Result<(), Error> {
-	let dbs = Datastore::new("memory").await?.with_notifications();
+	let dbs = new_ds().await?.with_notifications();
 	let ses = Session::owner().with_ns("test").with_db("test").with_rt(true);
 	let res = &mut dbs.execute("CREATE person:test_true SET condition = true", &ses, None).await?;
 	assert_eq!(res.len(), 1);

--- a/lib/tests/escape.rs
+++ b/lib/tests/escape.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -16,7 +17,7 @@ async fn complex_ids() -> Result<(), Error> {
 		CREATE person:`100`;
 		SELECT * FROM person;
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -94,7 +95,7 @@ async fn complex_strings() -> Result<(), Error> {
 		RETURN "String with some \"escaped double quoted\" characters";
 		RETURN "String with some 'single' and \"double\" quoted characters";
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);

--- a/lib/tests/fetch.rs
+++ b/lib/tests/fetch.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -21,7 +22,7 @@ async fn create_relate_select() -> Result<(), Error> {
 		SELECT *, ->bought AS products FROM user FETCH products;
 		SELECT *, ->(bought AS purchases) FROM user FETCH purchases, purchases.out;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 12);

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Thing;
 use surrealdb::sql::Value;
 
@@ -19,7 +20,7 @@ async fn field_definition_value_assert_failure() -> Result<(), Error> {
 		CREATE person:test SET email = 'info@surrealdb.com', other = 'ignore', age = 0;
 		CREATE person:test SET email = 'info@surrealdb.com', other = 'ignore', age = 13;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 9);
@@ -102,7 +103,7 @@ async fn field_definition_value_assert_success() -> Result<(), Error> {
 		DEFINE FIELD name ON person TYPE option<string> VALUE $value OR 'No name';
 		CREATE person:test SET email = 'info@surrealdb.com', other = 'ignore', age = 22;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -151,7 +152,7 @@ async fn field_definition_empty_nested_objects() -> Result<(), Error> {
 		};
 		SELECT * FROM person;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -205,7 +206,7 @@ async fn field_definition_empty_nested_arrays() -> Result<(), Error> {
 		};
 		SELECT * FROM person;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -257,7 +258,7 @@ async fn field_definition_empty_nested_flexible() -> Result<(), Error> {
 		};
 		SELECT * FROM person;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -322,7 +323,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 		UPDATE product:test SET secondary = false;
 		UPDATE product:test SET tertiary = 'something';
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 11);
@@ -435,7 +436,7 @@ async fn field_definition_value_reference() -> Result<(), Error> {
 		UPDATE product;
 		SELECT * FROM product;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -536,7 +537,7 @@ async fn field_definition_value_reference_with_future() -> Result<(), Error> {
 		UPDATE product;
 		SELECT * FROM product;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -638,7 +639,7 @@ async fn field_definition_edge_permissions() -> Result<(), Error> {
 		INSERT INTO user (id, name) VALUES (user:one, 'John'), (user:two, 'Lucy');
 		INSERT INTO business (id, owner) VALUES (business:one, user:one), (business:two, user:two);
 	";
-	let dbs = Datastore::new("memory").await?.with_auth_enabled(true);
+	let dbs = new_ds().await?.with_auth_enabled(true);
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 6);

--- a/lib/tests/foreach.rs
+++ b/lib/tests/foreach.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -30,7 +31,7 @@ async fn foreach() -> Result<(), Error> {
 		};
 		SELECT * FROM person;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 6);

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -1,12 +1,13 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::{Number, Value};
 
 async fn test_queries(sql: &str, desired_responses: &[&str]) -> Result<(), Error> {
-	let db = Datastore::new("memory").await?;
+	let db = new_ds().await?;
 	let session = Session::owner().with_ns("test").with_db("test");
 	let response = db.execute(sql, &session, None).await?;
 	for (i, r) in response.into_iter().map(|r| r.result).enumerate() {
@@ -35,7 +36,7 @@ async fn test_queries(sql: &str, desired_responses: &[&str]) -> Result<(), Error
 }
 
 async fn check_test_is_error(sql: &str, expected_errors: &[&str]) -> Result<(), Error> {
-	let db = Datastore::new("memory").await?;
+	let db = new_ds().await?;
 	let session = Session::owner().with_ns("test").with_db("test");
 	let response = db.execute(sql, &session, None).await?;
 	if response.len() != expected_errors.len() {
@@ -72,7 +73,7 @@ async fn function_array_add() -> Result<(), Error> {
 		RETURN array::add([1,2], 3);
 		RETURN array::add([1,2], [2,3]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -112,7 +113,7 @@ async fn function_array_all() -> Result<(), Error> {
 		RETURN array::all("some text");
 		RETURN array::all([1,2,"text",3,NONE,3,4]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -144,7 +145,7 @@ async fn function_array_any() -> Result<(), Error> {
 		RETURN array::any("some text");
 		RETURN array::any([1,2,"text",3,NONE,3,4]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -176,7 +177,7 @@ async fn function_array_append() -> Result<(), Error> {
 		RETURN array::append(3, true);
 		RETURN array::append([1,2], [2,3]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -212,7 +213,7 @@ async fn function_array_at() -> Result<(), Error> {
 		RETURN array::at([], 3);
 		RETURN array::at([], -3);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -306,7 +307,7 @@ async fn function_array_combine() -> Result<(), Error> {
 		RETURN array::combine(3, true);
 		RETURN array::combine([1,2], [2,3]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -352,7 +353,7 @@ async fn function_array_complement() -> Result<(), Error> {
 		RETURN array::complement(3, true);
 		RETURN array::complement([1,2,3,4], [3,4,5,6]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -386,7 +387,7 @@ async fn function_array_concat() -> Result<(), Error> {
 		RETURN array::concat([1,2,3,4], [3,4,5,6]);
 		RETURN array::concat([1,2,3,4], [3,4,5,6], [5,6,7,8], [7,8,9,0]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -431,7 +432,7 @@ async fn function_array_difference() -> Result<(), Error> {
 		RETURN array::difference(3, true);
 		RETURN array::difference([1,2,3,4], [3,4,5,6]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -462,7 +463,7 @@ async fn function_array_distinct() -> Result<(), Error> {
 		RETURN array::distinct("some text");
 		RETURN array::distinct([1,2,1,3,3,4]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -515,7 +516,7 @@ async fn function_array_first() -> Result<(), Error> {
 		RETURN array::first([["hello", "world"], 10]);
 		RETURN array::first([]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -543,7 +544,7 @@ async fn function_array_flatten() -> Result<(), Error> {
 		RETURN array::flatten([[1,2], [3,4]]);
 		RETURN array::flatten([[1,2], [3, 4], 'SurrealDB', [5, 6, [7, 8]]]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -579,7 +580,7 @@ async fn function_array_group() -> Result<(), Error> {
 		RETURN array::group(3);
 		RETURN array::group([ [1,2,3,4], [3,4,5,6] ]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -612,7 +613,7 @@ async fn function_array_insert() -> Result<(), Error> {
 		RETURN array::insert([3], 1, 1);
 		RETURN array::insert([1,2,3,4], 5, -1);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -643,7 +644,7 @@ async fn function_array_intersect() -> Result<(), Error> {
 		RETURN array::intersect(3, true);
 		RETURN array::intersect([1,2,3,4], [3,4,5,6]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -676,7 +677,7 @@ async fn function_string_join_arr() -> Result<(), Error> {
 		RETURN array::join(["again", "again", "again"], " and ");
 		RETURN array::join([42, true, "1.61"], " and ");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -707,7 +708,7 @@ async fn function_array_last() -> Result<(), Error> {
 		RETURN array::last([["hello", "world"], 10]);
 		RETURN array::last([]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -734,7 +735,7 @@ async fn function_array_len() -> Result<(), Error> {
 		RETURN array::len("some text");
 		RETURN array::len([1,2,"text",3,3,4]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -814,7 +815,7 @@ async fn function_array_max() -> Result<(), Error> {
 		RETURN array::max("some text");
 		RETURN array::max([1,2,"text",3,3,4]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -846,7 +847,7 @@ async fn function_array_min() -> Result<(), Error> {
 		RETURN array::min("some text");
 		RETURN array::min([1,2,"text",3,3,4]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -878,7 +879,7 @@ async fn function_array_pop() -> Result<(), Error> {
 		RETURN array::pop("some text");
 		RETURN array::pop([1,2,"text",3,3,4]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -910,7 +911,7 @@ async fn function_array_prepend() -> Result<(), Error> {
 		RETURN array::prepend(3, true);
 		RETURN array::prepend([1,2], [2,3]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -942,7 +943,7 @@ async fn function_array_push() -> Result<(), Error> {
 		RETURN array::push(3, true);
 		RETURN array::push([1,2], [2,3]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -975,7 +976,7 @@ async fn function_array_remove() -> Result<(), Error> {
 		RETURN array::remove([3,4,5], 1);
 		RETURN array::remove([1,2,3,4], -1);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -1006,7 +1007,7 @@ async fn function_array_reverse() -> Result<(), Error> {
 		RETURN array::reverse(3);
 		RETURN array::reverse([1,2,"text",3,3,4]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1042,7 +1043,7 @@ async fn function_array_slice() -> Result<(), Error> {
 		RETURN array::slice([1,2,"text",3,3,4], 3, -1);
 		RETURN array::slice([1,2,"text",3,3,4], -1);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -1094,7 +1095,7 @@ async fn function_array_sort() -> Result<(), Error> {
 		RETURN array::sort([4,2,"text",1,3,4], "asc");
 		RETURN array::sort([4,2,"text",1,3,4], "desc");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -1142,7 +1143,7 @@ async fn function_array_sort_asc() -> Result<(), Error> {
 		RETURN array::sort::asc(3);
 		RETURN array::sort::asc([4,2,"text",1,3,4]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1174,7 +1175,7 @@ async fn function_array_sort_desc() -> Result<(), Error> {
 		RETURN array::sort::desc(3);
 		RETURN array::sort::desc([4,2,"text",1,3,4]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1226,7 +1227,7 @@ async fn function_array_union() -> Result<(), Error> {
 		RETURN array::union(3, true);
 		RETURN array::union([1,2,1,6], [1,3,4,5,6]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1263,7 +1264,7 @@ async fn function_bytes_len() -> Result<(), Error> {
 		RETURN bytes::len(<bytes>"π");
 		RETURN bytes::len(<bytes>"ππ");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -1305,7 +1306,7 @@ async fn function_count() -> Result<(), Error> {
 		RETURN count(15 > 10);
 		RETURN count(15 < 10);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -1342,7 +1343,7 @@ async fn function_crypto_md5() -> Result<(), Error> {
 	let sql = r#"
 		RETURN crypto::md5('tobie');
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -1359,7 +1360,7 @@ async fn function_crypto_sha1() -> Result<(), Error> {
 	let sql = r#"
 		RETURN crypto::sha1('tobie');
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -1376,7 +1377,7 @@ async fn function_crypto_sha256() -> Result<(), Error> {
 	let sql = r#"
 		RETURN crypto::sha256('tobie');
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -1393,7 +1394,7 @@ async fn function_crypto_sha512() -> Result<(), Error> {
 	let sql = r#"
 		RETURN crypto::sha512('tobie');
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -1416,7 +1417,7 @@ async fn function_duration_days() -> Result<(), Error> {
 		RETURN duration::days(4w3d);
 		RETURN duration::days(4h);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1443,7 +1444,7 @@ async fn function_duration_hours() -> Result<(), Error> {
 		RETURN duration::hours(4d3h);
 		RETURN duration::hours(30m);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1470,7 +1471,7 @@ async fn function_duration_micros() -> Result<(), Error> {
 		RETURN duration::micros(1m100µs);
 		RETURN duration::micros(100ns);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1497,7 +1498,7 @@ async fn function_duration_millis() -> Result<(), Error> {
 		RETURN duration::millis(1m100ms);
 		RETURN duration::millis(100µs);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1524,7 +1525,7 @@ async fn function_duration_mins() -> Result<(), Error> {
 		RETURN duration::mins(1h30m);
 		RETURN duration::mins(45s);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1551,7 +1552,7 @@ async fn function_duration_nanos() -> Result<(), Error> {
 		RETURN duration::nanos(30ms100ns);
 		RETURN duration::nanos(0ns);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1578,7 +1579,7 @@ async fn function_duration_secs() -> Result<(), Error> {
 		RETURN duration::secs(1m25s);
 		RETURN duration::secs(350ms);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1605,7 +1606,7 @@ async fn function_duration_weeks() -> Result<(), Error> {
 		RETURN duration::weeks(1y3w);
 		RETURN duration::weeks(4d);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1632,7 +1633,7 @@ async fn function_duration_years() -> Result<(), Error> {
 		RETURN duration::years(7y4w30d);
 		RETURN duration::years(4w);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -1658,7 +1659,7 @@ async fn function_duration_from_days() -> Result<(), Error> {
 		RETURN duration::from::days(3);
 		RETURN duration::from::days(50);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -1680,7 +1681,7 @@ async fn function_duration_from_hours() -> Result<(), Error> {
 		RETURN duration::from::hours(3);
 		RETURN duration::from::hours(30);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -1702,7 +1703,7 @@ async fn function_duration_from_micros() -> Result<(), Error> {
 		RETURN duration::from::micros(300);
 		RETURN duration::from::micros(50500);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -1724,7 +1725,7 @@ async fn function_duration_from_millis() -> Result<(), Error> {
 		RETURN duration::from::millis(30);
 		RETURN duration::from::millis(1500);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -1746,7 +1747,7 @@ async fn function_duration_from_mins() -> Result<(), Error> {
 		RETURN duration::from::mins(3);
 		RETURN duration::from::mins(100);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -1768,7 +1769,7 @@ async fn function_duration_from_nanos() -> Result<(), Error> {
 		RETURN duration::from::nanos(30);
 		RETURN duration::from::nanos(5005000);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -1790,7 +1791,7 @@ async fn function_duration_from_secs() -> Result<(), Error> {
 		RETURN duration::from::secs(3);
 		RETURN duration::from::secs(100);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -1812,7 +1813,7 @@ async fn function_duration_from_weeks() -> Result<(), Error> {
 		RETURN duration::from::weeks(3);
 		RETURN duration::from::weeks(60);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -1838,7 +1839,7 @@ async fn function_encoding_base64_decode() -> Result<(), Error> {
 		RETURN encoding::base64::decode("");
 		RETURN encoding::base64::decode("aGVsbG8") = <bytes>"hello";
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -1860,7 +1861,7 @@ async fn function_encoding_base64_encode() -> Result<(), Error> {
 		RETURN encoding::base64::encode(<bytes>"");
 		RETURN encoding::base64::encode(<bytes>"hello");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -1892,7 +1893,7 @@ async fn function_parse_geo_area() -> Result<(), Error> {
 			]]
 		});
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -1918,7 +1919,7 @@ async fn function_parse_geo_bearing() -> Result<(), Error> {
 			}
 		);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -1942,7 +1943,7 @@ async fn function_parse_geo_centroid() -> Result<(), Error> {
 			]]
 		});
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -1976,7 +1977,7 @@ async fn function_parse_geo_distance() -> Result<(), Error> {
 			}
 		);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -1996,7 +1997,7 @@ async fn function_parse_geo_hash_encode() -> Result<(), Error> {
 			coordinates: [-0.136439, 51.509865]
 		});
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -2013,7 +2014,7 @@ async fn function_parse_geo_hash_decode() -> Result<(), Error> {
 	let sql = r#"
 		RETURN geo::hash::decode('gcpvhchdswz9');
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -2043,7 +2044,7 @@ async fn function_parse_is_alphanum() -> Result<(), Error> {
 		RETURN is::alphanum("abcdefg123");
 		RETURN is::alphanum("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2065,7 +2066,7 @@ async fn function_parse_is_alpha() -> Result<(), Error> {
 		RETURN is::alpha("abcdefg");
 		RETURN is::alpha("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2087,7 +2088,7 @@ async fn function_parse_is_ascii() -> Result<(), Error> {
 		RETURN is::ascii("abcdefg123");
 		RETURN is::ascii("this is a test 😀");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2109,7 +2110,7 @@ async fn function_parse_is_datetime() -> Result<(), Error> {
 		RETURN is::datetime("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
 		RETURN is::datetime("2012-06-22 23:56:04", "%T");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2131,7 +2132,7 @@ async fn function_parse_is_domain() -> Result<(), Error> {
 		RETURN is::domain("surrealdb.com");
 		RETURN is::domain("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2153,7 +2154,7 @@ async fn function_parse_is_email() -> Result<(), Error> {
 		RETURN is::email("info@surrealdb.com");
 		RETURN is::email("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2175,7 +2176,7 @@ async fn function_parse_is_hexadecimal() -> Result<(), Error> {
 		RETURN is::hexadecimal("ff009e");
 		RETURN is::hexadecimal("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2197,7 +2198,7 @@ async fn function_parse_is_latitude() -> Result<(), Error> {
 		RETURN is::latitude("51.509865");
 		RETURN is::latitude("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2219,7 +2220,7 @@ async fn function_parse_is_longitude() -> Result<(), Error> {
 		RETURN is::longitude("-0.136439");
 		RETURN is::longitude("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2241,7 +2242,7 @@ async fn function_parse_is_numeric() -> Result<(), Error> {
 		RETURN is::numeric("13136439");
 		RETURN is::numeric("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2263,7 +2264,7 @@ async fn function_parse_is_semver() -> Result<(), Error> {
 		RETURN is::semver("1.0.0-rc.1");
 		RETURN is::semver("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2285,7 +2286,7 @@ async fn function_parse_is_url() -> Result<(), Error> {
 		RETURN is::url("https://surrealdb.com/docs");
 		RETURN is::url("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2307,7 +2308,7 @@ async fn function_parse_is_uuid() -> Result<(), Error> {
 		RETURN is::uuid("e72bee20-f49b-11ec-b939-0242ac120002");
 		RETURN is::uuid("this is a test!");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2334,7 +2335,7 @@ async fn function_math_abs() -> Result<(), Error> {
 		RETURN math::abs(100);
 		RETURN math::abs(-100);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2361,7 +2362,7 @@ async fn function_math_bottom() -> Result<(), Error> {
 		RETURN math::bottom([1,2,3], 1);
 		RETURN math::bottom([1,2,3], 2);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2392,7 +2393,7 @@ async fn function_math_ceil() -> Result<(), Error> {
 		RETURN math::ceil(101);
 		RETURN math::ceil(101.5);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2415,7 +2416,7 @@ async fn function_math_fixed() -> Result<(), Error> {
 		RETURN math::fixed(101, 2);
 		RETURN math::fixed(101.5, 2);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2446,7 +2447,7 @@ async fn function_math_floor() -> Result<(), Error> {
 		RETURN math::floor(101);
 		RETURN math::floor(101.5);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2469,7 +2470,7 @@ async fn function_math_interquartile() -> Result<(), Error> {
 		RETURN math::interquartile([101, 213, 202]);
 		RETURN math::interquartile([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2495,7 +2496,7 @@ async fn function_math_max() -> Result<(), Error> {
 		RETURN math::max([101, 213, 202]);
 		RETURN math::max([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2522,7 +2523,7 @@ async fn function_math_mean() -> Result<(), Error> {
 		RETURN math::mean([101, 213, 202]);
 		RETURN math::mean([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2548,7 +2549,7 @@ async fn function_math_median() -> Result<(), Error> {
 		RETURN math::median([101, 213, 202]);
 		RETURN math::median([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2575,7 +2576,7 @@ async fn function_math_midhinge() -> Result<(), Error> {
 		RETURN math::midhinge([101, 213, 202]);
 		RETURN math::midhinge([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2601,7 +2602,7 @@ async fn function_math_min() -> Result<(), Error> {
 		RETURN math::min([101, 213, 202]);
 		RETURN math::min([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2628,7 +2629,7 @@ async fn function_math_mode() -> Result<(), Error> {
 		RETURN math::mode([101, 213, 202]);
 		RETURN math::mode([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2654,7 +2655,7 @@ async fn function_math_nearestrank() -> Result<(), Error> {
 		RETURN math::nearestrank([101, 213, 202], 75);
 		RETURN math::nearestrank([101.5, 213.5, 202.5], 75);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2680,7 +2681,7 @@ async fn function_math_percentile() -> Result<(), Error> {
 		RETURN math::percentile([101, 213, 202], 99);
 		RETURN math::percentile([101.5, 213.5, 202.5], 99);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2705,7 +2706,7 @@ async fn function_math_pow() -> Result<(), Error> {
 		RETURN math::pow(101, 3);
 		RETURN math::pow(101.5, 3);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2728,7 +2729,7 @@ async fn function_math_product() -> Result<(), Error> {
 		RETURN math::product([101, 213, 202]);
 		RETURN math::product([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2754,7 +2755,7 @@ async fn function_math_round() -> Result<(), Error> {
 		RETURN math::round(101);
 		RETURN math::round(101.5);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2777,7 +2778,7 @@ async fn function_math_spread() -> Result<(), Error> {
 		RETURN math::spread([101, 213, 202]);
 		RETURN math::spread([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2802,7 +2803,7 @@ async fn function_math_sqrt() -> Result<(), Error> {
 		RETURN math::sqrt(101);
 		RETURN math::sqrt(101.5);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -2825,7 +2826,7 @@ async fn function_math_stddev() -> Result<(), Error> {
 		RETURN math::stddev([101, 213, 202]);
 		RETURN math::stddev([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2851,7 +2852,7 @@ async fn function_math_sum() -> Result<(), Error> {
 		RETURN math::sum([101, 213, 202]);
 		RETURN math::sum([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2878,7 +2879,7 @@ async fn function_math_top() -> Result<(), Error> {
 		RETURN math::top([1,2,3], 1);
 		RETURN math::top([1,2,3], 2);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2910,7 +2911,7 @@ async fn function_math_trimean() -> Result<(), Error> {
 		RETURN math::trimean([101, 213, 202]);
 		RETURN math::trimean([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2936,7 +2937,7 @@ async fn function_math_variance() -> Result<(), Error> {
 		RETURN math::variance([101, 213, 202]);
 		RETURN math::variance([101.5, 213.5, 202.5]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -2964,7 +2965,7 @@ async fn function_parse_meta_id() -> Result<(), Error> {
 	let sql = r#"
 		RETURN meta::id("person:tobie");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -2981,7 +2982,7 @@ async fn function_parse_meta_table() -> Result<(), Error> {
 	let sql = r#"
 		RETURN meta::table("person:tobie");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -2998,7 +2999,7 @@ async fn function_parse_meta_tb() -> Result<(), Error> {
 	let sql = r#"
 		RETURN meta::tb("person:tobie");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3025,7 +3026,7 @@ async fn function_not() -> Result<(), Error> {
 		RETURN not(1);
 		RETURN not("hello");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -3070,7 +3071,7 @@ async fn function_parse_email_host() -> Result<(), Error> {
 	let sql = r#"
 		RETURN parse::email::host("john.doe@example.com");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3087,7 +3088,7 @@ async fn function_parse_email_user() -> Result<(), Error> {
 	let sql = r#"
 		RETURN parse::email::user("john.doe@example.com");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3104,7 +3105,7 @@ async fn function_parse_url_domain() -> Result<(), Error> {
 	let sql = r#"
 		RETURN parse::url::domain("https://user:pass@www.surrealdb.com:80/path/to/page?query=param#somefragment");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3121,7 +3122,7 @@ async fn function_parse_url_fragment() -> Result<(), Error> {
 	let sql = r#"
 		RETURN parse::url::fragment("https://user:pass@www.surrealdb.com:80/path/to/page?query=param#somefragment");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3138,7 +3139,7 @@ async fn function_parse_url_host() -> Result<(), Error> {
 	let sql = r#"
 		RETURN parse::url::host("https://user:pass@www.surrealdb.com:80/path/to/page?query=param#somefragment");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3155,7 +3156,7 @@ async fn function_parse_url_path() -> Result<(), Error> {
 	let sql = r#"
 		RETURN parse::url::path("https://user:pass@www.surrealdb.com:80/path/to/page?query=param#somefragment");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3172,7 +3173,7 @@ async fn function_parse_url_port() -> Result<(), Error> {
 	let sql = r#"
 		RETURN parse::url::port("https://user:pass@www.surrealdb.com:80/path/to/page?query=param#somefragment");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3189,7 +3190,7 @@ async fn function_parse_url_query() -> Result<(), Error> {
 	let sql = r#"
 		RETURN parse::url::query("https://user:pass@www.surrealdb.com:80/path/to/page?query=param#somefragment");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3206,7 +3207,7 @@ async fn function_parse_url_scheme() -> Result<(), Error> {
 	let sql = r#"
 		RETURN parse::url::scheme("https://user:pass@www.surrealdb.com:80/path/to/page?query=param#somefragment");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3227,7 +3228,7 @@ async fn function_rand() -> Result<(), Error> {
 	let sql = r#"
 		RETURN rand();
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3243,7 +3244,7 @@ async fn function_rand_bool() -> Result<(), Error> {
 	let sql = r#"
 		RETURN rand::bool();
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3259,7 +3260,7 @@ async fn function_rand_enum() -> Result<(), Error> {
 	let sql = r#"
 		RETURN rand::enum(["one", "two", "three"]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3276,7 +3277,7 @@ async fn function_rand_float() -> Result<(), Error> {
 		RETURN rand::float();
 		RETURN rand::float(5, 10);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -3297,7 +3298,7 @@ async fn function_rand_guid() -> Result<(), Error> {
 		RETURN rand::guid(10);
 		RETURN rand::guid(10, 15);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3320,7 +3321,7 @@ async fn function_rand_int() -> Result<(), Error> {
 		RETURN rand::int();
 		RETURN rand::int(5, 10);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -3341,7 +3342,7 @@ async fn function_rand_string() -> Result<(), Error> {
 		RETURN rand::string(10);
 		RETURN rand::string(10, 15);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3364,7 +3365,7 @@ async fn function_rand_time() -> Result<(), Error> {
 		RETURN rand::time();
 		RETURN rand::time(1577836800, 1893456000);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -3383,7 +3384,7 @@ async fn function_rand_ulid() -> Result<(), Error> {
 	let sql = r#"
 		RETURN rand::ulid();
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3399,7 +3400,7 @@ async fn function_rand_uuid() -> Result<(), Error> {
 	let sql = r#"
 		RETURN rand::uuid();
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3415,7 +3416,7 @@ async fn function_rand_uuid_v4() -> Result<(), Error> {
 	let sql = r#"
 		RETURN rand::uuid::v4();
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3431,7 +3432,7 @@ async fn function_rand_uuid_v7() -> Result<(), Error> {
 	let sql = r#"
 		RETURN rand::uuid::v7();
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -3453,7 +3454,7 @@ async fn function_string_concat() -> Result<(), Error> {
 		RETURN string::concat("test");
 		RETURN string::concat("this", " ", "is", " ", "a", " ", "test");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3492,7 +3493,7 @@ async fn function_string_contains() -> Result<(), Error> {
 		RETURN string::contains("* \t", " ");
 		RETURN string::contains("* \t", "?");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 15);
@@ -3567,7 +3568,7 @@ async fn function_string_ends_with() -> Result<(), Error> {
 		RETURN string::endsWith("", "test");
 		RETURN string::endsWith("this is a test", "test");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3594,7 +3595,7 @@ async fn function_string_join() -> Result<(), Error> {
 		RETURN string::join("test");
 		RETURN string::join(" ", "this", "is", "a", "test");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3621,7 +3622,7 @@ async fn function_string_len() -> Result<(), Error> {
 		RETURN string::len("test");
 		RETURN string::len("test this string");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3648,7 +3649,7 @@ async fn function_string_lowercase() -> Result<(), Error> {
 		RETURN string::lowercase("TeSt");
 		RETURN string::lowercase("THIS IS A TEST");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3675,7 +3676,7 @@ async fn function_string_repeat() -> Result<(), Error> {
 		RETURN string::repeat("test", 3);
 		RETURN string::repeat("test this", 3);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3702,7 +3703,7 @@ async fn function_string_replace() -> Result<(), Error> {
 		RETURN string::replace('this is a test', 'a test', 'awesome');
 		RETURN string::replace("this is an 😀 emoji test", "😀", "awesome 👍");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3729,7 +3730,7 @@ async fn function_string_reverse() -> Result<(), Error> {
 		RETURN string::reverse("test");
 		RETURN string::reverse("test this string");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3758,7 +3759,7 @@ async fn function_string_similarity_fuzzy() -> Result<(), Error> {
 		RETURN string::similarity::fuzzy("TEXT", "TEXT");
 		RETURN string::similarity::fuzzy("this could be a tricky test", "this test");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(&sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -3790,7 +3791,7 @@ async fn function_string_similarity_smithwaterman() -> Result<(), Error> {
 		RETURN string::similarity::smithwaterman("TEXT", "TEXT");
 		RETURN string::similarity::smithwaterman("this could be a tricky test", "this test");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(&sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -3824,7 +3825,7 @@ async fn function_string_slice() -> Result<(), Error> {
 		RETURN string::slice("the quick brown fox jumps over the lazy dog.", -9, -1);
 		RETURN string::slice("the quick brown fox jumps over the lazy dog.", -100, -100);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -3867,7 +3868,7 @@ async fn function_string_slug() -> Result<(), Error> {
 		RETURN string::slug("this is a test");
 		RETURN string::slug("blog - this is a test with 😀 emojis");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3894,7 +3895,7 @@ async fn function_string_split() -> Result<(), Error> {
 		RETURN string::split("this, is, a, list", ", ");
 		RETURN string::split("this - is - another - test", " - ");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3921,7 +3922,7 @@ async fn function_string_starts_with() -> Result<(), Error> {
 		RETURN string::startsWith("", "test");
 		RETURN string::startsWith("test this string", "test");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3948,7 +3949,7 @@ async fn function_string_trim() -> Result<(), Error> {
 		RETURN string::trim("test");
 		RETURN string::trim("   this is a test with text   ");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -3975,7 +3976,7 @@ async fn function_string_uppercase() -> Result<(), Error> {
 		RETURN string::uppercase("tEsT");
 		RETURN string::uppercase("this is a test");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -4002,7 +4003,7 @@ async fn function_string_words() -> Result<(), Error> {
 		RETURN string::words("test");
 		RETURN string::words("this is a test");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -4033,7 +4034,7 @@ async fn function_time_ceil() -> Result<(), Error> {
 		RETURN time::ceil("1987-06-22T08:30:45Z", 1y);
 		RETURN time::ceil("2023-05-11T03:09:00Z", 1s);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -4059,7 +4060,7 @@ async fn function_time_day() -> Result<(), Error> {
 		RETURN time::day();
 		RETURN time::day("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4081,7 +4082,7 @@ async fn function_time_floor() -> Result<(), Error> {
 		RETURN time::floor("1987-06-22T08:30:45Z", 1y);
 		RETURN time::floor("2023-05-11T03:09:00Z", 1s);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -4107,7 +4108,7 @@ async fn function_time_format() -> Result<(), Error> {
 		RETURN time::format("1987-06-22T08:30:45Z", "%Y-%m-%d");
 		RETURN time::format("1987-06-22T08:30:45Z", "%T");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4129,7 +4130,7 @@ async fn function_time_group() -> Result<(), Error> {
 		RETURN time::group("1987-06-22T08:30:45Z", 'hour');
 		RETURN time::group("1987-06-22T08:30:45Z", 'month');
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4151,7 +4152,7 @@ async fn function_time_hour() -> Result<(), Error> {
 		RETURN time::hour();
 		RETURN time::hour("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4171,7 +4172,7 @@ async fn function_time_min() -> Result<(), Error> {
 	let sql = r#"
 		RETURN time::min(["1987-06-22T08:30:45Z", "1988-06-22T08:30:45Z"]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -4188,7 +4189,7 @@ async fn function_time_max() -> Result<(), Error> {
 	let sql = r#"
 		RETURN time::max(["1987-06-22T08:30:45Z", "1988-06-22T08:30:45Z"]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -4206,7 +4207,7 @@ async fn function_time_minute() -> Result<(), Error> {
 		RETURN time::minute();
 		RETURN time::minute("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4227,7 +4228,7 @@ async fn function_time_month() -> Result<(), Error> {
 		RETURN time::month();
 		RETURN time::month("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4248,7 +4249,7 @@ async fn function_time_nano() -> Result<(), Error> {
 		RETURN time::nano();
 		RETURN time::nano("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4268,7 +4269,7 @@ async fn function_time_now() -> Result<(), Error> {
 	let sql = r#"
 		RETURN time::now();
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -4285,7 +4286,7 @@ async fn function_time_round() -> Result<(), Error> {
 		RETURN time::round("1987-06-22T08:30:45Z", 1w);
 		RETURN time::round("1987-06-22T08:30:45Z", 1y);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4307,7 +4308,7 @@ async fn function_time_second() -> Result<(), Error> {
 		RETURN time::second();
 		RETURN time::second("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4328,7 +4329,7 @@ async fn function_time_unix() -> Result<(), Error> {
 		RETURN time::unix();
 		RETURN time::unix("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4349,7 +4350,7 @@ async fn function_time_wday() -> Result<(), Error> {
 		RETURN time::wday();
 		RETURN time::wday("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4370,7 +4371,7 @@ async fn function_time_week() -> Result<(), Error> {
 		RETURN time::week();
 		RETURN time::week("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4391,7 +4392,7 @@ async fn function_time_yday() -> Result<(), Error> {
 		RETURN time::yday();
 		RETURN time::yday("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4412,7 +4413,7 @@ async fn function_time_year() -> Result<(), Error> {
 		RETURN time::year();
 		RETURN time::year("1987-06-22T08:30:45Z");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4433,7 +4434,7 @@ async fn function_time_from_micros() -> Result<(), Error> {
 		RETURN time::from::micros(384025770384840);
 		RETURN time::from::micros(2840257704384440);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4455,7 +4456,7 @@ async fn function_time_from_millis() -> Result<(), Error> {
 		RETURN time::from::millis(384025773840);
 		RETURN time::from::millis(2840257704440);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4477,7 +4478,7 @@ async fn function_time_from_secs() -> Result<(), Error> {
 		RETURN time::from::secs(384053840);
 		RETURN time::from::secs(2845704440);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4499,7 +4500,7 @@ async fn function_time_from_unix() -> Result<(), Error> {
 		RETURN time::from::unix(384053840);
 		RETURN time::from::unix(2845704440);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4525,7 +4526,7 @@ async fn function_type_bool() -> Result<(), Error> {
 		RETURN type::bool("true");
 		RETURN type::bool("false");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4547,7 +4548,7 @@ async fn function_type_datetime() -> Result<(), Error> {
 		RETURN type::datetime("1987-06-22");
 		RETURN type::datetime("2022-08-01");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4569,7 +4570,7 @@ async fn function_type_decimal() -> Result<(), Error> {
 		RETURN type::decimal("13.1043784018");
 		RETURN type::decimal("13.5719384719384719385639856394139476937756394756");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4593,7 +4594,7 @@ async fn function_type_duration() -> Result<(), Error> {
 		RETURN type::duration("1h30m");
 		RETURN type::duration("1h30m30s50ms");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4615,7 +4616,7 @@ async fn function_type_float() -> Result<(), Error> {
 		RETURN type::float("13.1043784018");
 		RETURN type::float("13.5719384719384719385639856394139476937756394756");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4637,7 +4638,7 @@ async fn function_type_int() -> Result<(), Error> {
 		RETURN type::int("194719");
 		RETURN type::int("1457105732053058");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4659,7 +4660,7 @@ async fn function_type_number() -> Result<(), Error> {
 		RETURN type::number("194719.1947104740");
 		RETURN type::number("1457105732053058.3957394823281756381849375");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4681,7 +4682,7 @@ async fn function_type_point() -> Result<(), Error> {
 		RETURN type::point([1.345, 6.789]);
 		RETURN type::point([-0.136439, 51.509865]);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4719,7 +4720,7 @@ async fn function_type_string() -> Result<(), Error> {
 		RETURN type::string(30s);
 		RETURN type::string(13);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4741,7 +4742,7 @@ async fn function_type_table() -> Result<(), Error> {
 		RETURN type::table("person");
 		RETURN type::table("animal");
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -4765,7 +4766,7 @@ async fn function_type_thing() -> Result<(), Error> {
 		CREATE type::thing('city', '8e60244d-95f6-4f95-9e30-09a98977efb0');
 		CREATE type::thing('temperature', ['London', '2022-09-30T20:25:01.406828Z']);
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);

--- a/lib/tests/future.rs
+++ b/lib/tests/future.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -12,7 +13,7 @@ async fn future_function_simple() -> Result<(), Error> {
 		UPDATE person:test SET birthday = <datetime> '2007-06-22';
 		UPDATE person:test SET birthday = <datetime> '2001-06-22';
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -44,7 +45,7 @@ async fn future_function_arguments() -> Result<(), Error> {
 			y = 'b-' + parse::email::user(b)
 		;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -91,7 +92,7 @@ async fn concurrency() -> Result<(), Error> {
 	/// Returns `true` iif `limit` futures are concurrently executed.
 	async fn test_limit(limit: usize) -> Result<bool, Error> {
 		let sql = query(limit, MILLIS);
-		let dbs = Datastore::new("memory").await?;
+		let dbs = new_ds().await?;
 		let ses = Session::owner().with_ns("test").with_db("test");
 		let res = dbs.execute(&sql, &ses, None).await;
 

--- a/lib/tests/geometry.rs
+++ b/lib/tests/geometry.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -11,7 +12,7 @@ async fn geometry_point() -> Result<(), Error> {
 		UPDATE city:london SET centre = (-0.118092, 51.509865);
 		SELECT * FROM city:london;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -68,7 +69,7 @@ async fn geometry_polygon() -> Result<(), Error> {
 		};
 		SELECT * FROM city:london;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -161,7 +162,7 @@ async fn geometry_multipoint() -> Result<(), Error> {
 		};
 		SELECT * FROM city:london;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -239,7 +240,7 @@ async fn geometry_multipolygon() -> Result<(), Error> {
 		};
 		SELECT * FROM university:oxford;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -344,7 +345,7 @@ async fn geometry_inner_access() -> Result<(), Error> {
 			],
 		};
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);

--- a/lib/tests/group.rs
+++ b/lib/tests/group.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -20,7 +21,7 @@ async fn select_limit_fetch() -> Result<(), Error> {
 		SELECT *, time::year(time) AS year FROM temperature;
 		SELECT count(), time::year(time) AS year, country FROM temperature GROUP BY country, year;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 11);
@@ -244,7 +245,7 @@ async fn select_multi_aggregate() -> Result<(), Error> {
 		SELECT group, math::sum(one) AS one, math::sum(two) AS two FROM test GROUP BY group;
 		SELECT group, math::sum(two) AS two, math::sum(one) AS one FROM test GROUP BY group;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 6);
@@ -349,7 +350,7 @@ async fn select_multi_aggregate_composed() -> Result<(), Error> {
 		SELECT group, math::sum(math::round(one)) AS one, math::sum(math::round(two)) AS two FROM test GROUP BY group;
 		SELECT group, math::sum(math::ceil(one)) AS one, math::sum(math::ceil(two)) AS two FROM test GROUP BY group;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);

--- a/lib/tests/helpers.rs
+++ b/lib/tests/helpers.rs
@@ -1,10 +1,17 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use surrealdb::dbs::capabilities::Capabilities;
 use surrealdb::dbs::Session;
+use surrealdb::err::Error;
 use surrealdb::iam::{Auth, Level, Role};
 use surrealdb::kvs::Datastore;
 
+pub async fn new_ds() -> Result<Datastore, Error> {
+	Ok(Datastore::new("memory").await?.with_capabilities(Capabilities::new_allow_all()))
+}
+
+#[allow(dead_code)]
 pub async fn iam_run_case(
 	prepare: &str,
 	test: &str,
@@ -86,6 +93,7 @@ pub async fn iam_run_case(
 	Ok(())
 }
 
+#[allow(dead_code)]
 pub async fn iam_check_cases(
 	cases: std::slice::Iter<'_, ((Level, Role), (&str, &str), bool)>,
 	scenario: &HashMap<&str, &str>,
@@ -105,14 +113,14 @@ pub async fn iam_check_cases(
 		};
 		// Auth enabled
 		{
-			let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(true);
+			let ds = new_ds().await.unwrap().with_auth_enabled(true);
 			iam_run_case(prepare, test, check, &expected_result, &ds, &sess, *should_succeed)
 				.await?;
 		}
 
 		// Auth disabled
 		{
-			let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(false);
+			let ds = new_ds().await.unwrap().with_auth_enabled(false);
 			iam_run_case(prepare, test, check, &expected_result, &ds, &sess, *should_succeed)
 				.await?;
 		}
@@ -128,7 +136,7 @@ pub async fn iam_check_cases(
 				auth_enabled =
 					auth_enabled.then(|| "auth enabled").unwrap_or_else(|| "auth disabled")
 			);
-			let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+			let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 			let expected_result = if auth_enabled {
 				check_results.get(1).unwrap()
 			} else {

--- a/lib/tests/helpers.rs
+++ b/lib/tests/helpers.rs
@@ -8,7 +8,7 @@ use surrealdb::iam::{Auth, Level, Role};
 use surrealdb::kvs::Datastore;
 
 pub async fn new_ds() -> Result<Datastore, Error> {
-	Ok(Datastore::new("memory").await?.with_capabilities(Capabilities::new_allow_all()))
+	Ok(Datastore::new("memory").await?.with_capabilities(Capabilities::all()))
 }
 
 #[allow(dead_code)]

--- a/lib/tests/info.rs
+++ b/lib/tests/info.rs
@@ -1,5 +1,3 @@
-mod parse;
-
 mod helpers;
 use helpers::*;
 
@@ -8,7 +6,6 @@ use std::collections::HashMap;
 use regex::Regex;
 use surrealdb::dbs::Session;
 use surrealdb::iam::Role;
-use surrealdb::kvs::Datastore;
 
 #[tokio::test]
 async fn info_for_root() {
@@ -17,7 +14,7 @@ async fn info_for_root() {
         DEFINE USER user ON ROOT PASSWORD 'pass';
         INFO FOR ROOT
     "#;
-	let dbs = Datastore::new("memory").await.unwrap();
+	let dbs = new_ds().await.unwrap();
 	let ses = Session::owner();
 
 	let mut res = dbs.execute(sql, &ses, None).await.unwrap();
@@ -45,7 +42,7 @@ async fn info_for_ns() {
         DEFINE TOKEN token ON NS TYPE HS512 VALUE 'secret';
         INFO FOR NS
     "#;
-	let dbs = Datastore::new("memory").await.unwrap();
+	let dbs = new_ds().await.unwrap();
 	let ses = Session::owner().with_ns("ns");
 
 	let mut res = dbs.execute(sql, &ses, None).await.unwrap();
@@ -79,7 +76,7 @@ async fn info_for_db() {
         DEFINE ANALYZER analyzer TOKENIZERS BLANK;
         INFO FOR DB
     "#;
-	let dbs = Datastore::new("memory").await.unwrap();
+	let dbs = new_ds().await.unwrap();
 	let ses = Session::owner().with_ns("ns").with_db("db");
 
 	let mut res = dbs.execute(sql, &ses, None).await.unwrap();
@@ -105,7 +102,7 @@ async fn info_for_scope() {
         DEFINE TOKEN token ON SCOPE account TYPE HS512 VALUE 'secret';
         INFO FOR SCOPE account;
     "#;
-	let dbs = Datastore::new("memory").await.unwrap();
+	let dbs = new_ds().await.unwrap();
 	let ses = Session::owner().with_ns("ns").with_db("db");
 
 	let mut res = dbs.execute(sql, &ses, None).await.unwrap();
@@ -133,7 +130,7 @@ async fn info_for_table() {
         DEFINE INDEX index ON TABLE TB FIELDS field;
         INFO FOR TABLE TB;
     "#;
-	let dbs = Datastore::new("memory").await.unwrap();
+	let dbs = new_ds().await.unwrap();
 	let ses = Session::owner().with_ns("ns").with_db("db");
 
 	let mut res = dbs.execute(sql, &ses, None).await.unwrap();
@@ -162,7 +159,7 @@ async fn info_for_user() {
         DEFINE USER user ON NS PASSWORD 'pass';
         DEFINE USER user ON DB PASSWORD 'pass';
     "#;
-	let dbs = Datastore::new("memory").await.unwrap();
+	let dbs = new_ds().await.unwrap();
 	let ses = Session::owner().with_ns("ns").with_db("db");
 
 	let res = dbs.execute(sql, &ses, None).await.unwrap();

--- a/lib/tests/insert.rs
+++ b/lib/tests/insert.rs
@@ -1,9 +1,10 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Part;
 use surrealdb::sql::Value;
 
@@ -16,7 +17,7 @@ async fn insert_statement_object_single() -> Result<(), Error> {
 			something: 'other',
 		};
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -44,7 +45,7 @@ async fn insert_statement_object_multiple() -> Result<(), Error> {
 			},
 		];
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -66,7 +67,7 @@ async fn insert_statement_values_single() -> Result<(), Error> {
 	let sql = "
 		INSERT INTO test (id, test, something) VALUES ('tester', true, 'other');
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -83,7 +84,7 @@ async fn insert_statement_values_multiple() -> Result<(), Error> {
 	let sql = "
 		INSERT INTO test (id, test, something) VALUES (1, true, 'other'), (2, false, 'else');
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -105,7 +106,7 @@ async fn insert_statement_values_retable_id() -> Result<(), Error> {
 	let sql = "
 		INSERT INTO test (id, test, something) VALUES (person:1, true, 'other'), (person:2, false, 'else');
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -128,7 +129,7 @@ async fn insert_statement_on_duplicate_key() -> Result<(), Error> {
 		INSERT INTO test (id, test, something) VALUES ('tester', true, 'other');
 		INSERT INTO test (id, test, something) VALUES ('tester', true, 'other') ON DUPLICATE KEY UPDATE something = 'else';
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -149,7 +150,7 @@ async fn insert_statement_output() -> Result<(), Error> {
 	let sql = "
 		INSERT INTO test (id, test, something) VALUES ('tester', true, 'other') RETURN something;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -169,7 +170,7 @@ async fn insert_statement_duplicate_key_update() -> Result<(), Error> {
 		INSERT INTO company (name, founded) VALUES ('SurrealDB', '2021-09-11') ON DUPLICATE KEY UPDATE founded = $input.founded;
 		INSERT INTO company (name, founded) VALUES ('SurrealDB', '2021-09-12') ON DUPLICATE KEY UPDATE founded = $input.founded PARALLEL;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -229,7 +230,7 @@ async fn common_permissions_checks(auth_enabled: bool) {
 
 		// Test the INSERT statement when the table has to be created
 		{
-			let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+			let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 			let mut resp = ds.execute(statement, &sess, None).await.unwrap();
 			let res = resp.remove(0).output();
@@ -252,7 +253,7 @@ async fn common_permissions_checks(auth_enabled: bool) {
 
 		// Test the INSERT statement when the table already exists
 		{
-			let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+			let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 			let mut resp = ds
 				.execute("CREATE person", &Session::owner().with_ns("NS").with_db("DB"), None)
@@ -321,7 +322,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table doesn't exist
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -343,7 +344,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table exists but grants no permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -371,7 +372,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table exists and grants full permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -412,7 +413,7 @@ async fn check_permissions_auth_disabled() {
 
 	// When the table doesn't exist
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -433,7 +434,7 @@ async fn check_permissions_auth_disabled() {
 
 	// When the table exists but grants no permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -461,7 +462,7 @@ async fn check_permissions_auth_disabled() {
 
 	// When the table exists and grants full permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(

--- a/lib/tests/limit.rs
+++ b/lib/tests/limit.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -15,7 +16,7 @@ async fn select_limit_fetch() -> Result<(), Error> {
 		CREATE person:jaime SET tags = [tag:js];
 		SELECT * FROM person LIMIT 1 FETCH tags;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 6);

--- a/lib/tests/merge.rs
+++ b/lib/tests/merge.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -17,7 +18,7 @@ async fn merge_record() -> Result<(), Error> {
 			}
 		};
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);

--- a/lib/tests/model.rs
+++ b/lib/tests/model.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -11,7 +12,7 @@ async fn model_count() -> Result<(), Error> {
 		CREATE |test:1000| SET time = time::now();
 		SELECT count() FROM test GROUP ALL;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -36,7 +37,7 @@ async fn model_range() -> Result<(), Error> {
 		CREATE |test:101..1100| SET time = time::now();
 		SELECT count() FROM test GROUP ALL;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);

--- a/lib/tests/param.rs
+++ b/lib/tests/param.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -14,7 +15,7 @@ async fn define_global_param() -> Result<(), Error> {
 		LET $test = 56789;
 		SELECT * FROM $test;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -57,7 +58,7 @@ async fn define_protected_param() -> Result<(), Error> {
 		SELECT * FROM $test WHERE some = 'thing';
 		LET $auth = { ID: admin:tester };
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -1,9 +1,9 @@
 mod parse;
-
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::{Response, Session};
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -118,7 +118,7 @@ async fn select_where_iterate_two_no_index() -> Result<(), Error> {
 }
 
 async fn execute_test(sql: &str, expected_result: usize) -> Result<Vec<Response>, Error> {
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let mut res = dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), expected_result);

--- a/lib/tests/query.rs
+++ b/lib/tests/query.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -13,7 +14,7 @@ async fn query_basic() -> Result<(), Error> {
 		RETURN $test;
 		$test;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -45,7 +46,7 @@ async fn query_basic_with_modification() -> Result<(), Error> {
 		RETURN $test + 11369;
 		$test + 11369;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -77,7 +78,7 @@ async fn query_root_function() -> Result<(), Error> {
 		string::lowercase($test);
 		string::slug($test);
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 4);
@@ -110,7 +111,7 @@ async fn query_root_record() -> Result<(), Error> {
 		<future> { person:tobie->knows->person.name };
 		person:tobie->knows->person.name;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);

--- a/lib/tests/relate.rs
+++ b/lib/tests/relate.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -12,7 +13,7 @@ async fn relate_with_parameters() -> Result<(), Error> {
 		LET $jaime = person:jaime;
 		RELATE $tobie->knows->$jaime SET id = knows:test, brother = true;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -50,7 +51,7 @@ async fn relate_and_overwrite() -> Result<(), Error> {
 		UPDATE knows:test CONTENT { test: true };
 		SELECT * FROM knows:test;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -1,4 +1,5 @@
 mod parse;
+use parse::Parse;
 
 mod helpers;
 use helpers::*;
@@ -8,11 +9,9 @@ mod util;
 
 use std::collections::HashMap;
 
-use parse::Parse;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -22,7 +21,7 @@ async fn remove_statement_table() -> Result<(), Error> {
 		REMOVE TABLE test;
 		INFO FOR DB;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -56,7 +55,7 @@ async fn remove_statement_analyzer() -> Result<(), Error> {
 		REMOVE ANALYZER english;
 		INFO FOR DB;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -96,7 +95,7 @@ async fn remove_statement_index() -> Result<(), Error> {
 		REMOVE INDEX ft_title ON book;
 		INFO FOR TABLE book;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 9);

--- a/lib/tests/script.rs
+++ b/lib/tests/script.rs
@@ -2,9 +2,10 @@
 
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -17,7 +18,7 @@ async fn script_function_error() -> Result<(), Error> {
 			throw new Error('error');
 		};
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -46,7 +47,7 @@ async fn script_function_simple() -> Result<(), Error> {
 			return "Line 1\nLine 2";
 		};
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -75,7 +76,7 @@ async fn script_function_context() -> Result<(), Error> {
 			}
 		;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -109,7 +110,7 @@ async fn script_function_arguments() -> Result<(), Error> {
 			return `${arguments[0]} is ${arguments[1].join(', ')}`;
 		};
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -152,7 +153,7 @@ async fn script_function_types() -> Result<(), Error> {
 			}
 		;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -182,7 +183,7 @@ async fn script_function_module_os() -> Result<(), Error> {
 			return platform();
 		};
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -200,7 +201,7 @@ async fn script_query_from_script_select() -> Result<(), Error> {
 		CREATE test SET name = "b", number = 1;
 		CREATE test SET name = "c", number = 2;
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 
 	// direct query
@@ -254,7 +255,7 @@ async fn script_query_from_script() -> Result<(), Error> {
 			return await surrealdb.query(`CREATE article:test SET name = "The daily news", issue_number = 3`)
 		}
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -293,7 +294,7 @@ async fn script_value_function_params() -> Result<(), Error> {
 			return await surrealdb.value(`$test.name`)
 		}
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -318,7 +319,7 @@ async fn script_value_function_inline_values() -> Result<(), Error> {
 			}
 		}
 	"#;
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);

--- a/lib/tests/strict.rs
+++ b/lib/tests/strict.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -15,7 +16,7 @@ async fn strict_mode_no_namespace() -> Result<(), Error> {
 		CREATE test:tester;
 		SELECT * FROM test;
 	";
-	let dbs = Datastore::new("memory").await?.with_strict_mode(true);
+	let dbs = new_ds().await?.with_strict_mode(true);
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -73,7 +74,7 @@ async fn strict_mode_no_database() -> Result<(), Error> {
 		CREATE test:tester;
 		SELECT * FROM test;
 	";
-	let dbs = Datastore::new("memory").await?.with_strict_mode(true);
+	let dbs = new_ds().await?.with_strict_mode(true);
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -126,7 +127,7 @@ async fn strict_mode_no_table() -> Result<(), Error> {
 		CREATE test:tester;
 		SELECT * FROM test;
 	";
-	let dbs = Datastore::new("memory").await?.with_strict_mode(true);
+	let dbs = new_ds().await?.with_strict_mode(true);
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
@@ -174,7 +175,7 @@ async fn strict_mode_all_ok() -> Result<(), Error> {
 		CREATE test:tester;
 		SELECT * FROM test;
 	";
-	let dbs = Datastore::new("memory").await?.with_strict_mode(true);
+	let dbs = new_ds().await?.with_strict_mode(true);
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 6);
@@ -213,7 +214,7 @@ async fn loose_mode_all_ok() -> Result<(), Error> {
 		INFO FOR DB;
 		INFO FOR TABLE test;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);

--- a/lib/tests/subquery.rs
+++ b/lib/tests/subquery.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -23,7 +24,7 @@ async fn subquery_select() -> Result<(), Error> {
 		-- Using an outer SELECT, select a specific record in a subquery, returning an array
 		SELECT * FROM (SELECT age >= 18 AS adult FROM person:test) WHERE adult = true;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -135,7 +136,7 @@ async fn subquery_ifelse_set() -> Result<(), Error> {
 			UPDATE person:test SET sport = ['basketball'] RETURN sport;
 		END;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 9);
@@ -250,7 +251,7 @@ async fn subquery_ifelse_array() -> Result<(), Error> {
 			UPDATE person:test SET sport = ['basketball'] RETURN sport;
 		END;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 9);

--- a/lib/tests/table.rs
+++ b/lib/tests/table.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -26,7 +27,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 		UPDATE person:two SET age = 39, score = 90;
 		SELECT * FROM person_by_age;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 9);

--- a/lib/tests/throw.rs
+++ b/lib/tests/throw.rs
@@ -1,14 +1,14 @@
-mod parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 
 #[tokio::test]
 async fn throw_basic() -> Result<(), Error> {
 	let sql = "
 		THROW 'there was an error';
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);

--- a/lib/tests/transaction.rs
+++ b/lib/tests/transaction.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -13,7 +14,7 @@ async fn transaction_basic() -> Result<(), Error> {
 		CREATE person:jaime;
 		COMMIT;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 2);
@@ -50,7 +51,7 @@ async fn transaction_with_return() -> Result<(), Error> {
 		RETURN { tobie: person:tobie, jaime: person:jaime };
 		COMMIT;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -76,7 +77,7 @@ async fn transaction_with_failure() -> Result<(), Error> {
 		CREATE person:tobie;
 		COMMIT;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -112,7 +113,7 @@ async fn transaction_with_failure_and_return() -> Result<(), Error> {
 		RETURN { tobie: person:tobie, jaime: person:jaime };
 		COMMIT;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
@@ -135,7 +136,7 @@ async fn transaction_with_throw() -> Result<(), Error> {
 		THROW 'there was an error';
 		COMMIT;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -171,7 +172,7 @@ async fn transaction_with_throw_and_return() -> Result<(), Error> {
 		RETURN { tobie: person:tobie, jaime: person:jaime };
 		COMMIT;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);

--- a/lib/tests/typing.rs
+++ b/lib/tests/typing.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -18,7 +19,7 @@ async fn strict_typing_inline() -> Result<(), Error> {
 		UPDATE person:test SET scores = <set<float, 5>> [1,1,2,2,3,3,4,4,5,5];
 		UPDATE person:test SET scores = <array<float, 5>> [1,1,2,2,3,3,4,4,5,5];
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 9);
@@ -134,7 +135,7 @@ async fn strict_typing_defined() -> Result<(), Error> {
 		UPDATE person:test SET age = 18, enabled = true, name = NONE, scored = [1,1,2,2,3,3,4,4,5,5];
 		UPDATE person:test SET age = 18, enabled = true, name = 'Tobie Morgan Hitchcock', scores = [1,1,2,2,3,3,4,4,5,5];
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 8);
@@ -207,7 +208,7 @@ async fn strict_typing_none_null() -> Result<(), Error> {
 		UPDATE person:test SET name = NULL;
 		UPDATE person:test SET name = NONE;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 15);

--- a/lib/tests/update.rs
+++ b/lib/tests/update.rs
@@ -1,9 +1,10 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -30,7 +31,7 @@ async fn update_simple_with_input() -> Result<(), Error> {
 		UPDATE person:test SET name = 'Tobie';
 		SELECT * FROM person:test;
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
@@ -110,7 +111,7 @@ async fn update_complex_with_input() -> Result<(), Error> {
 		;
 		CREATE product:test SET images = [' test.png '];
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -173,7 +174,7 @@ async fn common_permissions_checks(auth_enabled: bool) {
 		// Test the statement when the table has to be created
 
 		{
-			let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+			let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 			let mut resp = ds.execute(statement, &sess, None).await.unwrap();
 			let res = resp.remove(0).output();
@@ -196,7 +197,7 @@ async fn common_permissions_checks(auth_enabled: bool) {
 
 		// Test the statement when the table already exists
 		{
-			let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+			let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 			// Prepare datastore
 			let mut resp = ds
@@ -294,7 +295,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table doesn't exist
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(statement, &Session::default().with_ns("NS").with_db("DB"), None)
@@ -312,7 +313,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table grants no permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -360,7 +361,7 @@ async fn check_permissions_auth_enabled() {
 
 	// When the table exists and grants full permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -424,7 +425,7 @@ async fn check_permissions_auth_disabled() {
 
 	// When the table doesn't exist
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(statement, &Session::default().with_ns("NS").with_db("DB"), None)
@@ -441,7 +442,7 @@ async fn check_permissions_auth_disabled() {
 
 	// When the table grants no permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(
@@ -489,7 +490,7 @@ async fn check_permissions_auth_disabled() {
 
 	// When the table exists and grants full permissions
 	{
-		let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(auth_enabled);
+		let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 
 		let mut resp = ds
 			.execute(

--- a/lib/tests/yuse.rs
+++ b/lib/tests/yuse.rs
@@ -1,8 +1,9 @@
 mod parse;
 use parse::Parse;
+mod helpers;
+use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
-use surrealdb::kvs::Datastore;
 use surrealdb::sql::Value;
 
 #[tokio::test]
@@ -12,7 +13,7 @@ async fn use_statement_set_ns() -> Result<(), Error> {
 		USE NS my_ns;
 		SELECT * FROM $session.ns, session::ns(), $session.db, session::db();
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -38,7 +39,7 @@ async fn use_statement_set_db() -> Result<(), Error> {
 		USE DB my_db;
 		SELECT * FROM $session.ns, session::ns(), $session.db, session::db();
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);
@@ -64,7 +65,7 @@ async fn use_statement_set_both() -> Result<(), Error> {
 		USE NS my_ns DB my_db;
 		SELECT * FROM $session.ns, session::ns(), $session.db, session::db();
 	";
-	let dbs = Datastore::new("memory").await?;
+	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 3);

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -44,7 +44,7 @@ struct DbsCapabilities {
 	allow_all: bool,
 
 	#[cfg(feature = "scripting")]
-	#[arg(help = "Allow execution of scripting functions")]
+	#[arg(help = "Allow execution of embedded scripting functions")]
 	#[arg(env = "SURREAL_CAPS_ALLOW_SCRIPT", long, conflicts_with = "allow_all")]
 	#[arg(default_missing_value_os = "true", action = ArgAction::Set, num_args = 0..)]
 	#[arg(default_value_t = false, hide_default_value = true)]
@@ -95,7 +95,7 @@ Targets must be in the form of <host>[:<port>], <ipv4|ipv6>[/<mask>]. For exampl
 	deny_all: bool,
 
 	#[cfg(feature = "scripting")]
-	#[arg(help = "Deny execution of scripting functions")]
+	#[arg(help = "Deny execution of embedded scripting functions")]
 	#[arg(env = "SURREAL_CAPS_DENY_SCRIPT", long, conflicts_with = "deny_all")]
 	#[arg(default_missing_value_os = "true", action = ArgAction::Set, num_args = 0..)]
 	#[arg(default_value_t = false, hide_default_value = true)]

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -202,8 +202,8 @@ impl From<DbsCapabilities> for Capabilities {
 		Capabilities::default()
 			.with_scripting(caps.get_scripting())
 			.with_guest_access(caps.get_allow_guests())
-			.with_allow_funcs(caps.get_allow_funcs())
-			.with_deny_funcs(caps.get_deny_funcs())
+			.with_allow_functions(caps.get_allow_funcs())
+			.with_deny_functions(caps.get_deny_funcs())
 			.with_allow_net(caps.get_allow_net())
 			.with_deny_net(caps.get_deny_net())
 	}
@@ -360,7 +360,7 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_funcs(Targets::<FuncTarget>::All)
+						.with_allow_functions(Targets::<FuncTarget>::All)
 						.with_allow_net(Targets::<NetTarget>::All),
 				),
 				Session::owner(),
@@ -456,10 +456,10 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_funcs(Targets::<FuncTarget>::Some(
+						.with_allow_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::*").unwrap()].into(),
 						))
-						.with_deny_funcs(Targets::<FuncTarget>::Some(
+						.with_deny_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::len").unwrap()].into(),
 						)),
 				),
@@ -471,10 +471,10 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_funcs(Targets::<FuncTarget>::Some(
+						.with_allow_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::*").unwrap()].into(),
 						))
-						.with_deny_funcs(Targets::<FuncTarget>::Some(
+						.with_deny_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::len").unwrap()].into(),
 						)),
 				),
@@ -486,10 +486,10 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_funcs(Targets::<FuncTarget>::Some(
+						.with_allow_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::*").unwrap()].into(),
 						))
-						.with_deny_funcs(Targets::<FuncTarget>::Some(
+						.with_deny_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::len").unwrap()].into(),
 						)),
 				),
@@ -504,7 +504,7 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_funcs(Targets::<FuncTarget>::All)
+						.with_allow_functions(Targets::<FuncTarget>::All)
 						.with_allow_net(Targets::<NetTarget>::Some(
 							[
 								NetTarget::from_str(&server1.address().to_string()).unwrap(),
@@ -524,7 +524,7 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_funcs(Targets::<FuncTarget>::All)
+						.with_allow_functions(Targets::<FuncTarget>::All)
 						.with_allow_net(Targets::<NetTarget>::Some(
 							[
 								NetTarget::from_str(&server1.address().to_string()).unwrap(),
@@ -544,7 +544,7 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_funcs(Targets::<FuncTarget>::All)
+						.with_allow_functions(Targets::<FuncTarget>::All)
 						.with_allow_net(Targets::<NetTarget>::Some(
 							[
 								NetTarget::from_str(&server1.address().to_string()).unwrap(),

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -202,10 +202,10 @@ impl From<DbsCapabilities> for Capabilities {
 		Capabilities::default()
 			.with_scripting(caps.get_scripting())
 			.with_guest_access(caps.get_allow_guests())
-			.with_allow_functions(caps.get_allow_funcs())
-			.with_deny_functions(caps.get_deny_funcs())
-			.with_allow_net(caps.get_allow_net())
-			.with_deny_net(caps.get_deny_net())
+			.with_functions(caps.get_allow_funcs())
+			.without_functions(caps.get_deny_funcs())
+			.with_network_targets(caps.get_allow_net())
+			.without_network_targets(caps.get_deny_net())
 	}
 }
 
@@ -360,8 +360,8 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_functions(Targets::<FuncTarget>::All)
-						.with_allow_net(Targets::<NetTarget>::All),
+						.with_functions(Targets::<FuncTarget>::All)
+						.with_network_targets(Targets::<NetTarget>::All),
 				),
 				Session::owner(),
 				format!("RETURN http::get('{}')", server1.uri()),
@@ -456,10 +456,10 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_functions(Targets::<FuncTarget>::Some(
+						.with_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::*").unwrap()].into(),
 						))
-						.with_deny_functions(Targets::<FuncTarget>::Some(
+						.without_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::len").unwrap()].into(),
 						)),
 				),
@@ -471,10 +471,10 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_functions(Targets::<FuncTarget>::Some(
+						.with_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::*").unwrap()].into(),
 						))
-						.with_deny_functions(Targets::<FuncTarget>::Some(
+						.without_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::len").unwrap()].into(),
 						)),
 				),
@@ -486,10 +486,10 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_functions(Targets::<FuncTarget>::Some(
+						.with_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::*").unwrap()].into(),
 						))
-						.with_deny_functions(Targets::<FuncTarget>::Some(
+						.without_functions(Targets::<FuncTarget>::Some(
 							[FuncTarget::from_str("string::len").unwrap()].into(),
 						)),
 				),
@@ -504,15 +504,15 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_functions(Targets::<FuncTarget>::All)
-						.with_allow_net(Targets::<NetTarget>::Some(
+						.with_functions(Targets::<FuncTarget>::All)
+						.with_network_targets(Targets::<NetTarget>::Some(
 							[
 								NetTarget::from_str(&server1.address().to_string()).unwrap(),
 								NetTarget::from_str(&server2.address().to_string()).unwrap(),
 							]
 							.into(),
 						))
-						.with_deny_net(Targets::<NetTarget>::Some(
+						.without_network_targets(Targets::<NetTarget>::Some(
 							[NetTarget::from_str(&server1.address().to_string()).unwrap()].into(),
 						)),
 				),
@@ -524,15 +524,15 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_functions(Targets::<FuncTarget>::All)
-						.with_allow_net(Targets::<NetTarget>::Some(
+						.with_functions(Targets::<FuncTarget>::All)
+						.with_network_targets(Targets::<NetTarget>::Some(
 							[
 								NetTarget::from_str(&server1.address().to_string()).unwrap(),
 								NetTarget::from_str(&server2.address().to_string()).unwrap(),
 							]
 							.into(),
 						))
-						.with_deny_net(Targets::<NetTarget>::Some(
+						.without_network_targets(Targets::<NetTarget>::Some(
 							[NetTarget::from_str(&server1.address().to_string()).unwrap()].into(),
 						)),
 				),
@@ -544,15 +544,15 @@ mod tests {
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
-						.with_allow_functions(Targets::<FuncTarget>::All)
-						.with_allow_net(Targets::<NetTarget>::Some(
+						.with_functions(Targets::<FuncTarget>::All)
+						.with_network_targets(Targets::<NetTarget>::Some(
 							[
 								NetTarget::from_str(&server1.address().to_string()).unwrap(),
 								NetTarget::from_str(&server2.address().to_string()).unwrap(),
 							]
 							.into(),
 						))
-						.with_deny_net(Targets::<NetTarget>::Some(
+						.without_network_targets(Targets::<NetTarget>::Some(
 							[NetTarget::from_str(&server1.address().to_string()).unwrap()].into(),
 						)),
 				),

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -531,7 +531,7 @@ mod cli_integration {
 			);
 		}
 
-		// When all capabilities are allowed, anyone (including anon users) can execute functions and access any network address
+		// When all capabilities are allowed, anyone (including non-authenticated users) can execute functions and access any network address
 		info!("* When all capabilities are allowed");
 		{
 			let (addr, _server) = common::start_server(StartServerArguments {
@@ -629,11 +629,11 @@ mod cli_integration {
 			);
 		}
 
-		info!("* When auth is enabled and anonymous access is allowed");
+		info!("* When auth is enabled and guest access is allowed");
 		{
 			let (addr, _server) = common::start_server(StartServerArguments {
 				auth: true,
-				args: "--allow-anon-access".to_owned(),
+				args: "--allow-guests".to_owned(),
 				..Default::default()
 			})
 			.await
@@ -646,11 +646,11 @@ mod cli_integration {
 			assert!(output.contains("[1]"), "unexpected output: {output:?}");
 		}
 
-		info!("* When auth is enabled and anonymous access is denied");
+		info!("* When auth is enabled and guest access is denied");
 		{
 			let (addr, _server) = common::start_server(StartServerArguments {
 				auth: true,
-				args: "--deny-anon-access".to_owned(),
+				args: "--deny-guests".to_owned(),
 				..Default::default()
 			})
 			.await
@@ -666,11 +666,11 @@ mod cli_integration {
 			);
 		}
 
-		info!("* When auth is disabled, anonymous access is always allowed");
+		info!("* When auth is disabled, guest access is always allowed");
 		{
 			let (addr, _server) = common::start_server(StartServerArguments {
 				auth: false,
-				args: "--deny-anon-access".to_owned(),
+				args: "--deny-guests".to_owned(),
 				..Default::default()
 			})
 			.await

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -38,7 +38,13 @@ mod cli_integration {
 	#[test(tokio::test)]
 	async fn all_commands() {
 		// Commands without credentials when auth is disabled, should succeed
-		let (addr, _server) = common::start_server_without_auth().await.unwrap();
+		let (addr, _server) = common::start_server(StartServerArguments {
+			auth: false,
+			args: "--allow-all".to_string(),
+			..Default::default()
+		})
+		.await
+		.unwrap();
 		let creds = ""; // Anonymous user
 
 		info!("* Create a record");
@@ -498,31 +504,17 @@ mod cli_integration {
 
 	#[test(tokio::test)]
 	async fn test_capabilities() {
-		info!("* When all capabilities are enabled by default");
-		{
-			let (addr, _server) = common::start_server_without_auth().await.unwrap();
-
-			let cmd = format!("sql --conn ws://{addr} --ns N --db D --multi");
-
-			let query = format!("RETURN http::get('http://{}/version');\n\n", addr);
-			let output = common::run(&cmd).input(&query).output().unwrap();
-			assert!(output.starts_with("['surrealdb"), "unexpected output: {output:?}");
-
-			let query = "RETURN function() { return '1' };";
-			let output = common::run(&cmd).input(query).output().unwrap();
-			assert!(output.starts_with("['1']"), "unexpected output: {output:?}");
-		}
-
-		info!("* When all capabilities are denied");
+		// Deny all, denies all users to execute functions and access any network address
+		info!("* When all capabilities are denied by default");
 		{
 			let (addr, _server) = common::start_server(StartServerArguments {
-				args: "--deny-all".to_owned(),
+				args: "".to_owned(),
 				..Default::default()
 			})
 			.await
 			.unwrap();
 
-			let cmd = format!("sql --conn ws://{addr} --ns N --db D --multi");
+			let cmd = format!("sql --conn ws://{addr} -u root -p root --ns N --db D --multi");
 
 			let query = format!("RETURN http::get('http://{}/version');\n\n", addr);
 			let output = common::run(&cmd).input(&query).output().unwrap();
@@ -539,6 +531,27 @@ mod cli_integration {
 			);
 		}
 
+		// When all capabilities are allowed, anyone (including anon users) can execute functions and access any network address
+		info!("* When all capabilities are allowed");
+		{
+			let (addr, _server) = common::start_server(StartServerArguments {
+				args: "--allow-all".to_owned(),
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			let cmd = format!("sql --conn ws://{addr} --ns N --db D --multi");
+
+			let query = format!("RETURN http::get('http://{}/version');\n\n", addr);
+			let output = common::run(&cmd).input(&query).output().unwrap();
+			assert!(output.starts_with("['surrealdb"), "unexpected output: {output:?}");
+
+			let query = "RETURN function() { return '1' };";
+			let output = common::run(&cmd).input(query).output().unwrap();
+			assert!(output.starts_with("['1']"), "unexpected output: {output:?}");
+		}
+
 		info!("* When scripting is denied");
 		{
 			let (addr, _server) = common::start_server(StartServerArguments {
@@ -548,7 +561,7 @@ mod cli_integration {
 			.await
 			.unwrap();
 
-			let cmd = format!("sql --conn ws://{addr} --ns N --db D --multi");
+			let cmd = format!("sql --conn ws://{addr} -u root -p root --ns N --db D --multi");
 
 			let query = "RETURN function() { return '1' };";
 			let output = common::run(&cmd).input(query).output().unwrap();
@@ -567,7 +580,7 @@ mod cli_integration {
 			.await
 			.unwrap();
 
-			let cmd = format!("sql --conn ws://{addr} --ns N --db D --multi");
+			let cmd = format!("sql --conn ws://{addr} -u root -p root --ns N --db D --multi");
 
 			let query = format!("RETURN http::get('http://{}/version');\n\n", addr);
 			let output = common::run(&cmd).input(&query).output().unwrap();
@@ -583,13 +596,14 @@ mod cli_integration {
 		info!("* When net is enabled for an IP and also denied for a specific port that doesn't match");
 		{
 			let (addr, _server) = common::start_server(StartServerArguments {
-				args: "--allow-net 127.0.0.1 --deny-net 127.0.0.1:80".to_owned(),
+				args: "--allow-net 127.0.0.1 --deny-net 127.0.0.1:80 --allow-funcs http::get"
+					.to_owned(),
 				..Default::default()
 			})
 			.await
 			.unwrap();
 
-			let cmd = format!("sql --conn ws://{addr} --ns N --db D --multi");
+			let cmd = format!("sql --conn ws://{addr} -u root -p root --ns N --db D --multi");
 
 			let query = format!("RETURN http::get('http://{}/version');\n\n", addr);
 			let output = common::run(&cmd).input(&query).output().unwrap();
@@ -605,7 +619,7 @@ mod cli_integration {
 			.await
 			.unwrap();
 
-			let cmd = format!("sql --conn ws://{addr} --ns N --db D --multi");
+			let cmd = format!("sql --conn ws://{addr} -u root -p root --ns N --db D --multi");
 
 			let query = "RETURN http::get('https://surrealdb.com');\n\n";
 			let output = common::run(&cmd).input(query).output().unwrap();
@@ -613,6 +627,60 @@ mod cli_integration {
 				output.contains("Function 'http::get' is not allowed"),
 				"unexpected output: {output:?}"
 			);
+		}
+
+		info!("* When auth is enabled and anonymous access is allowed");
+		{
+			let (addr, _server) = common::start_server(StartServerArguments {
+				auth: true,
+				args: "--allow-anon-access".to_owned(),
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			let cmd = format!("sql --conn ws://{addr} --ns N --db D --multi");
+
+			let query = "RETURN 1;\n\n";
+			let output = common::run(&cmd).input(query).output().unwrap();
+			assert!(output.contains("[1]"), "unexpected output: {output:?}");
+		}
+
+		info!("* When auth is enabled and anonymous access is denied");
+		{
+			let (addr, _server) = common::start_server(StartServerArguments {
+				auth: true,
+				args: "--deny-anon-access".to_owned(),
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			let cmd = format!("sql --conn ws://{addr} --ns N --db D --multi");
+
+			let query = "RETURN 1;\n\n";
+			let output = common::run(&cmd).input(query).output().unwrap();
+			assert!(
+				output.contains("Not enough permissions to perform this action"),
+				"unexpected output: {output:?}"
+			);
+		}
+
+		info!("* When auth is disabled, anonymous access is always allowed");
+		{
+			let (addr, _server) = common::start_server(StartServerArguments {
+				auth: false,
+				args: "--deny-anon-access".to_owned(),
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			let cmd = format!("sql --conn ws://{addr} --ns N --db D --multi");
+
+			let query = "RETURN 1;\n\n";
+			let output = common::run(&cmd).input(query).output().unwrap();
+			assert!(output.contains("[1]"), "unexpected output: {output:?}");
 		}
 	}
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -155,7 +155,7 @@ impl Default for StartServerArguments {
 			tls: false,
 			wait_is_ready: true,
 			tick_interval: time::Duration::new(1, 0),
-			args: String::default(),
+			args: "--allow-all".to_string(),
 		}
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Make SurrealDB secure by default.

## What does this change do?

NOTE: I split this PR into 2 commits so it's easier to distinguish the actual code changes and the tests changes, because the 2nd one is mostly updating existing tests.

* Change the default values for capabilities from `allow-all` to `allow-none`
* Disable anonymous queries by default. Guest access was allowed because for Databases we used the `PERMISSIONS` layer to decide whether or not an anonymous user could actually interact with the data. With `PERMISSIONS` you can configure tables to be accessed by anyone, even non-authenticated users. This behaviour is not needed for most of the database use cases, so we decided to make it opt-in.

These changes apply to both SurrealDB Server but also to embedded databases, so users don't expose a too permissive database unintentionally.

## What is your testing strategy?

Added new tests and updated existing tests

## Is this related to any issues?

Feedback from issues like https://github.com/surrealdb/surrealdb/issues/2536 and others from the community

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
