### PR TITLE
Add `$before` and `$after` params to `RETURN` clauses

### DIFF
--- a/lib/src/doc/lives.rs
+++ b/lib/src/doc/lives.rs
@@ -172,10 +172,8 @@ impl<'a> Document<'a> {
 		if opt.check_perms(stm.into()) {
 			// Get the table
 			let tb = self.tb(opt, txn).await?;
-			// Get the permission clause
-			let perms = &tb.permissions.select;
 			// Process the table permissions
-			match perms {
+			match &tb.permissions.select {
 				Permission::None => return Err(Error::Ignore),
 				Permission::Full => return Ok(()),
 				Permission::Specific(e) => {

--- a/lib/tests/update.rs
+++ b/lib/tests/update.rs
@@ -206,6 +206,81 @@ async fn update_complex_with_input() -> Result<(), Error> {
 	Ok(())
 }
 
+#[tokio::test]
+async fn update_with_return_clause() -> Result<(), Error> {
+	let sql = "
+		CREATE person:test SET age = 18, name = 'John';
+		UPDATE person:test SET age = 25 RETURN VALUE $before;
+		UPDATE person:test SET age = 30 RETURN VALUE { old_age: $before.age, new_age: $after.age };
+		UPDATE person:test SET age = 35 RETURN age, name;
+		DELETE person:test RETURN VALUE $before;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 5);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				age: 18,
+				id: person:test,
+				name: 'John'
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				age: 18,
+				id: person:test,
+				name: 'John'
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				new_age: 30,
+				old_age: 25
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				age: 35,
+				name: 'John'
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				age: 35,
+				id: person:test,
+				name: 'John'
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
 //
 // Permissions
 //


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When running a `CREATE`, `UPDATE`, `RELATE`, or `DELETE` statement we don't currently have access to the initial document version in the final `RETURN` clause.

## What does this change do?

This pull request adds `$before` and `$after` parameters to the `RETURN` clauses on the `CREATE`, `UPDATE`, `RELATE`, or `DELETE` statements. This means it is now possible to do the following:

```sql
UPDATE user SET avatar = null RETURN VALUE $before.avatar;
```

or

```sql
UPDATE user SET avatar = 'tobiemh' RETURN VALUE {
    initial_avatar: $before.avatar,
    new_avatar: $after.avatar
};
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2659.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
