### PR TITLE
Feature: Define types for subfields when defining fields.

### DIFF
--- a/lib/src/sql/statements/define/field.rs
+++ b/lib/src/sql/statements/define/field.rs
@@ -3,6 +3,7 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
+use crate::sql::Part;
 use crate::sql::{
 	fmt::is_pretty, fmt::pretty_indent, Base, Ident, Idiom, Kind, Permissions, Strand, Value,
 };
@@ -47,6 +48,49 @@ impl DefineFieldStatement {
 		run.add_ns(opt.ns(), opt.strict).await?;
 		run.add_db(opt.ns(), opt.db(), opt.strict).await?;
 		run.add_tb(opt.ns(), opt.db(), &self.what, opt.strict).await?;
+
+		// Process possible recursive_definitions.
+		if let Some(mut cur_kind) = self.kind.as_ref().and_then(|x| x.inner_kind()) {
+			let mut name = self.name.clone();
+			// find existing field definitions.
+			let fields = run.all_tb_fields(opt.ns(), opt.db(), &self.what).await.ok();
+			loop {
+				let new_kind = cur_kind.inner_kind();
+				name.0.push(Part::All);
+
+				let fd = name.to_string();
+				let key = crate::key::table::fd::new(opt.ns(), opt.db(), &self.what, &fd);
+				run.add_ns(opt.ns(), opt.strict).await?;
+				run.add_db(opt.ns(), opt.db(), opt.strict).await?;
+
+				// merge the new definition with possible existing definitions.
+				let statement = if let Some(existing) =
+					fields.as_ref().and_then(|x| x.iter().find(|x| x.name == name))
+				{
+					DefineFieldStatement {
+						kind: Some(cur_kind),
+						..existing.clone()
+					}
+				} else {
+					DefineFieldStatement {
+						name: name.clone(),
+						what: self.what.clone(),
+						flex: self.flex,
+						kind: Some(cur_kind),
+						..Default::default()
+					}
+				};
+
+				run.set(key, statement).await?;
+
+				if let Some(new_kind) = new_kind {
+					cur_kind = new_kind;
+				} else {
+					break;
+				}
+			}
+		}
+
 		run.set(key, self).await?;
 		// Clear the cache
 		let key = crate::key::table::fd::prefix(opt.ns(), opt.db(), &self.what);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently when defining fields on a table if a field type has a sub type like for example:
```
DEFINE FIELD foo ON bar TYPE array<number>
```
Trying to assign to foo will fail unless we also define a type for its sub type:
```
DEFINE FIELD foo.* ON bar TYPE number
```

This is rather counterintuitive and there are already multiple issues which are about this strange behavior.

This PR makes the first define query automatically also define types for any sub types. 

## What does this change do?

This PR changes the behavior of a DEFINE FIELD query to also immediately define for subtypes.  
So `DEFINE FIELD foo ON bar TYPE array<number>` will also run `DEFINE FIELD foo.* ON bar TYPE number` but it will not touch any other parts of the field definition. So permissions, default values and assertions remain the same.

This is an alternative to #3038.

## What is your testing strategy?

I added a test to ensure that the behavior is as expected.

## Is this related to any issues?

Fixes #2932
Fixes #2881
Fixes #2150

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
