### PR TITLE
Fix memory leak

### DIFF
--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -214,7 +214,7 @@ impl Connection {
 				biased;
 				// Check if this has shutdown
 				_ = canceller.cancelled() => break,
-				//
+				// Remove any completed tasks
 				Some(_) = tasks.join_next() => continue,
 				// Wait for the next message to read
 				Some(msg) = receiver.next() => {

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -263,6 +263,13 @@ impl Connection {
 				}
 			}
 		}
+		// Wait for all tasks to finish
+		while let Some(res) = tasks.join_next().await {
+			if let Err(err) = res {
+				// There was an error with the task
+				trace!("WebSocket request error: {:?}", err);
+			}
+		}
 		// Abort all tasks
 		tasks.shutdown().await;
 	}

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -215,7 +215,7 @@ impl Connection {
 				// Check if this has shutdown
 				_ = canceller.cancelled() => break,
 				// Remove any completed tasks
-				Some(out) = tasks.join_next() => match out{
+				Some(out) = tasks.join_next() => match out {
 					// The task completed successfully
 					Ok(_) => continue,
 					// There was an uncaught panic in the task


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently spawned tasks in the WebSocket interface were collected in to a task set, and were not released when completed, but only released when the WebSocket connection terminated. This caused a large spike in memory usage over time.

## What does this change do?

Removes a memory leak in the WebSocket implementation.

## What is your testing strategy?

GitHub Actions testing, and manual testing.

## Is this related to any issues?

Closes #2750.
Closes #2783.
Related to #3056.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
