### PR TITLE
[mem] Use mimalloc instead of snmalloc

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,6 +13,20 @@ defaults:
     shell: bash
 
 jobs:
+  build-static:
+    name: Build static Linux binary
+    if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.event.label.name == 'nix' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v20
+      - uses: cachix/cachix-action@v12
+        with:
+          name: surrealdb
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extraPullNames: nix-community
+      - run: nix build .#static-binary
+      - run: ./result/bin/surreal help
 
   build-docker:
     name: Build Docker image

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,15 +1207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,6 +2758,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +2958,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -4821,24 +4831,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
-name = "snmalloc-rs"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038507ad9c0ff0d6901e057494abcdba49a1a44fe3236f281730a9278166710d"
-dependencies = [
- "snmalloc-sys",
-]
-
-[[package]]
-name = "snmalloc-sys"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cae3f7f662ebf11afe4d6534e63fa5846ec0143892c78ddb1040cc01249f143"
-dependencies = [
- "cmake",
-]
-
-[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4989,6 +4981,7 @@ dependencies = [
  "hyper",
  "ipnet",
  "jemallocator",
+ "mimalloc",
  "nix",
  "once_cell",
  "opentelemetry",
@@ -5004,7 +4997,6 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serial_test",
- "snmalloc-rs",
  "surrealdb",
  "temp-env",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ uuid = { version = "1.6.1", features = ["serde", "js", "v4", "v7"] }
 nix = "0.26.4"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))'.dependencies]
-snmalloc-rs = "0.3.4"
+mimalloc = { version = "0.1.39", default-features = false }
 
 [target.'cfg(any(target_os = "android", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 jemallocator = "0.5.4"

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -8,15 +8,15 @@ pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[cfg(target_os = "ios")]
 #[global_allocator]
-pub static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+pub static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[cfg(target_os = "linux")]
 #[global_allocator]
-pub static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+pub static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[cfg(target_os = "macos")]
 #[global_allocator]
-pub static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+pub static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[cfg(target_os = "netbsd")]
 #[global_allocator]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`snmalloc` has higher requirements in terms of tooling, like Cmake or C++ version. Use `mimalloc` so the binary can be compiled in older linux distros.

## What does this change do?

* It replaces the `snmalloc` by `mimalloc`
* Re-adds the removed nix job (see #3065)

## What is your testing strategy?

Let the automated tests run

## Is this related to any issues?

I found problems when compiling the binary in ubuntu:18.04 (see #3014 )

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
