### PR TITLE
Publish a nightly crate along with the nightly binary

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -252,6 +252,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add release-plz.toml
           git commit -am 'Prepare nightly release'
+          git checkout -b nightly
 
           # Install release-plz
           cargo install --force --version 0.3.30 release-plz

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -205,6 +205,47 @@ jobs:
             target/${{ matrix.arch }}/release/${{ matrix.file }}.txt
             target/${{ matrix.arch }}/release/${{ matrix.file }}.exe
 
+  crate:
+    name: Publish surrealdb-nightly to crates.io
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        shell: bash
+        run: |
+          # Install release-plz
+          cargo install --force --version 0.3.30 release-plz
+
+          # Change `surrealdb` crate name to `surrealdb-nightly`
+          git apply .patches/surrealdb-nightly.patch
+
+          # Get a timestamp of the last commit
+          timestamp=$(git show --no-patch --format=%ad --date=format:%Y%m%d%H%M%S)
+
+          # Get the short commit
+          shortRev=$(git rev-parse --short HEAD)
+
+          # Update the version to a nightly one
+          # This sets the nightly version to something like `1.20231117130416.72772367`
+          sed -i -E "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${timestamp}.${shortRev}\"#" lib/Cargo.toml
+
+          # Configure release-plz
+          cp -v .patches/release-nightly-plz.toml release-plz.toml
+
+          # Publish cargo crate
+          /home/runner/.cargo/bin/release-plz release
+
   docker:
     name: Build and publish Docker image
     needs: [build]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -227,24 +227,28 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         shell: bash
         run: |
-          # Install release-plz
-          cargo install --force --version 0.3.30 release-plz
-
           # Change `surrealdb` crate name to `surrealdb-nightly`
           git apply .patches/surrealdb-nightly.patch
 
-          # Get a timestamp of the last commit
-          timestamp=$(git show --no-patch --format=%ad --date=format:%Y%m%d%H%M%S)
+          # Get the date and time of the last commit
+          date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
+          time=$(git show --no-patch --format=%ad --date=format:%H%M%S)
+
+          # Update the version to a nightly one
+          # This sets the nightly version to something like `1.20231117.130416`
+          sed -i "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${date}.${time}\"#" lib/Cargo.toml
 
           # Get the short commit
           shortRev=$(git rev-parse --short HEAD)
 
-          # Update the version to a nightly one
-          # This sets the nightly version to something like `1.20231117130416.72772367`
-          sed -i "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${timestamp}.${shortRev}\"#" lib/Cargo.toml
+          # Update the description
+          sed -i "s#^description = `".*"`#description = \"A nightly release of the `surrealdb` crate based on commit `${shortRev}`\"#" lib/Cargo.toml
 
           # Configure release-plz
           cp -v .patches/release-nightly-plz.toml release-plz.toml
+
+          # Install release-plz
+          cargo install --force --version 0.3.30 release-plz
 
           # Publish cargo crate
           /home/runner/.cargo/bin/release-plz release

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -247,6 +247,12 @@ jobs:
           # Configure release-plz
           cp -v .patches/release-nightly-plz.toml release-plz.toml
 
+          # Commit changes
+          git config --local user.email "actions@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add release-plz.toml
+          git commit -am 'Prepare nightly release'
+
           # Install release-plz
           cargo install --force --version 0.3.30 release-plz
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -251,7 +251,7 @@ jobs:
           cargo install --force --version 0.3.30 release-plz
 
           # Publish cargo crate
-          /home/runner/.cargo/bin/release-plz release --dry-run --allow-dirty
+          /home/runner/.cargo/bin/release-plz release --dry-run
 
   docker:
     if: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -247,6 +247,12 @@ jobs:
           # Configure release-plz
           cp -v .patches/release-nightly-plz.toml release-plz.toml
 
+          ls -l
+
+          git status
+          git branch
+          git show
+
           # Install release-plz
           cargo install --force --version 0.3.30 release-plz
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -251,7 +251,7 @@ jobs:
           cargo install --force --version 0.3.30 release-plz
 
           # Publish cargo crate
-          /home/runner/.cargo/bin/release-plz release
+          /home/runner/.cargo/bin/release-plz release --dry-run
 
   docker:
     if: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,7 @@ name: Nightly release
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
 
@@ -12,8 +13,9 @@ defaults:
 jobs:
 
   test:
+    if: false
     name: Test
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
 
       - name: Install stable toolchain
@@ -70,8 +72,9 @@ jobs:
           retention-days: 5
 
   lint:
+    if: false
     name: Lint
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     steps:
 
       - name: Checkout sources
@@ -104,6 +107,7 @@ jobs:
         run: cargo make ci-clippy
 
   build:
+    if: false
     name: Build ${{ matrix.arch }}
     needs: [test, lint]
     strategy:
@@ -207,7 +211,6 @@ jobs:
 
   crate:
     name: Publish surrealdb-nightly to crates.io
-    needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
 
@@ -247,6 +250,7 @@ jobs:
           /home/runner/.cargo/bin/release-plz release
 
   docker:
+    if: false
     name: Build and publish Docker image
     needs: [build]
     runs-on: ubuntu-latest
@@ -327,6 +331,7 @@ jobs:
           tags: surrealdb/surrealdb:${{ env.VERSION }}
 
   publish:
+    if: false
     name: Publish binaries for ${{ matrix.arch }}
     needs: [docker]
     strategy:
@@ -377,6 +382,7 @@ jobs:
           aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.txt s3://download.surrealdb.com/nightly/
 
   package-macos:
+    if: false
     name: Package macOS universal binary
     needs: [publish]
     runs-on: macos-latest
@@ -412,6 +418,7 @@ jobs:
           aws s3 cp --cache-control 'no-store' $FILE.txt s3://download.surrealdb.com/nightly/
 
   deploy:
+    if: false
     name: Deploy
     needs: [publish, package-macos]
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -245,6 +245,8 @@ jobs:
           cp -v .patches/release-nightly-plz.toml release-plz.toml
 
           # Commit changes
+          # We are not going to push these changes. We do this because
+          # some git commands `release-plz` runs do not work in detached state.
           git config --local user.email "actions@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add release-plz.toml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -242,7 +242,7 @@ jobs:
           shortRev=$(git rev-parse --short HEAD)
 
           # Update the description
-          sed -i "s#^description = `".*"`#description = \"A nightly release of the `surrealdb` crate based on commit `${shortRev}`\"#" lib/Cargo.toml
+          sed -i "s#^description = \".*\"#description = \"A nightly release of the surrealdb crate based on commit ${shortRev}\"#" lib/Cargo.toml
 
           # Configure release-plz
           cp -v .patches/release-nightly-plz.toml release-plz.toml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -247,12 +247,6 @@ jobs:
           # Configure release-plz
           cp -v .patches/release-nightly-plz.toml release-plz.toml
 
-          ls -l
-
-          git status
-          git branch
-          git show
-
           # Install release-plz
           cargo install --force --version 0.3.30 release-plz
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,6 @@ name: Nightly release
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     - cron: '0 0 * * *'
 
@@ -13,9 +12,8 @@ defaults:
 jobs:
 
   test:
-    if: false
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     steps:
 
       - name: Install stable toolchain
@@ -72,9 +70,8 @@ jobs:
           retention-days: 5
 
   lint:
-    if: false
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     steps:
 
       - name: Checkout sources
@@ -107,7 +104,6 @@ jobs:
         run: cargo make ci-clippy
 
   build:
-    if: false
     name: Build ${{ matrix.arch }}
     needs: [test, lint]
     strategy:
@@ -211,6 +207,7 @@ jobs:
 
   crate:
     name: Publish surrealdb-nightly to crates.io
+    needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
 
@@ -261,7 +258,6 @@ jobs:
           /home/runner/.cargo/bin/release-plz release
 
   docker:
-    if: false
     name: Build and publish Docker image
     needs: [build]
     runs-on: ubuntu-latest
@@ -342,7 +338,6 @@ jobs:
           tags: surrealdb/surrealdb:${{ env.VERSION }}
 
   publish:
-    if: false
     name: Publish binaries for ${{ matrix.arch }}
     needs: [docker]
     strategy:
@@ -393,7 +388,6 @@ jobs:
           aws s3 cp --cache-control 'no-store' ${{ matrix.file }}.txt s3://download.surrealdb.com/nightly/
 
   package-macos:
-    if: false
     name: Package macOS universal binary
     needs: [publish]
     runs-on: macos-latest
@@ -429,7 +423,6 @@ jobs:
           aws s3 cp --cache-control 'no-store' $FILE.txt s3://download.surrealdb.com/nightly/
 
   deploy:
-    if: false
     name: Deploy
     needs: [publish, package-macos]
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -241,7 +241,7 @@ jobs:
 
           # Update the version to a nightly one
           # This sets the nightly version to something like `1.20231117130416.72772367`
-          sed -i -E "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${timestamp}.${shortRev}\"#" lib/Cargo.toml
+          sed -i "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${timestamp}.${shortRev}\"#" lib/Cargo.toml
 
           # Configure release-plz
           cp -v .patches/release-nightly-plz.toml release-plz.toml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -251,7 +251,7 @@ jobs:
           cargo install --force --version 0.3.30 release-plz
 
           # Publish cargo crate
-          /home/runner/.cargo/bin/release-plz release --dry-run
+          /home/runner/.cargo/bin/release-plz release --dry-run --allow-dirty
 
   docker:
     if: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -258,7 +258,7 @@ jobs:
           cargo install --force --version 0.3.30 release-plz
 
           # Publish cargo crate
-          /home/runner/.cargo/bin/release-plz release --dry-run
+          /home/runner/.cargo/bin/release-plz release
 
   docker:
     if: false

--- a/.patches/release-nightly-plz.toml
+++ b/.patches/release-nightly-plz.toml
@@ -1,0 +1,6 @@
+[workspace]
+publish_allow_dirty = true
+changelog_update = false
+git_release_enable = false
+semver_check = false
+git_tag_enable = false

--- a/.patches/release-nightly-plz.toml
+++ b/.patches/release-nightly-plz.toml
@@ -1,5 +1,4 @@
 [workspace]
-publish_allow_dirty = true
 changelog_update = false
 git_release_enable = false
 semver_check = false

--- a/.patches/surrealdb-nightly.patch
+++ b/.patches/surrealdb-nightly.patch
@@ -1,0 +1,82 @@
+commit 1dcd4e78a3c3e7d9cc73f421080106cfa9aef8a8
+Author: Rushmore Mushambi <rushmore@surrealdb.com>
+Date:   Fri Nov 17 12:06:02 2023 +0200
+
+    Rename surrealdb crate to surrealdb-nightly
+
+diff --git a/Cargo.toml b/Cargo.toml
+index 55b05199..1bcaab5d 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -9,13 +9,13 @@ authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
+ [features]
+ # Public features
+ default = ["storage-mem", "storage-rocksdb", "scripting", "http"]
+-storage-mem = ["surrealdb/kv-mem", "has-storage"]
+-storage-rocksdb = ["surrealdb/kv-rocksdb", "has-storage"]
+-storage-speedb = ["surrealdb/kv-speedb", "has-storage"]
+-storage-tikv = ["surrealdb/kv-tikv", "has-storage"]
+-storage-fdb = ["surrealdb/kv-fdb-7_1", "has-storage"]
+-scripting = ["surrealdb/scripting"]
+-http = ["surrealdb/http"]
++storage-mem = ["surrealdb-nightly/kv-mem", "has-storage"]
++storage-rocksdb = ["surrealdb-nightly/kv-rocksdb", "has-storage"]
++storage-speedb = ["surrealdb-nightly/kv-speedb", "has-storage"]
++storage-tikv = ["surrealdb-nightly/kv-tikv", "has-storage"]
++storage-fdb = ["surrealdb-nightly/kv-fdb-7_1", "has-storage"]
++scripting = ["surrealdb-nightly/scripting"]
++http = ["surrealdb-nightly/http"]
+ http-compression = []
+ # Private features
+ has-storage = []
+@@ -60,7 +60,7 @@ serde = { version = "1.0.183", features = ["derive"] }
+ serde_cbor = "0.11.2"
+ serde_json = "1.0.104"
+ serde_pack = { version = "1.1.2", package = "rmp-serde" }
+-surrealdb = { path = "lib", features = ["protocol-http", "protocol-ws", "rustls"] }
++surrealdb-nightly = { path = "lib", features = ["protocol-http", "protocol-ws", "rustls"] }
+ tempfile = "3.7.1"
+ thiserror = "1.0.44"
+ tokio = { version = "1.31.0", features = ["macros", "signal"] }
+diff --git a/lib/Cargo.toml b/lib/Cargo.toml
+index 6bbdeb53..da9c7530 100644
+--- a/lib/Cargo.toml
++++ b/lib/Cargo.toml
+@@ -1,5 +1,5 @@
+ [package]
+-name = "surrealdb"
++name = "surrealdb-nightly"
+ publish = true
+ edition = "2021"
+ version = "1.0.0"
+@@ -143,6 +143,7 @@ uuid = { version = "1.4.1", features = ["serde", "v4", "v7"] }
+ 
+ [lib]
+ bench = false
++name = "surrealdb"
+ 
+ [[bench]]
+ name = "executor"
+diff --git a/lib/examples/actix/Cargo.toml b/lib/examples/actix/Cargo.toml
+index 8287a2f1..001e79e4 100644
+--- a/lib/examples/actix/Cargo.toml
++++ b/lib/examples/actix/Cargo.toml
+@@ -8,5 +8,5 @@ publish = false
+ actix-web = { version = "4.3.1", features = ["macros"] }
+ once_cell = "1.18.0"
+ serde = { version = "1.0.183", features = ["derive"] }
+-surrealdb = { path = "../.." }
++surrealdb-nightly = { path = "../.." }
+ thiserror = "1.0.44"
+diff --git a/lib/examples/axum/Cargo.toml b/lib/examples/axum/Cargo.toml
+index 75aaf04f..7a72847c 100644
+--- a/lib/examples/axum/Cargo.toml
++++ b/lib/examples/axum/Cargo.toml
+@@ -7,6 +7,6 @@ publish = false
+ [dependencies]
+ axum = "0.6.20"
+ serde = { version = "1.0.183", features = ["derive"] }
+-surrealdb = { path = "../.." }
++surrealdb-nightly = { path = "../.." }
+ thiserror = "1.0.44"
+ tokio = { version = "1.31.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
## What is the motivation?

We currently publish a nightly binary. This is great for experimenting with upcoming features in SurrealDB or testing bug fixes before a proper release is out. We do not currently publish a nightly crate, however. This means embedded SurrealDB and Rust SDK users wishing to test said nightly features and bug fixes currently have to resort to `git` dependencies.

## What does this change do?

It introduces a new crate, `surrealdb-nightly`. This crate simply publishes the corresponding `surrealdb` crate when publishing a nightly binary. After this, users will simply need to do `cargo add surrealdb-nightly` to experiment with the nightly changes. The reason for introducing a separate crate is to avoid adding a lot of version noise to the main crate. It also makes it possible to stay on the nightly channel for those who wish to live on the bleeding edge.

Switching from a nightly crate to a stable one is easy. If one has

```toml
surrealdb-nightly = "1"
```

in their `Cargo.toml`, they simply need to drop the `-nightly` suffix:

```toml
surrealdb = "1"
```

Since the nightly crate will be published almost every night, we can't use the version in `Cargo.toml` because we don't want to bump it. Instead, this PR introduces a new version based on the major version of the crate and the latest commit on the repo. The new version looks like `1.20231117.130416`.

The major part of this version is the major version of the `surrealdb` crate in the repo. The minor part of the version is the date of the latest commit. The patch part is the time of the latest commit. This allows us to push always increasing versions to crates.io and since these versions are repeatable, no new crates will be published to crates.io if there are no new commits on main since the previous version.

## What is your testing strategy?

Added a new job to the `nightly` workflow.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
