### PR TITLE
use `sha1` crate instead of obsolete `sha-1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4959,21 +4959,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -5333,7 +5322,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha-1",
+ "sha1",
  "sha2",
  "snap",
  "speedb",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -103,7 +103,7 @@ scrypt = "0.11.0"
 semver = { version = "1.0.18", features = ["serde"] }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.104"
-sha-1 = "0.10.1"
+sha1 = "0.10.6"
 sha2 = "0.10.7"
 snap = "1.1.0"
 speedb = { version = "0.0.2", optional = true }


### PR DESCRIPTION
The `sha-1` crate was renamed to `sha1` and no longer maintained at the original location.