### PR TITLE
Bugfix: Respect alias for dynamic field queries with type::field

### DIFF
--- a/lib/src/sql/field.rs
+++ b/lib/src/sql/field.rs
@@ -204,8 +204,13 @@ impl Fields {
 										}
 										v => v.to_owned(),
 									};
-									// This value is always a string, so we can convert it
-									let name = syn::idiom(&name.to_raw_string())?;
+									// find the name for the field, either from the argument or the
+									// alias.
+									let name = if let Some(x) = alias.as_ref().map(Cow::Borrowed) {
+										x
+									} else {
+										Cow::Owned(syn::idiom(&name.to_raw_string())?)
+									};
 									// Add the projected field to the output document
 									out.set(ctx, opt, txn, name.as_ref(), expr).await?
 								}

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -314,11 +314,12 @@ async fn field_selection_variable_field_projection() -> Result<(), Error> {
 		SELECT type::field($param), type::field('name.last') FROM person;
 		SELECT VALUE { 'firstname': type::field($param), lastname: type::field('name.last') } FROM person;
 		SELECT VALUE [type::field($param), type::field('name.last')] FROM person;
+		SELECT type::field($param) AS first_name FROM person;
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 5);
+	assert_eq!(res.len(), 6);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
@@ -366,6 +367,14 @@ async fn field_selection_variable_field_projection() -> Result<(), Error> {
 	let val = Value::parse(
 		"[
 			['Tobie', 'Morgan Hitchcock']
+		]",
+	);
+	assert_eq!(tmp, val);
+
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+		{ first_name: 'Tobie' }
 		]",
 	);
 	assert_eq!(tmp, val);


### PR DESCRIPTION
## What is the motivation?

Currently the query `SELECT type::field('foo') AS bar FROM faz` ignores the given alias.

## What does this change do?

Backports #3163 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
