### PR TITLE
Bugfix - avoid panics when displaying error snippets.

### DIFF
--- a/lib/src/sql/error/render.rs
+++ b/lib/src/sql/error/render.rs
@@ -40,7 +40,7 @@ pub struct Snippet {
 	truncation: Truncation,
 	/// The location of the snippet in the orignal source code.
 	location: Location,
-	/// The offset into the snippet where the location is.
+	/// The offset, in chars, into the snippet where the location is.
 	offset: usize,
 	/// A possible explanation for this snippet.
 	explain: Option<String>,
@@ -58,7 +58,7 @@ impl Snippet {
 		explain: Option<&'static str>,
 	) -> Self {
 		let line = source.split('\n').nth(location.line - 1).unwrap();
-		let (line, truncation, offset) = Self::truncate_line(line, location.column);
+		let (line, truncation, offset) = Self::truncate_line(line, location.column - 1);
 
 		Snippet {
 			source: line.to_owned(),
@@ -71,9 +71,9 @@ impl Snippet {
 
 	/// Trims whitespace of an line and additionally truncates a string if it is too long.
 	fn truncate_line(mut line: &str, around_offset: usize) -> (&str, Truncation, usize) {
-		let full_line_length = line.len();
+		let full_line_length = line.chars().count();
 		line = line.trim_start();
-		let mut offset = around_offset - (full_line_length - line.len());
+		let mut offset = around_offset - (full_line_length - line.chars().count());
 		line = line.trim_end();
 		let mut truncation = Truncation::None;
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

OSS Fuzz found two families of inputs that crash the error snippet code.

## What does this change do?

- Properly handle chars vs bytes in snippet math
- More robust function to find substring's location
- Add more/better comments/variable names

## What is your testing strategy?

Manually tested with CLI and ensured known OSS fuzz inputs don't cause crash.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
