### PR TITLE
[gh actions] Use self-hosted runners

### DIFF
--- a/.github/workflows/reusable_docker.yml
+++ b/.github/workflows/reusable_docker.yml
@@ -48,6 +48,18 @@ jobs:
       build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
       push-matrix: ${{ steps.set-matrix.outputs.push-matrix }}
     steps:
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          set -x
+          set +e # Don't fail, do what we can
+          docker system prune -f
+          docker image prune -a -f
+
+          docker image ls
+          docker ps -a
+          df -h
+
       - name: Check if AWS credentials are set
         id: aws-credentials
         run: |

--- a/.github/workflows/reusable_docker.yml
+++ b/.github/workflows/reusable_docker.yml
@@ -246,8 +246,10 @@ jobs:
         if: ${{ always() }}
         run: |
           set -x
+          set +e # Don't fail, do what we can
+          docker system prune -f
           docker image rm ${{ steps.build.outputs.imageid }}
-          docker image rm ${{ steps.login-ecr.outputs.registry }}/surrealdb-ci:${{ matrix.tag }}-${{ github.run_id }} || true
+          docker image rm ${{ steps.login-ecr.outputs.registry }}/surrealdb-ci:${{ matrix.tag }}-${{ github.run_id }}
           docker system prune -f
 
           docker image ls

--- a/.github/workflows/reusable_docker.yml
+++ b/.github/workflows/reusable_docker.yml
@@ -241,6 +241,18 @@ jobs:
         run: |
           docker tag ${{ steps.build.outputs.imageid }} ${{ steps.login-ecr.outputs.registry }}/surrealdb-ci:${{ matrix.tag }}-${{ github.run_id }}
           docker push ${{ steps.login-ecr.outputs.registry }}/surrealdb-ci:${{ matrix.tag }}-${{ github.run_id }}
+      
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          set -x
+          docker image rm ${{ steps.build.outputs.imageid }}
+          docker image rm ${{ steps.login-ecr.outputs.registry }}/surrealdb-ci:${{ matrix.tag }}-${{ github.run_id }} || true
+          docker system prune -f
+
+          docker image ls
+          docker ps -a
+          df -h
 
   # Push a multi-arch manifest to the CI registry
   push-all-to-ecr-ci:

--- a/.github/workflows/reusable_docker.yml
+++ b/.github/workflows/reusable_docker.yml
@@ -77,7 +77,7 @@ jobs:
               - name: Binary image
                 dockerfile: Dockerfile.binary
                 platform: amd64
-                runner: ubuntu-latest-4-cores
+                runner: ["self-hosted", "amd64", "builder"]
                 tag: amd64-${{ steps.tag-prefix.outputs.tag-prefix }}-binary
               ########################################
               # Base images
@@ -88,12 +88,12 @@ jobs:
                 dockerfile: Dockerfile
                 build-target: prod
                 platform: amd64
-                runner: ubuntu-latest-4-cores
+                runner: ["self-hosted", "amd64", "builder"]
                 tag: amd64-${{ steps.tag-prefix.outputs.tag-prefix }}
               # Prod ARM64 image
               - <<: *base_image
                 platform: arm64
-                runner: ["self-hosted", "arm64", "4-cores"]
+                runner: ["self-hosted", "arm64", "builder"]
                 tag: arm64-${{ steps.tag-prefix.outputs.tag-prefix }}
               # Dev AMD64 image
               - <<: *base_image
@@ -103,7 +103,7 @@ jobs:
               - <<: *base_image
                 build-target: dev
                 platform: arm64
-                runner: ["self-hosted", "arm64", "4-cores"]
+                runner: ["self-hosted", "arm64", "builder"]
                 tag: arm64-${{ steps.tag-prefix.outputs.tag-prefix }}-dev
 
               ########################################
@@ -115,7 +115,7 @@ jobs:
                 dockerfile: Dockerfile.fdb
                 build-target: prod
                 platform: amd64
-                runner: ubuntu-latest-4-cores
+                runner: ["self-hosted", "amd64", "builder"]
                 tag: amd64-${{ steps.tag-prefix.outputs.tag-prefix }}-fdb
               # Dev AMD64 image
               - <<: *fdb_image

--- a/.github/workflows/reusable_docker.yml
+++ b/.github/workflows/reusable_docker.yml
@@ -48,17 +48,6 @@ jobs:
       build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
       push-matrix: ${{ steps.set-matrix.outputs.push-matrix }}
     steps:
-      - name: Cleanup
-        if: ${{ always() }}
-        run: |
-          set -x
-          set +e # Don't fail, do what we can
-          docker system prune -f
-          docker image prune -a -f
-
-          docker image ls
-          docker ps -a
-          df -h
 
       - name: Check if AWS credentials are set
         id: aws-credentials
@@ -199,6 +188,18 @@ jobs:
           mv _docker/docker .
           mv _docker/.dockerignore .
           rm -rf _docker
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          set -x
+          set +e # Don't fail, do what we can
+          docker system prune -f
+          docker image prune -a -f
+
+          docker image ls
+          docker ps -a
+          df -h
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -176,7 +176,7 @@ jobs:
 
           # Linux amd64
           - arch: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest-16-cores
+            runner: ["self-hosted", "amd64", "builder"]
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
               # Build
@@ -196,7 +196,7 @@ jobs:
 
           # Linux arm64
           - arch: aarch64-unknown-linux-gnu
-            runner: ["self-hosted", "arm64", "4-cores"]
+            runner: ["self-hosted", "arm64", "builder"]
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-arm64
             build-step: |
               # Build


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`ubuntu-latest-X-cores` runners are expensive (`$0.016/minute` or `$0.96/hour` for 4-cores vs `$0.2318/hour` for `m7a.xlarge` instances.

## What does this change do?

This PR changes the paid ubuntu runners for self-hosted runners.

## What is your testing strategy?

Let the CI run and also test the nightly workflows without publishing it.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
