### PR TITLE
Fix #2513 - Query results should be consistent and representative

### DIFF
--- a/lib/src/api/engine/any/mod.rs
+++ b/lib/src/api/engine/any/mod.rs
@@ -278,7 +278,7 @@ mod tests {
 		let mut res = db.query("INFO FOR ROOT").await.unwrap();
 		let users: Value = res.take("users").unwrap();
 
-		assert_eq!(users, Value::parse("[{}]"), "there should be no users in the system");
+		assert_eq!(users, Value::parse("{}"), "there should be no users in the system");
 	}
 
 	#[tokio::test]

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -374,24 +374,18 @@ fn process(responses: Vec<Response>) -> Result<QueryResponse> {
 
 async fn take(one: bool, responses: Vec<Response>) -> Result<Value> {
 	if let Some(result) = process(responses)?.0.remove(&0) {
-		let result = result?;
+		let value = result?;
 		match one {
-			true => match result {
+			true => match value {
 				Value::Array(Array(mut vec)) => {
 					if let [value] = &mut vec[..] {
 						return Ok(mem::take(value));
 					}
 				}
 				Value::None | Value::Null => {}
-				value => {
-					return Ok(value);
-				}
+				value => return Ok(value)
 			},
-			false => {
-				// TODO should this return a vec?
-				// My train of thought is that at an API level developers currently always expect a vec to be returned here
-				return Ok(result);
-			}
+			false => return Ok(value)
 		}
 	}
 	match one {

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -383,9 +383,9 @@ async fn take(one: bool, responses: Vec<Response>) -> Result<Value> {
 					}
 				}
 				Value::None | Value::Null => {}
-				value => return Ok(value)
+				value => return Ok(value),
 			},
-			false => return Ok(value)
+			false => return Ok(value),
 		}
 	}
 	match one {

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -390,7 +390,7 @@ async fn take(one: bool, responses: Vec<Response>) -> Result<Value> {
 			false => {
 				// TODO should this return a vec?
 				// My train of thought is that at an API level developers currently always expect a vec to be returned here
-				return Ok(Value::Array(Array(vec![result])));
+				return Ok(result);
 			}
 		}
 	}

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -197,9 +197,9 @@ async fn take(one: bool, request: RequestBuilder) -> Result<Value> {
 					}
 				}
 				Value::None | Value::Null => {}
-				value => return Ok(value)
+				value => return Ok(value),
 			},
-			false => return Ok(value)
+			false => return Ok(value),
 		}
 	}
 	match one {

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -175,11 +175,7 @@ async fn query(request: RequestBuilder) -> Result<QueryResponse> {
 	for (index, (_time, status, value)) in responses.into_iter().enumerate() {
 		match status {
 			Status::Ok => {
-				match value {
-					Value::Array(Array(array)) => map.insert(index, Ok(array)),
-					Value::None | Value::Null => map.insert(index, Ok(vec![])),
-					value => map.insert(index, Ok(vec![value])),
-				};
+				map.insert(index, Ok(value));
 			}
 			Status::Err => {
 				map.insert(index, Err(Error::Query(value.as_raw_string()).into()));
@@ -192,21 +188,23 @@ async fn query(request: RequestBuilder) -> Result<QueryResponse> {
 
 async fn take(one: bool, request: RequestBuilder) -> Result<Value> {
 	if let Some(result) = query(request).await?.0.remove(&0) {
-		let mut vec = result?;
+		let result = result?;
 		match one {
-			true => match vec.pop() {
-				Some(Value::Array(Array(mut vec))) => {
+			true => match result {
+				Value::Array(Array(mut vec)) => {
 					if let [value] = &mut vec[..] {
 						return Ok(mem::take(value));
 					}
 				}
-				Some(Value::None | Value::Null) | None => {}
-				Some(value) => {
+				Value::None | Value::Null => {}
+				value => {
 					return Ok(value);
 				}
 			},
 			false => {
-				return Ok(Value::Array(Array(vec)));
+				// TODO should this return a vec?
+				// My train of thought is that at an API level developers currently always expect a vec to be returned here
+				return Ok(Value::Array(Array(vec![result])));
 			}
 		}
 	}

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -204,7 +204,7 @@ async fn take(one: bool, request: RequestBuilder) -> Result<Value> {
 			false => {
 				// TODO should this return a vec?
 				// My train of thought is that at an API level developers currently always expect a vec to be returned here
-				return Ok(Value::Array(Array(vec![result])));
+				return Ok(result);
 			}
 		}
 	}

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -188,24 +188,18 @@ async fn query(request: RequestBuilder) -> Result<QueryResponse> {
 
 async fn take(one: bool, request: RequestBuilder) -> Result<Value> {
 	if let Some(result) = query(request).await?.0.remove(&0) {
-		let result = result?;
+		let value = result?;
 		match one {
-			true => match result {
+			true => match value {
 				Value::Array(Array(mut vec)) => {
 					if let [value] = &mut vec[..] {
 						return Ok(mem::take(value));
 					}
 				}
 				Value::None | Value::Null => {}
-				value => {
-					return Ok(value);
-				}
+				value => return Ok(value)
 			},
-			false => {
-				// TODO should this return a vec?
-				// My train of thought is that at an API level developers currently always expect a vec to be returned here
-				return Ok(result);
-			}
+			false => return Ok(value)
 		}
 	}
 	match one {

--- a/lib/src/api/engine/remote/ws/mod.rs
+++ b/lib/src/api/engine/remote/ws/mod.rs
@@ -14,7 +14,6 @@ use crate::api::Result;
 use crate::api::Surreal;
 use crate::dbs::Status;
 use crate::opt::IntoEndpoint;
-use crate::sql::Array;
 use crate::sql::Strand;
 use crate::sql::Value;
 use serde::Deserialize;
@@ -115,11 +114,7 @@ impl DbResponse {
 				results
 					.into_iter()
 					.map(|response| match response.status {
-						Status::Ok => match response.result {
-							Value::Array(Array(values)) => Ok(values),
-							Value::None | Value::Null => Ok(vec![]),
-							value => Ok(vec![value]),
-						},
+						Status::Ok => Ok(response.result),
 						Status::Err => match response.result {
 							Value::Strand(Strand(message)) => Err(Error::Query(message).into()),
 							message => Err(Error::Query(message.to_string()).into()),

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -498,7 +498,6 @@ mod tests {
 
 	#[test]
 	fn take_errors() {
-		// TODO fix this test
 		let response = vec![
 			Ok(0.into()),
 			Ok(1.into()),

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -131,7 +131,7 @@ where
 	}
 }
 
-pub(crate) type QueryResult = Result<Vec<Value>>;
+pub(crate) type QueryResult = Result<Value>;
 
 /// The response type of a `Surreal::query` request
 #[derive(Debug)]
@@ -296,7 +296,7 @@ impl Response {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::Error::Api;
+	// use crate::Error::Api;
 	use serde::Deserialize;
 
 	#[derive(Debug, Clone, Serialize, Deserialize)]
@@ -337,15 +337,15 @@ mod tests {
 
 	#[test]
 	fn take_from_empty_records() {
-		let mut response = Response(to_map(vec![Ok(vec![])]));
+		let mut response = Response(to_map(vec![Ok(Value::None)]));
 		let value: Value = response.take(0).unwrap();
-		assert_eq!(value, Value::Array(Default::default()));
+		assert_eq!(value, Default::default());
 
-		let mut response = Response(to_map(vec![Ok(vec![])]));
+		let mut response = Response(to_map(vec![Ok(Value::None)]));
 		let option: Option<String> = response.take(0).unwrap();
 		assert!(option.is_none());
 
-		let mut response = Response(to_map(vec![Ok(vec![])]));
+		let mut response = Response(to_map(vec![Ok(Value::None)]));
 		let vec: Vec<String> = response.take(0).unwrap();
 		assert!(vec.is_empty());
 	}
@@ -354,29 +354,29 @@ mod tests {
 	fn take_from_a_scalar_response() {
 		let scalar = 265;
 
-		let mut response = Response(to_map(vec![Ok(vec![scalar.into()])]));
+		let mut response = Response(to_map(vec![Ok(scalar.into())]));
 		let value: Value = response.take(0).unwrap();
 		assert_eq!(value, vec![Value::from(scalar)].into());
 
-		let mut response = Response(to_map(vec![Ok(vec![scalar.into()])]));
+		let mut response = Response(to_map(vec![Ok(scalar.into())]));
 		let option: Option<_> = response.take(0).unwrap();
 		assert_eq!(option, Some(scalar));
 
-		let mut response = Response(to_map(vec![Ok(vec![scalar.into()])]));
+		let mut response = Response(to_map(vec![Ok(scalar.into())]));
 		let vec: Vec<usize> = response.take(0).unwrap();
 		assert_eq!(vec, vec![scalar]);
 
 		let scalar = true;
 
-		let mut response = Response(to_map(vec![Ok(vec![scalar.into()])]));
+		let mut response = Response(to_map(vec![Ok(scalar.into())]));
 		let value: Value = response.take(0).unwrap();
 		assert_eq!(value, vec![Value::from(scalar)].into());
 
-		let mut response = Response(to_map(vec![Ok(vec![scalar.into()])]));
+		let mut response = Response(to_map(vec![Ok(scalar.into())]));
 		let option: Option<_> = response.take(0).unwrap();
 		assert_eq!(option, Some(scalar));
 
-		let mut response = Response(to_map(vec![Ok(vec![scalar.into()])]));
+		let mut response = Response(to_map(vec![Ok(scalar.into())]));
 		let vec: Vec<bool> = response.take(0).unwrap();
 		assert_eq!(vec, vec![scalar]);
 	}
@@ -384,14 +384,14 @@ mod tests {
 	#[test]
 	fn take_preserves_order() {
 		let mut response = Response(to_map(vec![
-			Ok(vec![0.into()]),
-			Ok(vec![1.into()]),
-			Ok(vec![2.into()]),
-			Ok(vec![3.into()]),
-			Ok(vec![4.into()]),
-			Ok(vec![5.into()]),
-			Ok(vec![6.into()]),
-			Ok(vec![7.into()]),
+			Ok(0.into()),
+			Ok(1.into()),
+			Ok(2.into()),
+			Ok(3.into()),
+			Ok(4.into()),
+			Ok(5.into()),
+			Ok(6.into()),
+			Ok(7.into()),
 		]));
 		let Some(four): Option<i32> = response.take(4).unwrap() else {
 			panic!("query not found");
@@ -416,17 +416,17 @@ mod tests {
 		};
 		let value = to_value(summary.clone()).unwrap();
 
-		let mut response = Response(to_map(vec![Ok(vec![value.clone()])]));
+		let mut response = Response(to_map(vec![Ok(value.clone())]));
 		let title: Value = response.take("title").unwrap();
 		assert_eq!(title, vec![Value::from(summary.title.as_str())].into());
 
-		let mut response = Response(to_map(vec![Ok(vec![value.clone()])]));
+		let mut response = Response(to_map(vec![Ok(value.clone())]));
 		let Some(title): Option<String> = response.take("title").unwrap() else {
 			panic!("title not found");
 		};
 		assert_eq!(title, summary.title);
 
-		let mut response = Response(to_map(vec![Ok(vec![value])]));
+		let mut response = Response(to_map(vec![Ok(value)]));
 		let vec: Vec<String> = response.take("title").unwrap();
 		assert_eq!(vec, vec![summary.title]);
 
@@ -436,7 +436,7 @@ mod tests {
 		};
 		let value = to_value(article.clone()).unwrap();
 
-		let mut response = Response(to_map(vec![Ok(vec![value.clone()])]));
+		let mut response = Response(to_map(vec![Ok(value.clone())]));
 		let Some(title): Option<String> = response.take("title").unwrap() else {
 			panic!("title not found");
 		};
@@ -446,89 +446,92 @@ mod tests {
 		};
 		assert_eq!(body, article.body);
 
-		let mut response = Response(to_map(vec![Ok(vec![value.clone()])]));
+		let mut response = Response(to_map(vec![Ok(value.clone())]));
 		let vec: Vec<String> = response.take("title").unwrap();
 		assert_eq!(vec, vec![article.title.clone()]);
 
-		let mut response = Response(to_map(vec![Ok(vec![value])]));
+		let mut response = Response(to_map(vec![Ok(value)]));
 		let value: Value = response.take("title").unwrap();
 		assert_eq!(value, vec![Value::from(article.title)].into());
 	}
 
 	#[test]
 	fn take_partial_records() {
-		let mut response = Response(to_map(vec![Ok(vec![true.into(), false.into()])]));
-		let value: Value = response.take(0).unwrap();
-		assert_eq!(value, vec![Value::from(true), Value::from(false)].into());
+		// TODO fix this test
+		// let mut response = Response(to_map(vec![Ok(Value::from(sql::Array::from(vec![true.into(), false.into()])))]));
+		// let value: Value = response.take(0).unwrap();
+		// assert_eq!(value, vec![Value::from(true), Value::from(false)].into());
 
-		let mut response = Response(to_map(vec![Ok(vec![true.into(), false.into()])]));
-		let vec: Vec<bool> = response.take(0).unwrap();
-		assert_eq!(vec, vec![true, false]);
+		// let mut response = Response(to_map(vec![Ok(Value::from(sql::Array::from(vec![true.into(), false.into()])))]));
+		// let vec: Vec<bool> = response.take(0).unwrap();
+		// assert_eq!(vec, vec![true, false]);
 
-		let mut response = Response(to_map(vec![Ok(vec![true.into(), false.into()])]));
-		let Err(Api(Error::LossyTake(Response(mut map)))): Result<Option<bool>> = response.take(0)
-		else {
-			panic!("silently dropping records not allowed");
-		};
-		let records = map.remove(&0).unwrap().unwrap();
-		assert_eq!(records, vec![true.into(), false.into()]);
+		// let mut response = Response(to_map(vec![Ok(Value::from(sql::Array::from(vec![true.into(), false.into()])))]));
+		// let Err(Api(Error::LossyTake(Response(mut map)))): Result<Option<bool>> = response.take(0)
+		// else {
+		// 	panic!("silently dropping records not allowed");
+		// };
+		// let records = map.remove(&0).unwrap().unwrap();
+		// assert_eq!(records, Value::from(sql::Array::from(vec![true.into(), false.into()])));
 	}
 
 	#[test]
 	fn check_returns_the_first_error() {
-		let response = vec![
-			Ok(vec![0.into()]),
-			Ok(vec![1.into()]),
-			Ok(vec![2.into()]),
-			Err(Error::ConnectionUninitialised.into()),
-			Ok(vec![3.into()]),
-			Ok(vec![4.into()]),
-			Ok(vec![5.into()]),
-			Err(Error::BackupsNotSupported.into()),
-			Ok(vec![6.into()]),
-			Ok(vec![7.into()]),
-			Err(Error::DuplicateRequestId(0).into()),
-		];
-		let response = Response(to_map(response));
-		let crate::Error::Api(Error::ConnectionUninitialised) = response.check().unwrap_err()
-		else {
-			panic!("check did not return the first error");
-		};
+		// TODO fix this test
+		// let response = vec![
+		// 	Ok(vec![0.into()]),
+		// 	Ok(vec![1.into()]),
+		// 	Ok(vec![2.into()]),
+		// 	Err(Error::ConnectionUninitialised.into()),
+		// 	Ok(vec![3.into()]),
+		// 	Ok(vec![4.into()]),
+		// 	Ok(vec![5.into()]),
+		// 	Err(Error::BackupsNotSupported.into()),
+		// 	Ok(vec![6.into()]),
+		// 	Ok(vec![7.into()]),
+		// 	Err(Error::DuplicateRequestId(0).into()),
+		// ];
+		// let response = Response(to_map(response));
+		// let crate::Error::Api(Error::ConnectionUninitialised) = response.check().unwrap_err()
+		// else {
+		// 	panic!("check did not return the first error");
+		// };
 	}
 
 	#[test]
 	fn take_errors() {
-		let response = vec![
-			Ok(vec![0.into()]),
-			Ok(vec![1.into()]),
-			Ok(vec![2.into()]),
-			Err(Error::ConnectionUninitialised.into()),
-			Ok(vec![3.into()]),
-			Ok(vec![4.into()]),
-			Ok(vec![5.into()]),
-			Err(Error::BackupsNotSupported.into()),
-			Ok(vec![6.into()]),
-			Ok(vec![7.into()]),
-			Err(Error::DuplicateRequestId(0).into()),
-		];
-		let mut response = Response(to_map(response));
-		let errors = response.take_errors();
-		assert_eq!(response.num_statements(), 8);
-		assert_eq!(errors.len(), 3);
-		let crate::Error::Api(Error::DuplicateRequestId(0)) = errors.get(&10).unwrap() else {
-			panic!("index `10` is not `DuplicateRequestId`");
-		};
-		let crate::Error::Api(Error::BackupsNotSupported) = errors.get(&7).unwrap() else {
-			panic!("index `7` is not `BackupsNotSupported`");
-		};
-		let crate::Error::Api(Error::ConnectionUninitialised) = errors.get(&3).unwrap() else {
-			panic!("index `3` is not `ConnectionUninitialised`");
-		};
-		let Some(value): Option<i32> = response.take(2).unwrap() else {
-			panic!("statement not found");
-		};
-		assert_eq!(value, 2);
-		let value: Value = response.take(4).unwrap();
-		assert_eq!(value, vec![Value::from(3)].into());
+		// TODO fix this test
+		// let response = vec![
+		// 	Ok(vec![0.into()]),
+		// 	Ok(vec![1.into()]),
+		// 	Ok(vec![2.into()]),
+		// 	Err(Error::ConnectionUninitialised.into()),
+		// 	Ok(vec![3.into()]),
+		// 	Ok(vec![4.into()]),
+		// 	Ok(vec![5.into()]),
+		// 	Err(Error::BackupsNotSupported.into()),
+		// 	Ok(vec![6.into()]),
+		// 	Ok(vec![7.into()]),
+		// 	Err(Error::DuplicateRequestId(0).into()),
+		// ];
+		// let mut response = Response(to_map(response));
+		// let errors = response.take_errors();
+		// assert_eq!(response.num_statements(), 8);
+		// assert_eq!(errors.len(), 3);
+		// let crate::Error::Api(Error::DuplicateRequestId(0)) = errors.get(&10).unwrap() else {
+		// 	panic!("index `10` is not `DuplicateRequestId`");
+		// };
+		// let crate::Error::Api(Error::BackupsNotSupported) = errors.get(&7).unwrap() else {
+		// 	panic!("index `7` is not `BackupsNotSupported`");
+		// };
+		// let crate::Error::Api(Error::ConnectionUninitialised) = errors.get(&3).unwrap() else {
+		// 	panic!("index `3` is not `ConnectionUninitialised`");
+		// };
+		// let Some(value): Option<i32> = response.take(2).unwrap() else {
+		// 	panic!("statement not found");
+		// };
+		// assert_eq!(value, 2);
+		// let value: Value = response.take(4).unwrap();
+		// assert_eq!(value, vec![Value::from(3)].into());
 	}
 }

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -296,7 +296,7 @@ impl Response {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	// use crate::Error::Api;
+	use crate::Error::Api;
 	use serde::Deserialize;
 
 	#[derive(Debug, Clone, Serialize, Deserialize)]
@@ -337,15 +337,15 @@ mod tests {
 
 	#[test]
 	fn take_from_empty_records() {
-		let mut response = Response(to_map(vec![Ok(Value::None)]));
+		let mut response = Response(to_map(vec![]));
 		let value: Value = response.take(0).unwrap();
 		assert_eq!(value, Default::default());
 
-		let mut response = Response(to_map(vec![Ok(Value::None)]));
+		let mut response = Response(to_map(vec![]));
 		let option: Option<String> = response.take(0).unwrap();
 		assert!(option.is_none());
 
-		let mut response = Response(to_map(vec![Ok(Value::None)]));
+		let mut response = Response(to_map(vec![]));
 		let vec: Vec<String> = response.take(0).unwrap();
 		assert!(vec.is_empty());
 	}
@@ -356,7 +356,7 @@ mod tests {
 
 		let mut response = Response(to_map(vec![Ok(scalar.into())]));
 		let value: Value = response.take(0).unwrap();
-		assert_eq!(value, vec![Value::from(scalar)].into());
+		assert_eq!(value, Value::from(scalar));
 
 		let mut response = Response(to_map(vec![Ok(scalar.into())]));
 		let option: Option<_> = response.take(0).unwrap();
@@ -370,7 +370,7 @@ mod tests {
 
 		let mut response = Response(to_map(vec![Ok(scalar.into())]));
 		let value: Value = response.take(0).unwrap();
-		assert_eq!(value, vec![Value::from(scalar)].into());
+		assert_eq!(value, Value::from(scalar));
 
 		let mut response = Response(to_map(vec![Ok(scalar.into())]));
 		let option: Option<_> = response.take(0).unwrap();
@@ -406,7 +406,7 @@ mod tests {
 		};
 		assert_eq!(zero, 0);
 		let one: Value = response.take(1).unwrap();
-		assert_eq!(one, vec![Value::from(1)].into());
+		assert_eq!(one, Value::from(1));
 	}
 
 	#[test]
@@ -418,7 +418,7 @@ mod tests {
 
 		let mut response = Response(to_map(vec![Ok(value.clone())]));
 		let title: Value = response.take("title").unwrap();
-		assert_eq!(title, vec![Value::from(summary.title.as_str())].into());
+		assert_eq!(title, Value::from(summary.title.as_str()));
 
 		let mut response = Response(to_map(vec![Ok(value.clone())]));
 		let Some(title): Option<String> = response.take("title").unwrap() else {
@@ -452,86 +452,84 @@ mod tests {
 
 		let mut response = Response(to_map(vec![Ok(value)]));
 		let value: Value = response.take("title").unwrap();
-		assert_eq!(value, vec![Value::from(article.title)].into());
+		assert_eq!(value, Value::from(article.title));
 	}
 
 	#[test]
 	fn take_partial_records() {
-		// TODO fix this test
-		// let mut response = Response(to_map(vec![Ok(Value::from(sql::Array::from(vec![true.into(), false.into()])))]));
-		// let value: Value = response.take(0).unwrap();
-		// assert_eq!(value, vec![Value::from(true), Value::from(false)].into());
+		let mut response = Response(to_map(vec![Ok(vec![true, false].into())]));
+		let value: Value = response.take(0).unwrap();
+		assert_eq!(value, vec![Value::from(true), Value::from(false)].into());
 
-		// let mut response = Response(to_map(vec![Ok(Value::from(sql::Array::from(vec![true.into(), false.into()])))]));
-		// let vec: Vec<bool> = response.take(0).unwrap();
-		// assert_eq!(vec, vec![true, false]);
+		let mut response = Response(to_map(vec![Ok(vec![true, false].into())]));
+		let vec: Vec<bool> = response.take(0).unwrap();
+		assert_eq!(vec, vec![true, false]);
 
-		// let mut response = Response(to_map(vec![Ok(Value::from(sql::Array::from(vec![true.into(), false.into()])))]));
-		// let Err(Api(Error::LossyTake(Response(mut map)))): Result<Option<bool>> = response.take(0)
-		// else {
-		// 	panic!("silently dropping records not allowed");
-		// };
-		// let records = map.remove(&0).unwrap().unwrap();
-		// assert_eq!(records, Value::from(sql::Array::from(vec![true.into(), false.into()])));
+		let mut response = Response(to_map(vec![Ok(vec![true, false].into())]));
+		let Err(Api(Error::LossyTake(Response(mut map)))): Result<Option<bool>> = response.take(0)
+		else {
+			panic!("silently dropping records not allowed");
+		};
+		let records = map.remove(&0).unwrap().unwrap();
+		assert_eq!(records, vec![true, false].into());
 	}
 
 	#[test]
 	fn check_returns_the_first_error() {
-		// TODO fix this test
-		// let response = vec![
-		// 	Ok(vec![0.into()]),
-		// 	Ok(vec![1.into()]),
-		// 	Ok(vec![2.into()]),
-		// 	Err(Error::ConnectionUninitialised.into()),
-		// 	Ok(vec![3.into()]),
-		// 	Ok(vec![4.into()]),
-		// 	Ok(vec![5.into()]),
-		// 	Err(Error::BackupsNotSupported.into()),
-		// 	Ok(vec![6.into()]),
-		// 	Ok(vec![7.into()]),
-		// 	Err(Error::DuplicateRequestId(0).into()),
-		// ];
-		// let response = Response(to_map(response));
-		// let crate::Error::Api(Error::ConnectionUninitialised) = response.check().unwrap_err()
-		// else {
-		// 	panic!("check did not return the first error");
-		// };
+		let response = vec![
+			Ok(0.into()),
+			Ok(1.into()),
+			Ok(2.into()),
+			Err(Error::ConnectionUninitialised.into()),
+			Ok(3.into()),
+			Ok(4.into()),
+			Ok(5.into()),
+			Err(Error::BackupsNotSupported.into()),
+			Ok(6.into()),
+			Ok(7.into()),
+			Err(Error::DuplicateRequestId(0).into()),
+		];
+		let response = Response(to_map(response));
+		let crate::Error::Api(Error::ConnectionUninitialised) = response.check().unwrap_err()
+		else {
+			panic!("check did not return the first error");
+		};
 	}
 
 	#[test]
 	fn take_errors() {
 		// TODO fix this test
-		// let response = vec![
-		// 	Ok(vec![0.into()]),
-		// 	Ok(vec![1.into()]),
-		// 	Ok(vec![2.into()]),
-		// 	Err(Error::ConnectionUninitialised.into()),
-		// 	Ok(vec![3.into()]),
-		// 	Ok(vec![4.into()]),
-		// 	Ok(vec![5.into()]),
-		// 	Err(Error::BackupsNotSupported.into()),
-		// 	Ok(vec![6.into()]),
-		// 	Ok(vec![7.into()]),
-		// 	Err(Error::DuplicateRequestId(0).into()),
-		// ];
-		// let mut response = Response(to_map(response));
-		// let errors = response.take_errors();
-		// assert_eq!(response.num_statements(), 8);
-		// assert_eq!(errors.len(), 3);
-		// let crate::Error::Api(Error::DuplicateRequestId(0)) = errors.get(&10).unwrap() else {
-		// 	panic!("index `10` is not `DuplicateRequestId`");
-		// };
-		// let crate::Error::Api(Error::BackupsNotSupported) = errors.get(&7).unwrap() else {
-		// 	panic!("index `7` is not `BackupsNotSupported`");
-		// };
-		// let crate::Error::Api(Error::ConnectionUninitialised) = errors.get(&3).unwrap() else {
-		// 	panic!("index `3` is not `ConnectionUninitialised`");
-		// };
-		// let Some(value): Option<i32> = response.take(2).unwrap() else {
-		// 	panic!("statement not found");
-		// };
-		// assert_eq!(value, 2);
-		// let value: Value = response.take(4).unwrap();
-		// assert_eq!(value, vec![Value::from(3)].into());
+		let response = vec![
+			Ok(0.into()),
+			Ok(1.into()),
+			Ok(2.into()),
+			Err(Error::ConnectionUninitialised.into()),
+			Ok(3.into()),
+			Ok(4.into()),
+			Ok(5.into()),
+			Err(Error::BackupsNotSupported.into()),
+			Ok(6.into()),
+			Ok(7.into()),
+			Err(Error::DuplicateRequestId(0).into()),
+		];
+		let mut response = Response(to_map(response));
+		let errors = response.take_errors();
+		assert_eq!(response.num_statements(), 8);
+		assert_eq!(errors.len(), 3);
+		let crate::Error::Api(Error::DuplicateRequestId(0)) = errors.get(&10).unwrap() else {
+			panic!("index `10` is not `DuplicateRequestId`");
+		};
+		let crate::Error::Api(Error::BackupsNotSupported) = errors.get(&7).unwrap() else {
+			panic!("index `7` is not `BackupsNotSupported`");
+		};
+		let crate::Error::Api(Error::ConnectionUninitialised) = errors.get(&3).unwrap() else {
+			panic!("index `3` is not `ConnectionUninitialised`");
+		};
+		let Some(value): Option<i32> = response.take(2).unwrap() else {
+			panic!("statement not found");
+		};
+		assert_eq!(value, 2);
+		let value: Value = response.take(4).unwrap();
+		assert_eq!(value, Value::from(3));
 	}
 }

--- a/lib/src/api/opt/query.rs
+++ b/lib/src/api/opt/query.rs
@@ -3,8 +3,8 @@ use crate::api::opt::from_value;
 use crate::api::Response as QueryResponse;
 use crate::api::Result;
 use crate::sql;
-use crate::sql::Array;
 use crate::sql::statements::*;
+use crate::sql::Array;
 use crate::sql::Object;
 use crate::sql::Statement;
 use crate::sql::Statements;
@@ -245,9 +245,9 @@ impl QueryResult<Value> for (usize, &str) {
 		let response = match response {
 			Value::Object(Object(object)) => match object.remove(key) {
 				Some(value) => value,
-				_ => Value::None
+				_ => Value::None,
 			},
-			_ => Value::None
+			_ => Value::None,
 		};
 
 		Ok(response.into())
@@ -302,7 +302,7 @@ where
 		let vec = match map.remove(&self) {
 			Some(result) => match result? {
 				Value::Array(Array(vec)) => vec,
-				vec => vec![vec]
+				vec => vec![vec],
 			},
 			None => {
 				return Ok(vec![]);
@@ -324,7 +324,7 @@ where
 					Value::Array(Array(vec)) => {
 						let vec = mem::take(vec);
 						vec
-					},
+					}
 					val => {
 						let val = mem::take(val);
 						vec![val]

--- a/lib/src/api/opt/query.rs
+++ b/lib/src/api/opt/query.rs
@@ -212,9 +212,13 @@ where
 				return Ok(None);
 			}
 		};
-		let result = {
-			let value = mem::take(value);
-			from_value(value).map_err(Into::into)
+
+		let result = match value {
+			Value::Array(_) => Err(Error::LossyTake(QueryResponse(mem::take(map))).into()),
+			value => {
+				let value = mem::take(value);
+				from_value(value).map_err(Into::into)
+			}
 		};
 		map.remove(&self);
 		result
@@ -270,6 +274,7 @@ where
 			}
 		};
 		match &mut value {
+			Value::Array(_) => Err(Error::LossyTake(QueryResponse(mem::take(map))).into()),
 			Value::None | Value::Null => {
 				map.remove(&index);
 				Ok(None)

--- a/lib/src/api/opt/query.rs
+++ b/lib/src/api/opt/query.rs
@@ -249,10 +249,7 @@ impl QueryResult<Value> for (usize, &str) {
 		};
 
 		let response = match response {
-			Value::Object(Object(object)) => match object.remove(key) {
-				Some(value) => value,
-				_ => Value::None,
-			},
+			Value::Object(Object(object)) => object.remove(key).unwrap_or_default(),
 			_ => Value::None,
 		};
 
@@ -266,7 +263,7 @@ where
 {
 	fn query_result(self, QueryResponse(map): &mut QueryResponse) -> Result<Option<T>> {
 		let (index, key) = self;
-		let mut value: &mut Value = match map.get_mut(&index) {
+		let value = match map.get_mut(&index) {
 			Some(result) => match result {
 				Ok(val) => val,
 				Err(error) => {
@@ -279,7 +276,7 @@ where
 				return Ok(None);
 			}
 		};
-		let mut value = match &mut value {
+		let value = match value {
 			Value::Array(Array(vec)) => match &mut vec[..] {
 				[] => {
 					map.remove(&index);
@@ -292,7 +289,7 @@ where
 			},
 			value => value,
 		};
-		match &mut value {
+		match value {
 			Value::None | Value::Null => {
 				map.remove(&index);
 				Ok(None)

--- a/lib/src/sql/array.rs
+++ b/lib/src/sql/array.rs
@@ -77,6 +77,12 @@ impl From<Vec<Operation>> for Array {
 	}
 }
 
+impl From<Vec<bool>> for Array {
+	fn from(v: Vec<bool>) -> Self {
+		Self(v.into_iter().map(Value::from).collect())
+	}
+}
+
 impl From<Array> for Vec<Value> {
 	fn from(s: Array) -> Self {
 		s.0

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -503,6 +503,12 @@ impl From<Vec<Operation>> for Value {
 	}
 }
 
+impl From<Vec<bool>> for Value {
+	fn from(v: Vec<bool>) -> Self {
+		Value::Array(Array::from(v))
+	}
+}
+
 impl From<HashMap<String, Value>> for Value {
 	fn from(v: HashMap<String, Value>) -> Self {
 		Value::Object(Object::from(v))

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -903,5 +903,5 @@ async fn return_bool() {
 	assert!(boolean);
 	let mut response = db.query("RETURN false").await.unwrap();
 	let value: Value = response.take(0).unwrap();
-	assert_eq!(value, vec![Value::Bool(false)].into());
+	assert_eq!(value, Value::Bool(false));
 }

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -216,7 +216,7 @@ fn process(pretty: bool, json: bool, res: surrealdb::Result<Response>) -> Result
 	// Get the number of statements the query contained
 	let num_statements = response.num_statements();
 	// Prepare a single value from the query response
-	let value = if num_statements > 1 {
+	let value = {
 		let mut output = Vec::<Value>::with_capacity(num_statements);
 		for index in 0..num_statements {
 			output.push(match response.take(index) {
@@ -225,8 +225,6 @@ fn process(pretty: bool, json: bool, res: surrealdb::Result<Response>) -> Result
 			});
 		}
 		Value::from(output)
-	} else {
-		response.take(0)?
 	};
 	// Check if we should emit JSON and/or prettify
 	Ok(match (json, pretty) {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -52,7 +52,7 @@ mod cli_integration {
 			let args = format!("sql --conn http://{addr} {creds} --ns N --db D --multi");
 			assert_eq!(
 				common::run(&args).input("CREATE thing:one;\n").output(),
-				Ok("[{ id: thing:one }]\n\n".to_owned()),
+				Ok("[[{ id: thing:one }]]\n\n".to_owned()),
 				"failed to send sql: {args}"
 			);
 		}
@@ -84,7 +84,7 @@ mod cli_integration {
 			let args = format!("sql --conn http://{addr} {creds} --ns N --db D2 --pretty");
 			assert_eq!(
 				common::run(&args).input("SELECT * FROM thing;\n").output(),
-				Ok("[\n\t{\n\t\tid: thing:one\n\t}\n]\n\n".to_owned()),
+				Ok("[\n\t[\n\t\t{\n\t\t\tid: thing:one\n\t\t}\n\t]\n]\n\n".to_owned()),
 				"failed to send sql: {args}"
 			);
 		}
@@ -319,7 +319,7 @@ mod cli_integration {
 			let args = format!("sql --conn http://{addr} {creds} --ns N --db D --multi");
 			assert_eq!(
 				common::run(&args).input("DEFINE TABLE thing CHANGEFEED 1s;\n").output(),
-				Ok("[]\n\n".to_owned()),
+				Ok("[NONE]\n\n".to_owned()),
 				"failed to send sql: {args}"
 			);
 		}
@@ -329,7 +329,7 @@ mod cli_integration {
 			let args = format!("sql --conn http://{addr} {creds} --ns N --db D --multi");
 			assert_eq!(
 				common::run(&args).input("BEGIN TRANSACTION; CREATE thing:one; COMMIT;\n").output(),
-				Ok("[{ id: thing:one }]\n\n".to_owned()),
+				Ok("[[{ id: thing:one }]]\n\n".to_owned()),
 				"failed to send sql: {args}"
 			);
 		}
@@ -341,7 +341,7 @@ mod cli_integration {
 				common::run(&args)
 					.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
 					.output(),
-				Ok("[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 65536 }, { changes: [{ update: { id: thing:one } }], versionstamp: 131072 }]\n\n"
+				Ok("[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 65536 }, { changes: [{ update: { id: thing:one } }], versionstamp: 131072 }]]\n\n"
 					.to_owned()),
 				"failed to send sql: {args}"
 			);
@@ -356,7 +356,7 @@ mod cli_integration {
 				common::run(&args)
 					.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
 					.output(),
-				Ok("[]\n\n".to_owned()),
+				Ok("[[]]\n\n".to_owned()),
 				"failed to send sql: {args}"
 			);
 		}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Query results are currently inconsistent and not always representative of what a query result might actually be.

### QueryResult should not be forced into a vec
A `QueryResult` is always forcefully represented as a vec. This is problemetic as values are now wrongfully represented, and it causes not inconsistent behaviour, but inconsistent results.

```sql
ns/db> true
[ true ]

ns/db> true; false
[
  [ true ],
  [ false ]
]

ns/db> create test:1;
[ { id: test:1 } ]

ns/db> create only test:1;
[ { id: test:1 } ]
```

1. You might not think much of it, but the `true` is actually falsely represented here.
2. This example better shows the issue of query 1.
3. Alright, we created a record, which can result in multiple records. This is correct
4. Wait, I used the `ONLY` keyword. What is going on here?

### Why do we only output one result if there is one query?
Referencing back to the first two queries in the above codeblock, you might not think much of it, but it causes inconsistent results. Besides that, to resolve the first issue, we need to tackle this too:

#### Above fixed, not this issue
When the `QueryResult` issue would be tackled, but not the fact that the CLI currently only outputs one result in case one statement was executed, the following would happen. Notice how it is now impossible to differentiate between the second and third example. See the `Suggestion for v2.0.0` down below for an ideal resolution

```sql
ns/db> true
true

ns/db> true; false
[
  true,
  false
]

ns/db> [ true, false ]
[
  true,
  false
]
```

## What does this change do?

- A `QueryResult` is no longer forcefully represented as a `vec`
- The CLI no longer conditionally shows only the first value, if a single statement was executed.
- As a convenience, I added a `From<Vec<bool>>` implementation for both `Value` and `Array`. Can remove if so desired

### Clearing up confusion
```sql
ns/db> true
[ true ]

ns/db> true; false
[ true, false ]

ns/db> [ true, false ]
[
  [ true, false ]
]
```

### Suggestion for v2.0.0
To make results more human readable in the CLI, we might want to split all the results to their own line, instead of listing them as an array. This could be behind either the `--friendly` or just the `--pretty` flag, and would look something like this:
```sql
ns/db> true
-- Query 1
true

ns/db> true; false
-- Query 1
true
-- Query 2
false 

ns/db> [true, false]
-- Query 1
[
  true, 
  false 
]
```

1. You might think that this PR does not solve the initial issue, but it does. The outer array now represents the output of a set of statements, instead of the output of a single query, where `QueryResult` was forcefully represented as a `vec`.
2. This output confirms the above
3. Further confirms the above

## What is your testing strategy?

Updated tests

## Is this related to any issues?

Fixes #2513
Fixes #2714

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
