### PR TITLE
Implement `LIMIT` clause for `UPDATE`, `DELETE`, `RELATE` and `CREATE` statements

### DIFF
--- a/lib/src/dbs/statement.rs
+++ b/lib/src/dbs/statement.rs
@@ -190,6 +190,10 @@ impl<'a> Statement<'a> {
 	pub fn limit(&self) -> Option<&Limit> {
 		match self {
 			Statement::Select(v) => v.limit.as_ref(),
+			Statement::Update(v) => v.limit.as_ref(),
+			Statement::Delete(v) => v.limit.as_ref(),
+			Statement::Relate(v) => v.limit.as_ref(),
+			Statement::Create(v) => v.limit.as_ref(),
 			_ => None,
 		}
 	}

--- a/lib/src/sql/statements/create.rs
+++ b/lib/src/sql/statements/create.rs
@@ -9,12 +9,13 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
-#[revisioned(revision = 2)]
+#[revisioned(revision = 3)]
 pub struct CreateStatement {
 	#[revision(start = 2)]
 	pub only: bool,
 	pub what: Values,
 	pub data: Option<Data>,
+	#[revision(start = 3)]
 	pub limit: Option<Limit>,
 	pub output: Option<Output>,
 	pub timeout: Option<Timeout>,

--- a/lib/src/sql/statements/create.rs
+++ b/lib/src/sql/statements/create.rs
@@ -2,7 +2,7 @@ use crate::ctx::Context;
 use crate::dbs::{Iterator, Options, Statement, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
-use crate::sql::{Data, Output, Timeout, Value, Values};
+use crate::sql::{Data, Limit, Output, Timeout, Value, Values};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -15,6 +15,7 @@ pub struct CreateStatement {
 	pub only: bool,
 	pub what: Values,
 	pub data: Option<Data>,
+	pub limit: Option<Limit>,
 	pub output: Option<Output>,
 	pub timeout: Option<Timeout>,
 	pub parallel: bool,
@@ -76,6 +77,9 @@ impl fmt::Display for CreateStatement {
 		}
 		write!(f, " {}", self.what)?;
 		if let Some(ref v) = self.data {
+			write!(f, " {v}")?
+		}
+		if let Some(ref v) = self.limit {
 			write!(f, " {v}")?
 		}
 		if let Some(ref v) = self.output {

--- a/lib/src/sql/statements/delete.rs
+++ b/lib/src/sql/statements/delete.rs
@@ -2,7 +2,7 @@ use crate::ctx::Context;
 use crate::dbs::{Iterator, Options, Statement, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
-use crate::sql::{Cond, Output, Timeout, Value, Values};
+use crate::sql::{Cond, Limit, Output, Timeout, Value, Values};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -15,6 +15,7 @@ pub struct DeleteStatement {
 	pub only: bool,
 	pub what: Values,
 	pub cond: Option<Cond>,
+	pub limit: Option<Limit>,
 	pub output: Option<Output>,
 	pub timeout: Option<Timeout>,
 	pub parallel: bool,
@@ -76,6 +77,9 @@ impl fmt::Display for DeleteStatement {
 		}
 		write!(f, " {}", self.what)?;
 		if let Some(ref v) = self.cond {
+			write!(f, " {v}")?
+		}
+		if let Some(ref v) = self.limit {
 			write!(f, " {v}")?
 		}
 		if let Some(ref v) = self.output {

--- a/lib/src/sql/statements/delete.rs
+++ b/lib/src/sql/statements/delete.rs
@@ -9,12 +9,13 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
-#[revisioned(revision = 2)]
+#[revisioned(revision = 3)]
 pub struct DeleteStatement {
 	#[revision(start = 2)]
 	pub only: bool,
 	pub what: Values,
 	pub cond: Option<Cond>,
+	#[revision(start = 3)]
 	pub limit: Option<Limit>,
 	pub output: Option<Output>,
 	pub timeout: Option<Timeout>,

--- a/lib/src/sql/statements/relate.rs
+++ b/lib/src/sql/statements/relate.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
-#[revisioned(revision = 2)]
+#[revisioned(revision = 3)]
 pub struct RelateStatement {
 	#[revision(start = 2)]
 	pub only: bool,
@@ -18,6 +18,7 @@ pub struct RelateStatement {
 	pub with: Value,
 	pub uniq: bool,
 	pub data: Option<Data>,
+	#[revision(start = 3)]
 	pub limit: Option<Limit>,
 	pub output: Option<Output>,
 	pub timeout: Option<Timeout>,

--- a/lib/src/sql/statements/relate.rs
+++ b/lib/src/sql/statements/relate.rs
@@ -2,7 +2,7 @@ use crate::ctx::Context;
 use crate::dbs::{Iterable, Iterator, Options, Statement, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
-use crate::sql::{Data, Output, Timeout, Value};
+use crate::sql::{Data, Limit, Output, Timeout, Value};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -18,6 +18,7 @@ pub struct RelateStatement {
 	pub with: Value,
 	pub uniq: bool,
 	pub data: Option<Data>,
+	pub limit: Option<Limit>,
 	pub output: Option<Output>,
 	pub timeout: Option<Timeout>,
 	pub parallel: bool,
@@ -179,6 +180,9 @@ impl fmt::Display for RelateStatement {
 			f.write_str(" UNIQUE")?
 		}
 		if let Some(ref v) = self.data {
+			write!(f, " {v}")?
+		}
+		if let Some(ref v) = self.limit {
 			write!(f, " {v}")?
 		}
 		if let Some(ref v) = self.output {

--- a/lib/src/sql/statements/update.rs
+++ b/lib/src/sql/statements/update.rs
@@ -2,20 +2,22 @@ use crate::ctx::Context;
 use crate::dbs::{Iterator, Options, Statement, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
-use crate::sql::{Cond, Data, Output, Timeout, Value, Values};
+use crate::sql::{Cond, Data, Limit, Output, Timeout, Value, Values};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
-#[revisioned(revision = 2)]
+#[revisioned(revision = 3)]
 pub struct UpdateStatement {
 	#[revision(start = 2)]
 	pub only: bool,
 	pub what: Values,
 	pub data: Option<Data>,
 	pub cond: Option<Cond>,
+	#[revision(start = 3)]
+	pub limit: Option<Limit>,
 	pub output: Option<Output>,
 	pub timeout: Option<Timeout>,
 	pub parallel: bool,
@@ -80,6 +82,9 @@ impl fmt::Display for UpdateStatement {
 			write!(f, " {v}")?
 		}
 		if let Some(ref v) = self.cond {
+			write!(f, " {v}")?
+		}
+		if let Some(ref v) = self.limit {
 			write!(f, " {v}")?
 		}
 		if let Some(ref v) = self.output {

--- a/lib/src/sql/value/serde/ser/statement/create.rs
+++ b/lib/src/sql/value/serde/ser/statement/create.rs
@@ -3,6 +3,7 @@ use crate::sql::statements::CreateStatement;
 use crate::sql::value::serde::ser;
 use crate::sql::Data;
 use crate::sql::Duration;
+use crate::sql::Limit;
 use crate::sql::Output;
 use crate::sql::Timeout;
 use crate::sql::Values;
@@ -42,6 +43,7 @@ pub struct SerializeCreateStatement {
 	only: Option<bool>,
 	what: Option<Values>,
 	data: Option<Data>,
+	limit: Option<Limit>,
 	output: Option<Output>,
 	timeout: Option<Timeout>,
 	parallel: Option<bool>,
@@ -64,6 +66,9 @@ impl serde::ser::SerializeStruct for SerializeCreateStatement {
 			}
 			"data" => {
 				self.data = value.serialize(ser::data::opt::Serializer.wrap())?;
+			}
+			"limit" => {
+				self.limit = value.serialize(ser::limit::opt::Serializer.wrap())?;
 			}
 			"output" => {
 				self.output = value.serialize(ser::output::opt::Serializer.wrap())?;
@@ -90,6 +95,7 @@ impl serde::ser::SerializeStruct for SerializeCreateStatement {
 				what,
 				parallel,
 				data: self.data,
+				limit: self.limit,
 				output: self.output,
 				timeout: self.timeout,
 			}),
@@ -113,6 +119,16 @@ mod tests {
 	fn with_data() {
 		let stmt = CreateStatement {
 			data: Some(Default::default()),
+			..Default::default()
+		};
+		let value: CreateStatement = stmt.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_limit() {
+		let stmt = CreateStatement {
+			limit: Some(Default::default()),
 			..Default::default()
 		};
 		let value: CreateStatement = stmt.serialize(Serializer.wrap()).unwrap();

--- a/lib/src/sql/value/serde/ser/statement/delete.rs
+++ b/lib/src/sql/value/serde/ser/statement/delete.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::sql::statements::DeleteStatement;
 use crate::sql::value::serde::ser;
 use crate::sql::Cond;
+use crate::sql::Limit;
 use crate::sql::Output;
 use crate::sql::Timeout;
 use crate::sql::Values;
@@ -41,6 +42,7 @@ pub struct SerializeDeleteStatement {
 	only: Option<bool>,
 	what: Option<Values>,
 	cond: Option<Cond>,
+	limit: Option<Limit>,
 	output: Option<Output>,
 	timeout: Option<Timeout>,
 	parallel: Option<bool>,
@@ -63,6 +65,9 @@ impl serde::ser::SerializeStruct for SerializeDeleteStatement {
 			}
 			"cond" => {
 				self.cond = value.serialize(ser::cond::opt::Serializer.wrap())?;
+			}
+			"limit" => {
+				self.limit = value.serialize(ser::limit::opt::Serializer.wrap())?;
 			}
 			"output" => {
 				self.output = value.serialize(ser::output::opt::Serializer.wrap())?;
@@ -87,6 +92,7 @@ impl serde::ser::SerializeStruct for SerializeDeleteStatement {
 				what,
 				parallel,
 				cond: self.cond,
+				limit: self.limit,
 				output: self.output,
 				timeout: self.timeout,
 			}),
@@ -110,6 +116,16 @@ mod tests {
 	fn with_cond() {
 		let stmt = DeleteStatement {
 			cond: Some(Default::default()),
+			..Default::default()
+		};
+		let value: DeleteStatement = stmt.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_limit() {
+		let stmt = DeleteStatement {
+			limit: Some(Default::default()),
 			..Default::default()
 		};
 		let value: DeleteStatement = stmt.serialize(Serializer.wrap()).unwrap();

--- a/lib/src/sql/value/serde/ser/statement/relate.rs
+++ b/lib/src/sql/value/serde/ser/statement/relate.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::sql::statements::RelateStatement;
 use crate::sql::value::serde::ser;
 use crate::sql::Data;
+use crate::sql::Limit;
 use crate::sql::Output;
 use crate::sql::Timeout;
 use crate::sql::Value;
@@ -44,6 +45,7 @@ pub struct SerializeRelateStatement {
 	with: Option<Value>,
 	uniq: Option<bool>,
 	data: Option<Data>,
+	limit: Option<Limit>,
 	output: Option<Output>,
 	timeout: Option<Timeout>,
 	parallel: Option<bool>,
@@ -76,6 +78,9 @@ impl serde::ser::SerializeStruct for SerializeRelateStatement {
 			"data" => {
 				self.data = value.serialize(ser::data::opt::Serializer.wrap())?;
 			}
+			"limit" => {
+				self.limit = value.serialize(ser::limit::opt::Serializer.wrap())?;
+			}
 			"output" => {
 				self.output = value.serialize(ser::output::opt::Serializer.wrap())?;
 			}
@@ -103,6 +108,7 @@ impl serde::ser::SerializeStruct for SerializeRelateStatement {
 					uniq,
 					parallel,
 					data: self.data,
+					limit: self.limit,
 					output: self.output,
 					timeout: self.timeout,
 				})
@@ -127,6 +133,16 @@ mod tests {
 	fn with_data() {
 		let stmt = RelateStatement {
 			data: Some(Default::default()),
+			..Default::default()
+		};
+		let value: RelateStatement = stmt.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_limit() {
+		let stmt = RelateStatement {
+			limit: Some(Default::default()),
 			..Default::default()
 		};
 		let value: RelateStatement = stmt.serialize(Serializer.wrap()).unwrap();

--- a/lib/src/sql/value/serde/ser/statement/update.rs
+++ b/lib/src/sql/value/serde/ser/statement/update.rs
@@ -4,6 +4,7 @@ use crate::sql::value::serde::ser;
 use crate::sql::Cond;
 use crate::sql::Data;
 use crate::sql::Duration;
+use crate::sql::Limit;
 use crate::sql::Output;
 use crate::sql::Timeout;
 use crate::sql::Values;
@@ -44,6 +45,7 @@ pub struct SerializeUpdateStatement {
 	what: Option<Values>,
 	data: Option<Data>,
 	cond: Option<Cond>,
+	limit: Option<Limit>,
 	output: Option<Output>,
 	timeout: Option<Timeout>,
 	parallel: Option<bool>,
@@ -69,6 +71,9 @@ impl serde::ser::SerializeStruct for SerializeUpdateStatement {
 			}
 			"cond" => {
 				self.cond = value.serialize(ser::cond::opt::Serializer.wrap())?;
+			}
+			"limit" => {
+				self.limit = value.serialize(ser::limit::opt::Serializer.wrap())?;
 			}
 			"output" => {
 				self.output = value.serialize(ser::output::opt::Serializer.wrap())?;
@@ -96,6 +101,7 @@ impl serde::ser::SerializeStruct for SerializeUpdateStatement {
 				parallel,
 				data: self.data,
 				cond: self.cond,
+				limit: self.limit,
 				output: self.output,
 				timeout: self.timeout,
 			}),
@@ -129,6 +135,16 @@ mod tests {
 	fn with_cond() {
 		let stmt = UpdateStatement {
 			cond: Some(Default::default()),
+			..Default::default()
+		};
+		let value: UpdateStatement = stmt.serialize(Serializer.wrap()).unwrap();
+		assert_eq!(value, stmt);
+	}
+
+	#[test]
+	fn with_limit() {
+		let stmt = UpdateStatement {
+			limit: Some(Default::default()),
 			..Default::default()
 		};
 		let value: UpdateStatement = stmt.serialize(Serializer.wrap()).unwrap();

--- a/lib/src/syn/v1/stmt/create.rs
+++ b/lib/src/syn/v1/stmt/create.rs
@@ -1,6 +1,6 @@
 use super::super::{
 	comment::shouldbespace,
-	part::{data, output, timeout},
+	part::{data, limit, output, timeout},
 	value::whats,
 	IResult,
 };
@@ -16,12 +16,13 @@ pub fn create(i: &str) -> IResult<&str, CreateStatement> {
 	let (i, only) = opt(preceded(shouldbespace, tag_no_case("ONLY")))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, what) = whats(i)?;
-	let (i, (data, output, timeout, parallel)) = cut(|i| {
+	let (i, (data, limit, output, timeout, parallel)) = cut(|i| {
 		let (i, data) = opt(preceded(shouldbespace, data))(i)?;
+		let (i, limit) = opt(preceded(shouldbespace, limit))(i)?;
 		let (i, output) = opt(preceded(shouldbespace, output))(i)?;
 		let (i, timeout) = opt(preceded(shouldbespace, timeout))(i)?;
 		let (i, parallel) = opt(preceded(shouldbespace, tag_no_case("PARALLEL")))(i)?;
-		Ok((i, (data, output, timeout, parallel)))
+		Ok((i, (data, limit, output, timeout, parallel)))
 	})(i)?;
 	Ok((
 		i,
@@ -29,6 +30,7 @@ pub fn create(i: &str) -> IResult<&str, CreateStatement> {
 			only: only.is_some(),
 			what,
 			data,
+			limit,
 			output,
 			timeout,
 			parallel: parallel.is_some(),

--- a/lib/src/syn/v1/stmt/delete.rs
+++ b/lib/src/syn/v1/stmt/delete.rs
@@ -1,6 +1,6 @@
 use super::super::{
 	comment::shouldbespace,
-	part::{cond, output, timeout},
+	part::{cond, limit, output, timeout},
 	value::whats,
 	IResult,
 };
@@ -14,6 +14,7 @@ pub fn delete(i: &str) -> IResult<&str, DeleteStatement> {
 	let (i, _) = shouldbespace(i)?;
 	let (i, what) = whats(i)?;
 	let (i, cond) = opt(preceded(shouldbespace, cond))(i)?;
+	let (i, limit) = opt(preceded(shouldbespace, limit))(i)?;
 	let (i, output) = opt(preceded(shouldbespace, output))(i)?;
 	let (i, timeout) = opt(preceded(shouldbespace, timeout))(i)?;
 	let (i, parallel) = opt(preceded(shouldbespace, tag_no_case("PARALLEL")))(i)?;
@@ -23,6 +24,7 @@ pub fn delete(i: &str) -> IResult<&str, DeleteStatement> {
 			only: only.is_some(),
 			what,
 			cond,
+			limit,
 			output,
 			timeout,
 			parallel: parallel.is_some(),

--- a/lib/src/syn/v1/stmt/relate.rs
+++ b/lib/src/syn/v1/stmt/relate.rs
@@ -2,7 +2,7 @@ use super::super::{
 	comment::{mightbespace, shouldbespace},
 	error::expected,
 	literal::{param, table},
-	part::{data, output, timeout},
+	part::{data, limit, output, timeout},
 	subquery::subquery,
 	thing::thing,
 	value::array,
@@ -23,6 +23,7 @@ pub fn relate(i: &str) -> IResult<&str, RelateStatement> {
 	let (i, path) = relate_oi(i)?;
 	let (i, uniq) = opt(preceded(shouldbespace, tag_no_case("UNIQUE")))(i)?;
 	let (i, data) = opt(preceded(shouldbespace, data))(i)?;
+	let (i, limit) = opt(preceded(shouldbespace, limit))(i)?;
 	let (i, output) = opt(preceded(shouldbespace, output))(i)?;
 	let (i, timeout) = opt(preceded(shouldbespace, timeout))(i)?;
 	let (i, parallel) = opt(preceded(shouldbespace, tag_no_case("PARALLEL")))(i)?;
@@ -35,6 +36,7 @@ pub fn relate(i: &str) -> IResult<&str, RelateStatement> {
 			with: path.2,
 			uniq: uniq.is_some(),
 			data,
+			limit,
 			output,
 			timeout,
 			parallel: parallel.is_some(),

--- a/lib/src/syn/v1/stmt/update.rs
+++ b/lib/src/syn/v1/stmt/update.rs
@@ -1,6 +1,6 @@
 use super::super::{
 	comment::shouldbespace,
-	part::{cond, data, output, timeout},
+	part::{cond, data, limit, output, timeout},
 	value::whats,
 	IResult,
 };
@@ -14,6 +14,7 @@ pub fn update(i: &str) -> IResult<&str, UpdateStatement> {
 	let (i, what) = whats(i)?;
 	let (i, data) = opt(preceded(shouldbespace, data))(i)?;
 	let (i, cond) = opt(preceded(shouldbespace, cond))(i)?;
+	let (i, limit) = opt(preceded(shouldbespace, limit))(i)?;
 	let (i, output) = opt(preceded(shouldbespace, output))(i)?;
 	let (i, timeout) = opt(preceded(shouldbespace, timeout))(i)?;
 	let (i, parallel) = opt(preceded(shouldbespace, tag_no_case("PARALLEL")))(i)?;
@@ -24,6 +25,7 @@ pub fn update(i: &str) -> IResult<&str, UpdateStatement> {
 			what,
 			data,
 			cond,
+			limit,
 			output,
 			timeout,
 			parallel: parallel.is_some(),

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -671,3 +671,37 @@ async fn check_permissions_auth_disabled() {
 		assert!(res.unwrap() != Value::parse("[]"), "{}", "anonymous user should be able to create a new record if the table exists and grants full permissions");
 	}
 }
+
+#[tokio::test]
+async fn create_limit_one() -> Result<(), Error> {
+	let sql = "
+		CREATE test:1, test:2 LIMIT 1;
+		SELECT * FROM test;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -1008,3 +1008,40 @@ async fn check_permissions_auth_disabled() {
 		);
 	}
 }
+
+#[tokio::test]
+async fn select_limit_one() -> Result<(), Error> {
+	let sql = "
+		CREATE test:1, test:2;
+		SELECT * FROM test LIMIT 1;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+			},
+			{
+				id: test:2,
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}

--- a/lib/tests/update.rs
+++ b/lib/tests/update.rs
@@ -681,3 +681,56 @@ async fn check_permissions_auth_disabled() {
 		);
 	}
 }
+
+#[tokio::test]
+async fn update_limit_one() -> Result<(), Error> {
+	let sql = "
+		CREATE test:1, test:2;
+		UPDATE test SET something = true LIMIT 1;
+		SELECT * FROM test;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 3);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+			},
+			{
+				id: test:2,
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+				something: true,
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+				something: true,
+			},
+			{
+				id: test:2,
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

In preparation of making the `ONLY` keyword deterministic, we add the capability to use the `LIMIT` clause on statements outside just `SELECT`.

## What does this change do?

It adds the `LIMIT` clause to the `UPDATE`, `DELETE`, `RELATE` and `CREATE` statements.

## What is your testing strategy?

Added tests for the `LIMIT` clause for all statements, including `SELECT`.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
