### PR TITLE
Drop uuid_unstable as it is no longer necessary

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,18 +1,13 @@
-[build]
-rustflags = ["--cfg", "uuid_unstable"]
-
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 
 [target.x86_64-unknown-linux-musl]
 rustflags = [
-	"--cfg", "uuid_unstable",
 	"-C", "target-feature=+crt-static"
 ]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = [
-	"--cfg", "uuid_unstable",
 	"-C", "target-feature=+crt-static",
 	"-C", "link-arg=/NODEFAULTLIB:libvcruntimed.lib",
 	"-C", "link-arg=/NODEFAULTLIB:vcruntime.lib",

--- a/lib/src/fnc/rand.rs
+++ b/lib/src/fnc/rand.rs
@@ -168,15 +168,7 @@ pub mod uuid {
 		Ok(Uuid::new_v4().into())
 	}
 
-	#[cfg(uuid_unstable)]
 	pub fn v7(_: ()) -> Result<Value, Error> {
 		Ok(Uuid::new_v7().into())
-	}
-	#[cfg(not(uuid_unstable))]
-	pub fn v7(_: ()) -> Result<Value, Error> {
-		return Err(Error::InvalidFunction {
-			name: String::from("rand::uuid::v7"),
-			message: format!("This function is not enabled in this version of SurrealDB."),
-		});
 	}
 }

--- a/lib/src/sql/id.rs
+++ b/lib/src/sql/id.rs
@@ -132,14 +132,8 @@ impl Id {
 		Self::String(Ulid::new().to_string())
 	}
 	/// Generate a new random UUID
-	#[cfg(uuid_unstable)]
 	pub fn uuid() -> Self {
 		Self::String(Uuid::new_v7().to_raw())
-	}
-	/// Generate a new random UUID
-	#[cfg(not(uuid_unstable))]
-	pub fn uuid() -> Self {
-		Self::String(Uuid::new_v4().to_raw())
 	}
 	/// Convert the Id to a raw String
 	pub fn to_raw(&self) -> String {

--- a/lib/src/sql/uuid.rs
+++ b/lib/src/sql/uuid.rs
@@ -66,23 +66,15 @@ impl Deref for Uuid {
 }
 
 impl Uuid {
-	/// Generate a new V4 UUID
+	/// Generate a new UUID
 	pub fn new() -> Self {
-		#[cfg(uuid_unstable)]
-		{
-			Self(uuid::Uuid::now_v7())
-		}
-		#[cfg(not(uuid_unstable))]
-		{
-			Self(uuid::Uuid::new_v4())
-		}
+		Self(uuid::Uuid::now_v7())
 	}
 	/// Generate a new V4 UUID
 	pub fn new_v4() -> Self {
 		Self(uuid::Uuid::new_v4())
 	}
 	/// Generate a new V7 UUID
-	#[cfg(uuid_unstable)]
 	pub fn new_v7() -> Self {
 		Self(uuid::Uuid::now_v7())
 	}


### PR DESCRIPTION
## What is the motivation?

All the previously unstable UUID features we were using are now stable.

## What does this change do?

It removes all mentions of `uuid_unstable` in the repo.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
