### PR TITLE
Support variable field projection with `type::field()` and `type::fields()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ strip = false
 argon2 = "0.5.1"
 axum = { version = "0.6.20", features = ["tracing", "ws", "headers"] }
 axum-client-ip = "0.4.1"
-axum-extra = { version = "0.7.7", features = ["typed-routing"] }
+axum-extra = { version = "0.7.7", features = ["query", "typed-routing"] }
 axum-server = { version = "0.5.1", features = ["tls-rustls"] }
 base64 = "0.21.2"
 bytes = "1.4.0"

--- a/lib/src/dbs/options.rs
+++ b/lib/src/dbs/options.rs
@@ -45,6 +45,8 @@ pub struct Options {
 	pub indexes: bool,
 	/// Should we process function futures?
 	pub futures: bool,
+	/// Should we process variable field projections?
+	pub projections: bool,
 	/// The channel over which we send notifications
 	pub sender: Option<Sender<Notification>>,
 	/// Datastore capabilities
@@ -74,6 +76,7 @@ impl Options {
 			tables: true,
 			indexes: true,
 			futures: false,
+			projections: false,
 			auth_enabled: true,
 			sender: None,
 			auth: Arc::new(Auth::default()),
@@ -195,6 +198,12 @@ impl Options {
 	///
 	pub fn with_futures(mut self, futures: bool) -> Self {
 		self.futures = futures;
+		self
+	}
+
+	///
+	pub fn with_projections(mut self, projections: bool) -> Self {
+		self.projections = projections;
 		self
 	}
 
@@ -320,6 +329,19 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			futures,
+			..*self
+		}
+	}
+
+	/// Create a new Options object for a subquery
+	pub fn new_with_projections(&self, projections: bool) -> Self {
+		Self {
+			sender: self.sender.clone(),
+			auth: self.auth.clone(),
+			capabilities: self.capabilities.clone(),
+			ns: self.ns.clone(),
+			db: self.db.clone(),
+			projections,
 			..*self
 		}
 	}

--- a/lib/src/fnc/args.rs
+++ b/lib/src/fnc/args.rs
@@ -91,6 +91,12 @@ impl FromArg for usize {
 	}
 }
 
+impl FromArg for Vec<String> {
+	fn from_arg(arg: Value) -> Result<Self, Error> {
+		arg.coerce_to_array_type(&Kind::String)?.into_iter().map(Value::try_into).collect()
+	}
+}
+
 impl FromArg for Vec<Number> {
 	fn from_arg(arg: Value) -> Result<Self, Error> {
 		arg.coerce_to_array_type(&Kind::Number)?.into_iter().map(Value::try_into).collect()

--- a/lib/src/fnc/script/modules/surrealdb/functions/mod.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/mod.rs
@@ -70,7 +70,7 @@ async fn fut(js_ctx: js::Ctx<'_>, name: &str, args: Vec<Value>) -> Result<Value>
 	// Create a default context
 	let ctx = Context::background();
 	// Process the called function
-	let res = fnc::asynchronous(&ctx, None, None, name, args).await;
+	let res = fnc::asynchronous(&ctx, None, None, None, name, args).await;
 	// Convert any response error
 	res.map_err(|err| {
 		js::Exception::from_message(js_ctx, &err.to_string())

--- a/lib/src/fnc/script/modules/surrealdb/functions/type.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/type.rs
@@ -1,5 +1,7 @@
+use super::fut;
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
+use js::prelude::Async;
 
 pub struct Package;
 
@@ -10,6 +12,8 @@ impl_module_def!(
 	"datetime" => run,
 	"decimal" => run,
 	"duration" => run,
+	"field" => fut Async,
+	"fields" => fut Async,
 	"float" => run,
 	"int" => run,
 	"number" => run,

--- a/lib/src/sql/field.rs
+++ b/lib/src/sql/field.rs
@@ -7,7 +7,8 @@ use crate::sql::common::commas;
 use crate::sql::ending::field as ending;
 use crate::sql::error::IResult;
 use crate::sql::fmt::Fmt;
-use crate::sql::idiom::{plain as idiom, Idiom};
+use crate::sql::idiom::{plain, Idiom};
+use crate::sql::parser::idiom;
 use crate::sql::part::Part;
 use crate::sql::value::{value, Value};
 use nom::branch::alt;
@@ -85,7 +86,6 @@ impl Fields {
 		doc: Option<&CursorDoc<'_>>,
 		group: bool,
 	) -> Result<Value, Error> {
-		// Ensure futures are run
 		if let Some(doc) = doc {
 			self.compute_value(ctx, opt, txn, doc, group).await
 		} else {
@@ -102,6 +102,7 @@ impl Fields {
 		doc: &CursorDoc<'_>,
 		group: bool,
 	) -> Result<Value, Error> {
+		// Ensure futures are run
 		let opt = &opt.new_with_futures(true);
 		// Process the desired output
 		let mut out = match self.is_all() {
@@ -115,7 +116,7 @@ impl Fields {
 					expr,
 					alias,
 				} => {
-					let idiom = alias
+					let name = alias
 						.as_ref()
 						.map(Cow::Borrowed)
 						.unwrap_or_else(|| Cow::Owned(expr.to_idiom()));
@@ -130,7 +131,7 @@ impl Fields {
 							};
 							// Check if this is a single VALUE field expression
 							match self.single().is_some() {
-								false => out.set(ctx, opt, txn, idiom.as_ref(), x).await?,
+								false => out.set(ctx, opt, txn, name.as_ref(), x).await?,
 								true => out = x,
 							}
 						}
@@ -173,13 +174,64 @@ impl Fields {
 								}
 							}
 						}
-						// This expression is a normal field expression
-						_ => {
-							let x = expr.compute(ctx, opt, txn, Some(doc)).await?;
+						// This expression is a variable fields expression
+						Value::Function(f) if f.name() == "type::fields" => {
+							// Process the function using variable field projections
+							let expr = expr.compute(ctx, opt, txn, Some(doc)).await?;
 							// Check if this is a single VALUE field expression
 							match self.single().is_some() {
-								false => out.set(ctx, opt, txn, idiom.as_ref(), x).await?,
-								true => out = x,
+								false => {
+									// Get the first argument which is guaranteed to exist
+									let args = match f.args().first().unwrap() {
+										Value::Param(v) => {
+											v.compute(ctx, opt, txn, Some(doc)).await?
+										}
+										v => v.to_owned(),
+									};
+									// This value is always an array, so we can convert it
+									let expr: Vec<Value> = expr.try_into()?;
+									// This value is always an array, so we can convert it
+									let args: Vec<Value> = args.try_into()?;
+									// This value is always an array, so we can convert it
+									for (name, expr) in args.into_iter().zip(expr) {
+										// This value is always a string, so we can convert it
+										let name = idiom(&name.to_raw_string())?;
+										// Check if this is a single VALUE field expression
+										out.set(ctx, opt, txn, name.as_ref(), expr).await?
+									}
+								}
+								true => out = expr,
+							}
+						}
+						// This expression is a variable field expression
+						Value::Function(f) if f.name() == "type::field" => {
+							// Process the function using variable field projections
+							let expr = expr.compute(ctx, opt, txn, Some(doc)).await?;
+							// Check if this is a single VALUE field expression
+							match self.single().is_some() {
+								false => {
+									// Get the first argument which is guaranteed to exist
+									let name = match f.args().first().unwrap() {
+										Value::Param(v) => {
+											v.compute(ctx, opt, txn, Some(doc)).await?
+										}
+										v => v.to_owned(),
+									};
+									// This value is always a string, so we can convert it
+									let name = idiom(&name.to_raw_string())?;
+									// Add the projected field to the output document
+									out.set(ctx, opt, txn, name.as_ref(), expr).await?
+								}
+								true => out = expr,
+							}
+						}
+						// This expression is a normal field expression
+						_ => {
+							let expr = expr.compute(ctx, opt, txn, Some(doc)).await?;
+							// Check if this is a single VALUE field expression
+							match self.single().is_some() {
+								false => out.set(ctx, opt, txn, name.as_ref(), expr).await?,
+								true => out = expr,
 							}
 						}
 					}
@@ -256,7 +308,7 @@ pub fn alone(i: &str) -> IResult<&str, Field> {
 	let (i, expr) = value(i)?;
 	let (i, alias) =
 		if let (i, Some(_)) = opt(delimited(shouldbespace, tag_no_case("AS"), shouldbespace))(i)? {
-			let (i, alias) = cut(idiom)(i)?;
+			let (i, alias) = cut(plain)(i)?;
 			(i, Some(alias))
 		} else {
 			(i, None)

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -166,7 +166,7 @@ impl Function {
 				// Compute the function arguments
 				let a = try_join_all(x.iter().map(|v| v.compute(ctx, opt, txn, doc))).await?;
 				// Run the normal function
-				fnc::run(ctx, txn, doc, s, a).await
+				fnc::run(ctx, opt, txn, doc, s, a).await
 			}
 			Self::Custom(s, x) => {
 				// Check this function is allowed
@@ -583,6 +583,8 @@ fn function_type(i: &str) -> IResult<&str, &str> {
 		tag("datetime"),
 		tag("decimal"),
 		tag("duration"),
+		tag("fields"),
+		tag("field"),
 		tag("float"),
 		tag("int"),
 		tag("number"),

--- a/lib/src/sql/parser.rs
+++ b/lib/src/sql/parser.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::iam::Error as IamError;
 use crate::sql::error::Error::{ExcessiveDepth, Field, Group, Order, Parser, Role, Split};
 use crate::sql::error::IResult;
+use crate::sql::idiom::Idiom;
 use crate::sql::query::{query, Query};
 use crate::sql::subquery::Subquery;
 use crate::sql::thing::Thing;
@@ -29,6 +30,12 @@ pub fn parse(input: &str) -> Result<Query, Error> {
 #[instrument(name = "parser", skip_all, fields(length = input.len()))]
 pub fn thing(input: &str) -> Result<Thing, Error> {
 	parse_impl(input, super::thing::thing)
+}
+
+/// Parses a SurrealQL [`Idiom`]
+#[instrument(name = "parser", skip_all, fields(length = input.len()))]
+pub fn idiom(input: &str) -> Result<Idiom, Error> {
+	parse_impl(input, super::idiom::plain)
 }
 
 /// Parses a SurrealQL [`Value`].

--- a/lib/src/sql/statements/delete.rs
+++ b/lib/src/sql/statements/delete.rs
@@ -59,7 +59,7 @@ impl DeleteStatement {
 		// Assign the statement
 		let stm = Statement::from(self);
 		// Ensure futures are stored
-		let opt = &opt.new_with_futures(false);
+		let opt = &opt.new_with_futures(false).with_projections(false);
 		// Loop over the delete targets
 		for w in self.what.0.iter() {
 			let v = w.compute(ctx, opt, txn, doc).await?;

--- a/lib/src/sql/statements/insert.rs
+++ b/lib/src/sql/statements/insert.rs
@@ -62,7 +62,7 @@ impl InsertStatement {
 		// Create a new iterator
 		let mut i = Iterator::new();
 		// Ensure futures are stored
-		let opt = &opt.new_with_futures(false);
+		let opt = &opt.new_with_futures(false).with_projections(false);
 		// Parse the expression
 		match self.into.compute(ctx, opt, txn, doc).await? {
 			Value::Table(into) => match &self.data {

--- a/lib/src/sql/statements/relate.rs
+++ b/lib/src/sql/statements/relate.rs
@@ -70,7 +70,7 @@ impl RelateStatement {
 		// Create a new iterator
 		let mut i = Iterator::new();
 		// Ensure futures are stored
-		let opt = &opt.new_with_futures(false);
+		let opt = &opt.new_with_futures(false).with_projections(false);
 		// Loop over the from targets
 		let from = {
 			let mut out = Vec::new();

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -93,8 +93,7 @@ impl SelectStatement {
 		// Create a new iterator
 		let mut i = Iterator::new();
 		// Ensure futures are stored
-		let opt = &opt.new_with_futures(false);
-
+		let opt = &opt.new_with_futures(false).with_projections(true);
 		// Get a query planner
 		let mut planner = QueryPlanner::new(opt, &self.with, &self.cond);
 		// Loop over the select targets
@@ -115,6 +114,9 @@ impl SelectStatement {
 				Value::Array(v) => {
 					for v in v {
 						match v {
+							Value::Table(t) => {
+								planner.add_iterables(ctx, txn, t, &mut i).await?;
+							}
 							Value::Thing(v) => i.ingest(Iterable::Thing(v)),
 							Value::Edges(v) => i.ingest(Iterable::Edges(*v)),
 							Value::Model(v) => {

--- a/lib/src/sql/statements/update.rs
+++ b/lib/src/sql/statements/update.rs
@@ -59,7 +59,7 @@ impl UpdateStatement {
 		// Assign the statement
 		let stm = Statement::from(self);
 		// Ensure futures are stored
-		let opt = &opt.new_with_futures(false);
+		let opt = &opt.new_with_futures(false).with_projections(false);
 		// Loop over the update targets
 		for w in self.what.0.iter() {
 			let v = w.compute(ctx, opt, txn, doc).await?;

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -79,7 +79,6 @@ async fn select_all(
 		None => "SELECT * FROM type::table($table) LIMIT $limit START $start",
 		_ => "SELECT type::fields($fields) FROM type::table($table) LIMIT $limit START $start",
 	};
-	println!("{:?}", query.fields);
 	// Specify the request variables
 	let vars = map! {
 		String::from("table") => Value::from(table),

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -3,10 +3,11 @@ use crate::err::Error;
 use crate::net::input::bytes_to_utf8;
 use crate::net::output;
 use crate::net::params::Params;
-use axum::extract::{DefaultBodyLimit, Path, Query};
+use axum::extract::{DefaultBodyLimit, Path};
 use axum::response::IntoResponse;
 use axum::routing::options;
 use axum::{Extension, Router, TypedHeader};
+use axum_extra::extract::Query;
 use bytes::Bytes;
 use http_body::Body as HttpBody;
 use serde::Deserialize;
@@ -21,8 +22,9 @@ const MAX: usize = 1024 * 16; // 16 KiB
 
 #[derive(Default, Deserialize, Debug, Clone)]
 struct QueryOptions {
-	pub limit: Option<String>,
-	pub start: Option<String>,
+	pub limit: Option<i64>,
+	pub start: Option<i64>,
+	pub fields: Option<Vec<String>>,
 }
 
 pub(super) fn router<S, B>() -> Router<S, B>
@@ -73,17 +75,20 @@ async fn select_all(
 	// Get the datastore reference
 	let db = DB.get().unwrap();
 	// Specify the request statement
-	let sql = format!(
-		"SELECT * FROM type::table($table) LIMIT {l} START {s}",
-		l = query.limit.unwrap_or_else(|| String::from("100")),
-		s = query.start.unwrap_or_else(|| String::from("0")),
-	);
+	let sql = match query.fields {
+		None => "SELECT * FROM type::table($table) LIMIT $limit START $start",
+		_ => "SELECT type::fields($fields) FROM type::table($table) LIMIT $limit START $start",
+	};
+	println!("{:?}", query.fields);
 	// Specify the request variables
 	let vars = map! {
 		String::from("table") => Value::from(table),
+		String::from("start") => Value::from(query.start.unwrap_or(0)),
+		String::from("limit") => Value::from(query.limit.unwrap_or(100)),
+		String::from("fields") => Value::from(query.fields.unwrap_or_default()),
 	};
 	// Execute the query and return the result
-	match db.execute(sql.as_str(), &session, Some(vars)).await {
+	match db.execute(sql, &session, Some(vars)).await {
 		Ok(ref res) => match maybe_output.as_deref() {
 			// Simple serialization
 			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
@@ -265,11 +270,15 @@ async fn select_one(
 	Extension(session): Extension<Session>,
 	maybe_output: Option<TypedHeader<Accept>>,
 	Path((table, id)): Path<(String, String)>,
+	Query(query): Query<QueryOptions>,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
 	// Get the datastore reference
 	let db = DB.get().unwrap();
 	// Specify the request statement
-	let sql = "SELECT * FROM type::thing($table, $id)";
+	let sql = match query.fields {
+		None => "SELECT * FROM type::thing($table, $id)",
+		_ => "SELECT type::fields($fields) FROM type::thing($table, $id)",
+	};
 	// Parse the Record ID as a SurrealQL value
 	let rid = match surrealdb::sql::json(&id) {
 		Ok(id) => id,
@@ -279,6 +288,7 @@ async fn select_one(
 	let vars = map! {
 		String::from("table") => Value::from(table),
 		String::from("id") => rid,
+		String::from("fields") => Value::from(query.fields.unwrap_or_default()),
 	};
 	// Execute the query and return the result
 	match db.execute(sql, &session, Some(vars)).await {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When wanting to use variable field projection, the current methods are to use string interpolation (which is insecure), or write an SQL query manually. This is especially relevant when using an, and wanting to only select certain field/fields from a record/records.

## What does this change do?

This change adds two functions `type::field($field)` and `type::fields([$field, $names])` which allows variable projection of fields within a `SELECT` statement:

```sql
CREATE person:test SET title = 'Mr', name.first = 'Tobie', name.last = 'Morgan Hitchcock';
LET $param = 'name.first';
SELECT type::field($param), type::field('name.last') FROM person;
SELECT VALUE { 'firstname': type::field($param), lastname: type::field('name.last') } FROM person;
SELECT VALUE [type::field($param), type::field('name.last')] FROM person;
```

```sql
CREATE person:test SET title = 'Mr', name.first = 'Tobie', name.last = 'Morgan Hitchcock';
LET $param = ['name.first', 'name.last'];
SELECT type::fields($param), type::fields(['title']) FROM person;
SELECT VALUE { 'names': type::fields($param) } FROM person;
SELECT VALUE type::fields($param) FROM person;
```

This change also improves the `/key` API endpoint:
- `GET /key/$table` endpoint, now uses parameters internally for `LIMIT` and `START` (instead of string interpolation)
- `GET /key/$table` now supports a `fields` query parameter, which can be specified multiple times.
- `GET /key/$table/$id` now supports a `fields` query parameter, which can be specified multiple times.

```bash
curl "http://127.0.0.1:8000/key/person?limit=10&fields=name&fields=age" -H 'Accept: application/json' -H 'NS: test' -H 'DB: test' -u 'root:root'
```

```bash
curl "http://127.0.0.1:8000/key/person/tobie?fields=name&fields=age" -H 'Accept: application/json' -H 'NS: test' -H 'DB: test' -u 'root:root'
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2415.
Closes #1836.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
