### PR TITLE
CLI: Split results by comment

### DIFF
--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -218,10 +218,8 @@ fn process(pretty: bool, json: bool, res: surrealdb::Result<Response>) -> Result
 	// Prepare a single value from the query response
 	let mut output = Vec::<Value>::with_capacity(num_statements);
 	for index in 0..num_statements {
-		output.push(match response.take(index) {
-			Ok(v) => v,
-			Err(e) => e.to_string().into(),
-		});
+        let result = response.take(index).unwrap_or_else(|e| e.to_string().into());
+		output.push(result);
 	}
 
 	// Check if we should emit JSON and/or prettify

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -218,7 +218,7 @@ fn process(pretty: bool, json: bool, res: surrealdb::Result<Response>) -> Result
 	// Prepare a single value from the query response
 	let mut output = Vec::<Value>::with_capacity(num_statements);
 	for index in 0..num_statements {
-        let result = response.take(index).unwrap_or_else(|e| e.to_string().into());
+		let result = response.take(index).unwrap_or_else(|e| e.to_string().into());
 		output.push(result);
 	}
 

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -216,16 +216,13 @@ fn process(pretty: bool, json: bool, res: surrealdb::Result<Response>) -> Result
 	// Get the number of statements the query contained
 	let num_statements = response.num_statements();
 	// Prepare a single value from the query response
-	let output = {
-		let mut output = Vec::<Value>::with_capacity(num_statements);
-		for index in 0..num_statements {
-			output.push(match response.take(index) {
-				Ok(v) => v,
-				Err(e) => e.to_string().into(),
-			});
-		}
-		output
-	};
+	let mut output = Vec::<Value>::with_capacity(num_statements);
+	for index in 0..num_statements {
+		output.push(match response.take(index) {
+			Ok(v) => v,
+			Err(e) => e.to_string().into(),
+		});
+	}
 
 	// Check if we should emit JSON and/or prettify
 	Ok(match (json, pretty) {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -84,7 +84,7 @@ mod cli_integration {
 			let args = format!("sql --conn http://{addr} {creds} --ns N --db D2 --pretty");
 			assert_eq!(
 				common::run(&args).input("SELECT * FROM thing;\n").output(),
-				Ok("[\n\t[\n\t\t{\n\t\t\tid: thing:one\n\t\t}\n\t]\n]\n\n".to_owned()),
+				Ok("-- Query 1\n[\n\t{\n\t\tid: thing:one\n\t}\n]\n\n".to_owned()),
 				"failed to send sql: {args}"
 			);
 		}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

As we discovered in #2887, the outputted result of the CLI can be somewhat unclear.
```sql
ns/db> true
[
  true
]
```

Put in perspective, it makes sense:
```sql
ns/db> true; false
[
  true,
  false
]
```

But we can make it even clearer.

## What does this change do?

Taking inspiration from [Surrealist](https://github.com/StarlaneStudios/Surrealist) by @macjuul, this PR alters the output of CLI results with the `--pretty` flag, so that query results are split up by a comment:
```sql
ns/db> true
-- Query 1
true

ns/db> true; false
-- Query 1
true
-- Query 2
false

ns/db> true; false; { bla: 123 }
-- Query 1
true
-- Query 2
false
-- Query 3
{
        "bla": 123
}
```

To make things even easier, we might introduce coloring of comments in a future PR.

## What is your testing strategy?

Ensure all tests pass

## Is this related to any issues?

This is an improvement as the result of a bugfix in #2887. We decided to split this task in multiple PRs to make the changes easier to understand, and to not block other team members from their work.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
