### PR TITLE
Use specific memory allocators depending on OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,6 +2643,26 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"
@@ -4792,6 +4821,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
+name = "snmalloc-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038507ad9c0ff0d6901e057494abcdba49a1a44fe3236f281730a9278166710d"
+dependencies = [
+ "snmalloc-sys",
+]
+
+[[package]]
+name = "snmalloc-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cae3f7f662ebf11afe4d6534e63fa5846ec0143892c78ddb1040cc01249f143"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4941,6 +4988,7 @@ dependencies = [
  "http-body",
  "hyper",
  "ipnet",
+ "jemallocator",
  "nix",
  "once_cell",
  "opentelemetry",
@@ -4956,6 +5004,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serial_test",
+ "snmalloc-rs",
  "surrealdb",
  "temp-env",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,12 @@ uuid = { version = "1.6.1", features = ["serde", "js", "v4", "v7"] }
 [target.'cfg(unix)'.dependencies]
 nix = "0.26.4"
 
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))'.dependencies]
+snmalloc-rs = "0.3.4"
+
+[target.'cfg(any(target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
+jemallocator = "0.5.4"
+
 [dev-dependencies]
 assert_fs = "1.0.13"
 env_logger = "0.10.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod cnf;
 mod dbs;
 mod env;
 mod err;
+mod mem;
 #[cfg(feature = "has-storage")]
 mod net;
 #[cfg(feature = "has-storage")]

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -1,0 +1,27 @@
+#[cfg(target_os = "android")]
+#[global_allocator]
+pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[cfg(target_os = "freebsd")]
+#[global_allocator]
+pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[cfg(target_os = "ios")]
+#[global_allocator]
+pub static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+
+#[cfg(target_os = "linux")]
+#[global_allocator]
+pub static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+
+#[cfg(target_os = "macos")]
+#[global_allocator]
+pub static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+
+#[cfg(target_os = "netbsd")]
+#[global_allocator]
+pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[cfg(target_os = "openbsd")]
+#[global_allocator]
+pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

By default, Rust uses the standard allocator provided by each operating system on which the programme is run. Some of these allocators, are less performant, and use more memory. In addition, some standard os memory allocators can experience memory fragmentation when dealing with small memory uses (like those created with spawned async tasks), as the freed memory block is less likely to be re-used, causing the overall memory usage to grow over time [[1]](https://www.svix.com/blog/heap-fragmentation-in-rust-applications/), [[2]](https://christianfscott.com/making-rust-as-fast-as-go/).

## What does this change do?

This change introduces custom allocators for each specific operating system, making use of `jemalloc` and `snmalloc`.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2750.
Closes #2783.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
