### PR TITLE
Add make check-wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ test: check-deps
 check: check-deps
 	cargo make check
 
+.PHONY: check-wasm
+check-wasm: check-deps
+	cargo make check-wasm
+
 .PHONY: clean
 clean: check-deps
 	cargo make clean

--- a/Makefile.local.toml
+++ b/Makefile.local.toml
@@ -32,6 +32,11 @@ category = "LOCAL USAGE"
 command = "cargo"
 args = ["check", "--workspace"]
 
+[tasks.cargo-check-wasm]
+category = "CI - CHECK"
+command = "cargo"
+args = ["check", "--locked", "--package", "surrealdb", "--features", "protocol-ws,protocol-http,kv-mem,kv-indxdb,http", "--target", "wasm32-unknown-unknown"]
+
 [tasks.cargo-fmt]
 category = "LOCAL USAGE"
 command = "cargo"
@@ -53,6 +58,10 @@ args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
 [tasks.check]
 category = "LOCAL USAGE"
 dependencies = ["cargo-check", "cargo-fmt", "cargo-fmt-unlinked", "cargo-clippy"]
+
+[tasks.check-wasm]
+category = "LOCAL USAGE"
+dependencies = ["cargo-check-wasm"]
 
 # Clean
 [tasks.clean]

--- a/Makefile.local.toml
+++ b/Makefile.local.toml
@@ -32,11 +32,6 @@ category = "LOCAL USAGE"
 command = "cargo"
 args = ["check", "--workspace"]
 
-[tasks.cargo-check-wasm]
-category = "CI - CHECK"
-command = "cargo"
-args = ["check", "--locked", "--package", "surrealdb", "--features", "protocol-ws,protocol-http,kv-mem,kv-indxdb,http", "--target", "wasm32-unknown-unknown"]
-
 [tasks.cargo-fmt]
 category = "LOCAL USAGE"
 command = "cargo"
@@ -61,7 +56,7 @@ dependencies = ["cargo-check", "cargo-fmt", "cargo-fmt-unlinked", "cargo-clippy"
 
 [tasks.check-wasm]
 category = "LOCAL USAGE"
-dependencies = ["cargo-check-wasm"]
+dependencies = ["ci-check-wasm"]
 
 # Clean
 [tasks.clean]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Enable wasm compilation correctness checking locally to easily verify code without full builds.

## What does this change do?

Add `make check-wasm` 

## What is your testing strategy?

Manual

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
