### PR TITLE
Bug fix: Issue with scoring on complex queries (#3174)

### DIFF
--- a/lib/src/dbs/processor.rs
+++ b/lib/src/dbs/processor.rs
@@ -602,7 +602,7 @@ impl<'a> Processor<'a> {
 							let pro = Processed {
 								ir: Some(ir),
 								rid: Some(rid),
-								doc_id: Some(doc_id),
+								doc_id,
 								val,
 							};
 							self.process(ctx, opt, txn, stm, pro).await?;

--- a/lib/src/idx/docids.rs
+++ b/lib/src/idx/docids.rs
@@ -12,8 +12,6 @@ use tokio::sync::Mutex;
 
 pub type DocId = u64;
 
-pub(crate) const NO_DOC_ID: u64 = u64::MAX;
-
 pub(crate) struct DocIds {
 	state_key: Key,
 	index_key_base: IndexKeyBase,

--- a/lib/src/idx/planner/iterators.rs
+++ b/lib/src/idx/planner/iterators.rs
@@ -1,6 +1,6 @@
 use crate::dbs::{Options, Transaction};
 use crate::err::Error;
-use crate::idx::docids::{DocId, DocIds, NO_DOC_ID};
+use crate::idx::docids::{DocId, DocIds};
 use crate::idx::ft::termdocs::TermsDocs;
 use crate::idx::ft::{FtIndex, HitsIterator};
 use crate::idx::planner::plan::RangeValue;
@@ -27,7 +27,7 @@ impl ThingIterator {
 		&mut self,
 		tx: &Transaction,
 		size: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		match self {
 			ThingIterator::IndexEqual(i) => i.next_batch(tx, size).await,
 			ThingIterator::UniqueEqual(i) => i.next_batch(tx).await,
@@ -61,7 +61,7 @@ impl IndexEqualThingIterator {
 		beg: &mut Vec<u8>,
 		end: &[u8],
 		limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		let min = beg.clone();
 		let max = end.to_owned();
 		let res = txn.lock().await.scan(min..max, limit).await?;
@@ -70,7 +70,7 @@ impl IndexEqualThingIterator {
 			key.push(0x00);
 			*beg = key;
 		}
-		let res = res.iter().map(|(_, val)| (val.into(), NO_DOC_ID)).collect();
+		let res = res.iter().map(|(_, val)| (val.into(), None)).collect();
 		Ok(res)
 	}
 
@@ -78,7 +78,7 @@ impl IndexEqualThingIterator {
 		&mut self,
 		txn: &Transaction,
 		limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		Self::next_scan(txn, &mut self.beg, &self.end, limit).await
 	}
 }
@@ -173,7 +173,7 @@ impl IndexRangeThingIterator {
 		&mut self,
 		txn: &Transaction,
 		limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		let min = self.r.beg.clone();
 		let max = self.r.end.clone();
 		let res = txn.lock().await.scan(min..max, limit).await?;
@@ -184,7 +184,7 @@ impl IndexRangeThingIterator {
 		let mut r = Vec::with_capacity(res.len());
 		for (k, v) in res {
 			if self.r.matches(&k) {
-				r.push((v.into(), NO_DOC_ID));
+				r.push((v.into(), None));
 			}
 		}
 		Ok(r)
@@ -219,7 +219,7 @@ impl IndexUnionThingIterator {
 		&mut self,
 		txn: &Transaction,
 		limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		while let Some(r) = &mut self.current {
 			let res = IndexEqualThingIterator::next_scan(txn, &mut r.0, &r.1, limit).await?;
 			if !res.is_empty() {
@@ -244,10 +244,13 @@ impl UniqueEqualThingIterator {
 		}
 	}
 
-	async fn next_batch(&mut self, txn: &Transaction) -> Result<Vec<(Thing, DocId)>, Error> {
+	async fn next_batch(
+		&mut self,
+		txn: &Transaction,
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		if let Some(key) = self.key.take() {
 			if let Some(val) = txn.lock().await.get(key).await? {
-				return Ok(vec![(val.into(), NO_DOC_ID)]);
+				return Ok(vec![(val.into(), None)]);
 			}
 		}
 		Ok(vec![])
@@ -303,7 +306,7 @@ impl UniqueRangeThingIterator {
 		&mut self,
 		txn: &Transaction,
 		mut limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		if self.done {
 			return Ok(vec![]);
 		}
@@ -320,13 +323,13 @@ impl UniqueRangeThingIterator {
 				return Ok(r);
 			}
 			if self.r.matches(&k) {
-				r.push((v.into(), NO_DOC_ID));
+				r.push((v.into(), None));
 			}
 		}
 		let end = self.r.end.clone();
 		if self.r.matches(&end) {
 			if let Some(v) = tx.get(end).await? {
-				r.push((v.into(), NO_DOC_ID));
+				r.push((v.into(), None));
 			}
 		}
 		self.done = true;
@@ -350,13 +353,13 @@ impl MatchesThingIterator {
 		&mut self,
 		txn: &Transaction,
 		mut limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		let mut res = vec![];
 		if let Some(hits) = &mut self.hits {
 			let mut run = txn.lock().await;
 			while limit > 0 {
-				if let Some(hit) = hits.next(&mut run).await? {
-					res.push(hit);
+				if let Some((thg, doc_id)) = hits.next(&mut run).await? {
+					res.push((thg, Some(doc_id)));
 				} else {
 					break;
 				}
@@ -383,7 +386,7 @@ impl DocIdsIterator {
 		&mut self,
 		txn: &Transaction,
 		mut limit: u32,
-	) -> Result<Vec<(Thing, DocId)>, Error> {
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
 		let mut res = vec![];
 		let mut tx = txn.lock().await;
 		while limit > 0 {
@@ -391,7 +394,7 @@ impl DocIdsIterator {
 				if let Some(doc_key) =
 					self.doc_ids.read().await.get_doc_key(&mut tx, doc_id).await?
 				{
-					res.push((doc_key.into(), doc_id));
+					res.push((doc_key.into(), Some(doc_id)));
 					limit -= 1;
 				}
 			} else {

--- a/lib/tests/matches.rs
+++ b/lib/tests/matches.rs
@@ -353,3 +353,64 @@ async fn select_where_matches_without_using_index_and_score() -> Result<(), Erro
 	assert_eq!(tmp, val);
 	Ok(())
 }
+
+#[tokio::test]
+async fn select_where_matches_without_complex_query() -> Result<(), Error> {
+	let sql = r"
+		CREATE page:1 SET title = 'the quick brown', content = 'fox jumped over the lazy dog', host = 'test';
+		CREATE page:2 SET title = 'the fast fox', content = 'jumped over the lazy dog', host = 'test';
+		DEFINE ANALYZER simple TOKENIZERS blank,class;
+		DEFINE INDEX page_title ON page FIELDS title SEARCH ANALYZER simple BM25;
+		DEFINE INDEX page_content ON page FIELDS content SEARCH ANALYZER simple BM25;
+		DEFINE INDEX page_host ON page FIELDS host;
+		SELECT id, search::score(1) as sc1, search::score(2) as sc2
+    		FROM page WHERE (title @1@ 'dog' OR content @2@ 'dog');
+ 		SELECT id, search::score(1) as sc1, search::score(2) as sc2
+    		FROM page WHERE
+    		host = 'test'
+    		AND (title @1@ 'dog' OR content @2@ 'dog') 
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 8);
+	//
+	for _ in 0..6 {
+		let _ = res.remove(0).result?;
+	}
+
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+				{
+					id: page:1,
+					sc1: 0f,
+					sc2: -1.5517289638519287f
+				},
+				{
+					id: page:2,
+					sc1: 0f,
+					sc2: -1.6716052293777466f
+				}
+			]",
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+				{
+					id: page:1,
+					sc1: 0f,
+					sc2: -1.5517289638519287f
+				},
+				{
+					id: page:2,
+					sc1: 0f,
+					sc2: -1.6716052293777466f
+				}
+			]",
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	Ok(())
+}


### PR DESCRIPTION
## What is the motivation?

When a query includes a predicate on an indexed field mixed with a full-text query, if the query planner is using the standard index, then the full-text scoring is lost (returns 0).

## What does this change do?

Backports #3174 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
