### PR TITLE
[tests/tikv] Make TiKV playground setup more resilient

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -192,7 +192,9 @@ script = """
         set -e
 
         echo "ERROR: TiUP Playground is unhealthy! Try again..."
-        kill $(cat /tmp/tiup.pid) || true 
+        kill $(cat /tmp/tiup.pid) || true
+
+        playground_attempts=$((playground_attempts + 1))
     done
 
     echo "PANIC: Couldn't start tiup playground! Here are the logs for the last attempt:"

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -143,54 +143,62 @@ run_task = { name = ["start-tikv", "ci-api-integration-tikv-tests", "stop-tikv"]
 category = "CI - SERVICES"
 dependencies = ["build-surrealdb"]
 script = """
-   #!/bin/bash -ex
+    #!/bin/bash -ex
 
-   target/debug/surreal start ${_START_SURREALDB_PATH} --allow-all &>/tmp/surrealdb-${_TEST_API_ENGINE}.log &
+    target/debug/surreal start ${_START_SURREALDB_PATH} --allow-all &>/tmp/surrealdb-${_TEST_API_ENGINE}.log &
 
-   echo $! > /tmp/surreal-${_TEST_API_ENGINE}.pid
+    echo $! > /tmp/surreal-${_TEST_API_ENGINE}.pid
 
-   set +e
-   echo "Waiting for surreal to be ready..."
-   tries=0
-   while [[ $tries < 5 ]]; do
-           target/debug/surreal is-ready 2>/dev/null && echo "Ready!" && exit 0 || sleep 1
-           tries=$((tries + 1))
-   done
+    set +e
+    echo "Waiting for surreal to be ready..."
+    tries=0
+    while [[ $tries < 5 ]]; do
+            target/debug/surreal is-ready 2>/dev/null && echo "Ready!" && exit 0 || sleep 1
+            tries=$((tries + 1))
+    done
 
-   echo "ERROR: Surreal is unhealthy!"
-   exit 1
+    echo "ERROR: Surreal is unhealthy!"
+    exit 1
 """
 
 [tasks.stop-surrealdb]
 category = "CI - SERVICES"
 script = """
-        kill $(cat /tmp/surreal-${_TEST_API_ENGINE}.pid) || true
-        sleep 5
-        kill -9 $(cat /tmp/surreal-${_TEST_API_ENGINE}.pid) || true
+    kill $(cat /tmp/surreal-${_TEST_API_ENGINE}.pid) || true
+    sleep 5
+    kill -9 $(cat /tmp/surreal-${_TEST_API_ENGINE}.pid) || true
 """
 
 [tasks.start-tikv]
 category = "CI - SERVICES"
 script = """
-   #!/bin/bash -ex
+    #!/bin/bash -ex
 
-   ${HOME}/.tiup/bin/tiup install pd tikv playground
+    ${HOME}/.tiup/bin/tiup install pd tikv playground
 
-   ${HOME}/.tiup/bin/tiup playground --mode tikv-slim --kv 3 --without-monitor &>/tmp/tiup.log &
+    playground_attempts=0
+    while [[ $playground_attempts < 5 ]]; do
+        nohup ${HOME}/.tiup/bin/tiup playground --mode tikv-slim --kv 3 --without-monitor > /tmp/tiup.log &
 
-   echo $! > /tmp/tiup.pid
+        echo $! > /tmp/tiup.pid
 
-   set +e
-   echo "Waiting for tiup playground to be ready..."
-   tries=0
-   while [[ $tries < 10 ]]; do
-           ${HOME}/.tiup/bin/tiup playground display >/dev/null && echo "Ready!" && exit 0 || sleep 5
-           tries=$((tries + 1))
-   done
-   set -e
+        set +e
+        echo "Waiting for tiup playground to be ready..."
+        tries=0
+        while [[ $tries < 10 ]]; do
+                ${HOME}/.tiup/bin/tiup playground display >/dev/null && echo "Ready!" && exit 0 || sleep 5
+                tries=$((tries + 1))
+        done
+        set -e
 
-   echo "ERROR: TiUP Playground is unhealthy!"
-   exit 1
+        echo "ERROR: TiUP Playground is unhealthy! Try again..."
+        kill $(cat /tmp/tiup.pid) || true 
+    done
+
+    echo "PANIC: Couldn't start tiup playground! Here are the logs for the last attempt:"
+    cat /tmp/tiup.log
+    
+    exit 1
 """
 
 [tasks.stop-tikv]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Sometimes the TiKV playground fails to start and make the job to fail

## What does this change do?

It makes the TiKV playground start a bit more resilient by trying to start it again if it doesn't become healthy.

## What is your testing strategy?

Make sure it works in a success scenario, and then try to run it a few times to see if we catch one of those failures and the verify we recover gracefully

## Is this related to any issues?

Example of failing job: https://github.com/surrealdb/surrealdb/actions/runs/7062124100/job/19225255925#step:8:47

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
