### PR TITLE
Fix decimal deserialisation

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -96,7 +96,7 @@ reqwest = { version = "0.11.18", default-features = false, features = ["json", "
 revision = "0.5.0"
 roaring = { version = "0.10.2", features = ["serde"] }
 rocksdb = { version = "0.21.0", optional = true }
-rust_decimal = { version = "1.31.0", features = ["maths"] }
+rust_decimal = { version = "1.31.0", features = ["maths", "serde-str"] }
 rust-stemmers = "1.2.0"
 rustls = { version = "0.20.8", optional = true }
 scrypt = "0.11.0"

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -192,6 +192,18 @@ async fn query() {
 }
 
 #[tokio::test]
+async fn query_decimals() {
+	let db = new_db().await;
+	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+	let sql = "
+	    DEFINE TABLE foo;
+	    DEFINE FIELD bar ON foo TYPE decimal;
+	    CREATE foo CONTENT { bar: 42.69 };
+    ";
+	let _ = db.query(sql).await.unwrap().check().unwrap();
+}
+
+#[tokio::test]
 async fn query_binds() {
 	let db = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();


### PR DESCRIPTION
## What is the motivation?

Decimals currently use `deserialize_any` which is not supported by `bincode`.

## What does this change do?

Enables the decimal crate's `serde-str` feature which avoids `deserialize_any`.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

Closes https://github.com/surrealdb/surrealdb/issues/2670.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
