### PR TITLE
Bugfix - Prevent niche parser recursion due to subqueries.

### DIFF
--- a/lib/src/sql/subquery.rs
+++ b/lib/src/sql/subquery.rs
@@ -255,6 +255,7 @@ fn subquery_value(i: &str) -> IResult<&str, Subquery> {
 }
 
 fn subquery_other(i: &str) -> IResult<&str, Subquery> {
+	let _diving = crate::sql::parser::depth::dive()?;
 	alt((
 		|i| {
 			let (i, _) = openparentheses(i)?;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

OSS fuzz found a niche case in which 12KB of nested 'other' subqueries triggers stack overflow.

## What does this change do?

Limits this specific recursion.

## What is your testing strategy?

Awaiting CI and ultimately OSS fuzz non-reproduction.

## Is this related to any issues?

Followup to #2369 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
