### PR TITLE
Ensure `DEFAULT` clause is displayed on `DEFINE FIELD` statements

### DIFF
--- a/lib/src/sql/statements/define/field.rs
+++ b/lib/src/sql/statements/define/field.rs
@@ -84,6 +84,9 @@ impl Display for DefineFieldStatement {
 		if let Some(ref v) = self.kind {
 			write!(f, " TYPE {v}")?
 		}
+		if let Some(ref v) = self.default {
+			write!(f, " DEFAULT {v}")?
+		}
 		if let Some(ref v) = self.value {
 			write!(f, " VALUE {v}")?
 		}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `DEFAULT` clause is not currently displayed when outputting `DEFINE FIELD` statements.

## What does this change do?

Ensures that the `DEFAULT` clause is displayed and output correctly.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2660.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
