### PR TITLE
Bugfix: Fix identifiers which look like numbers failing to parse.

### DIFF
--- a/lib/src/sql/number.rs
+++ b/lib/src/sql/number.rs
@@ -745,7 +745,7 @@ impl Sort for Vec<Number> {
 fn not_nan(i: &str) -> IResult<&str, Number> {
 	// recognize_float can return a failure, since identifiers in surrealql can look like numbers
 	// it should never prematuraly stop parsing if we encounter a number, which is why we change
-	// a failure here to an normal error.
+	// a failure here to a normal error.
 	let (i, v) = match recognize_float(i) {
 		Ok(x) => x,
 		Err(Err::Failure(e)) | Err(Err::Error(e)) => return Err(Err::Error(e)),

--- a/lib/src/sql/number.rs
+++ b/lib/src/sql/number.rs
@@ -743,7 +743,14 @@ impl Sort for Vec<Number> {
 }
 
 fn not_nan(i: &str) -> IResult<&str, Number> {
-	let (i, v) = recognize_float(i)?;
+	// recognize_float can return a failure, since identifiers in surrealql can look like numbers
+	// it should never prematuraly stop parsing if we encounter a number, which is why we change
+	// a failure here to an normal error.
+	let (i, v) = match recognize_float(i) {
+		Ok(x) => x,
+		Err(Err::Failure(e)) | Err(Err::Error(e)) => return Err(Err::Error(e)),
+		Err(x) => return Err(x),
+	};
 	let (i, suffix) = suffix(i)?;
 	let (i, _) = ending(i)?;
 	let number = match suffix {

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -3090,4 +3090,10 @@ mod tests {
 		let dec: Value = enc.try_into().unwrap();
 		assert_eq!(res, dec);
 	}
+
+	#[test]
+	fn parse_false_exponent_number() {
+		let (_, v) = what("3e").unwrap();
+		assert_eq!(v, Value::Table(Table("3e".to_owned())))
+	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What does this change do?

There is a bug in the current parser where identifiers which look like a number with a missing exponent, like for instance: `3e`, fail to parse. This PR fixes that bug.

## What is your testing strategy?

Introduced a test for this specific issue.

## Is this related to any issues?

None found.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
