### PR TITLE
Bugfix: Fix `ORDER BY RAND()` failing to parse when selecting specific fields.

### DIFF
--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -322,6 +322,8 @@ impl Datastore {
 			}
 			// The datastore path is not valid
 			_ => {
+				// use clock_override and default_clock to remove warning when no kv is enabled.
+				let _ = (clock_override, default_clock);
 				info!("Unable to load the specified datastore {}", path);
 				Err(Error::Ds("Unable to load the specified datastore".into()))
 			}

--- a/lib/src/kvs/tests/mod.rs
+++ b/lib/src/kvs/tests/mod.rs
@@ -16,6 +16,8 @@ pub(crate) enum Kvs {
 	Fdb,
 }
 
+// This type is unsused when no store is enabled.
+#[allow(dead_code)]
 type ClockType = Arc<RwLock<SizedClock>>;
 
 #[cfg(feature = "kv-mem")]

--- a/lib/src/sql/special.rs
+++ b/lib/src/sql/special.rs
@@ -64,6 +64,10 @@ pub fn check_order_by_fields<'a>(
 	if let Some(orders) = orders {
 		// Loop over each of the expressions in the ORDER BY clause
 		for order in orders.iter() {
+			if order.random {
+				// don't check for a field if the order is random.
+				continue;
+			}
 			if !contains_idiom(fields, order) {
 				// If the expression isn't specified in the SELECT clause, then error
 				return Err(Failure(ParseError::Order(i, order.to_string())));

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -323,6 +323,6 @@ mod tests {
 
 	#[test]
 	fn select_order_by_rand() {
-		assert_parsable("SELECT foo,bar FROM test ORDER BY RAND()");
+		assert_parsable("SELECT foo, bar FROM test ORDER BY RAND()");
 	}
 }

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -322,5 +322,7 @@ mod tests {
 	}
 
 	#[test]
-	fn select_with_function() {}
+	fn select_order_by_rand() {
+		assert_parsable("SELECT foo,bar FROM test ORDER BY RAND()");
+	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The parser checks, when doing an `ORDER BY` statement if the field to be ordered by is present in the fields to be selected. However when ordering by random no such field is required but the check is still performed, always failing unless using a wildcard field select.

## What does this change do?

Changed the check to skip checking for a field when ordering by random.

## What is your testing strategy?

Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

I added a test for this specific bug.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
