### PR TITLE
Ensure invalid sessions do not cause live queries to fail

### DIFF
--- a/lib/src/doc/lives.rs
+++ b/lib/src/doc/lives.rs
@@ -50,9 +50,15 @@ impl<'a> Document<'a> {
 					false => &self.current,
 				};
 				// Ensure that a session exists on the LIVE query
-				let sess = lv.session.as_ref().ok_or(Error::UnknownAuth)?;
+				let sess = match lv.session.as_ref() {
+					Some(v) => v,
+					None => continue,
+				};
 				// Ensure that auth info exists on the LIVE query
-				let auth = lv.auth.clone().ok_or(Error::UnknownAuth)?;
+				let auth = match lv.auth.clone() {
+					Some(v) => v,
+					None => continue,
+				};
 				// We need to create a new context which we will
 				// use for processing this LIVE query statement.
 				// This ensures that we are using the session
@@ -66,9 +72,7 @@ impl<'a> Document<'a> {
 				// use for processing this LIVE query statement.
 				// This ensures that we are using the auth data
 				// of the user who created the LIVE query.
-				let lqopt = Options::new_with_perms(opt, true)
-					.with_auth_enabled(true)
-					.with_auth(Arc::from(auth));
+				let lqopt = opt.new_with_perms(true).with_auth(Arc::from(auth));
 				// Add $before, $after, $value, and $event params
 				// to this LIVE query so that user can use these
 				// within field projections and WHERE clauses.


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Live queries can sometimes fail when upgrading from `1.0.0-beta.11`.

## What does this change do?

Ensures that failing live queries, because of missing sessions, do not cause queries to fail.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
