### PR TITLE
Update the surrealml-core version

### DIFF
--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -395,6 +395,9 @@ jobs:
               if [[ "${{ inputs.http-compression}}" == "true" ]]; then
                 features=${features},http-compression
               fi
+              if [[ "${{ inputs.ml}}" == "true" ]]; then
+                features=${features},ml
+              fi
               cargo build --features $features --release --locked --target x86_64-pc-windows-msvc
 
               # Package

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5433,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "surrealml-core"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aabe3c44a73d6f7a3d069400a4966d2ffcf643fb1d60399b1746787abc9dd12"
+checksum = "6cde4ceed0b05a8f512afe7fa1a260e4a67cfbba439eccb858e189f826fc3fff"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ serde_cbor = "0.11.2"
 serde_json = "1.0.108"
 serde_pack = { version = "1.1.2", package = "rmp-serde" }
 surrealdb = { path = "lib", features = ["protocol-http", "protocol-ws", "rustls"] }
-surrealml-core = { version = "0.0.2", optional = true}
+surrealml-core = { version = "0.0.3", optional = true}
 tempfile = "3.8.1"
 thiserror = "1.0.50"
 tokio = { version = "1.34.0", features = ["macros", "signal"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -113,7 +113,7 @@ sha2 = "0.10.8"
 snap = "1.1.0"
 speedb = { version = "0.0.4", features = ["lz4", "snappy"], optional = true }
 storekey = "0.5.0"
-surrealml-core = { version = "0.0.2", optional = true }
+surrealml-core = { version = "0.0.3", optional = true }
 thiserror = "1.0.50"
 tikv = { version = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }
 tokio-util = { version = "0.7.10", optional = true, features = ["compat"] }


### PR DESCRIPTION
## What is the motivation?
Enabling the support of ML in Windows builds

## What does this change do?

This pull request increases the version of `surrealml-core` to `0.0.3` to support ML in Windows builds 

## What is your testing strategy?

`surrealml-core` is passing tests

## Is this related to any issues?

None

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
