### PR TITLE
ci clippy + test workspace down to 4 cores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
   clippy:
     name: Check clippy
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
 
       - name: Install stable toolchain
@@ -217,7 +217,7 @@ jobs:
 
   test:
     name: Test workspace
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
 
       - name: Install stable toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
   clippy:
     name: Check clippy
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
 
       - name: Install stable toolchain
@@ -217,7 +217,7 @@ jobs:
 
   test:
     name: Test workspace
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
 
       - name: Install stable toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
   clippy:
     name: Check clippy
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
 
       - name: Install stable toolchain
@@ -217,7 +217,7 @@ jobs:
 
   test:
     name: Test workspace
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
 
       - name: Install stable toolchain


### PR DESCRIPTION
## What is the motivation?

Clippy and test workspace are the more resource-demanding tasks on CI.
The default runners are failing most of the time.
The 16-cores runners are successful but may be oversized.

## What does this change do?

Use the 4-core runner.

## What is your testing strategy?

N/A

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
