### PR TITLE
Feature: Add fallback reason to the explanation

### DIFF
--- a/lib/src/dbs/iterator.rs
+++ b/lib/src/dbs/iterator.rs
@@ -278,7 +278,7 @@ impl Iterator {
 		// Process the query START clause
 		self.setup_start(&cancel_ctx, opt, txn, stm).await?;
 		// Extract the expected behaviour depending on the presence of EXPLAIN with or without FULL
-		let (do_iterate, mut explanation) = Explanation::new(stm.explain(), &self.entries);
+		let (do_iterate, mut explanation) = Explanation::new(ctx, stm.explain(), &self.entries);
 
 		if do_iterate {
 			// Process prepared values

--- a/lib/src/doc/index.rs
+++ b/lib/src/doc/index.rs
@@ -57,7 +57,7 @@ impl<'a> Document<'a> {
 					Index::Search(p) => ic.index_full_text(&mut run, p).await?,
 					Index::MTree(_) => {
 						return Err(Error::FeatureNotYetImplemented {
-							feature: "MTree indexing",
+							feature: "MTree indexing".to_string(),
 						})
 					}
 				};

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -606,7 +606,7 @@ pub enum Error {
 	/// The feature has not yet being implemented
 	#[error("Feature not yet implemented: {feature}")]
 	FeatureNotYetImplemented {
-		feature: &'static str,
+		feature: String,
 	},
 
 	/// Duplicated match references are not allowed

--- a/lib/src/fnc/string.rs
+++ b/lib/src/fnc/string.rs
@@ -140,13 +140,13 @@ pub mod distance {
 
 	pub fn hamming((_, _): (String, String)) -> Result<Value, Error> {
 		Err(Error::FeatureNotYetImplemented {
-			feature: "string::distance::hamming() function",
+			feature: "string::distance::hamming() function".to_string(),
 		})
 	}
 
 	pub fn levenshtein((_, _): (String, String)) -> Result<Value, Error> {
 		Err(Error::FeatureNotYetImplemented {
-			feature: "string::distance::levenshtein() function",
+			feature: "string::distance::levenshtein() function".to_string(),
 		})
 	}
 }
@@ -234,7 +234,7 @@ pub mod similarity {
 
 	pub fn jaro((_, _): (String, String)) -> Result<Value, Error> {
 		Err(Error::FeatureNotYetImplemented {
-			feature: "string::similarity::jaro() function",
+			feature: "string::similarity::jaro() function".to_string(),
 		})
 	}
 

--- a/lib/src/fnc/vector.rs
+++ b/lib/src/fnc/vector.rs
@@ -66,7 +66,7 @@ pub mod distance {
 
 	pub fn mahalanobis((_, _): (Vec<Number>, Vec<Number>)) -> Result<Value, Error> {
 		Err(Error::FeatureNotYetImplemented {
-			feature: "vector::distance::mahalanobis() function",
+			feature: "vector::distance::mahalanobis() function".to_string(),
 		})
 	}
 
@@ -99,7 +99,7 @@ pub mod similarity {
 
 	pub fn spearman((_, _): (Vec<Number>, Vec<Number>)) -> Result<Value, Error> {
 		Err(Error::FeatureNotYetImplemented {
-			feature: "vector::similarity::spearman() function",
+			feature: "vector::similarity::spearman() function".to_string(),
 		})
 	}
 }

--- a/lib/src/idx/planner/executor.rs
+++ b/lib/src/idx/planner/executor.rs
@@ -122,7 +122,7 @@ impl QueryExecutor {
 				..
 			} => self.new_search_index_iterator(ir, io).await,
 			_ => Err(Error::FeatureNotYetImplemented {
-				feature: "VectorSearch iterator",
+				feature: "VectorSearch iterator".to_string(),
 			}),
 		}
 	}

--- a/lib/src/idx/planner/mod.rs
+++ b/lib/src/idx/planner/mod.rs
@@ -20,6 +20,7 @@ pub(crate) struct QueryPlanner<'a> {
 	/// There is one executor per table
 	executors: HashMap<String, QueryExecutor>,
 	requires_distinct: bool,
+	fallbacks: Vec<String>,
 }
 
 impl<'a> QueryPlanner<'a> {
@@ -30,6 +31,7 @@ impl<'a> QueryPlanner<'a> {
 			cond,
 			executors: HashMap::default(),
 			requires_distinct: false,
+			fallbacks: vec![],
 		}
 	}
 
@@ -40,31 +42,36 @@ impl<'a> QueryPlanner<'a> {
 		t: Table,
 		it: &mut Iterator,
 	) -> Result<(), Error> {
-		let res = Tree::build(ctx, self.opt, txn, &t, self.cond).await?;
-		if let Some((node, im)) = res {
-			let mut exe = QueryExecutor::new(self.opt, txn, &t, im).await?;
-			let ok = match PlanBuilder::build(node, self.with)? {
-				Plan::SingleIndex(exp, io) => {
-					let ir = exe.add_iterator(exp);
-					it.ingest(Iterable::Index(t.clone(), ir, io));
-					true
-				}
-				Plan::MultiIndex(v) => {
-					for (exp, io) in v {
+		match Tree::build(ctx, self.opt, txn, &t, self.cond).await? {
+			Some((node, im)) => {
+				let mut exe = QueryExecutor::new(self.opt, txn, &t, im).await?;
+				match PlanBuilder::build(node, self.with)? {
+					Plan::SingleIndex(exp, io) => {
 						let ir = exe.add_iterator(exp);
 						it.ingest(Iterable::Index(t.clone(), ir, io));
-						self.requires_distinct = true;
+						self.executors.insert(t.0.clone(), exe);
 					}
-					true
+					Plan::MultiIndex(v) => {
+						for (exp, io) in v {
+							let ir = exe.add_iterator(exp);
+							it.ingest(Iterable::Index(t.clone(), ir, io));
+							self.requires_distinct = true;
+						}
+						self.executors.insert(t.0.clone(), exe);
+					}
+					Plan::TableIterator(fallback) => {
+						if let Some(fallback) = fallback {
+							self.fallbacks.push(fallback);
+						}
+						self.executors.insert(t.0.clone(), exe);
+						it.ingest(Iterable::Table(t));
+					}
 				}
-				Plan::TableIterator => false,
-			};
-			self.executors.insert(t.0.clone(), exe);
-			if ok {
-				return Ok(());
+			}
+			None => {
+				it.ingest(Iterable::Table(t));
 			}
 		}
-		it.ingest(Iterable::Table(t));
 		Ok(())
 	}
 
@@ -78,5 +85,9 @@ impl<'a> QueryPlanner<'a> {
 
 	pub(crate) fn requires_distinct(&self) -> bool {
 		self.requires_distinct
+	}
+
+	pub(crate) fn fallbacks(&self) -> &Vec<String> {
+		&self.fallbacks
 	}
 }

--- a/lib/src/sql/statements/analyze.rs
+++ b/lib/src/sql/statements/analyze.rs
@@ -58,7 +58,7 @@ impl AnalyzeStatement {
 					}
 					_ => {
 						return Err(Error::FeatureNotYetImplemented {
-							feature: "Statistics on unique and non-unique indexes.",
+							feature: "Statistics on unique and non-unique indexes.".to_string(),
 						})
 					}
 				};

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -110,10 +110,10 @@ async fn select_where_iterate_two_no_index() -> Result<(), Error> {
 	let mut res = execute_test(&two_multi_index_query("WITH NOINDEX", ""), 9).await?;
 	// OR results
 	check_result(&mut res, "[{ name: 'Jaime' }, { name: 'Tobie' }]")?;
-	check_result(&mut res, &table_explain(2))?;
+	check_result(&mut res, &table_explain_no_index(2))?;
 	// AND results
 	check_result(&mut res, "[{name: 'Jaime'}]")?;
-	check_result(&mut res, &table_explain(1))?;
+	check_result(&mut res, &table_explain_no_index(1))?;
 	Ok(())
 }
 
@@ -174,6 +174,31 @@ fn table_explain(fetch_count: usize) -> String {
 					table: 'person'
 				}},
 				operation: 'Iterate Table'
+			}},
+			{{
+				detail: {{
+					count: {fetch_count}
+				}},
+				operation: 'Fetch'
+			}}
+		]"
+	)
+}
+
+fn table_explain_no_index(fetch_count: usize) -> String {
+	format!(
+		"[
+			{{
+				detail: {{
+					table: 'person'
+				}},
+				operation: 'Iterate Table'
+			}},
+			{{
+				detail: {{
+					reason: 'WITH NOINDEX'
+				}},
+				operation: 'Fallback'
 			}},
 			{{
 				detail: {{
@@ -332,3 +357,60 @@ const TWO_MULTI_INDEX_EXPLAIN: &str = "[
 					operation: 'Fetch'
 				}
 			]";
+
+#[tokio::test]
+async fn select_with_no_index_unary_operator() -> Result<(), Error> {
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let mut res = dbs
+		.execute("SELECT * FROM table WITH NOINDEX WHERE !param.subparam EXPLAIN", &ses, None)
+		.await?;
+	assert_eq!(res.len(), 1);
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+				{
+					detail: {
+						table: 'table'
+					},
+					operation: 'Iterate Table'
+				},
+				{
+					detail: {
+						reason: 'WITH NOINDEX'
+					},
+					operation: 'Fallback'
+				}
+			]"#,
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_unsupported_unary_operator() -> Result<(), Error> {
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let mut res =
+		dbs.execute("SELECT * FROM table WHERE !param.subparam EXPLAIN", &ses, None).await?;
+	assert_eq!(res.len(), 1);
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+				{
+					detail: {
+						table: 'table'
+					},
+					operation: 'Iterate Table'
+				},
+				{
+					detail: {
+						reason: 'unary expressions not supported'
+					},
+					operation: 'Fallback'
+				}
+			]"#,
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	Ok(())
+}


### PR DESCRIPTION
## What is the motivation?

The query planner tries to leverage the indexes to speed up the queries. Every possible type and operation is not supported by indexes

In some cases, the query planner properly falls back to the table iterator. 
In other cases, the query fails with an error.

## What does this change do?

The explanation now provides information about the reason for a fallback.
Non-supported operations do not anymore generate an error but provide fallback information.

Eg.:

```sql
SELECT * FROM table WHERE !param.subparam EXPLAIN
```

```js
[
  {
	  detail: {
		  table: 'table'
	  },
	  operation: 'Iterate Table'
  },
  {
	  detail: {
		  reason: 'unary expressions not supported'
	  },
	  operation: 'Fallback'
  }
 ]
```

```sql
SELECT * FROM table WITH NOINDEX WHERE !param.subparam EXPLAIN
```

```js
[
  {
	  detail: {
		  table: 'table'
	  },
	  operation: 'Iterate Table'
  },
  {
	  detail: {
		  reason: 'WITH NOINDEX'
	  },
	  operation: 'Fallback'
  }
]
```

## What is your testing strategy?

Tests have been added, some others updated.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
