### PR TITLE
Bug fix: Issue with scoring on complex queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6705,18 +6705,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/src/dbs/processor.rs
+++ b/lib/src/dbs/processor.rs
@@ -602,7 +602,7 @@ impl<'a> Processor<'a> {
 							let pro = Processed {
 								ir: Some(ir),
 								rid: Some(rid),
-								doc_id: Some(doc_id),
+								doc_id,
 								val,
 							};
 							self.process(ctx, opt, txn, stm, pro).await?;

--- a/lib/src/idx/docids.rs
+++ b/lib/src/idx/docids.rs
@@ -10,8 +10,6 @@ use serde::{Deserialize, Serialize};
 
 pub type DocId = u64;
 
-pub(crate) const NO_DOC_ID: u64 = u64::MAX;
-
 pub(crate) struct DocIds {
 	state_key: Key,
 	index_key_base: IndexKeyBase,

--- a/lib/src/idx/planner/iterators.rs
+++ b/lib/src/idx/planner/iterators.rs
@@ -1,6 +1,6 @@
 use crate::dbs::{Options, Transaction};
 use crate::err::Error;
-use crate::idx::docids::{DocId, DocIds, NO_DOC_ID};
+use crate::idx::docids::{DocId, DocIds};
 use crate::idx::ft::termdocs::TermsDocs;
 use crate::idx::ft::{FtIndex, HitsIterator};
 use crate::idx::planner::plan::RangeValue;
@@ -27,7 +27,7 @@ impl ThingIterator {
 		&mut self,
 		tx: &Transaction,
 		size: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		match self {
 			ThingIterator::IndexEqual(i) => i.next_batch(tx, size).await,
 			ThingIterator::UniqueEqual(i) => i.next_batch(tx).await,
@@ -61,7 +61,7 @@ impl IndexEqualThingIterator {
 		beg: &mut Vec<u8>,
 		end: &[u8],
 		limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		let min = beg.clone();
 		let max = end.to_owned();
 		let res = txn.lock().await.scan(min..max, limit).await?;
@@ -70,7 +70,7 @@ impl IndexEqualThingIterator {
 			key.push(0x00);
 			*beg = key;
 		}
-		let res = res.iter().map(|(_, val)| (val.into(), NO_DOC_ID)).collect();
+		let res = res.iter().map(|(_, val)| (val.into(), None)).collect();
 		Ok(res)
 	}
 
@@ -78,7 +78,7 @@ impl IndexEqualThingIterator {
 		&mut self,
 		txn: &Transaction,
 		limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		Self::next_scan(txn, &mut self.beg, &self.end, limit).await
 	}
 }
@@ -173,7 +173,7 @@ impl IndexRangeThingIterator {
 		&mut self,
 		txn: &Transaction,
 		limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		let min = self.r.beg.clone();
 		let max = self.r.end.clone();
 		let res = txn.lock().await.scan(min..max, limit).await?;
@@ -184,7 +184,7 @@ impl IndexRangeThingIterator {
 		let mut r = Vec::with_capacity(res.len());
 		for (k, v) in res {
 			if self.r.matches(&k) {
-				r.push((v.into(), NO_DOC_ID));
+				r.push((v.into(), None));
 			}
 		}
 		Ok(r)
@@ -219,7 +219,7 @@ impl IndexUnionThingIterator {
 		&mut self,
 		txn: &Transaction,
 		limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		while let Some(r) = &mut self.current {
 			let res = IndexEqualThingIterator::next_scan(txn, &mut r.0, &r.1, limit).await?;
 			if !res.is_empty() {
@@ -244,10 +244,13 @@ impl UniqueEqualThingIterator {
 		}
 	}
 
-	async fn next_batch(&mut self, txn: &Transaction) -> Result<Vec<(Thing, DocId)>, Error> {
+	async fn next_batch(
+		&mut self,
+		txn: &Transaction,
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		if let Some(key) = self.key.take() {
 			if let Some(val) = txn.lock().await.get(key).await? {
-				return Ok(vec![(val.into(), NO_DOC_ID)]);
+				return Ok(vec![(val.into(), None)]);
 			}
 		}
 		Ok(vec![])
@@ -303,7 +306,7 @@ impl UniqueRangeThingIterator {
 		&mut self,
 		txn: &Transaction,
 		mut limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		if self.done {
 			return Ok(vec![]);
 		}
@@ -320,13 +323,13 @@ impl UniqueRangeThingIterator {
 				return Ok(r);
 			}
 			if self.r.matches(&k) {
-				r.push((v.into(), NO_DOC_ID));
+				r.push((v.into(), None));
 			}
 		}
 		let end = self.r.end.clone();
 		if self.r.matches(&end) {
 			if let Some(v) = tx.get(end).await? {
-				r.push((v.into(), NO_DOC_ID));
+				r.push((v.into(), None));
 			}
 		}
 		self.done = true;
@@ -350,13 +353,13 @@ impl MatchesThingIterator {
 		&mut self,
 		txn: &Transaction,
 		mut limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		let mut res = vec![];
 		if let Some(hits) = &mut self.hits {
 			let mut run = txn.lock().await;
 			while limit > 0 {
-				if let Some(hit) = hits.next(&mut run).await? {
-					res.push(hit);
+				if let Some((thg, doc_id)) = hits.next(&mut run).await? {
+					res.push((thg, Some(doc_id)));
 				} else {
 					break;
 				}
@@ -383,7 +386,7 @@ impl DocIdsIterator {
 		&mut self,
 		txn: &Transaction,
 		mut limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		let mut res = vec![];
 		let mut tx = txn.lock().await;
 		while limit > 0 {
@@ -391,7 +394,7 @@ impl DocIdsIterator {
 				if let Some(doc_key) =
 					self.doc_ids.read().await.get_doc_key(&mut tx, doc_id).await?
 				{
-					res.push((doc_key.into(), doc_id));
+					res.push((doc_key.into(), Some(doc_id)));
 					limit -= 1;
 				}
 			} else {


### PR DESCRIPTION
## What is the motivation?

When a query includes a predicate on an indexed field mixed with a full-text query, if the query planner is using the standard index, then the full-text scoring is lost (returns 0).

## What does this change do?

The index iterators are now returning a vector with an optional doc_id. Previously (and that was the bug), it was returning a constant NO_DOC_ID (u64::MAX).

This PR also patches the `zerocopy` library due to a vulnerability issue.

## What is your testing strategy?

A test reproducing the issue has been created.

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
