### PR TITLE
Fix index plan for idiom param value

### DIFF
--- a/lib/src/idx/planner/tree.rs
+++ b/lib/src/idx/planner/tree.rs
@@ -4,7 +4,7 @@ use crate::err::Error;
 use crate::idx::planner::plan::{IndexOperator, IndexOption};
 use crate::sql::index::Index;
 use crate::sql::statements::DefineIndexStatement;
-use crate::sql::{Array, Cond, Expression, Idiom, Operator, Subquery, Table, Value, With};
+use crate::sql::{Array, Cond, Expression, Idiom, Operator, Part, Subquery, Table, Value, With};
 use async_recursion::async_recursion;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -101,7 +101,16 @@ impl<'a> TreeBuilder<'a> {
 	async fn eval_value(&mut self, v: &Value) -> Result<Node, Error> {
 		match v {
 			Value::Expression(e) => self.eval_expression(e).await,
-			Value::Idiom(i) => self.eval_idiom(i).await,
+			Value::Idiom(i) => {
+				// Compute the idiom value if it is a param
+				if let Some(Part::Start(x)) = i.0.first() {
+					if x.is_param() {
+						let v = i.compute(self.ctx, self.opt, self.txn, None).await?;
+						return self.eval_value(&v).await;
+					}
+				}
+				self.eval_idiom(i).await
+			},
 			Value::Strand(_) | Value::Number(_) | Value::Bool(_) | Value::Thing(_) => {
 				Ok(Node::Scalar(v.to_owned()))
 			}

--- a/lib/src/idx/planner/tree.rs
+++ b/lib/src/idx/planner/tree.rs
@@ -110,7 +110,7 @@ impl<'a> TreeBuilder<'a> {
 					}
 				}
 				self.eval_idiom(i).await
-			},
+			}
 			Value::Strand(_) | Value::Number(_) | Value::Bool(_) | Value::Thing(_) => {
 				Ok(Node::Scalar(v.to_owned()))
 			}

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -996,7 +996,6 @@ impl Value {
 		matches!(self, Value::Param(_))
 	}
 
-
 	/// Check if this Value is a Geometry of a specific type
 	pub fn is_geometry_type(&self, types: &[String]) -> bool {
 		match self {

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -991,6 +991,12 @@ impl Value {
 		}
 	}
 
+	/// Check if this Value is a Param
+	pub fn is_param(&self) -> bool {
+		matches!(self, Value::Param(_))
+	}
+
+
 	/// Check if this Value is a Geometry of a specific type
 	pub fn is_geometry_type(&self, types: &[String]) -> bool {
 		match self {

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -846,3 +846,43 @@ async fn select_index_single_range_operator_more_or_equal() -> Result<(), Error>
 async fn select_unique_single_range_operator_more_or_equal() -> Result<(), Error> {
 	select_single_range_operator(true, ">=", EXPLAIN_MORE_OR_EQUAL, RESULT_MORE_OR_EQUAL).await
 }
+
+#[tokio::test]
+async fn select_with_idiom_param_value() -> Result<(), Error> {
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let sql = format!("
+		CREATE person:tobie SET name = 'Tobie', genre='m', company='SurrealDB';
+		CREATE person:jaime SET name = 'Jaime', genre='m', company='SurrealDB';
+		DEFINE INDEX name ON TABLE person COLUMNS name UNIQUE;
+		LET $name = 'Tobie';
+		LET $nameObj = {{name:'Tobie'}};
+		SELECT name FROM person WHERE name = $nameObj.name EXPLAIN;");
+	let mut res = dbs
+		.execute(&sql, &ses, None)
+		.await?;
+	assert_eq!(res.len(), 6);
+	res.remove(0).result?;
+	res.remove(0).result?;
+	res.remove(0).result?;
+	res.remove(0).result?;
+	res.remove(0).result?;
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+				{
+					detail: {
+						plan: {
+							index: 'name',
+							operator: '=',
+							value: 'Tobie'
+						},
+						table: 'person'
+					},
+					operation: 'Iterate Index'
+				}
+			]"#,
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	Ok(())
+}

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -851,16 +851,16 @@ async fn select_unique_single_range_operator_more_or_equal() -> Result<(), Error
 async fn select_with_idiom_param_value() -> Result<(), Error> {
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
-	let sql = format!("
+	let sql = format!(
+		"
 		CREATE person:tobie SET name = 'Tobie', genre='m', company='SurrealDB';
 		CREATE person:jaime SET name = 'Jaime', genre='m', company='SurrealDB';
 		DEFINE INDEX name ON TABLE person COLUMNS name UNIQUE;
 		LET $name = 'Tobie';
 		LET $nameObj = {{name:'Tobie'}};
-		SELECT name FROM person WHERE name = $nameObj.name EXPLAIN;");
-	let mut res = dbs
-		.execute(&sql, &ses, None)
-		.await?;
+		SELECT name FROM person WHERE name = $nameObj.name EXPLAIN;"
+	);
+	let mut res = dbs.execute(&sql, &ses, None).await?;
 	assert_eq!(res.len(), 6);
 	res.remove(0).result?;
 	res.remove(0).result?;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently query planner fails to index idiom param value `$person.name` whereas it works fine with normal param like `$name`

Example
```
CREATE person:tobie SET name = 'Tobie', genre='m', company='SurrealDB';
CREATE person:jaime SET name = 'Jaime', genre='m', company='SurrealDB';
DEFINE INDEX name ON TABLE person COLUMNS name UNIQUE;
LET $name = 'Tobie';
LET $nameObj = {{name:'Tobie'}};
SELECT name FROM person WHERE name = $nameObj.name EXPLAIN;"); // Index plan fails here
SELECT name FROM person WHERE name = $name EXPLAIN;"); // This works fine
```

## What does this change do?

This PR adds an additional check to find any `param` value when given as an `idiom` and computes it to acquire the actual value to index

## What is your testing strategy?

Have added a test.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
