### PR TITLE
Forward custom thrown errors in SIGNIN and SIGNUP queries

### DIFF
--- a/lib/src/iam/signin.rs
+++ b/lib/src/iam/signin.rs
@@ -171,8 +171,8 @@ pub async fn sc(
 						},
 						Err(e) => match e {
 							Error::Thrown(_) => Err(e),
-							_ => Err(Error::SigninQueryFailed)
-						}
+							_ => Err(Error::SigninQueryFailed),
+						},
 					}
 				}
 				_ => Err(Error::ScopeNoSignin),

--- a/lib/src/iam/signin.rs
+++ b/lib/src/iam/signin.rs
@@ -169,7 +169,10 @@ pub async fn sc(
 							}
 							_ => Err(Error::NoRecordFound),
 						},
-						_ => Err(Error::SigninQueryFailed),
+						Err(e) => match e {
+							Error::Thrown(_) => Err(e),
+							_ => Err(Error::SigninQueryFailed)
+						}
 					}
 				}
 				_ => Err(Error::ScopeNoSignin),

--- a/lib/src/iam/signup.rs
+++ b/lib/src/iam/signup.rs
@@ -112,7 +112,7 @@ pub async fn sc(
 						},
 						Err(e) => match e {
 							Error::Thrown(_) => Err(e),
-							_ => Err(Error::SignupQueryFailed)
+							_ => Err(Error::SignupQueryFailed),
 						},
 					}
 				}

--- a/lib/src/iam/signup.rs
+++ b/lib/src/iam/signup.rs
@@ -110,7 +110,10 @@ pub async fn sc(
 							}
 							_ => Err(Error::NoRecordFound),
 						},
-						Err(_) => Err(Error::SignupQueryFailed),
+						Err(e) => match e {
+							Error::Thrown(_) => Err(e),
+							_ => Err(Error::SignupQueryFailed)
+						},
 					}
 				}
 				_ => Err(Error::ScopeNoSignup),

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -271,7 +271,7 @@ async fn scope_invalid_query() {
 	{
 		Err(Error::Db(surrealdb::err::Error::SigninQueryFailed)) => (),
 		Err(Error::Api(surrealdb::error::Api::Query(e))) => {
-			assert_eq!(e, "There was a problem with the database: The signup query failed")
+			assert_eq!(e, "There was a problem with the database: The signin query failed")
 		}
 		Err(Error::Api(surrealdb::error::Api::Http(e))) => assert_eq!(
 			e,

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -210,7 +210,7 @@ async fn scope_throws_error() {
 		),
 		Err(Error::Api(surrealdb::error::Api::Http(e))) => assert_eq!(
 			e,
-			"HTTP status client error (400 Bad Request) for url (http://127.0.0.1:8000/signup)"
+			"HTTP status client error (400 Bad Request) for url (http://127.0.0.1:8000/signin)"
 		),
 		v => panic!("Unexpected response or error: {v:?}"),
 	};

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -180,6 +180,14 @@ async fn scope_throws_error() {
 		.await
 	{
 		Err(Error::Db(surrealdb::err::Error::Thrown(e))) => assert_eq!(e, "signup_thrown_error"),
+		Err(Error::Api(surrealdb::error::Api::Query(e))) => assert_eq!(
+			e,
+			"There was a problem with the database: An error occurred: signup_thrown_error"
+		),
+		Err(Error::Api(surrealdb::error::Api::Http(e))) => assert_eq!(
+			e,
+			"HTTP status client error (400 Bad Request) for url (http://127.0.0.1:8000/signup)"
+		),
 		v => panic!("Unexpected response or error: {v:?}"),
 	};
 
@@ -196,6 +204,14 @@ async fn scope_throws_error() {
 		.await
 	{
 		Err(Error::Db(surrealdb::err::Error::Thrown(e))) => assert_eq!(e, "signin_thrown_error"),
+		Err(Error::Api(surrealdb::error::Api::Query(e))) => assert_eq!(
+			e,
+			"There was a problem with the database: An error occurred: signin_thrown_error"
+		),
+		Err(Error::Api(surrealdb::error::Api::Http(e))) => assert_eq!(
+			e,
+			"HTTP status client error (400 Bad Request) for url (http://127.0.0.1:8000/signup)"
+		),
 		v => panic!("Unexpected response or error: {v:?}"),
 	};
 }
@@ -231,6 +247,13 @@ async fn scope_invalid_query() {
 		.await
 	{
 		Err(Error::Db(surrealdb::err::Error::SignupQueryFailed)) => (),
+		Err(Error::Api(surrealdb::error::Api::Query(e))) => {
+			assert_eq!(e, "There was a problem with the database: The signup query failed")
+		}
+		Err(Error::Api(surrealdb::error::Api::Http(e))) => assert_eq!(
+			e,
+			"HTTP status client error (400 Bad Request) for url (http://127.0.0.1:8000/signup)"
+		),
 		v => panic!("Unexpected response or error: {v:?}"),
 	};
 
@@ -247,6 +270,13 @@ async fn scope_invalid_query() {
 		.await
 	{
 		Err(Error::Db(surrealdb::err::Error::SigninQueryFailed)) => (),
+		Err(Error::Api(surrealdb::error::Api::Query(e))) => {
+			assert_eq!(e, "There was a problem with the database: The signup query failed")
+		}
+		Err(Error::Api(surrealdb::error::Api::Http(e))) => assert_eq!(
+			e,
+			"HTTP status client error (400 Bad Request) for url (http://127.0.0.1:8000/signup)"
+		),
 		v => panic!("Unexpected response or error: {v:?}"),
 	};
 }

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -275,7 +275,7 @@ async fn scope_invalid_query() {
 		}
 		Err(Error::Api(surrealdb::error::Api::Http(e))) => assert_eq!(
 			e,
-			"HTTP status client error (400 Bad Request) for url (http://127.0.0.1:8000/signup)"
+			"HTTP status client error (400 Bad Request) for url (http://127.0.0.1:8000/signin)"
 		),
 		v => panic!("Unexpected response or error: {v:?}"),
 	};

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -167,32 +167,36 @@ async fn scope_throws_error() {
 	let response = db.query(sql).await.unwrap();
 	response.check().unwrap();
 
-	match db.signup(Scope {
-		namespace: NS,
-		database: &database,
-		scope: &scope,
-		params: AuthParams {
-			pass,
-			email: &email,
-		},
-	})
-	.await {
+	match db
+		.signup(Scope {
+			namespace: NS,
+			database: &database,
+			scope: &scope,
+			params: AuthParams {
+				pass,
+				email: &email,
+			},
+		})
+		.await
+	{
 		Err(Error::Db(surrealdb::err::Error::Thrown(e))) => assert_eq!(e, "signup_thrown_error"),
-		v => panic!("Unexpected response or error: {v:?}")
+		v => panic!("Unexpected response or error: {v:?}"),
 	};
 
-	match db.signin(Scope {
-		namespace: NS,
-		database: &database,
-		scope: &scope,
-		params: AuthParams {
-			pass,
-			email: &email,
-		},
-	})
-	.await {
+	match db
+		.signin(Scope {
+			namespace: NS,
+			database: &database,
+			scope: &scope,
+			params: AuthParams {
+				pass,
+				email: &email,
+			},
+		})
+		.await
+	{
 		Err(Error::Db(surrealdb::err::Error::Thrown(e))) => assert_eq!(e, "signin_thrown_error"),
-		v => panic!("Unexpected response or error: {v:?}")
+		v => panic!("Unexpected response or error: {v:?}"),
 	};
 }
 
@@ -214,32 +218,36 @@ async fn scope_invalid_query() {
 	let response = db.query(sql).await.unwrap();
 	response.check().unwrap();
 
-	match db.signup(Scope {
-		namespace: NS,
-		database: &database,
-		scope: &scope,
-		params: AuthParams {
-			pass,
-			email: &email,
-		},
-	})
-	.await {
+	match db
+		.signup(Scope {
+			namespace: NS,
+			database: &database,
+			scope: &scope,
+			params: AuthParams {
+				pass,
+				email: &email,
+			},
+		})
+		.await
+	{
 		Err(Error::Db(surrealdb::err::Error::SignupQueryFailed)) => (),
-		v => panic!("Unexpected response or error: {v:?}")
+		v => panic!("Unexpected response or error: {v:?}"),
 	};
 
-	match db.signin(Scope {
-		namespace: NS,
-		database: &database,
-		scope: &scope,
-		params: AuthParams {
-			pass,
-			email: &email,
-		},
-	})
-	.await {
+	match db
+		.signin(Scope {
+			namespace: NS,
+			database: &database,
+			scope: &scope,
+			params: AuthParams {
+				pass,
+				email: &email,
+			},
+		})
+		.await
+	{
 		Err(Error::Db(surrealdb::err::Error::SigninQueryFailed)) => (),
-		v => panic!("Unexpected response or error: {v:?}")
+		v => panic!("Unexpected response or error: {v:?}"),
 	};
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Signin and signup queries currently do not forward custom errors thrown by the queries they store. This is a feature we have advertised here and there and is one of the reasons the `THROW` statement was implemented in the first place.

## What does this change do?

This PR makes sure that custom THROWn errors are forwarded to the client.

## What is your testing strategy?

Added two tests:
- To ensure that errors thrown with a `THROW` statement get forwarded to the client.
- To ensure that other sort of queries will still result in a general "Query failed" error.

## Is this related to any issues?

Fixes #2892

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
