### PR TITLE
[logging] Move HTTP/WS logs to debug

### DIFF
--- a/src/net/tracer.rs
+++ b/src/net/tracer.rs
@@ -34,7 +34,7 @@ pub(crate) struct HttpTraceLayerHooks;
 impl<B> MakeSpan<B> for HttpTraceLayerHooks {
 	fn make_span(&mut self, req: &Request<B>) -> Span {
 		// The fields follow the OTEL semantic conventions: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.23.0/specification/trace/semantic_conventions/http.md
-		let span = tracing::info_span!(
+		let span = tracing::debug_span!(
 			"request",
 			otel.name = field::Empty,
 			otel.kind = "server",
@@ -102,7 +102,7 @@ impl<B> MakeSpan<B> for HttpTraceLayerHooks {
 
 impl<B> OnRequest<B> for HttpTraceLayerHooks {
 	fn on_request(&mut self, _: &Request<B>, _: &Span) {
-		tracing::event!(Level::INFO, "started processing request");
+		tracing::event!(Level::DEBUG, "started processing request");
 	}
 }
 
@@ -116,7 +116,7 @@ impl<B> OnResponse<B> for HttpTraceLayerHooks {
 		// Server errors are handled by the OnFailure hook
 		if !response.status().is_server_error() {
 			span.record("http.latency.ms", latency.as_millis());
-			tracing::event!(Level::INFO, "finished processing request");
+			tracing::event!(Level::DEBUG, "finished processing request");
 		}
 	}
 }

--- a/src/rpc/processor.rs
+++ b/src/rpc/processor.rs
@@ -34,7 +34,7 @@ impl Processor {
 	}
 
 	pub async fn process_request(&mut self, method: &str, params: Array) -> Result<Data, Failure> {
-		info!("Process RPC request");
+		debug!("Process RPC request");
 
 		// Match the method to a function
 		match method {

--- a/src/rpc/res.rs
+++ b/src/rpc/res.rs
@@ -96,7 +96,7 @@ impl Response {
 	pub async fn send(self, out: OutputFormat, chn: Sender<Message>) {
 		let span = Span::current();
 
-		info!("Process RPC response");
+		debug!("Process RPC response");
 
 		let is_error = self.result.is_err();
 		if let Err(err) = &self.result {

--- a/src/telemetry/traces/rpc.rs
+++ b/src/telemetry/traces/rpc.rs
@@ -2,7 +2,7 @@ use tracing::{field, Span};
 use uuid::Uuid;
 
 pub fn span_for_request(ws_id: &Uuid) -> Span {
-	let span = tracing::info_span!(
+	let span = tracing::debug_span!(
 		// Dynamic span names need to be 'recorded', can't be used on the macro. Use a static name here and overwrite later on
 		"rpc/call",
 		otel.name = field::Empty,


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Performance. While testing a local instance with RocksDB, I realised that when I configured the log-level to warn (effectively not showing logs for every HTTP/WS operation), I could double the request per second.

17,5k rps (warn level) vs 9k rps (info level)

## What does this change do?

It moves the HTTP and WS logs to `debug`.

## What is your testing strategy?

Tested locally

## Is this related to any issues?

Performance

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
