### PR TITLE
Avoid building the `ml` feature by default

### DIFF
--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -345,7 +345,7 @@ jobs:
               brew install protobuf
 
               # Build
-              cargo build --features storage-tikv,http-compression --release --locked --target x86_64-apple-darwin
+              cargo build --features storage-tikv,http-compression,ml --release --locked --target x86_64-apple-darwin
 
               # Package
               cp target/x86_64-apple-darwin/release/surreal surreal
@@ -362,7 +362,7 @@ jobs:
               brew install protobuf
 
               # Build
-              cargo build --features storage-tikv,http-compression --release --locked --target aarch64-apple-darwin
+              cargo build --features storage-tikv,http-compression,ml --release --locked --target aarch64-apple-darwin
 
               # Package
               cp target/aarch64-apple-darwin/release/surreal surreal
@@ -378,7 +378,7 @@ jobs:
               # Build
               docker build \
                 --platform linux/amd64 \
-                --build-arg="CARGO_EXTRA_FEATURES=storage-tikv,http-compression" \
+                --build-arg="CARGO_EXTRA_FEATURES=storage-tikv,http-compression,ml" \
                 -t binary \
                 -f docker/Dockerfile.binary \
                 .
@@ -398,7 +398,7 @@ jobs:
               # Build
               docker build \
                 --platform linux/arm64 \
-                --build-arg="CARGO_EXTRA_FEATURES=storage-tikv,http-compression" \
+                --build-arg="CARGO_EXTRA_FEATURES=storage-tikv,http-compression,ml" \
                 -t binary \
                 -f docker/Dockerfile.binary \
                 .

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 
 [features]
 # Public features
-default = ["storage-mem", "storage-rocksdb", "scripting", "http", "ml"]
+default = ["storage-mem", "storage-rocksdb", "scripting", "http"]
 storage-mem = ["surrealdb/kv-mem", "has-storage"]
 storage-rocksdb = ["surrealdb/kv-rocksdb", "has-storage"]
 storage-speedb = ["surrealdb/kv-speedb", "has-storage"]


### PR DESCRIPTION
## What is the motivation?

The `ml` feature is currently broken on Windows.

## What does this change do?

It removes the `ml` feature from default features and adds it back on non-Windows systems.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
