### PR TITLE
Ensure `dbs::Capabilities` are visible in Rust docs

### DIFF
--- a/lib/src/api/opt/capabilities.rs
+++ b/lib/src/api/opt/capabilities.rs
@@ -1,0 +1,6 @@
+//! The capabilities that can be enabled for a database instance
+
+pub use crate::dbs::capabilities::FuncTarget;
+pub use crate::dbs::capabilities::NetTarget;
+pub use crate::dbs::capabilities::Targets;
+pub use crate::dbs::Capabilities;

--- a/lib/src/api/opt/mod.rs
+++ b/lib/src/api/opt/mod.rs
@@ -1,6 +1,7 @@
 //! The different options and types for use in API functions
 
 pub mod auth;
+pub mod capabilities;
 
 mod config;
 mod endpoint;

--- a/lib/src/cnf/mod.rs
+++ b/lib/src/cnf/mod.rs
@@ -6,7 +6,7 @@ use once_cell::sync::Lazy;
 pub const MAX_CONCURRENT_TASKS: usize = 64;
 
 /// Specifies how deep various forms of computation will go before the query fails
-/// with [`Error::ComputationDepthExceeded`].
+/// with [`crate::error::Db::ComputationDepthExceeded`].
 ///
 /// For reference, use ~15 per MiB of stack in release mode.
 ///

--- a/lib/src/dbs/capabilities.rs
+++ b/lib/src/dbs/capabilities.rs
@@ -174,6 +174,43 @@ impl<T: Target + Hash + Eq + PartialEq + std::fmt::Display> std::fmt::Display fo
 /// - Allow all functions except `http.*`: `--allow-funcs --deny-funcs 'http.*'`
 /// - Allow all network addresses except AWS metadata endpoint: `--allow-net --deny-net='169.254.169.254'`
 ///
+/// # Examples
+///
+/// Create a new instance, and allow all capabilities
+/// ```
+/// # use surrealdb::opt::capabilities::Capabilities;
+/// # use surrealdb::opt::Config;
+/// # use surrealdb::Surreal;
+/// # use surrealdb::engine::local::File;
+/// ```no_run
+/// # #[tokio::main]
+/// # async fn main() -> surrealdb::Result<()> {
+/// let capabilities = Capabilities::all();
+/// let config = Config::default().capabilities(capabilities);
+/// let db = Surreal::new::<File>(("temp.db", config)).await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Create a new instance, and allow certain functions
+/// ```
+/// # use surrealdb::opt::capabilities::Capabilities;
+/// # use surrealdb::opt::Config;
+/// # use surrealdb::Surreal;
+/// # use surrealdb::engine::local::File;
+/// ```no_run
+/// # #[tokio::main]
+/// # async fn main() -> surrealdb::Result<()> {
+/// let capabilities = Capabilities::default()
+///     .with_functions(Targets::<FuncTarget>::All)
+///     .without_functions(Targets::<FuncTarget>::Some(
+///         [FuncTarget::from_str("http::*").unwrap()].into(),
+///     ));
+/// let config = Config::default().capabilities(capabilities);
+/// let db = Surreal::new::<File>(("temp.db", config)).await?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct Capabilities {
 	scripting: bool,

--- a/lib/src/dbs/capabilities.rs
+++ b/lib/src/dbs/capabilities.rs
@@ -177,12 +177,11 @@ impl<T: Target + Hash + Eq + PartialEq + std::fmt::Display> std::fmt::Display fo
 /// # Examples
 ///
 /// Create a new instance, and allow all capabilities
-/// ```
+/// ```no_run
 /// # use surrealdb::opt::capabilities::Capabilities;
 /// # use surrealdb::opt::Config;
 /// # use surrealdb::Surreal;
 /// # use surrealdb::engine::local::File;
-/// ```no_run
 /// # #[tokio::main]
 /// # async fn main() -> surrealdb::Result<()> {
 /// let capabilities = Capabilities::all();
@@ -193,12 +192,14 @@ impl<T: Target + Hash + Eq + PartialEq + std::fmt::Display> std::fmt::Display fo
 /// ```
 ///
 /// Create a new instance, and allow certain functions
-/// ```
+/// ```no_run
+/// # use std::str::FromStr;
+/// # use surrealdb::engine::local::File;
 /// # use surrealdb::opt::capabilities::Capabilities;
+/// # use surrealdb::opt::capabilities::FuncTarget;
+/// # use surrealdb::opt::capabilities::Targets;
 /// # use surrealdb::opt::Config;
 /// # use surrealdb::Surreal;
-/// # use surrealdb::engine::local::File;
-/// ```no_run
 /// # #[tokio::main]
 /// # async fn main() -> surrealdb::Result<()> {
 /// let capabilities = Capabilities::default()

--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -87,6 +87,7 @@ pub use self::block::Block;
 pub use self::bytes::Bytes;
 pub use self::cast::Cast;
 pub use self::cond::Cond;
+pub use self::constant::Constant;
 pub use self::data::Data;
 pub use self::datetime::Datetime;
 pub use self::dir::Dir;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently it is not possible to see `dbs::Capabilities` in the Rust docs.

## What does this change do?

Adds `dbs::Capabilities` to the Rust docs. Also adds some examples of how to use the `dbs::Capabilities`.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2591.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
