### PR TITLE
Make release and beta workflows idempotent

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -12,6 +12,11 @@ on:
         type: boolean
         default: false
         description: "Publish the beta release"
+      bump-version:
+        required: false
+        type: boolean
+        default: false
+        description: "Bump the version of the current beta if this is not the initial one"
 
 defaults:
   run:
@@ -48,6 +53,7 @@ jobs:
     with:
       environment: beta
       git-ref: ${{ needs.checks.outputs.branch }}
+      bump-version: ${{ inputs.bump-version }}
       publish: ${{ inputs.publish }}
       create-release: ${{ inputs.publish }}
     secrets: inherit

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -2,7 +2,7 @@
 
 name: Beta release
 
-run-name: "Beta release (publish: ${{ inputs.publish }})"
+run-name: "Beta release (publish: ${{ inputs.publish }}, bump version: ${{ inputs.bump-version }})"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,5 +143,5 @@ jobs:
         if: ${{ inputs.publish }}
         run: |
           set -x
-          git push origin --delete ${{ inputs.branch }}
-          git push origin --delete releases/stable
+          git push origin --delete ${{ inputs.branch }} || true
+          git push origin --delete releases/stable || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,12 @@ jobs:
         run: |
           set -x
 
+          # When moving from beta we are going to pull the version from the stable branch
+          if [[ "${{ inputs.branch }}" == "releases/beta" ]]; then
+            git fetch origin releases/stable
+            git checkout releases/stable
+          fi
+
           # Retrieve just released version
           version=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
           echo "version=${version}" >> $GITHUB_OUTPUT
@@ -135,4 +141,7 @@ jobs:
 
       - name: Delete the release branch
         if: ${{ inputs.publish }}
-        run: git push origin --delete ${{ inputs.branch }}
+        run: |
+          set -x
+          git push origin --delete ${{ inputs.branch }}
+          git push origin --delete releases/stable

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -69,6 +69,8 @@ jobs:
           currentVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
 
           if [[ $currentVersion == *"-beta"* ]]; then
+            git push origin --delete releases/stable || true
+            git checkout -b releases/stable
             major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
             minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
             betaNum=$(echo $currentVersion | tr "." "\n" | sed -n 4p)
@@ -143,7 +145,7 @@ jobs:
           set -x
 
           if [[ "${{ inputs.environment }}" == "beta" && "${{ inputs.publish }}" == "true" ]]; then
-            echo "git-ref=releases/beta" >> $GITHUB_OUTPUT
+            echo "git-ref=releases/stable" >> $GITHUB_OUTPUT
           else
             echo "git-ref=${{ inputs.git-ref || github.ref_name }}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -9,6 +9,11 @@ on:
         required: true
         type: string
         description: "The git ref of this release version. All 'actions/checkout' steps will use it"
+      bump-version:
+        required: false
+        type: boolean
+        default: false
+        description: "Bump the version of the current beta if this is not the initial one"
       latest:
         required: false
         type: boolean
@@ -93,11 +98,15 @@ jobs:
           currentVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
 
           if [[ $currentVersion == *"-beta"* ]]; then
-            major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
-            minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
-            patchAndMeta=$(echo $currentVersion | tr "." "\n" | sed -n 3p)
-            betaNum=$(echo $currentVersion | tr "." "\n" | sed -n 4p)
-            betaVersion=${major}.${minor}.${patchAndMeta}.$(($betaNum + 1))
+            if [[ "${{ inputs.bump-version }}" == "true" ]]; then
+              major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
+              minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
+              patchAndMeta=$(echo $currentVersion | tr "." "\n" | sed -n 3p)
+              betaNum=$(echo $currentVersion | tr "." "\n" | sed -n 4p)
+              betaVersion=${major}.${minor}.${patchAndMeta}.$(($betaNum + 1))
+            else
+              betaVersion=$currentVersion
+            fi
           else
             git checkout -b releases/beta
             major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -145,6 +145,8 @@ jobs:
           set -x
 
           if [[ "${{ inputs.environment }}" == "beta" && "${{ inputs.publish }}" == "true" ]]; then
+            echo "git-ref=releases/beta" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.environment }}" == "release" && "${{ inputs.git-ref }}" == "releases/beta" && "${{ inputs.publish }}" == "true" ]]; then
             echo "git-ref=releases/stable" >> $GITHUB_OUTPUT
           else
             echo "git-ref=${{ inputs.git-ref || github.ref_name }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -90,7 +90,7 @@ jobs:
           fi
 
           # Create the tag
-          git tag -a v${version} -m "Release ${version}"
+          git tag -a v${version} -m "Release ${version}" || true
 
       - name: Create or patch beta branch
         if: ${{ inputs.environment == 'beta' }}
@@ -124,10 +124,10 @@ jobs:
           cargo check --no-default-features --features storage-mem
 
           # Commit changes
-          git commit -am "Prepare v${betaVersion} release"
+          git commit -am "Prepare v${betaVersion} release" || true
 
           # Create the tag
-          git tag -a v${betaVersion} -m "Release ${betaVersion}"
+          git tag -a v${betaVersion} -m "Release ${betaVersion}" || true
 
       - name: Push changes
         if: ${{ inputs.publish && (inputs.environment == 'beta' || inputs.environment == 'release') }}
@@ -137,7 +137,7 @@ jobs:
         if: ${{ inputs.publish && (inputs.environment == 'beta' || inputs.environment == 'release') }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can push the tag
-        run: git push --tags
+        run: git push --tags || true
 
       - name: Set outputs
         id: outputs


### PR DESCRIPTION
## What is the motivation?

Re-running failed workflows should always be possible.

## What does this change do?

It makes it possible to re-run failed release and beta workflows.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

It closes https://github.com/surrealdb/surrealdb/issues/3124.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
