### PR TITLE
Refactor and improve `Surreal::export`

### DIFF
--- a/lib/src/api/conn.rs
+++ b/lib/src/api/conn.rs
@@ -119,7 +119,7 @@ pub struct Param {
 	pub(crate) query: Option<(Query, BTreeMap<String, Value>)>,
 	pub(crate) other: Vec<Value>,
 	pub(crate) file: Option<PathBuf>,
-	pub(crate) send: Option<channel::Sender<Vec<u8>>>,
+	pub(crate) sender: Option<channel::Sender<Result<Vec<u8>>>>,
 }
 
 impl Param {
@@ -128,7 +128,7 @@ impl Param {
 			query: None,
 			other,
 			file: None,
-			send: None,
+			sender: None,
 		}
 	}
 
@@ -137,7 +137,7 @@ impl Param {
 			query: Some((query, bindings)),
 			other: Vec::new(),
 			file: None,
-			send: None,
+			sender: None,
 		}
 	}
 
@@ -146,16 +146,16 @@ impl Param {
 			query: None,
 			other: Vec::new(),
 			file: Some(file),
-			send: None,
+			sender: None,
 		}
 	}
 
-	pub(crate) fn send(send: channel::Sender<Vec<u8>>) -> Self {
+	pub(crate) fn sender(send: channel::Sender<Result<Vec<u8>>>) -> Self {
 		Self {
 			query: None,
 			other: Vec::new(),
 			file: None,
-			send: Some(send),
+			sender: Some(send),
 		}
 	}
 }

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -59,6 +59,7 @@ use std::marker::PhantomData;
 use std::mem;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::fs::OpenOptions;
@@ -66,8 +67,6 @@ use tokio::fs::OpenOptions;
 use tokio::io;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::io::AsyncReadExt;
-#[cfg(not(target_arch = "wasm32"))]
-use tokio::io::AsyncWrite;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::io::AsyncWriteExt;
 
@@ -403,9 +402,46 @@ async fn take(one: bool, responses: Vec<Response>) -> Result<Value> {
 	}
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+async fn export(
+	kvs: &Datastore,
+	sess: &Session,
+	ns: String,
+	db: String,
+	chn: channel::Sender<Vec<u8>>,
+) -> Result<()> {
+	if let Err(error) = kvs.prepare_export(sess, ns, db, chn).await?.await {
+		if let crate::error::Db::Channel(message) = error {
+			// This is not really an error. Just logging it for improved visibility.
+			trace!("{message}");
+			return Ok(());
+		}
+		return Err(error.into());
+	}
+	Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn copy<'a, R, W>(
+	path: PathBuf,
+	reader: &'a mut R,
+	writer: &'a mut W,
+) -> std::result::Result<(), crate::Error>
+where
+	R: tokio::io::AsyncRead + Unpin + ?Sized,
+	W: tokio::io::AsyncWrite + Unpin + ?Sized,
+{
+	io::copy(reader, writer).await.map(|_| ()).map_err(|error| {
+		crate::Error::Api(crate::error::Api::FileRead {
+			path,
+			error,
+		})
+	})
+}
+
 async fn router(
 	(_, method, param): (i64, Method, Param),
-	kvs: &Datastore,
+	kvs: &Arc<Datastore>,
 	session: &mut Session,
 	vars: &mut BTreeMap<String, Value>,
 ) -> Result<DbResponse> {
@@ -514,34 +550,16 @@ async fn router(
 		Method::Export | Method::Import => unreachable!(),
 		#[cfg(not(target_arch = "wasm32"))]
 		Method::Export => {
-			let (tx, rx) = channel::new::<Vec<u8>>(1);
 			let ns = session.ns.clone().unwrap_or_default();
 			let db = session.db.clone().unwrap_or_default();
-			let (mut writer, mut reader) = io::duplex(10_240);
+			let (tx, rx) = channel::new(1);
 
-			// Write to channel.
-			async fn export_with_err(
-				kvs: &Datastore,
-				sess: &Session,
-				ns: String,
-				db: String,
-				chn: channel::Sender<Vec<u8>>,
-			) -> std::result::Result<(), crate::Error> {
-				let export = kvs.prepare_export(sess, ns, db, chn).await.map_err(|error| {
-					error!("Error preparing export: {error}");
-					crate::Error::Db(error)
-				})?;
-
-				export.await.map_err(|error| {
-					error!("Error processing export: {error}");
-					crate::Error::Db(error)
-				})
-			}
-			match (param.file, param.send) {
-				(None, None) => panic!("Expected file or channel, neither found"),
-				(Some(_), Some(_)) => panic!("Expected file or channel, found both"),
+			match (param.file, param.sender) {
 				(Some(path), None) => {
-					let export = export_with_err(kvs, session, ns, db, tx);
+					let (mut writer, mut reader) = io::duplex(10_240);
+
+					// Write to channel.
+					let export = export(kvs, session, ns, db, tx);
 
 					// Read from channel and write to pipe.
 					let bridge = async move {
@@ -555,56 +573,53 @@ async fn router(
 					};
 
 					// Output to stdout or file.
-					let mut output: Box<dyn AsyncWrite + Unpin + Send> =
-						match path.to_str().unwrap() {
-							"-" => Box::new(io::stdout()),
-							_ => {
-								let file = match OpenOptions::new()
-									.write(true)
-									.create(true)
-									.truncate(true)
-									.open(&path)
-									.await
-								{
-									Ok(path) => path,
-									Err(error) => {
-										return Err(Error::FileOpen {
-											path,
-											error,
-										}
-										.into());
-									}
-								};
-								Box::new(file)
+					let mut output = match OpenOptions::new()
+						.write(true)
+						.create(true)
+						.truncate(true)
+						.open(&path)
+						.await
+					{
+						Ok(path) => path,
+						Err(error) => {
+							return Err(Error::FileOpen {
+								path,
+								error,
+							}
+							.into());
+						}
+					};
+
+					// Copy from pipe to output.
+					let copy = copy(path, &mut reader, &mut output);
+
+					tokio::try_join!(export, bridge, copy)?;
+				}
+				(None, Some(backup)) => {
+					let kvs = kvs.clone();
+					let session = session.clone();
+					tokio::spawn(async move {
+						let export = async {
+							if let Err(error) = export(&kvs, &session, ns, db, tx).await {
+								let _ = backup.send(Err(error)).await;
 							}
 						};
 
-					// Copy from pipe to output.
-					async fn copy_with_err<'a, R, W>(
-						path: PathBuf,
-						reader: &'a mut R,
-						writer: &'a mut W,
-					) -> std::result::Result<(), crate::Error>
-					where
-						R: tokio::io::AsyncRead + Unpin + ?Sized,
-						W: tokio::io::AsyncWrite + Unpin + ?Sized,
-					{
-						io::copy(reader, writer).await.map(|_| ()).map_err(|error| {
-							crate::Error::Api(crate::error::Api::FileRead {
-								path,
-								error,
-							})
-						})
-					}
+						let bridge = async {
+							while let Ok(bytes) = rx.recv().await {
+								if backup.send(Ok(bytes)).await.is_err() {
+									break;
+								}
+							}
+						};
 
-					let copy = copy_with_err(path, &mut reader, &mut output);
-
-					tokio::try_join!(export, bridge, copy).map(|_| DbResponse::Other(Value::None))
+						tokio::join!(export, bridge);
+					});
 				}
-				(None, Some(chn)) => export_with_err(kvs, session, ns, db, chn)
-					.await
-					.map(|_| DbResponse::Other(Value::None)),
+				_ => unreachable!(),
 			}
+
+			Ok(DbResponse::Other(Value::None))
 		}
 		#[cfg(not(target_arch = "wasm32"))]
 		Method::Import => {

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -49,8 +49,6 @@ use tokio::io;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::io::AsyncReadExt;
 #[cfg(not(target_arch = "wasm32"))]
-use tokio::io::AsyncWrite;
-#[cfg(not(target_arch = "wasm32"))]
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use url::Url;
 
@@ -221,19 +219,24 @@ async fn take(one: bool, request: RequestBuilder) -> Result<Value> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn export(request: RequestBuilder, path: PathBuf) -> Result<Value> {
-	let mut response = request
-		.send()
-		.await?
-		.error_for_status()?
-		.bytes_stream()
-		.map_err(|e| futures::io::Error::new(futures::io::ErrorKind::Other, e))
-		.into_async_read()
-		.compat();
-	let mut writer: Box<dyn AsyncWrite + Unpin + Send> = match path.to_str().unwrap() {
-		"-" => Box::new(io::stdout()),
-		_ => {
-			let file = match OpenOptions::new()
+type BackupSender = channel::Sender<Result<Vec<u8>>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn export(
+	request: RequestBuilder,
+	(file, sender): (Option<PathBuf>, Option<BackupSender>),
+) -> Result<Value> {
+	match (file, sender) {
+		(Some(path), None) => {
+			let mut response = request
+				.send()
+				.await?
+				.error_for_status()?
+				.bytes_stream()
+				.map_err(|e| futures::io::Error::new(futures::io::ErrorKind::Other, e))
+				.into_async_read()
+				.compat();
+			let mut file = match OpenOptions::new()
 				.write(true)
 				.create(true)
 				.truncate(true)
@@ -249,17 +252,28 @@ async fn export(request: RequestBuilder, path: PathBuf) -> Result<Value> {
 					.into());
 				}
 			};
-			Box::new(file)
+			if let Err(error) = io::copy(&mut response, &mut file).await {
+				return Err(Error::FileRead {
+					path,
+					error,
+				}
+				.into());
+			}
 		}
-	};
+		(None, Some(tx)) => {
+			let mut response = request.send().await?.error_for_status()?.bytes_stream();
 
-	if let Err(error) = io::copy(&mut response, &mut writer).await {
-		return Err(Error::FileRead {
-			path,
-			error,
+			tokio::spawn(async move {
+				while let Ok(Some(bytes)) = response.try_next().await {
+					if tx.send(Ok(bytes.to_vec())).await.is_err() {
+						break;
+					}
+				}
+			});
 		}
-		.into());
+		_ => unreachable!(),
 	}
+
 	Ok(Value::None)
 }
 
@@ -490,13 +504,12 @@ async fn router(
 		#[cfg(not(target_arch = "wasm32"))]
 		Method::Export => {
 			let path = base_url.join(Method::Export.as_str())?;
-			let file = param.file.expect("file to export into");
 			let request = client
 				.get(path)
 				.headers(headers.clone())
 				.auth(auth)
 				.header(ACCEPT, "application/octet-stream");
-			let value = export(request, file).await?;
+			let value = export(request, (param.file, param.sender)).await?;
 			Ok(DbResponse::Other(value))
 		}
 		#[cfg(not(target_arch = "wasm32"))]

--- a/lib/src/api/opt/export.rs
+++ b/lib/src/api/opt/export.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ExportDestination {
+	File(PathBuf),
+	Memory,
+}
+
+/// A trait for converting inputs into database export locations
+pub trait IntoExportDestination<R> {
+	/// Converts an input into a database export location
+	fn into_export_destination(self) -> ExportDestination;
+}
+
+impl<T> IntoExportDestination<PathBuf> for T
+where
+	T: AsRef<Path>,
+{
+	fn into_export_destination(self) -> ExportDestination {
+		ExportDestination::File(self.as_ref().to_path_buf())
+	}
+}
+
+impl IntoExportDestination<()> for () {
+	fn into_export_destination(self) -> ExportDestination {
+		ExportDestination::Memory
+	}
+}

--- a/lib/src/api/opt/mod.rs
+++ b/lib/src/api/opt/mod.rs
@@ -4,6 +4,7 @@ pub mod auth;
 
 mod config;
 mod endpoint;
+mod export;
 mod query;
 mod resource;
 mod tls;
@@ -23,6 +24,7 @@ use serde_json::Value as JsonValue;
 
 pub use config::*;
 pub use endpoint::*;
+pub use export::*;
 pub use query::*;
 pub use resource::*;
 pub use tls::*;


### PR DESCRIPTION
## What is the motivation?

Currently `Surreal::export` allows exporting to file, standard output and to a channel by giving it a sender. The decision to export to standard output depends on whether the filename is `-` or not. At library level, we should avoid assumptions like that.

## What does this change do?

This PR makes `Surreal::export` export either to a file

```rust
db.export("dump.sql").await?;
```

or to a stream of bytes

```rust
let mut backup = db.export(()).await?;
```

## What is your testing strategy?

Github actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
