### PR TITLE
`NONE` with `ONLY` keyword for zero results

### DIFF
--- a/lib/src/sql/statements/create.rs
+++ b/lib/src/sql/statements/create.rs
@@ -71,7 +71,9 @@ impl CreateStatement {
 			Value::Array(mut a) if self.only => match a.len() {
 				// There was exactly one result
 				1 => Ok(a.remove(0)),
-				// There were no results
+				// There was no result
+				0 => Ok(Value::None),
+				// There was more than 1 result
 				_ => Err(Error::SingleOnlyOutput),
 			},
 			// This is standard query result

--- a/lib/src/sql/statements/delete.rs
+++ b/lib/src/sql/statements/delete.rs
@@ -70,7 +70,9 @@ impl DeleteStatement {
 			Value::Array(mut a) if self.only => match a.len() {
 				// There was exactly one result
 				1 => Ok(a.remove(0)),
-				// There were no results
+				// There was no result
+				0 => Ok(Value::None),
+				// There was more than 1 result
 				_ => Err(Error::SingleOnlyOutput),
 			},
 			// This is standard query result

--- a/lib/src/sql/statements/relate.rs
+++ b/lib/src/sql/statements/relate.rs
@@ -181,7 +181,9 @@ impl RelateStatement {
 			Value::Array(mut a) if self.only => match a.len() {
 				// There was exactly one result
 				1 => Ok(a.remove(0)),
-				// There were no results
+				// There was no result
+				0 => Ok(Value::None),
+				// There was more than 1 result
 				_ => Err(Error::SingleOnlyOutput),
 			},
 			// This is standard query result

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -144,7 +144,9 @@ impl SelectStatement {
 			Value::Array(mut a) if self.only => match a.len() {
 				// There was exactly one result
 				1 => Ok(a.remove(0)),
-				// There were no results
+				// There was no result
+				0 => Ok(Value::None),
+				// There was more than 1 result
 				_ => Err(Error::SingleOnlyOutput),
 			},
 			// This is standard query result

--- a/lib/src/sql/statements/update.rs
+++ b/lib/src/sql/statements/update.rs
@@ -72,7 +72,9 @@ impl UpdateStatement {
 			Value::Array(mut a) if self.only => match a.len() {
 				// There was exactly one result
 				1 => Ok(a.remove(0)),
-				// There were no results
+				// There was no result
+				0 => Ok(Value::None),
+				// There was more than 1 result
 				_ => Err(Error::SingleOnlyOutput),
 			},
 			// This is standard query result

--- a/lib/tests/relate.rs
+++ b/lib/tests/relate.rs
@@ -105,3 +105,39 @@ async fn relate_and_overwrite() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn relate_only() -> Result<(), Error> {
+	let sql: &str = "
+		RELATE ONLY test:1->edge:a->test:2;
+		RELATE ONLY []->edge:b->test:3;
+		RELATE ONLY [test:4, test:5]->edge:c->test:6;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 3);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"{
+			id: edge:a,
+			in: test:1,
+			out: test:2
+		}",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"NONE",
+	);
+	assert_eq!(tmp, val);
+	//
+	match res.remove(0).result {
+		Err(surrealdb::error::Db::SingleOnlyOutput) => (),
+		_ => panic!("Query should have failed with error: Expected a single result output when using the ONLY keyword")
+	}
+	//
+	Ok(())
+}

--- a/lib/tests/relate.rs
+++ b/lib/tests/relate.rs
@@ -129,9 +129,7 @@ async fn relate_only() -> Result<(), Error> {
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::parse(
-		"NONE",
-	);
+	let val = Value::parse("NONE");
 	assert_eq!(tmp, val);
 	//
 	match res.remove(0).result {

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -1008,3 +1008,49 @@ async fn check_permissions_auth_disabled() {
 		);
 	}
 }
+
+#[tokio::test]
+async fn select_only() -> Result<(), Error> {
+	let sql: &str = "
+		SELECT * FROM ONLY 123;
+		SELECT * FROM ONLY NONE;
+		SELECT * FROM ONLY [];
+		SELECT * FROM ONLY [123];
+		SELECT * FROM ONLY [1, 2, 3];
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 5);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"123",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"NONE",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"NONE",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"123",
+	);
+	assert_eq!(tmp, val);
+	//
+	match res.remove(0).result {
+		Err(surrealdb::error::Db::SingleOnlyOutput) => (),
+		_ => panic!("Query should have failed with error: Expected a single result output when using the ONLY keyword")
+	}
+	//
+	Ok(())
+}

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -1024,27 +1024,19 @@ async fn select_only() -> Result<(), Error> {
 	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::parse(
-		"123",
-	);
+	let val = Value::parse("123");
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::parse(
-		"NONE",
-	);
+	let val = Value::parse("NONE");
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::parse(
-		"NONE",
-	);
+	let val = Value::parse("NONE");
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::parse(
-		"123",
-	);
+	let val = Value::parse("123");
 	assert_eq!(tmp, val);
 	//
 	match res.remove(0).result {

--- a/lib/tests/update.rs
+++ b/lib/tests/update.rs
@@ -695,9 +695,7 @@ async fn update_only() -> Result<(), Error> {
 	assert_eq!(res.len(), 3);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::parse(
-		"NONE",
-	);
+	let val = Value::parse("NONE");
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

A statement like the following
```sql
SELECT * FROM ONLY user WHERE prop = 'val' LIMIT 1;
```
Results in `Expected a single result output when using the ONLY keyword`, as the result is `[]`. In certain scenario's you cannot directly select from an ID, in which can you need to trigger an index or a full table scan.

Given that selecting directly from an ID of a record that does not exist results in `NONE`, I believe this should too.

## What does this change do?

When `ONLY` statements result in an empty array, `NONE` will be returned instead of an empty array.

## What is your testing strategy?

Added tests for `ONLY` statements

## Is this related to any issues?

Fixes #2941

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
