### PR TITLE
Compute local variables before storing them

### DIFF
--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -655,7 +655,10 @@ async fn router(
 				[Value::Strand(Strand(key)), value] => (mem::take(key), mem::take(value)),
 				_ => unreachable!(),
 			};
-			vars.insert(key, value);
+			match kvs.compute(value, &*session, Some(vars.clone())).await? {
+				Value::None => vars.remove(&key),
+				v => vars.insert(key, v),
+			};
 			Ok(DbResponse::Other(Value::None))
 		}
 		Method::Unset => {


### PR DESCRIPTION
## What is the motivation?

Setting variables for the local engines doesn't currently work for values that contain subqueries.

## What does this change do?

It computes values before storing them.

## What is your testing strategy?

Tested manually in the CLI. Will add automated tests once all the engines are fixed.

## Is this related to any issues?

Closes https://github.com/surrealdb/surrealdb/issues/2648.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
