### PR TITLE
[import] Support larger files when connecting to an HTTP endpoint

### DIFF
--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -288,19 +288,17 @@ async fn import(request: RequestBuilder, path: PathBuf) -> Result<Value> {
 		}
 	};
 
-	let res = request
-		.header(ACCEPT, "application/octet-stream")
-		.body(file)
-		.send()
-		.await?;
+	let res = request.header(ACCEPT, "application/octet-stream").body(file).send().await?;
 
 	if res.error_for_status_ref().is_err() {
 		let res = res.text().await?;
 
 		match res.parse::<serde_json::Value>() {
 			Ok(body) => {
-				let error_msg =
-					format!("\n{}", serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".into()));
+				let error_msg = format!(
+					"\n{}",
+					serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".into())
+				);
 				return Err(Error::Http(error_msg).into());
 			}
 			Err(_) => {

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -47,8 +47,6 @@ use tokio::fs::OpenOptions;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::io;
 #[cfg(not(target_arch = "wasm32"))]
-use tokio::io::AsyncReadExt;
-#[cfg(not(target_arch = "wasm32"))]
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use url::Url;
 
@@ -279,7 +277,7 @@ async fn export(
 
 #[cfg(not(target_arch = "wasm32"))]
 async fn import(request: RequestBuilder, path: PathBuf) -> Result<Value> {
-	let mut file = match OpenOptions::new().read(true).open(&path).await {
+	let file = match OpenOptions::new().read(true).open(&path).await {
 		Ok(path) => path,
 		Err(error) => {
 			return Err(Error::FileOpen {
@@ -289,29 +287,26 @@ async fn import(request: RequestBuilder, path: PathBuf) -> Result<Value> {
 			.into());
 		}
 	};
-	let mut contents = vec![];
-	if let Err(error) = file.read_to_end(&mut contents).await {
-		return Err(Error::FileRead {
-			path,
-			error,
-		}
-		.into());
-	}
+
 	let res = request
 		.header(ACCEPT, "application/octet-stream")
-		// ideally we should pass `file` directly into the body
-		// but currently that results in
-		// "HTTP status client error (405 Method Not Allowed) for url"
-		.body(contents)
+		.body(file)
 		.send()
 		.await?;
 
 	if res.error_for_status_ref().is_err() {
-		let body: serde_json::Value = res.json().await?;
-		let error_msg =
-			format!("\n{}", serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".into()));
+		let res = res.text().await?;
 
-		return Err(Error::Http(error_msg).into());
+		match res.parse::<serde_json::Value>() {
+			Ok(body) => {
+				let error_msg =
+					format!("\n{}", serde_json::to_string_pretty(&body).unwrap_or_else(|_| "{}".into()));
+				return Err(Error::Http(error_msg).into());
+			}
+			Err(_) => {
+				return Err(Error::Http(res).into());
+			}
+		}
 	}
 	Ok(Value::None)
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When importing a large file to an HTTP server, we saw the connection breaking for no apparent reason. First intuition was that Axum was enforcing the max body size, but after refactoring the import's error handling so it can print non-json responses, I discovered that was not the reason (I could reproduce the body size limit, and the resulting error was different).

Then I did some tests on the client side and after passing the file directly to the RequestBuilder, it converts the request into a multipart request automatically and the server is able to handle it properly (based on the comment I found in the code, I assume warp was not able to handle it out of the box, but now with Axum it came for free).

### Steps to reproduce/test
During my tests I used this file and at the same time I locally increased the max request size for the `/import` route
```
$ du -sh surreal_deal_large.surql
7.4G    surreal_deal_large.surql
```

Before this PR I got this error:
```
$ surreal import --namespace test --database test  -e http://localhost:8000 surreal_deal_large.surql
2023-08-31T14:21:38.402809Z ERROR surreal::cli: There was a problem with the database: There was an error processing a remote HTTP request: error sending request for url (http://localhost:8000/import): error writing a body to connection: Invalid argument (os error 22)
```

After this PR I can successfully import it:
```
$ surreal import --namespace test --database test  -e http://localhost:8000 surreal_deal_large.surql
2023-08-31T16:24:28.142129Z INFO surreal::cli: The SQL file was imported successfully
```

## What does this change do?

* Fixes the import request in order to handle large files
* Increases server's max body size for the `/import` path

## What is your testing strategy?

Tested manually

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
