### PR TITLE
Remove `RPC diff` and use third argument in `RPC patch` method

### DIFF
--- a/src/rpc/args.rs
+++ b/src/rpc/args.rs
@@ -5,6 +5,7 @@ pub trait Take {
 	fn needs_one(self) -> Result<Value, ()>;
 	fn needs_two(self) -> Result<(Value, Value), ()>;
 	fn needs_one_or_two(self) -> Result<(Value, Value), ()>;
+	fn needs_one_two_or_three(self) -> Result<(Value, Value, Value), ()>;
 }
 
 impl Take for Array {
@@ -41,6 +42,19 @@ impl Take for Array {
 			(Some(a), Some(b)) => Ok((a, b)),
 			(Some(a), None) => Ok((a, Value::None)),
 			(_, _) => Ok((Value::None, Value::None)),
+		}
+	}
+	/// Convert the array to three arguments
+	fn needs_one_two_or_three(self) -> Result<(Value, Value, Value), ()> {
+		if self.is_empty() {
+			return Err(());
+		}
+		let mut x = self.into_iter();
+		match (x.next(), x.next(), x.next()) {
+			(Some(a), Some(b), Some(c)) => Ok((a, b, c)),
+			(Some(a), Some(b), None) => Ok((a, b, Value::None)),
+			(Some(a), None, None) => Ok((a, Value::None, Value::None)),
+			(_, _, _) => Ok((Value::None, Value::None, Value::None)),
 		}
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

In #2560 we introduced the `RPC diff` method for applying a `PATCH` to a record and returning a `DIFF`. Instead of using a new method, we can actually simplify this and use a third argument to the `RPC patch` method instead, which is either `true` or `false` (which is the default).

## What does this change do?

This pull request removes the `RPC diff` method introduced in #2560, and adds a third parameter to the `RPC patch` method.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
