### PR TITLE
Add `PERMISSIONS` to `DEFINE PARAM` and `DEFINE FUNCTION` clauses

### DIFF
--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -422,6 +422,18 @@ pub enum Error {
 		table: String,
 	},
 
+	/// The permissions do not allow this query to be run on this table
+	#[error("You don't have permission to view the ${name} parameter")]
+	ParamPermissions {
+		name: String,
+	},
+
+	/// The permissions do not allow this query to be run on this table
+	#[error("You don't have permission to run the fn::{name} function")]
+	FunctionPermissions {
+		name: String,
+	},
+
 	/// The specified table can not be written as it is setup as a foreign table view
 	#[error("Unable to write to the `{table}` table while setup as a view")]
 	TableIsView {

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -3,6 +3,7 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::fnc;
+use crate::iam::Action;
 use crate::sql::comment::mightbespace;
 use crate::sql::common::val_char;
 use crate::sql::common::{commas, openparentheses};
@@ -11,6 +12,7 @@ use crate::sql::fmt::Fmt;
 use crate::sql::idiom::Idiom;
 use crate::sql::script::{script as func, Script};
 use crate::sql::value::{value, Value};
+use crate::sql::Permission;
 use async_recursion::async_recursion;
 use futures::future::try_join_all;
 use nom::branch::alt;
@@ -178,6 +180,28 @@ impl Function {
 					// Get the function definition
 					run.get_fc(opt.ns(), opt.db(), s).await?
 				};
+				// Check permissions
+				if opt.check_perms(Action::View) {
+					match val.permissions {
+						Permission::Full => (),
+						Permission::None => {
+							return Err(Error::FunctionPermissions {
+								name: s.to_owned(),
+							})
+						}
+						Permission::Specific(e) => {
+							// Disable permissions
+							let opt = &opt.new_with_perms(false);
+							// Process the PERMISSION clause
+							if !e.compute(ctx, opt, txn, doc).await?.is_truthy() {
+								return Err(Error::FunctionPermissions {
+									name: s.to_owned(),
+								});
+							}
+						}
+					}
+				}
+				// Return the value
 				// Check the function arguments
 				if x.len() != val.args.len() {
 					return Err(Error::InvalidArguments {

--- a/lib/src/sql/permission.rs
+++ b/lib/src/sql/permission.rs
@@ -157,7 +157,7 @@ fn full(i: &str) -> IResult<&str, Permissions> {
 }
 
 fn specific(i: &str) -> IResult<&str, Permissions> {
-	let (i, perms) = separated_list1(commasorspace, permission)(i)?;
+	let (i, perms) = separated_list1(commasorspace, rule)(i)?;
 	Ok((
 		i,
 		Permissions {
@@ -215,6 +215,16 @@ impl Default for Permission {
 	}
 }
 
+impl Permission {
+	pub fn is_none(&self) -> bool {
+		matches!(self, Permission::None)
+	}
+
+	pub fn is_full(&self) -> bool {
+		matches!(self, Permission::Full)
+	}
+}
+
 impl Display for Permission {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
@@ -225,7 +235,17 @@ impl Display for Permission {
 	}
 }
 
-fn permission(i: &str) -> IResult<&str, Vec<(PermissionKind, Permission)>> {
+pub fn permission(i: &str) -> IResult<&str, Permission> {
+	alt((
+		combinator::value(Permission::None, tag_no_case("NONE")),
+		combinator::value(Permission::Full, tag_no_case("FULL")),
+		map(tuple((tag_no_case("WHERE"), shouldbespace, value)), |(_, _, v)| {
+			Permission::Specific(v)
+		}),
+	))(i)
+}
+
+fn rule(i: &str) -> IResult<&str, Vec<(PermissionKind, Permission)>> {
 	let (i, _) = tag_no_case("FOR")(i)?;
 	let (i, _) = shouldbespace(i)?;
 	cut(|i| {

--- a/lib/src/sql/statements/define/field.rs
+++ b/lib/src/sql/statements/define/field.rs
@@ -8,6 +8,8 @@ use crate::iam::ResourceKind;
 use crate::sql::base::Base;
 use crate::sql::comment::shouldbespace;
 use crate::sql::error::IResult;
+use crate::sql::fmt::is_pretty;
+use crate::sql::fmt::pretty_indent;
 use crate::sql::ident::{ident, Ident};
 use crate::sql::idiom;
 use crate::sql::idiom::Idiom;
@@ -23,7 +25,7 @@ use nom::multi::many0;
 use nom::sequence::tuple;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self, Display, Write};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
@@ -88,7 +90,13 @@ impl Display for DefineFieldStatement {
 			write!(f, " COMMENT {v}")?
 		}
 		if !self.permissions.is_full() {
-			write!(f, " {}", self.permissions)?;
+			let _indent = if is_pretty() {
+				Some(pretty_indent())
+			} else {
+				f.write_char(' ')?;
+				None
+			};
+			write!(f, "{}", self.permissions)?;
 		}
 		Ok(())
 	}

--- a/lib/src/sql/value/serde/ser/statement/define/function.rs
+++ b/lib/src/sql/value/serde/ser/statement/define/function.rs
@@ -4,6 +4,7 @@ use crate::sql::value::serde::ser;
 use crate::sql::Block;
 use crate::sql::Ident;
 use crate::sql::Kind;
+use crate::sql::Permission;
 use crate::sql::Strand;
 use ser::Serializer as _;
 use serde::ser::Error as _;
@@ -42,6 +43,7 @@ pub struct SerializeDefineFunctionStatement {
 	args: Vec<(Ident, Kind)>,
 	block: Block,
 	comment: Option<Strand>,
+	permissions: Permission,
 }
 
 impl serde::ser::SerializeStruct for SerializeDefineFunctionStatement {
@@ -65,6 +67,9 @@ impl serde::ser::SerializeStruct for SerializeDefineFunctionStatement {
 			"comment" => {
 				self.comment = value.serialize(ser::strand::opt::Serializer.wrap())?;
 			}
+			"permissions" => {
+				self.permissions = value.serialize(ser::permission::Serializer.wrap())?;
+			}
 			key => {
 				return Err(Error::custom(format!(
 					"unexpected field `DefineFunctionStatement::{key}`"
@@ -80,6 +85,7 @@ impl serde::ser::SerializeStruct for SerializeDefineFunctionStatement {
 			args: self.args,
 			block: self.block,
 			comment: self.comment,
+			permissions: self.permissions,
 		})
 	}
 }

--- a/lib/src/sql/value/serde/ser/statement/define/param.rs
+++ b/lib/src/sql/value/serde/ser/statement/define/param.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::sql::statements::DefineParamStatement;
 use crate::sql::value::serde::ser;
 use crate::sql::Ident;
+use crate::sql::Permission;
 use crate::sql::Strand;
 use crate::sql::Value;
 use ser::Serializer as _;
@@ -40,6 +41,7 @@ pub struct SerializeDefineParamStatement {
 	name: Ident,
 	value: Value,
 	comment: Option<Strand>,
+	permissions: Permission,
 }
 
 impl serde::ser::SerializeStruct for SerializeDefineParamStatement {
@@ -60,6 +62,9 @@ impl serde::ser::SerializeStruct for SerializeDefineParamStatement {
 			"comment" => {
 				self.comment = value.serialize(ser::strand::opt::Serializer.wrap())?;
 			}
+			"permissions" => {
+				self.permissions = value.serialize(ser::permission::Serializer.wrap())?;
+			}
 			key => {
 				return Err(Error::custom(format!(
 					"unexpected field `DefineParamStatement::{key}`"
@@ -74,6 +79,7 @@ impl serde::ser::SerializeStruct for SerializeDefineParamStatement {
 			name: self.name,
 			value: self.value,
 			comment: self.comment,
+			permissions: self.permissions,
 		})
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently custom functions, and global parameters can be run and accessed by anyone.

## What does this change do?

This pull request adds a `PERMISSIONS` clause to `DEFINE PARAM` and `DEFINE FUNCTION` statements, ensuring that custom functions, and global parameters can be prevented from access to scope authenticated users.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #1826.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
