### PR TITLE
[binary] Compile it in a supported environment

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -2,7 +2,7 @@
 # Dockerfile that builds the SurrealDB Linux binary and makes it depend on GLIBC 2.17.
 #
 
-FROM docker.io/ubuntu:18.04
+FROM docker.io/ubuntu:20.04
 
 ARG CARGO_EXTRA_FEATURES="http-compression,storage-tikv"
 


### PR DESCRIPTION
Even if we plan to run the binary in a supported environment, the compilation step is also necessary to happen in an up-to-date env

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Ubuntu 18.04 is not a supported Linux distro (LTS finished on May 31st 2023)

I'm working on using another distro that gives us better GLIBC compatibility, but I want this to go in before the next release.

## What does this change do?

Uses Ubuntu 20.04 LTS as the builder image for the linux binary

## What is your testing strategy?

I tested the Docker build

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
