### PR TITLE
Env flag: `SURREAL_INSECURE_FORWARD_SCOPE_ERRORS`

### DIFF
--- a/lib/src/cnf/mod.rs
+++ b/lib/src/cnf/mod.rs
@@ -38,6 +38,6 @@ pub const PROCESSOR_BATCH_SIZE: u32 = 50;
 
 /// Forward all signup/signin query errors to a client trying authenticate to a scope. Do not use in production.
 pub static INSECURE_FORWARD_SCOPE_ERRORS: Lazy<bool> = Lazy::new(|| {
-	let val = std::env::var("INSECURE_FORWARD_SCOPE_ERRORS").unwrap_or("".to_string());
+	let val = std::env::var("INSECURE_FORWARD_SCOPE_ERRORS").unwrap_or("false".to_string());
 	val.to_lowercase() != "false"
 });

--- a/lib/src/cnf/mod.rs
+++ b/lib/src/cnf/mod.rs
@@ -35,3 +35,9 @@ pub const SERVER_NAME: &str = "SurrealDB";
 
 /// Datastore processor batch size for scan operations
 pub const PROCESSOR_BATCH_SIZE: u32 = 50;
+
+/// Set the maximum WebSocket frame size to 16mb
+pub static INSECURE_FORWARD_SCOPE_ERRORS: Lazy<bool> = Lazy::new(|| {
+	let val = std::env::var("INSECURE_FORWARD_SCOPE_ERRORS").unwrap_or("".to_string());
+	val.to_lowercase() != "false"
+});

--- a/lib/src/cnf/mod.rs
+++ b/lib/src/cnf/mod.rs
@@ -38,6 +38,6 @@ pub const PROCESSOR_BATCH_SIZE: u32 = 50;
 
 /// Forward all signup/signin query errors to a client trying authenticate to a scope. Do not use in production.
 pub static INSECURE_FORWARD_SCOPE_ERRORS: Lazy<bool> = Lazy::new(|| {
-	let val = std::env::var("INSECURE_FORWARD_SCOPE_ERRORS").unwrap_or("false".to_string());
+	let val = std::env::var("SURREAL_INSECURE_FORWARD_SCOPE_ERRORS").unwrap_or("false".to_string());
 	val.to_lowercase() != "false"
 });

--- a/lib/src/cnf/mod.rs
+++ b/lib/src/cnf/mod.rs
@@ -38,6 +38,8 @@ pub const PROCESSOR_BATCH_SIZE: u32 = 50;
 
 /// Forward all signup/signin query errors to a client trying authenticate to a scope. Do not use in production.
 pub static INSECURE_FORWARD_SCOPE_ERRORS: Lazy<bool> = Lazy::new(|| {
-	let val = std::env::var("SURREAL_INSECURE_FORWARD_SCOPE_ERRORS").unwrap_or("false".to_string());
-	val.to_lowercase() != "false"
+ 	let default = false;
+ 	std::env::var("SURREAL_INSECURE_FORWARD_SCOPE_ERRORS")
+ 		.map(|v| v.parse::<bool>().unwrap_or(default))
+ 		.unwrap_or(default)
 });

--- a/lib/src/cnf/mod.rs
+++ b/lib/src/cnf/mod.rs
@@ -38,8 +38,8 @@ pub const PROCESSOR_BATCH_SIZE: u32 = 50;
 
 /// Forward all signup/signin query errors to a client trying authenticate to a scope. Do not use in production.
 pub static INSECURE_FORWARD_SCOPE_ERRORS: Lazy<bool> = Lazy::new(|| {
- 	let default = false;
- 	std::env::var("SURREAL_INSECURE_FORWARD_SCOPE_ERRORS")
- 		.map(|v| v.parse::<bool>().unwrap_or(default))
- 		.unwrap_or(default)
+	let default = false;
+	std::env::var("SURREAL_INSECURE_FORWARD_SCOPE_ERRORS")
+		.map(|v| v.parse::<bool>().unwrap_or(default))
+		.unwrap_or(default)
 });

--- a/lib/src/cnf/mod.rs
+++ b/lib/src/cnf/mod.rs
@@ -36,7 +36,7 @@ pub const SERVER_NAME: &str = "SurrealDB";
 /// Datastore processor batch size for scan operations
 pub const PROCESSOR_BATCH_SIZE: u32 = 50;
 
-/// Set the maximum WebSocket frame size to 16mb
+/// Forward all signup/signin query errors to a client trying authenticate to a scope. Do not use in production.
 pub static INSECURE_FORWARD_SCOPE_ERRORS: Lazy<bool> = Lazy::new(|| {
 	let val = std::env::var("INSECURE_FORWARD_SCOPE_ERRORS").unwrap_or("".to_string());
 	val.to_lowercase() != "false"

--- a/lib/src/iam/signin.rs
+++ b/lib/src/iam/signin.rs
@@ -1,6 +1,6 @@
 use super::verify::verify_creds;
 use super::{Actor, Level};
-use crate::cnf::SERVER_NAME;
+use crate::cnf::{SERVER_NAME, INSECURE_FORWARD_SCOPE_ERRORS};
 use crate::dbs::Session;
 use crate::err::Error;
 use crate::iam::token::{Claims, HEADER};
@@ -11,6 +11,7 @@ use crate::sql::Value;
 use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey};
 use std::sync::Arc;
+
 
 pub async fn signin(
 	kvs: &Datastore,
@@ -173,6 +174,7 @@ pub async fn sc(
 						},
 						Err(e) => match e {
 							Error::Thrown(_) => Err(e),
+							e if *INSECURE_FORWARD_SCOPE_ERRORS => Err(e),
 							_ => Err(Error::SigninQueryFailed),
 						},
 					}

--- a/lib/src/iam/signin.rs
+++ b/lib/src/iam/signin.rs
@@ -1,6 +1,6 @@
 use super::verify::verify_creds;
 use super::{Actor, Level};
-use crate::cnf::{SERVER_NAME, INSECURE_FORWARD_SCOPE_ERRORS};
+use crate::cnf::{INSECURE_FORWARD_SCOPE_ERRORS, SERVER_NAME};
 use crate::dbs::Session;
 use crate::err::Error;
 use crate::iam::token::{Claims, HEADER};
@@ -11,7 +11,6 @@ use crate::sql::Value;
 use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey};
 use std::sync::Arc;
-
 
 pub async fn signin(
 	kvs: &Datastore,

--- a/lib/src/iam/signup.rs
+++ b/lib/src/iam/signup.rs
@@ -1,4 +1,4 @@
-use crate::cnf::{SERVER_NAME, INSECURE_FORWARD_SCOPE_ERRORS};
+use crate::cnf::{INSECURE_FORWARD_SCOPE_ERRORS, SERVER_NAME};
 use crate::dbs::Session;
 use crate::err::Error;
 use crate::iam::token::{Claims, HEADER};

--- a/lib/src/iam/signup.rs
+++ b/lib/src/iam/signup.rs
@@ -1,4 +1,4 @@
-use crate::cnf::SERVER_NAME;
+use crate::cnf::{SERVER_NAME, INSECURE_FORWARD_SCOPE_ERRORS};
 use crate::dbs::Session;
 use crate::err::Error;
 use crate::iam::token::{Claims, HEADER};
@@ -114,6 +114,7 @@ pub async fn sc(
 						},
 						Err(e) => match e {
 							Error::Thrown(_) => Err(e),
+							e if *INSECURE_FORWARD_SCOPE_ERRORS => Err(e),
 							_ => Err(Error::SignupQueryFailed),
 						},
 					}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When there is an issue with a scope's signup or signin query, a generic error is returned, making it impossible in certain situations or at least extremely difficult to debug what the issue is.

## What does this change do?

This PR introduces a new environment variable: `SURREAL_INSECURE_FORWARD_SCOPE_ERRORS`. When set, errors thrown from a scope's signup or signin query will be forwarded to the user. This is meant for debugging purposes, as this can easily leak confidential information. 

This feature flag is eventually to be replaced with database-level configuration to prevent an overload of feature flags, but as this functionality is not yet available, and as more issues in this trend are starting to popup, we decided to implement this functionality like this the time being.

## What is your testing strategy?

Not sure if applicable?

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
