### PR TITLE
Implement `type::is::none()` function

### DIFF
--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -362,6 +362,7 @@
 "type::is::geometry("
 "type::is::int("
 "type::is::line("
+"type::is::none("
 "type::is::null("
 "type::is::multiline("
 "type::is::multipoint("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -360,6 +360,7 @@
 "type::is::geometry("
 "type::is::int("
 "type::is::line("
+"type::is::none("
 "type::is::null("
 "type::is::multiline("
 "type::is::multipoint("

--- a/lib/src/fnc/mod.rs
+++ b/lib/src/fnc/mod.rs
@@ -310,6 +310,7 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"type::is::geometry" => r#type::is::geometry,
 		"type::is::int" => r#type::is::int,
 		"type::is::line" => r#type::is::line,
+		"type::is::none" => r#type::is::none,
 		"type::is::null" => r#type::is::null,
 		"type::is::multiline" => r#type::is::multiline,
 		"type::is::multipoint" => r#type::is::multipoint,

--- a/lib/src/fnc/script/modules/surrealdb/functions/type/is.rs
+++ b/lib/src/fnc/script/modules/surrealdb/functions/type/is.rs
@@ -17,6 +17,7 @@ impl_module_def!(
 	"geometry" => run,
 	"int" => run,
 	"line" => run,
+	"none" => run,
 	"null" => run,
 	"multiline" => run,
 	"multipoint" => run,

--- a/lib/src/fnc/type.rs
+++ b/lib/src/fnc/type.rs
@@ -177,6 +177,10 @@ pub mod is {
 		Ok(matches!(arg, Value::Geometry(Geometry::Line(_))).into())
 	}
 
+	pub fn none((arg,): (Value,)) -> Result<Value, Error> {
+		Ok(arg.is_none().into())
+	}
+
 	pub fn null((arg,): (Value,)) -> Result<Value, Error> {
 		Ok(arg.is_null().into())
 	}

--- a/lib/src/syn/v1/builtin.rs
+++ b/lib/src/syn/v1/builtin.rs
@@ -444,6 +444,7 @@ pub(crate) fn builtin_name(i: &str) -> IResult<&str, BuiltinName<&str>, ParseErr
 				geometry => { fn },
 				int => { fn },
 				line => { fn },
+				none => { fn },
 				null => { fn },
 				multiline => { fn },
 				multipoint => { fn },

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -5124,6 +5124,28 @@ async fn function_type_is_line() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn function_type_is_none() -> Result<(), Error> {
+	let sql = r#"
+		RETURN type::is::none(none);
+		RETURN type::is::none("123");
+	"#;
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from(true);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from(false);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_type_is_null() -> Result<(), Error> {
 	let sql = r#"
 		RETURN type::is::null(null);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

This type-checking function was missing.

## What does this change do?

It implements the `type::is::none(...)` function.

## What is your testing strategy?

Added a test for the function.

## Is this related to any issues?

Closes #2984.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
