### PR TITLE
Change how bootstrap handles transactions and errors

### DIFF
--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -356,6 +356,7 @@ impl Datastore {
 				archived
 			}
 			Err(e) => {
+				error!("Error bootstrapping mark phase: {:?}", e);
 				tx.cancel().await?;
 				return Err(e);
 			}
@@ -364,7 +365,10 @@ impl Datastore {
 		let mut tx = self.transaction(true, false).await?;
 		match self.remove_archived(&mut tx, archived).await {
 			Ok(_) => tx.commit().await,
-			Err(_) => tx.cancel().await,
+			Err(e) => {
+				error!("Error bootstrapping sweep phase: {:?}", e);
+				tx.cancel().await
+			}
 		}
 	}
 


### PR DESCRIPTION
## What is the motivation?

Change how bootstrap handles transactions and errors. This might fix problems we are seeing with transactions being unhandled correctly.

## What does this change do?

Handle errors and close transactions correctly.
If there is an error, and the transaction isn't closed correctly, there is a risk that the storage engine will think that the transaction is still open.

## What is your testing strategy?

Make serve, CI

## Is this related to any issues?

Tikv failures

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
