### PR TITLE
[nix] Disable nix static job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,20 +13,22 @@ defaults:
     shell: bash
 
 jobs:
-  build-static:
-    name: Build static Linux binary
-    if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.event.label.name == 'nix' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v20
-      - uses: cachix/cachix-action@v12
-        with:
-          name: surrealdb
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          extraPullNames: nix-community
-      - run: nix build .#static-binary
-      - run: ./result/bin/surreal help
+  # TODO: Figure out why it fails to build
+  # 
+  # build-static:
+  #   name: Build static Linux binary
+  #   if: ${{ github.ref == 'refs/heads/main' }} || ${{ github.event.label.name == 'nix' }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: cachix/install-nix-action@v20
+  #     - uses: cachix/cachix-action@v12
+  #       with:
+  #         name: surrealdb
+  #         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+  #         extraPullNames: nix-community
+  #     - run: nix build .#static-binary
+  #     - run: ./result/bin/surreal help
 
   build-docker:
     name: Build Docker image


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Nix static build is broken: https://github.com/surrealdb/surrealdb/actions/runs/7100516552/job/19326764705

## What does this change do?

Disable the nix static build for now

## What is your testing strategy?

N/A

## Is this related to any issues?

Broken build

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
