### PR TITLE
Optional function arguments should be optional

### DIFF
--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -191,16 +191,17 @@ impl Function {
 				}
 				// Return the value
 				// Check the function arguments
-				let mut required_args_len = 0;
+				let max_args_len = val.args.len();
+				let mut min_args_len = 0;
 				val.args.iter().rev().for_each(|(_, kind)| match kind {
-					Kind::Option(_) if required_args_len == 0 => {}
-					_ => required_args_len += 1,
+					Kind::Option(_) if min_args_len == 0 => {}
+					_ => min_args_len += 1,
 				});
 
-				if x.len() < required_args_len {
+				if x.len() < min_args_len || max_args_len < x.len() {
 					return Err(Error::InvalidArguments {
 						name: format!("fn::{}", val.name),
-						message: match (required_args_len, val.args.len()) {
+						message: match (min_args_len, max_args_len) {
 							(1, 1) => String::from("The function expects 1 argument."),
 							(r, t) if r == t => format!("The function expects {r} arguments."),
 							(r, t) => format!("The function expects {r} to {t} arguments."),

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -6336,7 +6336,7 @@ async fn function_custom_optional_args() -> Result<(), Error> {
 	}
 	//
 	match res.remove(0).result {
-		Err(surrealdb::error::Db::InvalidArguments { name, message }) if name == "fn::zero_arg" && message == "The function expects 3 arguments." => (),
+		Err(surrealdb::error::Db::InvalidArguments { name, message }) if name == "fn::zero_arg" && message == "The function expects 0 arguments." => (),
 		_ => panic!("Query should have failed with error: Incorrect arguments for function fn::zero_arg(). The function expects 0 arguments.")
 	}
 	//

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -6325,23 +6325,23 @@ async fn function_custom_optional_args() -> Result<(), Error> {
 	}
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::from("[true]");
+	let val = Value::parse("[true]");
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::from("[true, NONE]");
+	let val = Value::parse("[true, NONE]");
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::from("[true, false]");
+	let val = Value::parse("[true, false]");
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::from("[true, false, true]");
+	let val = Value::parse("[true, false, true]");
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::from("[true, NONE, true]");
+	let val = Value::parse("[true, NONE, true]");
 	assert_eq!(tmp, val);
 	//
 	Ok(())

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -6298,7 +6298,7 @@ async fn function_custom_optional_args() -> Result<(), Error> {
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 11);
+	assert_eq!(res.len(), 14);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::None;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently, if let's say the last argument of a custom function is defined with the `option<T>` type, you need to pass `NONE` to not pass a value.

## What does this change do?

It allows you to omit the last argument(s) in case they are of the `option<T>` type.

## What is your testing strategy?

Added tests

## Is this related to any issues?

Fixes #2768

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
