### PR TITLE
Bugfix - parse error for invalid leading whitespace.

### DIFF
--- a/lib/src/sql/error/render.rs
+++ b/lib/src/sql/error/render.rs
@@ -73,7 +73,8 @@ impl Snippet {
 	fn truncate_line(mut line: &str, around_offset: usize) -> (&str, Truncation, usize) {
 		let full_line_length = line.chars().count();
 		line = line.trim_start();
-		let mut offset = around_offset - (full_line_length - line.chars().count());
+		// Saturate in case the error ocurred in invalid leading whitespace.
+		let mut offset = around_offset.saturating_sub(full_line_length - line.chars().count());
 		line = line.trim_end();
 		let mut truncation = Truncation::None;
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

OSS Fuzz found a crash due to invalid leading whitespace.

## What does this change do?

Don't crash if the error offset is within leading (trimmed) whitespace.

## What is your testing strategy?

No longer crashes on that input.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
