### PR TITLE
Fix stack overflow in graph traversal

### DIFF
--- a/Makefile.local.toml
+++ b/Makefile.local.toml
@@ -23,6 +23,7 @@ args = ["doc", "--open", "--no-deps", "--package", "surrealdb", "--features", "r
 [tasks.test]
 category = "LOCAL USAGE"
 command = "cargo"
+env = { RUST_MIN_STACK={ value = "4194304", condition = { env_not_set = ["RUST_MIN_STACK"] } } }
 args = ["test", "--workspace", "--no-fail-fast"]
 
 # Check

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -662,7 +662,6 @@ async fn field_definition_value_reference() -> Result<(), Error> {
 
 #[tokio::test]
 async fn field_definition_value_reference_with_future() -> Result<(), Error> {
-	// TODO this is failing
 	let sql = "
 		DEFINE TABLE product;
 		DEFINE FIELD subproducts ON product VALUE <future> { ->contains->product };

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -662,6 +662,7 @@ async fn field_definition_value_reference() -> Result<(), Error> {
 
 #[tokio::test]
 async fn field_definition_value_reference_with_future() -> Result<(), Error> {
+	// TODO this is failing
 	let sql = "
 		DEFINE TABLE product;
 		DEFINE FIELD subproducts ON product VALUE <future> { ->contains->product };


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

We have a failing test due to a stack overflow. Trace attached.
[field-stackoverflow.txt](https://github.com/surrealdb/surrealdb/files/12650225/field-stackoverflow.txt)
The test does not fail in CI but does locally.

## What does this change do?

Identify the cause of the stack overflow and resolve.

## What is your testing strategy?

Rerunning the test is deterministic.
`RUST_LOG=trace cargo test -p surrealdb --test field field_definition_value_reference_with_future --features kv-mem,kv-rocksdb -- --nocapture`

## Is this related to any issues?

Local builds

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
