### PR TITLE
Fix clippy warnings

### DIFF
--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -420,8 +420,8 @@ impl Datastore {
 				}
 			}
 		};
-		if resolve_err.is_err() {
-			err.push(resolve_err.unwrap_err());
+		if let Err(error) = resolve_err {
+			err.push(error);
 		}
 		if !err.is_empty() {
 			error!("Error bootstrapping sweep phase: {:?}", err);

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -7,7 +7,6 @@ use crate::dbs::node::ClusterMembership;
 use crate::dbs::node::Timestamp;
 use crate::err::Error;
 use crate::idg::u32::U32;
-use crate::key::debug;
 use crate::kvs::cache::Cache;
 use crate::kvs::cache::Entry;
 use crate::kvs::Check;
@@ -622,8 +621,8 @@ impl Transaction {
 		#[cfg(debug_assertions)]
 		trace!(
 			"Scan {:?} - {:?}",
-			debug::sprint_key(&rng.start.clone().into()),
-			debug::sprint_key(&rng.end.clone().into())
+			crate::key::debug::sprint_key(&rng.start.clone().into()),
+			crate::key::debug::sprint_key(&rng.end.clone().into())
 		);
 		match self {
 			#[cfg(feature = "kv-mem")]

--- a/lib/tests/changefeeds.rs
+++ b/lib/tests/changefeeds.rs
@@ -344,7 +344,7 @@ async fn changefeed_with_ts() -> Result<(), Error> {
 	let Value::Object(a) = a else {
 		unreachable!()
 	};
-	let Value::Number(versionstamp1) = a.get("versionstamp").unwrap() else {
+	let Value::Number(_versionstamp1) = a.get("versionstamp").unwrap() else {
 		unreachable!()
 	};
 	let changes = a.get("changes").unwrap().to_owned();


### PR DESCRIPTION
## What is the motivation?

Clippy prints some warnings on v1.0.

## What does this change do?

It addresses the warnings in `patches/1.0`.

## What is your testing strategy?

I ran

- `make check`
- `cargo make ci-check`
- `cargo make ci-check-wasm`
- `cargo make ci-clippy`
- `make serve` and `make test`

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
