### PR TITLE
#3139 Create Dockerfile.Windows for building native Windows container…

### DIFF
--- a/docker/Dockerfile.Windows
+++ b/docker/Dockerfile.Windows
@@ -1,0 +1,19 @@
+# Create Docker Image for native Windows Server 2022 & 2019
+# Windows requires the host OS version to match the container OS version.
+ARG WinVer=ltsc2022
+# ltsc2022 = Windows Server 2022
+# ltsc2019 = Windows Server 2019
+FROM mcr.microsoft.com/windows/nanoserver:${WinVer} as build
+
+LABEL Description="SurrealDB" Vendor="SurrealDB" Version="v1.0.0"
+# Create surrealdb directory
+WORKDIR c:/surrealdb
+# Add to PATH env
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;C:\\surrealdb"
+USER ContainerUser
+
+# download windows surreal
+RUN curl -s -o surreal.exe https://download.surrealdb.com/v1.0.0/surreal-v1.0.0.windows-amd64.exe
+
+ENTRYPOINT ["C:/surrealdb/surreal.exe"]


### PR DESCRIPTION
#3139 Create Dockerfile.Windows for building native Windows container images

Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

To provide native windows container images

## What does this change do?

adds Dockerfile.Windows for building native windows container images

## What is your testing strategy?

Run 
`docker build -t surreal-test2022 . -f Dockerfile --build-arg WinVer=ltsc2022` to build image for Windows 2022
`docker build -t surreal-test2019 . -f Dockerfile --build-arg WinVer=ltsc2019` to build image for Windows 2022

## Is this related to any issues?

https://github.com/surrealdb/surrealdb/issues/3139

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
