### PR TITLE
Ensure incorrect data causes error

### DIFF
--- a/lib/src/api/method/content.rs
+++ b/lib/src/api/method/content.rs
@@ -47,7 +47,11 @@ macro_rules! into_future {
 					None => resource?.into(),
 				};
 				let mut conn = Client::new(method);
-				conn.$method(router?, Param::new(vec![param, content?])).await
+				let params = match content? {
+					Value::None | Value::Null => vec![param],
+					content => vec![param, content],
+				};
+				conn.$method(router?, Param::new(params)).await
 			})
 		}
 	};

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -124,6 +124,18 @@ pub enum Error {
 		sql: String,
 	},
 
+	/// There was an error with the SQL query
+	#[error("Can not use {value} in a CONTENT clause")]
+	InvalidContent {
+		value: Value,
+	},
+
+	/// There was an error with the SQL query
+	#[error("Can not use {value} in a MERGE clause")]
+	InvalidMerge {
+		value: Value,
+	},
+
 	/// There was an error with the provided JSON Patch
 	#[error("The JSON Patch contains invalid operations. {message}")]
 	InvalidPatch {

--- a/lib/src/sql/value/merge.rs
+++ b/lib/src/sql/value/merge.rs
@@ -3,12 +3,17 @@ use crate::sql::value::Value;
 
 impl Value {
 	pub(crate) fn merge(&mut self, val: Value) -> Result<(), Error> {
-		if val.is_object() {
-			for k in val.every(None, false, false).iter() {
-				match val.pick(k) {
-					Value::None => self.cut(k),
-					v => self.put(k, v),
-				}
+		// If this value is not an object, then error
+		if !val.is_object() {
+			return Err(Error::InvalidMerge {
+				value: val,
+			});
+		}
+		// Otherwise loop through every object field
+		for k in val.every(None, false, false).iter() {
+			match val.pick(k) {
+				Value::None => self.cut(k),
+				v => self.put(k, v),
 			}
 		}
 		Ok(())

--- a/lib/src/sql/value/merge.rs
+++ b/lib/src/sql/value/merge.rs
@@ -37,18 +37,13 @@ mod tests {
 				},
 			}",
 		);
-		let mrg = Value::None;
-		let val = Value::parse(
-			"{
-				name: {
-					first: 'Tobie',
-					last: 'Morgan Hitchcock',
-					initials: 'TMH',
-				},
-			}",
-		);
-		res.merge(mrg).unwrap();
-		assert_eq!(res, val);
+		let none = Value::None;
+		match res.merge(none.clone()).unwrap_err() {
+			Error::InvalidMerge {
+				value,
+			} => assert_eq!(value, none),
+			error => panic!("unexpected error: {error:?}"),
+		}
 	}
 
 	#[tokio::test]

--- a/lib/src/sql/value/replace.rs
+++ b/lib/src/sql/value/replace.rs
@@ -3,9 +3,14 @@ use crate::sql::value::Value;
 
 impl Value {
 	pub(crate) fn replace(&mut self, val: Value) -> Result<(), Error> {
-		if val.is_object() {
-			*self = val;
+		// If this value is not an object, then error
+		if !val.is_object() {
+			return Err(Error::InvalidContent {
+				value: val,
+			});
 		}
+		// Otherwise replace the current value
+		*self = val;
 		Ok(())
 	}
 }

--- a/lib/tests/update.rs
+++ b/lib/tests/update.rs
@@ -8,6 +8,76 @@ use surrealdb::iam::Role;
 use surrealdb::sql::Value;
 
 #[tokio::test]
+async fn update_merge_and_content() -> Result<(), Error> {
+	let sql = "
+		CREATE person:test CONTENT { name: 'Tobie' };
+		UPDATE person:test CONTENT { name: 'Jaime' };
+		UPDATE person:test CONTENT 'some content';
+		UPDATE person:test REPLACE 'some content';
+		UPDATE person:test MERGE { age: 50 };
+		UPDATE person:test MERGE 'some content';
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 6);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:test,
+				name: 'Tobie',
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:test,
+				name: 'Jaime',
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == r#"Can not use 'some content' in a CONTENT clause"#
+	));
+	//
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == r#"Can not use 'some content' in a CONTENT clause"#
+	));
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:test,
+				name: 'Jaime',
+				age: 50,
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == r#"Can not use 'some content' in a MERGE clause"#
+	));
+	//
+	Ok(())
+}
+
+#[tokio::test]
 async fn update_simple_with_input() -> Result<(), Error> {
 	let sql = "
 		DEFINE FIELD name ON TABLE person

--- a/src/rpc/processor.rs
+++ b/src/rpc/processor.rs
@@ -357,7 +357,11 @@ impl Processor {
 		// Get a database reference
 		let kvs = DB.get().unwrap();
 		// Specify the SQL query string
-		let sql = "CREATE $what CONTENT $data RETURN AFTER";
+		let sql = if data.is_none_or_null() {
+			"CREATE $what RETURN AFTER"
+		} else {
+			"CREATE $what CONTENT $data RETURN AFTER"
+		};
 		// Specify the query parameters
 		let var = Some(map! {
 			String::from("what") => what.could_be_table(),
@@ -385,7 +389,11 @@ impl Processor {
 		// Get a database reference
 		let kvs = DB.get().unwrap();
 		// Specify the SQL query string
-		let sql = "UPDATE $what CONTENT $data RETURN AFTER";
+		let sql = if data.is_none_or_null() {
+			"UPDATE $what RETURN AFTER"
+		} else {
+			"UPDATE $what CONTENT $data RETURN AFTER"
+		};
 		// Specify the query parameters
 		let var = Some(map! {
 			String::from("what") => what.could_be_table(),

--- a/src/rpc/processor.rs
+++ b/src/rpc/processor.rs
@@ -421,7 +421,11 @@ impl Processor {
 		// Get a database reference
 		let kvs = DB.get().unwrap();
 		// Specify the SQL query string
-		let sql = "UPDATE $what MERGE $data RETURN AFTER";
+		let sql = if data.is_none_or_null() {
+			"UPDATE $what RETURN AFTER"
+		} else {
+			"UPDATE $what MERGE $data RETURN AFTER"
+		};
 		// Specify the query parameters
 		let var = Some(map! {
 			String::from("what") => what.could_be_table(),


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When executing a statement using a `CONTENT`, `REPLACE` or `MERGE` clause, you can pass invalid content which is not an object. This should error, whilst at the moment it just silently ignores the content.

## What does this change do?

Ensures that any invalid content used with a `CONTENT`, `REPLACE` or `MERGE` clause, result in an error.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2549.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
