### PR TITLE
made array::flatten function aggregate

### DIFF
--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -105,6 +105,7 @@ impl Function {
 		match self {
 			Self::Normal(f, _) if f == "array::distinct" => true,
 			Self::Normal(f, _) if f == "array::first" => true,
+			Self::Normal(f, _) if f == "array::flatten" => true,
 			Self::Normal(f, _) if f == "array::group" => true,
 			Self::Normal(f, _) if f == "array::last" => true,
 			Self::Normal(f, _) if f == "count" => true,


### PR DESCRIPTION
## What is the motivation?

To make array::flatten function aggregate.
Example with python driver:
```
await db.create(
            "person",
            {
                "name": "John",
                "role": "manager",
                "items": ["sandals", "jacket"],
            },
        )
        await db.create(
            "person",
            {
                "name": "Sally",
                "role": "manager",
                "items": ["sandals", "sweater", "hat"],
            },
        )
        print(await db.query("""
            select array::flatten(items), role from person group by role;
        """))
```
Output:
```
'array::flatten': ['sandals', 'jacket', 'sandals', 'sweater', 'hat'], 'role': 'manager'
```
Which is different from array::group function where it removes duplicates:
```
'array::group': ['sandals', 'sweater', 'hat', 'jacket'], 'role': 'manager'
```

## What does this change do?

Made array::flatten function aggregate.

## What is your testing strategy?

I have checked node.js, python, rust drivers and surrealist.app UI:
- node.js and python drivers work as expected
- rust driver and surrealist.app UI errored (I can't see why because couldn't find their repos):
`
Error: Db(InvalidQuery(RenderedError { text: "Found 'array::flatten(items)' in SELECT clause at line 1 column 61, but field is not an aggregate function, and is not present in GROUP BY expression", snippets: [Snippet { source: "UP BY role", truncation: Start, location: Location { line: 1, column: 61 }, offset: 10, explain: None }] }))
`

## Is this related to any issues?

Yes: [#2978](https://github.com/surrealdb/surrealdb/issues/2978) 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

Yes
