### PR TITLE
Default table permissions should be `NONE`

### DIFF
--- a/lib/src/sql/permission.rs
+++ b/lib/src/sql/permission.rs
@@ -139,7 +139,7 @@ pub enum Permission {
 
 impl Default for Permission {
 	fn default() -> Self {
-		Self::None
+		Self::Full
 	}
 }
 

--- a/lib/src/sql/permission.rs
+++ b/lib/src/sql/permission.rs
@@ -139,7 +139,7 @@ pub enum Permission {
 
 impl Default for Permission {
 	fn default() -> Self {
-		Self::Full
+		Self::None
 	}
 }
 

--- a/lib/src/syn/v1/part/permission.rs
+++ b/lib/src/syn/v1/part/permission.rs
@@ -17,10 +17,10 @@ use nom::{
 	sequence::tuple,
 };
 
-pub fn permissions(i: &str) -> IResult<&str, Permissions> {
+pub fn permissions(i: &str, default: Option<Permission>) -> IResult<&str, Permissions> {
 	let (i, _) = tag_no_case("PERMISSIONS")(i)?;
 	let (i, _) = shouldbespace(i)?;
-	cut(alt((none, full, specific)))(i)
+	cut(alt((none, full, specific(default))))(i)
 }
 
 fn none(i: &str) -> IResult<&str, Permissions> {
@@ -33,49 +33,53 @@ fn full(i: &str) -> IResult<&str, Permissions> {
 	Ok((i, Permissions::full()))
 }
 
-fn specific(i: &str) -> IResult<&str, Permissions> {
-	let (i, perms) = separated_list1(commasorspace, rule)(i)?;
-	Ok((
-		i,
-		Permissions {
-			select: perms
-				.iter()
-				.find_map(|x| {
-					x.iter().find_map(|y| match y {
-						(PermissionKind::Select, ref v) => Some(v.to_owned()),
-						_ => None,
+fn specific(default: Option<Permission>) -> impl Fn(&str) -> IResult<&str, Permissions> {
+	let default = default.unwrap_or_default();
+
+	move |i: &str| -> IResult<&str, Permissions> {
+		let (i, perms) = separated_list1(commasorspace, rule)(i)?;
+		Ok((
+			i,
+			Permissions {
+				select: perms
+					.iter()
+					.find_map(|x| {
+						x.iter().find_map(|y| match y {
+							(PermissionKind::Select, ref v) => Some(v.to_owned()),
+							_ => None,
+						})
 					})
-				})
-				.unwrap_or_default(),
-			create: perms
-				.iter()
-				.find_map(|x| {
-					x.iter().find_map(|y| match y {
-						(PermissionKind::Create, ref v) => Some(v.to_owned()),
-						_ => None,
+					.unwrap_or(default.to_owned()),
+				create: perms
+					.iter()
+					.find_map(|x| {
+						x.iter().find_map(|y| match y {
+							(PermissionKind::Create, ref v) => Some(v.to_owned()),
+							_ => None,
+						})
 					})
-				})
-				.unwrap_or_default(),
-			update: perms
-				.iter()
-				.find_map(|x| {
-					x.iter().find_map(|y| match y {
-						(PermissionKind::Update, ref v) => Some(v.to_owned()),
-						_ => None,
+					.unwrap_or(default.to_owned()),
+				update: perms
+					.iter()
+					.find_map(|x| {
+						x.iter().find_map(|y| match y {
+							(PermissionKind::Update, ref v) => Some(v.to_owned()),
+							_ => None,
+						})
 					})
-				})
-				.unwrap_or_default(),
-			delete: perms
-				.iter()
-				.find_map(|x| {
-					x.iter().find_map(|y| match y {
-						(PermissionKind::Delete, ref v) => Some(v.to_owned()),
-						_ => None,
+					.unwrap_or(default.to_owned()),
+				delete: perms
+					.iter()
+					.find_map(|x| {
+						x.iter().find_map(|y| match y {
+							(PermissionKind::Delete, ref v) => Some(v.to_owned()),
+							_ => None,
+						})
 					})
-				})
-				.unwrap_or_default(),
-		},
-	))
+					.unwrap_or(default.to_owned()),
+			},
+		))
+	}
 }
 
 pub fn permission(i: &str) -> IResult<&str, Permission> {
@@ -126,7 +130,7 @@ mod test {
 	#[test]
 	fn permissions_none() {
 		let sql = "PERMISSIONS NONE";
-		let res = permissions(sql);
+		let res = permissions(sql, None);
 		let out = res.unwrap().1;
 		assert_eq!("PERMISSIONS NONE", format!("{}", out));
 		assert_eq!(out, Permissions::none());
@@ -135,7 +139,7 @@ mod test {
 	#[test]
 	fn permissions_full() {
 		let sql = "PERMISSIONS FULL";
-		let res = permissions(sql);
+		let res = permissions(sql, None);
 		let out = res.unwrap().1;
 		assert_eq!("PERMISSIONS FULL", format!("{}", out));
 		assert_eq!(out, Permissions::full());
@@ -145,7 +149,7 @@ mod test {
 	fn permissions_specific() {
 		let sql =
 			"PERMISSIONS FOR select FULL, FOR create, update WHERE public = true, FOR delete NONE";
-		let res = permissions(sql);
+		let res = permissions(sql, None);
 		let out = res.unwrap().1;
 		assert_eq!(
 			"PERMISSIONS FOR select FULL, FOR create, update WHERE public = true, FOR delete NONE",

--- a/lib/src/syn/v1/stmt/define/field.rs
+++ b/lib/src/syn/v1/stmt/define/field.rs
@@ -142,6 +142,5 @@ fn field_comment(i: &str) -> IResult<&str, DefineFieldOption> {
 fn field_permissions(i: &str) -> IResult<&str, DefineFieldOption> {
 	let (i, _) = shouldbespace(i)?;
 	let (i, v) = permissions(i, None)?;
-	println!("perms {:?}", v);
 	Ok((i, DefineFieldOption::Permissions(v)))
 }

--- a/lib/src/syn/v1/stmt/define/field.rs
+++ b/lib/src/syn/v1/stmt/define/field.rs
@@ -9,7 +9,7 @@ use super::super::super::{
 	value::value,
 	IResult,
 };
-use crate::sql::{statements::DefineFieldStatement, Kind, Permission, Permissions, Strand, Value};
+use crate::sql::{statements::DefineFieldStatement, Kind, Permissions, Strand, Value};
 use nom::{
 	branch::alt,
 	bytes::complete::tag_no_case,
@@ -39,7 +39,6 @@ pub fn field(i: &str) -> IResult<&str, DefineFieldStatement> {
 	let mut res = DefineFieldStatement {
 		name,
 		what,
-		permissions: Permissions::full(),
 		..Default::default()
 	};
 	// Assign any defined options
@@ -142,7 +141,7 @@ fn field_comment(i: &str) -> IResult<&str, DefineFieldOption> {
 
 fn field_permissions(i: &str) -> IResult<&str, DefineFieldOption> {
 	let (i, _) = shouldbespace(i)?;
-	let (i, v) = permissions(i, Some(Permission::Full))?;
+	let (i, v) = permissions(i, None)?;
 	println!("perms {:?}", v);
 	Ok((i, DefineFieldOption::Permissions(v)))
 }

--- a/lib/src/syn/v1/stmt/define/field.rs
+++ b/lib/src/syn/v1/stmt/define/field.rs
@@ -9,7 +9,7 @@ use super::super::super::{
 	value::value,
 	IResult,
 };
-use crate::sql::{statements::DefineFieldStatement, Kind, Permissions, Strand, Value, Permission};
+use crate::sql::{statements::DefineFieldStatement, Kind, Permission, Permissions, Strand, Value};
 use nom::{
 	branch::alt,
 	bytes::complete::tag_no_case,

--- a/lib/src/syn/v1/stmt/define/field.rs
+++ b/lib/src/syn/v1/stmt/define/field.rs
@@ -9,7 +9,7 @@ use super::super::super::{
 	value::value,
 	IResult,
 };
-use crate::sql::{statements::DefineFieldStatement, Kind, Permissions, Strand, Value};
+use crate::sql::{statements::DefineFieldStatement, Kind, Permissions, Strand, Value, Permission};
 use nom::{
 	branch::alt,
 	bytes::complete::tag_no_case,
@@ -39,6 +39,7 @@ pub fn field(i: &str) -> IResult<&str, DefineFieldStatement> {
 	let mut res = DefineFieldStatement {
 		name,
 		what,
+		permissions: Permissions::full(),
 		..Default::default()
 	};
 	// Assign any defined options
@@ -141,6 +142,7 @@ fn field_comment(i: &str) -> IResult<&str, DefineFieldOption> {
 
 fn field_permissions(i: &str) -> IResult<&str, DefineFieldOption> {
 	let (i, _) = shouldbespace(i)?;
-	let (i, v) = permissions(i)?;
+	let (i, v) = permissions(i, Some(Permission::Full))?;
+	println!("perms {:?}", v);
 	Ok((i, DefineFieldOption::Permissions(v)))
 }

--- a/lib/src/syn/v1/stmt/define/field.rs
+++ b/lib/src/syn/v1/stmt/define/field.rs
@@ -9,7 +9,7 @@ use super::super::super::{
 	value::value,
 	IResult,
 };
-use crate::sql::{statements::DefineFieldStatement, Kind, Permissions, Strand, Value};
+use crate::sql::{statements::DefineFieldStatement, Kind, Permission, Permissions, Strand, Value};
 use nom::{
 	branch::alt,
 	bytes::complete::tag_no_case,
@@ -141,6 +141,6 @@ fn field_comment(i: &str) -> IResult<&str, DefineFieldOption> {
 
 fn field_permissions(i: &str) -> IResult<&str, DefineFieldOption> {
 	let (i, _) = shouldbespace(i)?;
-	let (i, v) = permissions(i, None)?;
+	let (i, v) = permissions(i, Permission::Full)?;
 	Ok((i, DefineFieldOption::Permissions(v)))
 }

--- a/lib/src/syn/v1/stmt/define/table.rs
+++ b/lib/src/syn/v1/stmt/define/table.rs
@@ -6,7 +6,7 @@ use super::super::super::{
 	part::{changefeed, permission::permissions, view},
 	IResult,
 };
-use crate::sql::{statements::DefineTableStatement, ChangeFeed, Permissions, Strand, View};
+use crate::sql::{statements::DefineTableStatement, ChangeFeed, Permissions, Strand, View, Permission};
 use nom::{branch::alt, bytes::complete::tag_no_case, combinator::cut, multi::many0};
 
 pub fn table(i: &str) -> IResult<&str, DefineTableStatement> {
@@ -21,6 +21,7 @@ pub fn table(i: &str) -> IResult<&str, DefineTableStatement> {
 	// Create the base statement
 	let mut res = DefineTableStatement {
 		name,
+		permissions: Permissions::none(),
 		..Default::default()
 	};
 	// Assign any defined options
@@ -116,7 +117,7 @@ fn table_comment(i: &str) -> IResult<&str, DefineTableOption> {
 
 fn table_permissions(i: &str) -> IResult<&str, DefineTableOption> {
 	let (i, _) = shouldbespace(i)?;
-	let (i, v) = permissions(i)?;
+	let (i, v) = permissions(i, Some(Permission::None))?;
 	Ok((i, DefineTableOption::Permissions(v)))
 }
 

--- a/lib/src/syn/v1/stmt/define/table.rs
+++ b/lib/src/syn/v1/stmt/define/table.rs
@@ -130,7 +130,7 @@ mod tests {
 
 	#[test]
 	fn define_table_with_changefeed() {
-		let sql = "TABLE mytable SCHEMALESS CHANGEFEED 1h";
+		let sql = "TABLE mytable SCHEMALESS CHANGEFEED 1h PERMISSIONS NONE";
 		let res = table(sql);
 		let out = res.unwrap().1;
 		assert_eq!(format!("DEFINE {sql}"), format!("{}", out));

--- a/lib/src/syn/v1/stmt/define/table.rs
+++ b/lib/src/syn/v1/stmt/define/table.rs
@@ -119,7 +119,7 @@ fn table_comment(i: &str) -> IResult<&str, DefineTableOption> {
 
 fn table_permissions(i: &str) -> IResult<&str, DefineTableOption> {
 	let (i, _) = shouldbespace(i)?;
-	let (i, v) = permissions(i, Some(Permission::None))?;
+	let (i, v) = permissions(i, Permission::None)?;
 	Ok((i, DefineTableOption::Permissions(v)))
 }
 

--- a/lib/src/syn/v1/stmt/define/table.rs
+++ b/lib/src/syn/v1/stmt/define/table.rs
@@ -6,7 +6,9 @@ use super::super::super::{
 	part::{changefeed, permission::permissions, view},
 	IResult,
 };
-use crate::sql::{statements::DefineTableStatement, ChangeFeed, Permissions, Strand, View, Permission};
+use crate::sql::{
+	statements::DefineTableStatement, ChangeFeed, Permission, Permissions, Strand, View,
+};
 use nom::{branch::alt, bytes::complete::tag_no_case, combinator::cut, multi::many0};
 
 pub fn table(i: &str) -> IResult<&str, DefineTableStatement> {

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -122,7 +122,7 @@ async fn define_statement_table_drop() -> Result<(), Error> {
 			functions: {},
 			params: {},
 			scopes: {},
-			tables: { test: 'DEFINE TABLE test DROP SCHEMALESS' },
+			tables: { test: 'DEFINE TABLE test DROP SCHEMALESS PERMISSIONS NONE' },
 			users: {},
 		}",
 	);
@@ -153,7 +153,7 @@ async fn define_statement_table_schemaless() -> Result<(), Error> {
 			functions: {},
 			params: {},
 			scopes: {},
-			tables: { test: 'DEFINE TABLE test SCHEMALESS' },
+			tables: { test: 'DEFINE TABLE test SCHEMALESS PERMISSIONS NONE' },
 			users: {},
 		}",
 	);
@@ -188,7 +188,7 @@ async fn define_statement_table_schemafull() -> Result<(), Error> {
 			functions: {},
 			params: {},
 			scopes: {},
-			tables: { test: 'DEFINE TABLE test SCHEMAFULL' },
+			tables: { test: 'DEFINE TABLE test SCHEMAFULL PERMISSIONS NONE' },
 			users: {},
 		}",
 	);
@@ -219,7 +219,7 @@ async fn define_statement_table_schemaful() -> Result<(), Error> {
 			functions: {},
 			params: {},
 			scopes: {},
-			tables: { test: 'DEFINE TABLE test SCHEMAFULL' },
+			tables: { test: 'DEFINE TABLE test SCHEMAFULL PERMISSIONS NONE' },
 			users: {},
 		}",
 	);
@@ -259,8 +259,8 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 			params: {},
 			scopes: {},
 			tables: {
-				test: 'DEFINE TABLE test SCHEMAFULL',
-				view: 'DEFINE TABLE view SCHEMALESS AS SELECT count() FROM test GROUP ALL',
+				test: 'DEFINE TABLE test SCHEMAFULL PERMISSIONS NONE',
+				view: 'DEFINE TABLE view SCHEMALESS AS SELECT count() FROM test GROUP ALL PERMISSIONS NONE',
 			},
 			users: {},
 		}",
@@ -272,7 +272,7 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 		"{
 			events: {},
 			fields: {},
-			tables: { view: 'DEFINE TABLE view SCHEMALESS AS SELECT count() FROM test GROUP ALL' },
+			tables: { view: 'DEFINE TABLE view SCHEMALESS AS SELECT count() FROM test GROUP ALL PERMISSIONS NONE' },
 			indexes: {},
 			lives: {},
 		}",
@@ -291,7 +291,7 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 			params: {},
 			scopes: {},
 			tables: {
-				test: 'DEFINE TABLE test SCHEMAFULL',
+				test: 'DEFINE TABLE test SCHEMAFULL PERMISSIONS NONE',
 			},
 			users: {},
 		}",
@@ -1871,7 +1871,7 @@ async fn permissions_checks_define_table() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: { TB: 'DEFINE TABLE TB SCHEMALESS' }, tokens: {  }, users: {  } }"],
+        vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: { TB: 'DEFINE TABLE TB SCHEMALESS PERMISSIONS NONE' }, tokens: {  }, users: {  } }"],
 		vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: {  }, tokens: {  }, users: {  } }"]
     ];
 

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -601,7 +601,7 @@ async fn permissions_checks_remove_table() {
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
 		vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: {  }, tokens: {  }, users: {  } }"],
-        vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: { TB: 'DEFINE TABLE TB SCHEMALESS' }, tokens: {  }, users: {  } }"],
+        vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: { TB: 'DEFINE TABLE TB SCHEMALESS PERMISSIONS NONE' }, tokens: {  }, users: {  } }"],
     ];
 
 	let test_cases = [

--- a/lib/tests/table.rs
+++ b/lib/tests/table.rs
@@ -43,7 +43,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 		"{
 			events: {},
 			fields: {},
-			tables: { person_by_age: 'DEFINE TABLE person_by_age SCHEMALESS AS SELECT count(), age, math::sum(age) AS total, math::mean(score) AS average FROM person GROUP BY age' },
+			tables: { person_by_age: 'DEFINE TABLE person_by_age SCHEMALESS AS SELECT count(), age, math::sum(age) AS total, math::mean(score) AS average FROM person GROUP BY age PERMISSIONS NONE' },
 			indexes: {},
 			lives: {},
 		}",


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

It is commonly expected that when you define a table, permissions are restrictive (`NONE` by default), and that when you define a field, permissions are submissive (`FULL` by default), making tables the restricting factor in scopes being able to perform CRUD operations on a table, with granular control for fields. This is currently not the case, as all permissions are submissive (`FULL`) by default.

## What does this change do?

It makes permissions restrictive for tables by default, and leaves them submissive for fields.

## What is your testing strategy?

Updated tests

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
