### PR TITLE
Disable building static binaries in Nix

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,21 +14,6 @@ defaults:
 
 jobs:
 
-  build-static:
-    name: Build static Linux binary
-    if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.event.label.name == 'nix' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v20
-      - uses: cachix/cachix-action@v12
-        with:
-          name: surrealdb
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          extraPullNames: nix-community
-      - run: nix build .#static-binary
-      - run: ./result/bin/surreal help
-
   build-docker:
     name: Build Docker image
     if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.event.label.name == 'nix' }}


### PR DESCRIPTION
## What is the motivation?

Building static binaries in Nix is currently broken on main.

## What does this change do?

It disables building such binaries in Nix.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
