### PR TITLE
Provide existing context to functions called from scripting functions

### DIFF
--- a/lib/src/cf/writer.rs
+++ b/lib/src/cf/writer.rs
@@ -141,8 +141,7 @@ mod tests {
 		let mut tx0 = ds.transaction(true, false).await.unwrap();
 		tx0.put(&crate::key::root::ns::new(ns), dns).await.unwrap();
 		tx0.put(&crate::key::namespace::db::new(ns, db), ddb).await.unwrap();
-		let tb = tb.clone();
-		tx0.put(&crate::key::database::tb::new(ns, db, tb.as_ref()), dtb.clone()).await.unwrap();
+		tx0.put(&crate::key::database::tb::new(ns, db, tb), dtb.clone()).await.unwrap();
 		tx0.commit().await.unwrap();
 
 		// Let the db remember the timestamp for the current versionstamp
@@ -197,7 +196,6 @@ mod tests {
 		let start: u64 = 0;
 
 		let mut tx4 = ds.transaction(true, false).await.unwrap();
-		let tb = tb.clone();
 		let r =
 			crate::cf::read(&mut tx4, ns, db, Some(tb), ShowSince::Versionstamp(start), Some(10))
 				.await
@@ -252,7 +250,6 @@ mod tests {
 
 		// Now we should see the gc_all results
 		let mut tx6 = ds.transaction(true, false).await.unwrap();
-		let tb = tb.clone();
 		let r =
 			crate::cf::read(&mut tx6, ns, db, Some(tb), ShowSince::Versionstamp(start), Some(10))
 				.await

--- a/lib/src/fnc/script/modules/surrealdb/functions/mod.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/mod.rs
@@ -71,8 +71,7 @@ async fn fut(js_ctx: js::Ctx<'_>, name: &str, args: Vec<Value>) -> Result<Value>
 	let this = js_ctx.globals().get::<_, OwnedBorrow<QueryContext>>(QUERY_DATA_PROP_NAME)?;
 	// Process the called function
 	let res =
-		fnc::asynchronous(&this.context, Some(this.opt), Some(this.txn), this.doc, name, args)
-			.await;
+		fnc::asynchronous(this.context, Some(this.opt), Some(this.txn), this.doc, name, args).await;
 	// Convert any response error
 	res.map_err(|err| {
 		js::Exception::from_message(js_ctx, &err.to_string())

--- a/lib/src/fnc/script/modules/surrealdb/functions/mod.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/mod.rs
@@ -1,4 +1,3 @@
-use crate::ctx::Context;
 use crate::fnc;
 use crate::fnc::script::modules::impl_module_def;
 use crate::sql::Value;

--- a/lib/tests/changefeeds.rs
+++ b/lib/tests/changefeeds.rs
@@ -189,7 +189,7 @@ async fn changefeed_with_ts() -> Result<(), Error> {
 	db.execute(sql, &ses, None).await?.remove(0).result?;
 	// Save timestamp 1
 	let ts1_dt = "2023-08-01T00:00:00Z";
-	let ts1 = DateTime::parse_from_rfc3339(ts1_dt.clone()).unwrap();
+	let ts1 = DateTime::parse_from_rfc3339(ts1_dt).unwrap();
 	db.tick_at(ts1.timestamp().try_into().unwrap()).await.unwrap();
 	// Create and update users
 	let sql = "
@@ -331,7 +331,7 @@ async fn changefeed_with_ts() -> Result<(), Error> {
 	);
 	// Save timestamp 2
 	let ts2_dt = "2023-08-01T00:00:05Z";
-	let ts2 = DateTime::parse_from_rfc3339(ts2_dt.clone()).unwrap();
+	let ts2 = DateTime::parse_from_rfc3339(ts2_dt).unwrap();
 	db.tick_at(ts2.timestamp().try_into().unwrap()).await.unwrap();
 	//
 	// Show changes using timestamp 1
@@ -372,7 +372,7 @@ async fn changefeed_with_ts() -> Result<(), Error> {
 	);
 	// Save timestamp 3
 	let ts3_dt = "2023-08-01T00:00:10Z";
-	let ts3 = DateTime::parse_from_rfc3339(ts3_dt.clone()).unwrap();
+	let ts3 = DateTime::parse_from_rfc3339(ts3_dt).unwrap();
 	db.tick_at(ts3.timestamp().try_into().unwrap()).await.unwrap();
 	//
 	// Show changes using timestamp 3


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Surrealdb functions called from scripting functions currently use `Contex::background`. This means that the functions are run with default capabilities resulting in some functions never being allowed.

## What does this change do?

This PR provides these functions with the current existing context allowing them to run with the same capabilities as the query they where run from.

Also fixes some warnings which prevented me from running tests.

## What is your testing strategy?

I added a test to ensure this will continue to work in the future.

## Is this related to any issues?

Fixes #2579 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
