### PR TITLE
Fix-link-for-documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/surrealdb/www.surrealdb.com/issues/
+    url: https://github.com/surrealdb/www.surrealdb.com/issues/new/choose
     about: Report issues with the documentation here.
   - name: Question or idea
     url: https://github.com/surrealdb/surrealdb/discussions

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/surrealdb/www.surrealdb.com/issues/new?assignees=Ekwuno&labels=documentation&projects=&template=documentation.yml&title=Documentation%3A+
+    url: https://github.com/surrealdb/www.surrealdb.com/issues/
+    about: Report issues with the documentation here.
   - name: Question or idea
     url: https://github.com/surrealdb/surrealdb/discussions
     about: Ask questions and discuss ideas here.


### PR DESCRIPTION
Link wasn't showing up for documentation repo. Should work now.