### PR TITLE
Calculate new beta version based on major and minor only

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -51,27 +51,22 @@ jobs:
           git config --local user.email "actions@users.noreply.github.com"
           git config --local user.name "github-actions"
 
-          # Bump the version
-          /home/runner/.cargo/bin/release-plz update --config .config/release-plz.toml
+          # Calculate new version
+          currentVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
+          major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
+          minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
+          version=${major}.$(($minor + 1)).0
+          betaVersion=${version}-beta.1
           
-          # Save the new version
-          newVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
-          version=${newVersion}-beta.1
-          
-          # Stash the Cargo.toml
-          tempDir=$(mktemp -d /tmp/cargo-toml.XXXXXXXXXXXXXXXXXX)
-          mv lib/Cargo.toml $tempDir/
-
-          # Temporarily revert the change and create the tag
-          git checkout -- lib/Cargo.toml
-          git tag -a v${version} -m "Release ${version}"
-
-          # Unstash Cargo.toml
-          mv $tempDir/Cargo.toml lib/
+          # Create the tag
+          git tag -a v${betaVersion} -m "Release ${betaVersion}"
 
           # Replace the crate name
           # We are just going to replace the first occurance of surrealdb
           sed -i "0,/surrealdb/s//surrealdb-beta/" lib/Cargo.toml
+
+          # Bump the crate version
+          sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
 
           # Commit changes
           git checkout -b beta
@@ -79,7 +74,6 @@ jobs:
           git commit -m "Prepare the beta crate"
 
       - name: Perfom release checks
-        if: ${{ !inputs.publish }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: /home/runner/.cargo/bin/release-plz release --dry-run --config .config/release-plz.toml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,7 +79,6 @@ jobs:
           git checkout -b nightly
 
       - name: Perfom release checks
-        if: ${{ !(inputs.publish || github.event_name == 'schedule') }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: /home/runner/.cargo/bin/release-plz release --dry-run --config .config/release-plz.toml


### PR DESCRIPTION
## What is the motivation?

`release-plz update` is calculating the wrong beta version.

## What does this change do?

It simply adds 1 to the minor version and restarts the patch from 0.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
