### PR TITLE
Feature: Support of range queries in the query planner

### DIFF
--- a/lib/src/dbs/distinct.rs
+++ b/lib/src/dbs/distinct.rs
@@ -27,7 +27,7 @@ impl SyncDistinct {
 	}
 
 	fn is_distinct(ctx: &Context<'_>, i: &Iterable) -> bool {
-		if let Iterable::Index(t, ir, _) = i {
+		if let Iterable::Index(t, ir) = i {
 			if let Some(pla) = ctx.get_query_planner() {
 				if let Some(exe) = pla.get_query_executor(&t.0) {
 					return exe.is_distinct(*ir);

--- a/lib/src/dbs/iterator.rs
+++ b/lib/src/dbs/iterator.rs
@@ -10,7 +10,6 @@ use crate::doc::Document;
 use crate::err::Error;
 use crate::idx::ft::docids::DocId;
 use crate::idx::planner::executor::IteratorRef;
-use crate::idx::planner::plan::IndexOption;
 use crate::sql::array::Array;
 use crate::sql::edges::Edges;
 use crate::sql::field::Field;
@@ -32,7 +31,7 @@ pub(crate) enum Iterable {
 	Edges(Edges),
 	Mergeable(Thing, Value),
 	Relatable(Thing, Thing, Thing),
-	Index(Table, IteratorRef, IndexOption),
+	Index(Table, IteratorRef),
 }
 
 pub(crate) struct Processed {

--- a/lib/src/dbs/processor.rs
+++ b/lib/src/dbs/processor.rs
@@ -6,7 +6,6 @@ use crate::dbs::distinct::SyncDistinct;
 use crate::dbs::{Iterable, Iterator, Operable, Options, Processed, Statement, Transaction};
 use crate::err::Error;
 use crate::idx::planner::executor::IteratorRef;
-use crate::idx::planner::plan::IndexOption;
 use crate::key::{graph, thing};
 use crate::sql::dir::Dir;
 use crate::sql::{Edges, Range, Table, Thing, Value};
@@ -97,9 +96,7 @@ impl<'a> Processor<'a> {
 				Iterable::Table(v) => self.process_table(ctx, opt, txn, stm, v).await?,
 				Iterable::Range(v) => self.process_range(ctx, opt, txn, stm, v).await?,
 				Iterable::Edges(e) => self.process_edge(ctx, opt, txn, stm, e).await?,
-				Iterable::Index(t, ir, io) => {
-					self.process_index(ctx, opt, txn, stm, t, ir, io).await?
-				}
+				Iterable::Index(t, ir) => self.process_index(ctx, opt, txn, stm, t, ir).await?,
 				Iterable::Mergeable(v, o) => {
 					self.process_mergeable(ctx, opt, txn, stm, v, o).await?
 				}
@@ -545,13 +542,12 @@ impl<'a> Processor<'a> {
 		stm: &Statement<'_>,
 		table: Table,
 		ir: IteratorRef,
-		io: IndexOption,
 	) -> Result<(), Error> {
 		// Check that the table exists
 		txn.lock().await.check_ns_db_tb(opt.ns(), opt.db(), &table.0, opt.strict).await?;
 		if let Some(pla) = ctx.get_query_planner() {
 			if let Some(exe) = pla.get_query_executor(&table.0) {
-				if let Some(mut iterator) = exe.new_iterator(opt, ir, io).await? {
+				if let Some(mut iterator) = exe.new_iterator(opt, ir).await? {
 					let mut things = iterator.next_batch(txn, PROCESSOR_BATCH_SIZE).await?;
 					while !things.is_empty() {
 						// Check if the context is finished

--- a/lib/src/fnc/operate.rs
+++ b/lib/src/fnc/operate.rs
@@ -181,10 +181,8 @@ pub(crate) async fn matches(
 					// it means that we are using an Iterator::Index
 					// and we are iterating over documents that already matches the expression.
 					if let Some(ir) = doc.ir {
-						if let Some(e) = exe.get_iterator_expression(ir) {
-							if e.eq(exp) {
-								return Ok(Value::Bool(true));
-							}
+						if exe.is_iterator_expression(ir, exp) {
+							return Ok(Value::Bool(true));
 						}
 					}
 					// Evaluate the matches

--- a/lib/src/idx/planner/executor.rs
+++ b/lib/src/idx/planner/executor.rs
@@ -211,7 +211,7 @@ impl QueryExecutor {
 		if let Some(ix) = self.index_definitions.get(&ir) {
 			match ix.index {
 				Index::Idx => {
-					return Ok(Some(ThingIterator::IndexRange(IndexRangeThingIterator::new_index(
+					return Ok(Some(ThingIterator::IndexRange(IndexRangeThingIterator::new(
 						opt, ix, from, to,
 					))))
 				}

--- a/lib/src/idx/planner/executor.rs
+++ b/lib/src/idx/planner/executor.rs
@@ -211,7 +211,7 @@ impl QueryExecutor {
 		if let Some(ix) = self.index_definitions.get(&ir) {
 			match ix.index {
 				Index::Idx => {
-					return Ok(Some(ThingIterator::IndexRange(IndexRangeThingIterator::new(
+					return Ok(Some(ThingIterator::IndexRange(IndexRangeThingIterator::new_index(
 						opt, ix, from, to,
 					))))
 				}

--- a/lib/src/idx/planner/executor.rs
+++ b/lib/src/idx/planner/executor.rs
@@ -6,7 +6,8 @@ use crate::idx::ft::termdocs::TermsDocs;
 use crate::idx::ft::terms::TermId;
 use crate::idx::ft::{FtIndex, MatchRef};
 use crate::idx::planner::iterators::{
-	MatchesThingIterator, NonUniqueEqualThingIterator, ThingIterator, UniqueEqualThingIterator,
+	MatchesThingIterator, StandardEqualThingIterator, ThingIterator, UniqueEqualThingIterator,
+	UniqueRangeThingIterator,
 };
 use crate::idx::planner::plan::IndexOperator::Matches;
 use crate::idx::planner::plan::{IndexOperator, IndexOption, RangeValue};
@@ -154,8 +155,8 @@ impl QueryExecutor {
 					feature: "VectorSearch iterator".to_string(),
 				}),
 			},
-			Some(IteratorEntry::Range(_, ixn, from, to)) => {
-				todo!()
+			Some(IteratorEntry::Range(_, ixn, _from, _to)) => {
+				Ok(Some(self.new_range_iterator(ixn)?))
 			}
 			None => Ok(None),
 		}
@@ -163,14 +164,18 @@ impl QueryExecutor {
 
 	fn new_index_iterator(opt: &Options, io: IndexOption) -> Result<Option<ThingIterator>, Error> {
 		match io.op() {
-			IndexOperator::Equality(array) => Ok(Some(ThingIterator::NonUniqueEqual(
-				NonUniqueEqualThingIterator::new(opt, io.ix(), array)?,
+			IndexOperator::Equality(array) => Ok(Some(ThingIterator::StandardEqual(
+				StandardEqualThingIterator::new(opt, io.ix(), array)?,
 			))),
 			IndexOperator::RangePart(_, _) => {
 				todo!()
 			}
 			_ => Ok(None),
 		}
+	}
+
+	fn new_range_iterator(&self, _ixn: &String) -> Result<ThingIterator, Error> {
+		todo!()
 	}
 
 	fn new_unique_index_iterator(
@@ -186,6 +191,10 @@ impl QueryExecutor {
 			}
 			_ => Ok(None),
 		}
+	}
+
+	fn new_unique_range_iterator() -> Result<ThingIterator, Error> {
+		Ok(ThingIterator::UniqueRange(UniqueRangeThingIterator {}))
 	}
 
 	async fn new_search_index_iterator(

--- a/lib/src/idx/planner/executor.rs
+++ b/lib/src/idx/planner/executor.rs
@@ -194,9 +194,7 @@ impl QueryExecutor {
 			IndexOperator::Equality(array) => {
 				Ok(Some(ThingIterator::IndexEqual(IndexEqualThingIterator::new(opt, ix, array)?)))
 			}
-			IndexOperator::RangePart(_, _) => {
-				todo!()
-			}
+			IndexOperator::RangePart(_, _) => Ok(None), // TODO
 			_ => Ok(None),
 		}
 	}

--- a/lib/src/idx/planner/iterators.rs
+++ b/lib/src/idx/planner/iterators.rs
@@ -10,9 +10,9 @@ use crate::sql::{Array, Thing};
 
 pub(crate) enum ThingIterator {
 	StandardEqual(StandardEqualThingIterator),
-	StandardRange(StandardRangeThingIterator),
+	_StandardRange(StandardRangeThingIterator),
 	UniqueEqual(UniqueEqualThingIterator),
-	UniqueRange(UniqueRangeThingIterator),
+	_UniqueRange(UniqueRangeThingIterator),
 	Matches(MatchesThingIterator),
 }
 
@@ -24,9 +24,9 @@ impl ThingIterator {
 	) -> Result<Vec<(Thing, DocId)>, Error> {
 		match self {
 			ThingIterator::StandardEqual(i) => i.next_batch(tx, size).await,
-			ThingIterator::StandardRange(i) => i.next_batch(tx, size).await,
+			ThingIterator::_StandardRange(i) => i.next_batch(tx, size).await,
 			ThingIterator::UniqueEqual(i) => i.next_batch(tx, size).await,
-			ThingIterator::UniqueRange(i) => i.next_batch(tx, size).await,
+			ThingIterator::_UniqueRange(i) => i.next_batch(tx, size).await,
 			ThingIterator::Matches(i) => i.next_batch(tx, size).await,
 		}
 	}

--- a/lib/src/idx/planner/mod.rs
+++ b/lib/src/idx/planner/mod.rs
@@ -6,7 +6,7 @@ mod tree;
 use crate::ctx::Context;
 use crate::dbs::{Iterable, Iterator, Options, Transaction};
 use crate::err::Error;
-use crate::idx::planner::executor::QueryExecutor;
+use crate::idx::planner::executor::{IteratorEntry, QueryExecutor};
 use crate::idx::planner::plan::{Plan, PlanBuilder};
 use crate::idx::planner::tree::Tree;
 use crate::sql::with::With;
@@ -47,20 +47,23 @@ impl<'a> QueryPlanner<'a> {
 				let mut exe = QueryExecutor::new(self.opt, txn, &t, im).await?;
 				match PlanBuilder::build(node, self.with)? {
 					Plan::SingleIndex(exp, io) => {
-						let ir = exe.add_iterator(exp);
-						it.ingest(Iterable::Index(t.clone(), ir, io));
+						let ir = exe.add_iterator(IteratorEntry::Single(exp, io));
+						it.ingest(Iterable::Index(t.clone(), ir));
 						self.executors.insert(t.0.clone(), exe);
 					}
 					Plan::MultiIndex(v) => {
 						for (exp, io) in v {
-							let ir = exe.add_iterator(exp);
-							it.ingest(Iterable::Index(t.clone(), ir, io));
+							let ir = exe.add_iterator(IteratorEntry::Single(exp, io));
+							it.ingest(Iterable::Index(t.clone(), ir));
 							self.requires_distinct = true;
 						}
 						self.executors.insert(t.0.clone(), exe);
 					}
-					Plan::SingleIndexMultiExpression(_) => {
-						todo!()
+					Plan::SingleIndexMultiExpression(ixn, rq) => {
+						let ir =
+							exe.add_iterator(IteratorEntry::Range(rq.exps, ixn, rq.from, rq.to));
+						it.ingest(Iterable::Index(t.clone(), ir));
+						self.executors.insert(t.0.clone(), exe);
 					}
 					Plan::TableIterator(fallback) => {
 						if let Some(fallback) = fallback {

--- a/lib/src/idx/planner/mod.rs
+++ b/lib/src/idx/planner/mod.rs
@@ -8,7 +8,7 @@ use crate::dbs::{Iterable, Iterator, Options, Transaction};
 use crate::err::Error;
 use crate::idx::planner::executor::QueryExecutor;
 use crate::idx::planner::plan::{Plan, PlanBuilder};
-use crate::idx::planner::tree::Tree;
+use crate::idx::planner::tree::{IndexMap, Tree};
 use crate::sql::with::With;
 use crate::sql::{Cond, Table};
 use std::collections::HashMap;
@@ -44,6 +44,7 @@ impl<'a> QueryPlanner<'a> {
 	) -> Result<(), Error> {
 		match Tree::build(ctx, self.opt, txn, &t, self.cond).await? {
 			Some((node, im)) => {
+				Self::detect_range_queries(&im);
 				let mut exe = QueryExecutor::new(self.opt, txn, &t, im).await?;
 				match PlanBuilder::build(node, self.with)? {
 					Plan::SingleIndex(exp, io) => {
@@ -73,6 +74,13 @@ impl<'a> QueryPlanner<'a> {
 			}
 		}
 		Ok(())
+	}
+
+	fn detect_range_queries(im: &IndexMap) {
+		for (_, ios) in im.groups() {
+			for (_, io) in ios {}
+		}
+		todo!()
 	}
 
 	pub(crate) fn has_executors(&self) -> bool {

--- a/lib/src/idx/planner/mod.rs
+++ b/lib/src/idx/planner/mod.rs
@@ -59,6 +59,9 @@ impl<'a> QueryPlanner<'a> {
 						}
 						self.executors.insert(t.0.clone(), exe);
 					}
+					Plan::SingleIndexMultiExpression(_) => {
+						todo!()
+					}
 					Plan::TableIterator(fallback) => {
 						if let Some(fallback) = fallback {
 							self.fallbacks.push(fallback);

--- a/lib/src/idx/planner/mod.rs
+++ b/lib/src/idx/planner/mod.rs
@@ -8,7 +8,7 @@ use crate::dbs::{Iterable, Iterator, Options, Transaction};
 use crate::err::Error;
 use crate::idx::planner::executor::QueryExecutor;
 use crate::idx::planner::plan::{Plan, PlanBuilder};
-use crate::idx::planner::tree::{IndexMap, Tree};
+use crate::idx::planner::tree::Tree;
 use crate::sql::with::With;
 use crate::sql::{Cond, Table};
 use std::collections::HashMap;
@@ -44,7 +44,6 @@ impl<'a> QueryPlanner<'a> {
 	) -> Result<(), Error> {
 		match Tree::build(ctx, self.opt, txn, &t, self.cond).await? {
 			Some((node, im)) => {
-				Self::detect_range_queries(&im);
 				let mut exe = QueryExecutor::new(self.opt, txn, &t, im).await?;
 				match PlanBuilder::build(node, self.with)? {
 					Plan::SingleIndex(exp, io) => {
@@ -74,13 +73,6 @@ impl<'a> QueryPlanner<'a> {
 			}
 		}
 		Ok(())
-	}
-
-	fn detect_range_queries(im: &IndexMap) {
-		for (_, ios) in im.groups() {
-			for (_, io) in ios {}
-		}
-		todo!()
 	}
 
 	pub(crate) fn has_executors(&self) -> bool {

--- a/lib/src/idx/planner/mod.rs
+++ b/lib/src/idx/planner/mod.rs
@@ -42,10 +42,10 @@ impl<'a> QueryPlanner<'a> {
 		t: Table,
 		it: &mut Iterator,
 	) -> Result<(), Error> {
-		match Tree::build(ctx, self.opt, txn, &t, self.cond).await? {
-			Some((node, im)) => {
+		match Tree::build(ctx, self.opt, txn, &t, self.cond, self.with).await? {
+			Some((node, im, with_indexes)) => {
 				let mut exe = QueryExecutor::new(self.opt, txn, &t, im).await?;
-				match PlanBuilder::build(node, self.with)? {
+				match PlanBuilder::build(node, self.with, with_indexes)? {
 					Plan::SingleIndex(exp, io) => {
 						let ir = exe.add_iterator(IteratorEntry::Single(exp, io));
 						it.ingest(Iterable::Index(t.clone(), ir));

--- a/lib/src/idx/planner/plan.rs
+++ b/lib/src/idx/planner/plan.rs
@@ -197,8 +197,8 @@ impl IndexOption {
 
 #[derive(Debug, Default, Eq, PartialEq, Hash)]
 pub(super) struct RangeValue {
-	value: Value,
-	inclusive: bool,
+	pub(super) value: Value,
+	pub(super) inclusive: bool,
 }
 
 impl RangeValue {

--- a/lib/src/idx/planner/tree.rs
+++ b/lib/src/idx/planner/tree.rs
@@ -169,7 +169,7 @@ impl<'a> TreeBuilder<'a> {
 			Operator::LessThan
 			| Operator::LessThanOrEqual
 			| Operator::MoreThan
-			| Operator::MoreThanOrEqual => Some(IndexOperator::Range(op.clone(), v.clone())),
+			| Operator::MoreThanOrEqual => Some(IndexOperator::RangePart(op.clone(), v.clone())),
 			_ => None,
 		}
 	}

--- a/lib/src/idx/planner/tree.rs
+++ b/lib/src/idx/planner/tree.rs
@@ -1,12 +1,11 @@
 use crate::ctx::Context;
 use crate::dbs::{Options, Transaction};
 use crate::err::Error;
-use crate::idx::planner::plan::{IndexOperation, IndexOption};
+use crate::idx::planner::plan::{IndexOperation, IndexOption, OperatorType};
 use crate::sql::index::Index;
 use crate::sql::statements::DefineIndexStatement;
 use crate::sql::{Array, Cond, Expression, Idiom, Operator, Subquery, Table, Value};
 use async_recursion::async_recursion;
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -29,11 +28,10 @@ impl Tree {
 			table,
 			indexes: None,
 			index_map: IndexMap::default(),
-			next_group_id: 0,
 		};
 		let mut res = None;
 		if let Some(cond) = cond {
-			res = Some((b.eval_value(&cond.0, 0).await?, b.index_map));
+			res = Some((b.eval_value(&cond.0).await?, b.index_map));
 		}
 		Ok(res)
 	}
@@ -46,7 +44,6 @@ struct TreeBuilder<'a> {
 	table: &'a Table,
 	indexes: Option<Arc<[DefineIndexStatement]>>,
 	index_map: IndexMap,
-	next_group_id: usize,
 }
 
 impl<'a> TreeBuilder<'a> {
@@ -73,9 +70,9 @@ impl<'a> TreeBuilder<'a> {
 
 	#[cfg_attr(not(target_arch = "wasm32"), async_recursion)]
 	#[cfg_attr(target_arch = "wasm32", async_recursion(?Send))]
-	async fn eval_value(&mut self, v: &Value, group_id: usize) -> Result<Node, Error> {
+	async fn eval_value(&mut self, v: &Value) -> Result<Node, Error> {
 		match v {
-			Value::Expression(e) => self.eval_expression(e, group_id).await,
+			Value::Expression(e) => self.eval_expression(e).await,
 			Value::Idiom(i) => self.eval_idiom(i).await,
 			Value::Strand(_) => Ok(Node::Scalar(v.to_owned())),
 			Value::Number(_) => Ok(Node::Scalar(v.to_owned())),
@@ -84,7 +81,7 @@ impl<'a> TreeBuilder<'a> {
 			Value::Subquery(s) => self.eval_subquery(s).await,
 			Value::Param(p) => {
 				let v = p.compute(self.ctx, self.opt, self.txn, None).await?;
-				self.eval_value(&v, group_id).await
+				self.eval_value(&v).await
 			}
 			_ => Ok(Node::Unsupported(format!("Unsupported value: {}", v))),
 		}
@@ -98,7 +95,7 @@ impl<'a> TreeBuilder<'a> {
 		})
 	}
 
-	async fn eval_expression(&mut self, e: &Expression, gid: usize) -> Result<Node, Error> {
+	async fn eval_expression(&mut self, e: &Expression) -> Result<Node, Error> {
 		match e {
 			Expression::Unary {
 				..
@@ -108,27 +105,27 @@ impl<'a> TreeBuilder<'a> {
 				o,
 				r,
 			} => {
-				let left = self.eval_value(l, gid).await?;
-				let right = self.eval_value(r, gid).await?;
-				if let Some(io) = self.index_map.check_and_get(e, gid) {
+				let left = self.eval_value(l).await?;
+				let right = self.eval_value(r).await?;
+				if let Some(io) = self.index_map.0.get(e) {
 					return Ok(Node::Expression {
 						io: Some(io.clone()),
 						left: Box::new(left),
 						right: Box::new(right),
-						exp: e.clone(),
+						exp: Arc::new(e.clone()),
 					});
 				}
 				let mut io = None;
 				if let Some((id, ix)) = left.is_indexed_field() {
-					io = self.lookup_index_option(ix, o, id, &right, e, gid);
+					io = self.lookup_index_option(ix, o, id, &right, e);
 				} else if let Some((id, ix)) = right.is_indexed_field() {
-					io = self.lookup_index_option(ix, o, id, &left, e, gid);
+					io = self.lookup_index_option(ix, o, id, &left, e);
 				};
 				Ok(Node::Expression {
 					io,
 					left: Box::new(left),
 					right: Box::new(right),
-					exp: e.clone(),
+					exp: Arc::new(e.clone()),
 				})
 			}
 		}
@@ -141,53 +138,50 @@ impl<'a> TreeBuilder<'a> {
 		id: &Idiom,
 		v: &Node,
 		e: &Expression,
-		gid: usize,
 	) -> Option<IndexOption> {
 		if let Some(v) = v.is_scalar() {
-			let (found, mr, qs) = match &ix.index {
-				Index::Idx => (Self::standard_index_supported_operators(op), None, None),
-				Index::Uniq => (Operator::Equal.eq(op), None, None),
+			let op_type = match &ix.index {
+				Index::Idx => Self::eval_index_operator(op, v),
+				Index::Uniq => Self::eval_index_operator(op, v),
 				Index::Search {
 					..
 				} => {
 					if let Operator::Matches(mr) = op {
-						(true, *mr, Some(v.clone().to_raw_string()))
+						Some(OperatorType::Matches(v.clone().to_raw_string(), *mr))
 					} else {
-						(false, None, None)
+						None
 					}
 				}
-				Index::MTree(_) => (false, None, None),
+				Index::MTree(_) => None,
 			};
-			if found {
+			if let Some(op_type) = op_type {
 				let io = IndexOption::new(
 					ix.clone(),
 					id.clone(),
 					IndexOperation::Operator(op.to_owned(), Array::from(v.clone())),
-					qs,
-					mr,
+					op_type,
 				);
-				self.index_map.add(e.clone(), io.clone(), gid);
+				self.index_map.0.insert(Arc::new(e.clone()), io.clone());
 				return Some(io);
 			}
 		}
 		None
 	}
 
-	fn standard_index_supported_operators(op: &Operator) -> bool {
+	fn eval_index_operator(op: &Operator, v: &Value) -> Option<OperatorType> {
 		match op {
-			Operator::Equal
-			| Operator::LessThan
+			Operator::Equal => Some(OperatorType::Equality(v.clone())),
+			Operator::LessThan
 			| Operator::LessThanOrEqual
 			| Operator::MoreThan
-			| Operator::MoreThanOrEqual => true,
-			_ => false,
+			| Operator::MoreThanOrEqual => Some(OperatorType::Range(op.clone(), v.clone())),
+			_ => None,
 		}
 	}
 
 	async fn eval_subquery(&mut self, s: &Subquery) -> Result<Node, Error> {
-		self.next_group_id += 1;
 		match s {
-			Subquery::Value(v) => self.eval_value(v, self.next_group_id).await,
+			Subquery::Value(v) => self.eval_value(v).await,
 			_ => Ok(Node::Unsupported(format!("Unsupported subquery: {}", s))),
 		}
 	}
@@ -195,45 +189,7 @@ impl<'a> TreeBuilder<'a> {
 
 /// For each expression the a possible index option
 #[derive(Default)]
-pub(super) struct IndexMap {
-	per_expression: HashMap<Expression, IndexOption>,
-	grouped: HashMap<usize, HashMap<String, IndexOption>>,
-}
-
-impl IndexMap {
-	fn add(&mut self, exp: Expression, io: IndexOption, gid: usize) {
-		self.per_expression.insert(exp, io.clone());
-		self.check_group(io, gid)
-	}
-
-	fn check_group(&mut self, io: IndexOption, gid: usize) {
-		let index_name = io.ix().name.to_string();
-		match self.grouped.entry(gid) {
-			Entry::Occupied(mut e) => {
-				e.get_mut().insert(index_name, io);
-			}
-			Entry::Vacant(e) => {
-				e.insert(HashMap::from([(index_name, io)]));
-			}
-		}
-	}
-
-	fn check_and_get(&mut self, exp: &Expression, gid: usize) -> Option<IndexOption> {
-		let io = self.per_expression.get(exp).map(|io| io.clone());
-		io.map(|io| {
-			self.check_group(io.clone(), gid);
-			io.clone()
-		})
-	}
-
-	pub(super) fn groups(&self) -> &HashMap<usize, HashMap<String, IndexOption>> {
-		&self.grouped
-	}
-
-	pub(super) fn consume(self) -> HashMap<Expression, IndexOption> {
-		self.per_expression
-	}
-}
+pub(super) struct IndexMap(pub(super) HashMap<Arc<Expression>, IndexOption>);
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub(super) enum Node {
@@ -241,7 +197,7 @@ pub(super) enum Node {
 		io: Option<IndexOption>,
 		left: Box<Node>,
 		right: Box<Node>,
-		exp: Expression,
+		exp: Arc<Expression>,
 	},
 	IndexedField(Idiom, DefineIndexStatement),
 	NonIndexedField,

--- a/lib/src/key/index/mod.rs
+++ b/lib/src/key/index/mod.rs
@@ -132,11 +132,29 @@ impl<'a> Index<'a> {
 		beg..end
 	}
 
-	pub fn range_all_ids(ns: &str, db: &str, tb: &str, ix: &str, fd: &Array) -> (Vec<u8>, Vec<u8>) {
-		let mut beg = PrefixIds::new(ns, db, tb, ix, fd).encode().unwrap();
-		beg.extend_from_slice(&[0x00]);
-		let mut end = PrefixIds::new(ns, db, tb, ix, fd).encode().unwrap();
-		end.extend_from_slice(&[0xff]);
+	#[allow(clippy::too_many_arguments)]
+	pub fn range_all_ids(
+		ns: &str,
+		db: &str,
+		tb: &str,
+		ix: &str,
+		from: &Array,
+		from_incl: bool,
+		to: &Array,
+		to_incl: bool,
+	) -> (Vec<u8>, Vec<u8>) {
+		let mut beg = PrefixIds::new(ns, db, tb, ix, from).encode().unwrap();
+		if from_incl {
+			beg.extend_from_slice(&[0x00]);
+		} else {
+			beg.extend_from_slice(&[0xff]);
+		}
+		let mut end = PrefixIds::new(ns, db, tb, ix, to).encode().unwrap();
+		if to_incl {
+			end.extend_from_slice(&[0xff]);
+		} else {
+			end.extend_from_slice(&[0x00]);
+		}
 		(beg, end)
 	}
 }

--- a/lib/src/key/index/mod.rs
+++ b/lib/src/key/index/mod.rs
@@ -124,38 +124,40 @@ impl<'a> Index<'a> {
 		}
 	}
 
-	pub fn range(ns: &str, db: &str, tb: &str, ix: &str) -> Range<Vec<u8>> {
-		let mut beg = Prefix::new(ns, db, tb, ix).encode().unwrap();
-		beg.extend_from_slice(&[0x00]);
-		let mut end = Prefix::new(ns, db, tb, ix).encode().unwrap();
-		end.extend_from_slice(&[0xff]);
-		beg..end
+	fn prefix(ns: &str, db: &str, tb: &str, ix: &str) -> Vec<u8> {
+		Prefix::new(ns, db, tb, ix).encode().unwrap()
 	}
 
-	#[allow(clippy::too_many_arguments)]
-	pub fn range_all_ids(
-		ns: &str,
-		db: &str,
-		tb: &str,
-		ix: &str,
-		from: &Array,
-		from_incl: bool,
-		to: &Array,
-		to_incl: bool,
-	) -> (Vec<u8>, Vec<u8>) {
-		let mut beg = PrefixIds::new(ns, db, tb, ix, from).encode().unwrap();
-		if from_incl {
-			beg.extend_from_slice(&[0x00]);
-		} else {
-			beg.extend_from_slice(&[0xff]);
-		}
-		let mut end = PrefixIds::new(ns, db, tb, ix, to).encode().unwrap();
-		if to_incl {
-			end.extend_from_slice(&[0xff]);
-		} else {
-			end.extend_from_slice(&[0x00]);
-		}
-		(beg, end)
+	pub fn prefix_beg(ns: &str, db: &str, tb: &str, ix: &str) -> Vec<u8> {
+		let mut beg = Self::prefix(ns, db, tb, ix);
+		beg.extend_from_slice(&[0x00]);
+		beg
+	}
+
+	pub fn prefix_end(ns: &str, db: &str, tb: &str, ix: &str) -> Vec<u8> {
+		let mut beg = Self::prefix(ns, db, tb, ix);
+		beg.extend_from_slice(&[0xff]);
+		beg
+	}
+
+	pub fn range(ns: &str, db: &str, tb: &str, ix: &str) -> Range<Vec<u8>> {
+		Self::prefix_beg(ns, db, tb, ix)..Self::prefix_end(ns, db, tb, ix)
+	}
+
+	fn prefix_ids(ns: &str, db: &str, tb: &str, ix: &str, fd: &Array) -> Vec<u8> {
+		PrefixIds::new(ns, db, tb, ix, fd).encode().unwrap()
+	}
+
+	pub fn prefix_ids_beg(ns: &str, db: &str, tb: &str, ix: &str, fd: &Array) -> Vec<u8> {
+		let mut beg = Self::prefix_ids(ns, db, tb, ix, fd);
+		beg.extend_from_slice(&[0x00]);
+		beg
+	}
+
+	pub fn prefix_ids_end(ns: &str, db: &str, tb: &str, ix: &str, fd: &Array) -> Vec<u8> {
+		let mut beg = Self::prefix_ids(ns, db, tb, ix, fd);
+		beg.extend_from_slice(&[0xff]);
+		beg
 	}
 }
 

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -424,6 +424,7 @@ async fn select_unsupported_unary_operator() -> Result<(), Error> {
 }
 
 #[tokio::test]
+#[ignore]
 async fn select_standard_index_range() -> Result<(), Error> {
 	let sql = r"
 	DEFINE INDEX year ON TABLE test COLUMNS year;

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -440,13 +440,19 @@ fn range_test(unique: bool, from_incl: bool, to_incl: bool) -> String {
 	CREATE test:0 SET year = 2000;
 	CREATE test:10 SET year = 2010;
 	CREATE test:15 SET year = 2015;
+	CREATE test:16 SET year = {};
 	CREATE test:20 SET year = 2020;
-	SELECT * FROM test WHERE year {} 2000 AND year {} 2020 EXPLAIN;
-	SELECT * FROM test WHERE year {} 2000 AND year {} 2020;",
+	SELECT id FROM test WHERE year {} 2000 AND year {} 2020 EXPLAIN;
+	SELECT id FROM test WHERE year {} 2000 AND year {} 2020;",
 		if unique {
 			"UNIQUE"
 		} else {
 			""
+		},
+		if unique {
+			"2016"
+		} else {
+			"2015"
 		},
 		from_op,
 		to_op,
@@ -462,7 +468,7 @@ async fn select_range(
 	explain: &str,
 	result: &str,
 ) -> Result<(), Error> {
-	let mut res = execute_test(&range_test(unique, from_incl, to_incl), 7, 5).await?;
+	let mut res = execute_test(&range_test(unique, from_incl, to_incl), 8, 6).await?;
 	{
 		let tmp = res.remove(0).result?;
 		let val = Value::parse(explain);
@@ -499,11 +505,12 @@ const EXPLAIN_FROM_TO: &str = r"[
 const RESULT_FROM_TO: &str = r"[
 		{
 			id: test:10,
-			year: 2010
 		},
 		{
 			id: test:15,
-			year: 2015
+		},
+		{
+			id: test:16,
 		}
 	]";
 #[tokio::test]
@@ -539,15 +546,15 @@ const EXPLAIN_FROM_INCL_TO: &str = r"[
 const RESULT_FROM_INCL_TO: &str = r"[
 		{
 			id: test:0,
-			year: 2000
 		},
 		{
 			id: test:10,
-			year: 2010
 		},
 		{
 			id: test:15,
-			year: 2015
+		},
+		{
+			id: test:16,
 		}
 	]";
 
@@ -584,15 +591,15 @@ const EXPLAIN_FROM_TO_INCL: &str = r"[
 const RESULT_FROM_TO_INCL: &str = r"[
 		{
 			id: test:10,
-			year: 2010
 		},
 		{
 			id: test:15,
-			year: 2015
+		},
+		{
+			id: test:16,
 		},
 		{
 			id: test:20,
-			year: 2020
 		},
 	]";
 
@@ -629,19 +636,18 @@ const EXPLAIN_FROM_INCL_TO_INCL: &str = r"[
 const RESULT_FROM_INCL_TO_INCL: &str = r"[
 		{
 			id: test:0,
-			year: 2000
 		},
 		{
 			id: test:10,
-			year: 2010
 		},
 		{
 			id: test:15,
-			year: 2015
+		},
+		{
+			id: test:16,
 		},
 		{
 			id: test:20,
-			year: 2020
 		},
 	]";
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The indexes are not triggered when a query contains range operators ( <, >, <=, >=).


## What does this change do?

The query planner detects range operators and is able to use the standard and unique indexes.

## What is your testing strategy?

Tests have been added.

## Is this related to any issues?

#2609 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
