### PR TITLE
Ensure compression is only enabled when response is a certain size

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -20,9 +20,15 @@ mod version;
 #[cfg(feature = "ml")]
 mod ml;
 
+use crate::cli::CF;
+use crate::cnf;
+use crate::err::Error;
+use crate::net::signals::graceful_shutdown;
+use crate::telemetry::metrics::HttpMetricsLayer;
 use axum::response::Redirect;
 use axum::routing::get;
 use axum::{middleware, Router};
+use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
 use http::header;
 use std::net::SocketAddr;
@@ -33,22 +39,17 @@ use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
 use tower_http::add_extension::AddExtensionLayer;
 use tower_http::auth::AsyncRequireAuthorizationLayer;
-#[cfg(feature = "http-compression")]
-use tower_http::compression::CompressionLayer;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::request_id::MakeRequestUuid;
-use tower_http::sensitive_headers::{
-	SetSensitiveRequestHeadersLayer, SetSensitiveResponseHeadersLayer,
-};
+use tower_http::sensitive_headers::SetSensitiveRequestHeadersLayer;
+use tower_http::sensitive_headers::SetSensitiveResponseHeadersLayer;
 use tower_http::trace::TraceLayer;
 use tower_http::ServiceBuilderExt;
 
-use crate::cli::CF;
-use crate::cnf;
-use crate::err::Error;
-use crate::net::signals::graceful_shutdown;
-use crate::telemetry::metrics::HttpMetricsLayer;
-use axum_server::tls_rustls::RustlsConfig;
+#[cfg(feature = "http-compression")]
+use tower_http::compression::predicate::{NotForContentType, Predicate, SizeAbove};
+#[cfg(feature = "http-compression")]
+use tower_http::compression::CompressionLayer;
 
 const LOG: &str = "surrealdb::net";
 
@@ -83,7 +84,16 @@ pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 		.propagate_x_request_id();
 
 	#[cfg(feature = "http-compression")]
-	let service = service.layer(CompressionLayer::new());
+	let service = service.layer(
+		CompressionLayer::new().compress_when(
+			// Don't compress below 512 bytes
+			SizeAbove::new(512)
+				// Don't compress gRPC
+				.and(NotForContentType::GRPC)
+				// Don't compress images
+				.and(NotForContentType::IMAGES),
+		),
+	);
 
 	#[cfg(feature = "http-compression")]
 	let allow_header = [

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -1341,8 +1341,12 @@ mod http_integration {
 
 		// Check that the content is gzip encoded
 		{
-			let res =
-				client.post(url).basic_auth(USER, Some(PASS)).body("CREATE |foo:100|").send().await?;
+			let res = client
+				.post(url)
+				.basic_auth(USER, Some(PASS))
+				.body("CREATE |foo:100|")
+				.send()
+				.await?;
 			assert_eq!(res.status(), 200);
 			assert_eq!(res.headers()["content-encoding"], "gzip");
 		}

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -668,31 +668,31 @@ mod http_integration {
 				-- --------------------------------
 				-- OPTION
 				-- ------------------------------
-	
+
 				OPTION IMPORT;
-	
+
 				-- ------------------------------
 				-- TABLE: foo
 				-- ------------------------------
-	
+
 				DEFINE TABLE foo SCHEMALESS PERMISSIONS NONE;
-	
+
 				-- ------------------------------
 				-- TRANSACTION
 				-- ------------------------------
-	
+
 				BEGIN TRANSACTION;
-	
+
 				-- ------------------------------
 				-- TABLE DATA: foo
 				-- ------------------------------
-	
+
 				UPDATE foo:bvklxkhtxumyrfzqoc5i CONTENT { id: foo:bvklxkhtxumyrfzqoc5i };
-	
+
 				-- ------------------------------
 				-- TRANSACTION
 				-- ------------------------------
-	
+
 				COMMIT TRANSACTION;
 			"#;
 			let res = client.post(url).basic_auth(USER, Some(PASS)).body(data).send().await?;
@@ -1342,7 +1342,7 @@ mod http_integration {
 		// Check that the content is gzip encoded
 		{
 			let res =
-				client.post(url).basic_auth(USER, Some(PASS)).body("CREATE foo").send().await?;
+				client.post(url).basic_auth(USER, Some(PASS)).body("CREATE |foo:100|").send().await?;
 			assert_eq!(res.status(), 200);
 			assert_eq!(res.headers()["content-encoding"], "gzip");
 		}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently HTTP compression is enabled on any response sizes above 32 bytes. However this has a cost on both the server and client side for compressing and decompressing responses, whilst at the same time, the size reduction is unlikely to be beneficial. Instead, Google, Amazon, Akamai, and others recommend to enable HTTP compression on requests over a certain size, ranging from 150bytes to 1000-2000bytes.

## What does this change do?

In this pull request, we have set the minimum response size to 512bytes - a middle ground between smaller responses, and larger response sizes.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
