### PR TITLE
Expand logic for static value validation

### DIFF
--- a/lib/src/doc/field.rs
+++ b/lib/src/doc/field.rs
@@ -35,11 +35,7 @@ impl<'a> Document<'a> {
 				let def = match &fd.default {
 					Some(v) => Some(v),
 					_ => match &fd.value {
-						Some(v) => match &v {
-							Value::Function(f) if f.args().is_empty() => Some(v),
-							v if v.is_static() => Some(*v),
-							_ => None,
-						},
+						Some(v) if v.is_static() => Some(v),
 						_ => None,
 					},
 				};

--- a/lib/src/doc/field.rs
+++ b/lib/src/doc/field.rs
@@ -35,7 +35,11 @@ impl<'a> Document<'a> {
 				let def = match &fd.default {
 					Some(v) => Some(v),
 					_ => match &fd.value {
-						Some(v) if v.is_static() => Some(v),
+						Some(v) => match &v {
+							Value::Function(f) if f.args().is_empty() => Some(v),
+							v if v.is_static() => Some(*v),
+							_ => None,
+						},
 						_ => None,
 					},
 				};

--- a/lib/src/sql/array.rs
+++ b/lib/src/sql/array.rs
@@ -149,6 +149,10 @@ impl Array {
 	pub(crate) fn is_all_none_or_null(&self) -> bool {
 		self.0.iter().all(|v| v.is_none_or_null())
 	}
+
+	pub(crate) fn is_static(&self) -> bool {
+		self.iter().all(Value::is_static)
+	}
 }
 
 impl Display for Array {

--- a/lib/src/sql/expression.rs
+++ b/lib/src/sql/expression.rs
@@ -87,6 +87,20 @@ impl Expression {
 		}
 	}
 
+	pub(crate) fn is_static(&self) -> bool {
+		match self {
+			Self::Unary {
+				v,
+				..
+			} => v.is_static(),
+			Self::Binary {
+				l,
+				r,
+				..
+			} => l.is_static() && r.is_static(),
+		}
+	}
+
 	/// Returns the operator
 	pub(crate) fn operator(&self) -> &Operator {
 		match self {

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -89,6 +89,14 @@ impl Function {
 		matches!(self, Self::Script(_, _))
 	}
 
+	/// Check if this function has static arguments
+	pub fn is_static(&self) -> bool {
+		match self {
+			Self::Normal(_, a) => a.iter().all(Value::is_static),
+			_ => false,
+		}
+	}
+
 	/// Check if this function is a rolling function
 	pub fn is_rolling(&self) -> bool {
 		match self {

--- a/lib/src/sql/object.rs
+++ b/lib/src/sql/object.rs
@@ -222,6 +222,10 @@ impl Object {
 		}
 		Ok(Value::Object(Object(x)))
 	}
+
+	pub(crate) fn is_static(&self) -> bool {
+		self.values().all(Value::is_static)
+	}
 }
 
 impl Display for Object {

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -2313,8 +2313,10 @@ impl Value {
 			Value::Duration(_) => true,
 			Value::Datetime(_) => true,
 			Value::Geometry(_) => true,
-			Value::Array(v) => v.iter().all(Value::is_static),
-			Value::Object(v) => v.values().all(Value::is_static),
+			Value::Array(v) => v.is_static(),
+			Value::Object(v) => v.is_static(),
+			Value::Expression(v) => v.is_static(),
+			Value::Function(v) => v.is_static(),
 			Value::Constant(_) => true,
 			_ => false,
 		}

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -443,13 +443,11 @@ async fn field_selection_variable_fields_projection() -> Result<(), Error> {
 #[tokio::test]
 async fn field_definition_default_value() -> Result<(), Error> {
 	let sql = "
-		DEFINE FUNCTION fn::opt_arg($arg: option<bool>) { $arg ?? true };
-		--
 		DEFINE TABLE product SCHEMAFULL;
 		DEFINE FIELD primary ON product TYPE number VALUE 123.456;
 		DEFINE FIELD secondary ON product TYPE bool DEFAULT true VALUE $value;
 		DEFINE FIELD tertiary ON product TYPE string DEFAULT 'hello' VALUE 'tester';
-		DEFINE FIELD quaternary ON product TYPE bool VALUE fn::opt_arg();
+		DEFINE FIELD quaternary ON product TYPE bool VALUE array::all([1, 2]);
 		--
 		CREATE product:test SET primary = NULL;
 		CREATE product:test SET secondary = 'oops';
@@ -463,10 +461,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 13);
-	//
-	let tmp = res.remove(0).result;
-	assert!(tmp.is_ok());
+	assert_eq!(res.len(), 12);
 	//
 	let tmp = res.remove(0).result;
 	assert!(tmp.is_ok());

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -443,10 +443,13 @@ async fn field_selection_variable_fields_projection() -> Result<(), Error> {
 #[tokio::test]
 async fn field_definition_default_value() -> Result<(), Error> {
 	let sql = "
+		DEFINE FUNCTION fn::opt_arg($arg: option<bool>) { $arg ?? true };
+		--
 		DEFINE TABLE product SCHEMAFULL;
 		DEFINE FIELD primary ON product TYPE number VALUE 123.456;
 		DEFINE FIELD secondary ON product TYPE bool DEFAULT true VALUE $value;
 		DEFINE FIELD tertiary ON product TYPE string DEFAULT 'hello' VALUE 'tester';
+		DEFINE FIELD quaternary ON product TYPE bool VALUE fn::opt_arg();
 		--
 		CREATE product:test SET primary = NULL;
 		CREATE product:test SET secondary = 'oops';
@@ -460,7 +463,13 @@ async fn field_definition_default_value() -> Result<(), Error> {
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 11);
+	assert_eq!(res.len(), 13);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
 	//
 	let tmp = res.remove(0).result;
 	assert!(tmp.is_ok());
@@ -510,6 +519,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 			{
 				id: product:test,
 				primary: 123.456,
+				quaternary: true,
 				secondary: true,
 				tertiary: 'tester',
 			}
@@ -523,6 +533,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 			{
 				id: product:test,
 				primary: 123.456,
+				quaternary: true,
 				secondary: true,
 				tertiary: 'tester',
 			}
@@ -536,6 +547,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 			{
 				id: product:test,
 				primary: 123.456,
+				quaternary: true,
 				secondary: false,
 				tertiary: 'tester',
 			}
@@ -549,6 +561,7 @@ async fn field_definition_default_value() -> Result<(), Error> {
 			{
 				id: product:test,
 				primary: 123.456,
+				quaternary: true,
 				secondary: false,
 				tertiary: 'tester',
 			}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Followup of #3148.

The `DEFAULT` clause has been a great improvements to field definitions since beta-10, but I believe some scenarios are still overly complex. Consider the following:
```surql
DEFINE FIELD created ON user 
  VALUE $before OR time::now() 
  DEFAULT time::now();

DEFINE FIELD updated ON user 
  VALUE time::now() 
  DEFAULT time::now();
```

## What does this change do?

This PR introduces one of two changes:
- If only a function invocation with only static arguments, or an expression with static parts, is passed to a `VALUE` clause, it will be used as the default value too. This was already possible with basic values.

This results in the following:
```surql
DEFINE FIELD updated ON user VALUE time::now();
```

## What is your testing strategy?

Updated the test for the `DEFAULT` clause to test this behaviour with a custom function.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
