### PR TITLE
Improve `type::is::record()` method

### DIFF
--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -201,8 +201,11 @@ pub mod is {
 		Ok(matches!(arg, Value::Geometry(Geometry::Polygon(_))).into())
 	}
 
-	pub fn record((arg,): (Value,)) -> Result<Value, Error> {
-		Ok(arg.is_record().into())
+	pub fn record((arg, table): (Value, Option<String>)) -> Result<Value, Error> {
+		Ok(match table {
+			Some(tb) => arg.is_record_of_table(tb).into(),
+			None => arg.is_record().into(),
+		})
 	}
 
 	pub fn string((arg,): (Value,)) -> Result<Value, Error> {

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -922,6 +922,14 @@ impl Value {
 		matches!(self, Value::Thing(_))
 	}
 
+	/// Check if this Value is a Thing, and belongs to a certain table
+	pub fn is_record_of_table(&self, table: String) -> bool {
+		match self {
+			Value::Thing(Thing { tb, .. }) => tb.to_string() == table,
+			_ => false,
+		}
+	}
+
 	/// Check if this Value is a Geometry
 	pub fn is_geometry(&self) -> bool {
 		matches!(self, Value::Geometry(_))

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -925,7 +925,10 @@ impl Value {
 	/// Check if this Value is a Thing, and belongs to a certain table
 	pub fn is_record_of_table(&self, table: String) -> bool {
 		match self {
-			Value::Thing(Thing { tb, .. }) => tb.to_string() == table,
+			Value::Thing(Thing {
+				tb,
+				..
+			}) => *tb == table,
 			_ => false,
 		}
 	}

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -5117,11 +5117,21 @@ async fn function_type_is_record() -> Result<(), Error> {
 	let sql = r#"
 		RETURN type::is::record(person:john);
 		RETURN type::is::record("123");
+		RETURN type::is::record(person:john, 'person');
+		RETURN type::is::record(person:john, 'user');
 	"#;
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 2);
+	assert_eq!(res.len(), 4);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from(true);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from(false);
+	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::from(true);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

added functionality

## What does this change do?

It allows the `type::is::record()` method to optionally accept a second argument, representing a table name, which will cause the method to not only validate if the passed value is a thing, but also if the table name matches.

## What is your testing strategy?

Expanded the test for the `type::is::record()` method.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
