### PR TITLE
Add live queries to `INFO FOR TB` statement

### DIFF
--- a/lib/src/sql/statements/info.rs
+++ b/lib/src/sql/statements/info.rs
@@ -194,6 +194,12 @@ impl InfoStatement {
 					tmp.insert(v.name.to_string(), v.to_string().into());
 				}
 				res.insert("indexes".to_owned(), tmp.into());
+				// Process the live queries
+				let mut tmp = Object::default();
+				for v in run.all_tb_lives(opt.ns(), opt.db(), tb).await?.iter() {
+					tmp.insert(v.id.to_string(), v.to_string().into());
+				}
+				res.insert("lives".to_owned(), tmp.into());
 				// Ok all good
 				Value::from(res).ok()
 			}

--- a/lib/src/sql/statements/info.rs
+++ b/lib/src/sql/statements/info.rs
@@ -197,7 +197,7 @@ impl InfoStatement {
 				// Process the live queries
 				let mut tmp = Object::default();
 				for v in run.all_tb_lives(opt.ns(), opt.db(), tb).await?.iter() {
-					tmp.insert(v.id.to_string(), v.to_string().into());
+					tmp.insert(v.id.to_raw(), v.to_string().into());
 				}
 				res.insert("lives".to_owned(), tmp.into());
 				// Ok all good

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -346,6 +346,7 @@ async fn define_statement_event() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -403,6 +404,7 @@ async fn define_statement_event_when_event() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: {},
+			lives: {},
 		}"#,
 	);
 	assert_eq!(tmp, val);
@@ -460,6 +462,7 @@ async fn define_statement_event_when_logic() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -509,6 +512,7 @@ async fn define_statement_field() -> Result<(), Error> {
 			fields: { test: 'DEFINE FIELD test ON user' },
 			tables: {},
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -541,6 +545,7 @@ async fn define_statement_field_type() -> Result<(), Error> {
 			fields: { test: 'DEFINE FIELD test ON user TYPE string' },
 			tables: {},
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -573,6 +578,7 @@ async fn define_statement_field_value() -> Result<(), Error> {
 			fields: { test: "DEFINE FIELD test ON user VALUE $value OR 'GBR'" },
 			tables: {},
 			indexes: {},
+			lives: {},
 		}"#,
 	);
 	assert_eq!(tmp, val);
@@ -605,6 +611,7 @@ async fn define_statement_field_assert() -> Result<(), Error> {
 			fields: { test: 'DEFINE FIELD test ON user ASSERT $value != NONE AND $value = /[A-Z]{3}/' },
 			tables: {},
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -637,6 +644,7 @@ async fn define_statement_field_type_value_assert() -> Result<(), Error> {
 			fields: { test: "DEFINE FIELD test ON user TYPE string VALUE $value OR 'GBR' ASSERT $value != NONE AND $value = /[A-Z]{3}/" },
 			tables: {},
 			indexes: {},
+			lives: {},
 		}"#,
 	);
 	assert_eq!(tmp, val);
@@ -679,6 +687,7 @@ async fn define_statement_index_single_simple() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: { test: 'DEFINE INDEX test ON user FIELDS age' },
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -721,6 +730,7 @@ async fn define_statement_index_single() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: { test: 'DEFINE INDEX test ON user FIELDS email' },
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -765,6 +775,7 @@ async fn define_statement_index_multiple() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: { test: 'DEFINE INDEX test ON user FIELDS account, email' },
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -817,6 +828,7 @@ async fn define_statement_index_single_unique() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: { test: 'DEFINE INDEX test ON user FIELDS email UNIQUE' },
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -875,6 +887,7 @@ async fn define_statement_index_multiple_unique() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: { test: 'DEFINE INDEX test ON user FIELDS account, email UNIQUE' },
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -961,6 +974,7 @@ async fn define_statement_index_single_unique_existing() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -1008,6 +1022,7 @@ async fn define_statement_index_multiple_unique_existing() -> Result<(), Error> 
 			fields: {},
 			tables: {},
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -1042,6 +1057,7 @@ async fn define_statement_index_single_unique_embedded_multiple() -> Result<(), 
 			fields: {},
 			tables: {},
 			indexes: { test: 'DEFINE INDEX test ON user FIELDS tags UNIQUE' },
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -1092,6 +1108,7 @@ async fn define_statement_index_multiple_unique_embedded_multiple() -> Result<()
 			fields: {},
 			tables: {},
 			indexes: { test: 'DEFINE INDEX test ON user FIELDS account, tags UNIQUE' },
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -1195,6 +1212,7 @@ async fn define_statement_search_index() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: { blog_title: 'DEFINE INDEX blog_title ON blog FIELDS title SEARCH ANALYZER simple BM25(1.2,0.75) DOC_IDS_ORDER 100 DOC_LENGTHS_ORDER 100 POSTINGS_ORDER 100 TERMS_ORDER 100 HIGHLIGHTS' },
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -1888,8 +1906,8 @@ async fn permissions_checks_define_event() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ events: { event: \"DEFINE EVENT event ON TB WHEN true THEN (RETURN 'foo')\" }, fields: {  }, indexes: {  }, tables: {  } }"],
-		vec!["{ events: {  }, fields: {  }, indexes: {  }, tables: {  } }"]
+        vec!["{ events: { event: \"DEFINE EVENT event ON TB WHEN true THEN (RETURN 'foo')\" }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"],
+		vec!["{ events: {  }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"]
     ];
 
 	let test_cases = [
@@ -1930,8 +1948,8 @@ async fn permissions_checks_define_field() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ events: {  }, fields: { field: 'DEFINE FIELD field ON TB' }, indexes: {  }, tables: {  } }"],
-		vec!["{ events: {  }, fields: {  }, indexes: {  }, tables: {  } }"]
+        vec!["{ events: {  }, fields: { field: 'DEFINE FIELD field ON TB' }, indexes: {  }, lives: {  }, tables: {  } }"],
+		vec!["{ events: {  }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"]
     ];
 
 	let test_cases = [
@@ -1972,8 +1990,8 @@ async fn permissions_checks_define_index() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ events: {  }, fields: {  }, indexes: { index: 'DEFINE INDEX index ON TB FIELDS field' }, tables: {  } }"],
-		vec!["{ events: {  }, fields: {  }, indexes: {  }, tables: {  } }"]
+        vec!["{ events: {  }, fields: {  }, indexes: { index: 'DEFINE INDEX index ON TB FIELDS field' }, lives: {  }, tables: {  } }"],
+		vec!["{ events: {  }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"]
     ];
 
 	let test_cases = [

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -274,6 +274,7 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 			fields: {},
 			tables: { view: 'DEFINE TABLE view SCHEMALESS AS SELECT count() FROM test GROUP ALL' },
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -304,6 +305,7 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 			fields: {},
 			tables: {},
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);

--- a/lib/tests/info.rs
+++ b/lib/tests/info.rs
@@ -140,7 +140,7 @@ async fn info_for_table() {
 	assert!(out.is_ok(), "Unexpected error: {:?}", out);
 
 	let output_regex = Regex::new(
-		r"\{ events: \{ event: .* \}, fields: \{ field: .* \}, indexes: \{ index: .* \}, tables: \{  \} \}",
+		r"\{ events: \{ event: .* \}, fields: \{ field: .* \}, indexes: \{ index: .* \}, lives: \{  \}, tables: \{  \} \}",
 	)
 	.unwrap();
 	let out_str = out.unwrap().to_string();
@@ -393,8 +393,8 @@ async fn permissions_checks_info_table() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-		vec!["{ events: {  }, fields: {  }, indexes: {  }, tables: {  } }"],
-		vec!["{ events: {  }, fields: {  }, indexes: {  }, tables: {  } }"],
+		vec!["{ events: {  }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"],
+		vec!["{ events: {  }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"],
 	];
 
 	let test_cases = [

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -111,6 +111,7 @@ async fn remove_statement_index() -> Result<(), Error> {
 			fields: {},
 			indexes: {},
 			tables: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);
@@ -640,8 +641,8 @@ async fn permissions_checks_remove_event() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-		vec!["{ events: {  }, fields: {  }, indexes: {  }, tables: {  } }"],
-        vec!["{ events: { event: \"DEFINE EVENT event ON TB WHEN true THEN (RETURN 'foo')\" }, fields: {  }, indexes: {  }, tables: {  } }"],
+		vec!["{ events: {  }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"],
+        vec!["{ events: { event: \"DEFINE EVENT event ON TB WHEN true THEN (RETURN 'foo')\" }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"],
     ];
 
 	let test_cases = [
@@ -682,8 +683,8 @@ async fn permissions_checks_remove_field() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-		vec!["{ events: {  }, fields: {  }, indexes: {  }, tables: {  } }"],
-        vec!["{ events: {  }, fields: { field: 'DEFINE FIELD field ON TB' }, indexes: {  }, tables: {  } }"],
+		vec!["{ events: {  }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"],
+        vec!["{ events: {  }, fields: { field: 'DEFINE FIELD field ON TB' }, indexes: {  }, lives: {  }, tables: {  } }"],
     ];
 
 	let test_cases = [
@@ -724,8 +725,8 @@ async fn permissions_checks_remove_index() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-		vec!["{ events: {  }, fields: {  }, indexes: {  }, tables: {  } }"],
-        vec!["{ events: {  }, fields: {  }, indexes: { index: 'DEFINE INDEX index ON TB FIELDS field' }, tables: {  } }"],
+		vec!["{ events: {  }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"],
+        vec!["{ events: {  }, fields: {  }, indexes: { index: 'DEFINE INDEX index ON TB FIELDS field' }, lives: {  }, tables: {  } }"],
     ];
 
 	let test_cases = [

--- a/lib/tests/strict.rs
+++ b/lib/tests/strict.rs
@@ -270,6 +270,7 @@ async fn loose_mode_all_ok() -> Result<(), Error> {
 			fields: { extra: 'DEFINE FIELD extra ON test VALUE true' },
 			tables: {},
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);

--- a/lib/tests/table.rs
+++ b/lib/tests/table.rs
@@ -45,6 +45,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 			fields: {},
 			tables: { person_by_age: 'DEFINE TABLE person_by_age SCHEMALESS AS SELECT count(), age, math::sum(age) AS total, math::mean(score) AS average FROM person GROUP BY age' },
 			indexes: {},
+			lives: {},
 		}",
 	);
 	assert_eq!(tmp, val);

--- a/src/rpc/processor.rs
+++ b/src/rpc/processor.rs
@@ -202,6 +202,7 @@ impl Processor {
 			.map(Into::into)
 			.map_err(Into::into)
 	}
+
 	async fn invalidate(&mut self) -> Result<Value, Error> {
 		surrealdb::iam::clear::clear(&mut self.session)?;
 		Ok(Value::None)


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently it's not possible to see what live queries are defined on a table.

Provide information on the motivation for why you have made this change.

## What does this change do?

Adds live query information to the `INFO FOR TB` statement.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2168.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
