### PR TITLE
Bug fix: Remove min/1000 in tx:delp

### DIFF
--- a/lib/src/idx/docids.rs
+++ b/lib/src/idx/docids.rs
@@ -1,8 +1,8 @@
 use crate::err::Error;
 use crate::idx::trees::bkeys::TrieKeys;
-use crate::idx::trees::btree::{BStatistics, BTree, BTreeStore};
+use crate::idx::trees::btree::{BState, BStatistics, BTree, BTreeStore};
 use crate::idx::trees::store::{IndexStores, TreeNodeProvider};
-use crate::idx::{trees, IndexKeyBase, VersionedSerdeState};
+use crate::idx::{IndexKeyBase, VersionedSerdeState};
 use crate::kvs::{Key, Transaction, TransactionType};
 use revision::revisioned;
 use roaring::RoaringTreemap;
@@ -154,7 +154,7 @@ impl DocIds {
 #[derive(Serialize, Deserialize)]
 #[revisioned(revision = 1)]
 struct State {
-	btree: trees::btree::BState,
+	btree: BState,
 	available_ids: Option<RoaringTreemap>,
 	next_doc_id: DocId,
 }
@@ -164,7 +164,7 @@ impl VersionedSerdeState for State {}
 impl State {
 	fn new(default_btree_order: u32) -> Self {
 		Self {
-			btree: trees::btree::BState::new(default_btree_order),
+			btree: BState::new(default_btree_order),
 			available_ids: None,
 			next_doc_id: 0,
 		}

--- a/lib/src/idx/ft/terms.rs
+++ b/lib/src/idx/ft/terms.rs
@@ -155,13 +155,22 @@ impl State {
 #[cfg(test)]
 mod tests {
 	use crate::idx::ft::postings::TermFrequency;
-	use crate::idx::ft::terms::Terms;
-	use crate::idx::IndexKeyBase;
+	use crate::idx::ft::terms::{State, Terms};
+	use crate::idx::{IndexKeyBase, VersionedSerdeState};
 	use crate::kvs::TransactionType::{Read, Write};
 	use crate::kvs::{Datastore, LockType::*, Transaction, TransactionType};
 	use rand::{thread_rng, Rng};
 	use std::collections::HashSet;
 	use test_log::test;
+
+	#[test]
+	fn test_state_serde() {
+		let s = State::new(3);
+		let val = s.try_to_val().unwrap();
+		let s = State::try_from_val(val).unwrap();
+		assert_eq!(s.btree.generation(), 0);
+		assert_eq!(s.next_term_id, 0);
+	}
 
 	fn random_term(key_length: usize) -> String {
 		thread_rng()

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -964,7 +964,7 @@ impl Transaction {
 		let end: Key = beg.clone().add(0xff);
 		let min = beg.clone();
 		let max = end.clone();
-		self.delr(min..max, limit).await?;
+		self.delr(min..max, num).await?;
 		Ok(())
 	}
 
@@ -2885,6 +2885,8 @@ impl Transaction {
 #[cfg(test)]
 #[cfg(feature = "kv-mem")]
 mod tests {
+	use crate::key::database::all::All;
+	use crate::key::database::tb::Tb;
 	use crate::{
 		kvs::{Datastore, LockType::*, TransactionType::*},
 		sql::{statements::DefineUserStatement, Base},
@@ -3093,5 +3095,46 @@ mod tests {
 		txn.remove_ns_id(nsid).await.unwrap();
 		txn.complete_changes(false).await.unwrap();
 		txn.commit().await.unwrap();
+	}
+
+	#[tokio::test]
+	async fn test_delp() {
+		let ds = Datastore::new("memory").await.unwrap();
+		// Create entries
+		{
+			let mut txn = ds.transaction(Write, Optimistic).await.unwrap();
+			for i in 0..2500 {
+				let t = format!("{i}");
+				let tb = Tb::new("test", "test", &t);
+				txn.set(tb, vec![]).await.unwrap();
+			}
+			txn.commit().await.unwrap();
+		}
+
+		let beg = crate::key::database::tb::prefix("test", "test");
+		let end = crate::key::database::tb::suffix("test", "test");
+		let rng = beg..end;
+
+		// Check we have the table keys
+		{
+			let mut txn = ds.transaction(Read, Optimistic).await.unwrap();
+			let res = txn.getr(rng.clone(), u32::MAX).await.unwrap();
+			assert_eq!(res.len(), 2500);
+		}
+
+		// Delete using the prefix
+		{
+			let mut txn = ds.transaction(Write, Optimistic).await.unwrap();
+			let all = All::new("test", "test");
+			txn.delp(all, u32::MAX).await.unwrap();
+			txn.commit().await.unwrap();
+		}
+
+		// Check we don't have any table key anymore
+		{
+			let mut txn = ds.transaction(Read, Optimistic).await.unwrap();
+			let res = txn.getr(rng, u32::MAX).await.unwrap();
+			assert_eq!(res.len(), 0);
+		}
 	}
 }

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -964,7 +964,7 @@ impl Transaction {
 		let end: Key = beg.clone().add(0xff);
 		let min = beg.clone();
 		let max = end.clone();
-		self.delr(min..max, num).await?;
+		self.delr(min..max, limit).await?;
 		Ok(())
 	}
 

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -964,8 +964,7 @@ impl Transaction {
 		let end: Key = beg.clone().add(0xff);
 		let min = beg.clone();
 		let max = end.clone();
-		let num = std::cmp::min(1000, limit);
-		self.delr(min..max, num).await?;
+		self.delr(min..max, limit).await?;
 		Ok(())
 	}
 


### PR DESCRIPTION
## What is the motivation?

The REMOVE statement is only removing the first 1000 keys.

## What does this change do?

Remove the limit to 1000.

## What is your testing strategy?

A non-regression test has been implemented

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
