### PR TITLE
Fix permission issues when pushing a Github release

### DIFF
--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -498,6 +498,7 @@ jobs:
           name: "Release ${{ needs.prepare-vars.outputs.git-ref }}"
           tag_name: ${{ needs.prepare-vars.outputs.git-ref }}
           token: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can push the release
+          prerelease: ${{ inputs.environment == 'beta' }}
           files: |
             LICENSE
             artifacts/*.tgz

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -505,6 +505,13 @@ jobs:
             artifacts/surreal-${{ needs.prepare-vars.outputs.git-ref }}.*/*.tgz
             artifacts/surreal-${{ needs.prepare-vars.outputs.git-ref }}.*/*.exe
 
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-2
+          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
+
       - name: Set latest release version
         if: ${{ inputs.create-release && inputs.latest }}
         run: |
@@ -516,13 +523,6 @@ jobs:
         run: |
           echo ${{ needs.prepare-vars.outputs.git-ref }} > ${{ inputs.environment }}.txt
           aws s3 cp --cache-control 'no-store' ${{ inputs.environment }}.txt s3://download.surrealdb.com/${{ inputs.environment }}.txt
-
-      - name: Configure AWS
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: us-east-2
-          aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
 
       - name: Publish binaries
         run: |

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -157,11 +157,8 @@ jobs:
 
             date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
             rev=$(git rev-parse --short HEAD)
-            echo "build-metadata=${date}.${rev}" >> $GITHUB_OUTPUT
           else
             echo "name=v${version}" >> $GITHUB_OUTPUT
-
-            echo "build-metadata=\"\"" >> $GITHUB_OUTPUT
           fi
 
   test:
@@ -329,8 +326,6 @@ jobs:
   build:
     name: Build ${{ matrix.arch }} binary
     needs: [prepare-vars]
-    env:
-      SURREAL_BUILD_METADATA: ${{ needs.prepare-vars.outputs.build-metadata }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -501,8 +501,7 @@ jobs:
           prerelease: ${{ inputs.environment == 'beta' }}
           files: |
             LICENSE
-            artifacts/*.tgz
-            artifacts/*.exe
+            artifacts/surreal-${{ needs.prepare-vars.outputs.git-ref }}.*
 
       - name: Set latest version
         if: ${{ inputs.create-release && inputs.latest }}

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -310,7 +310,14 @@ jobs:
       - name: Publish the crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: /home/runner/.cargo/bin/release-plz release --config .config/release-plz.toml
+        run: |
+          set -x
+
+          # Create a temporary branch
+          git checkout -b crate
+
+          # Publish the crate
+          /home/runner/.cargo/bin/release-plz release --config .config/release-plz.toml
 
   docker-build:
     name: Build Docker images
@@ -474,6 +481,11 @@ jobs:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-vars.outputs.git-ref }}
+
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -504,11 +504,17 @@ jobs:
             LICENSE
             artifacts/surreal-${{ needs.prepare-vars.outputs.git-ref }}.*/*.{tgz,exe}
 
-      - name: Set latest version
+      - name: Set latest release version
         if: ${{ inputs.create-release && inputs.latest }}
         run: |
           echo ${{ needs.prepare-vars.outputs.git-ref }} > latest.txt
           aws s3 cp --cache-control 'no-store' latest.txt s3://download.surrealdb.com/latest.txt
+
+      - name: Set latest beta version
+        if: ${{ inputs.publish && inputs.environment == 'beta' }}
+        run: |
+          echo ${{ needs.prepare-vars.outputs.git-ref }} > ${{ inputs.environment }}.txt
+          aws s3 cp --cache-control 'no-store' ${{ inputs.environment }}.txt s3://download.surrealdb.com/${{ inputs.environment }}.txt
 
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -499,6 +499,7 @@ jobs:
           tag_name: ${{ needs.prepare-vars.outputs.git-ref }}
           token: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can push the release
           prerelease: ${{ inputs.environment == 'beta' }}
+          fail_on_unmatched_files: true
           files: |
             LICENSE
             artifacts/surreal-${{ needs.prepare-vars.outputs.git-ref }}.*

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -496,6 +496,7 @@ jobs:
         if: ${{ inputs.create-release }}
         with:
           name: "Release ${{ needs.prepare-vars.outputs.git-ref }}"
+          tag_name: ${{ needs.prepare-vars.outputs.git-ref }}
           files: |
             LICENSE
             artifacts/*.tgz

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -497,6 +497,7 @@ jobs:
         with:
           name: "Release ${{ needs.prepare-vars.outputs.git-ref }}"
           tag_name: ${{ needs.prepare-vars.outputs.git-ref }}
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can push the release
           files: |
             LICENSE
             artifacts/*.tgz

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -502,7 +502,7 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             LICENSE
-            artifacts/surreal-${{ needs.prepare-vars.outputs.git-ref }}.*
+            artifacts/surreal-${{ needs.prepare-vars.outputs.git-ref }}.*/*.{tgz,exe}
 
       - name: Set latest version
         if: ${{ inputs.create-release && inputs.latest }}

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -144,10 +144,10 @@ jobs:
         run: |
           set -x
 
-          if [[ "${{ inputs.environment }}" == "beta" && "${{ inputs.publish }}" == "true" ]]; then
-            echo "git-ref=releases/beta" >> $GITHUB_OUTPUT
-          elif [[ "${{ inputs.environment }}" == "release" && "${{ inputs.git-ref }}" == "releases/beta" && "${{ inputs.publish }}" == "true" ]]; then
-            echo "git-ref=releases/stable" >> $GITHUB_OUTPUT
+          version=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
+
+          if [[ "${{ inputs.publish }}" == "true" && ("${{ inputs.environment }}" == "beta" || "${{ inputs.environment }}" == "release")  ]]; then
+            echo "git-ref=v${version}" >> $GITHUB_OUTPUT
           else
             echo "git-ref=${{ inputs.git-ref || github.ref_name }}" >> $GITHUB_OUTPUT
           fi
@@ -159,7 +159,6 @@ jobs:
             rev=$(git rev-parse --short HEAD)
             echo "build-metadata=${date}.${rev}" >> $GITHUB_OUTPUT
           else
-            version=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
             echo "name=v${version}" >> $GITHUB_OUTPUT
 
             echo "build-metadata=\"\"" >> $GITHUB_OUTPUT
@@ -489,7 +488,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: ${{ inputs.create-release }}
         with:
-          name: "Release ${{ github.ref_name }}"
+          name: "Release ${{ needs.prepare-vars.outputs.git-ref }}"
           files: |
             LICENSE
             artifacts/*.tgz

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -502,7 +502,8 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             LICENSE
-            artifacts/surreal-${{ needs.prepare-vars.outputs.git-ref }}.*/*.{tgz,exe}
+            artifacts/surreal-${{ needs.prepare-vars.outputs.git-ref }}.*/*.tgz
+            artifacts/surreal-${{ needs.prepare-vars.outputs.git-ref }}.*/*.exe
 
       - name: Set latest release version
         if: ${{ inputs.create-release && inputs.latest }}


### PR DESCRIPTION
## What is the motivation?

Currently pushing out a Github release fails.

## What does this change do?

It uses a token with enough permissions to push it out, among other small fixes and enhancements.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
