### PR TITLE
Building the server without the `start` command doesn’t make sense

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.108"
 serde_pack = { version = "1.1.2", package = "rmp-serde" }
-surrealdb = { path = "lib", features = ["kv-mem", "protocol-http", "protocol-ws", "rustls"] }
+surrealdb = { path = "lib", features = ["protocol-http", "protocol-ws", "rustls"] }
 surrealml-core = { version = "0.0.2", optional = true}
 tempfile = "3.8.1"
 thiserror = "1.0.50"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,15 @@ authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 [features]
 # Public features
 default = ["storage-mem", "storage-rocksdb", "scripting", "http"]
-storage-mem = ["surrealdb/kv-mem", "has-storage"]
-storage-rocksdb = ["surrealdb/kv-rocksdb", "has-storage"]
-storage-speedb = ["surrealdb/kv-speedb", "has-storage"]
-storage-tikv = ["surrealdb/kv-tikv", "has-storage"]
-storage-fdb = ["surrealdb/kv-fdb-7_1", "has-storage"]
+storage-mem = ["surrealdb/kv-mem"]
+storage-rocksdb = ["surrealdb/kv-rocksdb"]
+storage-speedb = ["surrealdb/kv-speedb"]
+storage-tikv = ["surrealdb/kv-tikv"]
+storage-fdb = ["surrealdb/kv-fdb-7_1"]
 scripting = ["surrealdb/scripting"]
 http = ["surrealdb/http"]
 http-compression = []
 ml = ["surrealdb/ml", "surrealml-core"]
-# Private features
-has-storage = []
 
 [workspace]
 members = ["lib", "lib/examples/actix", "lib/examples/axum"]
@@ -62,7 +60,7 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0.108"
 serde_pack = { version = "1.1.2", package = "rmp-serde" }
-surrealdb = { path = "lib", features = ["protocol-http", "protocol-ws", "rustls"] }
+surrealdb = { path = "lib", features = ["kv-mem", "protocol-http", "protocol-ws", "rustls"] }
 surrealml-core = { version = "0.0.2", optional = true}
 tempfile = "3.8.1"
 thiserror = "1.0.50"

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -15,7 +15,7 @@ args = ["check", "--locked", "--package", "surrealdb", "--features", "protocol-w
 [tasks.ci-clippy]
 category = "CI - CHECK"
 command = "cargo"
-args = ["clippy", "--all-targets", "--features", "storage-mem,storage-rocksdb,storage-speedb,storage-tikv,storage-fdb,scripting,http,has-storage", "--tests", "--benches", "--examples","--bins", "--", "-D", "warnings"]
+args = ["clippy", "--all-targets", "--features", "storage-mem,storage-rocksdb,storage-speedb,storage-tikv,storage-fdb,scripting,http", "--tests", "--benches", "--examples","--bins", "--", "-D", "warnings"]
 
 #
 # Integration Tests
@@ -205,7 +205,7 @@ script = """
 
     echo "PANIC: Couldn't start tiup playground! Here are the logs for the last attempt:"
     cat /tmp/tiup.log
-    
+
     exit 1
 """
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,10 +1,7 @@
-#[cfg(feature = "has-storage")]
 use crate::net::client_ip::ClientIp;
-#[cfg(feature = "has-storage")]
 use std::sync::OnceLock;
 use std::{net::SocketAddr, path::PathBuf};
 
-#[cfg(feature = "has-storage")]
 pub static CF: OnceLock<Config> = OnceLock::new();
 
 use std::time::Duration;
@@ -13,7 +10,6 @@ use std::time::Duration;
 pub struct Config {
 	pub bind: SocketAddr,
 	pub path: String,
-	#[cfg(feature = "has-storage")]
 	pub client_ip: ClientIp,
 	pub user: Option<String>,
 	pub pass: Option<String>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,7 +6,6 @@ mod import;
 mod isready;
 mod ml;
 mod sql;
-#[cfg(feature = "has-storage")]
 mod start;
 mod upgrade;
 mod validate;
@@ -16,14 +15,12 @@ mod version;
 use crate::cnf::LOGO;
 use backup::BackupCommandArguments;
 use clap::{Parser, Subcommand};
-#[cfg(feature = "has-storage")]
 pub use config::CF;
 use export::ExportCommandArguments;
 use import::ImportCommandArguments;
 use isready::IsReadyCommandArguments;
 use ml::MlCommand;
 use sql::SqlCommandArguments;
-#[cfg(feature = "has-storage")]
 use start::StartCommandArguments;
 use std::process::ExitCode;
 use upgrade::UpgradeCommandArguments;
@@ -55,7 +52,6 @@ struct Cli {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
 enum Commands {
-	#[cfg(feature = "has-storage")]
 	#[command(about = "Start the database server")]
 	Start(StartCommandArguments),
 	#[command(about = "Backup data to or from an existing database")]
@@ -84,7 +80,6 @@ enum Commands {
 pub async fn init() -> ExitCode {
 	let args = Cli::parse();
 	let output = match args.command {
-		#[cfg(feature = "has-storage")]
 		Commands::Start(args) => start::init(args).await,
 		Commands::Backup(args) => backup::init(args).await,
 		Commands::Import(args) => import::init(args).await,

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -182,12 +182,10 @@ pub async fn init(
 	// Start the kvs server
 	dbs::init(dbs).await?;
 	// Start the node agent
-	#[cfg(feature = "has-storage")]
 	let nd = node::init(ct.clone());
 	// Start the web server
 	net::init(ct).await?;
 	// Wait for the node agent to stop
-	#[cfg(feature = "has-storage")]
 	if let Err(e) = nd.await {
 		error!("Node agent failed while running: {}", e);
 		return Err(Error::NodeAgent);

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-#[cfg(feature = "has-storage")]
 use std::{
 	path::{Path, PathBuf},
 	str::FromStr,
@@ -10,7 +9,6 @@ use surrealdb::dbs::capabilities::{FuncTarget, NetTarget, Targets};
 
 pub(crate) mod parser;
 
-#[cfg(feature = "has-storage")]
 pub(crate) fn path_valid(v: &str) -> Result<String, String> {
 	match v {
 		"memory" => Ok(v.to_string()),
@@ -23,7 +21,6 @@ pub(crate) fn path_valid(v: &str) -> Result<String, String> {
 	}
 }
 
-#[cfg(feature = "has-storage")]
 pub(crate) fn file_exists(path: &str) -> Result<PathBuf, String> {
 	let path = Path::new(path);
 	if !*path.try_exists().as_ref().map_err(ToString::to_string)? {
@@ -65,7 +62,6 @@ pub(crate) fn into_valid(v: &str) -> Result<String, String> {
 	}
 }
 
-#[cfg(feature = "has-storage")]
 pub(crate) fn key_valid(v: &str) -> Result<String, String> {
 	match v.len() {
 		16 => Ok(v.to_string()),
@@ -75,7 +71,6 @@ pub(crate) fn key_valid(v: &str) -> Result<String, String> {
 	}
 }
 
-#[cfg(feature = "has-storage")]
 pub(crate) fn duration(v: &str) -> Result<Duration, String> {
 	surrealdb::sql::Duration::from_str(v).map(|d| d.0).map_err(|_| String::from("invalid duration"))
 }

--- a/src/cli/validator/parser/env_filter.rs
+++ b/src/cli/validator/parser/env_filter.rs
@@ -17,7 +17,6 @@ impl Clone for CustomEnvFilter {
 pub struct CustomEnvFilterParser;
 
 impl CustomEnvFilterParser {
-	#[cfg(feature = "has-storage")]
 	pub fn new() -> CustomEnvFilterParser {
 		Self
 	}

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -1,5 +1,4 @@
 use once_cell::sync::Lazy;
-#[cfg(feature = "has-storage")]
 use std::time::Duration;
 
 pub const LOGO: &str = "
@@ -15,22 +14,18 @@ Y88b  d88P Y88b 888 888     888     Y8b.     888  888 888 888  .d88P 888   d88P
 ";
 
 /// The publicly visible name of the server
-#[cfg(feature = "has-storage")]
 pub const PKG_NAME: &str = "surrealdb";
 
 /// The publicly visible user-agent of the command-line tool
 pub const SERVER_AGENT: &str = concat!("SurrealDB ", env!("CARGO_PKG_VERSION"));
 
 /// The public endpoint for the administration interface
-#[cfg(feature = "has-storage")]
 pub const APP_ENDPOINT: &str = "https://surrealdb.com/app";
 
 /// Specifies the frequency with which ping messages should be sent to the client
-#[cfg(feature = "has-storage")]
 pub const WEBSOCKET_PING_FREQUENCY: Duration = Duration::from_secs(5);
 
 /// What is the maximum WebSocket frame size (defaults to 16 MiB)
-#[cfg(feature = "has-storage")]
 pub static WEBSOCKET_MAX_FRAME_SIZE: Lazy<usize> = Lazy::new(|| {
 	option_env!("SURREAL_WEBSOCKET_MAX_FRAME_SIZE")
 		.and_then(|s| s.parse::<usize>().ok())
@@ -38,7 +33,6 @@ pub static WEBSOCKET_MAX_FRAME_SIZE: Lazy<usize> = Lazy::new(|| {
 });
 
 /// What is the maximum WebSocket message size (defaults to 128 MiB)
-#[cfg(feature = "has-storage")]
 pub static WEBSOCKET_MAX_MESSAGE_SIZE: Lazy<usize> = Lazy::new(|| {
 	option_env!("SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE")
 		.and_then(|s| s.parse::<usize>().ok())
@@ -46,7 +40,6 @@ pub static WEBSOCKET_MAX_MESSAGE_SIZE: Lazy<usize> = Lazy::new(|| {
 });
 
 /// How many concurrent tasks can be handled on each WebSocket (defaults to 24)
-#[cfg(feature = "has-storage")]
 pub static WEBSOCKET_MAX_CONCURRENT_REQUESTS: Lazy<usize> = Lazy::new(|| {
 	option_env!("SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS")
 		.and_then(|s| s.parse::<usize>().ok())
@@ -54,7 +47,6 @@ pub static WEBSOCKET_MAX_CONCURRENT_REQUESTS: Lazy<usize> = Lazy::new(|| {
 });
 
 /// What is the runtime thread memory stack size (defaults to 10MiB)
-#[cfg(feature = "has-storage")]
 pub static RUNTIME_STACK_SIZE: Lazy<usize> = Lazy::new(|| {
 	// Stack frames are generally larger in debug mode.
 	let default = if cfg!(debug_assertions) {
@@ -68,7 +60,6 @@ pub static RUNTIME_STACK_SIZE: Lazy<usize> = Lazy::new(|| {
 });
 
 /// How many threads which can be started for blocking operations (defaults to 512)
-#[cfg(feature = "has-storage")]
 pub static RUNTIME_MAX_BLOCKING_THREADS: Lazy<usize> = Lazy::new(|| {
 	option_env!("SURREAL_RUNTIME_MAX_BLOCKING_THREADS")
 		.and_then(|s| s.parse::<usize>().ok())

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,9 +1,7 @@
 use crate::cnf::PKG_VERSION;
-#[cfg(feature = "has-storage")]
 use crate::err::Error;
 use surrealdb::env::{arch, os};
 
-#[cfg(feature = "has-storage")]
 pub async fn init() -> Result<(), Error> {
 	// Log version
 	info!("Running {}", release());

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,22 +13,17 @@
 #[macro_use]
 extern crate tracing;
 
-#[cfg(feature = "has-storage")]
 #[macro_use]
 mod mac;
 
 mod cli;
 mod cnf;
-#[cfg(feature = "has-storage")]
 mod dbs;
 mod env;
 mod err;
 mod mem;
-#[cfg(feature = "has-storage")]
 mod net;
-#[cfg(feature = "has-storage")]
 mod node;
-#[cfg(feature = "has-storage")]
 mod rpc;
 mod telemetry;
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently when the server and command-line tool is built without the `storage-mem`, `storage-rocksdb`, `storage-speedb`, `storage-tikv`, `storage-fdb` features enabled, the `surreal start` command is disabled and removed from the build. This means we must use `#[cfg(feature = "has-storage")]` around the server codebase in order to remove code and imports when building without any storage layer. This makes development and maintenance of the server and command-line tool harder.

## What does this change do?

This change removes the internal, private `has-storage` feature. It doesn't change the dependency features, allowing the command-line tool and server to still be built without the `storage-mem` storage engine. When `surreal start` is called, and when no `storage-` feature has been enabled, the server will fail to start up and will return an error. All other command-line commands work unchanged.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
