### PR TITLE
Make `Stream` easier to send across threads

### DIFF
--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -676,7 +676,7 @@ where
 	/// ```
 	pub fn select<R>(&self, resource: impl opt::IntoResource<R>) -> Select<C, R> {
 		Select {
-			router: self.router.extract(),
+			client: self,
 			resource: resource.into_resource(),
 			range: None,
 			response_type: PhantomData,


### PR DESCRIPTION
## What is the motivation?

`Stream` currently contains a lifetime parameter, which makes it trickier to send across threads. 

## What does this change do?

It removes the lifetime parameter.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
