### PR TITLE
WIP adding elastic log aggregation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ bench: check-deps
 
 .PHONY: serve
 serve: check-deps
+	@echo ${OTEL_EXPORTER_OTLP_ENDPOINT}
 	cargo make serve
 
 .PHONY: sql

--- a/dev/docker/compose.yaml
+++ b/dev/docker/compose.yaml
@@ -60,6 +60,24 @@ services:
       - "9090"  # for prometheus
     volumes: ["./otel-collector.yaml:/etc/otel-collector.yaml"]
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    environment:
+      - discovery.type=single-node
+      - ELASTICSEARCH_USERNAME=admin
+      - ELASTICSEARCH_PASSWORD=admin
+    ports:
+      - 9200:9200
+    volumes:
+      - ./elasticsearch.yaml:/usr/share/elasticsearch/config/elasticsearch.yml
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.11.1
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - 5601:5601
+
 volumes:
   grafana:
     external: false

--- a/dev/docker/compose.yaml
+++ b/dev/docker/compose.yaml
@@ -64,19 +64,27 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
     environment:
       - discovery.type=single-node
-      - ELASTICSEARCH_USERNAME=admin
-      - ELASTICSEARCH_PASSWORD=admin
+#      - ES_SECURITY_ENABLE=true
+#      - ELASTICSEARCH_USERNAME=admin
+#      - ELASTICSEARCH_PASSWORD=admin
     ports:
       - 9200:9200
-    volumes:
-      - ./elasticsearch.yaml:/usr/share/elasticsearch/config/elasticsearch.yml
+#    volumes:
+      # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_configuration_files_must_be_readable_by_the_elasticsearch_user
+      # Must be in dir with gid=0, chmod g+rwx
+#      - ./elasticsearch/elasticsearch.yaml:/usr/share/elasticsearch/config/elasticsearch.yml
 
   kibana:
     image: docker.elastic.co/kibana/kibana:8.11.1
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+#      - ELASTICSEARCH_USERNAME=admin
+#      - ELASTICSEARCH_PASSWORD=admin
+      - ELASTICSEARCH_SSL_VERIFICATIONMODE=none
     ports:
       - 5601:5601
+    depends_on:
+      - elasticsearch
 
 volumes:
   grafana:

--- a/dev/docker/elasticsearch.yaml
+++ b/dev/docker/elasticsearch.yaml
@@ -1,3 +1,0 @@
-xpack.security.authc.api_key.enabled: true
-xpack.security.authc.api_key.default_enabled: true
-xpack.security.authc.api_key.key: your-bearer-token

--- a/dev/docker/elasticsearch.yaml
+++ b/dev/docker/elasticsearch.yaml
@@ -1,0 +1,3 @@
+xpack.security.authc.api_key.enabled: true
+xpack.security.authc.api_key.default_enabled: true
+xpack.security.authc.api_key.key: your-bearer-token

--- a/dev/docker/elasticsearch/elasticsearch.yaml
+++ b/dev/docker/elasticsearch/elasticsearch.yaml
@@ -1,0 +1,3 @@
+#xpack.security.authc.api_key.enabled: true
+#xpack.security.authc.api_key.default_enabled: true
+#xpack.security.authc.api_key.key: your-bearer-token

--- a/dev/docker/otel-collector.yaml
+++ b/dev/docker/otel-collector.yaml
@@ -9,6 +9,11 @@ exporters:
     tls:
       insecure: true
 
+  otlp/elastic:
+    endpoint: 'elasticsearch:9200'
+    headers:
+      Authorization: "Basic base64(admin:admin)"
+
   prometheus:
     endpoint:  ':9090'
     send_timestamps: true
@@ -34,3 +39,6 @@ service:
     metrics:
       receivers: [otlp]
       exporters: [prometheus]
+    logs:
+      receivers: [otlp]
+      exporters: [otlp/elastic]

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -146,6 +146,7 @@ pub async fn init(
 	}: StartCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
+	// TODO
 	crate::telemetry::builder().with_filter(log).init();
 	// Start metrics subsystem
 	crate::telemetry::metrics::init(&TelemetryContext::current())

--- a/src/telemetry/traces/rpc.rs
+++ b/src/telemetry/traces/rpc.rs
@@ -19,6 +19,7 @@ pub fn span_for_request(ws_id: &Uuid) -> Span {
 		rpc.request_id = field::Empty,
 		rpc.error_code = field::Empty,
 		rpc.error_message = field::Empty,
+		// TODO: Add locks? Each lock specific name and id, and value is status
 	);
 
 	span


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Add improved observability so that we can diagnose issues easier. With a separate log aggregator, we can filter and search logs that we are interested in (frequency, filters based on web request, filters based on shared field). For diagnosing lock issues, we can find a blocked request, find the last lock operation, then find all requests for that lock.

## What does this change do?

- [ ] Add elastic and kibana to local observability stack
- [ ] Log locks (create, request, acquire)
- [ ] Log LQ stages around notifications

## What is your testing strategy?

Manual

## Is this related to any issues?

Various observability

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
