### PR TITLE
Fix authentication issues with `LIVE SELECT` statements

### DIFF
--- a/lib/src/iam/signin.rs
+++ b/lib/src/iam/signin.rs
@@ -145,6 +145,8 @@ pub async fn sc(
 									id: Some(rid.to_raw()),
 									..Claims::default()
 								};
+								// Log the authenticated scope info
+								trace!("Signing in to scope `{}`", sc);
 								// Create the authentication token
 								let enc = encode(&HEADER, &val, &key);
 								// Set the authentication on the session
@@ -201,6 +203,8 @@ pub async fn db(
 				id: Some(user),
 				..Claims::default()
 			};
+			// Log the authenticated database info
+			trace!("Signing in to database `{}`", db);
 			// Create the authentication token
 			let enc = encode(&HEADER, &val, &key);
 			// Set the authentication on the session
@@ -241,6 +245,8 @@ pub async fn ns(
 				id: Some(user),
 				..Claims::default()
 			};
+			// Log the authenticated namespace info
+			trace!("Signing in to namespace `{}`", ns);
 			// Create the authentication token
 			let enc = encode(&HEADER, &val, &key);
 			// Set the authentication on the session
@@ -278,6 +284,8 @@ pub async fn kv(
 				id: Some(user),
 				..Claims::default()
 			};
+			// Log the authenticated root info
+			trace!("Signing in as root");
 			// Create the authentication token
 			let enc = encode(&HEADER, &val, &key);
 			// Set the authentication on the session

--- a/lib/src/iam/signup.rs
+++ b/lib/src/iam/signup.rs
@@ -86,6 +86,8 @@ pub async fn sc(
 									id: Some(rid.to_raw()),
 									..Claims::default()
 								};
+								// Log the authenticated scope info
+								trace!("Signing up to scope `{}`", sc);
 								// Create the authentication token
 								let enc = encode(&HEADER, &val, &key);
 								// Set the authentication on the session

--- a/lib/src/kvs/tests/cluster_init.rs
+++ b/lib/src/kvs/tests/cluster_init.rs
@@ -74,6 +74,7 @@ async fn expired_nodes_get_live_queries_archived() {
 		cond: None,
 		fetch: None,
 		archived: Some(crate::sql::uuid::Uuid::from(old_node)),
+		session: Some(Value::None),
 		auth: Some(Auth::for_root(Role::Owner)),
 	};
 	let ctx = context::Context::background();
@@ -150,6 +151,7 @@ async fn single_live_queries_are_garbage_collected() {
 		cond: None,
 		fetch: None,
 		archived: None,
+		session: Some(Value::None),
 		auth: Some(Auth::for_root(Role::Owner)),
 	};
 	live_st
@@ -166,6 +168,7 @@ async fn single_live_queries_are_garbage_collected() {
 		cond: None,
 		fetch: None,
 		archived: None,
+		session: Some(Value::None),
 		auth: Some(Auth::for_root(Role::Owner)),
 	};
 	live_st
@@ -230,6 +233,7 @@ async fn bootstrap_does_not_error_on_missing_live_queries() {
 		cond: None,
 		fetch: None,
 		archived: None,
+		session: Some(Value::None),
 		auth: Some(Auth::for_root(Role::Owner)),
 	};
 	live_st

--- a/lib/src/sql/statements/live.rs
+++ b/lib/src/sql/statements/live.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
-#[revisioned(revision = 1)]
+#[revisioned(revision = 2)]
 pub struct LiveStatement {
 	pub id: Uuid,
 	pub node: Uuid,
@@ -35,15 +35,24 @@ pub struct LiveStatement {
 	pub what: Value,
 	pub cond: Option<Cond>,
 	pub fetch: Option<Fetchs>,
-
-	// Non-query properties that are necessary for storage or otherwise carrying information
-
-	// When a live query is archived, this should be the node ID that archived the query.
-	pub archived: Option<Uuid>,
-	// A live query is run with permissions, and we must validate that during the run.
-	// It is optional, because the live query may be constructed without it being set.
-	// It is populated during compute.
-	pub auth: Option<Auth>,
+	// When a live query is marked for archiving, this will
+	// be set to the node ID that archived the query. This
+	// is an internal property, set by the database runtime.
+	// This is optional, and os only set when archived.
+	pub(crate) archived: Option<Uuid>,
+	// When a live query is created, we must also store the
+	// authenticated session of the user who made the query,
+	// so we can chack it later when sending notifications.
+	// This is optional as it is only set by the database
+	// runtime when storing the live query to storage.
+	#[revision(start = 2)]
+	pub(crate) session: Option<Value>,
+	// When a live query is created, we must also store the
+	// authenticated session of the user who made the query,
+	// so we can chack it later when sending notifications.
+	// This is optional as it is only set by the database
+	// runtime when storing the live query to storage.
+	pub(crate) auth: Option<Auth>,
 }
 
 impl LiveStatement {
@@ -59,33 +68,33 @@ impl LiveStatement {
 		opt.realtime()?;
 		// Valid options?
 		opt.valid_for_db()?;
+		// Get the Node ID
+		let nid = opt.id()?;
 		// Check that auth has been set
-		let self_override = LiveStatement {
-			auth: match self.auth {
-				Some(ref auth) => Some(auth.clone()),
-				None => Some(opt.auth.as_ref().clone()),
-			},
+		let mut stm = LiveStatement {
+			// Use the current session authentication
+			// for when we store the LIVE Statement
+			session: ctx.value("session").cloned(),
+			// Use the current session authentication
+			// for when we store the LIVE Statement
+			auth: Some(opt.auth.as_ref().clone()),
+			// Clone the rest of the original fields
+			// from the LIVE statement to the new one
 			..self.clone()
 		};
-		trace!("Evaluated live query auth to {:?}", self_override.auth);
+		let id = stm.id.0;
 		// Claim transaction
 		let mut run = txn.lock().await;
 		// Process the live query table
-		match self_override.what.compute(ctx, opt, txn, doc).await? {
+		match stm.what.compute(ctx, opt, txn, doc).await? {
 			Value::Table(tb) => {
-				// Clone the current statement
-				let mut stm = self_override.clone();
 				// Store the current Node ID
-				if let Err(e) = opt.id() {
-					trace!("No ID for live query {:?}, error={:?}", stm, e)
-				}
-				stm.node = Uuid(opt.id()?);
+				stm.node = nid.into();
 				// Insert the node live query
-				let key =
-					crate::key::node::lq::new(opt.id()?, self_override.id.0, opt.ns(), opt.db());
+				let key = crate::key::node::lq::new(opt.id()?, id, opt.ns(), opt.db());
 				run.putc(key, tb.as_str(), None).await?;
 				// Insert the table live query
-				let key = crate::key::table::lq::new(opt.ns(), opt.db(), &tb, self_override.id.0);
+				let key = crate::key::table::lq::new(opt.ns(), opt.db(), &tb, id);
 				run.putc(key, stm, None).await?;
 			}
 			v => {
@@ -95,8 +104,7 @@ impl LiveStatement {
 			}
 		};
 		// Return the query id
-		trace!("Live query after processing: {:?}", self_override);
-		Ok(self_override.id.clone().into())
+		Ok(id.into())
 	}
 
 	pub(crate) fn archive(mut self, node_id: Uuid) -> LiveStatement {

--- a/lib/src/sql/value/serde/ser/statement/live.rs
+++ b/lib/src/sql/value/serde/ser/statement/live.rs
@@ -47,6 +47,7 @@ pub struct SerializeLiveStatement {
 	cond: Option<Cond>,
 	fetch: Option<Fetchs>,
 	archived: Option<Uuid>,
+	session: Option<Value>,
 	auth: Option<Auth>,
 }
 
@@ -80,6 +81,9 @@ impl serde::ser::SerializeStruct for SerializeLiveStatement {
 			"archived" => {
 				self.archived = value.serialize(ser::uuid::opt::Serializer.wrap())?.map(Uuid);
 			}
+			"session" => {
+				self.session = None;
+			}
 			"auth" => {
 				self.auth = None;
 			}
@@ -99,6 +103,7 @@ impl serde::ser::SerializeStruct for SerializeLiveStatement {
 			cond: self.cond,
 			fetch: self.fetch,
 			archived: self.archived,
+			session: None,
 			auth: None,
 		})
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Previously, `LIVE` SELECT statements did not have access to the original `$session` information, and were therefore unable to  process `PERMISSIONS` clauses fully or correctly. In addition, `LIVE SELECT` statements were processed using the context of the current session, and not of the session which created the `LIVE SELECT` statement, giving access to parameters in the current scope.

## What does this change do?

It fixes authentication permissions for `LIVE SELECT` statements, and ensures that the correct context and options are used for processing each stored statement. It does this by storing the necessary `$session` information on each `LIVE STATEMENT`. In addition it introduces `$before`, `$after`, `$value`, and `$event` parameters, so that these can be used within the field projection and WHERE clauses of a `LIVE SELECT` statement.

## What is your testing strategy?

GitHub Actions testing, and manual testing.

## Is this related to any issues?

Closes #2437.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
