### PR TITLE
Remove environment key from crates

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -23,7 +23,6 @@ defaults:
 jobs:
   crate:
     name: Publish surrealdb to crates.io
-    environment: crate-beta
     runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -23,6 +23,7 @@ defaults:
 jobs:
   crate:
     name: Publish surrealdb to crates.io
+    environment: crate-beta
     runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain
@@ -86,7 +87,6 @@ jobs:
 
       - name: Publish the crate
         if: ${{ inputs.publish }}
-        environment: crate-beta
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           GIT_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,6 @@ jobs:
 
   crate:
     name: Publish surrealdb-nightly to crates.io
-    environment: crate-nightly
     runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain


### PR DESCRIPTION
## What is the motivation?

The `environment` key broke the beta workflow.

```
Invalid workflow file: .github/workflows/beta.yml#L89
The workflow is not valid. .github/workflows/beta.yml (Line: 89, Col: 9): Unexpected value 'environment'
```

## What does this change do?

It removes the environment key from crate jobs.

## What is your testing strategy?

Ran the workflow manually.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
