### PR TITLE
Revert breaking change on key clash and introduce new error

### DIFF
--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -79,8 +79,9 @@ pub enum Error {
 	TxConditionNotMet,
 
 	/// The key being inserted in the transaction already exists
-	#[error("The key being inserted already exists: {0}")]
-	TxKeyAlreadyExists(KeyCategory),
+	#[error("The key being inserted already exists")]
+	#[deprecated(note = "Use TxKeyAlreadyExistsCategory")]
+	TxKeyAlreadyExists,
 
 	/// The key exceeds a limit set by the KV store
 	#[error("Record id or key is too large")]
@@ -709,6 +710,10 @@ pub enum Error {
 	/// Auth was expected to be set but was unknown
 	#[error("Auth was expected to be set but was unknown")]
 	UnknownAuth,
+
+	/// The key being inserted in the transaction already exists
+	#[error("The key being inserted already exists: {0}")]
+	TxKeyAlreadyExistsCategory(KeyCategory),
 }
 
 impl From<Error> for String {
@@ -734,7 +739,7 @@ impl From<echodb::err::Error> for Error {
 	fn from(e: echodb::err::Error) -> Error {
 		match e {
 			echodb::err::Error::KeyAlreadyExists => {
-				Error::TxKeyAlreadyExists(crate::key::error::KeyCategory::Unknown)
+				Error::TxKeyAlreadyExistsCategory(crate::key::error::KeyCategory::Unknown)
 			}
 			echodb::err::Error::ValNotExpectedValue => Error::TxConditionNotMet,
 			_ => Error::Tx(e.to_string()),
@@ -747,7 +752,7 @@ impl From<indxdb::err::Error> for Error {
 	fn from(e: indxdb::err::Error) -> Error {
 		match e {
 			indxdb::err::Error::KeyAlreadyExists => {
-				Error::TxKeyAlreadyExists(crate::key::error::KeyCategory::Unknown)
+				Error::TxKeyAlreadyExistsCategory(crate::key::error::KeyCategory::Unknown)
 			}
 			indxdb::err::Error::ValNotExpectedValue => Error::TxConditionNotMet,
 			_ => Error::Tx(e.to_string()),
@@ -760,7 +765,7 @@ impl From<tikv::Error> for Error {
 	fn from(e: tikv::Error) -> Error {
 		match e {
 			tikv::Error::DuplicateKeyInsertion => {
-				Error::TxKeyAlreadyExists(crate::key::error::KeyCategory::Unknown)
+				Error::TxKeyAlreadyExistsCategory(crate::key::error::KeyCategory::Unknown)
 			}
 			tikv::Error::KeyError(ke) if ke.abort.contains("KeyTooLarge") => Error::TxKeyTooLarge,
 			tikv::Error::RegionError(re) if re.raft_entry_too_large.is_some() => Error::TxTooLarge,

--- a/lib/src/kvs/fdb/mod.rs
+++ b/lib/src/kvs/fdb/mod.rs
@@ -320,7 +320,7 @@ impl Transaction {
 		}
 		let key: Vec<u8> = key.into();
 		if self.exi(key.clone().as_slice()).await? {
-			return Err(Error::TxKeyAlreadyExists(category));
+			return Err(Error::TxKeyAlreadyExistsCategory(category));
 		}
 		// Set the key
 		let key: &[u8] = &key[..];

--- a/lib/src/kvs/rocksdb/mod.rs
+++ b/lib/src/kvs/rocksdb/mod.rs
@@ -293,7 +293,7 @@ impl Transaction {
 		// Set the key if empty
 		match inner.get_opt(&key, &self.ro)? {
 			None => inner.put(key, val)?,
-			_ => return Err(Error::TxKeyAlreadyExists(category)),
+			_ => return Err(Error::TxKeyAlreadyExistsCategory(category)),
 		};
 		// Return result
 		Ok(())

--- a/lib/src/kvs/speedb/mod.rs
+++ b/lib/src/kvs/speedb/mod.rs
@@ -293,7 +293,7 @@ impl Transaction {
 		// Set the key if empty
 		match inner.get_opt(&key, &self.ro)? {
 			None => inner.put(key, val)?,
-			_ => return Err(Error::TxKeyAlreadyExists(category)),
+			_ => return Err(Error::TxKeyAlreadyExistsCategory(category)),
 		};
 		// Return result
 		Ok(())

--- a/lib/src/kvs/tikv/mod.rs
+++ b/lib/src/kvs/tikv/mod.rs
@@ -292,7 +292,7 @@ impl Transaction {
 		// Set the key if empty
 		match self.inner.key_exists(key.clone()).await? {
 			false => self.inner.put(key, val).await?,
-			_ => return Err(Error::TxKeyAlreadyExists(category)),
+			_ => return Err(Error::TxKeyAlreadyExistsCategory(category)),
 		};
 		// Return result
 		Ok(())


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

There was a breaking change to errors that needs to be fixed.

## What does this change do?

This change reverts the break and introduces a new key to use instead.

## What is your testing strategy?

make server make test

## Is this related to any issues?

#2822 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
