### PR TITLE
Don't require Array subitems field definition

### DIFF
--- a/lib/src/sql/value/each.rs
+++ b/lib/src/sql/value/each.rs
@@ -54,7 +54,7 @@ impl Value {
 					let mut res = self._each(&[path, &[Part::All]].concat(), prev.clone());
 					res.push(prev.clone());
 					res
-				},
+				}
 				_ => vec![prev],
 			},
 		}

--- a/lib/src/sql/value/each.rs
+++ b/lib/src/sql/value/each.rs
@@ -49,7 +49,14 @@ impl Value {
 				_ => vec![],
 			},
 			// No more parts so get the value
-			None => vec![prev],
+			None => match self {
+				Value::Array(_) => {
+					let mut res = self._each(&[path, &[Part::All]].concat(), prev.clone());
+					res.push(prev.clone());
+					res
+				},
+				_ => vec![prev],
+			},
 		}
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently, when you define a field like `friends` with the type `array<record<person>>`, you will also need to define the field `friends.*` with the type `record<person>`. This is counterintuitive.

## What does this change do?

In the each function, when we encounter no more parts, but when the current value is an array, it will now push a path for the array's subitems aswell.

## What is your testing strategy?

Added a test to make sure you are not required to add a field definition for array subitems

## Is this related to any issues?

Fixes #2932
Fixes #2881
Fixes #2150

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
