### PR TITLE
Introduce ns, db, and tb aliases for easier renaming

### DIFF
--- a/lib/src/cf/gc.rs
+++ b/lib/src/cf/gc.rs
@@ -65,6 +65,7 @@ pub async fn gc_db(
 	watermark: Versionstamp,
 	limit: Option<u32>,
 ) -> Result<(), Error> {
+	let (ns, db) = tx.get_ns_db_ids(ns, db).await?;
 	let beg: Vec<u8> = change::prefix_ts(ns, db, vs::u64_to_versionstamp(0));
 	let end = change::prefix_ts(ns, db, watermark);
 

--- a/lib/src/dbs/iterator.rs
+++ b/lib/src/dbs/iterator.rs
@@ -269,6 +269,7 @@ impl Iterator {
 		stm: &Statement<'_>,
 	) -> Result<Value, Error> {
 		// Log the statement
+		trace!("Iterating: {}", stm);
 		// Enable context override
 		let mut cancel_ctx = Context::new(ctx);
 		self.run = cancel_ctx.add_cancel();

--- a/lib/src/dbs/iterator.rs
+++ b/lib/src/dbs/iterator.rs
@@ -269,7 +269,6 @@ impl Iterator {
 		stm: &Statement<'_>,
 	) -> Result<Value, Error> {
 		// Log the statement
-		trace!("Iterating: {}", stm);
 		// Enable context override
 		let mut cancel_ctx = Context::new(ctx);
 		self.run = cancel_ctx.add_cancel();

--- a/lib/src/dbs/processor.rs
+++ b/lib/src/dbs/processor.rs
@@ -285,15 +285,6 @@ impl<'a> Processor<'a> {
 		let tb_name: &str = &v;
 		let chk = txn.lock().await.check_ns_db_tb(opt.ns(), opt.db(), tb_name, opt.strict).await;
 		let (ns, db, tb) = match chk {
-			Err(Error::DbNotFound {
-				..
-			})
-			| Err(Error::TbNotFound {
-				..
-			})
-			| Err(Error::NsNotFound {
-				..
-			}) => return Ok(()),
 			Err(e) => return Err(e),
 			Ok(Some(v)) => v,
 			Ok(None) => return Ok(()),

--- a/lib/src/doc/edges.rs
+++ b/lib/src/doc/edges.rs
@@ -30,17 +30,22 @@ impl<'a> Document<'a> {
 		if let Workable::Relate(l, r) = &self.extras {
 			// Get temporary edge references
 			let (ref o, ref i) = (Dir::Out, Dir::In);
+			// Get ns and db ids
+			let (ns, db) = run.get_ns_db_ids(opt.ns(), opt.db()).await?;
 			// Store the left pointer edge
-			let key = crate::key::graph::new(opt.ns(), opt.db(), &l.tb, &l.id, o, rid);
+			let tb = run.get_tb_id_by_name(ns, db, &l.tb).await?;
+			let key = crate::key::graph::new(ns, db, tb, &l.id, o, rid);
 			run.set(key, vec![]).await?;
 			// Store the left inner edge
-			let key = crate::key::graph::new(opt.ns(), opt.db(), &rid.tb, &rid.id, i, l);
+			let tb = run.get_tb_id_by_name(ns, db, &rid.tb).await?;
+			let key = crate::key::graph::new(ns, db, tb, &rid.id, i, l);
 			run.set(key, vec![]).await?;
 			// Store the right inner edge
-			let key = crate::key::graph::new(opt.ns(), opt.db(), &rid.tb, &rid.id, o, r);
+			let key = crate::key::graph::new(ns, db, tb, &rid.id, o, r);
 			run.set(key, vec![]).await?;
 			// Store the right pointer edge
-			let key = crate::key::graph::new(opt.ns(), opt.db(), &r.tb, &r.id, i, rid);
+			let tb = run.get_tb_id_by_name(ns, db, &r.tb).await?;
+			let key = crate::key::graph::new(ns, db, tb, &r.id, i, rid);
 			run.set(key, vec![]).await?;
 			// Store the edges on the record
 			self.current.doc.to_mut().put(&*EDGE, Value::Bool(true));

--- a/lib/src/doc/edges.rs
+++ b/lib/src/doc/edges.rs
@@ -31,20 +31,26 @@ impl<'a> Document<'a> {
 			// Get temporary edge references
 			let (ref o, ref i) = (Dir::Out, Dir::In);
 			// Get ns and db ids
-			let (ns, db) = run.get_ns_db_ids(opt.ns(), opt.db()).await?;
+			let ns = run.add_and_cache_ns(opt.ns(), opt.strict).await?;
+			let ns = ns.id.unwrap();
+			let db = run.add_and_cache_db(opt.ns(), opt.db(), opt.strict).await?;
+			let db = db.id.unwrap();
 			// Store the left pointer edge
-			let tb = run.get_tb_id_by_name(ns, db, &l.tb).await?;
+			let tb = run.add_and_cache_tb(opt.ns(), opt.db(), &l.tb, opt.strict).await?;
+			let tb = tb.id.unwrap();
 			let key = crate::key::graph::new(ns, db, tb, &l.id, o, rid);
 			run.set(key, vec![]).await?;
 			// Store the left inner edge
-			let tb = run.get_tb_id_by_name(ns, db, &rid.tb).await?;
+			let tb = run.add_and_cache_tb(opt.ns(), opt.db(), &rid.tb, opt.strict).await?;
+			let tb = tb.id.unwrap();
 			let key = crate::key::graph::new(ns, db, tb, &rid.id, i, l);
 			run.set(key, vec![]).await?;
 			// Store the right inner edge
 			let key = crate::key::graph::new(ns, db, tb, &rid.id, o, r);
 			run.set(key, vec![]).await?;
 			// Store the right pointer edge
-			let tb = run.get_tb_id_by_name(ns, db, &r.tb).await?;
+			let tb = run.add_and_cache_tb(opt.ns(), opt.db(), &r.tb, opt.strict).await?;
+			let tb = tb.id.unwrap();
 			let key = crate::key::graph::new(ns, db, tb, &r.id, i, rid);
 			run.set(key, vec![]).await?;
 			// Store the edges on the record

--- a/lib/src/doc/process.rs
+++ b/lib/src/doc/process.rs
@@ -43,8 +43,29 @@ impl<'a> Document<'a> {
 				// we load the new record, and reprocess
 				Err(Error::RetryWithId(v)) => {
 					// Fetch the data from the store
-					let key = crate::key::thing::new(opt.ns(), opt.db(), &v.tb, &v.id);
-					let val = txn.clone().lock().await.get(key).await?;
+					let chk = txn
+						.clone()
+						.lock()
+						.await
+						.check_ns_db_tb(opt.ns(), opt.db(), &v.tb, opt.strict)
+						.await;
+					let val = match chk {
+						Err(Error::DbNotFound {
+							..
+						})
+						| Err(Error::TbNotFound {
+							..
+						})
+						| Err(Error::NsNotFound {
+							..
+						}) => None,
+						Err(e) => return Err(e),
+						Ok(Some((ns, db, tb))) => {
+							let key = crate::key::thing::new(ns, db, tb, &v.id);
+							txn.clone().lock().await.get(key).await?
+						}
+						Ok(None) => None,
+					};
 					// Parse the data from the store
 					let val = match val {
 						Some(v) => Value::from(v),

--- a/lib/src/doc/store.rs
+++ b/lib/src/doc/store.rs
@@ -24,8 +24,15 @@ impl<'a> Document<'a> {
 		let mut run = txn.lock().await;
 		// Get the record id
 		let rid = self.id.as_ref().unwrap();
+		// Get ns and db ids
+		let ns = run.add_and_cache_ns(opt.ns(), opt.strict).await?;
+		let ns = ns.id.unwrap();
+		let db = run.add_and_cache_db(opt.ns(), opt.db(), opt.strict).await?;
+		let db = db.id.unwrap();
+		let tb = run.add_and_cache_tb(opt.ns(), opt.db(), &rid.tb, opt.strict).await?;
+		let tb = tb.id.unwrap();
 		// Store the record data
-		let key = crate::key::thing::new(opt.ns(), opt.db(), &rid.tb, &rid.id);
+		let key = crate::key::thing::new(ns, db, tb, &rid.id);
 		run.set(key, self).await?;
 		// Carry on
 		Ok(())

--- a/lib/src/key/change/mod.rs
+++ b/lib/src/key/change/mod.rs
@@ -8,38 +8,38 @@ use std::str;
 
 // Cf stands for change feeds
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-pub struct Cf<'a> {
+pub struct Cf {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_d: u8,
 	// vs is the versionstamp of the change feed entry that is encoded in big-endian.
 	// Use the to_u64_be function to convert it to a u128.
 	pub vs: [u8; 10],
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 }
 
 #[allow(unused)]
-pub fn new<'a>(ns: &'a str, db: &'a str, ts: u64, tb: &'a str) -> Cf<'a> {
+pub fn new(ns: u32, db: u32, ts: u64, tb: u32) -> Cf {
 	Cf::new(ns, db, vs::u64_to_versionstamp(ts), tb)
 }
 
 #[allow(unused)]
-pub fn versionstamped_key_prefix(ns: &str, db: &str) -> Vec<u8> {
+pub fn versionstamped_key_prefix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = crate::key::database::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'#']);
 	k
 }
 
 #[allow(unused)]
-pub fn versionstamped_key_suffix(tb: &str) -> Vec<u8> {
+pub fn versionstamped_key_suffix(tb: u32) -> Vec<u8> {
 	let mut k: Vec<u8> = vec![];
 	k.extend_from_slice(&[b'*']);
-	k.extend_from_slice(tb.as_bytes());
-	// Without this, decoding fails with UnexpectedEOF errors
+	k.extend_from_slice(&tb.to_be_bytes());
+	// Without this, decoding fails with Un&ectedEOF errors
 	k.extend_from_slice(&[0x00]);
 	k
 }
@@ -47,7 +47,7 @@ pub fn versionstamped_key_suffix(tb: &str) -> Vec<u8> {
 /// Returns the prefix for the whole database change feeds since the
 /// specified versionstamp.
 #[allow(unused)]
-pub fn prefix_ts(ns: &str, db: &str, vs: vs::Versionstamp) -> Vec<u8> {
+pub fn prefix_ts(ns: u32, db: u32, vs: vs::Versionstamp) -> Vec<u8> {
 	let mut k = crate::key::database::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'#']);
 	k.extend_from_slice(&vs);
@@ -56,7 +56,7 @@ pub fn prefix_ts(ns: &str, db: &str, vs: vs::Versionstamp) -> Vec<u8> {
 
 /// Returns the prefix for the whole database change feeds
 #[allow(unused)]
-pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = crate::key::database::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'#']);
 	k
@@ -64,14 +64,14 @@ pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
 
 /// Returns the suffix for the whole database change feeds
 #[allow(unused)]
-pub fn suffix(ns: &str, db: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = crate::key::database::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'#', 0xff]);
 	k
 }
 
-impl<'a> Cf<'a> {
-	pub fn new(ns: &'a str, db: &'a str, vs: [u8; 10], tb: &'a str) -> Self {
+impl Cf {
+	pub fn new(ns: u32, db: u32, vs: [u8; 10], tb: u32) -> Self {
 		Cf {
 			__: b'/',
 			_a: b'*',
@@ -96,10 +96,10 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Cf::new(
-			"test",
-			"test",
+			1,
+			2,
 			try_u128_to_versionstamp(12345).unwrap(),
-			"test",
+			3,
 		);
 		let enc = Cf::encode(&val).unwrap();
 		println!("enc={}", show(&enc));

--- a/lib/src/key/database/all.rs
+++ b/lib/src/key/database/all.rs
@@ -3,20 +3,20 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-pub struct All<'a> {
+pub struct All {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str) -> All<'a> {
+pub fn new(ns: u32, db: u32) -> All {
 	All::new(ns, db)
 }
 
-impl<'a> All<'a> {
-	pub fn new(ns: &'a str, db: &'a str) -> Self {
+impl All {
+	pub fn new(ns: u32, db: u32) -> Self {
 		Self {
 			__: b'/', // /
 			_a: b'*', // *
@@ -34,8 +34,8 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = All::new(
-			"testns",
-			"testdb",
+			1,
+			2,
 		);
 		let enc = All::encode(&val).unwrap();
 		assert_eq!(enc, b"/*testns\0*testdb\0");

--- a/lib/src/key/database/all.rs
+++ b/lib/src/key/database/all.rs
@@ -38,7 +38,7 @@ mod tests {
 			2,
 		);
 		let enc = All::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02");
 
 		let dec = All::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/database/az.rs
+++ b/lib/src/key/database/az.rs
@@ -59,7 +59,7 @@ mod tests {
             "test",
         );
 		let enc = Az::encode(&val).unwrap();
-		assert_eq!(enc, b"/*ns\0*db\0!aztest\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!aztest\x00");
 		let dec = Az::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}
@@ -67,12 +67,12 @@ mod tests {
 	#[test]
 	fn prefix() {
 		let val = super::prefix(1, 2);
-		assert_eq!(val, b"/*namespace\0*database\0!az\0");
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!az\x00");
 	}
 
 	#[test]
 	fn suffix() {
 		let val = super::suffix(1, 2);
-		assert_eq!(val, b"/*namespace\0*database\0!az\xff");
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!az\xff");
 	}
 }

--- a/lib/src/key/database/az.rs
+++ b/lib/src/key/database/az.rs
@@ -6,33 +6,33 @@ use serde::{Deserialize, Serialize};
 pub struct Az<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
 	_d: u8,
 	_e: u8,
 	pub az: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, tb: &'a str) -> Az<'a> {
+pub fn new(ns: u32, db: u32, tb: &str) -> Az {
 	Az::new(ns, db, tb)
 }
 
-pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'a', b'z', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'a', b'z', 0xff]);
 	k
 }
 
 impl<'a> Az<'a> {
-	pub fn new(ns: &'a str, db: &'a str, az: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, az: &'a str) -> Self {
 		Self {
 			__: b'/', // /
 			_a: b'*', // *
@@ -54,8 +54,8 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
             let val = Az::new(
-            "ns",
-            "db",
+            1,
+            2,
             "test",
         );
 		let enc = Az::encode(&val).unwrap();
@@ -66,13 +66,13 @@ mod tests {
 
 	#[test]
 	fn prefix() {
-		let val = super::prefix("namespace", "database");
+		let val = super::prefix(1, 2);
 		assert_eq!(val, b"/*namespace\0*database\0!az\0");
 	}
 
 	#[test]
 	fn suffix() {
-		let val = super::suffix("namespace", "database");
+		let val = super::suffix(1, 2);
 		assert_eq!(val, b"/*namespace\0*database\0!az\xff");
 	}
 }

--- a/lib/src/key/database/db.rs
+++ b/lib/src/key/database/db.rs
@@ -1,10 +1,9 @@
-//! Stores database versionstamps
+/// Stores a DEFINE DATABASE config definition
 use derive::Key;
 use serde::{Deserialize, Serialize};
 
-// Vs stands for Database Versionstamp
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-pub struct Vs {
+pub struct Db {
 	__: u8,
 	_a: u8,
 	pub ns: u32,
@@ -15,22 +14,21 @@ pub struct Vs {
 	_e: u8,
 }
 
-#[allow(unused)]
-pub fn new(ns: u32, db: u32) -> Vs {
-	Vs::new(ns, db)
+pub fn new(ns: u32, db: u32) -> Db {
+	Db::new(ns, db)
 }
 
-impl Vs {
+impl Db {
 	pub fn new(ns: u32, db: u32) -> Self {
-		Vs {
+		Self {
 			__: b'/',
 			_a: b'*',
 			ns,
 			_b: b'*',
 			db,
 			_c: b'!',
-			_d: b'v',
-			_e: b's',
+			_d: b'd',
+			_e: b'b',
 		}
 	}
 }
@@ -41,12 +39,14 @@ mod tests {
 	fn key() {
 		use super::*;
 		#[rustfmt::skip]
-		let val = Vs::new(
+		let val = Db::new(
 			1,
 			2,
 		);
-		let enc = Vs::encode(&val).unwrap();
-		let dec = Vs::decode(&enc).unwrap();
+		let enc = Db::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0!dbtestdb\0");
+
+		let dec = Db::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}
 }

--- a/lib/src/key/database/db.rs
+++ b/lib/src/key/database/db.rs
@@ -44,7 +44,7 @@ mod tests {
 			2,
 		);
 		let enc = Db::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0!dbtestdb\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01!db\x00\x00\x00\x02");
 
 		let dec = Db::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/database/db.rs
+++ b/lib/src/key/database/db.rs
@@ -44,7 +44,7 @@ mod tests {
 			2,
 		);
 		let enc = Db::encode(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01!db\x00\x00\x00\x02");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!db");
 
 		let dec = Db::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/database/fc.rs
+++ b/lib/src/key/database/fc.rs
@@ -59,13 +59,7 @@ mod tests {
 			"testfc",
 		);
 		let enc = Fc::encode(&val).unwrap();
-		assert_eq!(
-			enc,
-			vec![
-				b'/', b'*', 0, 0, 0, 1u8, b'*', 0, 0, 0, 2u8, b'!', b'f', b'n', b't', b'e', b's',
-				b't', b'f', b'c', 0x00
-			]
-		);
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!fntestfc\x00");
 		let dec = Fc::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}
@@ -73,12 +67,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix(1, 2);
-		assert_eq!(val, vec![b'/', b'*', 0, 0, 0, 1u8, b'*', 0, 0, 0, 2u8, b'!', b'f', b'n', 0x00]);
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!fn\x00");
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix(1, 2);
-		assert_eq!(val, vec![b'/', b'*', 0, 0, 0, 1u8, b'*', 0, 0, 0, 2u8, b'!', b'f', b'n', 0xff]);
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!fn\xff");
 	}
 }

--- a/lib/src/key/database/lg.rs
+++ b/lib/src/key/database/lg.rs
@@ -59,7 +59,7 @@ mod tests {
 			"testdl",
 		);
 		let enc = Lg::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0!lgtestdl\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!lgtestdl\0");
 
 		let dec = Lg::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/database/lg.rs
+++ b/lib/src/key/database/lg.rs
@@ -6,33 +6,33 @@ use serde::{Deserialize, Serialize};
 pub struct Lg<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
 	_d: u8,
 	_e: u8,
 	pub dl: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, dl: &'a str) -> Lg<'a> {
+pub fn new(ns: u32, db: u32, dl: &str) -> Lg {
 	Lg::new(ns, db, dl)
 }
 
-pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'l', b'g', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'l', b'g', 0xff]);
 	k
 }
 
 impl<'a> Lg<'a> {
-	pub fn new(ns: &'a str, db: &'a str, dl: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, dl: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -54,8 +54,8 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Lg::new(
-			"testns",
-			"testdb",
+			1,
+			2,
 			"testdl",
 		);
 		let enc = Lg::encode(&val).unwrap();

--- a/lib/src/key/database/mod.rs
+++ b/lib/src/key/database/mod.rs
@@ -1,5 +1,6 @@
 pub mod all;
 pub mod az;
+pub mod db;
 pub mod fc;
 pub mod lg;
 pub mod pa;

--- a/lib/src/key/database/pa.rs
+++ b/lib/src/key/database/pa.rs
@@ -59,7 +59,7 @@ mod tests {
 			"testpa",
 		);
 		let enc = Pa::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0!patestpa\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!patestpa\0");
 
 		let dec = Pa::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/database/pa.rs
+++ b/lib/src/key/database/pa.rs
@@ -6,33 +6,33 @@ use serde::{Deserialize, Serialize};
 pub struct Pa<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
 	_d: u8,
 	_e: u8,
 	pub pa: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, pa: &'a str) -> Pa<'a> {
+pub fn new(ns: u32, db: u32, pa: &str) -> Pa {
 	Pa::new(ns, db, pa)
 }
 
-pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'p', b'a', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'p', b'a', 0xff]);
 	k
 }
 
 impl<'a> Pa<'a> {
-	pub fn new(ns: &'a str, db: &'a str, pa: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, pa: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -54,8 +54,8 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Pa::new(
-			"testns",
-			"testdb",
+			1,
+			2,
 			"testpa",
 		);
 		let enc = Pa::encode(&val).unwrap();

--- a/lib/src/key/database/sc.rs
+++ b/lib/src/key/database/sc.rs
@@ -59,7 +59,7 @@ mod tests {
 			"testsc",
 		);
 		let enc = Sc::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0!sctestsc\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!sctestsc\0");
 
 		let dec = Sc::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/database/sc.rs
+++ b/lib/src/key/database/sc.rs
@@ -6,33 +6,33 @@ use serde::{Deserialize, Serialize};
 pub struct Sc<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
 	_d: u8,
 	_e: u8,
 	pub sc: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, sc: &'a str) -> Sc<'a> {
+pub fn new(ns: u32, db: u32, sc: &str) -> Sc {
 	Sc::new(ns, db, sc)
 }
 
-pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b's', b'c', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b's', b'c', 0xff]);
 	k
 }
 
 impl<'a> Sc<'a> {
-	pub fn new(ns: &'a str, db: &'a str, sc: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, sc: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -54,8 +54,8 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Sc::new(
-			"testns",
-			"testdb",
+			1,
+			2,
 			"testsc",
 		);
 		let enc = Sc::encode(&val).unwrap();

--- a/lib/src/key/database/tb.rs
+++ b/lib/src/key/database/tb.rs
@@ -6,33 +6,33 @@ use serde::{Deserialize, Serialize};
 pub struct Tb<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
 	_d: u8,
 	_e: u8,
 	pub tb: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, tb: &'a str) -> Tb<'a> {
+pub fn new(ns: u32, db: u32, tb: &str) -> Tb {
 	Tb::new(ns, db, tb)
 }
 
-pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b't', b'b', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b't', b'b', 0xff]);
 	k
 }
 
 impl<'a> Tb<'a> {
-	pub fn new(ns: &'a str, db: &'a str, tb: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, tb: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -54,8 +54,8 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Tb::new(
-			"testns",
-			"testdb",
+			1,
+			2,
 			"testtb",
 		);
 		let enc = Tb::encode(&val).unwrap();

--- a/lib/src/key/database/tb.rs
+++ b/lib/src/key/database/tb.rs
@@ -59,7 +59,7 @@ mod tests {
 			"testtb",
 		);
 		let enc = Tb::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0!tbtesttb\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!tbtesttb\0");
 
 		let dec = Tb::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/database/ti.rs
+++ b/lib/src/key/database/ti.rs
@@ -23,7 +23,7 @@ impl Ti {
 	pub fn new(ns: u32, db: u32) -> Self {
 		Ti {
 			__: b'/',
-			_a: b'+',
+			_a: b'*',
 			ns,
 			_b: b'*',
 			db,
@@ -41,10 +41,11 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Ti::new(
-			123u32,
-			234u32,
+			1,
+			2,
 		);
 		let enc = Ti::encode(&val).unwrap();
+		assert_eq!(enc, b"/*\0\0\0\x01*\0\0\0\x02!ti");
 		let dec = Ti::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/database/tk.rs
+++ b/lib/src/key/database/tk.rs
@@ -6,33 +6,33 @@ use serde::{Deserialize, Serialize};
 pub struct Tk<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
 	_d: u8,
 	_e: u8,
 	pub tk: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, tk: &'a str) -> Tk<'a> {
+pub fn new(ns: u32, db: u32, tk: &str) -> Tk {
 	Tk::new(ns, db, tk)
 }
 
-pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b't', b'k', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b't', b'k', 0xff]);
 	k
 }
 
 impl<'a> Tk<'a> {
-	pub fn new(ns: &'a str, db: &'a str, tk: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, tk: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -54,8 +54,8 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Tk::new(
-			"testns",
-			"testdb",
+			1,
+			2,
 			"testtk",
 		);
 		let enc = Tk::encode(&val).unwrap();
@@ -67,13 +67,13 @@ mod tests {
 
 	#[test]
 	fn test_prefix() {
-		let val = super::prefix("testns", "testdb");
+		let val = super::prefix(1, 2);
 		assert_eq!(val, b"/*testns\0*testdb\0!tk\0");
 	}
 
 	#[test]
 	fn test_suffix() {
-		let val = super::suffix("testns", "testdb");
+		let val = super::suffix(1, 2);
 		assert_eq!(val, b"/*testns\0*testdb\0!tk\xff");
 	}
 }

--- a/lib/src/key/database/tk.rs
+++ b/lib/src/key/database/tk.rs
@@ -59,7 +59,7 @@ mod tests {
 			"testtk",
 		);
 		let enc = Tk::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\x00*testdb\x00!tktesttk\x00");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!tktesttk\x00");
 
 		let dec = Tk::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -68,12 +68,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix(1, 2);
-		assert_eq!(val, b"/*testns\0*testdb\0!tk\0");
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!tk\0");
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix(1, 2);
-		assert_eq!(val, b"/*testns\0*testdb\0!tk\xff");
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!tk\xff");
 	}
 }

--- a/lib/src/key/database/ts.rs
+++ b/lib/src/key/database/ts.rs
@@ -6,38 +6,38 @@ use serde::{Deserialize, Serialize};
 // Each Ts key is suffixed by a timestamp.
 // The value is the versionstamp that corresponds to the timestamp.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-pub struct Ts<'a> {
+pub struct Ts {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
 	_d: u8,
 	_e: u8,
 	pub ts: u64,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, ts: u64) -> Ts<'a> {
+pub fn new(ns: u32, db: u32, ts: u64) -> Ts {
 	Ts::new(ns, db, ts)
 }
 
 /// Returns the prefix for the whole database timestamps
-pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = crate::key::database::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b't', b's']);
 	k
 }
 
 /// Returns the prefix for the whole database timestamps
-pub fn suffix(ns: &str, db: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = prefix(ns, db);
 	k.extend_from_slice(&[0xff]);
 	k
 }
 
-impl<'a> Ts<'a> {
-	pub fn new(ns: &'a str, db: &'a str, ts: u64) -> Self {
+impl Ts {
+	pub fn new(ns: u32, db: u32, ts: u64) -> Self {
 		Ts {
 			__: b'/',
 			_a: b'*',
@@ -59,8 +59,8 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Ts::new(
-			"test",
-			"test",
+			1,
+			2,
 			123,
 		);
 		let enc = Ts::encode(&val).unwrap();

--- a/lib/src/key/database/us.rs
+++ b/lib/src/key/database/us.rs
@@ -5,33 +5,33 @@ use serde::{Deserialize, Serialize};
 pub struct Us<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
 	_d: u8,
 	_e: u8,
 	pub user: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, user: &'a str) -> Us<'a> {
+pub fn new(ns: u32, db: u32, user: &str) -> Us {
 	Us::new(ns, db, user)
 }
 
-pub fn prefix(ns: &str, db: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'u', b's', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'u', b's', 0xff]);
 	k
 }
 
 impl<'a> Us<'a> {
-	pub fn new(ns: &'a str, db: &'a str, user: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, user: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -53,8 +53,8 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Us::new(
-			"testns",
-			"testdb",
+			1,
+			2,
 			"testuser",
 		);
 		let enc = Us::encode(&val).unwrap();
@@ -65,13 +65,13 @@ mod tests {
 
 	#[test]
 	fn test_prefix() {
-		let val = super::prefix("testns", "testdb");
+		let val = super::prefix(1, 2);
 		assert_eq!(val, b"/*testns\0*testdb\0!us\0");
 	}
 
 	#[test]
 	fn test_suffix() {
-		let val = super::suffix("testns", "testdb");
+		let val = super::suffix(1, 2);
 		assert_eq!(val, b"/*testns\0*testdb\0!us\xff");
 	}
 }

--- a/lib/src/key/database/us.rs
+++ b/lib/src/key/database/us.rs
@@ -58,7 +58,7 @@ mod tests {
 			"testuser",
 		);
 		let enc = Us::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\x00*testdb\x00!ustestuser\x00");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!ustestuser\x00");
 		let dec = Us::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}
@@ -66,12 +66,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix(1, 2);
-		assert_eq!(val, b"/*testns\0*testdb\0!us\0");
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!us\0");
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix(1, 2);
-		assert_eq!(val, b"/*testns\0*testdb\0!us\xff");
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!us\xff");
 	}
 }

--- a/lib/src/key/graph/mod.rs
+++ b/lib/src/key/graph/mod.rs
@@ -192,7 +192,7 @@ mod tests {
 		let enc = Graph::encode(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*testns\0*testdb\0*testtb\x00~\0\0\0\x01testid\0\0\0\0\x01other\0\0\0\0\x01test\0"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03~\0\0\0\x01testid\0\0\0\0\x01other\0\0\0\0\x01test\0"
 		);
 
 		let dec = Graph::decode(&enc).unwrap();

--- a/lib/src/key/graph/mod.rs
+++ b/lib/src/key/graph/mod.rs
@@ -6,20 +6,20 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-struct Prefix<'a> {
+struct Prefix {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 	_d: u8,
 	pub id: Id,
 }
 
-impl<'a> Prefix<'a> {
-	fn new(ns: &'a str, db: &'a str, tb: &'a str, id: &Id) -> Self {
+impl Prefix {
+	fn new(ns: u32, db: u32, tb: u32, id: &Id) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -35,21 +35,21 @@ impl<'a> Prefix<'a> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-struct PrefixEg<'a> {
+struct PrefixEg {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 	_d: u8,
 	pub id: Id,
 	pub eg: Dir,
 }
 
-impl<'a> PrefixEg<'a> {
-	fn new(ns: &'a str, db: &'a str, tb: &'a str, id: &Id, eg: &Dir) -> Self {
+impl PrefixEg {
+	fn new(ns: u32, db: u32, tb: u32, id: &Id, eg: &Dir) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -69,11 +69,11 @@ impl<'a> PrefixEg<'a> {
 struct PrefixFt<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 	_d: u8,
 	pub id: Id,
 	pub eg: Dir,
@@ -81,7 +81,7 @@ struct PrefixFt<'a> {
 }
 
 impl<'a> PrefixFt<'a> {
-	fn new(ns: &'a str, db: &'a str, tb: &'a str, id: &Id, eg: &Dir, ft: &'a str) -> Self {
+	fn new(ns: u32, db: u32, tb: u32, id: &Id, eg: &Dir, ft: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -102,11 +102,11 @@ impl<'a> PrefixFt<'a> {
 pub struct Graph<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 	_d: u8,
 	pub id: Id,
 	pub eg: Dir,
@@ -114,55 +114,48 @@ pub struct Graph<'a> {
 	pub fk: Id,
 }
 
-pub fn new<'a>(
-	ns: &'a str,
-	db: &'a str,
-	tb: &'a str,
-	id: &Id,
-	eg: &Dir,
-	fk: &'a Thing,
-) -> Graph<'a> {
+pub fn new<'a>(ns: u32, db: u32, tb: u32, id: &Id, eg: &Dir, fk: &'a Thing) -> Graph<'a> {
 	Graph::new(ns, db, tb, id.to_owned(), eg.to_owned(), fk)
 }
 
-pub fn prefix(ns: &str, db: &str, tb: &str, id: &Id) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32, tb: u32, id: &Id) -> Vec<u8> {
 	let mut k = Prefix::new(ns, db, tb, id).encode().unwrap();
 	k.extend_from_slice(&[0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str, tb: &str, id: &Id) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32, tb: u32, id: &Id) -> Vec<u8> {
 	let mut k = Prefix::new(ns, db, tb, id).encode().unwrap();
 	k.extend_from_slice(&[0xff]);
 	k
 }
 
-pub fn egprefix(ns: &str, db: &str, tb: &str, id: &Id, eg: &Dir) -> Vec<u8> {
+pub fn egprefix(ns: u32, db: u32, tb: u32, id: &Id, eg: &Dir) -> Vec<u8> {
 	let mut k = PrefixEg::new(ns, db, tb, id, eg).encode().unwrap();
 	k.extend_from_slice(&[0x00]);
 	k
 }
 
-pub fn egsuffix(ns: &str, db: &str, tb: &str, id: &Id, eg: &Dir) -> Vec<u8> {
+pub fn egsuffix(ns: u32, db: u32, tb: u32, id: &Id, eg: &Dir) -> Vec<u8> {
 	let mut k = PrefixEg::new(ns, db, tb, id, eg).encode().unwrap();
 	k.extend_from_slice(&[0xff]);
 	k
 }
 
-pub fn ftprefix(ns: &str, db: &str, tb: &str, id: &Id, eg: &Dir, ft: &str) -> Vec<u8> {
+pub fn ftprefix(ns: u32, db: u32, tb: u32, id: &Id, eg: &Dir, ft: &str) -> Vec<u8> {
 	let mut k = PrefixFt::new(ns, db, tb, id, eg, ft).encode().unwrap();
 	k.extend_from_slice(&[0x00]);
 	k
 }
 
-pub fn ftsuffix(ns: &str, db: &str, tb: &str, id: &Id, eg: &Dir, ft: &str) -> Vec<u8> {
+pub fn ftsuffix(ns: u32, db: u32, tb: u32, id: &Id, eg: &Dir, ft: &str) -> Vec<u8> {
 	let mut k = PrefixFt::new(ns, db, tb, id, eg, ft).encode().unwrap();
 	k.extend_from_slice(&[0xff]);
 	k
 }
 
 impl<'a> Graph<'a> {
-	pub fn new(ns: &'a str, db: &'a str, tb: &'a str, id: Id, eg: Dir, fk: &'a Thing) -> Self {
+	pub fn new(ns: u32, db: u32, tb: u32, id: Id, eg: Dir, fk: &'a Thing) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -189,9 +182,9 @@ mod tests {
 		let fk = Thing::parse("other:test");
 		#[rustfmt::skip]
 		let val = Graph::new(
-			"testns",
-			"testdb",
-			"testtb",
+			1,
+			2,
+			3,
 			"testid".into(),
 			Dir::Out,
 			&fk,

--- a/lib/src/key/index/all.rs
+++ b/lib/src/key/index/all.rs
@@ -48,7 +48,7 @@ mod tests {
 			"testix",
 		);
 		let enc = All::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0+testix\0");
+		assert_eq!(enc, b"/*\0\0\0\x01*\0\0\0\x02*\0\0\0\x03+testix\0");
 
 		let dec = All::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/mod.rs
+++ b/lib/src/key/mod.rs
@@ -4,26 +4,28 @@
 /// crate::key::root::hb                 /!hb{ts}/{nd}
 /// crate::key::root::nd                 /!nd{nd}
 /// crate::key::root::ni                 /!ni
-/// crate::key::root::ns                 /!ns{ns}
+/// crate::key::root::ns                 /!ns{ns name}
 ///
 /// crate::key::node::all                /${nd}
 /// crate::key::node::lq                 /${nd}!lq{lq}{ns}{db}
 ///
 /// crate::key::namespace::all           /*{ns}
-/// crate::key::namespace::db            /*{ns}!db{db}
-/// crate::key::namespace::di            /+{ns id}!di
+/// crate::key::namespace::db            /*{ns}!db{db name}
+/// crate::key::namespace::di            /*{ns}!di
 /// crate::key::namespace::lg            /*{ns}!lg{lg}
+/// crate::key::namespace::ns            /*{ns}!ns [new]
 /// crate::key::namespace::tk            /*{ns}!tk{tk}
 ///
 /// crate::key::database::all            /*{ns}*{db}
-/// crate::key::database::az             /*{ns}*{db}!az{az}
-/// crate::key::database::fc             /*{ns}*{db}!fn{fc}
-/// crate::key::database::lg             /*{ns}*{db}!lg{lg}
-/// crate::key::database::pa             /*{ns}*{db}!pa{pa}
-/// crate::key::database::sc             /*{ns}*{db}!sc{sc}
-/// crate::key::database::tb             /*{ns}*{db}!tb{tb}
-/// crate::key::database::ti             /+{ns id}*{db id}!ti
-/// crate::key::database::tk             /*{ns}*{db}!tk{tk}
+/// crate::key::database::az             /*{ns}*{db}!az{az name}
+/// crate::key::database::db             /*{ns}*{db}!db
+/// crate::key::database::fc             /*{ns}*{db}!fn{fc name}
+/// crate::key::database::lg             /*{ns}*{db}!lg{lg name}
+/// crate::key::database::pa             /*{ns}*{db}!pa{pa name}
+/// crate::key::database::sc             /*{ns}*{db}!sc{sc name}
+/// crate::key::database::tb             /*{ns}*{db}!tb{tb name}
+/// crate::key::database::ti             /*{ns}*{db}!ti
+/// crate::key::database::tk             /*{ns}*{db}!tk{tk name}
 /// crate::key::database::ts             /*{ns}*{db}!ts{ts}
 /// crate::key::database::vs             /*{ns}*{db}!vs
 ///
@@ -36,6 +38,7 @@
 /// crate::key::table::ft                /*{ns}*{db}*{tb}!ft{ft}
 /// crate::key::table::ix                /*{ns}*{db}*{tb}!ix{ix}
 /// crate::key::table::lq                /*{ns}*{db}*{tb}!lq{lq}
+/// crate::key::table::tb                /*{ns}*{db}*{tb}!tb [new]
 ///
 /// crate::key::index::all               /*{ns}*{db}*{tb}+{ix}
 /// crate::key::index::bc                /*{ns}*{db}*{tb}+{ix}!bc{id}

--- a/lib/src/key/namespace/all.rs
+++ b/lib/src/key/namespace/all.rs
@@ -30,10 +30,10 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = All::new(
-			123,
+			1,
 		);
 		let enc = All::encode(&val).unwrap();
-		assert_eq!(enc, vec![b'/', b'*', 0, 0, 0, 123u8]);
+		assert_eq!(enc, b"/*\x00\x00\x00\x01");
 
 		let dec = All::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/namespace/db.rs
+++ b/lib/src/key/namespace/db.rs
@@ -50,7 +50,7 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Db::new(
-			123,
+			1,
 			"testdb",
 		);
 		let enc = Db::encode(&val).unwrap();
@@ -62,13 +62,13 @@ mod tests {
 
 	#[test]
 	fn test_prefix() {
-		let val = super::prefix(123);
+		let val = super::prefix(1);
 		assert_eq!(val, b"/*\x00\x00\x00\x01!db\0")
 	}
 
 	#[test]
 	fn test_suffix() {
-		let val = super::suffix(123);
-		assert_eq!(val, b"/*testns\0!db\xff")
+		let val = super::suffix(1);
+		assert_eq!(val, b"/*\0\0\0\x01!db\xff")
 	}
 }

--- a/lib/src/key/namespace/db.rs
+++ b/lib/src/key/namespace/db.rs
@@ -6,31 +6,31 @@ use serde::{Deserialize, Serialize};
 pub struct Db<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
 	_c: u8,
 	_d: u8,
 	pub db: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str) -> Db<'a> {
+pub fn new(ns: u32, db: &str) -> Db {
 	Db::new(ns, db)
 }
 
-pub fn prefix(ns: &str) -> Vec<u8> {
+pub fn prefix(ns: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'd', b'b', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str) -> Vec<u8> {
+pub fn suffix(ns: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'd', b'b', 0xff]);
 	k
 }
 
 impl<'a> Db<'a> {
-	pub fn new(ns: &'a str, db: &'a str) -> Self {
+	pub fn new(ns: u32, db: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -50,7 +50,7 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Db::new(
-			"testns",
+			123,
 			"testdb",
 		);
 		let enc = Db::encode(&val).unwrap();
@@ -62,13 +62,13 @@ mod tests {
 
 	#[test]
 	fn test_prefix() {
-		let val = super::prefix("testns");
+		let val = super::prefix(123);
 		assert_eq!(val, b"/*testns\0!db\0")
 	}
 
 	#[test]
 	fn test_suffix() {
-		let val = super::suffix("testns");
+		let val = super::suffix(123);
 		assert_eq!(val, b"/*testns\0!db\xff")
 	}
 }

--- a/lib/src/key/namespace/db.rs
+++ b/lib/src/key/namespace/db.rs
@@ -54,7 +54,7 @@ mod tests {
 			"testdb",
 		);
 		let enc = Db::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0!dbtestdb\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01!dbtestdb\0");
 
 		let dec = Db::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -63,7 +63,7 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix(123);
-		assert_eq!(val, b"/*testns\0!db\0")
+		assert_eq!(val, b"/*\x00\x00\x00\x01!db\0")
 	}
 
 	#[test]

--- a/lib/src/key/namespace/di.rs
+++ b/lib/src/key/namespace/di.rs
@@ -20,7 +20,7 @@ impl Di {
 	pub fn new(ns: u32) -> Self {
 		Self {
 			__: b'/',
-			_a: b'+',
+			_a: b'*',
 			ns,
 			_b: b'!',
 			_c: b'd',
@@ -36,10 +36,10 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Di::new(
-			123,
+			1,
 		);
 		let enc = Di::encode(&val).unwrap();
-		assert_eq!(enc, vec![0x2f, 0x2b, 0, 0, 0, 0x7b, 0x21, 0x64, 0x69]);
+		assert_eq!(enc, b"/*\0\0\0\x01!di");
 
 		let dec = Di::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/namespace/lg.rs
+++ b/lib/src/key/namespace/lg.rs
@@ -50,11 +50,11 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Lg::new(
-			123,
+			1,
 			"testus",
 		);
 		let enc = Lg::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0!lgtestus\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01!lgtestus\0");
 
 		let dec = Lg::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/namespace/lg.rs
+++ b/lib/src/key/namespace/lg.rs
@@ -6,31 +6,31 @@ use serde::{Deserialize, Serialize};
 pub struct Lg<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
 	_c: u8,
 	_d: u8,
 	pub us: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, us: &'a str) -> Lg<'a> {
+pub fn new(ns: u32, us: &str) -> Lg {
 	Lg::new(ns, us)
 }
 
-pub fn prefix(ns: &str) -> Vec<u8> {
+pub fn prefix(ns: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'l', b'g', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str) -> Vec<u8> {
+pub fn suffix(ns: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'l', b'g', 0xff]);
 	k
 }
 
 impl<'a> Lg<'a> {
-	pub fn new(ns: &'a str, us: &'a str) -> Self {
+	pub fn new(ns: u32, us: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -50,7 +50,7 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Lg::new(
-			"testns",
+			123,
 			"testus",
 		);
 		let enc = Lg::encode(&val).unwrap();

--- a/lib/src/key/namespace/mod.rs
+++ b/lib/src/key/namespace/mod.rs
@@ -2,5 +2,6 @@ pub mod all;
 pub mod db;
 pub mod di;
 pub mod lg;
+pub mod ns;
 pub mod tk;
 pub mod us;

--- a/lib/src/key/namespace/ns.rs
+++ b/lib/src/key/namespace/ns.rs
@@ -1,24 +1,30 @@
-//! Stores the key prefix for all keys under a namespace
+/// Stores a database ID generator state
 use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-pub struct All {
+pub struct Ns {
 	__: u8,
 	_a: u8,
 	pub ns: u32,
+	_b: u8,
+	_c: u8,
+	_d: u8,
 }
 
-pub fn new(ns: u32) -> All {
-	All::new(ns)
+pub fn new(ns: u32) -> Ns {
+	Ns::new(ns)
 }
 
-impl All {
+impl Ns {
 	pub fn new(ns: u32) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
 			ns,
+			_b: b'!',
+			_c: b'n',
+			_d: b's',
 		}
 	}
 }
@@ -29,13 +35,13 @@ mod tests {
 	fn key() {
 		use super::*;
 		#[rustfmt::skip]
-		let val = All::new(
-			123,
+		let val = Ns::new(
+			1,
 		);
-		let enc = All::encode(&val).unwrap();
-		assert_eq!(enc, vec![b'/', b'*', 0, 0, 0, 123u8]);
+		let enc = Ns::encode(&val).unwrap();
+		assert_eq!(enc, vec![b'/', b'*', 0, 0, 0, 0, 0, 0, 0, 0x1, b'!', b'n', b's']);
 
-		let dec = All::decode(&enc).unwrap();
+		let dec = Ns::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}
 }

--- a/lib/src/key/namespace/ns.rs
+++ b/lib/src/key/namespace/ns.rs
@@ -39,7 +39,7 @@ mod tests {
 			1,
 		);
 		let enc = Ns::encode(&val).unwrap();
-		assert_eq!(enc, vec![b'/', b'*', 0, 0, 0, 0, 0, 0, 0, 0x1, b'!', b'n', b's']);
+		assert_eq!(enc, b"/*\x00\x00\x00\x01!ns");
 
 		let dec = Ns::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/namespace/tk.rs
+++ b/lib/src/key/namespace/tk.rs
@@ -50,11 +50,11 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Tk::new(
-			123,
+			1,
 			"testtk",
 		);
 		let enc = Tk::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0!tktesttk\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01!tktesttk\0");
 		let dec = Tk::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/namespace/tk.rs
+++ b/lib/src/key/namespace/tk.rs
@@ -6,31 +6,31 @@ use serde::{Deserialize, Serialize};
 pub struct Tk<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
 	_c: u8,
 	_d: u8,
 	pub tk: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, tk: &'a str) -> Tk<'a> {
+pub fn new(ns: u32, tk: &str) -> Tk {
 	Tk::new(ns, tk)
 }
 
-pub fn prefix(ns: &str) -> Vec<u8> {
+pub fn prefix(ns: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns).encode().unwrap();
 	k.extend_from_slice(&[b'!', b't', b'k', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str) -> Vec<u8> {
+pub fn suffix(ns: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns).encode().unwrap();
 	k.extend_from_slice(&[b'!', b't', b'k', 0xff]);
 	k
 }
 
 impl<'a> Tk<'a> {
-	pub fn new(ns: &'a str, tk: &'a str) -> Self {
+	pub fn new(ns: u32, tk: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -50,7 +50,7 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Tk::new(
-			"testns",
+			123,
 			"testtk",
 		);
 		let enc = Tk::encode(&val).unwrap();

--- a/lib/src/key/namespace/us.rs
+++ b/lib/src/key/namespace/us.rs
@@ -5,31 +5,31 @@ use serde::{Deserialize, Serialize};
 pub struct Us<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
 	_c: u8,
 	_d: u8,
 	pub user: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, user: &'a str) -> Us<'a> {
+pub fn new(ns: u32, user: &str) -> Us {
 	Us::new(ns, user)
 }
 
-pub fn prefix(ns: &str) -> Vec<u8> {
+pub fn prefix(ns: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'u', b's', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str) -> Vec<u8> {
+pub fn suffix(ns: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'u', b's', 0xff]);
 	k
 }
 
 impl<'a> Us<'a> {
-	pub fn new(ns: &'a str, user: &'a str) -> Self {
+	pub fn new(ns: u32, user: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -49,7 +49,7 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Us::new(
-			"testns",
+			123,
 			"testuser",
 		);
 		let enc = Us::encode(&val).unwrap();
@@ -60,13 +60,13 @@ mod tests {
 
 	#[test]
 	fn test_prefix() {
-		let val = super::prefix("testns");
+		let val = super::prefix(123);
 		assert_eq!(val, b"/*testns\0!us\0");
 	}
 
 	#[test]
 	fn test_suffix() {
-		let val = super::suffix("testns");
+		let val = super::suffix(123);
 		assert_eq!(val, b"/*testns\0!us\xff");
 	}
 }

--- a/lib/src/key/namespace/us.rs
+++ b/lib/src/key/namespace/us.rs
@@ -49,24 +49,24 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Us::new(
-			123,
+			1,
 			"testuser",
 		);
 		let enc = Us::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\x00!ustestuser\x00");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01!ustestuser\x00");
 		let dec = Us::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}
 
 	#[test]
 	fn test_prefix() {
-		let val = super::prefix(123);
-		assert_eq!(val, b"/*testns\0!us\0");
+		let val = super::prefix(1);
+		assert_eq!(val, b"/*\x00\x00\x00\x01!us\0");
 	}
 
 	#[test]
 	fn test_suffix() {
-		let val = super::suffix(123);
-		assert_eq!(val, b"/*testns\0!us\xff");
+		let val = super::suffix(1);
+		assert_eq!(val, b"/*\x00\x00\x00\x01!us\xff");
 	}
 }

--- a/lib/src/key/root/ni.rs
+++ b/lib/src/key/root/ni.rs
@@ -34,6 +34,7 @@ mod tests {
 		use super::*;
 		let val = Ni::new();
 		let enc = Ni::encode(&val).unwrap();
+		assert_eq!(enc, b"/!ni");
 		let dec = Ni::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}

--- a/lib/src/key/table/all.rs
+++ b/lib/src/key/table/all.rs
@@ -3,22 +3,22 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-pub struct Table<'a> {
+pub struct Table {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, tb: &'a str) -> Table<'a> {
+pub fn new(ns: u32, db: u32, tb: u32) -> Table {
 	Table::new(ns, db, tb)
 }
 
-impl<'a> Table<'a> {
-	pub fn new(ns: &'a str, db: &'a str, tb: &'a str) -> Self {
+impl Table {
+	pub fn new(ns: u32, db: u32, tb: u32) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -38,9 +38,9 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Table::new(
-			"testns",
-			"testdb",
-			"testtb",
+			1,
+			2,
+			3,
 		);
 		let enc = Table::encode(&val).unwrap();
 		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0");

--- a/lib/src/key/table/all.rs
+++ b/lib/src/key/table/all.rs
@@ -43,7 +43,7 @@ mod tests {
 			3,
 		);
 		let enc = Table::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03");
 
 		let dec = Table::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/table/ev.rs
+++ b/lib/src/key/table/ev.rs
@@ -64,13 +64,7 @@ mod tests {
 			"testev",
 		);
 		let enc = Ev::encode(&val).unwrap();
-		assert_eq!(
-			enc,
-			vec![
-				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'e', b'v', b't',
-				b'e', b's', b't', b'e', b'v', 0,
-			]
-		);
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!evtestev\x00");
 
 		let dec = Ev::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -79,20 +73,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix(1, 2, 3);
-		assert_eq!(
-			val,
-			vec![b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'e', b'v', 0]
-		);
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!ev\x00");
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix(1, 2, 3);
-		assert_eq!(
-			val,
-			vec![
-				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'e', b'v', 0xff
-			]
-		);
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!ev\xff");
 	}
 }

--- a/lib/src/key/table/ev.rs
+++ b/lib/src/key/table/ev.rs
@@ -6,35 +6,35 @@ use serde::{Deserialize, Serialize};
 pub struct Ev<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 	_d: u8,
 	_e: u8,
 	_f: u8,
 	pub ev: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, tb: &'a str, ev: &'a str) -> Ev<'a> {
+pub fn new(ns: u32, db: u32, tb: u32, ev: &str) -> Ev {
 	Ev::new(ns, db, tb, ev)
 }
 
-pub fn prefix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'e', b'v', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'e', b'v', 0xff]);
 	k
 }
 
 impl<'a> Ev<'a> {
-	pub fn new(ns: &'a str, db: &'a str, tb: &'a str, ev: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, tb: u32, ev: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -58,13 +58,19 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Ev::new(
-			"testns",
-			"testdb",
-			"testtb",
+			1,
+			2,
+			3,
 			"testev",
 		);
 		let enc = Ev::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\x00*testdb\x00*testtb\x00!evtestev\x00");
+		assert_eq!(
+			enc,
+			vec![
+				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'e', b'v', b't',
+				b'e', b's', b't', b'e', b'v', 0,
+			]
+		);
 
 		let dec = Ev::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -72,13 +78,21 @@ mod tests {
 
 	#[test]
 	fn test_prefix() {
-		let val = super::prefix("testns", "testdb", "testtb");
-		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!ev\0");
+		let val = super::prefix(1, 2, 3);
+		assert_eq!(
+			val,
+			vec![b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'e', b'v', 0]
+		);
 	}
 
 	#[test]
 	fn test_suffix() {
-		let val = super::suffix("testns", "testdb", "testtb");
-		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!ev\xff");
+		let val = super::suffix(1, 2, 3);
+		assert_eq!(
+			val,
+			vec![
+				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'e', b'v', 0xff
+			]
+		);
 	}
 }

--- a/lib/src/key/table/fd.rs
+++ b/lib/src/key/table/fd.rs
@@ -64,13 +64,7 @@ mod tests {
 			"testfd",
 		);
 		let enc = Fd::encode(&val).unwrap();
-		assert_eq!(
-			enc,
-			vec![
-				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b'd', b't',
-				b'e', b's', b't', b'f', b'd', 0,
-			]
-		);
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!fdtestfd\x00");
 
 		let dec = Fd::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -79,20 +73,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix(1, 2, 3);
-		assert_eq!(
-			val,
-			vec![b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b'd', 0,]
-		);
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!fd\x00");
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix(1, 2, 3);
-		assert_eq!(
-			val,
-			vec![
-				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b'd', 0xff,
-			]
-		);
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!fd\xff");
 	}
 }

--- a/lib/src/key/table/fd.rs
+++ b/lib/src/key/table/fd.rs
@@ -6,35 +6,35 @@ use serde::{Deserialize, Serialize};
 pub struct Fd<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 	_d: u8,
 	_e: u8,
 	_f: u8,
 	pub fd: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, tb: &'a str, fd: &'a str) -> Fd<'a> {
+pub fn new(ns: u32, db: u32, tb: u32, fd: &str) -> Fd {
 	Fd::new(ns, db, tb, fd)
 }
 
-pub fn prefix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'f', b'd', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'f', b'd', 0xff]);
 	k
 }
 
 impl<'a> Fd<'a> {
-	pub fn new(ns: &'a str, db: &'a str, tb: &'a str, fd: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, tb: u32, fd: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -58,13 +58,19 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Fd::new(
-			"testns",
-			"testdb",
-			"testtb",
+			1,
+			2,
+			3,
 			"testfd",
 		);
 		let enc = Fd::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\x00*testdb\x00*testtb\x00!fdtestfd\x00");
+		assert_eq!(
+			enc,
+			vec![
+				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b'd', b't',
+				b'e', b's', b't', b'f', b'd', 0,
+			]
+		);
 
 		let dec = Fd::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -72,13 +78,21 @@ mod tests {
 
 	#[test]
 	fn test_prefix() {
-		let val = super::prefix("testns", "testdb", "testtb");
-		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!fd\0");
+		let val = super::prefix(1, 2, 3);
+		assert_eq!(
+			val,
+			vec![b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b'd', 0,]
+		);
 	}
 
 	#[test]
 	fn test_suffix() {
-		let val = super::suffix("testns", "testdb", "testtb");
-		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!fd\xff");
+		let val = super::suffix(1, 2, 3);
+		assert_eq!(
+			val,
+			vec![
+				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b'd', 0xff,
+			]
+		);
 	}
 }

--- a/lib/src/key/table/ft.rs
+++ b/lib/src/key/table/ft.rs
@@ -64,13 +64,7 @@ mod tests {
 			"testft",
 		);
 		let enc = Ft::encode(&val).unwrap();
-		assert_eq!(
-			enc,
-			vec![
-				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b't', b't',
-				b'e', b's', b't', b'f', b't', 0
-			]
-		);
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!fttestft\x00");
 
 		let dec = Ft::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -79,20 +73,12 @@ mod tests {
 	#[test]
 	fn test_prefix() {
 		let val = super::prefix(1, 2, 3);
-		assert_eq!(
-			val,
-			vec![b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b't', 0]
-		);
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!ft\x00");
 	}
 
 	#[test]
 	fn test_suffix() {
 		let val = super::suffix(1, 2, 3);
-		assert_eq!(
-			val,
-			vec![
-				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b't', 0xff
-			]
-		);
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!ft\xff");
 	}
 }

--- a/lib/src/key/table/ft.rs
+++ b/lib/src/key/table/ft.rs
@@ -6,35 +6,35 @@ use serde::{Deserialize, Serialize};
 pub struct Ft<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 	_d: u8,
 	_e: u8,
 	_f: u8,
 	pub ft: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, tb: &'a str, ft: &'a str) -> Ft<'a> {
+pub fn new(ns: u32, db: u32, tb: u32, ft: &str) -> Ft {
 	Ft::new(ns, db, tb, ft)
 }
 
-pub fn prefix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'f', b't', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'f', b't', 0xff]);
 	k
 }
 
 impl<'a> Ft<'a> {
-	pub fn new(ns: &'a str, db: &'a str, tb: &'a str, ft: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, tb: u32, ft: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -58,13 +58,19 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Ft::new(
-			"testns",
-			"testdb",
-			"testtb",
+			1,
+			2,
+			3,
 			"testft",
 		);
 		let enc = Ft::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\x00*testdb\x00*testtb\x00!fttestft\x00");
+		assert_eq!(
+			enc,
+			vec![
+				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b't', b't',
+				b'e', b's', b't', b'f', b't', 0
+			]
+		);
 
 		let dec = Ft::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -72,13 +78,21 @@ mod tests {
 
 	#[test]
 	fn test_prefix() {
-		let val = super::prefix("testns", "testdb", "testtb");
-		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!ft\0");
+		let val = super::prefix(1, 2, 3);
+		assert_eq!(
+			val,
+			vec![b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b't', 0]
+		);
 	}
 
 	#[test]
 	fn test_suffix() {
-		let val = super::suffix("testns", "testdb", "testtb");
-		assert_eq!(val, b"/*testns\0*testdb\0*testtb\0!ft\xff");
+		let val = super::suffix(1, 2, 3);
+		assert_eq!(
+			val,
+			vec![
+				b'/', b'*', 0, 0, 0, 1, b'*', 0, 0, 0, 2, b'*', 0, 0, 0, 3, b'!', b'f', b't', 0xff
+			]
+		);
 	}
 }

--- a/lib/src/key/table/ix.rs
+++ b/lib/src/key/table/ix.rs
@@ -64,7 +64,7 @@ mod tests {
 			"testix",
 		);
 		let enc = Ix::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0!ixtestix\0");
+		assert_eq!(enc, b"/*\0\0\0\x01*\0\0\0\x02*\0\0\0\x03!ixtestix\0");
 
 		let dec = Ix::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/table/ix.rs
+++ b/lib/src/key/table/ix.rs
@@ -6,35 +6,35 @@ use serde::{Deserialize, Serialize};
 pub struct Ix<'a> {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 	_d: u8,
 	_e: u8,
 	_f: u8,
 	pub ix: &'a str,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, tb: &'a str, ix: &'a str) -> Ix<'a> {
+pub fn new(ns: u32, db: u32, tb: u32, ix: &str) -> Ix {
 	Ix::new(ns, db, tb, ix)
 }
 
-pub fn prefix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'i', b'x', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'i', b'x', 0xff]);
 	k
 }
 
 impl<'a> Ix<'a> {
-	pub fn new(ns: &'a str, db: &'a str, tb: &'a str, ix: &'a str) -> Self {
+	pub fn new(ns: u32, db: u32, tb: u32, ix: &'a str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -58,9 +58,9 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Ix::new(
-			"testns",
-			"testdb",
-			"testtb",
+			1,
+			2,
+			3,
 			"testix",
 		);
 		let enc = Ix::encode(&val).unwrap();

--- a/lib/src/key/table/lq.rs
+++ b/lib/src/key/table/lq.rs
@@ -71,7 +71,7 @@ mod tests {
 		println!("{:?}", debug::sprint_key(&enc));
 		assert_eq!(
 			enc,
-			b"/*testns\x00*testdb\x00*testtb\x00!lq\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!lq\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10"
 		);
 
 		let dec = Lq::decode(&enc).unwrap();
@@ -81,12 +81,12 @@ mod tests {
 	#[test]
 	fn prefix() {
 		let val = super::prefix(1, 2, 3);
-		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!lq\x00")
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!lq\x00")
 	}
 
 	#[test]
 	fn suffix() {
 		let val = super::suffix(1, 2, 3);
-		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!lq\xff")
+		assert_eq!(val, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03!lq\xff")
 	}
 }

--- a/lib/src/key/table/lq.rs
+++ b/lib/src/key/table/lq.rs
@@ -8,14 +8,14 @@ use uuid::Uuid;
 ///
 /// The value of the lv is the statement.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-pub struct Lq<'a> {
+pub struct Lq {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 	_d: u8,
 	_e: u8,
 	_f: u8,
@@ -23,24 +23,24 @@ pub struct Lq<'a> {
 	pub lq: Uuid,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, tb: &'a str, lq: Uuid) -> Lq<'a> {
+pub fn new(ns: u32, db: u32, tb: u32, lq: Uuid) -> Lq {
 	Lq::new(ns, db, tb, lq)
 }
 
-pub fn prefix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'l', b'q', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = super::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'!', b'l', b'q', 0xff]);
 	k
 }
 
-impl<'a> Lq<'a> {
-	pub fn new(ns: &'a str, db: &'a str, tb: &'a str, lq: Uuid) -> Self {
+impl Lq {
+	pub fn new(ns: u32, db: u32, tb: u32, lq: Uuid) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -66,7 +66,7 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let live_query_id = Uuid::from_bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
-		let val = Lq::new("testns", "testdb", "testtb", live_query_id);
+		let val = Lq::new(1, 2, 3, live_query_id);
 		let enc = Lq::encode(&val).unwrap();
 		println!("{:?}", debug::sprint_key(&enc));
 		assert_eq!(
@@ -80,13 +80,13 @@ mod tests {
 
 	#[test]
 	fn prefix() {
-		let val = super::prefix("testns", "testdb", "testtb");
+		let val = super::prefix(1, 2, 3);
 		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!lq\x00")
 	}
 
 	#[test]
 	fn suffix() {
-		let val = super::suffix("testns", "testdb", "testtb");
+		let val = super::suffix(1, 2, 3);
 		assert_eq!(val, b"/*testns\x00*testdb\x00*testtb\x00!lq\xff")
 	}
 }

--- a/lib/src/key/table/mod.rs
+++ b/lib/src/key/table/mod.rs
@@ -4,3 +4,4 @@ pub mod fd;
 pub mod ft;
 pub mod ix;
 pub mod lq;
+pub mod tb;

--- a/lib/src/key/table/tb.rs
+++ b/lib/src/key/table/tb.rs
@@ -49,7 +49,7 @@ mod tests {
 			3,
 		);
 		let enc = Tb::encode(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!tb\x00\x00\x00\x03");
+		assert_eq!(enc, b"/*\0\0\0\x01*\0\0\0\x02*\0\0\0\x03!tb");
 
 		let dec = Tb::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/table/tb.rs
+++ b/lib/src/key/table/tb.rs
@@ -49,7 +49,7 @@ mod tests {
 			3,
 		);
 		let enc = Tb::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0!tbtesttb\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02!tb\x00\x00\x00\x03");
 
 		let dec = Tb::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/table/tb.rs
+++ b/lib/src/key/table/tb.rs
@@ -1,9 +1,9 @@
-//! Stores the key prefix for all keys under an index
+//! Stores a DEFINE TABLE config definition
 use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-pub struct All<'a> {
+pub struct Tb {
 	__: u8,
 	_a: u8,
 	pub ns: u32,
@@ -12,15 +12,16 @@ pub struct All<'a> {
 	_c: u8,
 	pub tb: u32,
 	_d: u8,
-	pub ix: &'a str,
+	_e: u8,
+	_f: u8,
 }
 
-pub fn new(ns: u32, db: u32, tb: u32, ix: &str) -> All {
-	All::new(ns, db, tb, ix)
+pub fn new(ns: u32, db: u32, tb: u32) -> Tb {
+	Tb::new(ns, db, tb)
 }
 
-impl<'a> All<'a> {
-	pub fn new(ns: u32, db: u32, tb: u32, ix: &'a str) -> Self {
+impl Tb {
+	pub fn new(ns: u32, db: u32, tb: u32) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -29,8 +30,9 @@ impl<'a> All<'a> {
 			db,
 			_c: b'*',
 			tb,
-			_d: b'+',
-			ix,
+			_d: b'!',
+			_e: b't',
+			_f: b'b',
 		}
 	}
 }
@@ -41,16 +43,15 @@ mod tests {
 	fn key() {
 		use super::*;
 		#[rustfmt::skip]
-		let val = All::new(
+		let val = Tb::new(
 			1,
 			2,
 			3,
-			"testix",
 		);
-		let enc = All::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0+testix\0");
+		let enc = Tb::encode(&val).unwrap();
+		assert_eq!(enc, b"/*testns\0*testdb\0!tbtesttb\0");
 
-		let dec = All::decode(&enc).unwrap();
+		let dec = Tb::decode(&enc).unwrap();
 		assert_eq!(val, dec);
 	}
 }

--- a/lib/src/key/thing/mod.rs
+++ b/lib/src/key/thing/mod.rs
@@ -74,7 +74,10 @@ mod tests {
 		let (_, id1) = crate::sql::id::id(id1).expect("Failed to parse the ID");
 		let val = Thing::new(1, 2, 3, id1);
 		let enc = Thing::encode(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03*\0\0\0\x02\0\0\0\x04test\0\x01");
+		assert_eq!(
+			enc,
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03*\0\0\0\x02\0\0\0\x04test\0\x01"
+		);
 
 		let dec = Thing::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/key/thing/mod.rs
+++ b/lib/src/key/thing/mod.rs
@@ -4,36 +4,36 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
-pub struct Thing<'a> {
+pub struct Thing {
 	__: u8,
 	_a: u8,
-	pub ns: &'a str,
+	pub ns: u32,
 	_b: u8,
-	pub db: &'a str,
+	pub db: u32,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: u32,
 	_d: u8,
 	pub id: Id,
 }
 
-pub fn new<'a>(ns: &'a str, db: &'a str, tb: &'a str, id: &Id) -> Thing<'a> {
+pub fn new(ns: u32, db: u32, tb: u32, id: &Id) -> Thing {
 	Thing::new(ns, db, tb, id.to_owned())
 }
 
-pub fn prefix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn prefix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = crate::key::table::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'*', 0x00]);
 	k
 }
 
-pub fn suffix(ns: &str, db: &str, tb: &str) -> Vec<u8> {
+pub fn suffix(ns: u32, db: u32, tb: u32) -> Vec<u8> {
 	let mut k = crate::key::table::all::new(ns, db, tb).encode().unwrap();
 	k.extend_from_slice(&[b'*', 0xff]);
 	k
 }
 
-impl<'a> Thing<'a> {
-	pub fn new(ns: &'a str, db: &'a str, tb: &'a str, id: Id) -> Self {
+impl Thing {
+	pub fn new(ns: u32, db: u32, tb: u32, id: Id) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -55,9 +55,9 @@ mod tests {
 		use super::*;
 		#[rustfmt::skip]
 		let val = Thing::new(
-			"testns",
-			"testdb",
-			"testtb",
+			1,
+			2,
+			3,
 			"testid".into(),
 		);
 		let enc = Thing::encode(&val).unwrap();
@@ -72,7 +72,7 @@ mod tests {
 		//
 		let id1 = "['test']";
 		let (_, id1) = crate::sql::id::id(id1).expect("Failed to parse the ID");
-		let val = Thing::new("testns", "testdb", "testtb", id1);
+		let val = Thing::new(1, 2, 3, id1);
 		let enc = Thing::encode(&val).unwrap();
 		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0*\0\0\0\x02\0\0\0\x04test\0\x01");
 
@@ -82,7 +82,7 @@ mod tests {
 		//
 		let id2 = "['f8e238f2-e734-47b8-9a16-476b291bd78a']";
 		let (_, id2) = crate::sql::id::id(id2).expect("Failed to parse the ID");
-		let val = Thing::new("testns", "testdb", "testtb", id2);
+		let val = Thing::new(1, 2, 3, id2);
 		let enc = Thing::encode(&val).unwrap();
 		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0*\0\0\0\x02\0\0\0\x07\xf8\xe2\x38\xf2\xe7\x34\x47\xb8\x9a\x16\x47\x6b\x29\x1b\xd7\x8a\x01");
 

--- a/lib/src/key/thing/mod.rs
+++ b/lib/src/key/thing/mod.rs
@@ -61,7 +61,7 @@ mod tests {
 			"testid".into(),
 		);
 		let enc = Thing::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0*\0\0\0\x01testid\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03*\0\0\0\x01testid\0");
 
 		let dec = Thing::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -74,7 +74,7 @@ mod tests {
 		let (_, id1) = crate::sql::id::id(id1).expect("Failed to parse the ID");
 		let val = Thing::new(1, 2, 3, id1);
 		let enc = Thing::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0*\0\0\0\x02\0\0\0\x04test\0\x01");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03*\0\0\0\x02\0\0\0\x04test\0\x01");
 
 		let dec = Thing::decode(&enc).unwrap();
 		assert_eq!(val, dec);
@@ -84,7 +84,7 @@ mod tests {
 		let (_, id2) = crate::sql::id::id(id2).expect("Failed to parse the ID");
 		let val = Thing::new(1, 2, 3, id2);
 		let enc = Thing::encode(&val).unwrap();
-		assert_eq!(enc, b"/*testns\0*testdb\0*testtb\0*\0\0\0\x02\0\0\0\x07\xf8\xe2\x38\xf2\xe7\x34\x47\xb8\x9a\x16\x47\x6b\x29\x1b\xd7\x8a\x01");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*\x00\x00\x00\x03*\0\0\0\x02\0\0\0\x07\xf8\xe2\x38\xf2\xe7\x34\x47\xb8\x9a\x16\x47\x6b\x29\x1b\xd7\x8a\x01");
 
 		let dec = Thing::decode(&enc).unwrap();
 		assert_eq!(val, dec);

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -25,7 +25,6 @@ use channel::Receiver;
 use channel::Sender;
 use futures::lock::Mutex;
 use futures::Future;
-use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
@@ -735,7 +734,6 @@ impl Datastore {
 			inner,
 			cache: super::cache::Cache::default(),
 			cf: cf::Writer::new(),
-			write_buffer: HashMap::new(),
 			vso: self.vso.clone(),
 		})
 	}

--- a/lib/src/kvs/tests/tb.rs
+++ b/lib/src/kvs/tests/tb.rs
@@ -11,8 +11,8 @@ async fn table_definitions_can_be_scanned() {
 	let mut tx = test.db.transaction(true, false).await.unwrap();
 
 	// Create a table definition
-	let namespace = "test_namespace";
-	let database = "test_database";
+	let namespace = 1;
+	let database = 2;
 	let table = "test_table";
 	let key = Tb::new(namespace, database, table);
 	let value = DefineTableStatement {
@@ -48,8 +48,8 @@ async fn table_definitions_can_be_deleted() {
 	let mut tx = test.db.transaction(true, false).await.unwrap();
 
 	// Create a table definition
-	let namespace = "test_namespace";
-	let database = "test_database";
+	let namespace = 1;
+	let database = 2;
 	let table = "test_table";
 	let key = Tb::new(namespace, database, table);
 	let value = DefineTableStatement {

--- a/lib/src/kvs/tests/timestamp_to_versionstamp.rs
+++ b/lib/src/kvs/tests/timestamp_to_versionstamp.rs
@@ -17,26 +17,32 @@ async fn timestamp_to_versionstamp() {
 	// Give the current versionstamp a timestamp of 0
 	let mut tx = ds.transaction(true, false).await.unwrap();
 	tx.set_timestamp_for_versionstamp(0, "myns", "mydb", true).await.unwrap();
+	tx.complete_changes(false).await.unwrap();
 	tx.commit().await.unwrap();
 	// Get the versionstamp for timestamp 0
 	let mut tx = ds.transaction(true, false).await.unwrap();
 	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb", true).await.unwrap().unwrap();
+	tx.complete_changes(false).await.unwrap();
 	tx.commit().await.unwrap();
 	// Give the current versionstamp a timestamp of 1
 	let mut tx = ds.transaction(true, false).await.unwrap();
 	tx.set_timestamp_for_versionstamp(1, "myns", "mydb", true).await.unwrap();
+	tx.complete_changes(false).await.unwrap();
 	tx.commit().await.unwrap();
 	// Get the versionstamp for timestamp 1
 	let mut tx = ds.transaction(true, false).await.unwrap();
 	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb", true).await.unwrap().unwrap();
+	tx.complete_changes(false).await.unwrap();
 	tx.commit().await.unwrap();
 	// Give the current versionstamp a timestamp of 2
 	let mut tx = ds.transaction(true, false).await.unwrap();
 	tx.set_timestamp_for_versionstamp(2, "myns", "mydb", true).await.unwrap();
+	tx.complete_changes(false).await.unwrap();
 	tx.commit().await.unwrap();
 	// Get the versionstamp for timestamp 2
 	let mut tx = ds.transaction(true, false).await.unwrap();
 	let vs3 = tx.get_versionstamp_from_timestamp(2, "myns", "mydb", true).await.unwrap().unwrap();
+	tx.complete_changes(false).await.unwrap();
 	tx.commit().await.unwrap();
 	assert!(vs1 < vs2);
 	assert!(vs2 < vs3);

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -1650,15 +1650,22 @@ impl Transaction {
 	) -> Result<Arc<[DefineFieldStatement]>, Error> {
 		let (ns, db, tb) = match self.get_ns_db_tb_ids(ns, db, tb).await {
 			Ok(v) => v,
-			Err(Error::NsNotFound {
-				..
-			})
-			| Err(Error::DbNotFound {
-				..
-			})
-			| Err(Error::TbNotFound {
-				..
-			}) => {
+			Err(
+				e @ Error::NsNotFound {
+					..
+				},
+			)
+			| Err(
+				e @ Error::DbNotFound {
+					..
+				},
+			)
+			| Err(
+				e @ Error::TbNotFound {
+					..
+				},
+			) => {
+				trace!("Failed to find fields for table {:?}: {:?}", tb, e);
 				return Ok(Arc::new([]));
 			}
 			Err(e) => return Err(e),

--- a/lib/src/sql/statements/define/analyzer.rs
+++ b/lib/src/sql/statements/define/analyzer.rs
@@ -45,9 +45,9 @@ impl DefineAnalyzerStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Process the statement
-		let key = crate::key::database::az::new(opt.ns(), opt.db(), &self.name);
-		run.add_ns(opt.ns(), opt.strict).await?;
-		run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+		let ns = run.add_ns(opt.ns(), opt.strict).await?;
+		let db = run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+		let key = crate::key::database::az::new(ns.id.unwrap(), db.id.unwrap(), &self.name);
 		run.set(key, self).await?;
 		// Release the transaction
 		drop(run); // Do we really need this?

--- a/lib/src/sql/statements/define/database.rs
+++ b/lib/src/sql/statements/define/database.rs
@@ -50,8 +50,14 @@ impl DefineDatabaseStatement {
 		let key = crate::key::namespace::db::new(ns, &self.name);
 		// Set the id
 		let (id, db) = if self.id.is_none() {
+			let id = match run.get_db_id(opt.ns(), self.name.as_str()).await {
+				Ok(id) => id,
+				Err(Error::DbNotFound {
+					value: _,
+				}) => run.get_next_db_id(ns).await?,
+				Err(err) => return Err(err),
+			};
 			let mut db = self.clone();
-			let id = run.get_next_db_id(ns).await?;
 			db.id = Some(id);
 			// Store the db
 			let db2 = db.clone();

--- a/lib/src/sql/statements/define/event.rs
+++ b/lib/src/sql/statements/define/event.rs
@@ -47,13 +47,16 @@ impl DefineEventStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Process the statement
-		let key = crate::key::table::ev::new(opt.ns(), opt.db(), &self.what, &self.name);
-		run.add_ns(opt.ns(), opt.strict).await?;
-		run.add_db(opt.ns(), opt.db(), opt.strict).await?;
-		run.add_tb(opt.ns(), opt.db(), &self.what, opt.strict).await?;
+		let ns = run.add_ns(opt.ns(), opt.strict).await?;
+		let ns = ns.id.unwrap();
+		let db = run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+		let db = db.id.unwrap();
+		let tb = run.add_tb(opt.ns(), opt.db(), &self.what, opt.strict).await?;
+		let tb = tb.id.unwrap();
+		let key = crate::key::table::ev::new(ns, db, tb, &self.name);
 		run.set(key, self).await?;
 		// Clear the cache
-		let key = crate::key::table::ev::prefix(opt.ns(), opt.db(), &self.what);
+		let key = crate::key::table::ev::prefix(ns, db, tb);
 		run.clr(key).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/define/field.rs
+++ b/lib/src/sql/statements/define/field.rs
@@ -56,13 +56,16 @@ impl DefineFieldStatement {
 		run.clear_cache();
 		// Process the statement
 		let fd = self.name.to_string();
-		let key = crate::key::table::fd::new(opt.ns(), opt.db(), &self.what, &fd);
-		run.add_ns(opt.ns(), opt.strict).await?;
-		run.add_db(opt.ns(), opt.db(), opt.strict).await?;
-		run.add_tb(opt.ns(), opt.db(), &self.what, opt.strict).await?;
+		let ns = run.add_ns(opt.ns(), opt.strict).await?;
+		let ns = ns.id.unwrap();
+		let db = run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+		let db = db.id.unwrap();
+		let tb = run.add_tb(opt.ns(), opt.db(), &self.what, opt.strict).await?;
+		let tb = tb.id.unwrap();
+		let key = crate::key::table::fd::new(ns, db, tb, &fd);
 		run.set(key, self).await?;
 		// Clear the cache
-		let key = crate::key::table::fd::prefix(opt.ns(), opt.db(), &self.what);
+		let key = crate::key::table::fd::prefix(ns, db, tb);
 		run.clr(key).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/define/function.rs
+++ b/lib/src/sql/statements/define/function.rs
@@ -50,10 +50,11 @@ impl DefineFunctionStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Process the statement
-		let (ns, db) = run.get_ns_db_ids(opt.ns(), opt.db()).await?;
+		let db = run.add_and_cache_db(opt.ns(), opt.db(), opt.strict).await?;
+		let db = db.id.unwrap();
+		let ns = run.add_and_cache_ns(opt.ns(), opt.strict).await?;
+		let ns = ns.id.unwrap();
 		let key = crate::key::database::fc::new(ns, db, &self.name);
-		run.add_ns(opt.ns(), opt.strict).await?;
-		run.add_db(opt.ns(), opt.db(), opt.strict).await?;
 		run.set(key, self).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/define/function.rs
+++ b/lib/src/sql/statements/define/function.rs
@@ -50,7 +50,8 @@ impl DefineFunctionStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Process the statement
-		let key = crate::key::database::fc::new(opt.ns(), opt.db(), &self.name);
+		let (ns, db) = run.get_ns_db_ids(opt.ns(), opt.db()).await?;
+		let key = crate::key::database::fc::new(ns, db, &self.name);
 		run.add_ns(opt.ns(), opt.strict).await?;
 		run.add_db(opt.ns(), opt.db(), opt.strict).await?;
 		run.set(key, self).await?;

--- a/lib/src/sql/statements/define/index.rs
+++ b/lib/src/sql/statements/define/index.rs
@@ -52,16 +52,19 @@ impl DefineIndexStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Process the statement
-		let key = crate::key::table::ix::new(opt.ns(), opt.db(), &self.what, &self.name);
-		run.add_ns(opt.ns(), opt.strict).await?;
-		run.add_db(opt.ns(), opt.db(), opt.strict).await?;
-		run.add_tb(opt.ns(), opt.db(), &self.what, opt.strict).await?;
+		let ns = run.add_ns(opt.ns(), opt.strict).await?;
+		let ns = ns.id.unwrap();
+		let db = run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+		let db = db.id.unwrap();
+		let tb = run.add_tb(opt.ns(), opt.db(), &self.what, opt.strict).await?;
+		let tb = tb.id.unwrap();
+		let key = crate::key::table::ix::new(ns, db, tb, &self.name);
 		run.set(key, self).await?;
 		// Remove the index data
-		let key = crate::key::index::all::new(opt.ns(), opt.db(), &self.what, &self.name);
+		let key = crate::key::index::all::new(ns, db, tb, &self.name);
 		run.delp(key, u32::MAX).await?;
 		// Clear the cache
-		let key = crate::key::table::ix::prefix(opt.ns(), opt.db(), &self.what);
+		let key = crate::key::table::ix::prefix(ns, db, tb);
 		run.clr(key).await?;
 		// Release the transaction
 		drop(run);

--- a/lib/src/sql/statements/define/namespace.rs
+++ b/lib/src/sql/statements/define/namespace.rs
@@ -46,8 +46,14 @@ impl DefineNamespaceStatement {
 		run.clear_cache();
 		// Set the id
 		let (id, ns) = if self.id.is_none() {
+			let id = match run.get_ns_id(self.name.as_str()).await {
+				Ok(id) => id,
+				Err(Error::NsNotFound {
+					value: _,
+				}) => run.get_next_ns_id().await?,
+				Err(err) => return Err(err),
+			};
 			let mut ns = self.clone();
-			let id = run.get_next_ns_id().await?;
 			ns.id = Some(id);
 			let ns2 = ns.clone();
 			run.set(key, ns).await?;

--- a/lib/src/sql/statements/define/namespace.rs
+++ b/lib/src/sql/statements/define/namespace.rs
@@ -45,13 +45,19 @@ impl DefineNamespaceStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Set the id
-		if self.id.is_none() {
+		let (id, ns) = if self.id.is_none() {
 			let mut ns = self.clone();
-			ns.id = Some(run.get_next_ns_id().await?);
+			let id = run.get_next_ns_id().await?;
+			ns.id = Some(id);
+			let ns2 = ns.clone();
 			run.set(key, ns).await?;
+			(id, ns2)
 		} else {
 			run.set(key, self).await?;
-		}
+			(self.id.unwrap(), self.clone())
+		};
+		let key = crate::key::namespace::ns::new(id);
+		run.set(key, ns).await?;
 		// Ok all good
 		Ok(Value::None)
 	}

--- a/lib/src/sql/statements/define/param.rs
+++ b/lib/src/sql/statements/define/param.rs
@@ -44,9 +44,11 @@ impl DefineParamStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Process the statement
-		let key = crate::key::database::pa::new(opt.ns(), opt.db(), &self.name);
-		run.add_ns(opt.ns(), opt.strict).await?;
-		run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+		let ns = run.add_ns(opt.ns(), opt.strict).await?;
+		let ns = ns.id.unwrap();
+		let db = run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+		let db = db.id.unwrap();
+		let key = crate::key::database::pa::new(ns, db, &self.name);
 		run.set(key, self).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/define/scope.rs
+++ b/lib/src/sql/statements/define/scope.rs
@@ -49,9 +49,11 @@ impl DefineScopeStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Process the statement
-		let key = crate::key::database::sc::new(opt.ns(), opt.db(), &self.name);
-		run.add_ns(opt.ns(), opt.strict).await?;
-		run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+		let ns = run.add_ns(opt.ns(), opt.strict).await?;
+		let ns = ns.id.unwrap();
+		let db = run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+		let db = db.id.unwrap();
+		let key = crate::key::database::sc::new(ns, db, &self.name);
 		run.set(key, self).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/define/table.rs
+++ b/lib/src/sql/statements/define/table.rs
@@ -59,8 +59,14 @@ impl DefineTableStatement {
 		let db = db.id.unwrap();
 		let key = crate::key::database::tb::new(ns, db, &self.name);
 		let (id, tb) = if self.id.is_none() {
+			let id = match run.get_tb_id_by_name(ns, db, self.name.as_str()).await {
+				Ok(id) => id,
+				Err(Error::TbNotFound {
+					value: _,
+				}) => run.get_next_tb_id(ns, db).await?,
+				Err(err) => return Err(err),
+			};
 			let mut tb = self.clone();
-			let id = run.get_next_tb_id(ns, db).await?;
 			tb.id = Some(id);
 			let tb2 = tb.clone();
 			run.set(key, tb).await?;

--- a/lib/src/sql/statements/define/token.rs
+++ b/lib/src/sql/statements/define/token.rs
@@ -49,8 +49,9 @@ impl DefineTokenStatement {
 				// Clear the cache
 				run.clear_cache();
 				// Process the statement
-				let key = crate::key::namespace::tk::new(opt.ns(), &self.name);
-				run.add_ns(opt.ns(), opt.strict).await?;
+				let ns = run.add_ns(opt.ns(), opt.strict).await?;
+				let ns = ns.id.unwrap();
+				let key = crate::key::namespace::tk::new(ns, &self.name);
 				run.set(key, self).await?;
 				// Ok all good
 				Ok(Value::None)
@@ -61,9 +62,11 @@ impl DefineTokenStatement {
 				// Clear the cache
 				run.clear_cache();
 				// Process the statement
-				let key = crate::key::database::tk::new(opt.ns(), opt.db(), &self.name);
-				run.add_ns(opt.ns(), opt.strict).await?;
-				run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+				let ns = run.add_ns(opt.ns(), opt.strict).await?;
+				let ns = ns.id.unwrap();
+				let db = run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+				let db = db.id.unwrap();
+				let key = crate::key::database::tk::new(ns, db, &self.name);
 				run.set(key, self).await?;
 				// Ok all good
 				Ok(Value::None)

--- a/lib/src/sql/statements/define/user.rs
+++ b/lib/src/sql/statements/define/user.rs
@@ -92,8 +92,9 @@ impl DefineUserStatement {
 				// Clear the cache
 				run.clear_cache();
 				// Process the statement
-				let key = crate::key::namespace::us::new(opt.ns(), &self.name);
-				run.add_ns(opt.ns(), opt.strict).await?;
+				let ns = run.add_ns(opt.ns(), opt.strict).await?;
+				let ns = ns.id.unwrap();
+				let key = crate::key::namespace::us::new(ns, &self.name);
 				run.set(key, self).await?;
 				// Ok all good
 				Ok(Value::None)
@@ -104,9 +105,11 @@ impl DefineUserStatement {
 				// Clear the cache
 				run.clear_cache();
 				// Process the statement
-				let key = crate::key::database::us::new(opt.ns(), opt.db(), &self.name);
-				run.add_ns(opt.ns(), opt.strict).await?;
-				run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+				let ns = run.add_ns(opt.ns(), opt.strict).await?;
+				let ns = ns.id.unwrap();
+				let db = run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+				let db = db.id.unwrap();
+				let key = crate::key::database::us::new(ns, db, &self.name);
 				run.set(key, self).await?;
 				// Ok all good
 				Ok(Value::None)

--- a/lib/src/sql/statements/kill.rs
+++ b/lib/src/sql/statements/kill.rs
@@ -67,7 +67,8 @@ impl KillStatement {
 						crate::key::node::lq::new(opt.id()?, live_query_id.0, opt.ns(), opt.db());
 					run.del(key).await?;
 					// Delete the table live query
-					let key = crate::key::table::lq::new(opt.ns(), opt.db(), tb, live_query_id.0);
+					let (ns, db, tb) = run.get_ns_db_tb_ids(opt.ns(), opt.db(), tb).await?;
+					let key = crate::key::table::lq::new(ns, db, tb, live_query_id.0);
 					run.del(key).await?;
 				}
 				_ => {

--- a/lib/src/sql/statements/remove/analyzer.rs
+++ b/lib/src/sql/statements/remove/analyzer.rs
@@ -34,7 +34,8 @@ impl RemoveAnalyzerStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Delete the definition
-		let key = crate::key::database::az::new(opt.ns(), opt.db(), &self.name);
+		let (ns, db) = run.get_ns_db_ids(opt.ns(), opt.db()).await?;
+		let key = crate::key::database::az::new(ns, db, &self.name);
 		run.del(key).await?;
 		// TODO Check that the analyzer is not used in any schema
 		// Ok all good

--- a/lib/src/sql/statements/remove/database.rs
+++ b/lib/src/sql/statements/remove/database.rs
@@ -35,11 +35,16 @@ impl RemoveDatabaseStatement {
 		let mut run = txn.lock().await;
 		// Clear the cache
 		run.clear_cache();
+		// Get ids
+		let (ns, db) = run.get_ns_db_ids(opt.ns(), &self.name).await?;
+		// Delete the alias
+		let key = crate::key::namespace::db::new(ns, &self.name);
+		run.del(key).await?;
 		// Delete the definition
-		let key = crate::key::namespace::db::new(opt.ns(), &self.name);
+		let key = crate::key::database::db::new(ns, db);
 		run.del(key).await?;
 		// Delete the resource data
-		let key = crate::key::database::all::new(opt.ns(), &self.name);
+		let key = crate::key::database::all::new(ns, db);
 		run.delp(key, u32::MAX).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/remove/event.rs
+++ b/lib/src/sql/statements/remove/event.rs
@@ -38,10 +38,11 @@ impl RemoveEventStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Delete the definition
-		let key = crate::key::table::ev::new(opt.ns(), opt.db(), &self.what, &self.name);
+		let (ns, db, tb) = run.get_ns_db_tb_ids(opt.ns(), opt.db(), &self.what).await?;
+		let key = crate::key::table::ev::new(ns, db, tb, &self.name);
 		run.del(key).await?;
 		// Clear the cache
-		let key = crate::key::table::ev::prefix(opt.ns(), opt.db(), &self.what);
+		let key = crate::key::table::ev::prefix(ns, db, tb);
 		run.clr(key).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/remove/field.rs
+++ b/lib/src/sql/statements/remove/field.rs
@@ -41,10 +41,11 @@ impl RemoveFieldStatement {
 		run.clear_cache();
 		// Delete the definition
 		let fd = self.name.to_string();
-		let key = crate::key::table::fd::new(opt.ns(), opt.db(), &self.what, &fd);
+		let (ns, db, tb) = run.get_ns_db_tb_ids(opt.ns(), opt.db(), &self.what).await?;
+		let key = crate::key::table::fd::new(ns, db, tb, &fd);
 		run.del(key).await?;
 		// Clear the cache
-		let key = crate::key::table::fd::prefix(opt.ns(), opt.db(), &self.what);
+		let key = crate::key::table::fd::prefix(ns, db, tb);
 		run.clr(key).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/remove/function.rs
+++ b/lib/src/sql/statements/remove/function.rs
@@ -39,7 +39,8 @@ impl RemoveFunctionStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Delete the definition
-		let key = crate::key::database::fc::new(opt.ns(), opt.db(), &self.name);
+		let (ns, db) = run.get_ns_db_ids(opt.ns(), opt.db()).await?;
+		let key = crate::key::database::fc::new(ns, db, &self.name);
 		run.del(key).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/remove/namespace.rs
+++ b/lib/src/sql/statements/remove/namespace.rs
@@ -35,11 +35,16 @@ impl RemoveNamespaceStatement {
 		let mut run = txn.lock().await;
 		// Clear the cache
 		run.clear_cache();
-		// Delete the definition
+		// Get the id
+		let ns = run.get_ns_id(opt.ns()).await?;
+		// Delete the alias
 		let key = crate::key::root::ns::new(&self.name);
 		run.del(key).await?;
+		// Delete the definition
+		let key = crate::key::namespace::ns::new(ns);
+		run.del(key).await?;
 		// Delete the resource data
-		let key = crate::key::namespace::all::new(&self.name);
+		let key = crate::key::namespace::all::new(ns);
 		run.delp(key, u32::MAX).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/remove/param.rs
+++ b/lib/src/sql/statements/remove/param.rs
@@ -36,7 +36,10 @@ impl RemoveParamStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Delete the definition
-		let key = crate::key::database::pa::new(opt.ns(), opt.db(), &self.name);
+		let ns_db = run.get_ns_db_ids(opt.ns(), opt.db()).await?;
+		let ns = ns_db.0;
+		let db = ns_db.1;
+		let key = crate::key::database::pa::new(ns, db, &self.name);
 		run.del(key).await?;
 		// Ok all good
 		Ok(Value::None)

--- a/lib/src/sql/statements/remove/scope.rs
+++ b/lib/src/sql/statements/remove/scope.rs
@@ -35,7 +35,10 @@ impl RemoveScopeStatement {
 		// Clear the cache
 		run.clear_cache();
 		// Delete the definition
-		let key = crate::key::database::sc::new(opt.ns(), opt.db(), &self.name);
+		let ns_db = run.get_ns_db_ids(opt.ns(), opt.db()).await?;
+		let ns = ns_db.0;
+		let db = ns_db.1;
+		let key = crate::key::database::sc::new(ns, db, &self.name);
 		run.del(key).await?;
 		// Remove the resource data
 		let key = crate::key::scope::all::new(opt.ns(), opt.db(), &self.name);

--- a/lib/src/sql/statements/remove/token.rs
+++ b/lib/src/sql/statements/remove/token.rs
@@ -39,7 +39,9 @@ impl RemoveTokenStatement {
 				// Clear the cache
 				run.clear_cache();
 				// Delete the definition
-				let key = crate::key::namespace::tk::new(opt.ns(), &self.name);
+				let ns = run.get_ns(opt.ns()).await?;
+				let ns = ns.id.unwrap();
+				let key = crate::key::namespace::tk::new(ns, &self.name);
 				run.del(key).await?;
 				// Ok all good
 				Ok(Value::None)
@@ -50,7 +52,11 @@ impl RemoveTokenStatement {
 				// Clear the cache
 				run.clear_cache();
 				// Delete the definition
-				let key = crate::key::database::tk::new(opt.ns(), opt.db(), &self.name);
+				let ns = run.get_ns(opt.ns()).await?;
+				let ns = ns.id.unwrap();
+				let db = run.get_db(opt.ns(), opt.db()).await?;
+				let db = db.id.unwrap();
+				let key = crate::key::database::tk::new(ns, db, &self.name);
 				run.del(key).await?;
 				// Ok all good
 				Ok(Value::None)

--- a/lib/src/sql/statements/remove/user.rs
+++ b/lib/src/sql/statements/remove/user.rs
@@ -50,7 +50,9 @@ impl RemoveUserStatement {
 				// Clear the cache
 				run.clear_cache();
 				// Delete the definition
-				let key = crate::key::namespace::us::new(opt.ns(), &self.name);
+				let ns = run.get_ns(opt.ns()).await?;
+				let ns = ns.id.unwrap();
+				let key = crate::key::namespace::us::new(ns, &self.name);
 				run.del(key).await?;
 				// Ok all good
 				Ok(Value::None)
@@ -61,7 +63,11 @@ impl RemoveUserStatement {
 				// Clear the cache
 				run.clear_cache();
 				// Delete the definition
-				let key = crate::key::database::us::new(opt.ns(), opt.db(), &self.name);
+				let ns = run.get_ns(opt.ns()).await?;
+				let ns = ns.id.unwrap();
+				let db = run.get_db(opt.db(), opt.db()).await?;
+				let db = db.id.unwrap();
+				let key = crate::key::database::us::new(ns, db, &self.name);
 				run.del(key).await?;
 				// Ok all good
 				Ok(Value::None)

--- a/lib/src/sql/statements/remove/user.rs
+++ b/lib/src/sql/statements/remove/user.rs
@@ -65,7 +65,7 @@ impl RemoveUserStatement {
 				// Delete the definition
 				let ns = run.get_ns(opt.ns()).await?;
 				let ns = ns.id.unwrap();
-				let db = run.get_db(opt.db(), opt.db()).await?;
+				let db = run.get_db(opt.ns(), opt.db()).await?;
 				let db = db.id.unwrap();
 				let key = crate::key::database::us::new(ns, db, &self.name);
 				run.del(key).await?;

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -79,6 +79,7 @@ mod api_integration {
 	#[cfg(feature = "protocol-ws")]
 	mod ws {
 		use super::*;
+		use serial_test::serial;
 		use surrealdb::engine::remote::ws::Client;
 		use surrealdb::engine::remote::ws::Ws;
 
@@ -101,6 +102,7 @@ mod api_integration {
 	#[cfg(feature = "protocol-http")]
 	mod http {
 		use super::*;
+		use serial_test::serial;
 		use surrealdb::engine::remote::http::Client;
 		use surrealdb::engine::remote::http::Http;
 
@@ -124,6 +126,7 @@ mod api_integration {
 	#[cfg(feature = "kv-mem")]
 	mod mem {
 		use super::*;
+		use serial_test::serial;
 		use surrealdb::engine::any;
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::Mem;
@@ -217,6 +220,7 @@ mod api_integration {
 	#[cfg(feature = "kv-rocksdb")]
 	mod file {
 		use super::*;
+		use serial_test::serial;
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::File;
 
@@ -244,6 +248,7 @@ mod api_integration {
 	#[cfg(feature = "kv-rocksdb")]
 	mod rocksdb {
 		use super::*;
+		use serial_test::serial;
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::RocksDb;
 
@@ -271,6 +276,7 @@ mod api_integration {
 	#[cfg(feature = "kv-speedb")]
 	mod speedb {
 		use super::*;
+		use serial_test::serial;
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::SpeeDb;
 
@@ -352,6 +358,7 @@ mod api_integration {
 	#[cfg(feature = "protocol-http")]
 	mod any {
 		use super::*;
+		use serial_test::serial;
 		use surrealdb::engine::any::Any;
 
 		async fn new_db() -> Surreal<Any> {

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -298,6 +298,7 @@ mod api_integration {
 	#[cfg(feature = "kv-tikv")]
 	mod tikv {
 		use super::*;
+		use serial_test::serial;
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::TiKv;
 
@@ -324,6 +325,7 @@ mod api_integration {
 	#[cfg(feature = "kv-fdb")]
 	mod fdb {
 		use super::*;
+		use serial_test::serial;
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::FDb;
 

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -1,12 +1,14 @@
 // Tests common to all protocols and storage engines
 
 #[tokio::test]
+#[serial]
 async fn connect() {
 	let db = new_db().await;
 	db.health().await.unwrap();
 }
 
 #[tokio::test]
+#[serial]
 async fn yuse() {
 	let db = new_db().await;
 	let item = Ulid::new().to_string();
@@ -30,6 +32,7 @@ async fn yuse() {
 }
 
 #[tokio::test]
+#[serial]
 async fn invalidate() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -43,6 +46,7 @@ async fn invalidate() {
 }
 
 #[tokio::test]
+#[serial]
 async fn signup_scope() {
 	let db = new_db().await;
 	let database = Ulid::new().to_string();
@@ -71,6 +75,7 @@ async fn signup_scope() {
 }
 
 #[tokio::test]
+#[serial]
 async fn signin_ns() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -89,6 +94,7 @@ async fn signin_ns() {
 }
 
 #[tokio::test]
+#[serial]
 async fn signin_db() {
 	let db = new_db().await;
 	let database = Ulid::new().to_string();
@@ -109,6 +115,7 @@ async fn signin_db() {
 }
 
 #[tokio::test]
+#[serial]
 async fn signin_scope() {
 	let db = new_db().await;
 	let database = Ulid::new().to_string();
@@ -150,6 +157,7 @@ async fn signin_scope() {
 }
 
 #[tokio::test]
+#[serial]
 async fn authenticate() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -170,6 +178,7 @@ async fn authenticate() {
 }
 
 #[tokio::test]
+#[serial]
 async fn query() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -192,6 +201,7 @@ async fn query() {
 }
 
 #[tokio::test]
+#[serial]
 async fn query_binds() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -224,9 +234,10 @@ async fn query_binds() {
 }
 
 #[tokio::test]
+#[serial]
 async fn query_chaining() {
 	let db = new_db().await;
-	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+	db.use_ns(Ulid::new().to_string()).use_db(Ulid::new().to_string()).await.unwrap();
 	let response = db
 		.query(BeginStatement)
 		.query("CREATE account:one SET balance = 135605.16")
@@ -240,6 +251,7 @@ async fn query_chaining() {
 }
 
 #[tokio::test]
+#[serial]
 async fn mixed_results_query() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -250,6 +262,7 @@ async fn mixed_results_query() {
 }
 
 #[tokio::test]
+#[serial]
 async fn create_record_no_id() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -258,6 +271,7 @@ async fn create_record_no_id() {
 }
 
 #[tokio::test]
+#[serial]
 async fn create_record_with_id() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -267,6 +281,7 @@ async fn create_record_with_id() {
 }
 
 #[tokio::test]
+#[serial]
 async fn create_record_no_id_with_content() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -287,6 +302,7 @@ async fn create_record_no_id_with_content() {
 }
 
 #[tokio::test]
+#[serial]
 async fn create_record_with_id_with_content() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -309,6 +325,7 @@ async fn create_record_with_id_with_content() {
 }
 
 #[tokio::test]
+#[serial]
 async fn select_table() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -321,6 +338,7 @@ async fn select_table() {
 }
 
 #[tokio::test]
+#[serial]
 async fn select_record_id() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -335,6 +353,7 @@ async fn select_record_id() {
 }
 
 #[tokio::test]
+#[serial]
 async fn select_record_ranges() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -370,6 +389,7 @@ async fn select_record_ranges() {
 }
 
 #[tokio::test]
+#[serial]
 async fn update_table() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -382,6 +402,7 @@ async fn update_table() {
 }
 
 #[tokio::test]
+#[serial]
 async fn update_record_id() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -393,6 +414,7 @@ async fn update_record_id() {
 }
 
 #[tokio::test]
+#[serial]
 async fn update_table_with_content() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -436,6 +458,7 @@ async fn update_table_with_content() {
 }
 
 #[tokio::test]
+#[serial]
 async fn update_record_range_with_content() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -494,6 +517,7 @@ async fn update_record_range_with_content() {
 }
 
 #[tokio::test]
+#[serial]
 async fn update_record_id_with_content() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -534,6 +558,7 @@ struct Person {
 }
 
 #[tokio::test]
+#[serial]
 async fn merge_record_id() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -570,6 +595,7 @@ async fn merge_record_id() {
 }
 
 #[tokio::test]
+#[serial]
 async fn patch_record_id() {
 	#[derive(Debug, Deserialize, Eq, PartialEq)]
 	struct Record {
@@ -608,6 +634,7 @@ async fn patch_record_id() {
 }
 
 #[tokio::test]
+#[serial]
 async fn delete_table() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -624,6 +651,7 @@ async fn delete_table() {
 }
 
 #[tokio::test]
+#[serial]
 async fn delete_record_id() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -642,6 +670,7 @@ async fn delete_record_id() {
 }
 
 #[tokio::test]
+#[serial]
 async fn delete_record_range() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -685,6 +714,7 @@ async fn delete_record_range() {
 }
 
 #[tokio::test]
+#[serial]
 async fn changefeed() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -836,12 +866,14 @@ async fn changefeed() {
 }
 
 #[tokio::test]
+#[serial]
 async fn version() {
 	let db = new_db().await;
 	db.version().await.unwrap();
 }
 
 #[tokio::test]
+#[serial]
 async fn set_unset() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
@@ -860,6 +892,7 @@ async fn set_unset() {
 }
 
 #[tokio::test]
+#[serial]
 async fn return_bool() {
 	let db = new_db().await;
 	let mut response = db.query("RETURN true").await.unwrap();

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -184,7 +184,7 @@ async fn create_with_custom_function() -> Result<(), Error> {
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result;
-	assert!(tmp.is_ok());
+	assert!(tmp.is_ok(), "failed to create function: {:?}", tmp);
 	//
 	let tmp = res.remove(0).result?.pick(&[Part::from("data")]);
 	let val = Value::parse(

--- a/lib/tests/helpers.rs
+++ b/lib/tests/helpers.rs
@@ -56,9 +56,12 @@ pub async fn iam_run_case(
 		for (i, r) in resp.into_iter().enumerate() {
 			let tmp = r.output();
 			if tmp.is_err() {
-				return Err(
-					format!("Check statement errored for test: {}", tmp.unwrap_err()).into()
-				);
+				return Err(format!(
+					"Check statement errored for test: {}: {}",
+					check,
+					tmp.unwrap_err()
+				)
+				.into());
 			}
 
 			let tmp = tmp.unwrap().to_string();

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -116,8 +116,12 @@ async fn remove_statement_index() -> Result<(), Error> {
 	assert_eq!(tmp, val);
 
 	let mut tx = dbs.transaction(false, false).await?;
+	let (ns, db, tb) = tx.check_ns_db_tb("test", "test", "book", true).await?.unwrap();
+	tx.cancel().await?;
+
+	let mut tx = dbs.transaction(false, false).await?;
 	for ix in ["uniq_isbn", "idx_author", "ft_title"] {
-		assert_empty_prefix!(&mut tx, surrealdb::key::index::all::new("test", "test", "book", ix));
+		assert_empty_prefix!(&mut tx, surrealdb::key::index::all::new(ns, db, tb, ix));
 	}
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

This introduces aliases to namespaces, databases, and tables.

For example, a "table alias" has a "table name" and the ID of the "table instance".
The ID never changes. The table name can be changed without changing the ID and moving all the "things" in it.
All in all, this enables SurrealDB support "table renaming" in the future.

Old model: The table name is the ID, and you cannot easily change the name without moving all the things in it(=all the relevant KVS keys that share the prefix).
New model: The table name and the table ID are separate things. You can change the table name easily (once we implement something like `RENAME TABLE`).

As we introduce aliases to namespaces and databases too, merging this results in giving foundations for namespace and database renaming as well.

## What does this change do?

- Change namespace, database, and table IDs from `&str` to `u32`.
- Add three new keys for mapping from namespace/database/table names to their respective IDs.
- Fix all the affected sub-keys under `/*{ns}`(`crate::key::namespace::all`), including `/*{ns}*{db}*/`(`crate::key::database::all`) , `/*{ns}*{db}*{tb}`(`crate::key::table::all`), all the way down to ev, fd, ft, ix, lq and so on that are under the table prefix... (There are a lot of them! That's almost why this PR is so big)
- Add several helpers in tx
- Modify the query executor to create ns/db/tb alises/ids/instances implicitly when in the non-strict mode

## What is your testing strategy?

I've updated unit tests according to the implementation changes and made the implementation to pass all the existing cli/http/ws/etc integration test cases without any modification.

## Is this related to any issues?



## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
