### PR TITLE
Repetitive expressions and idioms are not anymore re-evaluated

### DIFF
--- a/lib/src/idx/planner/executor.rs
+++ b/lib/src/idx/planner/executor.rs
@@ -11,7 +11,7 @@ use crate::idx::planner::iterators::{
 };
 use crate::idx::planner::plan::IndexOperator::Matches;
 use crate::idx::planner::plan::{IndexOperator, IndexOption, RangeValue};
-use crate::idx::planner::tree::{IndexMap, IndexRef};
+use crate::idx::planner::tree::{IndexRef, IndexesMap};
 use crate::idx::trees::mtree::MTreeIndex;
 use crate::idx::trees::store::TreeStoreType;
 use crate::idx::IndexKeyBase;
@@ -31,8 +31,8 @@ pub(crate) struct QueryExecutor {
 	mr_entries: HashMap<MatchRef, FtEntry>,
 	exp_entries: HashMap<Arc<Expression>, FtEntry>,
 	it_entries: Vec<IteratorEntry>,
-	index_definitions: HashMap<IndexRef, DefineIndexStatement>,
-	mt_exp: HashMap<Arc<Expression>, MtEntry>,
+	index_definitions: Vec<DefineIndexStatement>,
+	mt_entries: HashMap<Arc<Expression>, MtEntry>,
 }
 
 pub(crate) type IteratorRef = u16;
@@ -47,7 +47,7 @@ impl IteratorEntry {
 		match self {
 			Self::Single(_, io) => {
 				io.explain(e);
-				io.ir()
+				io.ix_ref()
 			}
 			Self::Range(_, ir, from, to) => {
 				e.insert("from", Value::from(from));
@@ -62,25 +62,24 @@ impl QueryExecutor {
 		opt: &Options,
 		txn: &Transaction,
 		table: &Table,
-		im: IndexMap,
+		im: IndexesMap,
 	) -> Result<Self, Error> {
 		let mut run = txn.lock().await;
-
 		let mut mr_entries = HashMap::default();
 		let mut exp_entries = HashMap::default();
 		let mut ft_map = HashMap::default();
 		let mut mt_map: HashMap<IndexRef, MTreeIndex> = HashMap::default();
-		let mut mt_exp = HashMap::default();
+		let mut mt_entries = HashMap::default();
 
 		// Create all the instances of FtIndex
-		// Build the FtEntries and map them to Expressions and MatchRef
+		// Build the FtEntries and map them to Idioms and MatchRef
 		for (exp, io) in im.options {
-			let ir = io.ir();
-			if let Some(idx_def) = im.definitions.get(&ir) {
+			let ix_ref = io.ix_ref();
+			if let Some(idx_def) = im.definitions.get(ix_ref as usize) {
 				match &idx_def.index {
 					Index::Search(p) => {
 						let mut ft_entry = None;
-						if let Some(ft) = ft_map.get(&ir) {
+						if let Some(ft) = ft_map.get(&ix_ref) {
 							if ft_entry.is_none() {
 								ft_entry = FtEntry::new(&mut run, ft, io).await?;
 							}
@@ -92,7 +91,7 @@ impl QueryExecutor {
 							if ft_entry.is_none() {
 								ft_entry = FtEntry::new(&mut run, &ft, io).await?;
 							}
-							ft_map.insert(ir, ft);
+							ft_map.insert(ix_ref, ft);
 						}
 						if let Some(e) = ft_entry {
 							if let Matches(_, Some(mr)) = e.0.index_option.op() {
@@ -107,17 +106,17 @@ impl QueryExecutor {
 					}
 					Index::MTree(p) => {
 						if let IndexOperator::Knn(a, k) = io.op() {
-							let entry = if let Some(mt) = mt_map.get(&ir) {
+							let entry = if let Some(mt) = mt_map.get(&ix_ref) {
 								MtEntry::new(&mut run, mt, a.clone(), *k).await?
 							} else {
 								let ikb = IndexKeyBase::new(opt, idx_def);
 								let mt =
 									MTreeIndex::new(&mut run, ikb, p, TreeStoreType::Read).await?;
 								let entry = MtEntry::new(&mut run, &mt, a.clone(), *k).await?;
-								mt_map.insert(ir, mt);
+								mt_map.insert(ix_ref, mt);
 								entry
 							};
-							mt_exp.insert(exp, entry);
+							mt_entries.insert(exp, entry);
 						}
 					}
 					_ => {}
@@ -132,7 +131,7 @@ impl QueryExecutor {
 			exp_entries,
 			it_entries: Vec::new(),
 			index_definitions: im.definitions,
-			mt_exp,
+			mt_entries,
 		})
 	}
 
@@ -158,6 +157,7 @@ impl QueryExecutor {
 		(ir as usize) < self.it_entries.len()
 	}
 
+	/// Returns `true` if either the expression is matching the current iterator.
 	pub(crate) fn is_iterator_expression(&self, ir: IteratorRef, exp: &Expression) -> bool {
 		match self.it_entries.get(ir as usize) {
 			Some(IteratorEntry::Single(e, ..)) => exp.eq(e.as_ref()),
@@ -171,7 +171,7 @@ impl QueryExecutor {
 			Some(ie) => {
 				let mut e = HashMap::default();
 				let ir = ie.explain(&mut e);
-				if let Some(ix) = self.index_definitions.get(&ir) {
+				if let Some(ix) = self.index_definitions.get(ir as usize) {
 					e.insert("index", Value::from(ix.name.0.to_owned()));
 				}
 				Value::from(Object::from(e))
@@ -192,19 +192,19 @@ impl QueryExecutor {
 	pub(crate) async fn new_iterator(
 		&self,
 		opt: &Options,
-		ir: IteratorRef,
+		it_ref: IteratorRef,
 	) -> Result<Option<ThingIterator>, Error> {
-		if let Some(it_entry) = self.it_entries.get(ir as usize) {
+		if let Some(it_entry) = self.it_entries.get(it_ref as usize) {
 			match it_entry {
 				IteratorEntry::Single(_, io) => {
-					if let Some(ix) = self.index_definitions.get(&io.ir()) {
+					if let Some(ix) = self.index_definitions.get(io.ix_ref() as usize) {
 						match ix.index {
 							Index::Idx => Ok(Self::new_index_iterator(opt, ix, io.clone())),
 							Index::Uniq => Ok(Self::new_unique_index_iterator(opt, ix, io.clone())),
 							Index::Search {
 								..
-							} => self.new_search_index_iterator(ir, io.clone()).await,
-							Index::MTree(_) => Ok(self.new_mtree_index_knn_iterator(ir)),
+							} => self.new_search_index_iterator(it_ref, io.clone()).await,
+							Index::MTree(_) => Ok(self.new_mtree_index_knn_iterator(it_ref)),
 						}
 					} else {
 						Ok(None)
@@ -242,7 +242,7 @@ impl QueryExecutor {
 		from: &RangeValue,
 		to: &RangeValue,
 	) -> Option<ThingIterator> {
-		if let Some(ix) = self.index_definitions.get(&ir) {
+		if let Some(ix) = self.index_definitions.get(ir as usize) {
 			match ix.index {
 				Index::Idx => {
 					return Some(ThingIterator::IndexRange(IndexRangeThingIterator::new(
@@ -275,12 +275,12 @@ impl QueryExecutor {
 
 	async fn new_search_index_iterator(
 		&self,
-		ir: IteratorRef,
+		it_ref: IteratorRef,
 		io: IndexOption,
 	) -> Result<Option<ThingIterator>, Error> {
-		if let Some(IteratorEntry::Single(exp, ..)) = self.it_entries.get(ir as usize) {
+		if let Some(IteratorEntry::Single(exp, ..)) = self.it_entries.get(it_ref as usize) {
 			if let Matches(_, _) = io.op() {
-				if let Some(fti) = self.ft_map.get(&io.ir()) {
+				if let Some(fti) = self.ft_map.get(&io.ix_ref()) {
 					if let Some(fte) = self.exp_entries.get(exp.as_ref()) {
 						let it = MatchesThingIterator::new(fti, fte.0.terms_docs.clone()).await?;
 						return Ok(Some(ThingIterator::Matches(it)));
@@ -291,9 +291,9 @@ impl QueryExecutor {
 		Ok(None)
 	}
 
-	fn new_mtree_index_knn_iterator(&self, ir: IteratorRef) -> Option<ThingIterator> {
-		if let Some(IteratorEntry::Single(exp, ..)) = self.it_entries.get(ir as usize) {
-			if let Some(mte) = self.mt_exp.get(exp.as_ref()) {
+	fn new_mtree_index_knn_iterator(&self, it_ref: IteratorRef) -> Option<ThingIterator> {
+		if let Some(IteratorEntry::Single(exp, ..)) = self.it_entries.get(it_ref as usize) {
+			if let Some(mte) = self.mt_entries.get(exp.as_ref()) {
 				let it = KnnThingIterator::new(mte.doc_ids.clone(), mte.res.clone());
 				return Some(ThingIterator::Knn(it));
 			}
@@ -353,7 +353,7 @@ impl QueryExecutor {
 
 	fn get_ft_entry_and_index(&self, match_ref: &Value) -> Option<(&FtEntry, &FtIndex)> {
 		if let Some(e) = self.get_ft_entry(match_ref) {
-			if let Some(ft) = self.ft_map.get(&e.0.index_option.ir()) {
+			if let Some(ft) = self.ft_map.get(&e.0.index_option.ix_ref()) {
 				return Some((e, ft));
 			}
 		}
@@ -372,7 +372,15 @@ impl QueryExecutor {
 		if let Some((e, ft)) = self.get_ft_entry_and_index(match_ref) {
 			let mut run = txn.lock().await;
 			return ft
-				.highlight(&mut run, thg, &e.0.terms, prefix, suffix, e.0.index_option.id(), doc)
+				.highlight(
+					&mut run,
+					thg,
+					&e.0.terms,
+					prefix,
+					suffix,
+					e.0.index_option.id_ref(),
+					doc,
+				)
 				.await;
 		}
 		Ok(Value::None)

--- a/lib/src/idx/planner/plan.rs
+++ b/lib/src/idx/planner/plan.rs
@@ -2,8 +2,8 @@ use crate::err::Error;
 use crate::idx::ft::MatchRef;
 use crate::idx::planner::tree::{IndexRef, Node};
 use crate::sql::with::With;
-use crate::sql::{Array, Object};
-use crate::sql::{Expression, Idiom, Operator, Value};
+use crate::sql::{Array, Idiom, Object};
+use crate::sql::{Expression, Operator, Value};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
@@ -27,14 +27,14 @@ impl PlanBuilder {
 			return Ok(Plan::TableIterator(Some("WITH NOINDEX".to_string())));
 		}
 		let mut b = PlanBuilder {
-			indexes: Vec::new(),
-			range_queries: HashMap::new(),
+			indexes: Default::default(),
+			range_queries: Default::default(),
 			with_indexes,
 			all_and: true,
 			all_exp_with_index: true,
 		};
 		// Browse the AST and collect information
-		if let Err(e) = b.eval_node(root) {
+		if let Err(e) = b.eval_node(&root) {
 			return Ok(Plan::TableIterator(Some(e.to_string())));
 		}
 		// If we didn't found any index, we're done with no index plan
@@ -62,16 +62,16 @@ impl PlanBuilder {
 	}
 
 	// Check if we have an explicit list of index we can use
-	fn filter_index_option(&self, io: Option<IndexOption>) -> Option<IndexOption> {
+	fn filter_index_option(&self, io: Option<&IndexOption>) -> Option<IndexOption> {
 		if let Some(io) = &io {
-			if !self.with_indexes.is_empty() && !self.with_indexes.contains(&io.ir()) {
+			if !self.with_indexes.is_empty() && !self.with_indexes.contains(&io.ix_ref()) {
 				return None;
 			}
 		}
-		io
+		io.cloned()
 	}
 
-	fn eval_node(&mut self, node: Node) -> Result<(), String> {
+	fn eval_node(&mut self, node: &Node) -> Result<(), String> {
 		match node {
 			Node::Expression {
 				io,
@@ -83,16 +83,16 @@ impl PlanBuilder {
 					self.all_and = false;
 				}
 				let is_bool = self.check_boolean_operator(exp.operator());
-				if let Some(io) = self.filter_index_option(io) {
-					self.add_index_option(exp, io);
+				if let Some(io) = self.filter_index_option(io.as_ref()) {
+					self.add_index_option(exp.clone(), io);
 				} else if self.all_exp_with_index && !is_bool {
 					self.all_exp_with_index = false;
 				}
-				self.eval_node(*left)?;
-				self.eval_node(*right)?;
+				self.eval_node(left)?;
+				self.eval_node(right)?;
 				Ok(())
 			}
-			Node::Unsupported(reason) => Err(reason),
+			Node::Unsupported(reason) => Err(reason.to_owned()),
 			_ => Ok(()),
 		}
 	}
@@ -112,7 +112,7 @@ impl PlanBuilder {
 
 	fn add_index_option(&mut self, exp: Arc<Expression>, io: IndexOption) {
 		if let IndexOperator::RangePart(o, v) = io.op() {
-			match self.range_queries.entry(io.ir()) {
+			match self.range_queries.entry(io.ix_ref()) {
 				Entry::Occupied(mut e) => {
 					e.get_mut().add(exp.clone(), o, v);
 				}
@@ -140,7 +140,7 @@ pub(crate) struct IndexOption(Arc<Inner>);
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub(super) struct Inner {
 	ir: IndexRef,
-	id: Idiom,
+	id: Arc<Idiom>,
 	op: IndexOperator,
 }
 
@@ -154,7 +154,7 @@ pub(super) enum IndexOperator {
 }
 
 impl IndexOption {
-	pub(super) fn new(ir: IndexRef, id: Idiom, op: IndexOperator) -> Self {
+	pub(super) fn new(ir: IndexRef, id: Arc<Idiom>, op: IndexOperator) -> Self {
 		Self(Arc::new(Inner {
 			ir,
 			id,
@@ -166,7 +166,7 @@ impl IndexOption {
 		matches!(self.0.op, IndexOperator::Union(_))
 	}
 
-	pub(super) fn ir(&self) -> IndexRef {
+	pub(super) fn ix_ref(&self) -> IndexRef {
 		self.0.ir
 	}
 
@@ -174,8 +174,8 @@ impl IndexOption {
 		&self.0.op
 	}
 
-	pub(super) fn id(&self) -> &Idiom {
-		&self.0.id
+	pub(super) fn id_ref(&self) -> &Idiom {
+		self.0.id.as_ref()
 	}
 
 	fn reduce_array(v: &Value) -> Value {
@@ -307,21 +307,23 @@ impl RangeQueryBuilder {
 #[cfg(test)]
 mod tests {
 	use crate::idx::planner::plan::{IndexOperator, IndexOption, RangeValue};
+	use crate::sql::test::Parse;
 	use crate::sql::{Array, Idiom, Value};
 	use std::collections::HashSet;
+	use std::sync::Arc;
 
 	#[test]
 	fn test_hash_index_option() {
 		let mut set = HashSet::new();
 		let io1 = IndexOption::new(
 			1,
-			Idiom::from("a.b".to_string()),
+			Arc::new(Idiom::parse("test")),
 			IndexOperator::Equality(Value::Array(Array::from(vec!["test"]))),
 		);
 
 		let io2 = IndexOption::new(
 			1,
-			Idiom::from("a.b".to_string()),
+			Arc::new(Idiom::parse("test")),
 			IndexOperator::Equality(Value::Array(Array::from(vec!["test"]))),
 		);
 

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -116,7 +116,7 @@ pub async fn init(
 	};
 
 	if !hide_welcome {
-		let hints = vec![
+		let hints = [
 			(true, "Different statements within a query should be separated by a (;) semicolon."),
 			(!multi, "To create a multi-line query, end your lines with a (\\) backslash, and press enter."),
 			(true, "To exit, send a SIGTERM or press CTRL+C")


### PR DESCRIPTION
## What is the motivation?

Along a WHERE clause, it is not rare (for range per example) for the same idiom to be repeated.
Eg.: 
```sql
SELECT * FROM student WHERE age > 18 and age < 21;
```

The same expression (combined with OR and AND) may also be repeated.

```sql
SELECT * FROM student WHERE (name = 'Foo' AND age > 18)  OR  (name = 'Bar' AND age > 21);
```

Actually the query planner re-evaluates the repeated expressions (evaluating the left and right values) and idioms (detecting if an index exists).

## What does this change do?

The query planner remembers if an expression or an idiom has already been evaluated and reuses the same outcome.
Some code cleaning has been also done, renaming some variables to avoid ambiguity.
Hashmap (previously used to deduplicate the resolved expression) has been replaced by Vector.

## What is your testing strategy?

No new test has been added.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
