### PR TITLE
Support patch releases for v1.0

### DIFF
--- a/.config/release-plz.toml
+++ b/.config/release-plz.toml
@@ -1,5 +1,0 @@
-[workspace]
-changelog_update = false
-git_release_enable = false
-semver_check = false
-git_tag_enable = false

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -74,7 +74,7 @@ jobs:
 
           # Commit changes
           git checkout -b patches/${major}.${minor}
-          git commit -am "Bump version"
+          git commit -am "Bump version to v${version}"
 
       - name: Push the new branch
         run: git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 
 name: Stable release
 
-run-name: "Stable release '${{ inputs.branch }}' (publish: ${{ inputs.publish }}, latest: ${{ inputs.branch == 'releases/beta' || inputs.latest }})"
+run-name: "Stable release '${{ inputs.branch }}' (publish: ${{ inputs.publish }}, latest: ${{ inputs.branch == 'releases/beta' || inputs.latest }}, HTTP compression: ${{ inputs.http-compression }}, ML: ${{ inputs.ml }})"
 
 on:
   workflow_dispatch:
@@ -22,6 +22,16 @@ on:
         type: boolean
         default: false
         description: "Publish the release"
+      http-compression:
+        required: false
+        type: boolean
+        default: true
+        description: "Enable HTTP compression in binaries"
+      ml:
+        required: false
+        type: boolean
+        default: true
+        description: "Enable ML support in binaries"
 
 defaults:
   run:
@@ -56,6 +66,8 @@ jobs:
       latest: ${{ inputs.branch == 'releases/beta' || inputs.latest }}
       publish: ${{ inputs.publish }}
       create-release: ${{ inputs.publish }}
+      http-compression: ${{ inputs.http-compression }}
+      ml: ${{ inputs.ml }}
     secrets: inherit
 
   release-branch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [checks]
     uses: ./.github/workflows/reusable_publish_version.yml
     with:
-      environment: release
+      environment: stable
       git-ref: ${{ inputs.branch }}
       latest: ${{ inputs.branch == 'releases/beta' || inputs.latest }}
       publish: ${{ inputs.publish }}

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -274,6 +274,16 @@ jobs:
       - name: Create a temporary branch
         run: git checkout -b crate
 
+      - name: Configure release-plz
+        run: |
+          cat << EOF > /tmp/release-plz.toml
+          [workspace]
+          changelog_update = false
+          git_release_enable = false
+          semver_check = false
+          git_tag_enable = false
+          EOF
+
       - name: Patch beta crate version
         if: ${{ inputs.environment == 'beta' }}
         run: |
@@ -321,7 +331,7 @@ jobs:
       - name: Publish the crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: /home/runner/.cargo/bin/release-plz release --config .config/release-plz.toml
+        run: /home/runner/.cargo/bin/release-plz release --config /tmp/release-plz.toml
 
   docker-build:
     name: Build Docker images

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -568,7 +568,6 @@ jobs:
         with:
           name: "Release ${{ needs.prepare-vars.outputs.git-ref }}"
           tag_name: ${{ needs.prepare-vars.outputs.git-ref }}
-          token: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can push the release
           prerelease: ${{ inputs.environment == 'beta' }}
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -247,92 +247,6 @@ jobs:
       - name: Check clippy
         run: cargo make ci-clippy
 
-  crate:
-    name: Publish crate to crates.io
-    if: ${{ inputs.publish }}
-    needs: [test, lint, prepare-vars]
-    environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare-vars.outputs.git-ref }}
-
-      - name: Install release-plz
-        run: cargo install --force --locked --version 0.3.30 release-plz
-
-      - name: Install a TOML parser
-        if: ${{ inputs.environment == 'beta' }}
-        run: cargo install --force --locked --version 0.8.1 taplo-cli
-
-      - name: Create a temporary branch
-        run: git checkout -b crate
-
-      - name: Configure release-plz
-        run: |
-          cat << EOF > /tmp/release-plz.toml
-          [workspace]
-          changelog_update = false
-          git_release_enable = false
-          semver_check = false
-          git_tag_enable = false
-          EOF
-
-      - name: Patch beta crate version
-        if: ${{ inputs.environment == 'beta' }}
-        run: |
-          set -x
-
-          # Derive crate version
-          currentVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
-          major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
-          minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
-          betaNum=$(echo $currentVersion | tr "." "\n" | sed -n 4p)
-          version=${major}.${minor}.$(($betaNum - 1))
-
-          # Update crate version
-          sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
-
-      - name:  Patch nightly crate version
-        if: ${{ inputs.environment == 'nightly' }}
-        run: |
-          # Get the date and time of the last commit
-          date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
-          time=$(git show --no-patch --format=%ad --date=format:%H%M%S)
-
-          # Update the version to a nightly one
-          # This sets the nightly version to something like `1.20231117.1130416`
-          # The 1 at the beginning of the patch number is just so it never starts with zero
-          sed -i "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${date}.1${time}\"#" lib/Cargo.toml
-
-      - name: Patch crate name and description
-        if: ${{ inputs.environment == 'nightly' || inputs.environment == 'beta' }}
-        run: |
-          set -x
-
-          # Patch crate name
-          sed -i "0,/surrealdb/s//surrealdb-${{ inputs.environment }}/" lib/Cargo.toml
-
-          # Patch the description
-          sed -i "s#^description = \".*\"#description = \"A ${{ inputs.environment }} release of the surrealdb crate\"#" lib/Cargo.toml
-
-          # Temporarily commit patches
-          # These should not be pushed back to the repo
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          git commit -am "Name and version patches"
-
-      - name: Publish the crate
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: /home/runner/.cargo/bin/release-plz release --config /tmp/release-plz.toml
-
   docker-build:
     name: Build Docker images
     needs: [prepare-vars]
@@ -546,7 +460,7 @@ jobs:
             ${{ matrix.file }}.exe
 
   publish:
-    name: Publish artifacts binaries
+    name: Publish crate and artifacts binaries
     needs: [prepare-vars, test, lint, build, docker-build]
     if: ${{ inputs.publish }}
     environment: ${{ inputs.environment }}
@@ -556,6 +470,80 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare-vars.outputs.git-ref }}
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Install release-plz
+        run: cargo install --force --locked --version 0.3.30 release-plz
+
+      - name: Install a TOML parser
+        if: ${{ inputs.environment == 'beta' }}
+        run: cargo install --force --locked --version 0.8.1 taplo-cli
+
+      - name: Create a temporary branch
+        run: git checkout -b crate
+
+      - name: Configure release-plz
+        run: |
+          cat << EOF > /tmp/release-plz.toml
+          [workspace]
+          changelog_update = false
+          git_release_enable = false
+          semver_check = false
+          git_tag_enable = false
+          EOF
+
+      - name: Patch beta crate version
+        if: ${{ inputs.environment == 'beta' }}
+        run: |
+          set -x
+
+          # Derive crate version
+          currentVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
+          major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
+          minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
+          betaNum=$(echo $currentVersion | tr "." "\n" | sed -n 4p)
+          version=${major}.${minor}.$(($betaNum - 1))
+
+          # Update crate version
+          sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
+
+      - name:  Patch nightly crate version
+        if: ${{ inputs.environment == 'nightly' }}
+        run: |
+          # Get the date and time of the last commit
+          date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
+          time=$(git show --no-patch --format=%ad --date=format:%H%M%S)
+
+          # Update the version to a nightly one
+          # This sets the nightly version to something like `1.20231117.1130416`
+          # The 1 at the beginning of the patch number is just so it never starts with zero
+          sed -i "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${date}.1${time}\"#" lib/Cargo.toml
+
+      - name: Patch crate name and description
+        if: ${{ inputs.environment == 'nightly' || inputs.environment == 'beta' }}
+        run: |
+          set -x
+
+          # Patch crate name
+          sed -i "0,/surrealdb/s//surrealdb-${{ inputs.environment }}/" lib/Cargo.toml
+
+          # Patch the description
+          sed -i "s#^description = \".*\"#description = \"A ${{ inputs.environment }} release of the surrealdb crate\"#" lib/Cargo.toml
+
+          # Temporarily commit patches
+          # These should not be pushed back to the repo
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git commit -am "Name and version patches"
+
+      - name: Publish the crate
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: /home/runner/.cargo/bin/release-plz release --config /tmp/release-plz.toml
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -568,7 +556,7 @@ jobs:
         with:
           name: "Release ${{ needs.prepare-vars.outputs.git-ref }}"
           tag_name: ${{ needs.prepare-vars.outputs.git-ref }}
-          prerelease: ${{ inputs.environment == 'beta' }}
+          prerelease: ${{ inputs.environment == 'beta' || inputs.environment == 'nightly' }}
           fail_on_unmatched_files: true
           files: |
             LICENSE
@@ -591,8 +579,8 @@ jobs:
       - name: Set latest beta version
         if: ${{ inputs.publish && inputs.environment == 'beta' }}
         run: |
-          echo ${{ needs.prepare-vars.outputs.git-ref }} > ${{ inputs.environment }}.txt
-          aws s3 cp --cache-control 'no-store' ${{ inputs.environment }}.txt s3://download.surrealdb.com/${{ inputs.environment }}.txt
+          echo ${{ needs.prepare-vars.outputs.git-ref }} > beta.txt
+          aws s3 cp --cache-control 'no-store' beta.txt s3://download.surrealdb.com/beta.txt
 
       - name: Publish binaries
         run: |

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -286,7 +286,6 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
-              export SURREAL_BUILD_METADATA=${{ needs.prepare-vars.outputs.build-metadata }}
               cargo build --features $features --release --locked --target x86_64-apple-darwin
 
               # Package
@@ -313,7 +312,6 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
-              export SURREAL_BUILD_METADATA=${{ needs.prepare-vars.outputs.build-metadata }}
               cargo build --features $features --release --locked --target aarch64-apple-darwin
 
               # Package
@@ -340,7 +338,7 @@ jobs:
               docker build \
                 --platform linux/amd64 \
                 --build-arg="CARGO_EXTRA_FEATURES=${features}" \
-                --build-arg="SURREAL_BUILD_METADATA=${{ needs.prepare-vars.outputs.build-metadata }}" \
+                --build-arg="SURREAL_BUILD_METADATA=${SURREAL_BUILD_METADATA}" \
                 -t binary \
                 -f docker/Dockerfile.binary \
                 .
@@ -370,7 +368,7 @@ jobs:
               docker build \
                 --platform linux/arm64 \
                 --build-arg="CARGO_EXTRA_FEATURES=${features}" \
-                --build-arg="SURREAL_BUILD_METADATA=${{ needs.prepare-vars.outputs.build-metadata }}" \
+                --build-arg="SURREAL_BUILD_METADATA=${SURREAL_BUILD_METADATA}" \
                 -t binary \
                 -f docker/Dockerfile.binary \
                 .
@@ -397,7 +395,6 @@ jobs:
               if [[ "${{ inputs.http-compression}}" == "true" ]]; then
                 features=${features},http-compression
               fi
-              export SURREAL_BUILD_METADATA=${{ needs.prepare-vars.outputs.build-metadata }}
               cargo build --features $features --release --locked --target x86_64-pc-windows-msvc
 
               # Package
@@ -440,6 +437,8 @@ jobs:
           go version ; cargo version ; rustc --version ; cmake --version ; gcc --version ; g++ --version ; perl -v
 
       - name: Build step
+        env:
+          SURREAL_BUILD_METADATA: ${{ needs.prepare-vars.outputs.build-metadata }}
         run: ${{ matrix.build-step }}
 
       - name: Upload artifacts

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -363,6 +363,9 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
+              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "release" ]]; then
+                export SURREAL_BUILD_METADATA=""
+              fi
               cargo build --features $features --release --locked --target x86_64-apple-darwin
 
               # Package
@@ -387,6 +390,9 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
+              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "release" ]]; then
+                export SURREAL_BUILD_METADATA=""
+              fi
               cargo build --features $features --release --locked --target aarch64-apple-darwin
 
               # Package
@@ -408,9 +414,17 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
+              if [[ "${{ inputs.environment}}" == "nightly" ]]; then
+                date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
+                rev=$(git rev-parse --short HEAD)
+                buildMetadata=${date}.${rev}
+              else
+                buildMetadata=""
+              fi
               docker build \
                 --platform linux/amd64 \
                 --build-arg="CARGO_EXTRA_FEATURES=${features}" \
+                --build-arg="SURREAL_BUILD_METADATA=${buildMetadata}" \
                 -t binary \
                 -f docker/Dockerfile.binary \
                 .
@@ -435,9 +449,17 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
+              if [[ "${{ inputs.environment}}" == "nightly" ]]; then
+                date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
+                rev=$(git rev-parse --short HEAD)
+                buildMetadata=${date}.${rev}
+              else
+                buildMetadata=""
+              fi
               docker build \
                 --platform linux/arm64 \
                 --build-arg="CARGO_EXTRA_FEATURES=${features}" \
+                --build-arg="SURREAL_BUILD_METADATA=${buildMetadata}" \
                 -t binary \
                 -f docker/Dockerfile.binary \
                 .
@@ -461,6 +483,9 @@ jobs:
               features=storage-tikv
               if [[ "${{ inputs.http-compression}}" == "true" ]]; then
                 features=${features},http-compression
+              fi
+              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "release" ]]; then
+                export SURREAL_BUILD_METADATA=""
               fi
               cargo build --features $features --release --locked --target x86_64-pc-windows-msvc
 

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -272,6 +272,8 @@ jobs:
             runner: macos-latest-xl
             file: surreal-${{ needs.prepare-vars.outputs.name }}.darwin-amd64
             build-step: |
+              set -x
+
               # Prepare deps
               brew install protobuf
 
@@ -297,6 +299,8 @@ jobs:
             runner: macos-latest-xl
             file: surreal-${{ needs.prepare-vars.outputs.name }}.darwin-arm64
             build-step: |
+              set -x
+
               # Prepare deps
               brew install protobuf
 
@@ -322,6 +326,8 @@ jobs:
             runner: ["self-hosted", "amd64", "builder"]
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
+              set -x
+
               # Build
               features=storage-tikv
               if [[ "${{ inputs.http-compression}}" == "true" ]]; then
@@ -350,6 +356,8 @@ jobs:
             runner: ["self-hosted", "arm64", "builder"]
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-arm64
             build-step: |
+              set -x
+
               # Build
               features=storage-tikv
               if [[ "${{ inputs.http-compression}}" == "true" ]]; then
@@ -378,6 +386,8 @@ jobs:
             runner: windows-latest
             file: surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64
             build-step: |
+              set -x
+
               # Prepare deps
               vcpkg integrate install
 

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -72,7 +72,7 @@ jobs:
           git config --add --bool push.autoSetupRemote true
 
       - name: Patch release version
-        if: ${{ inputs.environment == 'release' }}
+        if: ${{ inputs.environment == 'stable' }}
         run: |
           set -x
 
@@ -140,11 +140,11 @@ jobs:
           git tag -a v${betaVersion} -m "Release ${betaVersion}" || true
 
       - name: Push changes
-        if: ${{ inputs.publish && (inputs.environment == 'beta' || inputs.environment == 'release') }}
+        if: ${{ inputs.publish && (inputs.environment == 'beta' || inputs.environment == 'stable') }}
         run: git push
 
       - name: Push tag
-        if: ${{ inputs.publish && (inputs.environment == 'beta' || inputs.environment == 'release') }}
+        if: ${{ inputs.publish && (inputs.environment == 'beta' || inputs.environment == 'stable') }}
         run: git push --tags || true
 
       - name: Set outputs
@@ -154,7 +154,7 @@ jobs:
 
           version=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
 
-          if [[ "${{ inputs.publish }}" == "true" && ("${{ inputs.environment }}" == "beta" || "${{ inputs.environment }}" == "release")  ]]; then
+          if [[ "${{ inputs.publish }}" == "true" && ("${{ inputs.environment }}" == "beta" || "${{ inputs.environment }}" == "stable")  ]]; then
             echo "git-ref=v${version}" >> $GITHUB_OUTPUT
           else
             echo "git-ref=${{ inputs.git-ref || github.ref_name }}" >> $GITHUB_OUTPUT
@@ -367,7 +367,7 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
-              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "release" ]]; then
+              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "stable" ]]; then
                 export SURREAL_BUILD_METADATA=""
               fi
               cargo build --features $features --release --locked --target x86_64-apple-darwin
@@ -394,7 +394,7 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
-              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "release" ]]; then
+              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "stable" ]]; then
                 export SURREAL_BUILD_METADATA=""
               fi
               cargo build --features $features --release --locked --target aarch64-apple-darwin
@@ -488,7 +488,7 @@ jobs:
               if [[ "${{ inputs.http-compression}}" == "true" ]]; then
                 features=${features},http-compression
               fi
-              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "release" ]]; then
+              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "stable" ]]; then
                 export SURREAL_BUILD_METADATA=""
               fi
               cargo build --features $features --release --locked --target x86_64-pc-windows-msvc

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -271,6 +271,9 @@ jobs:
         if: ${{ inputs.environment == 'beta' }}
         run: cargo install --force --locked --version 0.8.1 taplo-cli
 
+      - name: Create a temporary branch
+        run: git checkout -b crate
+
       - name: Patch beta crate version
         if: ${{ inputs.environment == 'beta' }}
         run: |
@@ -318,14 +321,7 @@ jobs:
       - name: Publish the crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          set -x
-
-          # Create a temporary branch
-          git checkout -b crate
-
-          # Publish the crate
-          /home/runner/.cargo/bin/release-plz release --config .config/release-plz.toml
+        run: /home/runner/.cargo/bin/release-plz release --config .config/release-plz.toml
 
   docker-build:
     name: Build Docker images

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -29,6 +29,16 @@ on:
         type: boolean
         default: false
         description: "Create a GitHub release"
+      http-compression:
+        required: false
+        type: boolean
+        default: true
+        description: "Enable HTTP compression in binaries"
+      ml:
+        required: false
+        type: boolean
+        default: true
+        description: "Enable ML support in binaries"
 
 defaults:
   run:
@@ -346,7 +356,14 @@ jobs:
               brew install protobuf
 
               # Build
-              cargo build --features storage-tikv,http-compression,ml --release --locked --target x86_64-apple-darwin
+              features=storage-tikv
+              if [[ "${{ inputs.http-compression}}" == "true" ]]; then
+                features=${features},http-compression
+              fi
+              if [[ "${{ inputs.ml}}" == "true" ]]; then
+                features=${features},ml
+              fi
+              cargo build --features $features --release --locked --target x86_64-apple-darwin
 
               # Package
               cp target/x86_64-apple-darwin/release/surreal surreal
@@ -363,7 +380,14 @@ jobs:
               brew install protobuf
 
               # Build
-              cargo build --features storage-tikv,http-compression,ml --release --locked --target aarch64-apple-darwin
+              features=storage-tikv
+              if [[ "${{ inputs.http-compression}}" == "true" ]]; then
+                features=${features},http-compression
+              fi
+              if [[ "${{ inputs.ml}}" == "true" ]]; then
+                features=${features},ml
+              fi
+              cargo build --features $features --release --locked --target aarch64-apple-darwin
 
               # Package
               cp target/aarch64-apple-darwin/release/surreal surreal
@@ -377,9 +401,16 @@ jobs:
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
               # Build
+              features=storage-tikv
+              if [[ "${{ inputs.http-compression}}" == "true" ]]; then
+                features=${features},http-compression
+              fi
+              if [[ "${{ inputs.ml}}" == "true" ]]; then
+                features=${features},ml
+              fi
               docker build \
                 --platform linux/amd64 \
-                --build-arg="CARGO_EXTRA_FEATURES=storage-tikv,http-compression,ml" \
+                --build-arg="CARGO_EXTRA_FEATURES=${features}" \
                 -t binary \
                 -f docker/Dockerfile.binary \
                 .
@@ -397,9 +428,16 @@ jobs:
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-arm64
             build-step: |
               # Build
+              features=storage-tikv
+              if [[ "${{ inputs.http-compression}}" == "true" ]]; then
+                features=${features},http-compression
+              fi
+              if [[ "${{ inputs.ml}}" == "true" ]]; then
+                features=${features},ml
+              fi
               docker build \
                 --platform linux/arm64 \
-                --build-arg="CARGO_EXTRA_FEATURES=storage-tikv,http-compression,ml" \
+                --build-arg="CARGO_EXTRA_FEATURES=${features}" \
                 -t binary \
                 -f docker/Dockerfile.binary \
                 .
@@ -420,7 +458,11 @@ jobs:
               vcpkg integrate install
 
               # Build
-              cargo build --features storage-tikv,http-compression --release --locked --target x86_64-pc-windows-msvc
+              features=storage-tikv
+              if [[ "${{ inputs.http-compression}}" == "true" ]]; then
+                features=${features},http-compression
+              fi
+              cargo build --features $features --release --locked --target x86_64-pc-windows-msvc
 
               # Package
               cp target/x86_64-pc-windows-msvc/release/surreal.exe surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -145,8 +145,6 @@ jobs:
 
       - name: Push tag
         if: ${{ inputs.publish && (inputs.environment == 'beta' || inputs.environment == 'release') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can push the tag
         run: git push --tags || true
 
       - name: Set outputs

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -165,8 +165,10 @@ jobs:
 
             date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
             rev=$(git rev-parse --short HEAD)
+            echo "build-metadata=${date}.${rev}" >> $GITHUB_OUTPUT
           else
             echo "name=v${version}" >> $GITHUB_OUTPUT
+            echo "build-metadata=\"\"" >> $GITHUB_OUTPUT
           fi
 
   test:
@@ -281,9 +283,7 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
-              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "stable" ]]; then
-                export SURREAL_BUILD_METADATA=""
-              fi
+              export SURREAL_BUILD_METADATA=${{ needs.prepare-vars.outputs.build-metadata }}
               cargo build --features $features --release --locked --target x86_64-apple-darwin
 
               # Package
@@ -308,9 +308,7 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
-              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "stable" ]]; then
-                export SURREAL_BUILD_METADATA=""
-              fi
+              export SURREAL_BUILD_METADATA=${{ needs.prepare-vars.outputs.build-metadata }}
               cargo build --features $features --release --locked --target aarch64-apple-darwin
 
               # Package
@@ -332,17 +330,10 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
-              if [[ "${{ inputs.environment}}" == "nightly" ]]; then
-                date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
-                rev=$(git rev-parse --short HEAD)
-                buildMetadata=${date}.${rev}
-              else
-                buildMetadata=""
-              fi
               docker build \
                 --platform linux/amd64 \
                 --build-arg="CARGO_EXTRA_FEATURES=${features}" \
-                --build-arg="SURREAL_BUILD_METADATA=${buildMetadata}" \
+                --build-arg="SURREAL_BUILD_METADATA=${{ needs.prepare-vars.outputs.build-metadata }}" \
                 -t binary \
                 -f docker/Dockerfile.binary \
                 .
@@ -367,17 +358,10 @@ jobs:
               if [[ "${{ inputs.ml}}" == "true" ]]; then
                 features=${features},ml
               fi
-              if [[ "${{ inputs.environment}}" == "nightly" ]]; then
-                date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
-                rev=$(git rev-parse --short HEAD)
-                buildMetadata=${date}.${rev}
-              else
-                buildMetadata=""
-              fi
               docker build \
                 --platform linux/arm64 \
                 --build-arg="CARGO_EXTRA_FEATURES=${features}" \
-                --build-arg="SURREAL_BUILD_METADATA=${buildMetadata}" \
+                --build-arg="SURREAL_BUILD_METADATA=${{ needs.prepare-vars.outputs.build-metadata }}" \
                 -t binary \
                 -f docker/Dockerfile.binary \
                 .
@@ -402,9 +386,7 @@ jobs:
               if [[ "${{ inputs.http-compression}}" == "true" ]]; then
                 features=${features},http-compression
               fi
-              if [[ "${{ inputs.environment}}" == "beta" || "${{ inputs.environment}}" == "stable" ]]; then
-                export SURREAL_BUILD_METADATA=""
-              fi
+              export SURREAL_BUILD_METADATA=${{ needs.prepare-vars.outputs.build-metadata }}
               cargo build --features $features --release --locked --target x86_64-pc-windows-msvc
 
               # Package

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.git-ref || github.ref_name }}
+          ref: ${{ inputs.git-ref }}
 
       - name: Install a TOML parser
         run: cargo install --force --locked --version 0.8.1 taplo-cli
@@ -158,7 +158,7 @@ jobs:
           if [[ "${{ inputs.publish }}" == "true" && ("${{ inputs.environment }}" == "beta" || "${{ inputs.environment }}" == "stable")  ]]; then
             echo "git-ref=v${version}" >> $GITHUB_OUTPUT
           else
-            echo "git-ref=${{ inputs.git-ref || github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "git-ref=${{ inputs.git-ref }}" >> $GITHUB_OUTPUT
           fi
 
           if [[ "${{ inputs.environment }}" == "nightly" ]]; then

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -51,6 +51,7 @@ jobs:
     outputs:
       git-ref: ${{ steps.outputs.outputs.git-ref }}
       name: ${{ steps.outputs.outputs.name }}
+      build-metadata: ${{ steps.outputs.outputs.build-metadata }}
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir /surrealdb
 WORKDIR /surrealdb
 COPY . /surrealdb/
 
-RUN cargo build  --features http-compression,storage-tikv --release --locked
+RUN cargo build  --features storage-tikv --release --locked
 
 #
 # Development image

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -4,7 +4,7 @@
 
 FROM docker.io/ubuntu:20.04
 
-ARG CARGO_EXTRA_FEATURES="http-compression,storage-tikv"
+ARG CARGO_EXTRA_FEATURES="storage-tikv"
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl patch clang gpg build-essential git

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -5,6 +5,7 @@
 FROM docker.io/ubuntu:20.04
 
 ARG CARGO_EXTRA_FEATURES="storage-tikv"
+ARG SURREAL_BUILD_METADATA=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl patch clang gpg build-essential git

--- a/docker/Dockerfile.fdb
+++ b/docker/Dockerfile.fdb
@@ -15,7 +15,7 @@ COPY . /surrealdb/
 RUN  curl -L https://github.com/apple/foundationdb/releases/download/7.1.42/libfdb_c.x86_64.so -o libfdb_c.so && \
     echo "9501a7910fe2d47b805c48c467fddaf485ccf4b1195863e3c5fb0c86648084f1  libfdb_c.so" | sha256sum -c -s - || exit 1 && \
     mv libfdb_c.so /usr/lib/ && \
-    cargo build --features http-compression,storage-tikv,storage-fdb --release --locked
+    cargo build --features storage-tikv,storage-fdb --release --locked
 
 #
 # Development image


### PR DESCRIPTION
## What is the motivation?

v1.0.0 didn't have the `http-compression` and `ml` Cargo features. Having them in the workflows causes the release workflow to fail when trying to release v1.0 patches.

## What does this change do?

It makes those features optional so that we can turn them off when releasing v1.0 patches.

## What is your testing strategy?

Successfully released v1.0.1 with this changeset.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
