### PR TITLE
Optimize `time::from::nanos` function.

### DIFF
--- a/lib/src/fnc/time.rs
+++ b/lib/src/fnc/time.rs
@@ -250,7 +250,7 @@ pub mod from {
 		const NANOS_PER_SEC: i64 = 1_000_000_000;
 
 		let seconds = val.div_euclid(NANOS_PER_SEC);
-		let nanoseconds = val.rem_euclid(NANOS_PER_SEC);
+		let nanoseconds = val.rem_euclid(NANOS_PER_SEC) as u32;
 
 		match NaiveDateTime::from_timestamp_opt(seconds, nanoseconds) {
 			Some(v) => match Utc.fix().from_local_datetime(&v).earliest() {

--- a/lib/src/fnc/time.rs
+++ b/lib/src/fnc/time.rs
@@ -247,21 +247,10 @@ pub mod from {
 	use chrono::{NaiveDateTime, Offset, TimeZone, Utc};
 
 	pub fn nanos((val,): (i64,)) -> Result<Value, Error> {
-		// Example unix nanoseconds timestamp: 1_696_537_096_309_565_400ns
-		// Get seconds part:                   1_696_537_096s
-		// Get nanoseconds part:               309_565_400ns
-		let s = val.to_string();
+		const NANOS_PER_SEC: i64 = 1_000_000_000;
 
-		let seconds: i64 = if s.len() > 9 {
-			s.as_str()[..(s.len() - 9)].parse().unwrap()
-		} else {
-			0
-		};
-		let nanoseconds: u32 = if s.len() > 9 {
-			s.as_str()[(s.len() - 9)..].parse().unwrap()
-		} else {
-			s.as_str().parse().unwrap()
-		};
+		let seconds: i64 = val.div_euclid(NANOS_PER_SEC);
+		let nanoseconds = val.rem_euclid(NANOS_PER_SEC);
 
 		match NaiveDateTime::from_timestamp_opt(seconds, nanoseconds) {
 			Some(v) => match Utc.fix().from_local_datetime(&v).earliest() {

--- a/lib/src/fnc/time.rs
+++ b/lib/src/fnc/time.rs
@@ -249,7 +249,7 @@ pub mod from {
 	pub fn nanos((val,): (i64,)) -> Result<Value, Error> {
 		const NANOS_PER_SEC: i64 = 1_000_000_000;
 
-		let seconds: i64 = val.div_euclid(NANOS_PER_SEC);
+		let seconds = val.div_euclid(NANOS_PER_SEC);
 		let nanoseconds = val.rem_euclid(NANOS_PER_SEC);
 
 		match NaiveDateTime::from_timestamp_opt(seconds, nanoseconds) {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`time::from::nanos` currently does string allocation and parsing, and appears to mishandle negative Unix timestamps.

## What does this change do?

Do the math directly instead. This may also make the function more correct for negative Unix timestamps.

## What is your testing strategy?

Make sure existing test still passes.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
