### PR TITLE
Backport JWT decoding bug fix merged in #3165

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6699,18 +6699,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

To backport the changes made in #3165, which resolve a bug with decoding JWT for authentication.

## What does this change do?

Backports the changes on top of the `releases/beta` branch to be included in `v1.1.0-beta.2`.
It includes the bug fix as well as a dependency update that was made at the same time.

## What is your testing strategy?

Same as #3165:
- Added tests for scope authentication with token.
- Added tests for multiple types of generic and custom resource identifiers in token.
- Verified that the tests failed with the custom parser and pass with the changes in this PR.

## Is this related to any issues?

This bug is the cause for issue https://github.com/surrealdb/surrealdb/issues/2963.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
