### PR TITLE
Bug fix: possible corruption of MTree and incomplete knn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,6 +1741,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "distances"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e326dfe6005e22948261065eec25180c39787702a73db3a3e63d4b8bee5604d"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "dmp"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5283,6 +5292,7 @@ dependencies = [
  "chrono",
  "criterion",
  "deunicode",
+ "distances",
  "dmp",
  "echodb",
  "env_logger",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -64,6 +64,7 @@ channel = { version = "1.9.0", package = "async-channel" }
 chrono = { version = "0.4.26", features = ["serde"] }
 derive = { version = "0.12.0", package = "surrealdb-derive" }
 deunicode = "1.3.3"
+distances = "1.6.2"
 dmp = "0.2.0"
 echodb = { version = "0.4.0", optional = true }
 executor = { version = "1.5.1", package = "async-executor" }

--- a/lib/src/idx/trees/mtree.rs
+++ b/lib/src/idx/trees/mtree.rs
@@ -518,18 +518,6 @@ impl MTree {
 		}
 	}
 
-	#[cfg(debug_assertions)]
-	fn check_internal_node(info: &str, node: &InternalNode) -> Result<(), Error> {
-		let mut node_ids = HashSet::new();
-		for r in node.values() {
-			if !node_ids.insert(r.node) {
-				debug!("InternalNode: {} - Duplicate node id: {} - {:?}", info, r.node, node);
-				return Err(Error::Unreachable);
-			}
-		}
-		Ok(())
-	}
-
 	#[allow(clippy::too_many_arguments)]
 	async fn insert_node_internal(
 		&mut self,
@@ -574,16 +562,12 @@ impl MTree {
 					node.insert(o1, p1);
 					node.insert(o2, p2);
 					let max_dist = self.compute_internal_max_distance(&node);
-					#[cfg(debug_assertions)]
-					Self::check_internal_node("if (N U P will fit into N)", &node)?;
 					Self::set_stored_node(store, node_id, node_key, node.into_mtree_node(), true)?;
 					Ok(InsertionResult::CoveringRadius(max_dist))
 				} else {
 					node.insert(o1, p1);
 					node.insert(o2, p2);
 					// Split(N U P)
-					#[cfg(debug_assertions)]
-					Self::check_internal_node("Split(N U P)", &node)?;
 					let (o1, p1, o2, p2) = self.split_node(store, node_id, node_key, node)?;
 					Ok(InsertionResult::PromotedEntries(o1, p1, o2, p2))
 				}
@@ -1004,8 +988,6 @@ impl MTree {
 		}
 		// Return max(On E N) { parentDistance(On) + r(On)}
 		let max_dist = self.compute_internal_max_distance(&n_node);
-		#[cfg(debug_assertions)]
-		Self::check_internal_node("Return max(On E N) { parentDistance(On) + r(On)}", &n_node)?;
 		Self::set_stored_node(store, node_id, node_key, n_node.into_mtree_node(), n_updated)?;
 		Ok(DeletionResult::CoveringRadius(max_dist))
 	}


### PR DESCRIPTION
## What is the motivation?

The state of the MTree index was only updated if the root of the tree was updated. If intermediate internal nodes are created, the state of the index will not be stored (including the last node id), ending up with nodes sharing the same node id.

The eviction process of the priority list used in the knn-search was incomplete.

The node split didn't promote the right entries.

## What does this change do?

Fixes the 3 bugs.

## What is your testing strategy?

Test and checks have been updated.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
