### PR TITLE
Fix typo in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ reports and do our best to quickly fix the problem.
 Please report any issues or vulnerabilities via [Github Security
 Advisories](https://github.com/surrealdb/surrealdb/security/advisories) instead of posting a public issue in GitHub.
 You can also send security communications to [security@surrealdb.com](mailto:security@surrealdb.com). Please include the
-version identifier obtained by running `surrealdb version` on the command line and details on how the vulnerability
+version identifier obtained by running `surreal version` on the command line and details on how the vulnerability
 can be exploited.
 
 ### Do


### PR DESCRIPTION
## What is the motivation?

SECURITY.md has a typo for the `surreal version` command.

## What does this change do?

It fixes the typo.

## What is your testing strategy?

N/A

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
