### PR TITLE
No need for custom serialization of `sql::Datetime`

### DIFF
--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -26,7 +26,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Datetime";
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Datetime")]
 #[revisioned(revision = 1)]
-pub struct Datetime(#[serde(with = "ts_binary")] pub DateTime<Utc>);
+pub struct Datetime(pub DateTime<Utc>);
 
 impl Default for Datetime {
 	fn default() -> Self {
@@ -272,57 +272,6 @@ fn sign(i: &str) -> IResult<&str, i32> {
 		'-' => -1,
 		_ => 1,
 	})(i)
-}
-
-/// Lexicographic, relatively size efficient binary serialization
-pub mod ts_binary {
-	use chrono::{offset::TimeZone, DateTime, Utc};
-	use core::fmt;
-	use serde::{
-		de::{self, SeqAccess},
-		ser::{self, SerializeTuple},
-	};
-
-	/// Serialize a UTC datetime into an integer number of nanoseconds since the epoch
-	pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: ser::Serializer,
-	{
-		let mut tuple = serializer.serialize_tuple(2)?;
-		tuple.serialize_element(&dt.timestamp())?;
-		tuple.serialize_element(&dt.timestamp_subsec_nanos())?;
-		tuple.end()
-	}
-
-	/// Deserialize a [`DateTime`] from a nanosecond timestamp
-	pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
-	where
-		D: de::Deserializer<'de>,
-	{
-		d.deserialize_tuple(2, TimestampVisitor)
-	}
-
-	struct TimestampVisitor;
-
-	impl<'de> de::Visitor<'de> for TimestampVisitor {
-		type Value = DateTime<Utc>;
-
-		fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-			formatter.write_str("a unix timestamp tuple")
-		}
-
-		fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-		where
-			A: SeqAccess<'de>,
-		{
-			let secs = seq.next_element()?.ok_or_else(|| de::Error::custom("invalid timestamp"))?;
-			let nanos =
-				seq.next_element()?.ok_or_else(|| de::Error::custom("invalid timestamp"))?;
-			Utc.timestamp_opt(secs, nanos)
-				.single()
-				.ok_or_else(|| de::Error::custom("invalid timestamp"))
-		}
-	}
 }
 
 #[cfg(test)]

--- a/lib/src/sql/value/serde/ser/datetime/mod.rs
+++ b/lib/src/sql/value/serde/ser/datetime/mod.rs
@@ -1,94 +1,58 @@
 use crate::err::Error;
 use crate::sql::value::serde::ser;
-use crate::sql::Datetime;
 use chrono::offset::Utc;
-use chrono::TimeZone;
-use ser::Serializer as _;
+use chrono::DateTime;
 use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::Serialize;
+use std::fmt::Display;
 
 pub(super) struct Serializer;
 
 impl ser::Serializer for Serializer {
-	type Ok = Datetime;
+	type Ok = DateTime<Utc>;
 	type Error = Error;
 
-	type SerializeSeq = Impossible<Datetime, Error>;
-	type SerializeTuple = SerializeDatetime;
-	type SerializeTupleStruct = Impossible<Datetime, Error>;
-	type SerializeTupleVariant = Impossible<Datetime, Error>;
-	type SerializeMap = Impossible<Datetime, Error>;
-	type SerializeStruct = Impossible<Datetime, Error>;
-	type SerializeStructVariant = Impossible<Datetime, Error>;
+	type SerializeSeq = Impossible<DateTime<Utc>, Error>;
+	type SerializeTuple = Impossible<DateTime<Utc>, Error>;
+	type SerializeTupleStruct = Impossible<DateTime<Utc>, Error>;
+	type SerializeTupleVariant = Impossible<DateTime<Utc>, Error>;
+	type SerializeMap = Impossible<DateTime<Utc>, Error>;
+	type SerializeStruct = Impossible<DateTime<Utc>, Error>;
+	type SerializeStructVariant = Impossible<DateTime<Utc>, Error>;
 
-	const EXPECTED: &'static str = "a struct `Datetime`";
+	const EXPECTED: &'static str = "a struct `DateTime<Utc>`";
 
 	#[inline]
-	fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-		debug_assert_eq!(len, 2);
-		Ok(SerializeDatetime::default())
+	fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: Display,
+	{
+		value.to_string().parse().map_err(Error::custom)
 	}
 
 	#[inline]
 	fn serialize_newtype_struct<T>(
 		self,
-		name: &'static str,
+		_name: &'static str,
 		value: &T,
 	) -> Result<Self::Ok, Self::Error>
 	where
 		T: ?Sized + Serialize,
 	{
-		debug_assert_eq!(name, crate::sql::datetime::TOKEN);
 		value.serialize(self.wrap())
-	}
-}
-
-#[derive(Default)]
-pub(super) struct SerializeDatetime {
-	secs: Option<i64>,
-	nanos: Option<u32>,
-}
-
-impl serde::ser::SerializeTuple for SerializeDatetime {
-	type Ok = Datetime;
-	type Error = Error;
-
-	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
-	where
-		T: Serialize + ?Sized,
-	{
-		if self.secs.is_none() {
-			self.secs = Some(value.serialize(ser::primitive::i64::Serializer.wrap())?);
-		} else if self.nanos.is_none() {
-			self.nanos = Some(value.serialize(ser::primitive::u32::Serializer.wrap())?);
-		} else {
-			return Err(Error::custom("unexpected `Datetime` 3rd field`".to_string()));
-		}
-		Ok(())
-	}
-
-	fn end(self) -> Result<Self::Ok, Self::Error> {
-		match (self.secs, self.nanos) {
-			(Some(secs), Some(nanos)) => Utc
-				.timestamp_opt(secs, nanos)
-				.single()
-				.map(Datetime)
-				.ok_or_else(|| Error::custom("invalid `Datetime`")),
-			_ => Err(Error::custom("`Datetime` missing required value(s)")),
-		}
 	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::sql::Datetime;
+	use ser::Serializer as _;
 	use serde::Serialize;
 
 	#[test]
 	fn now() {
-		let dt = Datetime::from(Utc::now());
+		let dt = Utc::now();
 		let serialized = dt.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(dt, serialized);
 	}

--- a/lib/src/sql/value/serde/ser/statement/show/since.rs
+++ b/lib/src/sql/value/serde/ser/statement/show/since.rs
@@ -1,4 +1,5 @@
 use crate::err::Error;
+use crate::sql::datetime::Datetime;
 use crate::sql::statements::show::ShowSince;
 use crate::sql::value::serde::ser;
 use serde::ser::Error as _;
@@ -33,9 +34,9 @@ impl ser::Serializer for Serializer {
 		T: ?Sized + Serialize,
 	{
 		match variant {
-			"Timestamp" => {
-				Ok(ShowSince::Timestamp(value.serialize(ser::datetime::Serializer.wrap())?))
-			}
+			"Timestamp" => Ok(ShowSince::Timestamp(Datetime(
+				value.serialize(ser::datetime::Serializer.wrap())?,
+			))),
 			"Versionstamp" => Ok(ShowSince::Versionstamp(
 				value.serialize(ser::primitive::u64::Serializer.wrap())?,
 			)),

--- a/lib/src/sql/value/serde/ser/value/mod.rs
+++ b/lib/src/sql/value/serde/ser/value/mod.rs
@@ -10,6 +10,7 @@ use crate::sql::value::serde::ser;
 use crate::sql::value::Value;
 use crate::sql::Block;
 use crate::sql::Bytes;
+use crate::sql::Datetime;
 use crate::sql::Duration;
 use crate::sql::Future;
 use crate::sql::Ident;
@@ -232,7 +233,7 @@ impl ser::Serializer for Serializer {
 				Ok(Value::Uuid(Uuid(value.serialize(ser::uuid::Serializer.wrap())?)))
 			}
 			sql::datetime::TOKEN => {
-				Ok(Value::Datetime(value.serialize(ser::datetime::Serializer.wrap())?))
+				Ok(Value::Datetime(Datetime(value.serialize(ser::datetime::Serializer.wrap())?)))
 			}
 			_ => value.serialize(self.wrap()),
 		}

--- a/lib/src/sql/value/serde/ser/version/opt.rs
+++ b/lib/src/sql/value/serde/ser/version/opt.rs
@@ -1,5 +1,6 @@
 use crate::err::Error;
 use crate::sql::value::serde::ser;
+use crate::sql::Datetime;
 use crate::sql::Version;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
@@ -30,20 +31,7 @@ impl ser::Serializer for Serializer {
 	where
 		T: ?Sized + Serialize,
 	{
-		value.serialize(self.wrap())
-	}
-
-	#[inline]
-	fn serialize_newtype_struct<T>(
-		self,
-		name: &'static str,
-		value: &T,
-	) -> Result<Self::Ok, Self::Error>
-	where
-		T: ?Sized + Serialize,
-	{
-		debug_assert_eq!(name, "Version");
-		Ok(Some(Version(value.serialize(ser::datetime::Serializer.wrap())?)))
+		Ok(Some(Version(Datetime(value.serialize(ser::datetime::Serializer.wrap())?))))
 	}
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

We used custom serialisation and deserialisation logic for `sql::Datetime` values when we used Serde to store data to disk. However, this is no longer the case, and no longer necessary. It also causes issues when serialising and deserialising to custom user types. See #2592 for more information.

## What does this change do?

Removes custom serialisation and deserialisation logic for `sql::Datetimes`.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2592.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
