### PR TITLE
Make cargo install use pinned dependencies

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           sudo apt-get -qq -y update
           sudo apt-get -qq -y install clang curl
-          cargo install --quiet critcmp cargo-make
+          cargo install --quiet --locked critcmp cargo-make
 
       - name: Checkout changes
         uses: actions/checkout@v3
@@ -136,7 +136,7 @@ jobs:
         run: |
           sudo apt-get -qq -y update
           sudo apt-get -qq -y install clang curl
-          cargo install --quiet critcmp cargo-make
+          cargo install --quiet --locked critcmp cargo-make
 
       # Install FoundationDB if needed
       - name: Setup FoundationDB

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Check format
         run: cargo make ci-format
@@ -62,7 +62,7 @@ jobs:
           sudo apt-get -y update
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Check workspace
         run: cargo make ci-check
@@ -87,7 +87,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Check wasm
         run: cargo make ci-check-wasm
@@ -116,7 +116,7 @@ jobs:
           sudo apt-get -y update
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Run clippy
         run: cargo make ci-clippy
@@ -144,7 +144,7 @@ jobs:
           sudo apt-get -y update
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Run CLI integration tests
         run: cargo make ci-cli-integration
@@ -182,7 +182,7 @@ jobs:
           sudo apt-get -y update
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Run HTTP integration tests
         run: cargo make ci-http-integration
@@ -210,7 +210,7 @@ jobs:
           sudo apt-get -y update
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Run WS integration tests
         run: cargo make ci-ws-integration
@@ -252,7 +252,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test workspace + coverage
         run: cargo make ci-workspace-coverage
@@ -289,7 +289,7 @@ jobs:
           sudo apt-get -y update
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test ws engine
         run: cargo make ci-api-integration-ws
@@ -326,7 +326,7 @@ jobs:
           sudo apt-get -y update
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test http engine
         run: cargo make ci-api-integration-http
@@ -363,7 +363,7 @@ jobs:
           sudo apt-get -y update
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test any engine
         run: cargo make ci-api-integration-any
@@ -396,7 +396,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test mem engine
         run: cargo make ci-api-integration-mem
@@ -420,7 +420,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test file engine
         run: cargo make ci-api-integration-file
@@ -444,7 +444,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test rocksdb engine
         run: cargo make ci-api-integration-rocksdb
@@ -468,7 +468,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test speedb engine
         run: cargo make ci-api-integration-speedb
@@ -503,7 +503,7 @@ jobs:
           done
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test tikv engine
         run: cargo make ci-api-integration-tikv
@@ -541,7 +541,7 @@ jobs:
           version: "7.1.30"
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test fdb engine
         run: cargo make ci-api-integration-fdb

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test workspace + coverage
         run: cargo make ci-workspace-coverage
@@ -89,7 +89,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Check workspace
         run: cargo make ci-check
@@ -254,7 +254,7 @@ jobs:
           git checkout -b nightly
 
           # Install release-plz
-          cargo install --force --version 0.3.30 release-plz
+          cargo install --force --locked --version 0.3.30 release-plz
 
           # Publish cargo crate
           /home/runner/.cargo/bin/release-plz release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Test workspace + coverage
         run: cargo make ci-workspace-coverage
@@ -89,7 +89,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install cargo-make
-        run: cargo install --debug cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Check workspace
         run: cargo make ci-check

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ default:
 check-deps:
 	@cargo make --help >/dev/null 2>&1 || { \
 		echo >&2 "ERROR: Install cargo-make to use make tasks."; \
-		echo >&2 "$ cargo install --no-default-features --force cargo-make"; \
+		echo >&2 "$ cargo install --no-default-features --force --locked cargo-make"; \
 		echo >&2 "More info: https://sagiegurari.github.io/cargo-make"; \
 		echo >&2; \
 		exit 1; \


### PR DESCRIPTION
## What is the motivation?

Some Cargo dependencies are currently broken, which is affecting `cargo install`.

## What does this change do?

It locks dependencies of binaries when running `cargo install` to the pinned ones to avoid the issue.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
