### PR TITLE
Introduce http-compression feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
   clippy:
     name: Check clippy
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -217,7 +217,7 @@ jobs:
 
   test:
     name: Test workspace
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -113,19 +113,19 @@ jobs:
           - arch: x86_64-apple-darwin
             os: macos-latest-xl
             file: surreal-nightly.darwin-amd64
-            opts: --features storage-tikv
+            opts: --features storage-tikv,http-compression
           - arch: aarch64-apple-darwin
             os: macos-latest-xl
             file: surreal-nightly.darwin-arm64
-            opts: --features storage-tikv
+            opts: --features storage-tikv,http-compression
           - arch: x86_64-unknown-linux-gnu
             os: ubuntu-latest-16-cores
             file: surreal-nightly.linux-amd64
-            opts: --features storage-tikv
+            opts: --features storage-tikv,http-compression
           - arch: aarch64-unknown-linux-gnu
             os: ubuntu-latest-16-cores
             file: surreal-nightly.linux-arm64
-            opts: --features storage-tikv
+            opts: --features storage-tikv,http-compression
           - arch: x86_64-pc-windows-msvc
             os: windows-latest
             file: surreal-nightly.windows-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,19 +113,19 @@ jobs:
           - arch: x86_64-apple-darwin
             os: macos-latest-xl
             file: surreal-${{ github.ref_name }}.darwin-amd64
-            opts: --features storage-tikv
+            opts: --features storage-tikv,http-compression
           - arch: aarch64-apple-darwin
             os: macos-latest-xl
             file: surreal-${{ github.ref_name }}.darwin-arm64
-            opts: --features storage-tikv
+            opts: --features storage-tikv,http-compression
           - arch: x86_64-unknown-linux-gnu
             os: ubuntu-latest-16-cores
             file: surreal-${{ github.ref_name }}.linux-amd64
-            opts: --features storage-tikv
+            opts: --features storage-tikv,http-compression
           - arch: aarch64-unknown-linux-gnu
             os: ubuntu-latest-16-cores
             file: surreal-${{ github.ref_name }}.linux-arm64
-            opts: --features storage-tikv
+            opts: --features storage-tikv,http-compression
           - arch: x86_64-pc-windows-msvc
             os: windows-latest
             file: surreal-${{ github.ref_name }}.windows-amd64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ storage-tikv = ["surrealdb/kv-tikv", "has-storage"]
 storage-fdb = ["surrealdb/kv-fdb-7_1", "has-storage"]
 scripting = ["surrealdb/scripting"]
 http = ["surrealdb/http"]
+http-compression = []
 # Private features
 has-storage = []
 

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -15,7 +15,7 @@ args = ["check", "--locked", "--package", "surrealdb", "--features", "protocol-w
 [tasks.ci-clippy]
 category = "CI - CHECK"
 command = "cargo"
-args = ["clippy", "--all-targets", "--all-features", "--tests", "--benches", "--examples","--bins", "--", "-D", "warnings"]
+args = ["clippy", "--all-targets", "--features", "storage-mem,storage-rocksdb,storage-speedb,storage-tikv,storage-fdb,scripting,http,has-storage", "--tests", "--benches", "--examples","--bins", "--", "-D", "warnings"]
 
 #
 # Integration Tests

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -31,7 +31,7 @@ args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_LOG={ value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem", "--workspace", "--test", "http_integration", "--", "http_integration", "--nocapture"]
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression", "--workspace", "--test", "http_integration", "--", "http_integration", "--nocapture"]
 
 [tasks.ci-ws-integration]
 category = "CI - INTEGRATION TESTS"

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -29,6 +29,7 @@ use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
 use tower_http::add_extension::AddExtensionLayer;
 use tower_http::auth::AsyncRequireAuthorizationLayer;
+#[cfg(feature = "http-compression")]
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::request_id::MakeRequestUuid;
@@ -75,8 +76,35 @@ pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 	let service = ServiceBuilder::new()
 		.catch_panic()
 		.set_x_request_id(MakeRequestUuid)
-		.propagate_x_request_id()
-		.layer(CompressionLayer::new())
+		.propagate_x_request_id();
+
+	#[cfg(feature = "http-compression")]
+	let service = service.layer(CompressionLayer::new());
+
+	#[cfg(feature = "http-compression")]
+	let allow_header = [
+		http::header::ACCEPT,
+		http::header::ACCEPT_ENCODING,
+		http::header::AUTHORIZATION,
+		http::header::CONTENT_TYPE,
+		http::header::ORIGIN,
+		headers::NS.parse().unwrap(),
+		headers::DB.parse().unwrap(),
+		headers::ID.parse().unwrap(),
+	];
+
+	#[cfg(not(feature = "http-compression"))]
+	let allow_header = [
+		http::header::ACCEPT,
+		http::header::AUTHORIZATION,
+		http::header::CONTENT_TYPE,
+		http::header::ORIGIN,
+		headers::NS.parse().unwrap(),
+		headers::DB.parse().unwrap(),
+		headers::ID.parse().unwrap(),
+	];
+
+	let service = service
 		.layer(AddExtensionLayer::new(app_state))
 		.layer(middleware::from_fn(client_ip::client_ip_middleware))
 		.layer(SetSensitiveRequestHeadersLayer::from_shared(Arc::clone(&headers)))
@@ -102,16 +130,7 @@ pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 					http::Method::DELETE,
 					http::Method::OPTIONS,
 				])
-				.allow_headers([
-					http::header::ACCEPT,
-					http::header::ACCEPT_ENCODING,
-					http::header::AUTHORIZATION,
-					http::header::CONTENT_TYPE,
-					http::header::ORIGIN,
-					headers::NS.parse().unwrap(),
-					headers::DB.parse().unwrap(),
-					headers::ID.parse().unwrap(),
-				])
+				.allow_headers(allow_header)
 				// allow requests from any origin
 				.allow_origin(Any)
 				.max_age(Duration::from_secs(86400)),

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -542,6 +542,7 @@ mod http_integration {
 	}
 
 	#[test(tokio::test)]
+	#[cfg(feature = "http-compression")]
 	async fn sql_endpoint_with_compression() -> Result<(), Box<dyn std::error::Error>> {
 		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 		let url = &format!("http://{addr}/sql");


### PR DESCRIPTION
## What is the motivation?

Since the HTTP compression has been added, the CI tasks `Check clippy` and `Test workspace` require a 4-core machine. 

## What does this change do?

The HTTP compression has to be enabled through a feature flag `http-compression`.
It is enabled only for the HTTP integration test and for the release.

The feature is just for the `build` task in `nightly.yml`, `release.yml`, and for the `ci-integration tests` on `ci.yml`.
Both tasks `ci-clippy` and `test-workspaces` are back to ubuntu-latest.

## What is your testing strategy?

N/A

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
