### PR TITLE
Add mimalloc as a Nix dependency

### DIFF
--- a/pkg/nix/spec/x86_64-unknown-linux-musl.nix
+++ b/pkg/nix/spec/x86_64-unknown-linux-musl.nix
@@ -6,7 +6,7 @@
   features = with util.features; [ storage-mem ];
 
   buildSpec = with pkgs; {
-    nativeBuildInputs = with pkgsStatic; [ stdenv.cc openssl ];
+    nativeBuildInputs = with pkgsStatic; [ stdenv.cc openssl mimalloc ];
 
     CARGO_BUILD_TARGET = target;
 


### PR DESCRIPTION
## What is the motivation?

Static binaries are broken on main.

## What does this change do?

It adds mimalloc as a dependency so that the compiler can discover it.

## What is your testing strategy?

Github actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
