### PR TITLE
fix: interchangable limit & order

### DIFF
--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -30,7 +30,6 @@ use crate::sql::value::{selects, Value, Values};
 use crate::sql::version::{version, Version};
 use crate::sql::with::{with, With};
 use derive::Store;
-use nom::branch::permutation;
 use nom::bytes::complete::tag_no_case;
 use nom::combinator::cut;
 use nom::combinator::opt;
@@ -224,12 +223,15 @@ pub fn select(i: &str) -> IResult<&str, SelectStatement> {
 	let (i, order) = opt(preceded(shouldbespace, order))(i)?;
 	check_order_by_fields(i, &expr, &order)?;
 
-	// limit & start should be in any order (#117)
-	let (i, limit_or_start) = opt(permutation((
-		opt(preceded(shouldbespace, limit)),
-		opt(preceded(shouldbespace, start)),
-	)))(i)?;
-	let (limit, start) = limit_or_start.unwrap_or((None, None));
+	let (i, (limit, start)) = if let Ok((i, limit)) = peek(preceded(shouldbespace, limit))(i) {
+		let (i, start) = opt(preceded(shouldbespace, start))(i)?;
+		(i, (Some(limit), start))
+	} else if let Ok((i, start)) = peek(preceded(shouldbespace, start))(i) {
+		let (i, limit) = opt(preceded(shouldbespace, limit))(i)?;
+		(i, (limit, Some(start)))
+	} else {
+		(i, (None, None))
+	};
 
 	let (i, fetch) = opt(preceded(shouldbespace, fetch))(i)?;
 	let (i, version) = opt(preceded(shouldbespace, version))(i)?;

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -223,10 +223,10 @@ pub fn select(i: &str) -> IResult<&str, SelectStatement> {
 	let (i, order) = opt(preceded(shouldbespace, order))(i)?;
 	check_order_by_fields(i, &expr, &order)?;
 
-	let (i, (limit, start)) = if let Ok((i, limit)) = peek(preceded(shouldbespace, limit))(i) {
+	let (i, (limit, start)) = if let Ok((i, limit)) = preceded(shouldbespace, limit)(i) {
 		let (i, start) = opt(preceded(shouldbespace, start))(i)?;
 		(i, (Some(limit), start))
-	} else if let Ok((i, start)) = peek(preceded(shouldbespace, start))(i) {
+	} else if let Ok((i, start)) = preceded(shouldbespace, start)(i) {
 		let (i, limit) = opt(preceded(shouldbespace, limit))(i)?;
 		(i, (limit, Some(start)))
 	} else {

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -271,53 +271,54 @@ mod tests {
 
 	use super::*;
 
+	fn assert_parsable(sql: &str) {
+		let res = select(sql);
+		assert!(res.is_ok());
+		let (_, out) = res.unwrap();
+		assert_eq!(sql, format!("{}", out))
+	}
+
 	#[test]
 	fn select_statement_param() {
-		let sql = "SELECT * FROM $test";
-		let res = select(sql);
-		let out = res.unwrap().1;
-		assert_eq!(sql, format!("{}", out))
+		assert_parsable("SELECT * FROM $test");
 	}
 
 	#[test]
 	fn select_statement_table() {
-		let sql = "SELECT * FROM test";
-		let res = select(sql);
-		let out = res.unwrap().1;
-		assert_eq!(sql, format!("{}", out));
+		assert_parsable("SELECT * FROM test");
 	}
 
 	#[test]
 	fn select_statement_omit() {
-		let sql = "SELECT * OMIT password FROM test";
-		let res = select(sql);
-		assert!(res.is_ok());
-		let out = res.unwrap().1;
-		assert_eq!(sql, format!("{}", out));
+		assert_parsable("SELECT * OMIT password FROM test");
 	}
 
 	#[test]
 	fn select_statement_thing() {
-		let sql = "SELECT * FROM test:thingy ORDER BY name";
-		let res = select(sql);
-		let out = res.unwrap().1;
-		assert_eq!(sql, format!("{}", out))
+		assert_parsable("SELECT * FROM test:thingy ORDER BY name");
 	}
 
 	#[test]
 	fn select_statement_clash() {
-		let sql = "SELECT * FROM order ORDER BY order";
-		let res = select(sql);
-		let out = res.unwrap().1;
-		assert_eq!(sql, format!("{}", out))
+		assert_parsable("SELECT * FROM order ORDER BY order");
+	}
+
+	#[test]
+	fn select_statement_limit_select() {
+		assert_parsable("SELECT * FROM table LIMIT 3 START 2");
+	}
+
+	#[test]
+	fn select_statement_limit_select_unordered() {
+		let res = select("SELECT * FROM table START 2 LIMIT 1");
+		assert!(res.is_ok());
+		let (_, out) = res.unwrap();
+		assert_eq!("SELECT * FROM table LIMIT 1 START 2", format!("{}", out))
 	}
 
 	#[test]
 	fn select_statement_table_thing() {
-		let sql = "SELECT *, ((1 + 3) / 4), 1.3999f AS tester FROM test, test:thingy";
-		let res = select(sql);
-		let out = res.unwrap().1;
-		assert_eq!(sql, format!("{}", out))
+		assert_parsable("SELECT *, ((1 + 3) / 4), 1.3999f AS tester FROM test, test:thingy");
 	}
 
 	#[test]

--- a/lib/tests/range.rs
+++ b/lib/tests/range.rs
@@ -20,7 +20,7 @@ async fn select_start_limit_fetch() -> Result<(), Error> {
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 6);
+	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(

--- a/lib/tests/range.rs
+++ b/lib/tests/range.rs
@@ -7,7 +7,7 @@ use surrealdb::err::Error;
 use surrealdb::sql::Value;
 
 #[tokio::test]
-async fn select_limit_fetch() -> Result<(), Error> {
+async fn select_start_limit_fetch() -> Result<(), Error> {
 	let sql = "
 		CREATE tag:rs SET name = 'Rust';
 		CREATE tag:go SET name = 'Golang';
@@ -15,6 +15,7 @@ async fn select_limit_fetch() -> Result<(), Error> {
 		CREATE person:tobie SET tags = [tag:rs, tag:go, tag:js];
 		CREATE person:jaime SET tags = [tag:js];
 		SELECT * FROM person LIMIT 1 FETCH tags;
+		SELECT * FROM person START 1 LIMIT 1 FETCH tags;
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
@@ -91,6 +92,29 @@ async fn select_limit_fetch() -> Result<(), Error> {
 		]",
 	);
 	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:tobie,
+				tags: [
+					{
+						id: tag:rs,
+						name: 'Rust'
+					},
+					{
+						id: tag:go,
+						name: 'Golang'
+					},
+					{
+						id: tag:js,
+						name: 'JavaScript'
+					}
+				]
+			}
+		]",
+	);
 	//
 	Ok(())
 }

--- a/lib/tests/range.rs
+++ b/lib/tests/range.rs
@@ -115,6 +115,7 @@ async fn select_start_limit_fetch() -> Result<(), Error> {
 			}
 		]",
 	);
+	assert_eq!(tmp, val);
 	//
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently only LIMIT followed by START works.

## What does this change do?

Allow interchangeable order for LIMIT and SET

## What is your testing strategy?

Moves the "limit" test to a general "range" test, and immediately adds the mixed order

## Is this related to any issues?

https://github.com/surrealdb/surrealdb/issues/117

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
