### PR TITLE
Add `X-Forwarded-For` Client-IP header

### DIFF
--- a/src/net/client_ip.rs
+++ b/src/net/client_ip.rs
@@ -34,6 +34,9 @@ pub enum ClientIp {
 	/// Nginx real IP
 	#[clap(name = "X-Real-IP")]
 	XRealIp,
+	/// Industry standard header used by many proxies
+	#[clap(name = "X-Forwarded-For")]
+	XForwardedFor,
 }
 
 impl std::fmt::Display for ClientIp {
@@ -45,6 +48,7 @@ impl std::fmt::Display for ClientIp {
 			ClientIp::FlyClientIp => write!(f, "Fly-Client-IP"),
 			ClientIp::TrueClientIP => write!(f, "True-Client-IP"),
 			ClientIp::XRealIp => write!(f, "X-Real-IP"),
+			ClientIp::XForwardedFor => write!(f, "X-Forwarded-For"),
 		}
 	}
 }
@@ -58,6 +62,7 @@ impl ClientIp {
 			ClientIp::FlyClientIp => true,
 			ClientIp::TrueClientIP => true,
 			ClientIp::XRealIp => true,
+			ClientIp::XForwardedFor => true,
 		}
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The industry standard `X-Forwarded-For` header was missing from the `--client-ip` option. 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For

## What does this change do?

Implements the `X-Forwarded-For` header for the `--client-ip` option. 

## What is your testing strategy?

Manually tested to see if header was added

## Is this related to any issues?

fixes #2587

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
