### PR TITLE
Add FETCH example

### DIFF
--- a/lib/examples/fetch/main.rs
+++ b/lib/examples/fetch/main.rs
@@ -7,10 +7,10 @@ use surrealdb::Surreal;
 
 // Dance classes table name
 const DANCE: &str = "dance";
-// Student classes table name
+// Students table name
 const STUDENT: &str = "student";
 
-// Dance class schema
+// Dance class table schema
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DanceClass {
@@ -19,7 +19,7 @@ struct DanceClass {
 	created_at: Datetime,
 }
 
-// Student schema
+// Student table schema
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct Student {
@@ -41,7 +41,7 @@ async fn main() -> surrealdb::Result<()> {
 	})
 	.await?;
 
-	// Select the username and namespace to use
+	// Select the namespace and database to use
 	db.use_ns("namespace").use_db("database").await?;
 
 	// Create a dance class and store the result
@@ -56,7 +56,8 @@ async fn main() -> surrealdb::Result<()> {
 
 	// Create a student and assign them to the previous dance class
 	// We don't care about the result here so we don't need to
-	// type-hint and store it. We use `Resource::from` to avoid that.
+	// type-hint and store it. We use `Resource::from` to return
+	// a `sql::Value` instead and ignore it.
 	db.create(Resource::from(STUDENT))
 		.content(Student {
 			classes,

--- a/lib/examples/fetch/main.rs
+++ b/lib/examples/fetch/main.rs
@@ -1,10 +1,9 @@
-use chrono::DateTime;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use surrealdb::engine::remote::ws::Ws;
 use surrealdb::opt::auth::Root;
 use surrealdb::opt::Resource;
-use surrealdb::sql::Thing;
+use surrealdb::sql::{Datetime, Thing};
 use surrealdb::Surreal;
 
 // Dance classes table name
@@ -18,7 +17,7 @@ const STUDENT: &str = "student";
 struct DanceClass {
 	id: Thing,
 	name: String,
-	created_at: DateTime<Utc>,
+	created_at: Datetime,
 }
 
 // Student schema
@@ -28,7 +27,7 @@ struct Student {
 	id: Thing,
 	name: String,
 	classes: Vec<DanceClass>,
-	created_at: DateTime<Utc>,
+	created_at: Datetime,
 }
 
 #[tokio::main]
@@ -52,7 +51,7 @@ async fn main() -> surrealdb::Result<()> {
 		.content(DanceClass {
 			id: Thing::from((DANCE, "dc101")),
 			name: "Introduction to Dancing".to_owned(),
-			created_at: Utc::now(),
+			created_at: Utc::now().into(),
 		})
 		.await?;
 
@@ -64,7 +63,7 @@ async fn main() -> surrealdb::Result<()> {
 			classes,
 			id: Thing::from((STUDENT, "jane")),
 			name: "Jane Doe".to_owned(),
-			created_at: Utc::now(),
+			created_at: Utc::now().into(),
 		})
 		.await?;
 

--- a/lib/examples/fetch/main.rs
+++ b/lib/examples/fetch/main.rs
@@ -1,0 +1,84 @@
+use chrono::DateTime;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use surrealdb::engine::remote::ws::Ws;
+use surrealdb::opt::auth::Root;
+use surrealdb::opt::Resource;
+use surrealdb::sql::Thing;
+use surrealdb::Surreal;
+
+// Dance classes table name
+const DANCE: &str = "dance";
+// Student classes table name
+const STUDENT: &str = "student";
+
+// Dance class schema
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DanceClass {
+	id: Thing,
+	name: String,
+	created_at: DateTime<Utc>,
+}
+
+// Student schema
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Student {
+	id: Thing,
+	name: String,
+	classes: Vec<DanceClass>,
+	created_at: DateTime<Utc>,
+}
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+	// Connect to the database server
+	let db = Surreal::new::<Ws>("localhost:8000").await?;
+
+	// Sign in into the server
+	db.signin(Root {
+		username: "root",
+		password: "root",
+	})
+	.await?;
+
+	// Select the username and namespace to use
+	db.use_ns("namespace").use_db("database").await?;
+
+	// Create a dance class and store the result
+	let classes = db
+		.create(DANCE)
+		.content(DanceClass {
+			id: Thing::from((DANCE, "dc101")),
+			name: "Introduction to Dancing".to_owned(),
+			created_at: Utc::now(),
+		})
+		.await?;
+
+	// Create a student and assign them to the previous dance class
+	// We don't care about the result here so we don't need to
+	// type-hint and store it. We use `Resource::from` to avoid that.
+	db.create(Resource::from(STUDENT))
+		.content(Student {
+			classes,
+			id: Thing::from((STUDENT, "jane")),
+			name: "Jane Doe".to_owned(),
+			created_at: Utc::now(),
+		})
+		.await?;
+
+	// Prepare the SQL query to retrieve students and full class info
+	let sql = format!("SELECT * FROM {STUDENT} FETCH classes");
+
+	// Run the query
+	let mut results = db.query(sql).await?;
+
+	// Extract the first query statement result and deserialise it as a vector of students
+	let students: Vec<Student> = results.take(0)?;
+
+	// Use the result as you see fit. In this case we are simply pretty printing it.
+	dbg!(students);
+
+	Ok(())
+}

--- a/lib/examples/fetch/main.rs
+++ b/lib/examples/fetch/main.rs
@@ -1,9 +1,8 @@
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use surrealdb::engine::remote::ws::Ws;
 use surrealdb::opt::auth::Root;
 use surrealdb::opt::Resource;
-use surrealdb::sql::{Datetime, Thing};
+use surrealdb::sql::{Datetime, Id, Thing};
 use surrealdb::Surreal;
 
 // Dance classes table name
@@ -49,9 +48,9 @@ async fn main() -> surrealdb::Result<()> {
 	let classes = db
 		.create(DANCE)
 		.content(DanceClass {
-			id: Thing::from((DANCE, "dc101")),
+			id: Thing::from((DANCE, Id::rand())),
 			name: "Introduction to Dancing".to_owned(),
-			created_at: Utc::now().into(),
+			created_at: Datetime::default(),
 		})
 		.await?;
 
@@ -61,9 +60,9 @@ async fn main() -> surrealdb::Result<()> {
 	db.create(Resource::from(STUDENT))
 		.content(Student {
 			classes,
-			id: Thing::from((STUDENT, "jane")),
+			id: Thing::from((STUDENT, Id::rand())),
 			name: "Jane Doe".to_owned(),
-			created_at: Utc::now().into(),
+			created_at: Datetime::default(),
 		})
 		.await?;
 


### PR DESCRIPTION
## What is the motivation?

Our examples do not currently show how to use `FETCH` with the Rust SDK.

## What does this change do?

Adds `examples/fetch` showcasing how to use that statement and deserialising the response.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

- [Requested on Discord](https://discord.com/channels/902568124350599239/1014970959461105664/1172600541096972368)
- Closes https://github.com/surrealdb/surrealdb/issues/2918.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
