### PR TITLE
Immutable and improved default values

### DIFF
--- a/lib/src/doc/field.rs
+++ b/lib/src/doc/field.rs
@@ -33,7 +33,10 @@ impl<'a> Document<'a> {
 				let inp = inp.pick(&k);
 				// Check for IMMUTABLE clause
 				if fd.immutable && !self.is_new() && val != old {
-					return Err(Error::FieldImmutable{ field: fd.name.clone(), thing: rid.to_string() })
+					return Err(Error::FieldImmutable {
+						field: fd.name.clone(),
+						thing: rid.to_string(),
+					});
 				}
 				// Get the default value
 				let def = match &fd.default {
@@ -43,7 +46,7 @@ impl<'a> Document<'a> {
 							Value::Function(_) => Some(v),
 							v if v.is_static() => Some(*v),
 							_ => None,
-						}
+						},
 						_ => None,
 					},
 				};

--- a/lib/src/doc/field.rs
+++ b/lib/src/doc/field.rs
@@ -43,7 +43,7 @@ impl<'a> Document<'a> {
 					Some(v) => Some(v),
 					_ => match &fd.value {
 						Some(v) => match &v {
-							Value::Function(f) if f.args() == &[] => Some(v),
+							Value::Function(f) if f.args().is_empty() => Some(v),
 							v if v.is_static() => Some(*v),
 							_ => None,
 						},

--- a/lib/src/doc/field.rs
+++ b/lib/src/doc/field.rs
@@ -35,7 +35,11 @@ impl<'a> Document<'a> {
 				let def = match &fd.default {
 					Some(v) => Some(v),
 					_ => match &fd.value {
-						Some(v) if v.is_static() => Some(v),
+						Some(v) => match &v {
+							Value::Function(_) => Some(v),
+							v if v.is_static() => Some(*v),
+							_ => None,
+						}
 						_ => None,
 					},
 				};

--- a/lib/src/doc/field.rs
+++ b/lib/src/doc/field.rs
@@ -43,7 +43,7 @@ impl<'a> Document<'a> {
 					Some(v) => Some(v),
 					_ => match &fd.value {
 						Some(v) => match &v {
-							Value::Function(_) => Some(v),
+							Value::Function(f) if f.args() == &[] => Some(v),
 							v if v.is_static() => Some(*v),
 							_ => None,
 						},

--- a/lib/src/doc/field.rs
+++ b/lib/src/doc/field.rs
@@ -31,6 +31,10 @@ impl<'a> Document<'a> {
 				let old = self.initial.doc.pick(&k);
 				// Get the input value
 				let inp = inp.pick(&k);
+				// Check for IMMUTABLE clause
+				if fd.immutable && !self.is_new() && val != old {
+					return Err(Error::FieldImmutable{ field: fd.name.clone(), thing: rid.to_string() })
+				}
 				// Get the default value
 				let def = match &fd.default {
 					Some(v) => Some(v),
@@ -75,14 +79,17 @@ impl<'a> Document<'a> {
 				}
 				// Check for a VALUE clause
 				if let Some(expr) = &fd.value {
-					// Configure the context
-					let mut ctx = Context::new(ctx);
-					ctx.add_value("input", &inp);
-					ctx.add_value("value", &val);
-					ctx.add_value("after", &val);
-					ctx.add_value("before", &old);
-					// Process the VALUE clause
-					val = expr.compute(&ctx, opt, txn, Some(&self.current)).await?;
+					// Only run value clause for mutable and new fields
+					if !fd.immutable || self.is_new() {
+						// Configure the context
+						let mut ctx = Context::new(ctx);
+						ctx.add_value("input", &inp);
+						ctx.add_value("value", &val);
+						ctx.add_value("after", &val);
+						ctx.add_value("before", &old);
+						// Process the VALUE clause
+						val = expr.compute(&ctx, opt, txn, Some(&self.current)).await?;
+					}
 				}
 				// Check for a TYPE clause
 				if let Some(kind) = &fd.kind {

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -530,7 +530,9 @@ pub enum Error {
 	},
 
 	/// The specified field did not conform to the field ASSERT clause
-	#[error("Found changed value for field `{field}`, with record `{thing}`, but field is immutable")]
+	#[error(
+		"Found changed value for field `{field}`, with record `{thing}`, but field is immutable"
+	)]
 	FieldImmutable {
 		thing: String,
 		field: Idiom,

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -529,6 +529,13 @@ pub enum Error {
 		check: String,
 	},
 
+	/// The specified field did not conform to the field ASSERT clause
+	#[error("Found changed value for field `{field}`, with record `{thing}`, but field is immutable")]
+	FieldImmutable {
+		thing: String,
+		field: Idiom,
+	},
+
 	/// Found a record id for the record but we are creating a specific record
 	#[error("Found {value} for the id field, but a specific record has been specified")]
 	IdMismatch {

--- a/lib/src/sql/statements/define/field.rs
+++ b/lib/src/sql/statements/define/field.rs
@@ -12,12 +12,14 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Write};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
-#[revisioned(revision = 1)]
+#[revisioned(revision = 2)]
 pub struct DefineFieldStatement {
 	pub name: Idiom,
 	pub what: Ident,
 	pub flex: bool,
 	pub kind: Option<Kind>,
+	#[revision(start = 2)]
+	pub immutable: bool,
 	pub value: Option<Value>,
 	pub assert: Option<Value>,
 	pub default: Option<Value>,
@@ -66,6 +68,9 @@ impl Display for DefineFieldStatement {
 		}
 		if let Some(ref v) = self.default {
 			write!(f, " DEFAULT {v}")?
+		}
+		if self.immutable {
+			write!(f, " IMMUTABLE")?
 		}
 		if let Some(ref v) = self.value {
 			write!(f, " VALUE {v}")?

--- a/lib/src/sql/value/serde/ser/statement/define/field.rs
+++ b/lib/src/sql/value/serde/ser/statement/define/field.rs
@@ -44,6 +44,7 @@ pub struct SerializeDefineFieldStatement {
 	what: Ident,
 	flex: bool,
 	kind: Option<Kind>,
+	immutable: bool,
 	value: Option<Value>,
 	assert: Option<Value>,
 	default: Option<Value>,
@@ -71,6 +72,9 @@ impl serde::ser::SerializeStruct for SerializeDefineFieldStatement {
 			}
 			"kind" => {
 				self.kind = value.serialize(ser::kind::opt::Serializer.wrap())?;
+			}
+			"immutable" => {
+				self.immutable = value.serialize(ser::primitive::bool::Serializer.wrap())?;
 			}
 			"value" => {
 				self.value = value.serialize(ser::value::opt::Serializer.wrap())?;
@@ -102,6 +106,7 @@ impl serde::ser::SerializeStruct for SerializeDefineFieldStatement {
 			what: self.what,
 			flex: self.flex,
 			kind: self.kind,
+			immutable: self.immutable,
 			value: self.value,
 			assert: self.assert,
 			default: self.default,

--- a/lib/src/syn/v1/stmt/define/field.rs
+++ b/lib/src/syn/v1/stmt/define/field.rs
@@ -30,7 +30,7 @@ pub fn field(i: &str) -> IResult<&str, DefineFieldStatement> {
 		let (i, what) = ident(i)?;
 		let (i, opts) = many0(field_opts)(i)?;
 		let (i, _) = expected(
-			"one of FLEX(IBLE), TYPE, VALUE, ASSERT, DEFAULT, or COMMENT",
+			"one of FLEX(IBLE), TYPE, IMMUTABLE, VALUE, ASSERT, DEFAULT, or COMMENT",
 			cut(ending::query),
 		)(i)?;
 		Ok((i, (name, what, opts)))
@@ -49,6 +49,9 @@ pub fn field(i: &str) -> IResult<&str, DefineFieldStatement> {
 			}
 			DefineFieldOption::Kind(v) => {
 				res.kind = Some(v);
+			}
+			DefineFieldOption::Immutable => {
+				res.immutable = true;
 			}
 			DefineFieldOption::Value(v) => {
 				res.value = Some(v);
@@ -74,6 +77,7 @@ pub fn field(i: &str) -> IResult<&str, DefineFieldStatement> {
 enum DefineFieldOption {
 	Flex,
 	Kind(Kind),
+	Immutable,
 	Value(Value),
 	Assert(Value),
 	Default(Value),
@@ -85,6 +89,7 @@ fn field_opts(i: &str) -> IResult<&str, DefineFieldOption> {
 	alt((
 		field_flex,
 		field_kind,
+		field_immutable,
 		field_value,
 		field_assert,
 		field_default,
@@ -105,6 +110,12 @@ fn field_kind(i: &str) -> IResult<&str, DefineFieldOption> {
 	let (i, _) = shouldbespace(i)?;
 	let (i, v) = cut(kind)(i)?;
 	Ok((i, DefineFieldOption::Kind(v)))
+}
+
+fn field_immutable(i: &str) -> IResult<&str, DefineFieldOption> {
+	let (i, _) = shouldbespace(i)?;
+	let (i, _) = tag_no_case("IMMUTABLE")(i)?;
+	Ok((i, DefineFieldOption::Immutable))
 }
 
 fn field_value(i: &str) -> IResult<&str, DefineFieldOption> {

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -857,7 +857,7 @@ async fn field_definition_immutable() -> Result<(), Error> {
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 9);
+	assert_eq!(res.len(), 5);
 	//
 	let tmp = res.remove(0).result;
 	assert!(tmp.is_ok());

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -478,6 +478,12 @@ async fn field_definition_default_value() -> Result<(), Error> {
 	assert!(tmp.is_ok());
 	//
 	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
 	assert!(
 		matches!(
 			&tmp,
@@ -856,7 +862,7 @@ async fn field_definition_edge_permissions() -> Result<(), Error> {
 async fn field_definition_immutable() -> Result<(), Error> {
 	let sql = "
 		DEFINE TABLE person SCHEMAFULL;
-		DEFINE FIELD birthdate ON person TYPE option<string> IMMUTABLE;
+		DEFINE FIELD birthdate ON person TYPE datetime IMMUTABLE;
 		CREATE person:test SET birthdate = '2023-12-13T21:27:55.632Z';
 		UPDATE person:test SET birthdate = '2023-12-13T21:27:55.632Z';
 		UPDATE person:test SET birthdate = '2024-12-13T21:27:55.632Z';

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -882,7 +882,7 @@ async fn field_definition_immutable() -> Result<(), Error> {
 	let val = Value::parse(
 		"[
 			{
-				birthdate: '2024-12-13T21:27:55.632Z',
+				birthdate: '2023-12-13T21:27:55.632Z',
 				id: person:test
 			}
 		]",
@@ -893,7 +893,7 @@ async fn field_definition_immutable() -> Result<(), Error> {
 	let val = Value::parse(
 		"[
 			{
-				birthdate: '2024-12-13T21:27:55.632Z',
+				birthdate: '2023-12-13T21:27:55.632Z',
 				id: person:test
 			}
 		]",

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -443,10 +443,13 @@ async fn field_selection_variable_fields_projection() -> Result<(), Error> {
 #[tokio::test]
 async fn field_definition_default_value() -> Result<(), Error> {
 	let sql = "
+		DEFINE FUNCTION fn::opt_arg($arg: option<bool>) { $arg ?? true };
+		--
 		DEFINE TABLE product SCHEMAFULL;
 		DEFINE FIELD primary ON product TYPE number VALUE 123.456;
 		DEFINE FIELD secondary ON product TYPE bool DEFAULT true VALUE $value;
 		DEFINE FIELD tertiary ON product TYPE string DEFAULT 'hello' VALUE 'tester';
+		DEFINE FIELD quaternary ON product TYPE bool VALUE fn::opt_arg();
 		--
 		CREATE product:test SET primary = NULL;
 		CREATE product:test SET secondary = 'oops';
@@ -460,7 +463,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 11);
+	assert_eq!(res.len(), 13);
 	//
 	let tmp = res.remove(0).result;
 	assert!(tmp.is_ok());
@@ -510,6 +513,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 			{
 				id: product:test,
 				primary: 123.456,
+				quaternary: true,
 				secondary: true,
 				tertiary: 'tester',
 			}
@@ -523,6 +527,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 			{
 				id: product:test,
 				primary: 123.456,
+				quaternary: true,
 				secondary: true,
 				tertiary: 'tester',
 			}
@@ -536,6 +541,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 			{
 				id: product:test,
 				primary: 123.456,
+				quaternary: true,
 				secondary: false,
 				tertiary: 'tester',
 			}
@@ -549,6 +555,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 			{
 				id: product:test,
 				primary: 123.456,
+				quaternary: true,
 				secondary: false,
 				tertiary: 'tester',
 			}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The `DEFAULT` clause has been a great improvements to field definitions since beta-10, but I believe some scenarios are still overly complex. Consider the following:
```surql
DEFINE FIELD created ON user 
  VALUE $before OR time::now() 
  DEFAULT time::now();

DEFINE FIELD updated ON user 
  VALUE time::now() 
  DEFAULT time::now();
```

## What does this change do?

This PR introduces two changes:
- If only a function is passed to a value clause, it will be used as the default value too. This was already possible with basic values.
- It introduces a new `IMMUTABLE` keyword to field definitions, allowing users to create custom immutable fields.

This results in the following:
```surql
DEFINE FIELD created ON user IMMUTABLE VALUE time::now();
DEFINE FIELD updated ON user VALUE time::now();
```

## What is your testing strategy?

Need to add test cases

## Is this related to any issues?

Not that I'm aware

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
