### PR TITLE
Return an error when `db.connect()` is called multiple times

### DIFF
--- a/lib/src/api/err/mod.rs
+++ b/lib/src/api/err/mod.rs
@@ -33,6 +33,10 @@ pub enum Error {
 	#[error("Connection uninitialised")]
 	ConnectionUninitialised,
 
+	/// Tried to call `connect` on an instance already connected
+	#[error("Already connected")]
+	AlreadyConnected,
+
 	/// `Query::bind` not called with an object nor a key/value tuple
 	#[error("Invalid bindings: {0}")]
 	InvalidBindings(Value),


### PR DESCRIPTION
## What is the motivation?

Currently when you call `db.connect()` multiple times only the first connection is kept. Subsequent attempts create a new connection but immediately ignore it, keeping the connection established earlier. Establishing subsequent connections is unnecessary.

## What does this change do?

It returns an error on subsequent connection attempts.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
