### PR TITLE
Bugfix - prevent infinite parser recursion in stmts & binary exprs.

### DIFF
--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2837,6 +2837,7 @@ pub fn select(i: &str) -> IResult<&str, Value> {
 
 /// Used in CREATE, UPDATE, and DELETE clauses
 pub fn what(i: &str) -> IResult<&str, Value> {
+	let _diving = crate::sql::parser::depth::dive(i)?;
 	let (i, v) = alt((
 		into(idiom::multi_without_start),
 		function_or_const,

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2707,6 +2707,7 @@ impl TryNeg for Value {
 pub fn value(i: &str) -> IResult<&str, Value> {
 	let (i, start) = single(i)?;
 	if let (i, Some(o)) = opt(operator::binary)(i)? {
+		let _diving = crate::sql::parser::depth::dive(i)?;
 		let (i, r) = cut(value)(i)?;
 		let expr = match r {
 			Value::Expression(r) => r.augment(start, o),


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

OSS Fuzz found several cases of infinite recursion in the parser, affecting CREATE, DELETE, and UPDATE statements (12KB inputs) and binary expressions (70KB inputs).

## What does this change do?

Closes two small loopholes in the recursion depth limiter, mirroring existing solutions for SELECT statements and single values.

## What is your testing strategy?

Awaiting CI, OSS fuzz.

## Is this related to any issues?

Followup to #2369 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
