### PR TITLE
Fix returned value of bootstrap to not lose errors

### DIFF
--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -367,7 +367,13 @@ impl Datastore {
 			Ok(_) => tx.commit().await,
 			Err(e) => {
 				error!("Error bootstrapping sweep phase: {:?}", e);
-				tx.cancel().await
+				match tx.cancel().await {
+					Ok(_) => return Err(e),
+					Err(e) => {
+						// We have a nested error
+						return Err(Error::Tx(format!("Error bootstrapping sweep phase: {:?} and error cancelling transaction: {:?}", e, e)));
+					}
+				}
 			}
 		}
 	}

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -368,10 +368,10 @@ impl Datastore {
 			Err(e) => {
 				error!("Error bootstrapping sweep phase: {:?}", e);
 				match tx.cancel().await {
-					Ok(_) => return Err(e),
+					Ok(_) => Err(e),
 					Err(e) => {
 						// We have a nested error
-						return Err(Error::Tx(format!("Error bootstrapping sweep phase: {:?} and error cancelling transaction: {:?}", e, e)));
+						Err(Error::Tx(format!("Error bootstrapping sweep phase: {:?} and error cancelling transaction: {:?}", e, e)))
 					}
 				}
 			}

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -340,15 +340,6 @@ impl Datastore {
 		self
 	}
 
-	/// Creates a new datastore instance
-	///
-	/// Use this for clustered environments.
-	pub async fn new_with_bootstrap(path: &str) -> Result<Datastore, Error> {
-		let ds = Datastore::new(path).await?;
-		ds.bootstrap().await?;
-		Ok(ds)
-	}
-
 	// Initialise bootstrap with implicit values intended for runtime
 	pub async fn bootstrap(&self) -> Result<(), Error> {
 		self.bootstrap_full(&self.id).await
@@ -359,12 +350,26 @@ impl Datastore {
 		trace!("Bootstrapping {}", self.id);
 		let mut tx = self.transaction(true, false).await?;
 		let now = tx.clock();
-		let archived = self.register_remove_and_archive(&mut tx, node_id, now).await?;
-		tx.commit().await?;
+		let archived = match self.register_remove_and_archive(&mut tx, node_id, now).await {
+			Ok(archived) => {
+				tx.commit().await?;
+				archived
+			}
+			Err(e) => {
+				error!("Error bootstrapping mark phase: {:?}", e);
+				tx.cancel().await?;
+				return Err(e);
+			}
+		};
 
 		let mut tx = self.transaction(true, false).await?;
-		self.remove_archived(&mut tx, archived).await?;
-		tx.commit().await
+		match self.remove_archived(&mut tx, archived).await {
+			Ok(_) => tx.commit().await,
+			Err(e) => {
+				error!("Error bootstrapping sweep phase: {:?}", e);
+				tx.cancel().await
+			}
+		}
 	}
 
 	// Node registration + "mark" stage of mark-and-sweep gc
@@ -405,6 +410,7 @@ impl Datastore {
 		let mut nodes = vec![];
 		for hb in hbs {
 			trace!("Deleting node {}", &hb.nd);
+			// TODO should be delr in case of nested entries
 			tx.del_nd(hb.nd).await?;
 			nodes.push(crate::sql::uuid::Uuid::from(hb.nd));
 		}
@@ -546,6 +552,7 @@ impl Datastore {
 	) -> Result<Vec<Hb>, Error> {
 		let limit = 1000;
 		let dead = tx.scan_hb(ts, limit).await?;
+		// Delete the heartbeat and everything nested
 		tx.delr_hb(dead.clone(), 1000).await?;
 		for dead_node in dead.clone() {
 			tx.del_nd(dead_node.nd).await?;


### PR DESCRIPTION
## What is the motivation?

Fix the return value of bootstrap so that errors aren't lost.

## What does this change do?

Handle the case of `tx.cancel` failing, and wrapping both errors if that is the case.
Fix to return error that wasn't lost.

## What is your testing strategy?

make serve

## Is this related to any issues?

tikv failures; general traceability

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
