### PR TITLE
Improve test isolation

### DIFF
--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -19,8 +19,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -59,10 +59,13 @@ mod http_integration {
 		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 		let url = &format!("http://{addr}/sql");
 
+		let ns = Ulid::new().to_string();
+		let db = Ulid::new().to_string();
+
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", ns.parse()?);
+		headers.insert("DB", db.parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -86,8 +89,8 @@ mod http_integration {
 		{
 			let req_body = serde_json::to_string(
 				json!({
-					"ns": "N",
-					"db": "D",
+					"ns": ns,
+					"db": db,
 					"user": "user",
 					"pass": "pass",
 				})
@@ -113,16 +116,16 @@ mod http_integration {
 			// Check the selected namespace and database
 			let res = client
 				.post(url)
-				.header("NS", "N2")
-				.header("DB", "D2")
+				.header("NS", Ulid::new().to_string())
+				.header("DB", Ulid::new().to_string())
 				.bearer_auth(&token)
 				.body("SELECT * FROM session::ns(); SELECT * FROM session::db()")
 				.send()
 				.await?;
 			assert_eq!(res.status(), 200, "body: {}", res.text().await?);
 			let body = res.text().await?;
-			assert!(body.contains(r#""result":["N"]"#), "body: {}", body);
-			assert!(body.contains(r#""result":["D"]"#), "body: {}", body);
+			assert!(body.contains(&format!(r#""result":["{ns}"]"#)), "body: {}", body);
+			assert!(body.contains(&format!(r#""result":["{db}"]"#)), "body: {}", body);
 		}
 
 		// Request with invalid token, returns 401
@@ -147,8 +150,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -201,8 +204,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -273,8 +276,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -304,10 +307,13 @@ mod http_integration {
 		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 		let url = &format!("http://{addr}/signin");
 
+		let ns = Ulid::new().to_string();
+		let db = Ulid::new().to_string();
+
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", ns.parse()?);
+		headers.insert("DB", db.parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -329,8 +335,8 @@ mod http_integration {
 		{
 			let req_body = serde_json::to_string(
 				json!({
-					"ns": "N",
-					"db": "D",
+					"ns": ns,
+					"db": db,
 					"user": "user",
 					"pass": "pass",
 				})
@@ -350,8 +356,8 @@ mod http_integration {
 		{
 			let req_body = serde_json::to_string(
 				json!({
-					"ns": "N",
-					"db": "D",
+					"ns": ns,
+					"db": db,
 					"user": "user",
 					"pass": "invalid_pass",
 				})
@@ -372,10 +378,13 @@ mod http_integration {
 		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 		let url = &format!("http://{addr}/signup");
 
+		let ns = Ulid::new().to_string();
+		let db = Ulid::new().to_string();
+
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", ns.parse()?);
+		headers.insert("DB", db.parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -404,8 +413,8 @@ mod http_integration {
 		{
 			let req_body = serde_json::to_string(
 				json!({
-					"ns": "N",
-					"db": "D",
+					"ns": ns,
+					"db": db,
 					"sc": "scope",
 					"email": "email@email.com",
 					"pass": "pass",
@@ -436,8 +445,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 
 		let client = reqwest::Client::builder()
@@ -550,8 +559,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		headers.insert(header::ACCEPT_ENCODING, "gzip".parse()?);
 
@@ -579,8 +588,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -655,8 +664,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -743,8 +752,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -808,8 +817,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -877,8 +886,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -946,8 +955,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -998,8 +1007,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -1037,8 +1046,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -1134,8 +1143,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -1210,8 +1219,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))
@@ -1287,8 +1296,8 @@ mod http_integration {
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
-		headers.insert("NS", "N".parse()?);
-		headers.insert("DB", "D".parse()?);
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
 		headers.insert(header::ACCEPT, "application/json".parse()?);
 		let client = reqwest::Client::builder()
 			.connect_timeout(Duration::from_millis(10))

--- a/tests/ws_integration.rs
+++ b/tests/ws_integration.rs
@@ -6,6 +6,7 @@ mod ws_integration {
 
 	use serde_json::json;
 	use test_log::test;
+	use ulid::Ulid;
 
 	use super::common::{self, PASS, USER};
 	use crate::common::error::TestError;
@@ -39,12 +40,15 @@ mod ws_integration {
 		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 		let socket = &mut common::connect_ws(&addr).await?;
 
+		let ns = Ulid::new().to_string();
+		let db = Ulid::new().to_string();
+
 		//
 		// Prepare the connection
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res = common::ws_use(socket, Some(&ns), Some(&db)).await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//
@@ -77,7 +81,7 @@ mod ws_integration {
 
 		// Sign in
 		let res =
-			common::ws_signin(socket, "user", "pass", Some("N"), Some("D"), Some("scope")).await;
+			common::ws_signin(socket, "user", "pass", Some(&ns), Some(&db), Some("scope")).await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Send the info command
@@ -106,12 +110,15 @@ mod ws_integration {
 		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 		let socket = &mut common::connect_ws(&addr).await?;
 
+		let ns = Ulid::new().to_string();
+		let db = Ulid::new().to_string();
+
 		//
 		// Prepare the connection
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res = common::ws_use(socket, Some(&ns), Some(&db)).await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Setup scope
@@ -133,8 +140,8 @@ mod ws_integration {
 				"id": "1",
 				"method": "signup",
 				"params": [{
-					"ns": "N",
-					"db": "D",
+					"ns": ns,
+					"db": db,
 					"sc": "scope",
 					"email": "email@email.com",
 					"pass": "pass",
@@ -164,12 +171,15 @@ mod ws_integration {
 		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 		let socket = &mut common::connect_ws(&addr).await?;
 
+		let ns = Ulid::new().to_string();
+		let db = Ulid::new().to_string();
+
 		//
 		// Prepare the connection
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res = common::ws_use(socket, Some(&ns), Some(&db)).await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Setup scope
@@ -191,8 +201,8 @@ mod ws_integration {
 				"id": "1",
 				"method": "signup",
 				"params": [{
-					"ns": "N",
-					"db": "D",
+					"ns": ns,
+					"db": db,
 					"sc": "scope",
 					"email": "email@email.com",
 					"pass": "pass",
@@ -210,8 +220,8 @@ mod ws_integration {
 				"id": "1",
 				"method": "signin",
 				"params": [{
-					"ns": "N",
-					"db": "D",
+					"ns": ns,
+					"db": db,
 					"sc": "scope",
 					"email": "email@email.com",
 					"pass": "pass",
@@ -241,12 +251,15 @@ mod ws_integration {
 		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
 		let socket = &mut common::connect_ws(&addr).await?;
 
+		let ns = Ulid::new().to_string();
+		let db = Ulid::new().to_string();
+
 		//
 		// Prepare the connection
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res = common::ws_use(socket, Some(&ns), Some(&db)).await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Setup scope
@@ -264,8 +277,8 @@ mod ws_integration {
 				"id": "1",
 				"method": "signup",
 				"params": [{
-					"ns": "N",
-					"db": "D",
+					"ns": ns,
+					"db": db,
 					"sc": "scope",
 					"user": "user",
 					"pass": "pass",
@@ -278,7 +291,7 @@ mod ws_integration {
 
 		// Sign in
 		let res =
-			common::ws_signin(socket, "user", "pass", Some("N"), Some("D"), Some("scope")).await;
+			common::ws_signin(socket, "user", "pass", Some(&ns), Some(&db), Some("scope")).await;
 		assert!(res.is_ok(), "result: {:?}", res);
 		let res = res.unwrap();
 
@@ -308,7 +321,7 @@ mod ws_integration {
 
 		// Signin
 		let res =
-			common::ws_signin(socket2, "user", "pass", Some("N"), Some("D"), Some("scope")).await;
+			common::ws_signin(socket2, "user", "pass", Some(&ns), Some(&db), Some("scope")).await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Insert
@@ -348,7 +361,11 @@ mod ws_integration {
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Verify we have a ROOT session
-		let res = common::ws_query(socket, "DEFINE NAMESPACE NS").await;
+		let res = common::ws_query(
+			socket,
+			&format!("DEFINE NAMESPACE {throwaway}", throwaway = Ulid::new()),
+		)
+		.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Invalidate session
@@ -364,7 +381,11 @@ mod ws_integration {
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Verify we invalidated the root session
-		let res = common::ws_query(socket, "DEFINE NAMESPACE NS2").await;
+		let res = common::ws_query(
+			socket,
+			&format!("DEFINE NAMESPACE {throwaway}", throwaway = Ulid::new()),
+		)
+		.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 		let res = res.unwrap();
 
@@ -414,7 +435,11 @@ mod ws_integration {
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Verify we have a ROOT session
-		let res = common::ws_query(socket, "DEFINE NAMESPACE D2").await;
+		let res = common::ws_query(
+			socket,
+			&format!("DEFINE NAMESPACE {throwaway}", throwaway = Ulid::new()),
+		)
+		.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 		let res = res.unwrap();
 		assert_eq!(res[0]["status"], "OK", "result: {:?}", res);
@@ -428,10 +453,10 @@ mod ws_integration {
 
 		let socket = &mut common::connect_ws(&addr).await?;
 
-		let ns = "DE4E65C08E7248FB851CBB4D939C13C7";
-		let db = "D7C40F656162434DB4888E334032B52C";
 		let _ = common::ws_signin(socket, USER, PASS, None, None, None).await?;
-		let _ = common::ws_use(socket, Some(ns), Some(db)).await?;
+		let _ =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await?;
 
 		// LIVE query via live endpoint
 		let live_res = common::ws_send_msg_and_wait_response(
@@ -504,10 +529,10 @@ mod ws_integration {
 
 		let socket = &mut common::connect_ws(&addr).await?;
 
-		let ns = "3CB1D26373AF45F78D836EF2F78384A2";
-		let db = "622772B60DEB46958B6450EE43ED2515";
 		let _ = common::ws_signin(socket, USER, PASS, None, None, None).await?;
-		let _ = common::ws_use(socket, Some(ns), Some(db)).await?;
+		let _ =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await?;
 
 		// LIVE query via live endpoint
 		let live_res = common::ws_send_msg_and_wait_response(
@@ -581,10 +606,10 @@ mod ws_integration {
 
 		let socket = &mut common::connect_ws(&addr).await?;
 
-		let ns = "3498b03b44b5452a9d3f15252b454db1";
-		let db = "2cf93e52ff0a42f39d271412404a01f6";
 		let _ = common::ws_signin(socket, USER, PASS, None, None, None).await?;
-		let _ = common::ws_use(socket, Some(ns), Some(db)).await?;
+		let _ =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await?;
 
 		// LIVE query via live endpoint
 		let live_res = common::ws_send_msg_and_wait_response(
@@ -662,10 +687,10 @@ mod ws_integration {
 
 		let socket = &mut common::connect_ws(&addr).await?;
 
-		let ns = "3498b03b44b5452a9d3f15252b454db1";
-		let db = "2cf93e52ff0a42f39d271412404a01f6";
 		let _ = common::ws_signin(socket, USER, PASS, None, None, None).await?;
-		let _ = common::ws_use(socket, Some(ns), Some(db)).await?;
+		let _ =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await?;
 
 		// LIVE query via query endpoint
 		let lq_res =
@@ -738,7 +763,9 @@ mod ws_integration {
 		//
 		// Prepare the connection
 		//
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Define variable using let
@@ -790,7 +817,9 @@ mod ws_integration {
 		//
 		// Prepare the connection
 		//
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Define variable
@@ -854,7 +883,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//
@@ -897,7 +928,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Insert data
@@ -942,7 +975,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		// Insert data
@@ -981,7 +1016,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//
@@ -1030,7 +1067,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//
@@ -1092,7 +1131,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//
@@ -1166,7 +1207,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//
@@ -1227,7 +1270,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//
@@ -1274,7 +1319,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//
@@ -1334,7 +1381,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//
@@ -1393,7 +1442,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//
@@ -1463,7 +1514,9 @@ mod ws_integration {
 		//
 		let res = common::ws_signin(socket, USER, PASS, None, None, None).await;
 		assert!(res.is_ok(), "result: {:?}", res);
-		let res = common::ws_use(socket, Some("N"), Some("D")).await;
+		let res =
+			common::ws_use(socket, Some(&Ulid::new().to_string()), Some(&Ulid::new().to_string()))
+				.await;
 		assert!(res.is_ok(), "result: {:?}", res);
 
 		//


### PR DESCRIPTION
## What is the motivation?

CLI, WS and HTTP integration tests are flaky.

## What does this change do?

Currently these tests are isolated by spinning up a server for each test. In theory this should be enough but these tests randomly fail every now and then. This PR adds an extra layer of isolation by using different namespaces and databases. In theory, this shouldn't eliminate the flakiness but it does open  these tests to a possibility of exploring alternative approaches, like re-using the same external server like we do for API integration tests.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
