### PR TITLE
Make `SELECT ONLY` deterministic

### DIFF
--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -69,12 +69,12 @@ impl SelectStatement {
 		// Get a query planner
 		let mut planner = QueryPlanner::new(opt, &self.with, &self.cond);
 		// Used for ONLY: is the limit 1?
-		let limit_is_one = self.limit.clone().is_some_and(|l| match l.0 {
+		let limit_is_one_or_zero = self.limit.clone().is_some_and(|l| match l.0 {
 			Value::Number(l) => l.to_usize() <= 1,
 			_ => false,
 		});
 		// Fail for multiple targets without a limit
-		if self.only && !limit_is_one && self.what.0.len() > 1 {
+		if self.only && !limit_is_one_or_zero && self.what.0.len() > 1 {
 			return Err(Error::SingleOnlyOutput);
 		}
 		// Loop over the select targets
@@ -83,27 +83,27 @@ impl SelectStatement {
 			match v {
 				Value::Table(t) => {
 					planner.add_iterables(ctx, txn, t, &mut i).await?;
-					if self.only && !limit_is_one {
+					if self.only && !limit_is_one_or_zero {
 						return Err(Error::SingleOnlyOutput);
 					}
 				}
 				Value::Thing(v) => i.ingest(Iterable::Thing(v)),
 				Value::Range(v) => {
-					if self.only && !limit_is_one {
+					if self.only && !limit_is_one_or_zero {
 						return Err(Error::SingleOnlyOutput);
 					}
 
 					i.ingest(Iterable::Range(*v))
 				}
 				Value::Edges(v) => {
-					if self.only && !limit_is_one {
+					if self.only && !limit_is_one_or_zero {
 						return Err(Error::SingleOnlyOutput);
 					}
 
 					i.ingest(Iterable::Edges(*v))
 				}
 				Value::Mock(v) => {
-					if self.only && !limit_is_one {
+					if self.only && !limit_is_one_or_zero {
 						return Err(Error::SingleOnlyOutput);
 					}
 
@@ -112,7 +112,7 @@ impl SelectStatement {
 					}
 				}
 				Value::Array(v) => {
-					if self.only && !limit_is_one {
+					if self.only && !limit_is_one_or_zero {
 						return Err(Error::SingleOnlyOutput);
 					}
 

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -68,22 +68,54 @@ impl SelectStatement {
 		let opt = &opt.new_with_futures(false).with_projections(true);
 		// Get a query planner
 		let mut planner = QueryPlanner::new(opt, &self.with, &self.cond);
+		// Used for ONLY: is the limit 1?
+		let limit_is_one = self.limit.clone().is_some_and(|l| match l.0 {
+			Value::Number(l) => l.to_usize() <= 1,
+			_ => false,
+		});
+		// Fail for multiple targets without a limit
+		if self.only && !limit_is_one && self.what.0.len() > 1 {
+			return Err(Error::SingleOnlyOutput);
+		}
 		// Loop over the select targets
 		for w in self.what.0.iter() {
 			let v = w.compute(ctx, opt, txn, doc).await?;
 			match v {
 				Value::Table(t) => {
 					planner.add_iterables(ctx, txn, t, &mut i).await?;
+					if self.only && !limit_is_one {
+						return Err(Error::SingleOnlyOutput);
+					}
 				}
 				Value::Thing(v) => i.ingest(Iterable::Thing(v)),
-				Value::Range(v) => i.ingest(Iterable::Range(*v)),
-				Value::Edges(v) => i.ingest(Iterable::Edges(*v)),
+				Value::Range(v) => {
+					if self.only && !limit_is_one {
+						return Err(Error::SingleOnlyOutput);
+					}
+
+					i.ingest(Iterable::Range(*v))
+				}
+				Value::Edges(v) => {
+					if self.only && !limit_is_one {
+						return Err(Error::SingleOnlyOutput);
+					}
+
+					i.ingest(Iterable::Edges(*v))
+				}
 				Value::Mock(v) => {
+					if self.only && !limit_is_one {
+						return Err(Error::SingleOnlyOutput);
+					}
+
 					for v in v {
 						i.ingest(Iterable::Thing(v));
 					}
 				}
 				Value::Array(v) => {
+					if self.only && !limit_is_one {
+						return Err(Error::SingleOnlyOutput);
+					}
+
 					for v in v {
 						match v {
 							Value::Table(t) => {
@@ -115,6 +147,8 @@ impl SelectStatement {
 		match i.output(&ctx, opt, txn, &stm).await? {
 			// This is a single record result
 			Value::Array(mut a) if self.only => match a.len() {
+				// There were no results
+				0 => Ok(Value::None),
 				// There was exactly one result
 				1 => Ok(a.remove(0)),
 				// There were no results

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -69,10 +69,10 @@ impl SelectStatement {
 		// Get a query planner
 		let mut planner = QueryPlanner::new(opt, &self.with, &self.cond);
 		// Used for ONLY: is the limit 1?
-		let limit_is_one_or_zero = self.limit.to_owned().is_some_and(|l| match l.0 {
-			Value::Number(l) => l.to_usize() <= 1,
+		let limit_is_one_or_zero = match &self.limit {
+			Some(l) => l.process(ctx, opt, txn, doc).await? <= 1,
 			_ => false,
-		});
+		};
 		// Fail for multiple targets without a limit
 		if self.only && !limit_is_one_or_zero && self.what.0.len() > 1 {
 			return Err(Error::SingleOnlyOutput);

--- a/lib/src/sql/statements/select.rs
+++ b/lib/src/sql/statements/select.rs
@@ -69,7 +69,7 @@ impl SelectStatement {
 		// Get a query planner
 		let mut planner = QueryPlanner::new(opt, &self.with, &self.cond);
 		// Used for ONLY: is the limit 1?
-		let limit_is_one_or_zero = self.limit.clone().is_some_and(|l| match l.0 {
+		let limit_is_one_or_zero = self.limit.to_owned().is_some_and(|l| match l.0 {
 			Value::Number(l) => l.to_usize() <= 1,
 			_ => false,
 		});
@@ -82,10 +82,11 @@ impl SelectStatement {
 			let v = w.compute(ctx, opt, txn, doc).await?;
 			match v {
 				Value::Table(t) => {
-					planner.add_iterables(ctx, txn, t, &mut i).await?;
 					if self.only && !limit_is_one_or_zero {
 						return Err(Error::SingleOnlyOutput);
 					}
+
+					planner.add_iterables(ctx, txn, t, &mut i).await?;
 				}
 				Value::Thing(v) => i.ingest(Iterable::Thing(v)),
 				Value::Range(v) => {

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -1008,3 +1008,69 @@ async fn check_permissions_auth_disabled() {
 		);
 	}
 }
+
+#[tokio::test]
+async fn select_only() -> Result<(), Error> {
+	let sql: &str = "
+		SELECT * FROM ONLY 1;
+		SELECT * FROM ONLY NONE;
+		SELECT * FROM ONLY [];
+		SELECT * FROM ONLY [1];
+		SELECT * FROM ONLY [1, 2];
+		SELECT * FROM ONLY [] LIMIT 1;
+		SELECT * FROM ONLY [1] LIMIT 1;
+		SELECT * FROM ONLY [1, 2] LIMIT 1;
+		SELECT * FROM ONLY 1, 2;
+		SELECT * FROM ONLY 1, 2 LIMIT 1;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 10);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("1");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("NONE");
+	assert_eq!(tmp, val);
+	//
+	match res.remove(0).result {
+		Err(surrealdb::error::Db::SingleOnlyOutput) => (),
+		_ => panic!("Query should have failed with error: Expected a single result output when using the ONLY keyword")
+	}
+	//
+	match res.remove(0).result {
+		Err(surrealdb::error::Db::SingleOnlyOutput) => (),
+		_ => panic!("Query should have failed with error: Expected a single result output when using the ONLY keyword")
+	}
+	//
+	match res.remove(0).result {
+		Err(surrealdb::error::Db::SingleOnlyOutput) => (),
+		_ => panic!("Query should have failed with error: Expected a single result output when using the ONLY keyword")
+	}
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("NONE");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("1");
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("1");
+	assert_eq!(tmp, val);
+	//
+	match res.remove(0).result {
+		Err(surrealdb::error::Db::SingleOnlyOutput) => (),
+		_ => panic!("Query should have failed with error: Expected a single result output when using the ONLY keyword")
+	}
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("1");
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `ONLY` keyword is currently non-deterministic, and will throw an error when there are 0 results.
See #2941, #2947 and #3008 for more details.

## What does this change do?

This PR makes the `ONLY` keyword deterministic for the `SELECT` statement. The other statements are out of scope, as they first require an implementation of `LIMIT`. I started on this in #3008.

The way that `LIMIT` is implemented (and start too), is that it's applied based on the output, and not on the actual items being iterated. This is likely possible with the query planner, which I'd like to look into together with @emmanuel-keller, however not realistic before the v1.1.0 release of SurrealDB, thus this PR!

## What is your testing strategy?

Added tests for the `ONLY` keyword used with the `SELECT` statement.

## Is this related to any issues?

Fixes #2941 (only for the select statement, but that's what that issue focusses on)
Besides that, read above and linked PRs.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
