### PR TITLE
[docker] Support docker volumes when running as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Use ChainGuard's glibc-dynamic image as the base image. More information about this image can be found at https://www.chainguard.dev/chainguard-images
-FROM cgr.dev/chainguard/glibc-dynamic
+# More information about this image can be found at https://www.chainguard.dev/chainguard-images
+FROM cgr.dev/chainguard/wolfi-base
+
+RUN apk add libstdc++
 
 # Declare a build-time argument for the target architecture
 ARG TARGETARCH
@@ -7,5 +9,28 @@ ARG TARGETARCH
 # Add the binary file 'surreal' from the specified path on the host machine to the root directory in the container
 ADD $TARGETARCH/surreal /
 
-# Set the entry point for the container to be the 'surreal' binary
-ENTRYPOINT ["/surreal"]
+# Add the 'surreal' user to the container
+RUN adduser -D surreal
+
+# Set default data directory
+ENV SURREAL_DATA=/data
+
+COPY <<EOF /surreal-entrypoint.sh
+#!/bin/sh
+
+set -e
+
+# allow the container to be started with `--user`
+# Change ownership of the data directory to surreal
+if [ "\$(id -u)" = '0' ]; then
+    find "\$SURREAL_DATA" \! -user surreal -exec chown surreal '{}' +
+
+    # then restart script as surreal user
+    exec su - surreal -c "\$0 \$*"
+fi
+
+exec /surreal "\$@"
+EOF
+RUN chmod +x /surreal-entrypoint.sh
+
+ENTRYPOINT ["/surreal-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ COPY <<EOF /surreal-entrypoint.sh
 
 set -e
 
-# allow the container to be started with `--user`
+#
+# Run the process as `surreal` user
+#
 # Change ownership of the data directory to surreal
 if [ "\$(id -u)" = '0' ]; then
     find "\$SURREAL_DATA" \! -user surreal -exec chown surreal '{}' +


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

In Docker, when running the `surreal` process as non-root user, the local data volume may be mounted with root ownership and the process will not have permissions to use it.

## What does this change do?

It creates an entrypoint that changes the ownership of the `SURREAL_DATA` directory so the process has permissions on it.

## What is your testing strategy?

Followed the steps to reproduce  here https://github.com/surrealdb/surrealdb/issues/2582 and it no longer fails.

## Is this related to any issues?

Yes, this PR fixes https://github.com/surrealdb/surrealdb/issues/2582 and https://github.com/surrealdb/surrealdb/issues/2601

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
