### PR TITLE
Make Remove{Table,Database,Namespace} faster for TiKV and FDB

### DIFF
--- a/lib/src/kvs/fdb/mod.rs
+++ b/lib/src/kvs/fdb/mod.rs
@@ -518,4 +518,25 @@ impl Transaction {
 		}
 		Ok(res)
 	}
+
+	/// Delete a range of keys from the databases
+	pub(crate) async fn delr<K>(&mut self, rng: Range<K>) -> Result<(), Error>
+	where
+		K: Into<Key>,
+	{
+		// Check to see if transaction is closed
+		if self.done {
+			return Err(Error::TxFinished);
+		}
+		// Check to see if transaction is writable
+		if !self.write {
+			return Err(Error::TxReadonly);
+		}
+		let begin: &[u8] = &rng.start.into();
+		let end: &[u8] = &rng.end.into();
+		let inner = self.inner.lock().await;
+		let inner = inner.as_ref().unwrap();
+		inner.clear_range(begin, end);
+		Ok(())
+	}
 }

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -850,6 +850,29 @@ impl Transaction {
 	{
 		#[cfg(debug_assertions)]
 		trace!("Delr {:?}..{:?} (limit: {limit})", rng.start, rng.end);
+		match self {
+			#[cfg(feature = "kv-tikv")]
+			Transaction {
+				inner: Inner::TiKV(v),
+				..
+			} => v.delr(rng, limit).await,
+			#[cfg(feature = "kv-fdb")]
+			Transaction {
+				inner: Inner::FoundationDB(v),
+				..
+			} => v.delr(rng).await,
+			#[allow(unreachable_patterns)]
+			_ => self._delr(rng, limit).await,
+		}
+	}
+
+	/// Delete a range of keys from the datastore.
+	///
+	/// This function fetches key-value pairs from the underlying datastore in batches of 1000.
+	async fn _delr<K>(&mut self, rng: Range<K>, limit: u32) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+	{
 		let beg: Key = rng.start.into();
 		let end: Key = rng.end.into();
 		let mut nxt: Option<Key> = None;
@@ -955,44 +978,10 @@ impl Transaction {
 		trace!("Delp {:?} (limit: {limit})", key);
 		let beg: Key = key.into();
 		let end: Key = beg.clone().add(0xff);
-		let mut nxt: Option<Key> = None;
-		let mut num = limit;
-		// Start processing
-		while num > 0 {
-			// Get records batch
-			let res = match nxt {
-				None => {
-					let min = beg.clone();
-					let max = end.clone();
-					let num = std::cmp::min(1000, num);
-					self.scan(min..max, num).await?
-				}
-				Some(ref mut beg) => {
-					beg.push(0);
-					let min = beg.clone();
-					let max = end.clone();
-					let num = std::cmp::min(1000, num);
-					self.scan(min..max, num).await?
-				}
-			};
-			// Get total results
-			let n = res.len();
-			// Exit when settled
-			if n == 0 {
-				break;
-			}
-			// Loop over results
-			for (i, (k, _)) in res.into_iter().enumerate() {
-				// Ready the next
-				if n == i + 1 {
-					nxt = Some(k.clone());
-				}
-				// Delete
-				self.del(k).await?;
-				// Count
-				num -= 1;
-			}
-		}
+		let min = beg.clone();
+		let max = end.clone();
+		let num = std::cmp::min(1000, limit);
+		self.delr(min..max, num).await?;
 		Ok(())
 	}
 


### PR DESCRIPTION
## What is the motivation?

TL;DR; Use more KVS implementation-specific and appropriate operations for doing range clears.

## What does this change do?

We enhance our internal utility functions `delr` and `delp` present in `Transaction` leveraging functions specific to TiKV and FDB, respectively.

For TiKV, we now use `scan_keys` followed by `delete` on each key. We previously used `scan`, which resulted in receiving not only keys but also values. Thanks to we are not wasting compute and network resources for receiving unused values, it should be faster. Alleviate #2869 for TiKV.

For FDB, we now use `clear_range`, which can very quickly delete all the keys within the specified range. Previously we did `scan` followed by `delete`, which can result in thousands or more ops when removing a large namespace/database/table as similar to TiKV. As it's now one operation in terms of FDB and FDB does it very quickly, it should almost resolve #2869 for FDB.

Fix #2869

## What is your testing strategy?

- This is a kind of refactoring that affects our existing `delr` and `delp` functions of `Transaction,` and we already have tests that involve those.

## Is this related to any issues?

#2869

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
