### PR TITLE
Feature: Add `READONLY` keyword to `DEFINE FIELD` statement

### DIFF
--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -531,6 +531,15 @@ pub enum Error {
 		check: String,
 	},
 
+	/// The specified field did not conform to the field ASSERT clause
+	#[error(
+		"Found changed value for field `{field}`, with record `{thing}`, but field is readonly"
+	)]
+	FieldReadonly {
+		thing: String,
+		field: Idiom,
+	},
+
 	/// Found a record id for the record but we are creating a specific record
 	#[error("Found {value} for the id field, but a specific record has been specified")]
 	IdMismatch {

--- a/lib/src/sql/statements/define/field.rs
+++ b/lib/src/sql/statements/define/field.rs
@@ -13,12 +13,14 @@ use std::fmt::{self, Display, Write};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
+#[revisioned(revision = 2)]
 pub struct DefineFieldStatement {
 	pub name: Idiom,
 	pub what: Ident,
 	pub flex: bool,
 	pub kind: Option<Kind>,
+	#[revision(start = 2)]
+	pub readonly: bool,
 	pub value: Option<Value>,
 	pub assert: Option<Value>,
 	pub default: Option<Value>,
@@ -67,6 +69,9 @@ impl Display for DefineFieldStatement {
 		}
 		if let Some(ref v) = self.default {
 			write!(f, " DEFAULT {v}")?
+		}
+		if self.readonly {
+			write!(f, " READONLY")?
 		}
 		if let Some(ref v) = self.value {
 			write!(f, " VALUE {v}")?

--- a/lib/src/sql/value/serde/ser/statement/define/field.rs
+++ b/lib/src/sql/value/serde/ser/statement/define/field.rs
@@ -44,6 +44,7 @@ pub struct SerializeDefineFieldStatement {
 	what: Ident,
 	flex: bool,
 	kind: Option<Kind>,
+	readonly: bool,
 	value: Option<Value>,
 	assert: Option<Value>,
 	default: Option<Value>,
@@ -71,6 +72,9 @@ impl serde::ser::SerializeStruct for SerializeDefineFieldStatement {
 			}
 			"kind" => {
 				self.kind = value.serialize(ser::kind::opt::Serializer.wrap())?;
+			}
+			"readonly" => {
+				self.readonly = value.serialize(ser::primitive::bool::Serializer.wrap())?;
 			}
 			"value" => {
 				self.value = value.serialize(ser::value::opt::Serializer.wrap())?;
@@ -102,6 +106,7 @@ impl serde::ser::SerializeStruct for SerializeDefineFieldStatement {
 			what: self.what,
 			flex: self.flex,
 			kind: self.kind,
+			readonly: self.readonly,
 			value: self.value,
 			assert: self.assert,
 			default: self.default,

--- a/lib/src/syn/v1/stmt/define/field.rs
+++ b/lib/src/syn/v1/stmt/define/field.rs
@@ -30,7 +30,7 @@ pub fn field(i: &str) -> IResult<&str, DefineFieldStatement> {
 		let (i, what) = ident(i)?;
 		let (i, opts) = many0(field_opts)(i)?;
 		let (i, _) = expected(
-			"one of FLEX(IBLE), TYPE, VALUE, ASSERT, DEFAULT, or COMMENT",
+			"one of FLEX(IBLE), TYPE, READONLY, VALUE, ASSERT, DEFAULT, or COMMENT",
 			cut(ending::query),
 		)(i)?;
 		Ok((i, (name, what, opts)))
@@ -49,6 +49,9 @@ pub fn field(i: &str) -> IResult<&str, DefineFieldStatement> {
 			}
 			DefineFieldOption::Kind(v) => {
 				res.kind = Some(v);
+			}
+			DefineFieldOption::ReadOnly => {
+				res.readonly = true;
 			}
 			DefineFieldOption::Value(v) => {
 				res.value = Some(v);
@@ -74,6 +77,7 @@ pub fn field(i: &str) -> IResult<&str, DefineFieldStatement> {
 enum DefineFieldOption {
 	Flex,
 	Kind(Kind),
+	ReadOnly,
 	Value(Value),
 	Assert(Value),
 	Default(Value),
@@ -85,6 +89,7 @@ fn field_opts(i: &str) -> IResult<&str, DefineFieldOption> {
 	alt((
 		field_flex,
 		field_kind,
+		field_readonly,
 		field_value,
 		field_assert,
 		field_default,
@@ -105,6 +110,12 @@ fn field_kind(i: &str) -> IResult<&str, DefineFieldOption> {
 	let (i, _) = shouldbespace(i)?;
 	let (i, v) = cut(kind)(i)?;
 	Ok((i, DefineFieldOption::Kind(v)))
+}
+
+fn field_readonly(i: &str) -> IResult<&str, DefineFieldOption> {
+	let (i, _) = shouldbespace(i)?;
+	let (i, _) = tag_no_case("READONLY")(i)?;
+	Ok((i, DefineFieldOption::ReadOnly))
 }
 
 fn field_value(i: &str) -> IResult<&str, DefineFieldOption> {

--- a/lib/src/syn/v2/lexer/keywords.rs
+++ b/lib/src/syn/v2/lexer/keywords.rs
@@ -112,6 +112,7 @@ pub(crate) static KEYWORDS: phf::Map<UniCase<&'static str>, TokenKind> = phf_map
 	UniCase::ascii("POSTINGS_CACHE") => TokenKind::Keyword(Keyword::PostingsCache),
 	UniCase::ascii("POSTINGS_ORDER") => TokenKind::Keyword(Keyword::PostingsOrder),
 	UniCase::ascii("PUNCT") => TokenKind::Keyword(Keyword::Punct),
+	UniCase::ascii("READONLY") => TokenKind::Keyword(Keyword::Readonly),
 	UniCase::ascii("RELATE") => TokenKind::Keyword(Keyword::Relate),
 	UniCase::ascii("REMOVE") => TokenKind::Keyword(Keyword::Remove),
 	UniCase::ascii("REPLACE") => TokenKind::Keyword(Keyword::Replace),

--- a/lib/src/syn/v2/parser/stmt/define.rs
+++ b/lib/src/syn/v2/parser/stmt/define.rs
@@ -372,6 +372,10 @@ impl Parser<'_> {
 					self.pop_peek();
 					res.kind = Some(self.parse_inner_kind()?);
 				}
+				t!("READONLY") => {
+					self.pop_peek();
+					res.readonly = true;
+				}
 				t!("VALUE") => {
 					self.pop_peek();
 					res.value = Some(self.parse_value()?);

--- a/lib/src/syn/v2/parser/test/stmt.rs
+++ b/lib/src/syn/v2/parser/test/stmt.rs
@@ -359,6 +359,7 @@ fn parse_define_field() {
 				Kind::Number,
 				Kind::Array(Box::new(Kind::Record(vec![Table("foo".to_owned())])), Some(10))
 			])))),
+			readonly: false,
 			value: Some(Value::Null),
 			assert: Some(Value::Bool(true)),
 			default: Some(Value::Bool(false)),

--- a/lib/src/syn/v2/parser/test/streaming.rs
+++ b/lib/src/syn/v2/parser/test/streaming.rs
@@ -258,6 +258,7 @@ fn statements() -> Vec<Statement> {
 				Kind::Number,
 				Kind::Array(Box::new(Kind::Record(vec![Table("foo".to_owned())])), Some(10)),
 			])))),
+			readonly: false,
 			value: Some(Value::Null),
 			assert: Some(Value::Bool(true)),
 			default: Some(Value::Bool(false)),

--- a/lib/src/syn/v2/token/keyword.rs
+++ b/lib/src/syn/v2/token/keyword.rs
@@ -120,6 +120,7 @@ keyword! {
 	PostingsCache => "POSTINGS_CACHE",
 	PostingsOrder => "POSTINGS_ORDER",
 	Punct => "PUNCT",
+	Readonly => "READONLY",
 	Relate => "RELATE",
 	Remove => "REMOVE",
 	Replace => "REPLACE",

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -870,9 +870,9 @@ async fn field_definition_readonly() -> Result<(), Error> {
 	let sql = "
 		DEFINE TABLE person SCHEMAFULL;
 		DEFINE FIELD birthdate ON person TYPE datetime READONLY;
-		CREATE person:test SET birthdate = '2023-12-13T21:27:55.632Z';
-		UPDATE person:test SET birthdate = '2023-12-13T21:27:55.632Z';
-		UPDATE person:test SET birthdate = '2024-12-13T21:27:55.632Z';
+		CREATE person:test SET birthdate = d'2023-12-13T21:27:55.632Z';
+		UPDATE person:test SET birthdate = d'2023-12-13T21:27:55.632Z';
+		UPDATE person:test SET birthdate = d'2024-12-13T21:27:55.632Z';
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
@@ -889,7 +889,7 @@ async fn field_definition_readonly() -> Result<(), Error> {
 	let val = Value::parse(
 		"[
 			{
-				birthdate: '2023-12-13T21:27:55.632Z',
+				birthdate: d'2023-12-13T21:27:55.632Z',
 				id: person:test
 			}
 		]",
@@ -900,7 +900,7 @@ async fn field_definition_readonly() -> Result<(), Error> {
 	let val = Value::parse(
 		"[
 			{
-				birthdate: '2023-12-13T21:27:55.632Z',
+				birthdate: d'2023-12-13T21:27:55.632Z',
 				id: person:test
 			}
 		]",

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -864,3 +864,59 @@ async fn field_definition_edge_permissions() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn field_definition_readonly() -> Result<(), Error> {
+	let sql = "
+		DEFINE TABLE person SCHEMAFULL;
+		DEFINE FIELD birthdate ON person TYPE datetime READONLY;
+		CREATE person:test SET birthdate = '2023-12-13T21:27:55.632Z';
+		UPDATE person:test SET birthdate = '2023-12-13T21:27:55.632Z';
+		UPDATE person:test SET birthdate = '2024-12-13T21:27:55.632Z';
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 5);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				birthdate: '2023-12-13T21:27:55.632Z',
+				id: person:test
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				birthdate: '2023-12-13T21:27:55.632Z',
+				id: person:test
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result;
+	assert!(
+		matches!(
+			&tmp,
+			Err(e) if e.to_string() == "Found changed value for field `birthdate`, with record `person:test`, but field is readonly",
+
+		),
+		"{}",
+		tmp.unwrap_err().to_string()
+	);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Followup of #3148.

The `DEFAULT` clause has been a great improvements to field definitions since beta-10, but I believe some scenarios are still overly complex. Consider the following:
```surql
DEFINE FIELD created ON user 
  VALUE $before OR time::now() 
  DEFAULT time::now();

DEFINE FIELD updated ON user 
  VALUE time::now() 
  DEFAULT time::now();
```

## What does this change do?

This PR introduces one of two changes:
- It introduces a new `READONLY` keyword to field definitions, allowing users to create custom readonly fields.

This results in the following:
```surql
DEFINE FIELD created ON user READONLY VALUE time::now();
```

## What is your testing strategy?

Added a new test that will validate the behaviour of the `READONLY` clause.

## Is this related to any issues?

N/A

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
