### PR TITLE
Allow any value  to be used for error type in `THROW` statement

### DIFF
--- a/lib/src/sql/value/serde/ser/statement/throw.rs
+++ b/lib/src/sql/value/serde/ser/statement/throw.rs
@@ -1,7 +1,7 @@
 use crate::err::Error;
 use crate::sql::statements::ThrowStatement;
 use crate::sql::value::serde::ser;
-use crate::sql::Strand;
+use crate::sql::Value;
 use ser::Serializer as _;
 use serde::ser::Error as _;
 use serde::ser::Impossible;
@@ -35,7 +35,7 @@ impl ser::Serializer for Serializer {
 
 #[derive(Default)]
 pub struct SerializeThrowStatement {
-	error: Strand,
+	error: Value,
 }
 
 impl serde::ser::SerializeStruct for SerializeThrowStatement {
@@ -48,7 +48,7 @@ impl serde::ser::SerializeStruct for SerializeThrowStatement {
 	{
 		match key {
 			"error" => {
-				self.error = Strand(value.serialize(ser::string::Serializer.wrap())?);
+				self.error = value.serialize(ser::value::Serializer.wrap())?;
 			}
 			key => {
 				return Err(Error::custom(format!("unexpected field `ThrowStatement::{key}`")));

--- a/lib/tests/throw.rs
+++ b/lib/tests/throw.rs
@@ -21,3 +21,51 @@ async fn throw_basic() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn throw_param() -> Result<(), Error> {
+	let sql = "
+		LET $err = 'there was an error';
+		THROW $err;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == r#"An error occurred: there was an error"#
+	));
+	//
+	Ok(())
+}
+
+#[tokio::test]
+async fn throw_value() -> Result<(), Error> {
+	let sql = "
+		LET $err = string::concat('found unexpected value: ', {
+			test: true
+		});
+		THROW $err;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == r#"An error occurred: found unexpected value: { test: true }"#
+	));
+
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Instead of allowing just static strings as the error type in a `THROW` statement, users might want to throw any value which can be converted to a string. This could include parameters, functions, and other values. See #2590.

## What does this change do?

It adds support for throwing any value with a `THROW` statement.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2590.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
