### PR TITLE
Ensure live queries are killed correctly

### DIFF
--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -802,7 +802,6 @@ impl Transaction {
 					nxt = Some(k.clone());
 				}
 				// Delete
-				trace!("Found getr {:?} {:?}", crate::key::debug::sprint_key(&k), v);
 				out.push((k, v));
 				// Count
 				num -= 1;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -15,8 +15,8 @@ use uuid::Uuid;
 
 static CONN_CLOSED_ERR: &str = "Connection closed normally";
 
-// Mapping of WebSocketID to WebSocket
 pub struct WebSocketRef(Sender<Message>, CancellationToken);
+// Mapping of WebSocketID to WebSocket
 type WebSockets = RwLock<HashMap<Uuid, WebSocketRef>>;
 // Mapping of LiveQueryID to WebSocketID
 type LiveQueries = RwLock<HashMap<Uuid, Uuid>>;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Live queries are not correctly garbage collected when a WebSocket disconnects
## What does this change do?

Ensures that live queries are cleaned up correctly when a WebSocket disconnects.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
