### PR TITLE
Fix for default table `PERMISSIONS` and always display permissions

### DIFF
--- a/lib/src/sql/statements/define/field.rs
+++ b/lib/src/sql/statements/define/field.rs
@@ -17,7 +17,7 @@ use crate::sql::ident::{ident, Ident};
 use crate::sql::idiom;
 use crate::sql::idiom::Idiom;
 use crate::sql::kind::{kind, Kind};
-use crate::sql::permission::{permissions, Permissions};
+use crate::sql::permission::{permissions, Permission, Permissions};
 use crate::sql::strand::{strand, Strand};
 use crate::sql::value::{value, Value};
 use derive::Store;
@@ -232,6 +232,6 @@ fn field_comment(i: &str) -> IResult<&str, DefineFieldOption> {
 
 fn field_permissions(i: &str) -> IResult<&str, DefineFieldOption> {
 	let (i, _) = shouldbespace(i)?;
-	let (i, v) = permissions(i)?;
+	let (i, v) = permissions(i, Permission::Full)?;
 	Ok((i, DefineFieldOption::Permissions(v)))
 }

--- a/lib/src/sql/statements/define/field.rs
+++ b/lib/src/sql/statements/define/field.rs
@@ -96,15 +96,13 @@ impl Display for DefineFieldStatement {
 		if let Some(ref v) = self.comment {
 			write!(f, " COMMENT {v}")?
 		}
-		if !self.permissions.is_full() {
-			let _indent = if is_pretty() {
-				Some(pretty_indent())
-			} else {
-				f.write_char(' ')?;
-				None
-			};
-			write!(f, "{}", self.permissions)?;
-		}
+		let _indent = if is_pretty() {
+			Some(pretty_indent())
+		} else {
+			f.write_char(' ')?;
+			None
+		};
+		write!(f, "{}", self.permissions)?;
 		Ok(())
 	}
 }

--- a/lib/src/sql/statements/define/function.rs
+++ b/lib/src/sql/statements/define/function.rs
@@ -83,15 +83,13 @@ impl fmt::Display for DefineFunctionStatement {
 		if let Some(ref v) = self.comment {
 			write!(f, " COMMENT {v}")?
 		}
-		if !self.permissions.is_full() {
-			let _indent = if is_pretty() {
-				Some(pretty_indent())
-			} else {
-				f.write_char(' ')?;
-				None
-			};
-			write!(f, "PERMISSIONS {}", self.permissions)?;
-		}
+		let _indent = if is_pretty() {
+			Some(pretty_indent())
+		} else {
+			f.write_char(' ')?;
+			None
+		};
+		write!(f, "PERMISSIONS {}", self.permissions)?;
 		Ok(())
 	}
 }

--- a/lib/src/sql/statements/define/param.rs
+++ b/lib/src/sql/statements/define/param.rs
@@ -66,15 +66,13 @@ impl Display for DefineParamStatement {
 		if let Some(ref v) = self.comment {
 			write!(f, " COMMENT {v}")?
 		}
-		if !self.permissions.is_full() {
-			let _indent = if is_pretty() {
-				Some(pretty_indent())
-			} else {
-				f.write_char(' ')?;
-				None
-			};
-			write!(f, "PERMISSIONS {}", self.permissions)?;
-		}
+		let _indent = if is_pretty() {
+			Some(pretty_indent())
+		} else {
+			f.write_char(' ')?;
+			None
+		};
+		write!(f, "PERMISSIONS {}", self.permissions)?;
 		Ok(())
 	}
 }

--- a/lib/src/sql/statements/define/table.rs
+++ b/lib/src/sql/statements/define/table.rs
@@ -129,15 +129,13 @@ impl Display for DefineTableStatement {
 		if let Some(ref v) = self.changefeed {
 			write!(f, " {v}")?;
 		}
-		if !self.permissions.is_full() {
-			let _indent = if is_pretty() {
-				Some(pretty_indent())
-			} else {
-				f.write_char(' ')?;
-				None
-			};
-			write!(f, "{}", self.permissions)?;
-		}
+		let _indent = if is_pretty() {
+			Some(pretty_indent())
+		} else {
+			f.write_char(' ')?;
+			None
+		};
+		write!(f, "{}", self.permissions)?;
 		Ok(())
 	}
 }

--- a/lib/src/sql/statements/define/table.rs
+++ b/lib/src/sql/statements/define/table.rs
@@ -14,7 +14,7 @@ use crate::sql::error::IResult;
 use crate::sql::fmt::is_pretty;
 use crate::sql::fmt::pretty_indent;
 use crate::sql::ident::{ident, Ident};
-use crate::sql::permission::{permissions, Permissions};
+use crate::sql::permission::{permissions, Permission, Permissions};
 use crate::sql::statements::UpdateStatement;
 use crate::sql::strand::{strand, Strand};
 use crate::sql::value::{Value, Values};
@@ -154,6 +154,7 @@ pub fn table(i: &str) -> IResult<&str, DefineTableStatement> {
 	// Create the base statement
 	let mut res = DefineTableStatement {
 		name,
+		permissions: Permissions::none(),
 		..Default::default()
 	};
 	// Assign any defined options
@@ -248,7 +249,7 @@ fn table_comment(i: &str) -> IResult<&str, DefineTableOption> {
 
 fn table_permissions(i: &str) -> IResult<&str, DefineTableOption> {
 	let (i, _) = shouldbespace(i)?;
-	let (i, v) = permissions(i)?;
+	let (i, v) = permissions(i, Permission::None)?;
 	Ok((i, DefineTableOption::Permissions(v)))
 }
 
@@ -259,7 +260,7 @@ mod tests {
 
 	#[test]
 	fn define_table_with_changefeed() {
-		let sql = "TABLE mytable SCHEMALESS CHANGEFEED 1h";
+		let sql = "TABLE mytable SCHEMALESS CHANGEFEED 1h PERMISSIONS NONE";
 		let res = table(sql);
 		let out = res.unwrap().1;
 		assert_eq!(format!("DEFINE {sql}"), format!("{}", out));

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -122,7 +122,7 @@ async fn define_statement_table_drop() -> Result<(), Error> {
 			functions: {},
 			params: {},
 			scopes: {},
-			tables: { test: 'DEFINE TABLE test DROP SCHEMALESS' },
+			tables: { test: 'DEFINE TABLE test DROP SCHEMALESS PERMISSIONS NONE' },
 			users: {},
 		}",
 	);
@@ -153,7 +153,7 @@ async fn define_statement_table_schemaless() -> Result<(), Error> {
 			functions: {},
 			params: {},
 			scopes: {},
-			tables: { test: 'DEFINE TABLE test SCHEMALESS' },
+			tables: { test: 'DEFINE TABLE test SCHEMALESS PERMISSIONS NONE' },
 			users: {},
 		}",
 	);
@@ -188,7 +188,7 @@ async fn define_statement_table_schemafull() -> Result<(), Error> {
 			functions: {},
 			params: {},
 			scopes: {},
-			tables: { test: 'DEFINE TABLE test SCHEMAFULL' },
+			tables: { test: 'DEFINE TABLE test SCHEMAFULL PERMISSIONS NONE' },
 			users: {},
 		}",
 	);
@@ -219,7 +219,7 @@ async fn define_statement_table_schemaful() -> Result<(), Error> {
 			functions: {},
 			params: {},
 			scopes: {},
-			tables: { test: 'DEFINE TABLE test SCHEMAFULL' },
+			tables: { test: 'DEFINE TABLE test SCHEMAFULL PERMISSIONS NONE' },
 			users: {},
 		}",
 	);
@@ -259,8 +259,8 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 			params: {},
 			scopes: {},
 			tables: {
-				test: 'DEFINE TABLE test SCHEMAFULL',
-				view: 'DEFINE TABLE view SCHEMALESS AS SELECT count() FROM test GROUP ALL',
+				test: 'DEFINE TABLE test SCHEMAFULL PERMISSIONS NONE',
+				view: 'DEFINE TABLE view SCHEMALESS AS SELECT count() FROM test GROUP ALL PERMISSIONS NONE',
 			},
 			users: {},
 		}",
@@ -272,7 +272,7 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 		"{
 			events: {},
 			fields: {},
-			tables: { view: 'DEFINE TABLE view SCHEMALESS AS SELECT count() FROM test GROUP ALL' },
+			tables: { view: 'DEFINE TABLE view SCHEMALESS AS SELECT count() FROM test GROUP ALL PERMISSIONS NONE' },
 			indexes: {},
 			lives: {},
 		}",
@@ -291,7 +291,7 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 			params: {},
 			scopes: {},
 			tables: {
-				test: 'DEFINE TABLE test SCHEMAFULL',
+				test: 'DEFINE TABLE test SCHEMAFULL PERMISSIONS NONE',
 			},
 			users: {},
 		}",
@@ -1866,7 +1866,7 @@ async fn permissions_checks_define_table() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: { TB: 'DEFINE TABLE TB SCHEMALESS' }, tokens: {  }, users: {  } }"],
+        vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: { TB: 'DEFINE TABLE TB SCHEMALESS PERMISSIONS NONE' }, tokens: {  }, users: {  } }"],
 		vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: {  }, tokens: {  }, users: {  } }"]
     ];
 

--- a/lib/tests/param.rs
+++ b/lib/tests/param.rs
@@ -29,7 +29,7 @@ async fn define_global_param() -> Result<(), Error> {
 			analyzers: {},
 			tokens: {},
 			functions: {},
-			params: { test: 'DEFINE PARAM $test VALUE 12345' },
+			params: { test: 'DEFINE PARAM $test VALUE 12345 PERMISSIONS FULL' },
 			scopes: {},
 			tables: {},
 			users: {},

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -600,7 +600,7 @@ async fn permissions_checks_remove_table() {
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
 		vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: {  }, tokens: {  }, users: {  } }"],
-        vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: { TB: 'DEFINE TABLE TB SCHEMALESS' }, tokens: {  }, users: {  } }"],
+        vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: { TB: 'DEFINE TABLE TB SCHEMALESS PERMISSIONS NONE' }, tokens: {  }, users: {  } }"],
     ];
 
 	let test_cases = [

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -222,7 +222,7 @@ async fn permissions_checks_remove_function() {
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
 		vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: {  }, tokens: {  }, users: {  } }"],
-        vec!["{ analyzers: {  }, functions: { greet: \"DEFINE FUNCTION fn::greet() { RETURN 'Hello'; }\" }, params: {  }, scopes: {  }, tables: {  }, tokens: {  }, users: {  } }"],
+        vec!["{ analyzers: {  }, functions: { greet: \"DEFINE FUNCTION fn::greet() { RETURN 'Hello'; } PERMISSIONS FULL\" }, params: {  }, scopes: {  }, tables: {  }, tokens: {  }, users: {  } }"],
     ];
 
 	let test_cases = [
@@ -558,7 +558,7 @@ async fn permissions_checks_remove_param() {
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
 		vec!["{ analyzers: {  }, functions: {  }, params: {  }, scopes: {  }, tables: {  }, tokens: {  }, users: {  } }"],
-        vec!["{ analyzers: {  }, functions: {  }, params: { param: \"DEFINE PARAM $param VALUE 'foo'\" }, scopes: {  }, tables: {  }, tokens: {  }, users: {  } }"],
+        vec!["{ analyzers: {  }, functions: {  }, params: { param: \"DEFINE PARAM $param VALUE 'foo' PERMISSIONS FULL\" }, scopes: {  }, tables: {  }, tokens: {  }, users: {  } }"],
     ];
 
 	let test_cases = [
@@ -684,7 +684,7 @@ async fn permissions_checks_remove_field() {
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
 		vec!["{ events: {  }, fields: {  }, indexes: {  }, lives: {  }, tables: {  } }"],
-        vec!["{ events: {  }, fields: { field: 'DEFINE FIELD field ON TB' }, indexes: {  }, lives: {  }, tables: {  } }"],
+        vec!["{ events: {  }, fields: { field: 'DEFINE FIELD field ON TB PERMISSIONS FULL' }, indexes: {  }, lives: {  }, tables: {  } }"],
     ];
 
 	let test_cases = [

--- a/lib/tests/strict.rs
+++ b/lib/tests/strict.rs
@@ -267,7 +267,7 @@ async fn loose_mode_all_ok() -> Result<(), Error> {
 	let val = Value::parse(
 		"{
 			events: {},
-			fields: { extra: 'DEFINE FIELD extra ON test VALUE true' },
+			fields: { extra: 'DEFINE FIELD extra ON test VALUE true PERMISSIONS FULL' },
 			tables: {},
 			indexes: {},
 			lives: {},

--- a/lib/tests/table.rs
+++ b/lib/tests/table.rs
@@ -43,7 +43,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 		"{
 			events: {},
 			fields: {},
-			tables: { person_by_age: 'DEFINE TABLE person_by_age SCHEMALESS AS SELECT count(), age, math::sum(age) AS total, math::mean(score) AS average FROM person GROUP BY age' },
+			tables: { person_by_age: 'DEFINE TABLE person_by_age SCHEMALESS AS SELECT count(), age, math::sum(age) AS total, math::mean(score) AS average FROM person GROUP BY age PERMISSIONS NONE' },
 			indexes: {},
 			lives: {},
 		}",


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`v1.0.0` included an unfortunate design decision which caused permissions for tables to be Permissive (`FULL`) by default. 

## What does this change do?

Cherry picked #3079 and #3083 on top of the v1.0.0 release. See those PRs

## What is your testing strategy?

Ensure all tests still pass

## Is this related to any issues?

Related to #3079
Related to #3083

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
