### PR TITLE
Change math::median indexing for even length arrays

### DIFF
--- a/lib/src/fnc/util/math/median.rs
+++ b/lib/src/fnc/util/math/median.rs
@@ -13,7 +13,35 @@ impl Median for Sorted<&Vec<Number>> {
 			self.0[self.0.len() / 2].to_float()
 		} else {
 			// return the average of the middles: _ _ X Y _ _
-			(self.0[self.0.len() / 2].to_float() + self.0[self.0.len() / 2 + 1].to_float()) / 2.0
+			(self.0[self.0.len() / 2 - 1].to_float() + self.0[self.0.len() / 2].to_float()) / 2.0
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::sql::number::Sort;
+
+	#[test]
+	fn test_median() {
+		let tests: Vec<(Vec<Number>, f64)> = vec![
+			(vec![], f64::NAN),
+			(vec![1.into()], 1.0),
+			(vec![1.into(), 2.into()], 1.5),
+			(vec![1.into(), 2.into(), 3.into()], 2.0),
+			(vec![1.into(), 2.into(), 3.into(), 4.into()], 2.5),
+		];
+
+		for (mut data, expected) in tests {
+			let sorted = data.sorted();
+
+			let actual = sorted.median();
+			if f64::is_nan(expected) {
+				assert!(f64::is_nan(actual));
+			} else {
+				assert_eq!(expected, actual);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What is the motivation?

`math::median` does not work as expected.

## What does this change do?

Fix indexing to use middle values for even length arrays in `math::median`.

## What is your testing strategy?

Added unit tests.

## Is this related to any issues?

Related issue https://github.com/surrealdb/surrealdb/issues/2970

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
