### PR TITLE
Implement string prefixes for old parser.

### DIFF
--- a/lib/src/sql/escape.rs
+++ b/lib/src/sql/escape.rs
@@ -49,7 +49,12 @@ pub fn quote_str(s: &str) -> String {
 	ret.push(quote);
 	escape_into(&mut ret, s, quote == DOUBLE);
 	ret.push(quote);
+	ret
+}
 
+#[inline]
+pub fn quote_plain_str(s: &str) -> String {
+	let mut ret = quote_str(s);
 	#[cfg(not(feature = "experimental_parser"))]
 	{
 		// HACK: We need to prefix strands which look like records, uuids, or datetimes with an `s`
@@ -59,7 +64,7 @@ pub fn quote_str(s: &str) -> String {
 		// directly to avoid having to create a common interface between the old and new parser.
 		if crate::syn::v1::literal::uuid(&ret).is_ok()
 			|| crate::syn::v1::literal::datetime(&ret).is_ok()
-			|| crate::syn::thing_raw(&ret).is_ok()
+			|| crate::syn::thing(&ret).is_ok()
 		{
 			ret.insert(0, 's');
 		}

--- a/lib/src/sql/escape.rs
+++ b/lib/src/sql/escape.rs
@@ -49,6 +49,22 @@ pub fn quote_str(s: &str) -> String {
 	ret.push(quote);
 	escape_into(&mut ret, s, quote == DOUBLE);
 	ret.push(quote);
+
+	#[cfg(not(feature = "experimental_parser"))]
+	{
+		// HACK: We need to prefix strands which look like records, uuids, or datetimes with an `s`
+		// otherwise the strands will parsed as a different type when parsed again.
+		// This is not required for the new parser.
+		// Because this only required for the old parse we just reference the partial parsers
+		// directly to avoid having to create a common interface between the old and new parser.
+		if crate::syn::v1::literal::uuid(&ret).is_ok()
+			|| crate::syn::v1::literal::datetime(&ret).is_ok()
+			|| crate::syn::thing_raw(&ret).is_ok()
+		{
+			ret.insert(0, 's');
+		}
+	}
+
 	ret
 }
 

--- a/lib/src/sql/strand.rs
+++ b/lib/src/sql/strand.rs
@@ -135,7 +135,7 @@ mod test {
 		use super::Strand;
 
 		let strand = Strand("a:b".to_owned());
-		assert_eq!(strand.to_string().as_str(), "s\"a:b\"");
+		assert_eq!(strand.to_string().as_str(), "s'a:b'");
 
 		let strand = Strand("2012-04-23T18:25:43.0000511Z".to_owned());
 		assert_eq!(strand.to_string().as_str(), "s\"2012-04-23T18:25:43.0000511Z\"");

--- a/lib/src/sql/strand.rs
+++ b/lib/src/sql/strand.rs
@@ -125,3 +125,22 @@ pub(crate) mod no_nul_bytes {
 		deserializer.deserialize_string(NoNulBytesVisitor)
 	}
 }
+
+#[cfg(test)]
+mod test {
+
+	#[cfg(not(feature = "experimental_parser"))]
+	#[cfg(test)]
+	fn ensure_strands_are_prefixed() {
+		use super::Strand;
+
+		let strand = Strand("a:b".to_owned());
+		assert_eq!(strand.to_string().as_str(), "s\"a:b\"");
+
+		let strand = Strand("2012-04-23T18:25:43.0000511Z".to_owned());
+		assert_eq!(strand.to_string().as_str(), "s\"2012-04-23T18:25:43.0000511Z\"");
+
+		let strand = Strand("b19bc00b-aa98-486c-ae37-c8e1c54295b1".to_owned());
+		assert_eq!(strand.to_string().as_str(), "s\"b19bc00b-aa98-486c-ae37-c8e1c54295b1\"");
+	}
+}

--- a/lib/src/sql/strand.rs
+++ b/lib/src/sql/strand.rs
@@ -138,9 +138,9 @@ mod test {
 		assert_eq!(strand.to_string().as_str(), "s'a:b'");
 
 		let strand = Strand("2012-04-23T18:25:43.0000511Z".to_owned());
-		assert_eq!(strand.to_string().as_str(), "s\"2012-04-23T18:25:43.0000511Z\"");
+		assert_eq!(strand.to_string().as_str(), "s'2012-04-23T18:25:43.0000511Z'");
 
 		let strand = Strand("b19bc00b-aa98-486c-ae37-c8e1c54295b1".to_owned());
-		assert_eq!(strand.to_string().as_str(), "s\"b19bc00b-aa98-486c-ae37-c8e1c54295b1\"");
+		assert_eq!(strand.to_string().as_str(), "s'b19bc00b-aa98-486c-ae37-c8e1c54295b1'");
 	}
 }

--- a/lib/src/sql/strand.rs
+++ b/lib/src/sql/strand.rs
@@ -1,4 +1,4 @@
-use crate::sql::escape::quote_str;
+use crate::sql::escape::quote_plain_str;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
@@ -58,7 +58,7 @@ impl Strand {
 
 impl Display for Strand {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		Display::fmt(&quote_str(&self.0), f)
+		Display::fmt(&quote_plain_str(&self.0), f)
 	}
 }
 

--- a/lib/src/sql/strand.rs
+++ b/lib/src/sql/strand.rs
@@ -130,7 +130,7 @@ pub(crate) mod no_nul_bytes {
 mod test {
 
 	#[cfg(not(feature = "experimental_parser"))]
-	#[cfg(test)]
+	#[test]
 	fn ensure_strands_are_prefixed() {
 		use super::Strand;
 

--- a/lib/src/syn/v1/literal/datetime.rs
+++ b/lib/src/syn/v1/literal/datetime.rs
@@ -22,14 +22,14 @@ pub fn datetime(i: &str) -> IResult<&str, Datetime> {
 
 fn datetime_single(i: &str) -> IResult<&str, Datetime> {
 	alt((
-		delimited(tag("t\'"), cut(datetime_raw), cut(char('\''))),
+		delimited(tag("d\'"), cut(datetime_raw), cut(char('\''))),
 		delimited(char('\''), datetime_raw, char('\'')),
 	))(i)
 }
 
 fn datetime_double(i: &str) -> IResult<&str, Datetime> {
 	alt((
-		delimited(tag("t\""), cut(datetime_raw), cut(char('\"'))),
+		delimited(tag("d\""), cut(datetime_raw), cut(char('\"'))),
 		delimited(char('\"'), datetime_raw, char('\"')),
 	))(i)
 }
@@ -280,7 +280,7 @@ mod tests {
 		assert_eq!("'2012-04-23T18:25:43.000051100Z'", format!("{}", out));
 		assert_eq!(out, Datetime::try_from("2012-04-23T18:25:43.000051100Z").unwrap());
 
-		let sql = "t'2012-04-23T18:25:43.0000511Z'";
+		let sql = "d'2012-04-23T18:25:43.0000511Z'";
 		let res = Value::parse(sql);
 		let Value::Datetime(out) = res else {
 			panic!();

--- a/lib/src/syn/v1/literal/datetime.rs
+++ b/lib/src/syn/v1/literal/datetime.rs
@@ -274,7 +274,7 @@ mod tests {
 	fn date_time_timezone_utc_sub_nanoseconds_from_value() {
 		let sql = "'2012-04-23T18:25:43.0000511Z'";
 		let res = Value::parse(sql);
-		let Value::Uuid(out) = res else {
+		let Value::Datetime(out) = res else {
 			panic!();
 		};
 		assert_eq!("'2012-04-23T18:25:43.000051100Z'", format!("{}", out));
@@ -282,7 +282,7 @@ mod tests {
 
 		let sql = "t'2012-04-23T18:25:43.0000511Z'";
 		let res = Value::parse(sql);
-		let Value::Uuid(out) = res else {
+		let Value::Datetime(out) = res else {
 			panic!();
 		};
 		assert_eq!("'2012-04-23T18:25:43.000051100Z'", format!("{}", out));

--- a/lib/src/syn/v1/literal/datetime.rs
+++ b/lib/src/syn/v1/literal/datetime.rs
@@ -6,8 +6,14 @@ use super::super::{
 use crate::sql::Datetime;
 use chrono::{FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Utc};
 use nom::{
-	branch::alt, character::complete::char, combinator::map, error::ErrorKind, error_position,
-	sequence::delimited, Err,
+	branch::alt,
+	bytes::complete::tag,
+	character::complete::char,
+	combinator::{cut, map},
+	error::ErrorKind,
+	error_position,
+	sequence::delimited,
+	Err,
 };
 
 pub fn datetime(i: &str) -> IResult<&str, Datetime> {
@@ -15,11 +21,17 @@ pub fn datetime(i: &str) -> IResult<&str, Datetime> {
 }
 
 fn datetime_single(i: &str) -> IResult<&str, Datetime> {
-	delimited(char('\''), datetime_raw, char('\''))(i)
+	alt((
+		delimited(tag("t\'"), cut(datetime_raw), cut(char('\''))),
+		delimited(char('\''), datetime_raw, char('\'')),
+	))(i)
 }
 
 fn datetime_double(i: &str) -> IResult<&str, Datetime> {
-	delimited(char('\"'), datetime_raw, char('\"'))(i)
+	alt((
+		delimited(tag("t\""), cut(datetime_raw), cut(char('\"'))),
+		delimited(char('\"'), datetime_raw, char('\"')),
+	))(i)
 }
 
 pub fn datetime_all_raw(i: &str) -> IResult<&str, Datetime> {

--- a/lib/src/syn/v1/literal/datetime.rs
+++ b/lib/src/syn/v1/literal/datetime.rs
@@ -194,6 +194,8 @@ mod tests {
 
 	// use chrono::Date;
 
+	use crate::{sql::Value, syn::test::Parse};
+
 	use super::*;
 
 	#[test]
@@ -264,6 +266,25 @@ mod tests {
 		let sql = "2012-04-23T18:25:43.0000511Z";
 		let res = datetime_raw(sql);
 		let out = res.unwrap().1;
+		assert_eq!("'2012-04-23T18:25:43.000051100Z'", format!("{}", out));
+		assert_eq!(out, Datetime::try_from("2012-04-23T18:25:43.000051100Z").unwrap());
+	}
+
+	#[test]
+	fn date_time_timezone_utc_sub_nanoseconds_from_value() {
+		let sql = "'2012-04-23T18:25:43.0000511Z'";
+		let res = Value::parse(sql);
+		let Value::Uuid(out) = res else {
+			panic!();
+		};
+		assert_eq!("'2012-04-23T18:25:43.000051100Z'", format!("{}", out));
+		assert_eq!(out, Datetime::try_from("2012-04-23T18:25:43.000051100Z").unwrap());
+
+		let sql = "t'2012-04-23T18:25:43.0000511Z'";
+		let res = Value::parse(sql);
+		let Value::Uuid(out) = res else {
+			panic!();
+		};
 		assert_eq!("'2012-04-23T18:25:43.000051100Z'", format!("{}", out));
 		assert_eq!(out, Datetime::try_from("2012-04-23T18:25:43.000051100Z").unwrap());
 	}

--- a/lib/src/syn/v1/literal/uuid.rs
+++ b/lib/src/syn/v1/literal/uuid.rs
@@ -54,6 +54,8 @@ fn uuid_raw(i: &str) -> IResult<&str, Uuid> {
 #[cfg(test)]
 mod tests {
 
+	use crate::{sql::Value, syn::test::Parse};
+
 	use super::*;
 
 	#[test]
@@ -72,6 +74,25 @@ mod tests {
 		let res = uuid_raw(sql);
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
+		assert_eq!("'b19bc00b-aa98-486c-ae37-c8e1c54295b1'", format!("{}", out));
+		assert_eq!(out, Uuid::try_from("b19bc00b-aa98-486c-ae37-c8e1c54295b1").unwrap());
+	}
+
+	#[test]
+	fn uuid_v4_from_value() {
+		let sql = "'b19bc00b-aa98-486c-ae37-c8e1c54295b1'";
+		let res = Value::parse(sql);
+		let Value::Uuid(out) = res else {
+			panic!()
+		};
+		assert_eq!("'b19bc00b-aa98-486c-ae37-c8e1c54295b1'", format!("{}", out));
+		assert_eq!(out, Uuid::try_from("b19bc00b-aa98-486c-ae37-c8e1c54295b1").unwrap());
+
+		let sql = "u'b19bc00b-aa98-486c-ae37-c8e1c54295b1'";
+		let res = Value::parse(sql);
+		let Value::Uuid(out) = res else {
+			panic!()
+		};
 		assert_eq!("'b19bc00b-aa98-486c-ae37-c8e1c54295b1'", format!("{}", out));
 		assert_eq!(out, Uuid::try_from("b19bc00b-aa98-486c-ae37-c8e1c54295b1").unwrap());
 	}

--- a/lib/src/syn/v1/literal/uuid.rs
+++ b/lib/src/syn/v1/literal/uuid.rs
@@ -2,9 +2,9 @@ use super::super::{common::is_hex, IResult};
 use crate::sql::Uuid;
 use nom::{
 	branch::alt,
-	bytes::complete::take_while_m_n,
+	bytes::complete::{tag, take_while_m_n},
 	character::complete::char,
-	combinator::recognize,
+	combinator::{cut, recognize},
 	sequence::{delimited, tuple},
 };
 
@@ -13,11 +13,17 @@ pub fn uuid(i: &str) -> IResult<&str, Uuid> {
 }
 
 fn uuid_single(i: &str) -> IResult<&str, Uuid> {
-	delimited(char('\''), uuid_raw, char('\''))(i)
+	alt((
+		delimited(tag("u\'"), cut(uuid_raw), cut(char('\''))),
+		delimited(char('\''), uuid_raw, char('\'')),
+	))(i)
 }
 
 fn uuid_double(i: &str) -> IResult<&str, Uuid> {
-	delimited(char('\"'), uuid_raw, char('\"'))(i)
+	alt((
+		delimited(tag("u\""), cut(uuid_raw), cut(char('\"'))),
+		delimited(char('\"'), uuid_raw, char('\"')),
+	))(i)
 }
 
 fn uuid_raw(i: &str) -> IResult<&str, Uuid> {

--- a/lib/src/syn/v1/mod.rs
+++ b/lib/src/syn/v1/mod.rs
@@ -2,7 +2,7 @@ use crate::sql::{Datetime, Duration, Idiom, Query, Range, Thing, Value};
 use crate::{err::Error, sql::Subquery};
 use nom::{Err, Finish};
 
-mod literal;
+pub mod literal;
 mod part;
 mod stmt;
 

--- a/lib/src/syn/v1/thing.rs
+++ b/lib/src/syn/v1/thing.rs
@@ -65,6 +65,7 @@ mod tests {
 	use crate::sql::array::Array;
 	use crate::sql::object::Object;
 	use crate::sql::value::Value;
+	use crate::syn::test::Parse;
 
 	#[test]
 	fn thing_normal() {
@@ -86,6 +87,37 @@ mod tests {
 		let sql = "test:001";
 		let res = thing(sql);
 		let out = res.unwrap().1;
+		assert_eq!("test:1", format!("{}", out));
+		assert_eq!(
+			out,
+			Thing {
+				tb: String::from("test"),
+				id: Id::from(1),
+			}
+		);
+	}
+
+	#[test]
+	fn thing_string() {
+		let sql = "'test:001'";
+		let res = Value::parse(sql);
+		let Value::Thing(out) = res else {
+			panic!()
+		};
+		assert_eq!("test:1", format!("{}", out));
+		assert_eq!(
+			out,
+			Thing {
+				tb: String::from("test"),
+				id: Id::from(1),
+			}
+		);
+
+		let sql = "r'test:001'";
+		let res = Value::parse(sql);
+		let Value::Thing(out) = res else {
+			panic!()
+		};
 		assert_eq!("test:1", format!("{}", out));
 		assert_eq!(
 			out,

--- a/lib/src/syn/v1/thing.rs
+++ b/lib/src/syn/v1/thing.rs
@@ -9,7 +9,7 @@ use nom::{
 	branch::alt,
 	bytes::complete::tag,
 	character::complete::char,
-	combinator::{map, value},
+	combinator::{cut, map, value},
 	sequence::delimited,
 };
 
@@ -18,11 +18,17 @@ pub fn thing(i: &str) -> IResult<&str, Thing> {
 }
 
 fn thing_single(i: &str) -> IResult<&str, Thing> {
-	delimited(char('\''), thing_raw, char('\''))(i)
+	alt((
+		delimited(tag("r\'"), cut(thing_raw), cut(char('\''))),
+		delimited(char('\''), thing_raw, char('\'')),
+	))(i)
 }
 
 fn thing_double(i: &str) -> IResult<&str, Thing> {
-	delimited(char('\"'), thing_raw, char('\"'))(i)
+	alt((
+		delimited(tag("r\""), cut(thing_raw), cut(char('\"'))),
+		delimited(char('\"'), thing_raw, char('\"')),
+	))(i)
 }
 
 pub fn thing_raw(i: &str) -> IResult<&str, Thing> {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

With the new parser we're introducing string prefixes to differentiate between the different kinds of strands: Uuid, Record, Datetime, and plain. This PR add supported for strand prefixes in the old parser. 

This makes the old parser more forward compatible with the upcoming parser and also allows user to get used to using prefixed strings. This also is somewhat of a fix for issues like #1409 as user can now use the `s` string prefix to ensure the string is parsed as a plain string.

## What does this change do?

This PR implements the `u`, `d`, `r` and `s` string prefixes.
Each string prefix denotes a specific type of string: 
- `u` for UUID's
- `d` for date-times
- `r` for records
- `s` for plain strings. 

For example, the query `'a:b'` will return an record id however when prefixed with an `s` like so `s'a:b'` it will always be a plain string even if the contents match record syntax.

Unlike in the new parser, non-prefixed strings will continue to function as they did previously, dynamically returning either an UUID, Record, Datetime or plain string depending on which type matches the contents first.

In order to make sure exports can be properly re-imported this PR also makes plain strings which match strand subtypes format with a `s` prefix. This ensures that when an export is parsed again plain strings will remain plain strings.

## What is your testing strategy?

I have added tests to ensure the prefixes work as described.

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
