### PR TITLE
Bugfix: Prevent overflow in `math::power`

### DIFF
--- a/lib/src/fnc/math.rs
+++ b/lib/src/fnc/math.rs
@@ -13,7 +13,7 @@ use crate::fnc::util::math::top::Top;
 use crate::fnc::util::math::trimean::Trimean;
 use crate::fnc::util::math::variance::Variance;
 use crate::sql::number::{Number, Sort};
-use crate::sql::value::Value;
+use crate::sql::value::{TryPow, Value};
 
 pub fn abs((arg,): (Number,)) -> Result<Value, Error> {
 	Ok(arg.abs().into())
@@ -95,7 +95,7 @@ pub fn percentile((mut array, n): (Vec<Number>, Number)) -> Result<Value, Error>
 }
 
 pub fn pow((arg, pow): (Number, Number)) -> Result<Value, Error> {
-	Ok(arg.pow(pow).into())
+	Ok(arg.try_pow(pow)?.into())
 }
 
 pub fn product((array,): (Vec<Number>,)) -> Result<Value, Error> {

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -2428,6 +2428,15 @@ async fn function_math_pow() -> Result<(), Error> {
 	let tmp = res.remove(0).result?;
 	let val = Value::from(1045678.375);
 	assert_eq!(tmp, val);
+
+	let sql = r#"
+		RETURN math::pow(101, 50);
+	"#;
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 1);
+
+	let res = res.remove(0).result;
+	assert!(matches!(res, Err(Error::TryPow(_, _))));
 	//
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

Fixes a bug where `math::pow` could overflow numbers without returning an error.

## What does this change do?

Backports  #3162 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
