### PR TITLE
Make all futures easier to send across threads

### DIFF
--- a/lib/src/api/method/authenticate.rs
+++ b/lib/src/api/method/authenticate.rs
@@ -1,9 +1,11 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
+use crate::api::method::OnceLockExt;
 use crate::api::opt::auth::Jwt;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::Surreal;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::pin::Pin;
@@ -12,7 +14,7 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Authenticate<'r, C: Connection> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) token: Jwt,
 }
 
@@ -25,7 +27,7 @@ where
 
 	fn into_future(self) -> Self::IntoFuture {
 		Box::pin(async move {
-			let router = self.router?;
+			let router = self.client.router.extract()?;
 			let mut conn = Client::new(Method::Authenticate);
 			conn.execute_unit(router, Param::new(vec![self.token.0.into()])).await
 		})

--- a/lib/src/api/method/content.rs
+++ b/lib/src/api/method/content.rs
@@ -1,15 +1,17 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::opt::Range;
 use crate::api::opt::Resource;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
 use crate::sql::to_value;
 use crate::sql::Id;
 use crate::sql::Value;
+use crate::Surreal;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
@@ -21,7 +23,7 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Content<'r, C: Connection, D, R> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) method: Method,
 	pub(super) resource: Result<Resource>,
 	pub(super) range: Option<Range<Id>>,
@@ -29,11 +31,24 @@ pub struct Content<'r, C: Connection, D, R> {
 	pub(super) response_type: PhantomData<R>,
 }
 
+impl<C, D, R> Content<'_, C, D, R>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Content<'static, C, D, R> {
+		Content {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
+}
+
 macro_rules! into_future {
 	($method:ident) => {
 		fn into_future(self) -> Self::IntoFuture {
 			let Content {
-				router,
+				client,
 				method,
 				resource,
 				range,
@@ -51,7 +66,7 @@ macro_rules! into_future {
 					Value::None | Value::Null => vec![param],
 					content => vec![param, content],
 				};
-				conn.$method(router?, Param::new(params)).await
+				conn.$method(client.router.extract()?, Param::new(params)).await
 			})
 		}
 	};

--- a/lib/src/api/method/delete.rs
+++ b/lib/src/api/method/delete.rs
@@ -1,13 +1,15 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::opt::Range;
 use crate::api::opt::Resource;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
 use crate::sql::Id;
 use crate::sql::Value;
+use crate::Surreal;
 use serde::de::DeserializeOwned;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
@@ -17,28 +19,41 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Delete<'r, C: Connection, R> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) resource: Result<Resource>,
 	pub(super) range: Option<Range<Id>>,
 	pub(super) response_type: PhantomData<R>,
+}
+
+impl<C, R> Delete<'_, C, R>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Delete<'static, C, R> {
+		Delete {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
 }
 
 macro_rules! into_future {
 	($method:ident) => {
 		fn into_future(self) -> Self::IntoFuture {
 			let Delete {
-				router,
+				client,
 				resource,
 				range,
 				..
 			} = self;
-			Box::pin(async {
+			Box::pin(async move {
 				let param = match range {
 					Some(range) => resource?.with_range(range)?.into(),
 					None => resource?.into(),
 				};
 				let mut conn = Client::new(Method::Delete);
-				conn.$method(router?, Param::new(vec![param])).await
+				conn.$method(client.router.extract()?, Param::new(vec![param])).await
 			})
 		}
 	};

--- a/lib/src/api/method/export.rs
+++ b/lib/src/api/method/export.rs
@@ -1,14 +1,16 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::Connection;
 use crate::api::Error;
 use crate::api::ExtraFeatures;
 use crate::api::Result;
+use crate::method::OnceLockExt;
 use crate::opt::ExportDestination;
+use crate::Surreal;
 use channel::Receiver;
 use futures::Stream;
 use futures::StreamExt;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
@@ -21,9 +23,22 @@ use std::task::Poll;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Export<'r, C: Connection, R> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) target: ExportDestination,
 	pub(super) response: PhantomData<R>,
+}
+
+impl<C, R> Export<'_, C, R>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Export<'static, C, R> {
+		Export {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
 }
 
 impl<'r, Client> IntoFuture for Export<'r, Client, PathBuf>
@@ -34,8 +49,8 @@ where
 	type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
 	fn into_future(self) -> Self::IntoFuture {
-		Box::pin(async {
-			let router = self.router?;
+		Box::pin(async move {
+			let router = self.client.router.extract()?;
 			if !router.features.contains(&ExtraFeatures::Backup) {
 				return Err(Error::BackupsNotSupported.into());
 			}
@@ -57,7 +72,7 @@ where
 
 	fn into_future(self) -> Self::IntoFuture {
 		Box::pin(async move {
-			let router = self.router?;
+			let router = self.client.router.extract()?;
 			if !router.features.contains(&ExtraFeatures::Backup) {
 				return Err(Error::BackupsNotSupported.into());
 			}

--- a/lib/src/api/method/import.rs
+++ b/lib/src/api/method/import.rs
@@ -1,10 +1,12 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::Connection;
 use crate::api::Error;
 use crate::api::ExtraFeatures;
 use crate::api::Result;
+use crate::method::OnceLockExt;
+use crate::Surreal;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::path::PathBuf;
@@ -14,8 +16,21 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Import<'r, C: Connection> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) file: PathBuf,
+}
+
+impl<C> Import<'_, C>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Import<'static, C> {
+		Import {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
 }
 
 impl<'r, Client> IntoFuture for Import<'r, Client>
@@ -26,8 +41,8 @@ where
 	type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
 	fn into_future(self) -> Self::IntoFuture {
-		Box::pin(async {
-			let router = self.router?;
+		Box::pin(async move {
+			let router = self.client.router.extract()?;
 			if !router.features.contains(&ExtraFeatures::Backup) {
 				return Err(Error::BackupsNotSupported.into());
 			}

--- a/lib/src/api/method/invalidate.rs
+++ b/lib/src/api/method/invalidate.rs
@@ -1,8 +1,10 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
+use crate::Surreal;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::pin::Pin;
@@ -11,7 +13,19 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Invalidate<'r, C: Connection> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
+}
+
+impl<C> Invalidate<'_, C>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Invalidate<'static, C> {
+		Invalidate {
+			client: Cow::Owned(self.client.into_owned()),
+		}
+	}
 }
 
 impl<'r, Client> IntoFuture for Invalidate<'r, Client>
@@ -22,8 +36,8 @@ where
 	type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
 	fn into_future(self) -> Self::IntoFuture {
-		Box::pin(async {
-			let router = self.router?;
+		Box::pin(async move {
+			let router = self.client.router.extract()?;
 			let mut conn = Client::new(Method::Invalidate);
 			conn.execute_unit(router, Param::new(Vec::new())).await
 		})

--- a/lib/src/api/method/merge.rs
+++ b/lib/src/api/method/merge.rs
@@ -1,15 +1,17 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::opt::Range;
 use crate::api::opt::Resource;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
 use crate::sql::to_value;
 use crate::sql::Id;
 use crate::sql::Value;
+use crate::Surreal;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
@@ -19,18 +21,31 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Merge<'r, C: Connection, D, R> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) resource: Result<Resource>,
 	pub(super) range: Option<Range<Id>>,
 	pub(super) content: D,
 	pub(super) response_type: PhantomData<R>,
 }
 
+impl<C, D, R> Merge<'_, C, D, R>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Merge<'static, C, D, R> {
+		Merge {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
+}
+
 macro_rules! into_future {
 	($method:ident) => {
 		fn into_future(self) -> Self::IntoFuture {
 			let Merge {
-				router,
+				client,
 				resource,
 				range,
 				content,
@@ -43,7 +58,7 @@ macro_rules! into_future {
 					None => resource?.into(),
 				};
 				let mut conn = Client::new(Method::Merge);
-				conn.$method(router?, Param::new(vec![param, content?])).await
+				conn.$method(client.router.extract()?, Param::new(vec![param, content?])).await
 			})
 		}
 	};

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -75,6 +75,7 @@ use crate::opt::IntoExportDestination;
 use crate::sql::to_value;
 use crate::sql::Value;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::Arc;
@@ -274,7 +275,7 @@ where
 	/// ```
 	pub fn use_ns(&self, ns: impl Into<String>) -> UseNs<C> {
 		UseNs {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			ns: ns.into(),
 		}
 	}
@@ -293,7 +294,7 @@ where
 	/// ```
 	pub fn use_db(&self, db: impl Into<String>) -> UseDb<C> {
 		UseDb {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			ns: Value::None,
 			db: db.into(),
 		}
@@ -333,7 +334,7 @@ where
 	/// ```
 	pub fn set(&self, key: impl Into<String>, value: impl Serialize) -> Set<C> {
 		Set {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			key: key.into(),
 			value: to_value(value).map_err(Into::into),
 		}
@@ -373,7 +374,7 @@ where
 	/// ```
 	pub fn unset(&self, key: impl Into<String>) -> Unset<C> {
 		Unset {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			key: key.into(),
 		}
 	}
@@ -432,7 +433,7 @@ where
 	/// ```
 	pub fn signup<R>(&self, credentials: impl Credentials<auth::Signup, R>) -> Signup<C, R> {
 		Signup {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			credentials: to_value(credentials).map_err(Into::into),
 			response_type: PhantomData,
 		}
@@ -551,7 +552,7 @@ where
 	/// ```
 	pub fn signin<R>(&self, credentials: impl Credentials<auth::Signin, R>) -> Signin<C, R> {
 		Signin {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			credentials: to_value(credentials).map_err(Into::into),
 			response_type: PhantomData,
 		}
@@ -571,7 +572,7 @@ where
 	/// ```
 	pub fn invalidate(&self) -> Invalidate<C> {
 		Invalidate {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 		}
 	}
 
@@ -590,7 +591,7 @@ where
 	/// ```
 	pub fn authenticate(&self, token: impl Into<Jwt>) -> Authenticate<C> {
 		Authenticate {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			token: token.into(),
 		}
 	}
@@ -629,7 +630,7 @@ where
 	/// ```
 	pub fn query(&self, query: impl opt::IntoQuery) -> Query<C> {
 		Query {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			query: vec![query.into_query()],
 			bindings: Ok(Default::default()),
 		}
@@ -676,7 +677,7 @@ where
 	/// ```
 	pub fn select<R>(&self, resource: impl opt::IntoResource<R>) -> Select<C, R> {
 		Select {
-			client: self,
+			client: Cow::Borrowed(self),
 			resource: resource.into_resource(),
 			range: None,
 			response_type: PhantomData,
@@ -731,7 +732,7 @@ where
 	/// ```
 	pub fn create<R>(&self, resource: impl opt::IntoResource<R>) -> Create<C, R> {
 		Create {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			resource: resource.into_resource(),
 			response_type: PhantomData,
 		}
@@ -889,7 +890,7 @@ where
 	/// ```
 	pub fn update<R>(&self, resource: impl opt::IntoResource<R>) -> Update<C, R> {
 		Update {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			resource: resource.into_resource(),
 			range: None,
 			response_type: PhantomData,
@@ -922,7 +923,7 @@ where
 	/// ```
 	pub fn delete<R>(&self, resource: impl opt::IntoResource<R>) -> Delete<C, R> {
 		Delete {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			resource: resource.into_resource(),
 			range: None,
 			response_type: PhantomData,
@@ -943,7 +944,7 @@ where
 	/// ```
 	pub fn version(&self) -> Version<C> {
 		Version {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 		}
 	}
 
@@ -961,7 +962,7 @@ where
 	/// ```
 	pub fn health(&self) -> Health<C> {
 		Health {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 		}
 	}
 
@@ -1001,7 +1002,7 @@ where
 	/// ```
 	pub fn export<R>(&self, target: impl IntoExportDestination<R>) -> Export<C, R> {
 		Export {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			target: target.into_export_destination(),
 			response: PhantomData,
 		}
@@ -1031,7 +1032,7 @@ where
 		P: AsRef<Path>,
 	{
 		Import {
-			router: self.router.extract(),
+			client: Cow::Borrowed(self),
 			file: file.as_ref().to_owned(),
 		}
 	}

--- a/lib/src/api/method/patch.rs
+++ b/lib/src/api/method/patch.rs
@@ -1,15 +1,17 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::opt::PatchOp;
 use crate::api::opt::Range;
 use crate::api::opt::Resource;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
 use crate::sql::Array;
 use crate::sql::Id;
 use crate::sql::Value;
+use crate::Surreal;
 use serde::de::DeserializeOwned;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
@@ -20,18 +22,31 @@ use std::result::Result as StdResult;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Patch<'r, C: Connection, R> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) resource: Result<Resource>,
 	pub(super) range: Option<Range<Id>>,
 	pub(super) patches: Vec<StdResult<Value, crate::err::Error>>,
 	pub(super) response_type: PhantomData<R>,
 }
 
+impl<C, R> Patch<'_, C, R>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Patch<'static, C, R> {
+		Patch {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
+}
+
 macro_rules! into_future {
 	($method:ident) => {
 		fn into_future(self) -> Self::IntoFuture {
 			let Patch {
-				router,
+				client,
 				resource,
 				range,
 				patches,
@@ -48,7 +63,7 @@ macro_rules! into_future {
 				}
 				let patches = Value::Array(Array(vec));
 				let mut conn = Client::new(Method::Patch);
-				conn.$method(router?, Param::new(vec![param, patches])).await
+				conn.$method(client.router.extract()?, Param::new(vec![param, patches])).await
 			})
 		}
 	};

--- a/lib/src/api/method/set.rs
+++ b/lib/src/api/method/set.rs
@@ -1,9 +1,11 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
 use crate::sql::Value;
+use crate::Surreal;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::pin::Pin;
@@ -12,9 +14,22 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Set<'r, C: Connection> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) key: String,
 	pub(super) value: Result<Value>,
+}
+
+impl<C> Set<'_, C>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Set<'static, C> {
+		Set {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
 }
 
 impl<'r, Client> IntoFuture for Set<'r, Client>
@@ -27,7 +42,11 @@ where
 	fn into_future(self) -> Self::IntoFuture {
 		Box::pin(async move {
 			let mut conn = Client::new(Method::Set);
-			conn.execute_unit(self.router?, Param::new(vec![self.key.into(), self.value?])).await
+			conn.execute_unit(
+				self.client.router.extract()?,
+				Param::new(vec![self.key.into(), self.value?]),
+			)
+			.await
 		})
 	}
 }

--- a/lib/src/api/method/signin.rs
+++ b/lib/src/api/method/signin.rs
@@ -1,10 +1,12 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
 use crate::sql::Value;
+use crate::Surreal;
 use serde::de::DeserializeOwned;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
@@ -14,9 +16,22 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Signin<'r, C: Connection, R> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) credentials: Result<Value>,
 	pub(super) response_type: PhantomData<R>,
+}
+
+impl<C, R> Signin<'_, C, R>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Signin<'static, C, R> {
+		Signin {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
 }
 
 impl<'r, Client, R> IntoFuture for Signin<'r, Client, R>
@@ -29,12 +44,12 @@ where
 
 	fn into_future(self) -> Self::IntoFuture {
 		let Signin {
-			router,
+			client,
 			credentials,
 			..
 		} = self;
 		Box::pin(async move {
-			let router = router?;
+			let router = client.router.extract()?;
 			let mut conn = Client::new(Method::Signin);
 			conn.execute(router, Param::new(vec![credentials?])).await
 		})

--- a/lib/src/api/method/signup.rs
+++ b/lib/src/api/method/signup.rs
@@ -1,10 +1,12 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
 use crate::sql::Value;
+use crate::Surreal;
 use serde::de::DeserializeOwned;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
@@ -14,9 +16,22 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Signup<'r, C: Connection, R> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) credentials: Result<Value>,
 	pub(super) response_type: PhantomData<R>,
+}
+
+impl<C, R> Signup<'_, C, R>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Signup<'static, C, R> {
+		Signup {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
 }
 
 impl<'r, Client, R> IntoFuture for Signup<'r, Client, R>
@@ -29,12 +44,12 @@ where
 
 	fn into_future(self) -> Self::IntoFuture {
 		let Signup {
-			router,
+			client,
 			credentials,
 			..
 		} = self;
 		Box::pin(async move {
-			let router = router?;
+			let router = client.router.extract()?;
 			let mut conn = Client::new(Method::Signup);
 			conn.execute(router, Param::new(vec![credentials?])).await
 		})

--- a/lib/src/api/method/unset.rs
+++ b/lib/src/api/method/unset.rs
@@ -1,8 +1,10 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
+use crate::Surreal;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::pin::Pin;
@@ -11,8 +13,21 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Unset<'r, C: Connection> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) key: String,
+}
+
+impl<C> Unset<'_, C>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Unset<'static, C> {
+		Unset {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
 }
 
 impl<'r, Client> IntoFuture for Unset<'r, Client>
@@ -25,7 +40,8 @@ where
 	fn into_future(self) -> Self::IntoFuture {
 		Box::pin(async move {
 			let mut conn = Client::new(Method::Unset);
-			conn.execute_unit(self.router?, Param::new(vec![self.key.into()])).await
+			conn.execute_unit(self.client.router.extract()?, Param::new(vec![self.key.into()]))
+				.await
 		})
 	}
 }

--- a/lib/src/api/method/update.rs
+++ b/lib/src/api/method/update.rs
@@ -1,6 +1,5 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::method::Content;
 use crate::api::method::Merge;
 use crate::api::method::Patch;
@@ -9,10 +8,13 @@ use crate::api::opt::Range;
 use crate::api::opt::Resource;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
 use crate::sql::Id;
 use crate::sql::Value;
+use crate::Surreal;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
@@ -22,17 +24,30 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Update<'r, C: Connection, R> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) resource: Result<Resource>,
 	pub(super) range: Option<Range<Id>>,
 	pub(super) response_type: PhantomData<R>,
+}
+
+impl<C, R> Update<'_, C, R>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Update<'static, C, R> {
+		Update {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
 }
 
 macro_rules! into_future {
 	($method:ident) => {
 		fn into_future(self) -> Self::IntoFuture {
 			let Update {
-				router,
+				client,
 				resource,
 				range,
 				..
@@ -43,7 +58,7 @@ macro_rules! into_future {
 					None => resource?.into(),
 				};
 				let mut conn = Client::new(Method::Update);
-				conn.$method(router?, Param::new(vec![param])).await
+				conn.$method(client.router.extract()?, Param::new(vec![param])).await
 			})
 		}
 	};
@@ -114,7 +129,7 @@ where
 		D: Serialize,
 	{
 		Content {
-			router: self.router,
+			client: self.client,
 			method: Method::Update,
 			resource: self.resource,
 			range: self.range,
@@ -129,7 +144,7 @@ where
 		D: Serialize,
 	{
 		Merge {
-			router: self.router,
+			client: self.client,
 			resource: self.resource,
 			range: self.range,
 			content: data,
@@ -140,7 +155,7 @@ where
 	/// Patches the current document / record data with the specified JSON Patch data
 	pub fn patch(self, PatchOp(patch): PatchOp) -> Patch<'r, C, R> {
 		Patch {
-			router: self.router,
+			client: self.client,
 			resource: self.resource,
 			range: self.range,
 			patches: vec![patch],

--- a/lib/src/api/method/use_db.rs
+++ b/lib/src/api/method/use_db.rs
@@ -1,9 +1,11 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
 use crate::sql::Value;
+use crate::Surreal;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::pin::Pin;
@@ -11,9 +13,22 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct UseDb<'r, C: Connection> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) ns: Value,
 	pub(super) db: String,
+}
+
+impl<C> UseDb<'_, C>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> UseDb<'static, C> {
+		UseDb {
+			client: Cow::Owned(self.client.into_owned()),
+			..self
+		}
+	}
 }
 
 impl<'r, Client> IntoFuture for UseDb<'r, Client>
@@ -26,7 +41,11 @@ where
 	fn into_future(self) -> Self::IntoFuture {
 		Box::pin(async move {
 			let mut conn = Client::new(Method::Use);
-			conn.execute_unit(self.router?, Param::new(vec![self.ns, self.db.into()])).await
+			conn.execute_unit(
+				self.client.router.extract()?,
+				Param::new(vec![self.ns, self.db.into()]),
+			)
+			.await
 		})
 	}
 }

--- a/lib/src/api/method/version.rs
+++ b/lib/src/api/method/version.rs
@@ -1,9 +1,11 @@
 use crate::api::conn::Method;
 use crate::api::conn::Param;
-use crate::api::conn::Router;
 use crate::api::err::Error;
 use crate::api::Connection;
 use crate::api::Result;
+use crate::method::OnceLockExt;
+use crate::Surreal;
+use std::borrow::Cow;
 use std::future::Future;
 use std::future::IntoFuture;
 use std::pin::Pin;
@@ -12,7 +14,19 @@ use std::pin::Pin;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Version<'r, C: Connection> {
-	pub(super) router: Result<&'r Router<C>>,
+	pub(super) client: Cow<'r, Surreal<C>>,
+}
+
+impl<C> Version<'_, C>
+where
+	C: Connection,
+{
+	/// Converts to an owned type which can easily be moved to a different thread
+	pub fn into_owned(self) -> Version<'static, C> {
+		Version {
+			client: Cow::Owned(self.client.into_owned()),
+		}
+	}
 }
 
 impl<'r, Client> IntoFuture for Version<'r, Client>
@@ -23,10 +37,10 @@ where
 	type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
 	fn into_future(self) -> Self::IntoFuture {
-		Box::pin(async {
+		Box::pin(async move {
 			let mut conn = Client::new(Method::Version);
 			let version = conn
-				.execute_value(self.router?, Param::new(Vec::new()))
+				.execute_value(self.client.router.extract()?, Param::new(Vec::new()))
 				.await?
 				.convert_to_string()?;
 			let semantic = version.trim_start_matches("surrealdb-");


### PR DESCRIPTION
## What is the motivation?

After https://github.com/surrealdb/surrealdb/pull/3042 it occurred to me that we may want to make the rest of our futures easier to move across threads.

## What does this change do?

It adds an `into_owned` method for all futures and streams that have a lifetime parameter. After calling `into_owned` on a type, the lifetime parameter is converted to `'static`. This makes it possible to move that type entirely into a different thread.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
