### PR TITLE
Improved transactions

### DIFF
--- a/lib/src/api/method/cancel.rs
+++ b/lib/src/api/method/cancel.rs
@@ -22,7 +22,7 @@ where
 
 	fn into_future(self) -> Self::IntoFuture {
 		Box::pin(async move {
-			self.client.query(CancelStatement).await?;
+			self.client.query(CancelStatement { dryrun: false }).await?;
 			Ok(self.client)
 		})
 	}

--- a/lib/src/api/method/cancel.rs
+++ b/lib/src/api/method/cancel.rs
@@ -22,7 +22,11 @@ where
 
 	fn into_future(self) -> Self::IntoFuture {
 		Box::pin(async move {
-			self.client.query(CancelStatement { dryrun: false }).await?;
+			self.client
+				.query(CancelStatement {
+					dryrun: false,
+				})
+				.await?;
 			Ok(self.client)
 		})
 	}

--- a/lib/src/dbs/executor.rs
+++ b/lib/src/dbs/executor.rs
@@ -35,7 +35,7 @@ impl<'a> Executor<'a> {
 			kvs,
 			txn: None,
 			err: false,
-			dryrun: false
+			dryrun: false,
 		}
 	}
 
@@ -118,7 +118,7 @@ impl<'a> Executor<'a> {
 				result: Err(Error::QueryCancelled),
 				query_type: QueryType::Other,
 			},
-			true => v
+			true => v,
 		}
 	}
 
@@ -233,7 +233,9 @@ impl<'a> Executor<'a> {
 					continue;
 				}
 				// Cancel a running transaction
-				Statement::Cancel(CancelStatement { dryrun }) => {
+				Statement::Cancel(CancelStatement {
+					dryrun,
+				}) => {
 					self.dryrun = dryrun;
 					self.cancel(true).await;
 					self.clear(&ctx, recv.clone()).await;

--- a/lib/src/sql/statements/cancel.rs
+++ b/lib/src/sql/statements/cancel.rs
@@ -29,13 +29,17 @@ pub fn cancel(i: &str) -> IResult<&str, CancelStatement> {
 	let (i, _) = tag_no_case("CANCEL")(i)?;
 	let (i, _) = opt(tuple((shouldbespace, tag_no_case("TRANSACTION"))))(i)?;
 	let (i, dryrun) = opt(dryrun)(i)?;
-	Ok((i, CancelStatement {
-		dryrun: dryrun.is_some_and(|d| d)
-	}))
+	Ok((
+		i,
+		CancelStatement {
+			dryrun: dryrun.is_some_and(|d| d),
+		},
+	))
 }
 
 pub fn dryrun(i: &str) -> IResult<&str, bool> {
-	let (i, _) = tuple((shouldbespace, tag_no_case("AS"), shouldbespace, tag_no_case("DRYRUN")))(i)?;
+	let (i, _) =
+		tuple((shouldbespace, tag_no_case("AS"), shouldbespace, tag_no_case("DRYRUN")))(i)?;
 	Ok((i, true))
 }
 

--- a/lib/src/sql/statements/cancel.rs
+++ b/lib/src/sql/statements/cancel.rs
@@ -69,7 +69,7 @@ mod tests {
 		let sql = "CANCEL AS DRYRUN";
 		let res = cancel(sql);
 		let out = res.unwrap().1;
-		assert_eq!("CANCEL TRANSACTION AS DRYRYN", format!("{}", out))
+		assert_eq!("CANCEL TRANSACTION AS DRYRUN", format!("{}", out))
 	}
 
 	#[test]
@@ -77,6 +77,6 @@ mod tests {
 		let sql = "CANCEL TRANSACTION AS DRYRUN";
 		let res = cancel(sql);
 		let out = res.unwrap().1;
-		assert_eq!("CANCEL TRANSACTION AS DRYRYN", format!("{}", out))
+		assert_eq!("CANCEL TRANSACTION AS DRYRUN", format!("{}", out))
 	}
 }

--- a/lib/src/sql/value/serde/ser/statement/cancel.rs
+++ b/lib/src/sql/value/serde/ser/statement/cancel.rs
@@ -23,7 +23,7 @@ impl ser::Serializer for Serializer {
 	#[inline]
 	fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Error> {
 		match name {
-			"CancelStatement" => Ok(CancelStatement),
+			"CancelStatement" => Ok(CancelStatement { dryrun: false }),
 			name => Err(Error::custom(format!("unexpected unit struct `{name}`"))),
 		}
 	}
@@ -37,7 +37,7 @@ mod tests {
 
 	#[test]
 	fn default() {
-		let stmt = CancelStatement;
+		let stmt = CancelStatement { dryrun: false };
 		let value: CancelStatement = stmt.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(value, stmt);
 	}

--- a/lib/src/sql/value/serde/ser/statement/cancel.rs
+++ b/lib/src/sql/value/serde/ser/statement/cancel.rs
@@ -23,7 +23,9 @@ impl ser::Serializer for Serializer {
 	#[inline]
 	fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Error> {
 		match name {
-			"CancelStatement" => Ok(CancelStatement { dryrun: false }),
+			"CancelStatement" => Ok(CancelStatement {
+				dryrun: false,
+			}),
 			name => Err(Error::custom(format!("unexpected unit struct `{name}`"))),
 		}
 	}
@@ -37,7 +39,9 @@ mod tests {
 
 	#[test]
 	fn default() {
-		let stmt = CancelStatement { dryrun: false };
+		let stmt = CancelStatement {
+			dryrun: false,
+		};
 		let value: CancelStatement = stmt.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(value, stmt);
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Cancelling a transaction currently gives back a generic error, it would be useful however to be able to able to see how changes would have unfolded without committing them.

## What does this change do?

Introduces `AS DRYRUN` keywords to allow you to cancel a transaction, but still see the result as if the transaction was committed.

## What is your testing strategy?

Added tests, ensure CI still passes

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)

<hr />

## ⚠️ State of this PR
See [comments](https://github.com/surrealdb/surrealdb/pull/2873#issuecomment-1775246037) for state of this PR
