### PR TITLE
Fix clippy warnings in tests and clippy check tests in CI

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -15,7 +15,7 @@ args = ["check", "--locked", "--package", "surrealdb", "--features", "protocol-w
 [tasks.ci-clippy]
 category = "CI - CHECK"
 command = "cargo"
-args = ["clippy", "--all-targets", "--all-features", "--tests", "--benches", "--examples", "--", "-D", "warnings"]
+args = ["clippy", "--all-targets", "--all-features", "--tests", "--benches", "--examples","--bins", "--", "-D", "warnings"]
 
 #
 # Integration Tests

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -15,7 +15,7 @@ args = ["check", "--locked", "--package", "surrealdb", "--features", "protocol-w
 [tasks.ci-clippy]
 category = "CI - CHECK"
 command = "cargo"
-args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
+args = ["clippy", "--all-targets", "--all-features", "--tests", "--benches", "--examples", "--", "-D", "warnings"]
 
 #
 # Integration Tests

--- a/lib/src/cf/mutations.rs
+++ b/lib/src/cf/mutations.rs
@@ -171,13 +171,13 @@ mod tests {
 				vec![
 					TableMutation::Set(
 						Thing::from(("mytb".to_string(), "tobie".to_string())),
-						Value::from(Value::Object(Object::from(HashMap::from([
+						Value::Object(Object::from(HashMap::from([
 							(
 								"id",
 								Value::from(Thing::from(("mytb".to_string(), "tobie".to_string()))),
 							),
 							("note", Value::from("surreal")),
-						])))),
+						]))),
 					),
 					TableMutation::Del(Thing::from(("mytb".to_string(), "tobie".to_string()))),
 					TableMutation::Def(DefineTableStatement {

--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -436,7 +436,7 @@ mod tests {
 			{
 				let ds = Datastore::new("memory").await.unwrap().with_auth_enabled(true);
 
-				let res = ds.execute(statement, &session, None).await;
+				let res = ds.execute(statement, session, None).await;
 
 				if *should_succeed {
 					assert!(res.is_ok(), "{}: {:?}", msg, res);

--- a/lib/src/idg/u32.rs
+++ b/lib/src/idg/u32.rs
@@ -122,11 +122,8 @@ mod tests {
 	}
 
 	async fn finish(mut tx: Transaction, mut d: U32) -> Result<(), Error> {
-		match d.finish() {
-			Some((key, val)) => {
-				tx.set(key, val).await?;
-			}
-			None => {}
+		if let Some((key, val)) = d.finish() {
+			tx.set(key, val).await?;
 		}
 		tx.commit().await
 	}

--- a/lib/src/idx/planner/plan.rs
+++ b/lib/src/idx/planner/plan.rs
@@ -323,20 +323,20 @@ mod tests {
 	fn test_range_default_value() {
 		let r = RangeValue::default();
 		assert_eq!(r.value, Value::None);
-		assert_eq!(r.inclusive, false);
+		assert!(!r.inclusive);
 	}
 	#[test]
 	fn test_range_value_from_inclusive() {
 		let mut r = RangeValue::default();
 		r.set_from_inclusive(&20.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, true);
+		assert!(r.inclusive);
 		r.set_from_inclusive(&10.into());
 		assert_eq!(r.value, 10.into());
-		assert_eq!(r.inclusive, true);
+		assert!(r.inclusive);
 		r.set_from_inclusive(&20.into());
 		assert_eq!(r.value, 10.into());
-		assert_eq!(r.inclusive, true);
+		assert!(r.inclusive);
 	}
 
 	#[test]
@@ -344,13 +344,13 @@ mod tests {
 		let mut r = RangeValue::default();
 		r.set_from(&20.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, false);
+		assert!(!r.inclusive);
 		r.set_from(&10.into());
 		assert_eq!(r.value, 10.into());
-		assert_eq!(r.inclusive, false);
+		assert!(!r.inclusive);
 		r.set_from(&20.into());
 		assert_eq!(r.value, 10.into());
-		assert_eq!(r.inclusive, false);
+		assert!(!r.inclusive);
 	}
 
 	#[test]
@@ -358,13 +358,13 @@ mod tests {
 		let mut r = RangeValue::default();
 		r.set_to_inclusive(&10.into());
 		assert_eq!(r.value, 10.into());
-		assert_eq!(r.inclusive, true);
+		assert!(r.inclusive);
 		r.set_to_inclusive(&20.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, true);
+		assert!(r.inclusive);
 		r.set_to_inclusive(&10.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, true);
+		assert!(r.inclusive);
 	}
 
 	#[test]
@@ -372,13 +372,13 @@ mod tests {
 		let mut r = RangeValue::default();
 		r.set_to(&10.into());
 		assert_eq!(r.value, 10.into());
-		assert_eq!(r.inclusive, false);
+		assert!(!r.inclusive);
 		r.set_to(&20.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, false);
+		assert!(!r.inclusive);
 		r.set_to(&10.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, false);
+		assert!(!r.inclusive);
 	}
 
 	#[test]
@@ -386,13 +386,13 @@ mod tests {
 		let mut r = RangeValue::default();
 		r.set_to(&20.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, false);
+		assert!(!r.inclusive);
 		r.set_to_inclusive(&20.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, true);
+		assert!(r.inclusive);
 		r.set_to(&20.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, true);
+		assert!(r.inclusive);
 	}
 
 	#[test]
@@ -400,12 +400,12 @@ mod tests {
 		let mut r = RangeValue::default();
 		r.set_from(&20.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, false);
+		assert!(!r.inclusive);
 		r.set_from_inclusive(&20.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, true);
+		assert!(r.inclusive);
 		r.set_from(&20.into());
 		assert_eq!(r.value, 20.into());
-		assert_eq!(r.inclusive, true);
+		assert!(r.inclusive);
 	}
 }

--- a/lib/src/idx/trees/btree.rs
+++ b/lib/src/idx/trees/btree.rs
@@ -1236,7 +1236,7 @@ mod tests {
 
 		{
 			let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-			print_tree(&mut tx, &mut t).await;
+			print_tree(&mut tx, &t).await;
 			tx.commit().await.unwrap();
 		}
 

--- a/lib/src/idx/trees/mtree.rs
+++ b/lib/src/idx/trees/mtree.rs
@@ -1647,7 +1647,7 @@ mod tests {
 	}
 
 	fn check_routing_vec(
-		m: &Vec<RoutingEntry>,
+		m: &[RoutingEntry],
 		idx: usize,
 		center: &Vector,
 		node_id: NodeId,

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -421,8 +421,8 @@ impl Datastore {
 				}
 			}
 		};
-		if resolve_err.is_err() {
-			err.push(resolve_err.unwrap_err());
+		if let Err(e) = resolve_err {
+			err.push(e);
 		}
 		if !err.is_empty() {
 			error!("Error bootstrapping sweep phase: {:?}", err);

--- a/lib/src/kvs/tests/cluster_init.rs
+++ b/lib/src/kvs/tests/cluster_init.rs
@@ -129,7 +129,7 @@ async fn single_live_queries_are_garbage_collected() {
 	let table = "test_table";
 	let options = Options::default()
 		.with_required(
-			node_id.clone(),
+			node_id,
 			Some(Arc::from(namespace)),
 			Some(Arc::from(database)),
 			Arc::new(Auth::for_root(Role::Owner)),
@@ -211,7 +211,7 @@ async fn bootstrap_does_not_error_on_missing_live_queries() {
 	let table = "test_table";
 	let options = Options::default()
 		.with_required(
-			old_node_id.clone(),
+			old_node_id,
 			Some(Arc::from(namespace)),
 			Some(Arc::from(database)),
 			Arc::new(Auth::for_root(Role::Owner)),

--- a/lib/src/kvs/tests/helper.rs
+++ b/lib/src/kvs/tests/helper.rs
@@ -43,12 +43,12 @@ impl TestContext {
 
 		let mut tx = self.db.transaction(Write, Optimistic).await?;
 		self.db.remove_archived(&mut tx, values).await?;
-		Ok(tx.commit().await?)
+		tx.commit().await
 	}
 
 	// Use this to generate strings that have the test uuid associated with it
 	pub fn test_str(&self, prefix: &str) -> String {
-		return format!("{}-{}", prefix, self.context_id);
+		format!("{}-{}", prefix, self.context_id)
 	}
 }
 
@@ -56,11 +56,11 @@ impl TestContext {
 /// In the future it would be nice to handle multiple datastores
 pub(crate) async fn init(node_id: Uuid) -> Result<TestContext, Error> {
 	let (db, kvs) = new_ds(node_id).await;
-	return Ok(TestContext {
+	Ok(TestContext {
 		db,
 		kvs,
 		context_id: node_id.to_string(), // The context does not always have to be a uuid
-	});
+	})
 }
 
 /// Scan the entire storage layer displaying keys
@@ -69,7 +69,7 @@ async fn _debug_scan(tx: &mut Transaction, message: &str) {
 	let r = tx.scan(vec![0]..vec![u8::MAX], 100000).await.unwrap();
 	println!("START OF RANGE SCAN - {}", message);
 	for (k, _v) in r.iter() {
-		println!("{}", crate::key::debug::sprint_key(k.as_ref()));
+		println!("{}", crate::key::debug::sprint_key(k));
 	}
 	println!("END OF RANGE SCAN - {}", message);
 }

--- a/lib/src/kvs/tests/lq.rs
+++ b/lib/src/kvs/tests/lq.rs
@@ -18,11 +18,11 @@ async fn scan_node_lq() {
 		key.encode()
 			.unwrap()
 			.iter()
-			.flat_map(|byte| std::ascii::escape_default(byte.clone()))
+			.flat_map(|byte| std::ascii::escape_default(*byte))
 			.map(|byte| byte as char)
 			.collect::<String>()
 	);
-	let _ = tx.putc(key, "value", None).await.unwrap();
+	tx.putc(key, "value", None).await.unwrap();
 	tx.commit().await.unwrap();
 	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 

--- a/lib/src/kvs/tests/nq.rs
+++ b/lib/src/kvs/tests/nq.rs
@@ -16,7 +16,7 @@ async fn archive_lv_for_node_archives() {
 		0x1F,
 	]));
 
-	let key = crate::key::node::lq::new(node_id.clone(), lv_id.0.clone(), namespace, database);
+	let key = crate::key::node::lq::new(node_id, lv_id.0, namespace, database);
 	tx.putc(key, table, None).await.unwrap();
 
 	let (_, mut stm) = live(format!("LIVE SELECT * FROM {}", table).as_str()).unwrap();
@@ -34,7 +34,7 @@ async fn archive_lv_for_node_archives() {
 	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
 	let results = test
 		.db
-		.archive_lv_for_node(&mut tx, &sql::uuid::Uuid(node_id.clone()), this_node_id.clone())
+		.archive_lv_for_node(&mut tx, &sql::uuid::Uuid(node_id), this_node_id.clone())
 		.await
 		.unwrap();
 	assert_eq!(results.len(), 1);
@@ -48,7 +48,7 @@ async fn archive_lv_for_node_archives() {
 			panic!("Unexpected error: {:?}", err);
 		}
 	}
-	assert_eq!(lq.nd, sql::uuid::Uuid(node_id.clone()));
+	assert_eq!(lq.nd, sql::uuid::Uuid(node_id));
 	assert_eq!(lq.ns, namespace);
 	assert_eq!(lq.db, database);
 	assert_eq!(lq.tb, table);

--- a/lib/src/kvs/tests/raw.rs
+++ b/lib/src/kvs/tests/raw.rs
@@ -42,7 +42,7 @@ async fn get() {
 	let val = tx.get("test").await.unwrap();
 	assert!(matches!(val.as_deref(), Some(b"ok")));
 	let val = tx.get("none").await.unwrap();
-	assert!(matches!(val.as_deref(), None));
+	assert!(val.as_deref().is_none());
 	tx.cancel().await.unwrap();
 }
 
@@ -115,7 +115,7 @@ async fn del() {
 	// Create a readonly transaction
 	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
-	assert!(matches!(val.as_deref(), None));
+	assert!(val.as_deref().is_none());
 	tx.cancel().await.unwrap();
 }
 
@@ -180,7 +180,7 @@ async fn delc() {
 	// Create a readonly transaction
 	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
 	let val = tx.get("test").await.unwrap();
-	assert!(matches!(val.as_deref(), None));
+	assert!(val.as_deref().is_none());
 	tx.cancel().await.unwrap();
 }
 

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -2788,7 +2788,7 @@ mod tests {
 			..Default::default()
 		};
 		let key = crate::key::root::us::new("user");
-		let _ = txn.set(key, data.to_owned()).await.unwrap();
+		txn.set(key, data.to_owned()).await.unwrap();
 		let res = txn.get_root_user("user").await.unwrap();
 		assert_eq!(res, data);
 		txn.commit().await.unwrap()
@@ -2814,7 +2814,7 @@ mod tests {
 		};
 
 		let key = crate::key::namespace::us::new("ns", "user");
-		let _ = txn.set(key, data.to_owned()).await.unwrap();
+		txn.set(key, data.to_owned()).await.unwrap();
 		let res = txn.get_ns_user("ns", "user").await.unwrap();
 		assert_eq!(res, data);
 		txn.commit().await.unwrap();
@@ -2840,7 +2840,7 @@ mod tests {
 		};
 
 		let key = crate::key::database::us::new("ns", "db", "user");
-		let _ = txn.set(key, data.to_owned()).await.unwrap();
+		txn.set(key, data.to_owned()).await.unwrap();
 		let res = txn.get_db_user("ns", "db", "user").await.unwrap();
 		assert_eq!(res, data);
 		txn.commit().await.unwrap();
@@ -2864,8 +2864,8 @@ mod tests {
 
 		let key1 = crate::key::root::us::new("user1");
 		let key2 = crate::key::root::us::new("user2");
-		let _ = txn.set(key1, data.to_owned()).await.unwrap();
-		let _ = txn.set(key2, data.to_owned()).await.unwrap();
+		txn.set(key1, data.to_owned()).await.unwrap();
+		txn.set(key2, data.to_owned()).await.unwrap();
 		let res = txn.all_root_users().await.unwrap();
 
 		assert_eq!(res.len(), 2);
@@ -2891,8 +2891,8 @@ mod tests {
 
 		let key1 = crate::key::namespace::us::new("ns", "user1");
 		let key2 = crate::key::namespace::us::new("ns", "user2");
-		let _ = txn.set(key1, data.to_owned()).await.unwrap();
-		let _ = txn.set(key2, data.to_owned()).await.unwrap();
+		txn.set(key1, data.to_owned()).await.unwrap();
+		txn.set(key2, data.to_owned()).await.unwrap();
 
 		txn.cache.clear();
 
@@ -2921,8 +2921,8 @@ mod tests {
 
 		let key1 = crate::key::database::us::new("ns", "db", "user1");
 		let key2 = crate::key::database::us::new("ns", "db", "user2");
-		let _ = txn.set(key1, data.to_owned()).await.unwrap();
-		let _ = txn.set(key2, data.to_owned()).await.unwrap();
+		txn.set(key1, data.to_owned()).await.unwrap();
+		txn.set(key2, data.to_owned()).await.unwrap();
 
 		txn.cache.clear();
 

--- a/lib/src/sql/idiom.rs
+++ b/lib/src/sql/idiom.rs
@@ -105,9 +105,11 @@ impl Idiom {
 	/// Simplifies this Idiom for use in object keys
 	pub(crate) fn simplify(&self) -> Idiom {
 		self.0
-			.iter().filter(|&p| {
+			.iter()
+			.filter(|&p| {
 				matches!(p, Part::Field(_) | Part::Start(_) | Part::Value(_) | Part::Graph(_))
-			}).cloned()
+			})
+			.cloned()
 			.collect::<Vec<_>>()
 			.into()
 	}

--- a/lib/src/sql/idiom.rs
+++ b/lib/src/sql/idiom.rs
@@ -105,11 +105,9 @@ impl Idiom {
 	/// Simplifies this Idiom for use in object keys
 	pub(crate) fn simplify(&self) -> Idiom {
 		self.0
-			.iter()
-			.cloned()
-			.filter(|p| {
+			.iter().filter(|&p| {
 				matches!(p, Part::Field(_) | Part::Start(_) | Part::Value(_) | Part::Graph(_))
-			})
+			}).cloned()
 			.collect::<Vec<_>>()
 			.into()
 	}

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -82,6 +82,7 @@ mod api_integration {
 		use surrealdb::engine::remote::ws::Client;
 		use surrealdb::engine::remote::ws::Ws;
 
+		#[allow(clippy::await_holding_lock)]
 		async fn new_db() -> Surreal<Client> {
 			let _guard = SETUP_MUTEX.lock().unwrap();
 			init_logger();
@@ -104,6 +105,7 @@ mod api_integration {
 		use surrealdb::engine::remote::http::Client;
 		use surrealdb::engine::remote::http::Http;
 
+		#[allow(clippy::await_holding_lock)]
 		async fn new_db() -> Surreal<Client> {
 			let _guard = SETUP_MUTEX.lock().unwrap();
 			init_logger();
@@ -220,6 +222,7 @@ mod api_integration {
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::File;
 
+		#[allow(clippy::await_holding_lock)]
 		async fn new_db() -> Surreal<Db> {
 			let _guard = SETUP_MUTEX.lock().unwrap();
 			init_logger();
@@ -247,6 +250,7 @@ mod api_integration {
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::RocksDb;
 
+		#[allow(clippy::await_holding_lock)]
 		async fn new_db() -> Surreal<Db> {
 			let _guard = SETUP_MUTEX.lock().unwrap();
 			init_logger();
@@ -274,6 +278,7 @@ mod api_integration {
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::SpeeDb;
 
+		#[allow(clippy::await_holding_lock)]
 		async fn new_db() -> Surreal<Db> {
 			let _guard = SETUP_MUTEX.lock().unwrap();
 			init_logger();
@@ -301,6 +306,7 @@ mod api_integration {
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::TiKv;
 
+		#[allow(clippy::await_holding_lock)]
 		async fn new_db() -> Surreal<Db> {
 			let _guard = SETUP_MUTEX.lock().unwrap();
 			init_logger();
@@ -327,6 +333,7 @@ mod api_integration {
 		use surrealdb::engine::local::Db;
 		use surrealdb::engine::local::FDb;
 
+		#[allow(clippy::await_holding_lock)]
 		async fn new_db() -> Surreal<Db> {
 			let _guard = SETUP_MUTEX.lock().unwrap();
 			init_logger();
@@ -352,6 +359,7 @@ mod api_integration {
 		use super::*;
 		use surrealdb::engine::any::Any;
 
+		#[allow(clippy::await_holding_lock)]
 		async fn new_db() -> Surreal<Any> {
 			let _guard = SETUP_MUTEX.lock().unwrap();
 			init_logger();

--- a/lib/tests/changefeeds.rs
+++ b/lib/tests/changefeeds.rs
@@ -35,7 +35,7 @@ async fn database_change_feeds() -> Result<(), Error> {
 	let start_ts = 0u64;
 	let end_ts = start_ts + 1;
 	dbs.tick_at(start_ts).await?;
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	dbs.tick_at(end_ts).await?;
 	assert_eq!(res.len(), 6);
 	// DEFINE DATABASE
@@ -95,12 +95,12 @@ async fn database_change_feeds() -> Result<(), Error> {
         SHOW CHANGES FOR TABLE person SINCE 0;
 	";
 	dbs.tick_at(end_ts + 3599).await?;
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	let tmp = res.remove(0).result?;
 	assert_eq!(tmp, val);
 	// GC after 1hs
 	dbs.tick_at(end_ts + 3600).await?;
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	let tmp = res.remove(0).result?;
 	let val = Value::parse("[]");
 	assert_eq!(tmp, val);
@@ -140,7 +140,7 @@ async fn table_change_feeds() -> Result<(), Error> {
 	let start_ts = 0u64;
 	let end_ts = start_ts + 1;
 	dbs.tick_at(start_ts).await?;
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	dbs.tick_at(end_ts).await?;
 	assert_eq!(res.len(), 10);
 	// DEFINE TABLE
@@ -276,12 +276,12 @@ async fn table_change_feeds() -> Result<(), Error> {
         SHOW CHANGES FOR TABLE person SINCE 0;
 	";
 	dbs.tick_at(end_ts + 3599).await?;
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	let tmp = res.remove(0).result?;
 	assert_eq!(tmp, val);
 	// GC after 1hs
 	dbs.tick_at(end_ts + 3600).await?;
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	let tmp = res.remove(0).result?;
 	let val = Value::parse("[]");
 	assert_eq!(tmp, val);
@@ -344,7 +344,7 @@ async fn changefeed_with_ts() -> Result<(), Error> {
 	let Value::Object(a) = a else {
 		unreachable!()
 	};
-	let Value::Number(versionstamp1) = a.get("versionstamp").unwrap() else {
+	let Value::Number(_versionstamp1) = a.get("versionstamp").unwrap() else {
 		unreachable!()
 	};
 	let changes = a.get("changes").unwrap().to_owned();

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -1041,7 +1041,7 @@ async fn define_statement_index_single_unique_embedded_multiple() -> Result<(), 
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
@@ -1092,7 +1092,7 @@ async fn define_statement_index_multiple_unique_embedded_multiple() -> Result<()
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
 	//
 	let tmp = res.remove(0).result;
@@ -1265,7 +1265,7 @@ async fn define_statement_user_root() -> Result<(), Error> {
 	let define_str = tmp.pick(&["users".into(), "test".into()]).to_string();
 
 	assert!(define_str
-		.strip_prefix("\"")
+		.strip_prefix('\"')
 		.unwrap()
 		.starts_with("DEFINE USER test ON ROOT PASSHASH '$argon2id$"));
 	Ok(())

--- a/lib/tests/delete.rs
+++ b/lib/tests/delete.rs
@@ -436,9 +436,8 @@ fn recv_notification(
 	poll_rate: std::time::Duration,
 ) -> Result<Notification, TryRecvError> {
 	for _ in 0..tries {
-		match notifications.try_recv() {
-			Ok(not) => return Ok(not),
-			Err(_) => {}
+		if let Ok(not) = notifications.try_recv() {
+			return Ok(not);
 		}
 		std::thread::sleep(poll_rate);
 	}

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -13,7 +13,7 @@ async fn test_queries(sql: &str, desired_responses: &[&str]) -> Result<(), Error
 	for (i, r) in response.into_iter().map(|r| r.result).enumerate() {
 		let v = r?;
 		if let Some(desired_response) = desired_responses.get(i) {
-			let desired_value = Value::parse(*desired_response);
+			let desired_value = Value::parse(desired_response);
 			// If both values are NaN, they are equal from a test PoV
 			if !desired_value.is_nan() || !v.is_nan() {
 				assert_eq!(
@@ -3756,7 +3756,7 @@ async fn function_string_similarity_fuzzy() -> Result<(), Error> {
 	"#;
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;
@@ -3788,7 +3788,7 @@ async fn function_string_similarity_smithwaterman() -> Result<(), Error> {
 	"#;
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;

--- a/lib/tests/matches.rs
+++ b/lib/tests/matches.rs
@@ -291,7 +291,7 @@ async fn select_where_matches_using_index_and_score() -> Result<(), Error> {
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
 	//
 	for _ in 0..6 {
@@ -329,7 +329,7 @@ async fn select_where_matches_without_using_index_and_score() -> Result<(), Erro
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
-	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 9);
 	//
 	for _ in 0..7 {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The current CI tests check if the main code base is free of clippy lints, but doesn't check test, benchmarks, or examples. 
The main code base is current free of warnings, but the code for tests generate a bunch of warnings when run through clippy which where not caught by CI.
While not essential it is probably a good idea to fix these warnings. 

## What does this change do?

Fixes the clippy warning in tests and alters the clippy CI check to also check benchmarks, examples, and tests.

## What is your testing strategy?

All fixes should not introduce any change in behavior.

## Is this related to any issues?

None found.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
