### PR TITLE
[instrument] Move traces to debug

### DIFF
--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -169,7 +169,7 @@ impl<'a> Executor<'a> {
 		opt.set_db(Some(db.into()));
 	}
 
-	#[instrument(name = "executor", skip_all)]
+	#[instrument(level = "debug", name = "executor", skip_all)]
 	pub async fn execute(
 		&mut self,
 		mut ctx: Context<'_>,

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -726,7 +726,7 @@ impl Datastore {
 	///     Ok(())
 	/// }
 	/// ```
-	#[instrument(skip_all)]
+	#[instrument(level = "debug", skip_all)]
 	pub async fn execute(
 		&self,
 		txt: &str,
@@ -756,7 +756,7 @@ impl Datastore {
 	///     Ok(())
 	/// }
 	/// ```
-	#[instrument(skip_all)]
+	#[instrument(level = "debug", skip_all)]
 	pub async fn process(
 		&self,
 		ast: Query,
@@ -821,7 +821,7 @@ impl Datastore {
 	///     Ok(())
 	/// }
 	/// ```
-	#[instrument(skip_all)]
+	#[instrument(level = "debug", skip_all)]
 	pub async fn compute(
 		&self,
 		val: Value,
@@ -897,13 +897,13 @@ impl Datastore {
 	///     Ok(())
 	/// }
 	/// ```
-	#[instrument(skip_all)]
+	#[instrument(level = "debug", skip_all)]
 	pub fn notifications(&self) -> Option<Receiver<Notification>> {
 		self.notification_channel.as_ref().map(|v| v.1.clone())
 	}
 
 	/// Performs a full database export as SQL
-	#[instrument(skip(self, sess, chn))]
+	#[instrument(level = "debug", skip(self, sess, chn))]
 	pub async fn export(
 		&self,
 		sess: &Session,
@@ -928,7 +928,7 @@ impl Datastore {
 	}
 
 	/// Performs a database import from SQL
-	#[instrument(skip(self, sess, sql))]
+	#[instrument(level = "debug", skip(self, sess, sql))]
 	pub async fn import(&self, sql: &str, sess: &Session) -> Result<Vec<Response>, Error> {
 		// Skip auth for Anonymous users if auth is disabled
 		let skip_auth = !self.is_auth_enabled() && sess.au.is_anon();

--- a/lib/src/sql/parser.rs
+++ b/lib/src/sql/parser.rs
@@ -19,37 +19,37 @@ use tracing::instrument;
 ///
 /// If you encounter this limit and believe that it should be increased,
 /// please [open an issue](https://github.com/surrealdb/surrealdb/issues)!
-#[instrument(name = "parser", skip_all, fields(length = input.len()))]
+#[instrument(level = "debug", name = "parser", skip_all, fields(length = input.len()))]
 pub fn parse(input: &str) -> Result<Query, Error> {
 	parse_impl(input, query)
 }
 
 /// Parses a SurrealQL [`Thing`]
-#[instrument(name = "parser", skip_all, fields(length = input.len()))]
+#[instrument(level = "debug", name = "parser", skip_all, fields(length = input.len()))]
 pub fn thing(input: &str) -> Result<Thing, Error> {
 	parse_impl(input, super::thing::thing)
 }
 
 /// Parses a SurrealQL [`Idiom`]
-#[instrument(name = "parser", skip_all, fields(length = input.len()))]
+#[instrument(level = "debug", name = "parser", skip_all, fields(length = input.len()))]
 pub fn idiom(input: &str) -> Result<Idiom, Error> {
 	parse_impl(input, super::idiom::plain)
 }
 
 /// Parses a SurrealQL [`Value`].
-#[instrument(name = "parser", skip_all, fields(length = input.len()))]
+#[instrument(level = "debug", name = "parser", skip_all, fields(length = input.len()))]
 pub fn value(input: &str) -> Result<Value, Error> {
 	parse_impl(input, super::value::value)
 }
 
 /// Parses a SurrealQL Subquery [`Subquery`]
-#[instrument(name = "parser", skip_all, fields(length = input.len()))]
+#[instrument(level = "debug", name = "parser", skip_all, fields(length = input.len()))]
 pub fn subquery(input: &str) -> Result<Subquery, Error> {
 	parse_impl(input, super::subquery::subquery)
 }
 
 /// Parses JSON into an inert SurrealQL [`Value`]
-#[instrument(name = "parser", skip_all, fields(length = input.len()))]
+#[instrument(level = "debug", name = "parser", skip_all, fields(length = input.len()))]
 pub fn json(input: &str) -> Result<Value, Error> {
 	parse_impl(input.trim(), super::value::json)
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Follow up from #2650 

## What does this change do?

Move all traces generated from the instrumentation layer, to debug to avoid performance degradation when in `info`

## What is your testing strategy?

Tested locally

## Is this related to any issues?

Follow up from #2650 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
