### PR TITLE
Ensure parameters are computed before being stored on WebSocket

### DIFF
--- a/src/rpc/processor.rs
+++ b/src/rpc/processor.rs
@@ -235,7 +235,12 @@ impl Processor {
 	// ------------------------------
 
 	async fn set(&mut self, key: Strand, val: Value) -> Result<Value, Error> {
-		match val {
+		// Get a database reference
+		let kvs = DB.get().unwrap();
+		// Specify the query parameters
+		let var = Some(self.vars.to_owned());
+		// Compute the specified parameter
+		match kvs.compute(val, &self.session, var).await? {
 			// Remove the variable if undefined
 			Value::None => self.vars.remove(&key.0),
 			// Store the variable if defined


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Setting variables on the WebSocket RPC ;ayer engines doesn't currently work for values that contain subqueries, or any values that need to be computed.

## What does this change do?

It computes values before storing them.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2648.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
