### PR TITLE
Fixed broken documentation links to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,28 +200,28 @@ Getting started with SurrealDB is as easy as starting up the SurrealDB database 
 
 ##### Client side apps
 
-- [x] [Getting started with Javascript](https://surrealdb.com/docs/integration/libraries/javascript)
-- [x] [Getting started with WebAssembly](https://surrealdb.com/docs/integration/libraries/webassembly)
-- [x] [Getting started with Ember.js](https://surrealdb.com/docs/integration/libraries/emberjs)
-- [ ] [Getting started with React.js](https://surrealdb.com/docs/integration/libraries/reactjs)
-- [ ] [Getting started with Angular.js](https://surrealdb.com/docs/integration/libraries/angularjs)
-- [ ] [Getting started with Vue.js](https://surrealdb.com/docs/integration/libraries/vuejs)
-- [ ] [Getting started with Apollo GraphQL](https://surrealdb.com/docs/integration/libraries/apollo)
+- [x] [Getting started with Javascript](https://docs.surrealdb.com/docs/integration/sdks/javascript)
+- [x] [Getting started with WebAssembly](https://docs.surrealdb.com/docs/integration/sdks/webassembly)
+- [x] [Getting started with Ember.js](https://docs.surrealdb.com/docs/integration/sdks/emberjs)
+- [ ] [Getting started with React.js](https://docs.surrealdb.com/docs/integration/sdks/reactjs)
+- [ ] [Getting started with Angular.js](https://docs.surrealdb.com/docs/integration/sdks/angularjs)
+- [ ] [Getting started with Vue.js](https://docs.surrealdb.com/docs/integration/sdks/vuejs)
+- [ ] [Getting started with Apollo GraphQL](https://docs.surrealdb.com/docs/integration/sdks/apollo)
 
 ##### Server side code
 
-- [x] [Getting started with Javascript](https://surrealdb.com/docs/integration/libraries/javascript)
-- [x] [Getting started with Node.js](https://surrealdb.com/docs/integration/libraries/nodejs)
-- [x] [Getting started with Golang](https://surrealdb.com/docs/integration/libraries/golang)
-- [x] [Getting started with Rust](https://surrealdb.com/docs/integration/libraries/rust)
-- [x] [Getting started with Deno](https://surrealdb.com/docs/integration/libraries/deno)
-- [ ] [Getting started with Python](https://surrealdb.com/docs/integration/libraries/python) (coming soon)
-- [ ] [Getting started with C](https://surrealdb.com/docs/integration/libraries/c) (coming soon)
-- [ ] [Getting started with Java](https://surrealdb.com/docs/integration/libraries/java) (coming soon)
-- [ ] [Getting started with Ruby](https://surrealdb.com/docs/integration/libraries/ruby) (coming soon)
-- [ ] [Getting started with PHP](https://surrealdb.com/docs/integration/libraries/php) (coming soon)
-- [ ] [Getting started with Swift](https://surrealdb.com/docs/integration/libraries/swift) (coming soon)
-- [ ] [Getting started with R](https://surrealdb.com/docs/integration/libraries/r) (coming soon)
+- [x] [Getting started with Javascript](https://docs.surrealdb.com/docs/integration/sdks/javascript)
+- [x] [Getting started with Node.js](https://docs.surrealdb.com/docs/integration/sdks/nodejs)
+- [x] [Getting started with Golang](https://docs.surrealdb.com/docs/integration/sdks/golang)
+- [x] [Getting started with Rust](https://docs.surrealdb.com/docs/integration/sdks/rust)
+- [x] [Getting started with Deno](https://docs.surrealdb.com/docs/integration/sdks/deno)
+- [ ] [Getting started with Python](https://docs.surrealdb.com/docs/integration/sdks/python) (coming soon)
+- [ ] [Getting started with C](https://docs.surrealdb.com/docs/integration/sdks/c) (coming soon)
+- [ ] [Getting started with Java](https://docs.surrealdb.com/docs/integration/sdks/java) (coming soon)
+- [ ] [Getting started with Ruby](https://docs.surrealdb.com/docs/integration/sdks/ruby) (coming soon)
+- [ ] [Getting started with PHP](https://docs.surrealdb.com/docs/integration/sdks/php) (coming soon)
+- [ ] [Getting started with Swift](https://docs.surrealdb.com/docs/integration/sdks/swift) (coming soon)
+- [ ] [Getting started with R](https://docs.surrealdb.com/docs/integration/sdks/r) (coming soon)
 
 <h2><img height="20" src="./img/features.svg">&nbsp;&nbsp;Quick look</h2>
 


### PR DESCRIPTION
## What is the motivation?

To fix broken links to the documentation on surraldb.com in the readme.

## What does this change do?

Updates links in the readme file.

## What is your testing strategy?

1. click link
2. link should work

## Is this related to any issues?

no

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
