### PR TITLE
Add identity implementations of IntoEndpoint on Endpoint

### DIFF
--- a/lib/src/api/engine/any/mod.rs
+++ b/lib/src/api/engine/any/mod.rs
@@ -165,6 +165,12 @@ where
 	}
 }
 
+impl IntoEndpoint for Endpoint {
+	fn into_endpoint(self) -> Result<Endpoint> {
+		Ok(self)
+	}
+}
+
 /// A dynamic connection that supports any engine and allows you to pick at runtime
 #[derive(Debug, Clone)]
 pub struct Any {

--- a/lib/src/api/opt/endpoint/fdb.rs
+++ b/lib/src/api/opt/endpoint/fdb.rs
@@ -38,3 +38,4 @@ macro_rules! endpoints {
 }
 
 endpoints!(&str, &String, String, &Path, PathBuf);
+identity!(Client = Db, Http, Https);

--- a/lib/src/api/opt/endpoint/http.rs
+++ b/lib/src/api/opt/endpoint/http.rs
@@ -1,3 +1,4 @@
+use super::identity;
 use crate::api::engine::remote::http::Client;
 use crate::api::engine::remote::http::Http;
 use crate::api::engine::remote::http::Https;
@@ -62,3 +63,4 @@ macro_rules! endpoints {
 }
 
 endpoints!(&str, &String, String, SocketAddr);
+identity!(Client = Client, Http, Https);

--- a/lib/src/api/opt/endpoint/indxdb.rs
+++ b/lib/src/api/opt/endpoint/indxdb.rs
@@ -1,3 +1,4 @@
+use super::identity;
 use crate::api::engine::local::Db;
 use crate::api::engine::local::IndxDb;
 use crate::api::opt::Config;
@@ -36,3 +37,4 @@ macro_rules! endpoints {
 }
 
 endpoints!(&str, &String, String);
+identity!(Client = Db, IndxDb);

--- a/lib/src/api/opt/endpoint/mem.rs
+++ b/lib/src/api/opt/endpoint/mem.rs
@@ -1,3 +1,4 @@
+use super::identity;
 use crate::api::engine::local::Db;
 use crate::api::engine::local::Mem;
 use crate::api::opt::Endpoint;
@@ -27,3 +28,5 @@ impl IntoEndpoint<Mem> for Config {
 		Ok(endpoint)
 	}
 }
+
+identity!(Client = Db, Mem);

--- a/lib/src/api/opt/endpoint/mod.rs
+++ b/lib/src/api/opt/endpoint/mod.rs
@@ -23,7 +23,7 @@ use url::Url;
 use super::Config;
 
 /// A server address used to connect to the server
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)] // used by the embedded and remote connections
 pub struct Endpoint {
 	#[doc(hidden)]
@@ -63,6 +63,23 @@ pub(crate) fn path_to_string(protocol: &str, path: impl AsRef<std::path::Path>) 
 	let cleaned = Path::new(&expanded).clean();
 	format!("{protocol}{}", cleaned.display())
 }
+
+// Macro for implementing the identity implementation of IntoEndpoint for Endpoint for various schemes
+macro_rules! identity {
+	(Client = $client:ty, $($scheme:ty),*) => {
+		$(
+			impl IntoEndpoint<$scheme> for Endpoint {
+				type Client = $client;
+
+				fn into_endpoint(self) -> Result<Endpoint> {
+					Ok(self)
+				}
+			}
+		)*
+	}
+}
+
+pub(crate) use identity;
 
 #[cfg(test)]
 mod tests {

--- a/lib/src/api/opt/endpoint/rocksdb.rs
+++ b/lib/src/api/opt/endpoint/rocksdb.rs
@@ -1,3 +1,4 @@
+use super::identity;
 use crate::api::engine::local::Db;
 use crate::api::engine::local::File;
 use crate::api::engine::local::RocksDb;
@@ -62,3 +63,4 @@ macro_rules! endpoints {
 }
 
 endpoints!(&str, &String, String, &Path, PathBuf);
+identity!(Client = Db, File, RocksDb);

--- a/lib/src/api/opt/endpoint/speedb.rs
+++ b/lib/src/api/opt/endpoint/speedb.rs
@@ -1,3 +1,4 @@
+use super::identity;
 use crate::api::engine::local::Db;
 use crate::api::engine::local::SpeeDb;
 use crate::api::opt::Config;
@@ -38,3 +39,4 @@ macro_rules! endpoints {
 }
 
 endpoints!(&str, &String, String, &Path, PathBuf);
+identity!(Client = Db, SpeeDb);

--- a/lib/src/api/opt/endpoint/tikv.rs
+++ b/lib/src/api/opt/endpoint/tikv.rs
@@ -1,3 +1,4 @@
+use super::identity;
 use crate::api::engine::local::Db;
 use crate::api::engine::local::TiKv;
 use crate::api::opt::Config;
@@ -37,3 +38,4 @@ macro_rules! endpoints {
 }
 
 endpoints!(&str, &String, String, SocketAddr);
+identity!(Client = Db, TiKv);

--- a/lib/src/api/opt/endpoint/ws.rs
+++ b/lib/src/api/opt/endpoint/ws.rs
@@ -1,3 +1,4 @@
+use super::identity;
 use crate::api::engine::remote::ws::Client;
 use crate::api::engine::remote::ws::Ws;
 use crate::api::engine::remote::ws::Wss;
@@ -62,3 +63,4 @@ macro_rules! endpoints {
 }
 
 endpoints!(&str, &String, String, SocketAddr);
+identity!(Client = Client, Ws, Wss);


### PR DESCRIPTION
## What is the motivation?

Currently, when instantiating a SurrealDB client, i.e. when calling `Surreal::new()` or just `connect()` we must
provide an input that implements `IntoEndpoint` in the form `impl IntoEndpoint<...>`. However, we cannot
simply provide an instance of `Endpoint` itself. Not only does this feel incomplete, but it also makes writing
libraries such as connection pools on top of Surreal a pain. In my case, as author of `surreal_bb8` (not yet published),
I need to get the configuration for the connection from the user and store it for later use. I of course want the user to
be able to submit any valid configuration, so any valid `impl IntoEndpoint` is desired. However, I neither want
the added complexity and runtime overhead of needing to store `Box<dyn IntoEndpoint>` in my pool struct
nor do I want to jump through the hoops required to figure out how to get Surreal::new() to accept the Boxed impl.
I'd rather just convert the input into the concrete `Endpoint` and store that. The problem is that nothing that requires
`impl IntoEndpoint` can actually receive an instance of `Endpoint` directly. Although it is possible to workaround
this issue, it would be better to not need the workaround and to just allow any function that requires `impl IntoEndpoint`
to submit an actual endpoint. This solution allows this by implementing IntoEndpoint on Endpoint, such that calling
`into_endpoint` on `Endpoint` returns itself back to the caller.

## What does this change do?

In short, now if I want to make a wrapper struct to hold a SurrealDb configuration for later use, I need to make a strict with Box<dyn ...>, liks this:

```rust
pub struct Wrapper<C, S> {
    config: Box<dyn IntoEndpoint<S, Client = C>>,
}
```

The trick after this is actually getting `Surreal::new()` to accept the Boxed value. I haven't yet found a way to do this.

```rust
impl<C, S> Wrapper<C, S> {
    fn build_conn(&self) {
        let thing = Surreal::new::<S>(self.config.as_ref().clone()); // <-- Does not work
    }
}
```

The realization I had after reviewing the sourceode, however, was that Surreal::new() does not care at all what kind
of IntoEndpoint it received -- it immediately transforms it into the concrete `Endpoint` and stores it. I thought, well why can't I
just store the endpoint and then use that to instantiate my Surreal instance later? Unfortunately, this is not possible
because Surreal will not accept an `Endpoint` as input -- it will only accept something that can become an `Endpoint`.

This PR allows such an operation. After this change, the above code can be written as follows:

```rust
pub struct Wrapper {
    config: Endpoint,
}

impl Wrapper {
    fn build_conn(&self) {
        let thing = Surreal::new(self.config);
    }
}
```

When the endpoint is passed to Surreal, Surreal will call `into_endpoint` on it and `into_endpoint` will simply return
the Endpoint instance back again.

## What is your testing strategy?

No testing strategy. This implementation's correctness should be verified at compile time. Please let me know if my
assumptions about this are incorrect.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
