### PR TITLE
Documentation Fix: Update outdated connection flag -c to -e

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -90,7 +90,7 @@ docker run --rm --pull always --name surrealdb -p 8000:8000 surrealdb/surrealdb:
 Access to the surrealdb CLI with:
 
 ```bash
-docker exec -it <container_name> /surreal sql -c http://localhost:8000 -u root -p root --ns test --db test --pretty
+docker exec -it <container_name> /surreal sql -e http://localhost:8000 -u root -p root --ns test --db test --pretty
 ```
 
 <h2><img height="20" src="https://github.com/surrealdb/surrealdb/blob/main/img/gettingstarted.svg?raw=true">&nbsp;&nbsp;Run using Docker Compose</h2>


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?
The "--conn" flag was recently renamed to "--endpoint". We can use either "--endpoint", "-e" or "--conn" to provide a connection address. 
Currently the documentation has not reflected this update and hence the community is running into issues trying to set up the same.

## What does this change do?
Update outdated flag

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
