### PR TITLE
switch to non-deprecated chrono methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec 1.11.0",
  "socket2 0.4.9",
- "time 0.3.27",
+ "time",
  "url",
 ]
 
@@ -1138,18 +1138,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1338,7 +1337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.27",
+ "time",
  "version_check",
 ]
 
@@ -4090,7 +4089,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem 1.1.1",
  "ring",
- "time 0.3.27",
+ "time",
  "yasna",
 ]
 
@@ -4913,7 +4912,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.27",
+ "time",
 ]
 
 [[package]]
@@ -5035,7 +5034,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.27",
+ "time",
 ]
 
 [[package]]
@@ -5339,7 +5338,7 @@ dependencies = [
  "temp-dir",
  "test-log",
  "thiserror",
- "time 0.3.27",
+ "time",
  "tokio 1.32.0",
  "tokio-tungstenite 0.18.0",
  "tokio-util",
@@ -5578,17 +5577,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6437,12 +6425,6 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -6796,7 +6778,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.27",
+ "time",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -61,7 +61,7 @@ bincode = "1.3.3"
 bytes = "1.4.0"
 cedar-policy = "2.3.2"
 channel = { version = "1.9.0", package = "async-channel" }
-chrono = { version = "0.4.26", features = ["serde"] }
+chrono = { version = "0.4.31", features = ["serde"] }
 derive = { version = "0.12.0", package = "surrealdb-derive" }
 deunicode = "1.3.3"
 dmp = "0.2.0"

--- a/lib/src/fnc/time.rs
+++ b/lib/src/fnc/time.rs
@@ -147,10 +147,12 @@ pub fn month((val,): (Option<Datetime>,)) -> Result<Value, Error> {
 }
 
 pub fn nano((val,): (Option<Datetime>,)) -> Result<Value, Error> {
-	Ok(match val {
-		Some(v) => v.timestamp_nanos().into(),
-		None => Datetime::default().timestamp_nanos().into(),
-	})
+	let time_opt = match val {
+		Some(v) => v.timestamp_nanos_opt(),
+		None => Datetime::default().timestamp_nanos_opt(),
+	};
+
+	Ok(time_opt.ok_or(Error::Internal("error in nanosecond time".to_string()))?.into())
 }
 
 pub fn now(_: ()) -> Result<Value, Error> {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

timestamp_nanos has been deprecated and can cause deprecation warnings for users of the surrealdb crate.
https://github.com/chronotope/chrono/commit/a174b8afad1e753c8857c785293d761e8a6fef7a

## What does this change do?

switches to the non-deprecated equivalents of the functions, these are identical except return an option with none instead of panicing in situations the old version would.

## What is your testing strategy?

no new features so relying on existing tests

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
