### PR TITLE
New code owners to prevent blocks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,7 @@
 ./lib/src/doc @surrealdb/api
 ./lib/src/fnc @surrealdb/sql
 ./lib/src/ctx @surrealdb/api
-./lib/src/exe @usrrealdb/api
+./lib/src/exe @surrealdb/api
 ./lib/src/sql @surrealdb/api
 ./lib/src/* @surrealdb/api
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,7 +48,7 @@
 ./src/dbs @surrealdb/cli
 ./src/err @surrealdb/cli
 ./src/cli @surrealdb/cli
-./src/env @sureraldb/cli
+./src/env @surrealdb/cli
 ./src/cnf @surrealdb/cli
 ./src/mac @surrealdb/cli
 ./src/telemetry @surrealdb/monitoring

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,49 +9,49 @@
 # Configuration for GitHub
 /.github/ @tobiemh @sgirones
 
-./lib/tests/ @surrealdb/API
+./lib/tests/ @surrealdb/api
 
-./lib/examples @surrealdb/API
+./lib/examples @surrealdb/api
 
-./lib/benches @surrealdb/API
+./lib/benches @surrealdb/api
 
 # Code for fuzzing configuration
-./lib/fuzz @surrealdb/Monitoring
+./lib/fuzz @surrealdb/monitoring
 
 # All lib/src paths go here
-./lib/src/vs @surrealdb/CDC
-./lib/src/idx @surrealdb/Indexing
-./lib/src/kvs @surrealdb/API
-./lib/src/dbs @surrealdb/API
-./lib/src/err @surrealdb/API
-./lib/src/cf @surrealdb/CDC
-./lib/src/key @surrealdb/API
+./lib/src/vs @surrealdb/cdc
+./lib/src/idx @surrealdb/indexing
+./lib/src/kvs @surrealdb/api
+./lib/src/dbs @surrealdb/api
+./lib/src/err @surrealdb/api
+./lib/src/cf @surrealdb/cdc
+./lib/src/key @surrealdb/api
 ./lib/src/env @rushmorem
-./lib/src/cnf @surrealdb/API
+./lib/src/cnf @surrealdb/api
 ./lib/src/mac @rushmorem
-./lib/src/iam @surrealdb/Monitoring
-./lib/src/idg @surrealdb/API
-./lib/src/api @surrealdb/API
-./lib/src/doc @surrealdb/API
-./lib/src/fnc @surrealdb/SQL
-./lib/src/ctx @surrealdb/API
-./lib/src/exe @usrrealdb/API
-./lib/src/sql @surrealdb/API
-./lib/src/* @surrealdb/API
+./lib/src/iam @surrealdb/monitoring
+./lib/src/idg @surrealdb/api
+./lib/src/api @surrealdb/api
+./lib/src/doc @surrealdb/api
+./lib/src/fnc @surrealdb/sql
+./lib/src/ctx @surrealdb/api
+./lib/src/exe @usrrealdb/api
+./lib/src/sql @surrealdb/api
+./lib/src/* @surrealdb/api
 
-./dev @surrealdb/Monitoring
-./doc @surrealdb/API
+./dev @surrealdb/monitoring
+./doc @surrealdb/api
 ./pkg @sgirones @rushmorem
 
 # ./src/* paths
-./src/net @surrealdb/API
-./src/dbs @surrealdb/CLI
-./src/err @surrealdb/CLI
-./src/cli @surrealdb/CLI
-./src/env @sureraldb/CLI
-./src/cnf @surrealdb/CLI
-./src/mac @surrealdb/CLI
-./src/telemetry @surrealdb/Monitoring
-./src/node @surrealdb/CLI
-./src/rpc @surrealdb/API
-./src/* @surrealdb/CLI
+./src/net @surrealdb/api
+./src/dbs @surrealdb/cli
+./src/err @surrealdb/cli
+./src/cli @surrealdb/cli
+./src/env @sureraldb/cli
+./src/cnf @surrealdb/cli
+./src/mac @surrealdb/cli
+./src/telemetry @surrealdb/monitoring
+./src/node @surrealdb/cli
+./src/rpc @surrealdb/api
+./src/* @surrealdb/cli

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,41 +1,57 @@
 # Default owners for the repository
 * @tobiemh
 
+./app/ @tobiemh
+./tests/ @surrealdb/api
+./img/ @tobiemh
+./.cargo/ @surrealdb/api
+
 # Configuration for GitHub
-/.github/ @tobiemh
+/.github/ @tobiemh @sgirones
+
+./lib/tests/ @surrealdb/API
+
+./lib/examples @surrealdb/API
+
+./lib/benches @surrealdb/API
 
 # Code for fuzzing configuration
-/lib/fuzz/ @surrealdb/security
+./lib/fuzz @surrealdb/Monitoring
 
-# Code and tests for the Rust API
-/lib/CARGO.md @surrealdb/api
-/lib/README.md @surrealdb/api
-/lib/examples/ @surrealdb/api
-/lib/src/api/ @surrealdb/api
-/lib/src/tests/api/ @surrealdb/api
-/lib/src/tests/api.rs @surrealdb/api
+# All lib/src paths go here
+./lib/src/vs @surrealdb/CDC
+./lib/src/idx @surrealdb/Indexing
+./lib/src/kvs @surrealdb/API
+./lib/src/dbs @surrealdb/API
+./lib/src/err @surrealdb/API
+./lib/src/cf @surrealdb/CDC
+./lib/src/key @surrealdb/API
+./lib/src/env @rushmorem
+./lib/src/cnf @surrealdb/API
+./lib/src/mac @rushmorem
+./lib/src/iam @surrealdb/Monitoring
+./lib/src/idg @surrealdb/API
+./lib/src/api @surrealdb/API
+./lib/src/doc @surrealdb/API
+./lib/src/fnc @surrealdb/SQL
+./lib/src/ctx @surrealdb/API
+./lib/src/exe @usrrealdb/API
+./lib/src/sql @surrealdb/API
+./lib/src/* @surrealdb/API
 
-# Code and tests for indexing
-/lib/src/idx/ @surrealdb/indexing
+./dev @surrealdb/Monitoring
+./doc @surrealdb/API
+./pkg @sgirones @rushmorem
 
-# Code and tests for scripting
-/lib/src/fnc/script/ @surrealdb/scripting
-
-# Code and tests for the server
-/src/net/ @surrealdb/api
-/src/rpc/ @surrealdb/api
-/tests/http_integration.rs @surrealdb/api
-/tests/ws_integration.rs @surrealdb/api
-
-# Code and tests for the command-line
-/src/cli/ @surrealdb/cli
-/tests/cli_integration.rs @surrealdb/cli
-
-# Code and tests for opentelemetry
-/src/telemetry/ @surrealdb/monitoring
-
-# Tests related to the key-value store
-/lib/src/kvs/tests/ @tobiemh @phughk
-
-# IAM
-/lib/src/iam/ @surrealdb/api @surrealdb/security
+# ./src/* paths
+./src/net @surrealdb/API
+./src/dbs @surrealdb/CLI
+./src/err @surrealdb/CLI
+./src/cli @surrealdb/CLI
+./src/env @sureraldb/CLI
+./src/cnf @surrealdb/CLI
+./src/mac @surrealdb/CLI
+./src/telemetry @surrealdb/Monitoring
+./src/node @surrealdb/CLI
+./src/rpc @surrealdb/API
+./src/* @surrealdb/CLI


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

There is an issue in the github codeowners, that the owners are not aligned with the config. This is because we changed the github config without changing the owners file.

## What does this change do?

Propose a new code owners structure that includes all folders up to 2 levels with catch-all for `./lib/src`, `./src/`, and `./`.

The [teams](https://github.com/orgs/surrealdb/teams) we have in Backend are
- SQL
- API
- CLI
- Indexing
- Monitoring
- CDC

## What is your testing strategy?

We will see if this works once merged I think

## Is this related to any issues?

Tobie is blocking everything by default because the rules are written for different owners

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
