### PR TITLE
Add `surreal sql` welcome message

### DIFF
--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -2,6 +2,7 @@ use crate::cli::abstraction::{
 	AuthArguments, DatabaseConnectionArguments, DatabaseSelectionOptionalArguments,
 };
 use crate::err::Error;
+use crate::cnf::PKG_VERSION;
 use clap::Args;
 use rustyline::error::ReadlineError;
 use rustyline::validate::{ValidationContext, ValidationResult, Validator};
@@ -32,6 +33,9 @@ pub struct SqlCommandArguments {
 	/// Whether omitting semicolon causes a newline
 	#[arg(long)]
 	multi: bool,
+	/// Whether to show welcome message
+	#[arg(long, env = "SURREAL_HIDE_WELCOME")]
+	hide_welcome: bool,
 }
 
 pub async fn init(
@@ -47,6 +51,7 @@ pub async fn init(
 		pretty,
 		json,
 		multi,
+		hide_welcome,
 		..
 	}: SqlCommandArguments,
 ) -> Result<(), Error> {
@@ -109,6 +114,22 @@ pub async fn init(
 			_ => {}
 		}
 	};
+
+	if !hide_welcome {
+		eprintln!("
+#
+#  Welcome to the SurrealDB SQL Shell
+#
+#  How to use this shell:
+#    - Different statements within a query should be separated by a (;) semicolon.
+#    - To create a multi-line query, end your lines with a (\\) backslash, and press enter.
+#    - To exit, send a SIGTERM or press CTRL+C
+#  Consult https://surrealdb.com/docs/cli/sql for further instructions
+#
+#  SurrealDB version: {:#}
+#
+	", PKG_VERSION.to_string());
+	}
 
 	// Loop over each command-line input
 	loop {

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -1,8 +1,8 @@
 use crate::cli::abstraction::{
 	AuthArguments, DatabaseConnectionArguments, DatabaseSelectionOptionalArguments,
 };
-use crate::err::Error;
 use crate::cnf::PKG_VERSION;
+use crate::err::Error;
 use clap::Args;
 use rustyline::error::ReadlineError;
 use rustyline::validate::{ValidationContext, ValidationResult, Validator};
@@ -116,7 +116,8 @@ pub async fn init(
 	};
 
 	if !hide_welcome {
-		eprintln!("
+		eprintln!(
+			"
 #
 #  Welcome to the SurrealDB SQL Shell
 #
@@ -128,7 +129,9 @@ pub async fn init(
 #
 #  SurrealDB version: {:#}
 #
-	", PKG_VERSION.to_string());
+	",
+			PKG_VERSION.to_string()
+		);
 	}
 
 	// Loop over each command-line input

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -116,22 +116,28 @@ pub async fn init(
 	};
 
 	if !hide_welcome {
-		eprintln!(
-			"
+		let hints = vec![
+			(true, "Different statements within a query should be separated by a (;) semicolon."),
+			(!multi, "To create a multi-line query, end your lines with a (\\) backslash, and press enter."),
+			(true, "To exit, send a SIGTERM or press CTRL+C")
+		]
+			.iter()
+			.filter(|(show, _)| *show)
+			.map(|(_, hint)| format!("#    - {hint}"))
+			.collect::<Vec<String>>()
+			.join("\n");
+
+		eprintln!("
 #
 #  Welcome to the SurrealDB SQL Shell
 #
 #  How to use this shell:
-#    - Different statements within a query should be separated by a (;) semicolon.
-#    - To create a multi-line query, end your lines with a (\\) backslash, and press enter.
-#    - To exit, send a SIGTERM or press CTRL+C
+{hints}
 #  Consult https://surrealdb.com/docs/cli/sql for further instructions
 #
-#  SurrealDB version: {:#}
+#  SurrealDB version: {}
 #
-	",
-			PKG_VERSION.to_string()
-		);
+		", *PKG_VERSION);
 	}
 
 	// Loop over each command-line input

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -121,13 +121,14 @@ pub async fn init(
 			(!multi, "To create a multi-line query, end your lines with a (\\) backslash, and press enter."),
 			(true, "To exit, send a SIGTERM or press CTRL+C")
 		]
-			.iter()
-			.filter(|(show, _)| *show)
-			.map(|(_, hint)| format!("#    - {hint}"))
-			.collect::<Vec<String>>()
-			.join("\n");
+		.iter()
+		.filter(|(show, _)| *show)
+		.map(|(_, hint)| format!("#    - {hint}"))
+		.collect::<Vec<String>>()
+		.join("\n");
 
-		eprintln!("
+		eprintln!(
+			"
 #
 #  Welcome to the SurrealDB SQL Shell
 #
@@ -137,7 +138,9 @@ pub async fn init(
 #
 #  SurrealDB version: {}
 #
-		", *PKG_VERSION);
+		",
+			*PKG_VERSION
+		);
 	}
 
 	// Loop over each command-line input

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -130,10 +130,11 @@ pub async fn init(
 		eprintln!(
 			"
 #
-#  Welcome to the SurrealDB SQL Shell
+#  Welcome to the SurrealDB SQL shell
 #
 #  How to use this shell:
 {hints}
+#
 #  Consult https://surrealdb.com/docs/cli/sql for further instructions
 #
 #  SurrealDB version: {}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -49,7 +49,8 @@ mod cli_integration {
 
 		info!("* Create a record");
 		{
-			let args = format!("sql --conn http://{addr} {creds} --ns N --db D --multi");
+			let args =
+				format!("sql --conn http://{addr} {creds} --ns N --db D --multi --hide-welcome");
 			assert_eq!(
 				common::run(&args).input("CREATE thing:one;\n").output(),
 				Ok("[{ id: thing:one }]\n\n".to_owned()),
@@ -81,7 +82,8 @@ mod cli_integration {
 
 		info!("* Query from the import (pretty-printed this time)");
 		{
-			let args = format!("sql --conn http://{addr} {creds} --ns N --db D2 --pretty");
+			let args =
+				format!("sql --conn http://{addr} {creds} --ns N --db D2 --pretty --hide-welcome");
 			assert_eq!(
 				common::run(&args).input("SELECT * FROM thing;\n").output(),
 				Ok("[\n\t{\n\t\tid: thing:one\n\t}\n]\n\n".to_owned()),
@@ -316,7 +318,8 @@ mod cli_integration {
 
 		info!("* Define a table");
 		{
-			let args = format!("sql --conn http://{addr} {creds} --ns N --db D --multi");
+			let args =
+				format!("sql --conn http://{addr} {creds} --ns N --db D --multi --hide-welcome");
 			assert_eq!(
 				common::run(&args).input("DEFINE TABLE thing CHANGEFEED 1s;\n").output(),
 				Ok("[]\n\n".to_owned()),
@@ -326,7 +329,8 @@ mod cli_integration {
 
 		info!("* Create a record");
 		{
-			let args = format!("sql --conn http://{addr} {creds} --ns N --db D --multi");
+			let args =
+				format!("sql --conn http://{addr} {creds} --ns N --db D --multi --hide-welcome");
 			assert_eq!(
 				common::run(&args).input("BEGIN TRANSACTION; CREATE thing:one; COMMIT;\n").output(),
 				Ok("[{ id: thing:one }]\n\n".to_owned()),
@@ -336,7 +340,8 @@ mod cli_integration {
 
 		info!("* Show changes");
 		{
-			let args = format!("sql --conn http://{addr} {creds} --ns N --db D --multi");
+			let args =
+				format!("sql --conn http://{addr} {creds} --ns N --db D --multi --hide-welcome");
 			assert_eq!(
 				common::run(&args)
 					.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
@@ -351,7 +356,8 @@ mod cli_integration {
 
 		info!("* Show changes after GC");
 		{
-			let args = format!("sql --conn http://{addr} {creds} --ns N --db D --multi");
+			let args =
+				format!("sql --conn http://{addr} {creds} --ns N --db D --multi --hide-welcome");
 			assert_eq!(
 				common::run(&args)
 					.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

It's helpful to add a welcome message with basic instructions as to how to use the `surreal sql` repl.

## What does this change do?

It adds a welcome message which can be disabled with a `--hide-welcome` flag, or with the `SURREAL_HIDE_WELCOME` environment variable.

```sh
➜  surreal sql --conn memory

#
#  Welcome to the SurrealDB SQL shell
#
#  How to use this shell:
#    - Different statements within a query should be separated by a (;) semicolon.
#    - To create a multi-line query, end your lines with a (\) backslash, and press enter.
#    - To exit, send a SIGTERM or press CTRL+C
#
#  Consult https://surrealdb.com/docs/cli/sql for further instructions
#
#  SurrealDB version: 1.0.0+20231026.015fbd35.dirty
#

> 
```

#### With `--multi`
```sh
➜  surreal sql --conn memory --multi

#
#  Welcome to the SurrealDB SQL shell
#
#  How to use this shell:
#    - Different statements within a query should be separated by a (;) semicolon.
#    - To exit, send a SIGTERM or press CTRL+C
#
#  Consult https://surrealdb.com/docs/cli/sql for further instructions
#
#  SurrealDB version: 1.0.0+20231026.015fbd35.dirty
#

> 
```

#### With `--hide-welcome` flag, or `SURREAL_HIDE_WELCOME` environment variable
```sh
➜  surreal sql --conn memory --hide-welcome
> 
```

## What is your testing strategy?

Ensure tests still pass

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
