### PR TITLE
`INSERT` should respect unique indexes

### DIFF
--- a/lib/src/doc/insert.rs
+++ b/lib/src/doc/insert.rs
@@ -60,10 +60,10 @@ impl<'a> Document<'a> {
 		self.clean(ctx, opt, txn, stm).await?;
 		// Check if allowed
 		self.allow(ctx, opt, txn, stm).await?;
-		// Store record data
-		self.store(ctx, opt, txn, stm).await?;
 		// Store index data
 		self.index(ctx, opt, txn, stm).await?;
+		// Store record data
+		self.store(ctx, opt, txn, stm).await?;
 		// Run table queries
 		self.table(ctx, opt, txn, stm).await?;
 		// Run lives queries
@@ -95,10 +95,10 @@ impl<'a> Document<'a> {
 		self.clean(ctx, opt, txn, stm).await?;
 		// Check if allowed
 		self.allow(ctx, opt, txn, stm).await?;
-		// Store record data
-		self.store(ctx, opt, txn, stm).await?;
 		// Store index data
 		self.index(ctx, opt, txn, stm).await?;
+		// Store record data
+		self.store(ctx, opt, txn, stm).await?;
 		// Run table queries
 		self.table(ctx, opt, txn, stm).await?;
 		// Run lives queries


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

As found in #3090, the `INSERT` statement currently does not respect unique indexes. This happens because of a change in #3001 which causes indexes to be checked and stored only after the record itself is stored, to improve performance.

This change is alright for other CRUD statements, as they will thrown an error and cancel the transaction if a duplicate record for a unique index is found. `INSERT` on the other hand will simply continue and return the existing record, possibly updating if it an `ON DUPLICATE KEY UPDATE` clause is present.

This results in:
- The record getting stored
- An existing record for a unique index being found
- The existing record being returned which makes it look like everything is fine
- A new record is still created.

## What does this change do?

- Added a test that ensures no records are silently created.
- For now reverted the change #3001 introduced for the `INSERT` statement, but I am happy to learn about a potential better resolution.

## What is your testing strategy?

Added a test that ensures no records are silently created.

## Is this related to any issues?

Fixes #3090 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
