### PR TITLE
[rocksdb/speedb] Define keep_log_file_num. Default to 20

### DIFF
--- a/lib/src/kvs/rocksdb/cnf.rs
+++ b/lib/src/kvs/rocksdb/cnf.rs
@@ -55,3 +55,10 @@ pub static ROCKSDB_MIN_BLOB_SIZE: Lazy<u64> = Lazy::new(|| {
 		.map(|v| v.parse::<u64>().unwrap_or(default))
 		.unwrap_or(default)
 });
+
+pub static ROCKSDB_KEEP_LOG_FILE_NUM: Lazy<usize> = Lazy::new(|| {
+	let default = 20;
+	std::env::var("SURREAL_ROCKSDB_KEEP_LOG_FILE_NUM")
+		.map(|v| v.parse::<usize>().unwrap_or(default))
+		.unwrap_or(default)
+});

--- a/lib/src/kvs/rocksdb/mod.rs
+++ b/lib/src/kvs/rocksdb/mod.rs
@@ -79,6 +79,8 @@ impl Datastore {
 		opts.set_use_fsync(false);
 		// Only use warning log level
 		opts.set_log_level(LogLevel::Warn);
+		// Set the number of log files to keep
+		opts.set_keep_log_file_num(*cnf::ROCKSDB_KEEP_LOG_FILE_NUM);
 		// Create database if missing
 		opts.create_if_missing(true);
 		// Create column families if missing

--- a/lib/src/kvs/speedb/cnf.rs
+++ b/lib/src/kvs/speedb/cnf.rs
@@ -55,3 +55,10 @@ pub static SPEEDB_MIN_BLOB_SIZE: Lazy<u64> = Lazy::new(|| {
 		.map(|v| v.parse::<u64>().unwrap_or(default))
 		.unwrap_or(default)
 });
+
+pub static SPEEDB_KEEP_LOG_FILE_NUM: Lazy<usize> = Lazy::new(|| {
+	let default = 20;
+	std::env::var("SURREAL_SPEEDB_KEEP_LOG_FILE_NUM")
+		.map(|v| v.parse::<usize>().unwrap_or(default))
+		.unwrap_or(default)
+});

--- a/lib/src/kvs/speedb/mod.rs
+++ b/lib/src/kvs/speedb/mod.rs
@@ -79,6 +79,8 @@ impl Datastore {
 		opts.set_use_fsync(false);
 		// Only use warning log level
 		opts.set_log_level(LogLevel::Warn);
+		// Set the number of log files to keep
+		opts.set_keep_log_file_num(*cnf::SPEEDB_KEEP_LOG_FILE_NUM);
 		// Create database if missing
 		opts.create_if_missing(true);
 		// Create column families if missing


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

By default RocksDB/SpeeDB keeps 1000 log files, and SurrealDB don't allow setting a different number.

## What does this change do?

Gets the configuration number from an env var, and also sets a default value of 20

## What is your testing strategy?

Set `SURREAL_ROCKSDB_KEEP_LOG_FILE_NUM=5`, restart SurrealDB (backed by RocksDB) more than 5 times, and verify I never get more than 5 old LOG files.

Same for SpeeDB

## Is this related to any issues?

No, just lack of configurability

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
