### PR TITLE
Switch transaction to enum from bool

### DIFF
--- a/lib/benches/index_btree.rs
+++ b/lib/benches/index_btree.rs
@@ -53,7 +53,7 @@ where
 	BK: BKeys + Default,
 {
 	let ds = Datastore::new("memory").await.unwrap();
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	let mut t = BTree::<BK>::new(BState::new(100));
 	let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Write, 20);
 	let mut s = s.lock().await;

--- a/lib/benches/index_btree.rs
+++ b/lib/benches/index_btree.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use surrealdb::idx::trees::bkeys::{BKeys, FstKeys, TrieKeys};
 use surrealdb::idx::trees::btree::{BState, BTree, Payload};
 use surrealdb::idx::trees::store::{TreeNodeProvider, TreeNodeStore, TreeStoreType};
-use surrealdb::kvs::{Datastore, Key};
+use surrealdb::kvs::{Datastore, Key, LockType::*, TransactionType::*};
 
 macro_rules! get_key_value {
 	($idx:expr) => {{

--- a/lib/src/dbs/test.rs
+++ b/lib/src/dbs/test.rs
@@ -2,13 +2,13 @@ use crate::ctx::Context;
 use crate::dbs::{Options, Transaction};
 use crate::iam::Auth;
 use crate::iam::Role;
-use crate::kvs::Datastore;
+use crate::kvs::{Datastore, LockType::*, TransactionType::*};
 use std::sync::Arc;
 
 pub async fn mock<'a>() -> (Context<'a>, Options, Transaction) {
 	let ctx = Context::default();
 	let opt = Options::default().with_auth(Arc::new(Auth::for_root(Role::Owner)));
 	let kvs = Datastore::new("memory").await.unwrap();
-	let txn = kvs.transaction(true, false).await.unwrap().rollback_and_ignore().enclose();
+	let txn = kvs.transaction(Write, Optimistic).await.unwrap().rollback_and_ignore().enclose();
 	(ctx, opt, txn)
 }

--- a/lib/src/iam/signin.rs
+++ b/lib/src/iam/signin.rs
@@ -5,7 +5,7 @@ use crate::dbs::Session;
 use crate::err::Error;
 use crate::iam::token::{Claims, HEADER};
 use crate::iam::Auth;
-use crate::kvs::Datastore;
+use crate::kvs::{Datastore, LockType::*, TransactionType::*};
 use crate::sql::Object;
 use crate::sql::Value;
 use chrono::{Duration, Utc};
@@ -102,7 +102,7 @@ pub async fn sc(
 	vars: Object,
 ) -> Result<Option<String>, Error> {
 	// Create a new readonly transaction
-	let mut tx = kvs.transaction(false, false).await?;
+	let mut tx = kvs.transaction(Read, Optimistic).await?;
 	// Fetch the specified scope from storage
 	let scope = tx.get_sc(&ns, &db, &sc).await;
 	// Ensure that the transaction is cancelled

--- a/lib/src/iam/signup.rs
+++ b/lib/src/iam/signup.rs
@@ -4,7 +4,7 @@ use crate::err::Error;
 use crate::iam::token::{Claims, HEADER};
 use crate::iam::Auth;
 use crate::iam::{Actor, Level};
-use crate::kvs::Datastore;
+use crate::kvs::{Datastore, LockType::*, TransactionType::*};
 use crate::sql::Object;
 use crate::sql::Value;
 use chrono::{Duration, Utc};
@@ -43,7 +43,7 @@ pub async fn sc(
 	vars: Object,
 ) -> Result<Option<String>, Error> {
 	// Create a new readonly transaction
-	let mut tx = kvs.transaction(false, false).await?;
+	let mut tx = kvs.transaction(Read, Optimistic).await?;
 	// Fetch the specified scope from storage
 	let scope = tx.get_sc(&ns, &db, &sc).await;
 	// Ensure that the transaction is cancelled

--- a/lib/src/iam/verify.rs
+++ b/lib/src/iam/verify.rs
@@ -3,7 +3,7 @@ use crate::err::Error;
 use crate::iam::token::Claims;
 use crate::iam::Auth;
 use crate::iam::{Actor, Level, Role};
-use crate::kvs::Datastore;
+use crate::kvs::{Datastore, LockType::*, TransactionType::*};
 use crate::sql::json;
 use crate::sql::statements::DefineUserStatement;
 use crate::sql::Algorithm;
@@ -152,7 +152,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the decoded authentication claims
 			trace!("Authenticating to scope `{}` with token `{}`", sc, tk);
 			// Create a new readonly transaction
-			let mut tx = kvs.transaction(false, false).await?;
+			let mut tx = kvs.transaction(Read, Optimistic).await?;
 			// Parse the record id
 			let id = match id {
 				Some(id) => crate::sql::thing(&id)?.into(),
@@ -189,7 +189,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the decoded authentication claims
 			trace!("Authenticating to scope `{}`", sc);
 			// Create a new readonly transaction
-			let mut tx = kvs.transaction(false, false).await?;
+			let mut tx = kvs.transaction(Read, Optimistic).await?;
 			// Parse the record id
 			let id = crate::sql::thing(&id)?;
 			// Get the scope
@@ -222,7 +222,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the decoded authentication claims
 			trace!("Authenticating to database `{}` with token `{}`", db, tk);
 			// Create a new readonly transaction
-			let mut tx = kvs.transaction(false, false).await?;
+			let mut tx = kvs.transaction(Read, Optimistic).await?;
 			// Get the database token
 			let de = tx.get_db_token(&ns, &db, &tk).await?;
 			let cf = config(de.kind, de.code)?;
@@ -263,7 +263,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the decoded authentication claims
 			trace!("Authenticating to database `{}` with user `{}`", db, id);
 			// Create a new readonly transaction
-			let mut tx = kvs.transaction(false, false).await?;
+			let mut tx = kvs.transaction(Read, Optimistic).await?;
 			// Get the database user
 			let de = tx.get_db_user(&ns, &db, &id).await?;
 			let cf = config(Algorithm::Hs512, de.code)?;
@@ -291,7 +291,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the decoded authentication claims
 			trace!("Authenticating to namespace `{}` with token `{}`", ns, tk);
 			// Create a new readonly transaction
-			let mut tx = kvs.transaction(false, false).await?;
+			let mut tx = kvs.transaction(Read, Optimistic).await?;
 			// Get the namespace token
 			let de = tx.get_ns_token(&ns, &tk).await?;
 			let cf = config(de.kind, de.code)?;
@@ -327,7 +327,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the decoded authentication claims
 			trace!("Authenticating to namespace `{}` with user `{}`", ns, id);
 			// Create a new readonly transaction
-			let mut tx = kvs.transaction(false, false).await?;
+			let mut tx = kvs.transaction(Read, Optimistic).await?;
 			// Get the namespace user
 			let de = tx.get_ns_user(&ns, &id).await?;
 			let cf = config(Algorithm::Hs512, de.code)?;
@@ -353,7 +353,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the decoded authentication claims
 			trace!("Authenticating to root level with user `{}`", id);
 			// Create a new readonly transaction
-			let mut tx = kvs.transaction(false, false).await?;
+			let mut tx = kvs.transaction(Read, Optimistic).await?;
 			// Get the namespace user
 			let de = tx.get_root_user(&id).await?;
 			let cf = config(Algorithm::Hs512, de.code)?;
@@ -436,7 +436,7 @@ async fn verify_root_creds(
 	pass: &str,
 ) -> Result<DefineUserStatement, Error> {
 	// Create a new readonly transaction
-	let mut tx = ds.transaction(false, false).await?;
+	let mut tx = ds.transaction(Read, Optimistic).await?;
 	// Fetch the specified user from storage
 	let user = tx.get_root_user(user).await?;
 	// Verify the specified password for the user
@@ -452,7 +452,7 @@ async fn verify_ns_creds(
 	pass: &str,
 ) -> Result<DefineUserStatement, Error> {
 	// Create a new readonly transaction
-	let mut tx = ds.transaction(false, false).await?;
+	let mut tx = ds.transaction(Read, Optimistic).await?;
 	// Fetch the specified user from storage
 	let user = tx.get_ns_user(ns, user).await?;
 	// Verify the specified password for the user
@@ -469,7 +469,7 @@ async fn verify_db_creds(
 	pass: &str,
 ) -> Result<DefineUserStatement, Error> {
 	// Create a new readonly transaction
-	let mut tx = ds.transaction(false, false).await?;
+	let mut tx = ds.transaction(Read, Optimistic).await?;
 	// Fetch the specified user from storage
 	let user = tx.get_db_user(ns, db, user).await?;
 	// Verify the specified password for the user

--- a/lib/src/idg/u32.rs
+++ b/lib/src/idg/u32.rs
@@ -111,10 +111,10 @@ impl SerdeState for State {}
 mod tests {
 	use crate::err::Error;
 	use crate::idg::u32::U32;
-	use crate::kvs::{Datastore, Transaction};
+	use crate::kvs::{Datastore, LockType::*, Transaction, TransactionType::*};
 
 	async fn get_ids(ds: &Datastore) -> (Transaction, U32) {
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		let key = "foo";
 		let v = tx.get(key).await.unwrap();
 		let d = U32::new(key.into(), v).await.unwrap();

--- a/lib/src/idx/docids.rs
+++ b/lib/src/idx/docids.rs
@@ -201,12 +201,12 @@ mod tests {
 	use crate::idx::docids::{DocIds, Resolved};
 	use crate::idx::trees::store::TreeStoreType;
 	use crate::idx::IndexKeyBase;
-	use crate::kvs::{Datastore, Transaction};
+	use crate::kvs::{Datastore, LockType::*, Transaction, TransactionType::*};
 
 	const BTREE_ORDER: u32 = 7;
 
 	async fn get_doc_ids(ds: &Datastore, store_type: TreeStoreType) -> (Transaction, DocIds) {
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		let d =
 			DocIds::new(&mut tx, IndexKeyBase::default(), BTREE_ORDER, store_type).await.unwrap();
 		(tx, d)

--- a/lib/src/idx/ft/doclength.rs
+++ b/lib/src/idx/ft/doclength.rs
@@ -83,7 +83,7 @@ mod tests {
 	use crate::idx::ft::doclength::DocLengths;
 	use crate::idx::trees::store::TreeStoreType;
 	use crate::idx::IndexKeyBase;
-	use crate::kvs::Datastore;
+	use crate::kvs::{Datastore, LockType::*, TransactionType::*};
 
 	#[tokio::test]
 	async fn test_doc_lengths() {
@@ -92,7 +92,7 @@ mod tests {
 		let ds = Datastore::new("memory").await.unwrap();
 
 		// Check empty state
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		let l = DocLengths::new(
 			&mut tx,
 			IndexKeyBase::default(),

--- a/lib/src/idx/ft/mod.rs
+++ b/lib/src/idx/ft/mod.rs
@@ -456,7 +456,7 @@ mod tests {
 	use crate::idx::ft::{FtIndex, HitsIterator};
 	use crate::idx::trees::store::TreeStoreType;
 	use crate::idx::IndexKeyBase;
-	use crate::kvs::{Datastore, Transaction};
+	use crate::kvs::{Datastore, LockType::*, Transaction};
 	use crate::sql::index::SearchParams;
 	use crate::sql::scoring::Scoring;
 	use crate::sql::statements::define::analyzer;
@@ -507,7 +507,7 @@ mod tests {
 		hl: bool,
 	) -> (Transaction, FtIndex) {
 		let write = matches!(store_type, TreeStoreType::Write);
-		let mut tx = ds.transaction(write, false).await.unwrap();
+		let mut tx = ds.transaction(write.into(), Optimistic).await.unwrap();
 		let fti = FtIndex::new(
 			&mut tx,
 			az.clone(),

--- a/lib/src/idx/ft/postings.rs
+++ b/lib/src/idx/ft/postings.rs
@@ -92,7 +92,7 @@ mod tests {
 	use crate::idx::ft::postings::Postings;
 	use crate::idx::trees::store::TreeStoreType;
 	use crate::idx::IndexKeyBase;
-	use crate::kvs::Datastore;
+	use crate::kvs::{Datastore, LockType::*, TransactionType::*};
 	use test_log::test;
 
 	#[test(tokio::test)]
@@ -100,7 +100,7 @@ mod tests {
 		const DEFAULT_BTREE_ORDER: u32 = 5;
 
 		let ds = Datastore::new("memory").await.unwrap();
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		// Check empty state
 		let mut p = Postings::new(
 			&mut tx,
@@ -119,7 +119,7 @@ mod tests {
 		p.finish(&mut tx).await.unwrap();
 		tx.commit().await.unwrap();
 
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		let mut p = Postings::new(
 			&mut tx,
 			IndexKeyBase::default(),

--- a/lib/src/idx/ft/terms.rs
+++ b/lib/src/idx/ft/terms.rs
@@ -160,7 +160,7 @@ mod tests {
 	use crate::idx::ft::terms::Terms;
 	use crate::idx::trees::store::TreeStoreType;
 	use crate::idx::IndexKeyBase;
-	use crate::kvs::Datastore;
+	use crate::kvs::{Datastore, LockType::*, TransactionType::*};
 	use rand::{thread_rng, Rng};
 	use std::collections::HashSet;
 
@@ -189,7 +189,7 @@ mod tests {
 		let ds = Datastore::new("memory").await.unwrap();
 
 		{
-			let mut tx = ds.transaction(true, false).await.unwrap();
+			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 			let mut t =
 				Terms::new(&mut tx, idx.clone(), BTREE_ORDER, TreeStoreType::Write).await.unwrap();
 			t.finish(&mut tx).await.unwrap();
@@ -198,7 +198,7 @@ mod tests {
 
 		// Resolve a first term
 		{
-			let mut tx = ds.transaction(true, false).await.unwrap();
+			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 			let mut t =
 				Terms::new(&mut tx, idx.clone(), BTREE_ORDER, TreeStoreType::Write).await.unwrap();
 			assert_eq!(t.resolve_term_id(&mut tx, "C").await.unwrap(), 0);
@@ -209,7 +209,7 @@ mod tests {
 
 		// Resolve a second term
 		{
-			let mut tx = ds.transaction(true, false).await.unwrap();
+			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 			let mut t =
 				Terms::new(&mut tx, idx.clone(), BTREE_ORDER, TreeStoreType::Write).await.unwrap();
 			assert_eq!(t.resolve_term_id(&mut tx, "D").await.unwrap(), 1);
@@ -220,7 +220,7 @@ mod tests {
 
 		// Resolve two existing terms with new frequencies
 		{
-			let mut tx = ds.transaction(true, false).await.unwrap();
+			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 			let mut t =
 				Terms::new(&mut tx, idx.clone(), BTREE_ORDER, TreeStoreType::Write).await.unwrap();
 			assert_eq!(t.resolve_term_id(&mut tx, "C").await.unwrap(), 0);
@@ -233,7 +233,7 @@ mod tests {
 
 		// Resolve one existing terms and two new terms
 		{
-			let mut tx = ds.transaction(true, false).await.unwrap();
+			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 			let mut t =
 				Terms::new(&mut tx, idx.clone(), BTREE_ORDER, TreeStoreType::Write).await.unwrap();
 
@@ -255,7 +255,7 @@ mod tests {
 
 		let ds = Datastore::new("memory").await.unwrap();
 
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		let mut t =
 			Terms::new(&mut tx, idx.clone(), BTREE_ORDER, TreeStoreType::Write).await.unwrap();
 
@@ -299,7 +299,7 @@ mod tests {
 	async fn test_resolve_100_docs_with_50_words_one_by_one() {
 		let ds = Datastore::new("memory").await.unwrap();
 		for _ in 0..100 {
-			let mut tx = ds.transaction(true, false).await.unwrap();
+			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 			let mut t = Terms::new(&mut tx, IndexKeyBase::default(), 100, TreeStoreType::Write)
 				.await
 				.unwrap();
@@ -316,7 +316,7 @@ mod tests {
 	async fn test_resolve_100_docs_with_50_words_batch_of_10() {
 		let ds = Datastore::new("memory").await.unwrap();
 		for _ in 0..10 {
-			let mut tx = ds.transaction(true, false).await.unwrap();
+			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 			let mut t = Terms::new(&mut tx, IndexKeyBase::default(), 100, TreeStoreType::Write)
 				.await
 				.unwrap();

--- a/lib/src/idx/trees/btree.rs
+++ b/lib/src/idx/trees/btree.rs
@@ -698,7 +698,7 @@ mod tests {
 	};
 	use crate::idx::VersionedSerdeState;
 	use crate::kvs::TransactionType::*;
-	use crate::kvs::{Datastore, Key, LockType::*, Transaction, TransactionType::*};
+	use crate::kvs::{Datastore, Key, LockType::*, Transaction};
 	use rand::prelude::SliceRandom;
 	use rand::thread_rng;
 	use std::collections::{HashMap, VecDeque};

--- a/lib/src/idx/trees/btree.rs
+++ b/lib/src/idx/trees/btree.rs
@@ -697,7 +697,8 @@ mod tests {
 		NodeId, TreeNode, TreeNodeProvider, TreeNodeStore, TreeStoreType,
 	};
 	use crate::idx::VersionedSerdeState;
-	use crate::kvs::{Datastore, Key, Transaction};
+	use crate::kvs::TransactionType::*;
+	use crate::kvs::{Datastore, Key, LockType::*, Transaction, TransactionType::*};
 	use rand::prelude::SliceRandom;
 	use rand::thread_rng;
 	use std::collections::{HashMap, VecDeque};
@@ -757,11 +758,11 @@ mod tests {
 		let mut s = s.lock().await;
 		let mut t = BTree::new(BState::new(5));
 		let ds = Datastore::new("memory").await.unwrap();
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		insertions_test::<_, FstKeys>(&mut tx, &mut s, &mut t, 100, get_key_value).await;
 		s.finish(&mut tx).await.unwrap();
 		tx.commit().await.unwrap();
-		let mut tx = ds.transaction(false, false).await.unwrap();
+		let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 		assert_eq!(
 			t.statistics(&mut tx, &mut TreeNodeStore::Traversal(TreeNodeProvider::Debug))
 				.await
@@ -782,12 +783,12 @@ mod tests {
 		let mut s = s.lock().await;
 		let mut t = BTree::new(BState::new(6));
 		let ds = Datastore::new("memory").await.unwrap();
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		insertions_test::<_, TrieKeys>(&mut tx, &mut s, &mut t, 100, get_key_value).await;
 		s.finish(&mut tx).await.unwrap();
 		tx.commit().await.unwrap();
 
-		let mut tx = ds.transaction(false, false).await.unwrap();
+		let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 		assert_eq!(
 			t.statistics(&mut tx, &mut TreeNodeStore::Traversal(TreeNodeProvider::Debug))
 				.await
@@ -807,7 +808,7 @@ mod tests {
 		let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Write, 20);
 		let mut s = s.lock().await;
 		let ds = Datastore::new("memory").await.unwrap();
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		let mut t = BTree::new(BState::new(8));
 		let mut samples: Vec<usize> = (0..100).collect();
 		let mut rng = thread_rng();
@@ -817,7 +818,7 @@ mod tests {
 		s.finish(&mut tx).await.unwrap();
 		tx.commit().await.unwrap();
 
-		let mut tx = ds.transaction(false, false).await.unwrap();
+		let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 		let s = t
 			.statistics(&mut tx, &mut TreeNodeStore::Traversal(TreeNodeProvider::Debug))
 			.await
@@ -831,7 +832,7 @@ mod tests {
 		let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Write, 20);
 		let mut s = s.lock().await;
 		let ds = Datastore::new("memory").await.unwrap();
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		let mut t = BTree::new(BState::new(75));
 		let mut samples: Vec<usize> = (0..100).collect();
 		let mut rng = thread_rng();
@@ -841,7 +842,7 @@ mod tests {
 		s.finish(&mut tx).await.unwrap();
 		tx.commit().await.unwrap();
 
-		let mut tx = ds.transaction(false, false).await.unwrap();
+		let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 		let s = t
 			.statistics(&mut tx, &mut TreeNodeStore::Traversal(TreeNodeProvider::Debug))
 			.await
@@ -855,13 +856,13 @@ mod tests {
 		let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Write, 20);
 		let mut s = s.lock().await;
 		let ds = Datastore::new("memory").await.unwrap();
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		let mut t = BTree::new(BState::new(60));
 		insertions_test::<_, FstKeys>(&mut tx, &mut s, &mut t, 10000, get_key_value).await;
 		s.finish(&mut tx).await.unwrap();
 		tx.commit().await.unwrap();
 
-		let mut tx = ds.transaction(false, false).await.unwrap();
+		let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 		assert_eq!(
 			t.statistics(&mut tx, &mut TreeNodeStore::Traversal(TreeNodeProvider::Debug))
 				.await
@@ -881,13 +882,13 @@ mod tests {
 		let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Write, 20);
 		let mut s = s.lock().await;
 		let ds = Datastore::new("memory").await.unwrap();
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		let mut t = BTree::new(BState::new(60));
 		insertions_test::<_, TrieKeys>(&mut tx, &mut s, &mut t, 10000, get_key_value).await;
 		s.finish(&mut tx).await.unwrap();
 		tx.commit().await.unwrap();
 
-		let mut tx = ds.transaction(false, false).await.unwrap();
+		let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 		assert_eq!(
 			t.statistics(&mut tx, &mut TreeNodeStore::Traversal(TreeNodeProvider::Debug))
 				.await
@@ -915,7 +916,7 @@ mod tests {
 		let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Write, 20);
 		let mut s = s.lock().await;
 		let ds = Datastore::new("memory").await.unwrap();
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		let mut t = BTree::new(BState::new(default_minimum_degree));
 		insertions_test::<_, BK>(&mut tx, &mut s, &mut t, REAL_WORLD_TERMS.len(), |i| {
 			(REAL_WORLD_TERMS[i].as_bytes().to_vec(), i as Payload)
@@ -924,7 +925,7 @@ mod tests {
 		s.finish(&mut tx).await.unwrap();
 		tx.commit().await.unwrap();
 
-		let mut tx = ds.transaction(false, false).await.unwrap();
+		let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 		let statistics = t
 			.statistics(&mut tx, &mut TreeNodeStore::Traversal(TreeNodeProvider::Debug))
 			.await
@@ -1024,14 +1025,14 @@ mod tests {
 		let mut s = s.lock().await;
 		let ds = Datastore::new("memory").await.unwrap();
 		let mut t = BTree::<TrieKeys>::new(BState::new(3));
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		for (key, payload) in CLRS_EXAMPLE {
 			t.insert(&mut tx, &mut s, key.into(), payload).await.unwrap();
 		}
 		s.finish(&mut tx).await.unwrap();
 		tx.commit().await.unwrap();
 
-		let mut tx = ds.transaction(false, false).await.unwrap();
+		let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 		let s = t
 			.statistics(&mut tx, &mut TreeNodeStore::Traversal(TreeNodeProvider::Debug))
 			.await
@@ -1116,7 +1117,7 @@ mod tests {
 		{
 			let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Write, 20);
 			let mut s = s.lock().await;
-			let mut tx = ds.transaction(true, false).await.unwrap();
+			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 			for (key, payload) in CLRS_EXAMPLE {
 				t.insert(&mut tx, &mut s, key.into(), payload).await.unwrap();
 			}
@@ -1128,7 +1129,7 @@ mod tests {
 			for (key, payload) in [("f", 6), ("m", 13), ("g", 7), ("d", 4), ("b", 2)] {
 				let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Write, 20);
 				let mut s = s.lock().await;
-				let mut tx = ds.transaction(true, false).await.unwrap();
+				let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 				debug!("Delete {}", key);
 				assert_eq!(t.delete(&mut tx, &mut s, key.into()).await.unwrap(), Some(payload));
 				s.finish(&mut tx).await.unwrap();
@@ -1136,7 +1137,7 @@ mod tests {
 			}
 		}
 
-		let mut tx = ds.transaction(false, false).await.unwrap();
+		let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 		let s = t
 			.statistics(&mut tx, &mut TreeNodeStore::Traversal(TreeNodeProvider::Debug))
 			.await
@@ -1224,7 +1225,7 @@ mod tests {
 		{
 			let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Write, 20);
 			let mut s = s.lock().await;
-			let mut tx = ds.transaction(true, false).await.unwrap();
+			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 			for (key, payload) in CLRS_EXAMPLE {
 				expected_keys.insert(key.to_string(), payload);
 				t.insert(&mut tx, &mut s, key.into(), payload).await.unwrap();
@@ -1234,7 +1235,7 @@ mod tests {
 		}
 
 		{
-			let mut tx = ds.transaction(true, false).await.unwrap();
+			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 			print_tree(&mut tx, &mut t).await;
 			tx.commit().await.unwrap();
 		}
@@ -1243,7 +1244,7 @@ mod tests {
 			debug!("------------------------");
 			debug!("Delete {}", key);
 			{
-				let mut tx = ds.transaction(true, false).await.unwrap();
+				let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 				let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Write, 20);
 				let mut s = s.lock().await;
 				t.delete(&mut tx, &mut s, key.into()).await.unwrap();
@@ -1256,7 +1257,7 @@ mod tests {
 			expected_keys.remove(key);
 
 			{
-				let mut tx = ds.transaction(true, false).await.unwrap();
+				let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 				let s = TreeNodeStore::new(TreeNodeProvider::Debug, TreeStoreType::Read, 20);
 				let mut s = s.lock().await;
 				for (key, payload) in &expected_keys {
@@ -1269,7 +1270,7 @@ mod tests {
 			}
 		}
 
-		let mut tx = ds.transaction(false, false).await.unwrap();
+		let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 		let s = t
 			.statistics(&mut tx, &mut TreeNodeStore::Traversal(TreeNodeProvider::Debug))
 			.await

--- a/lib/src/idx/trees/mtree.rs
+++ b/lib/src/idx/trees/mtree.rs
@@ -1106,6 +1106,7 @@ mod tests {
 	};
 	use crate::idx::trees::store::{NodeId, TreeNodeProvider, TreeNodeStore, TreeStoreType};
 	use crate::kvs::Datastore;
+	use crate::kvs::LockType::*;
 	use crate::kvs::Transaction;
 	use crate::sql::index::Distance;
 	use indexmap::IndexMap;
@@ -1120,7 +1121,7 @@ mod tests {
 		t: TreeStoreType,
 	) -> (Arc<Mutex<TreeNodeStore<MTreeNode>>>, Transaction) {
 		let s = TreeNodeStore::new(TreeNodeProvider::Debug, t, 20);
-		let tx = ds.transaction(t == TreeStoreType::Write, false).await.unwrap();
+		let tx = ds.transaction(t.into(), Optimistic).await.unwrap();
 		(s, tx)
 	}
 

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -112,6 +112,16 @@ impl fmt::Display for Datastore {
 	}
 }
 
+pub enum TransactionType {
+	Read,
+	Write,
+}
+
+pub enum LockType {
+	Pessimistic,
+	Optimistic,
+}
+
 impl Datastore {
 	/// Creates a new datastore instance
 	///
@@ -740,7 +750,17 @@ impl Datastore {
 	///     Ok(())
 	/// }
 	/// ```
-	pub async fn transaction(&self, write: bool, lock: bool) -> Result<Transaction, Error> {
+	pub async fn transaction(&self, write: TransactionType, lock: LockType) -> Result<Transaction, Error> {
+		let write = match write {
+			TransactionType::Read => {false}
+			TransactionType::Write => {true}
+		};
+
+		let lock = match lock {
+			LockType::Pessimistic => {true}
+			LockType::Optimistic => {false}
+		};
+
 		#![allow(unused_variables)]
 		let inner = match &self.inner {
 			#[cfg(feature = "kv-mem")]

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -14,6 +14,7 @@ use crate::err::Error;
 use crate::iam::ResourceKind;
 use crate::iam::{Action, Auth, Error as IamError, Role};
 use crate::key::root::hb::Hb;
+use crate::kvs::{LockType, LockType::*, TransactionType, TransactionType::*};
 use crate::opt::auth::Root;
 use crate::sql;
 use crate::sql::statements::DefineUserStatement;
@@ -34,7 +35,6 @@ use tracing::instrument;
 use tracing::trace;
 #[cfg(target_arch = "wasm32")]
 use wasmtimer::std::{SystemTime, UNIX_EPOCH};
-use crate::kvs::{LockType::*, LockType, TransactionType::*, TransactionType};
 
 /// Used for cluster logic to move LQ data to LQ cleanup code
 /// Not a stored struct; Used only in this module
@@ -741,18 +741,22 @@ impl Datastore {
 	///     Ok(())
 	/// }
 	/// ```
-	pub async fn transaction(&self, write: TransactionType, lock: LockType) -> Result<Transaction, Error> {
+	pub async fn transaction(
+		&self,
+		write: TransactionType,
+		lock: LockType,
+	) -> Result<Transaction, Error> {
+		#![allow(unused_variables)]
 		let write = match write {
-			TransactionType::Read => {false}
-			TransactionType::Write => {true}
+			TransactionType::Read => false,
+			TransactionType::Write => true,
 		};
 
 		let lock = match lock {
-			LockType::Pessimistic => {true}
-			LockType::Optimistic => {false}
+			LockType::Pessimistic => true,
+			LockType::Optimistic => false,
 		};
 
-		#![allow(unused_variables)]
 		let inner = match &self.inner {
 			#[cfg(feature = "kv-mem")]
 			Inner::Mem(v) => {

--- a/lib/src/kvs/tests/cluster_init.rs
+++ b/lib/src/kvs/tests/cluster_init.rs
@@ -5,6 +5,7 @@ use crate::ctx::context;
 
 use crate::dbs::{Options, Session};
 use crate::iam::{Auth, Role};
+use crate::kvs::{LockType::*, TransactionType::*};
 use crate::sql;
 use crate::sql::statements::LiveStatement;
 use crate::sql::Value::Table;
@@ -32,7 +33,7 @@ async fn expired_nodes_are_garbage_collected() {
 	test.bootstrap_at_time(sql::Uuid::from(new_node), new_time.clone()).await.unwrap();
 
 	// Now scan the heartbeats to validate there is only one node left
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let scanned = tx.scan_hb(&new_time, 100).await.unwrap();
 	assert_eq!(scanned.len(), 1);
 	for hb in scanned.iter() {
@@ -86,7 +87,7 @@ async fn expired_nodes_get_live_queries_archived() {
 		.with_live(true)
 		.with_id(old_node);
 	let opt = Options::new_with_sender(&opt, sender);
-	let tx = Arc::new(Mutex::new(test.db.transaction(true, false).await.unwrap()));
+	let tx = Arc::new(Mutex::new(test.db.transaction(Write, Optimistic).await.unwrap()));
 	let res = lq.compute(&ctx, &opt, &tx, None).await.unwrap();
 	match res {
 		Value::Uuid(_) => {}
@@ -104,7 +105,7 @@ async fn expired_nodes_get_live_queries_archived() {
 	test.bootstrap_at_time(sql::Uuid::from(new_node), new_time.clone()).await.unwrap();
 
 	// Now validate lq was removed
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let scanned = tx
 		.all_tb_lives(ses.ns().unwrap().as_ref(), ses.db().unwrap().as_ref(), table)
 		.await
@@ -141,7 +142,7 @@ async fn single_live_queries_are_garbage_collected() {
 
 	// We set up 2 live queries, one of which we want to garbage collect
 	trace!("Setting up live queries");
-	let tx = Arc::new(Mutex::new(test.db.transaction(true, false).await.unwrap()));
+	let tx = Arc::new(Mutex::new(test.db.transaction(Write, Optimistic).await.unwrap()));
 	let live_query_to_delete = Uuid::parse_str("8aed07c4-9683-480e-b1e4-f0db8b331530").unwrap();
 	let live_st = LiveStatement {
 		id: sql::Uuid(live_query_to_delete),
@@ -184,7 +185,7 @@ async fn single_live_queries_are_garbage_collected() {
 
 	// Validate
 	trace!("Validating live queries");
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let scanned = tx.all_tb_lives(namespace, database, table).await.unwrap();
 	assert_eq!(scanned.len(), 1, "The scanned values are {:?}", scanned);
 	assert_eq!(&scanned[0].id.0, &live_query_to_keep);
@@ -223,7 +224,7 @@ async fn bootstrap_does_not_error_on_missing_live_queries() {
 
 	// We set up 2 live queries, one of which we want to garbage collect
 	trace!("Setting up live queries");
-	let tx = Arc::new(Mutex::new(test.db.transaction(true, false).await.unwrap()));
+	let tx = Arc::new(Mutex::new(test.db.transaction(Write, Optimistic).await.unwrap()));
 	let live_query_to_corrupt = Uuid::parse_str("d4cee7ce-5c78-4a30-9fa9-2444d58029f6").unwrap();
 	let live_st = LiveStatement {
 		id: sql::Uuid(live_query_to_corrupt),
@@ -270,7 +271,7 @@ async fn bootstrap_does_not_error_on_missing_live_queries() {
 	}
 
 	// Verify node live query was deleted
-	let mut tx = second_node.transaction(true, false).await.unwrap();
+	let mut tx = second_node.transaction(Write, Optimistic).await.unwrap();
 	let found = tx
 		.scan_ndlq(&old_node_id, 100)
 		.await

--- a/lib/src/kvs/tests/helper.rs
+++ b/lib/src/kvs/tests/helper.rs
@@ -19,7 +19,7 @@ impl TestContext {
 		time: Timestamp,
 	) -> Result<(), Error> {
 		// TODO we shouldn't test bootstrapping manually
-		let mut tx = self.db.transaction(true, false).await?;
+		let mut tx = self.db.transaction(Write, Optimistic).await?;
 		let archived = self.db.register_remove_and_archive(&mut tx, &node_id, time).await?;
 		tx.commit().await?;
 
@@ -41,7 +41,7 @@ impl TestContext {
 			panic!("Encountered errors: {:?}", errors);
 		}
 
-		let mut tx = self.db.transaction(true, false).await?;
+		let mut tx = self.db.transaction(Write, Optimistic).await?;
 		self.db.remove_archived(&mut tx, values).await?;
 		Ok(tx.commit().await?)
 	}

--- a/lib/src/kvs/tests/lq.rs
+++ b/lib/src/kvs/tests/lq.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 async fn scan_node_lq() {
 	let node_id = Uuid::parse_str("63bb5c1a-b14e-4075-a7f8-680267fbe136").unwrap();
 	let test = init(node_id).await.unwrap();
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let namespace = "test_namespace";
 	let database = "test_database";
 	let live_query_id = Uuid::from_bytes([
@@ -24,7 +24,7 @@ async fn scan_node_lq() {
 	);
 	let _ = tx.putc(key, "value", None).await.unwrap();
 	tx.commit().await.unwrap();
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 
 	let res = tx.scan_ndlq(&node_id, 100).await.unwrap();
 	assert_eq!(res.len(), 1);

--- a/lib/src/kvs/tests/mod.rs
+++ b/lib/src/kvs/tests/mod.rs
@@ -17,14 +17,16 @@ mod mem {
 
 	use crate::kvs::tests::Kvs;
 	use crate::kvs::Datastore;
+	use crate::kvs::LockType;
 	use crate::kvs::Transaction;
+	use crate::kvs::TransactionType;
 	use serial_test::serial;
 
 	async fn new_ds(id: Uuid) -> (Datastore, Kvs) {
 		(Datastore::new("memory").await.unwrap().with_node_id(sql::Uuid::from(id)), Kvs::Mem)
 	}
 
-	async fn new_tx(write: bool, lock: bool) -> Transaction {
+	async fn new_tx(write: TransactionType, lock: LockType) -> Transaction {
 		// Shared node id for one-off transactions
 		// We should delete this, node IDs should be known.
 		let new_tx_uuid = Uuid::parse_str("361893b5-a041-40c0-996c-c3a8828ef06b").unwrap();

--- a/lib/src/kvs/tests/mod.rs
+++ b/lib/src/kvs/tests/mod.rs
@@ -50,7 +50,9 @@ mod rocksdb {
 
 	use crate::kvs::tests::Kvs;
 	use crate::kvs::Datastore;
+	use crate::kvs::LockType;
 	use crate::kvs::Transaction;
+	use crate::kvs::TransactionType;
 	use serial_test::serial;
 	use temp_dir::TempDir;
 
@@ -65,7 +67,7 @@ mod rocksdb {
 		)
 	}
 
-	async fn new_tx(write: bool, lock: bool) -> Transaction {
+	async fn new_tx(write: TransactionType, lock: LockType) -> Transaction {
 		// Shared node id for one-off transactions
 		// We should delete this, node IDs should be known.
 		let new_tx_uuid = Uuid::parse_str("22358e5e-87bd-4040-8c63-01db896191ab").unwrap();
@@ -145,7 +147,7 @@ mod tikv {
 			.unwrap()
 			.with_node_id(sql::Uuid::from(node_id));
 		// Clear any previous test entries
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		tx.delp(vec![], u32::MAX).await.unwrap();
 		tx.commit().await.unwrap();
 		// Return the datastore
@@ -189,7 +191,7 @@ mod fdb {
 			.unwrap()
 			.with_node_id(sql::Uuid::from(node_id));
 		// Clear any previous test entries
-		let mut tx = ds.transaction(true, false).await.unwrap();
+		let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 		tx.delp(vec![], u32::MAX).await.unwrap();
 		tx.commit().await.unwrap();
 		// Return the datastore

--- a/lib/src/kvs/tests/multireader.rs
+++ b/lib/src/kvs/tests/multireader.rs
@@ -5,19 +5,19 @@ async fn multireader() {
 	let node_id = Uuid::parse_str("b7afc077-2123-476f-bee0-43d7504f1e0a").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Insert an initial key
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	tx.set("test", "some text").await.unwrap();
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx1 = ds.transaction(false, false).await.unwrap();
+	let mut tx1 = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx1.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"some text");
 	// Create a readonly transaction
-	let mut tx2 = ds.transaction(false, false).await.unwrap();
+	let mut tx2 = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx2.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"some text");
 	// Create a readonly transaction
-	let mut tx3 = ds.transaction(false, false).await.unwrap();
+	let mut tx3 = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx3.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"some text");
 	// Cancel both readonly transactions

--- a/lib/src/kvs/tests/multiwriter_different_keys.rs
+++ b/lib/src/kvs/tests/multiwriter_different_keys.rs
@@ -5,24 +5,24 @@ async fn multiwriter_different_keys() {
 	let node_id = Uuid::parse_str("7f0153b0-79cf-4922-85ef-61e390970514").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Insert an initial key
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	tx.set("test", "some text").await.unwrap();
 	tx.commit().await.unwrap();
 	// Create a writeable transaction
-	let mut tx1 = ds.transaction(true, false).await.unwrap();
+	let mut tx1 = ds.transaction(Write, Optimistic).await.unwrap();
 	tx1.set("test1", "other text 1").await.unwrap();
 	// Create a writeable transaction
-	let mut tx2 = ds.transaction(true, false).await.unwrap();
+	let mut tx2 = ds.transaction(Write, Optimistic).await.unwrap();
 	tx2.set("test2", "other text 2").await.unwrap();
 	// Create a writeable transaction
-	let mut tx3 = ds.transaction(true, false).await.unwrap();
+	let mut tx3 = ds.transaction(Write, Optimistic).await.unwrap();
 	tx3.set("test3", "other text 3").await.unwrap();
 	// Cancel both writeable transactions
 	tx1.commit().await.unwrap();
 	tx2.commit().await.unwrap();
 	tx3.commit().await.unwrap();
 	// Check that the key was updated ok
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"some text");
 	let val = tx.get("test1").await.unwrap().unwrap();

--- a/lib/src/kvs/tests/multiwriter_same_keys_allow.rs
+++ b/lib/src/kvs/tests/multiwriter_same_keys_allow.rs
@@ -5,33 +5,33 @@ async fn multiwriter_same_keys_allow() {
 	let node_id = Uuid::parse_str("a19cf00d-f95b-42c6-95e5-7b310162d570").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Insert an initial key
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	tx.set("test", "some text").await.unwrap();
 	tx.commit().await.unwrap();
 	// Create a writeable transaction
-	let mut tx1 = ds.transaction(true, false).await.unwrap();
+	let mut tx1 = ds.transaction(Write, Optimistic).await.unwrap();
 	tx1.set("test", "other text 1").await.unwrap();
 	// Create a writeable transaction
-	let mut tx2 = ds.transaction(true, false).await.unwrap();
+	let mut tx2 = ds.transaction(Write, Optimistic).await.unwrap();
 	tx2.set("test", "other text 2").await.unwrap();
 	// Create a writeable transaction
-	let mut tx3 = ds.transaction(true, false).await.unwrap();
+	let mut tx3 = ds.transaction(Write, Optimistic).await.unwrap();
 	tx3.set("test", "other text 3").await.unwrap();
 	// Cancel both writeable transactions
 	assert!(tx1.commit().await.is_ok());
 	assert!(tx2.commit().await.is_ok());
 	assert!(tx3.commit().await.is_ok());
 	// Check that the key was updated ok
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"other text 3");
 	tx.cancel().await.unwrap();
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	tx.set("test", "original text").await.unwrap();
 	tx.commit().await.unwrap();
 	// Check that the key was updated ok
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"original text");
 	tx.cancel().await.unwrap();

--- a/lib/src/kvs/tests/multiwriter_same_keys_conflict.rs
+++ b/lib/src/kvs/tests/multiwriter_same_keys_conflict.rs
@@ -5,33 +5,33 @@ async fn multiwriter_same_keys_conflict() {
 	let node_id = Uuid::parse_str("96ebbb5c-8040-497a-9459-838e4931aca7").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Insert an initial key
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	tx.set("test", "some text").await.unwrap();
 	tx.commit().await.unwrap();
 	// Create a writeable transaction
-	let mut tx1 = ds.transaction(true, false).await.unwrap();
+	let mut tx1 = ds.transaction(Write, Optimistic).await.unwrap();
 	tx1.set("test", "other text 1").await.unwrap();
 	// Create a writeable transaction
-	let mut tx2 = ds.transaction(true, false).await.unwrap();
+	let mut tx2 = ds.transaction(Write, Optimistic).await.unwrap();
 	tx2.set("test", "other text 2").await.unwrap();
 	// Create a writeable transaction
-	let mut tx3 = ds.transaction(true, false).await.unwrap();
+	let mut tx3 = ds.transaction(Write, Optimistic).await.unwrap();
 	tx3.set("test", "other text 3").await.unwrap();
 	// Cancel both writeable transactions
 	assert!(tx1.commit().await.is_ok());
 	assert!(tx2.commit().await.is_err());
 	assert!(tx3.commit().await.is_err());
 	// Check that the key was updated ok
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"other text 1");
 	tx.cancel().await.unwrap();
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	tx.set("test", "original text").await.unwrap();
 	tx.commit().await.unwrap();
 	// Check that the key was updated ok
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"original text");
 	tx.cancel().await.unwrap();

--- a/lib/src/kvs/tests/ndlq.rs
+++ b/lib/src/kvs/tests/ndlq.rs
@@ -7,7 +7,7 @@ async fn write_scan_ndlq() {
 	let test = init(nd).await.unwrap();
 
 	// Write some data
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let ns = "namespace";
 	let db = "database";
 	let tb = "table";
@@ -17,7 +17,7 @@ async fn write_scan_ndlq() {
 	tx.commit().await.unwrap();
 
 	// Verify scan
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let res = tx.scan_ndlq(&nd, 100).await.unwrap();
 	assert_eq!(
 		res,

--- a/lib/src/kvs/tests/nq.rs
+++ b/lib/src/kvs/tests/nq.rs
@@ -5,7 +5,7 @@ use crate::sql::statements::live::live;
 async fn archive_lv_for_node_archives() {
 	let node_id = Uuid::parse_str("9ab2d498-757f-48cc-8c07-a7d337997445").unwrap();
 	let test = init(node_id).await.unwrap();
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let namespace = "test_namespace";
 	let database = "test_database";
 	let table = "test_table";
@@ -31,7 +31,7 @@ async fn archive_lv_for_node_archives() {
 	// i.e. setup data is part of same transaction as required implementation checks
 	tx.commit().await.unwrap();
 
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let results = test
 		.db
 		.archive_lv_for_node(&mut tx, &sql::uuid::Uuid(node_id.clone()), this_node_id.clone())
@@ -54,7 +54,7 @@ async fn archive_lv_for_node_archives() {
 	assert_eq!(lq.tb, table);
 	assert_eq!(lq.lq, lv_id);
 
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let lv = tx.all_tb_lives(namespace, database, table).await.unwrap();
 	assert_eq!(lv.len(), 1, "{:?}", lv);
 	assert_eq!(lv[0].archived, Some(this_node_id));

--- a/lib/src/kvs/tests/raw.rs
+++ b/lib/src/kvs/tests/raw.rs
@@ -13,11 +13,11 @@ async fn exi() {
 	let node_id = Uuid::parse_str("463a5008-ee1d-43db-9662-5e752b6ea3f9").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.put("test", "ok").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.exi("test").await.unwrap();
 	assert!(val);
 	let val = tx.exi("none").await.unwrap();
@@ -32,11 +32,11 @@ async fn get() {
 	let node_id = Uuid::parse_str("477e2895-8c98-4606-a827-0add82eb466b").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.put("test", "ok").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), Some(b"ok")));
 	let val = tx.get("none").await.unwrap();
@@ -51,20 +51,20 @@ async fn set() {
 	let node_id = Uuid::parse_str("32b80d8b-dd16-4f6f-a687-1192f6cfc6f1").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.set("test", "one").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), Some(b"one")));
 	tx.cancel().await.unwrap();
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.set("test", "two").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), Some(b"two")));
 	tx.cancel().await.unwrap();
@@ -77,20 +77,20 @@ async fn put() {
 	let node_id = Uuid::parse_str("80149655-db34-451c-8711-6fa662a44b70").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.put("test", "one").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), Some(b"one")));
 	tx.cancel().await.unwrap();
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.put("test", "two").await.is_err());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), Some(b"one")));
 	tx.cancel().await.unwrap();
@@ -103,15 +103,15 @@ async fn del() {
 	let node_id = Uuid::parse_str("e0acb360-9187-401f-8192-f870b09e2c9e").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.put("test", "one").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.del("test").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), None));
 	tx.cancel().await.unwrap();
@@ -124,29 +124,29 @@ async fn putc() {
 	let node_id = Uuid::parse_str("705bb520-bc2b-4d52-8e64-d1214397e408").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.put("test", "one").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), Some(b"one")));
 	tx.cancel().await.unwrap();
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.putc("test", "two", Some("one")).await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), Some(b"two")));
 	tx.cancel().await.unwrap();
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.putc("test", "tre", Some("one")).await.is_err());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), Some(b"two")));
 	tx.cancel().await.unwrap();
@@ -159,24 +159,24 @@ async fn delc() {
 	let node_id = Uuid::parse_str("0985488e-cf2f-417a-bd10-7f4aa9c99c15").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.put("test", "one").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.delc("test", Some("two")).await.is_err());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), Some(b"one")));
 	tx.cancel().await.unwrap();
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.delc("test", Some("one")).await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), None));
 	tx.cancel().await.unwrap();
@@ -189,7 +189,7 @@ async fn scan() {
 	let node_id = Uuid::parse_str("83b81cc2-9609-4533-bede-c170ab9f7bbe").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Create a writeable transaction
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	assert!(tx.put("test1", "1").await.is_ok());
 	assert!(tx.put("test2", "2").await.is_ok());
 	assert!(tx.put("test3", "3").await.is_ok());
@@ -197,7 +197,7 @@ async fn scan() {
 	assert!(tx.put("test5", "5").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.scan("test1".."test9", u32::MAX).await.unwrap();
 	assert_eq!(val.len(), 5);
 	assert_eq!(val[0].0, b"test1");
@@ -212,7 +212,7 @@ async fn scan() {
 	assert_eq!(val[4].1, b"5");
 	tx.cancel().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.scan("test2".."test4", u32::MAX).await.unwrap();
 	assert_eq!(val.len(), 2);
 	assert_eq!(val[0].0, b"test2");
@@ -221,7 +221,7 @@ async fn scan() {
 	assert_eq!(val[1].1, b"3");
 	tx.cancel().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.scan("test1".."test9", 2).await.unwrap();
 	assert_eq!(val.len(), 2);
 	assert_eq!(val[0].0, b"test1");

--- a/lib/src/kvs/tests/raw.rs
+++ b/lib/src/kvs/tests/raw.rs
@@ -1,7 +1,7 @@
 #[tokio::test]
 #[serial]
 async fn initialise() {
-	let mut tx = new_tx(true, false).await;
+	let mut tx = new_tx(Write, Optimistic).await;
 	assert!(tx.put("test", "ok").await.is_ok());
 	tx.commit().await.unwrap();
 }

--- a/lib/src/kvs/tests/snapshot.rs
+++ b/lib/src/kvs/tests/snapshot.rs
@@ -5,24 +5,24 @@ async fn snapshot() {
 	let node_id = Uuid::parse_str("056804f2-b379-4397-9ceb-af8ebd527beb").unwrap();
 	let (ds, _) = new_ds(node_id).await;
 	// Insert an initial key
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	tx.set("test", "some text").await.unwrap();
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx1 = ds.transaction(false, false).await.unwrap();
+	let mut tx1 = ds.transaction(Read, Optimistic).await.unwrap();
 	// Check that the key was inserted ok
 	let val = tx1.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"some text");
 	// Create a new writeable transaction
-	let mut txw = ds.transaction(true, false).await.unwrap();
+	let mut txw = ds.transaction(Write, Optimistic).await.unwrap();
 	// Update the test key content
 	txw.set("test", "other text").await.unwrap();
 	// Create a readonly transaction
-	let mut tx2 = ds.transaction(false, false).await.unwrap();
+	let mut tx2 = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx2.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"some text");
 	// Create a readonly transaction
-	let mut tx3 = ds.transaction(false, false).await.unwrap();
+	let mut tx3 = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx3.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"some text");
 	// Update the test key content
@@ -37,7 +37,7 @@ async fn snapshot() {
 	// Commit the writable transaction
 	txw.commit().await.unwrap();
 	// Check that the key was updated ok
-	let mut tx = ds.transaction(false, false).await.unwrap();
+	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap().unwrap();
 	assert_eq!(val, b"extra text");
 	tx.cancel().await.unwrap();

--- a/lib/src/kvs/tests/tb.rs
+++ b/lib/src/kvs/tests/tb.rs
@@ -8,7 +8,7 @@ async fn table_definitions_can_be_scanned() {
 	// Setup
 	let node_id = Uuid::parse_str("f7b2ba17-90ed-45f9-9aa2-906c6ba0c289").unwrap();
 	let test = init(node_id).await.unwrap();
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 
 	// Create a table definition
 	let namespace = "test_namespace";
@@ -45,7 +45,7 @@ async fn table_definitions_can_be_deleted() {
 	// Setup
 	let node_id = Uuid::parse_str("13c0e650-1710-489e-bb80-f882bce50b56").unwrap();
 	let test = init(node_id).await.unwrap();
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 
 	// Create a table definition
 	let namespace = "test_namespace";

--- a/lib/src/kvs/tests/tblq.rs
+++ b/lib/src/kvs/tests/tblq.rs
@@ -5,7 +5,7 @@ async fn write_scan_tblq() {
 	let test = init(node_id).await.unwrap();
 
 	// Write some data
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let ns = "namespace";
 	let db = "database";
 	let tb = "table";
@@ -26,7 +26,7 @@ async fn write_scan_tblq() {
 	tx.commit().await.unwrap();
 
 	// Verify scan
-	let mut tx = test.db.transaction(true, false).await.unwrap();
+	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let res = tx.scan_tblq(ns, db, tb, 100).await.unwrap();
 	assert_eq!(
 		res,

--- a/lib/src/kvs/tests/timestamp_to_versionstamp.rs
+++ b/lib/src/kvs/tests/timestamp_to_versionstamp.rs
@@ -15,27 +15,27 @@ async fn timestamp_to_versionstamp() {
 	// Create a new datastore
 	let (ds, _) = new_ds(Uuid::parse_str("A905CA25-56ED-49FB-B759-696AEA87C342").unwrap()).await;
 	// Give the current versionstamp a timestamp of 0
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	tx.set_timestamp_for_versionstamp(0, "myns", "mydb", true).await.unwrap();
 	tx.commit().await.unwrap();
 	// Get the versionstamp for timestamp 0
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb", true).await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 	// Give the current versionstamp a timestamp of 1
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	tx.set_timestamp_for_versionstamp(1, "myns", "mydb", true).await.unwrap();
 	tx.commit().await.unwrap();
 	// Get the versionstamp for timestamp 1
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb", true).await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 	// Give the current versionstamp a timestamp of 2
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	tx.set_timestamp_for_versionstamp(2, "myns", "mydb", true).await.unwrap();
 	tx.commit().await.unwrap();
 	// Get the versionstamp for timestamp 2
-	let mut tx = ds.transaction(true, false).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	let vs3 = tx.get_versionstamp_from_timestamp(2, "myns", "mydb", true).await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 	assert!(vs1 < vs2);

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -47,6 +47,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
 #[cfg(target_arch = "wasm32")]
 use wasmtimer::std::{SystemTime, UNIX_EPOCH};
+use crate::idx::trees::store::TreeStoreType;
 
 /// A set of undoable updates and requests against a dataset.
 #[allow(dead_code)]
@@ -83,6 +84,16 @@ impl From<bool> for TransactionType {
 		match value {
 			true => TransactionType::Write,
 			false => TransactionType::Read,
+		}
+	}
+}
+
+impl From<TreeStoreType> for TransactionType {
+	fn from(value: TreeStoreType) -> Self {
+		match value {
+			TreeStoreType::Write => {TransactionType::Write}
+			TreeStoreType::Read => {TransactionType::Read}
+			TreeStoreType::Traversal => {TransactionType::Read}
 		}
 	}
 }

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
+use surrealdb::kvs::{LockType::*, TransactionType::*};
 use surrealdb::sql::Value;
 
 #[tokio::test]

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -116,7 +116,7 @@ async fn remove_statement_index() -> Result<(), Error> {
 	);
 	assert_eq!(tmp, val);
 
-	let mut tx = dbs.transaction(false, false).await?;
+	let mut tx = dbs.transaction(Read, Optimistic).await?;
 	for ix in ["uniq_isbn", "idx_author", "ft_title"] {
 		assert_empty_prefix!(&mut tx, surrealdb::key::index::all::new("test", "test", "book", ix));
 	}

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -262,7 +262,7 @@ mod tests {
 
 	use surrealdb::dbs::Session;
 	use surrealdb::iam::verify::verify_creds;
-	use surrealdb::kvs::Datastore;
+	use surrealdb::kvs::{Datastore, LockType::*, TransactionType::*};
 	use test_log::test;
 	use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
 

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -278,12 +278,12 @@ mod tests {
 
 		// Setup the initial user if there are no root users
 		assert_eq!(
-			ds.transaction(false, false).await.unwrap().all_root_users().await.unwrap().len(),
+			ds.transaction(Read, Optimistic).await.unwrap().all_root_users().await.unwrap().len(),
 			0
 		);
 		ds.setup_initial_creds(creds).await.unwrap();
 		assert_eq!(
-			ds.transaction(false, false).await.unwrap().all_root_users().await.unwrap().len(),
+			ds.transaction(Read, Optimistic).await.unwrap().all_root_users().await.unwrap().len(),
 			1
 		);
 		verify_creds(&ds, None, None, creds.username, creds.password).await.unwrap();
@@ -294,7 +294,7 @@ mod tests {
 		let sess = Session::owner();
 		ds.execute(sql, &sess, None).await.unwrap();
 		let pass_hash = ds
-			.transaction(false, false)
+			.transaction(Read, Optimistic)
 			.await
 			.unwrap()
 			.get_root_user(creds.username)
@@ -305,7 +305,7 @@ mod tests {
 		ds.setup_initial_creds(creds).await.unwrap();
 		assert_eq!(
 			pass_hash,
-			ds.transaction(false, false)
+			ds.transaction(Read, Optimistic)
 				.await
 				.unwrap()
 				.get_root_user(creds.username)

--- a/src/net/health.rs
+++ b/src/net/health.rs
@@ -17,7 +17,7 @@ async fn handler() -> impl IntoResponse {
 	// Get the datastore reference
 	let db = DB.get().unwrap();
 	// Attempt to open a transaction
-	match db.transaction(false, false).await {
+	match db.transaction(Read, Optimistic).await {
 		// The transaction failed to start
 		Err(_) => Err(Error::InvalidStorage),
 		// The transaction was successful

--- a/src/net/health.rs
+++ b/src/net/health.rs
@@ -4,6 +4,7 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::Router;
 use http_body::Body as HttpBody;
+use surrealdb::kvs::{LockType::*, TransactionType::*};
 
 pub(super) fn router<S, B>() -> Router<S, B>
 where


### PR DESCRIPTION
## What is the motivation?

```rust
dbs.transaction(true, false)
``` 
was a common signature, but its very confusing and unclear what the booleans mean

## What does this change do?

It introduces the TransactionType and LockType enums, with to replace the bools, the above function signature would now be: 
```rust
dbs.transaction(Write, Optimistic)
```
this makes it clear what is actually happening, and also means that other options can be added down the line, such as alternative lock methods.
the methods on the underlying kvs api still take a boolean but this can be changed easily later.

## What is your testing strategy?

There are no additional tests, this should not change any behaviour, so any bugs will hopefully be caught by existing tests.

## Is this related to any issues?

no

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
