### PR TITLE
Ability to cast string to a Thing/Record ID

### DIFF
--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -115,6 +115,10 @@ pub fn thing((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 	} else {
 		match arg1 {
 			Value::Thing(v) => v.into(),
+			Value::Strand(v) => match Thing::try_from(v) {
+				Ok(v) => v.into(),
+				_ => Value::None
+			},
 			_ => Value::None,
 		}
 	})

--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -117,7 +117,7 @@ pub fn thing((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 			Value::Thing(v) => v.into(),
 			Value::Strand(v) => match Thing::try_from(v) {
 				Ok(v) => v.into(),
-				_ => Value::None
+				_ => Value::None,
 			},
 			_ => Value::None,
 		}

--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -114,13 +114,16 @@ pub fn thing((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 		})
 	} else {
 		match arg1 {
-			Value::Thing(v) => v.into(),
-			Value::Strand(v) => match Thing::try_from(v) {
-				Ok(v) => v.into(),
-				_ => Value::None,
-			},
-			_ => Value::None,
-		}
+			Value::Thing(v) => Ok(v),
+			Value::Strand(v) => Thing::try_from(v.as_str()).map_err(move |_| Error::ConvertTo {
+				from: Value::Strand(v),
+				into: "record".into(),
+			}),
+			v => Err(Error::ConvertTo {
+				from: v,
+				into: "record".into(),
+			})
+		}?.into()
 	})
 }
 

--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -122,8 +122,9 @@ pub fn thing((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 			v => Err(Error::ConvertTo {
 				from: v,
 				into: "record".into(),
-			})
-		}?.into()
+			}),
+		}?
+		.into()
 	})
 }
 

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2134,9 +2134,16 @@ impl Value {
 
 	/// Try to convert this value to a Record or `Thing`
 	pub(crate) fn convert_to_record(self) -> Result<Thing, Error> {
-		match self {
+		match self.clone() {
 			// Records are allowed
 			Value::Thing(v) => Ok(v),
+			Value::Strand(v) => match Thing::try_from(v) {
+				Ok(v) => Ok(v),
+				_ => Err(Error::ConvertTo {
+					from: self,
+					into: "record".into(),
+				}),
+			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2134,16 +2134,13 @@ impl Value {
 
 	/// Try to convert this value to a Record or `Thing`
 	pub(crate) fn convert_to_record(self) -> Result<Thing, Error> {
-		match self.clone() {
+		match self {
 			// Records are allowed
 			Value::Thing(v) => Ok(v),
-			Value::Strand(v) => match Thing::try_from(v) {
-				Ok(v) => Ok(v),
-				_ => Err(Error::ConvertTo {
-					from: self,
-					into: "record".into(),
-				}),
-			},
+			Value::Strand(v) => Thing::try_from(v.as_str()).map_err(move |_| Error::ConvertTo {
+				from: Value::Strand(v),
+				into: "record".into(),
+			}),
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,

--- a/lib/tests/cast.rs
+++ b/lib/tests/cast.rs
@@ -1,0 +1,24 @@
+mod parse;
+use parse::Parse;
+mod helpers;
+use helpers::new_ds;
+use surrealdb::dbs::Session;
+use surrealdb::err::Error;
+use surrealdb::sql::Value;
+
+#[tokio::test]
+async fn cast_string_to_record() -> Result<(), Error> {
+	let sql = r#"
+		<record> <string> a:1
+	"#;
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 1);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("a:1");
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -5361,6 +5361,7 @@ async fn function_type_thing() -> Result<(), Error> {
 	let sql = r#"
 		CREATE type::thing('person', 'test');
 		CREATE type::thing('person', 1434619);
+		CREATE type::thing(<string> person:john);
 		CREATE type::thing('city', '8e60244d-95f6-4f95-9e30-09a98977efb0');
 		CREATE type::thing('temperature', ['London', '2022-09-30T20:25:01.406828Z']);
 	"#;

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -5368,7 +5368,7 @@ async fn function_type_thing() -> Result<(), Error> {
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 4);
+	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
@@ -5385,6 +5385,16 @@ async fn function_type_thing() -> Result<(), Error> {
 		"[
 			{
 				id: person:1434619,
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:john,
 			}
 		]",
 	);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Casting a string to a record type will currently throw an error

## What does this change do?

It adds the ability to cast an explicit string to a Record ID, and to pass a string to the `type::thing()` function.

```sql
<record> <string> a:1;
type::thing(<string> a:1);
-- Both now result in a record ID, instead of an error and NONE respectively
```

## What is your testing strategy?

I added a test for both the `type::thing()` function and for this scenario of casting.

## Is this related to any issues?

Slightly related to surrealdb/surrealdb.node#12

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
