### PR TITLE
[docker] Run Docker container as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ ARG TARGETARCH
 # Add the binary file 'surreal' from the specified path on the host machine to the root directory in the container
 ADD $TARGETARCH/surreal /
 
+USER root
+
 # Set the entry point for the container to be the 'surreal' binary
 ENTRYPOINT ["/surreal"]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Before going with https://github.com/surrealdb/surrealdb/pull/2610, let's change the Docker user for now so we can unblock users.

When deployed to production where no local datastore is used, users can deploy as `user: nonroot` anyways.

## What does this change do?

Makes the Docker container run as root so users can use local docker volumes

## What is your testing strategy?

Followed the steps to reproduce here https://github.com/surrealdb/surrealdb/issues/2582 and it no longer fails.

## Is this related to any issues?

Closes #2582.
Closes #2601.
Closes #2574.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
