### PR TITLE
Use wasm32 cfg flag for kvs (#3131)

### DIFF
--- a/lib/src/kvs/clock.rs
+++ b/lib/src/kvs/clock.rs
@@ -1,7 +1,10 @@
 use crate::dbs::node::Timestamp;
 use crate::sql;
 use sql::Duration;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(target_arch = "wasm32")]
+use wasmtimer::std::{SystemTime, UNIX_EPOCH};
 
 // Traits cannot have async and we need sized structs for Clone + Send + Sync
 #[allow(dead_code)]
@@ -101,5 +104,16 @@ impl SystemClock {
 impl Default for SystemClock {
 	fn default() -> Self {
 		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::kvs::clock::SystemClock;
+
+	#[test]
+	fn get_clock_now() {
+		let clock = SystemClock::new();
+		let _ = clock.now();
 	}
 }


### PR DESCRIPTION
## What is the motivation?

Surrealdb doesn't work for wasm32 right now due to SystemTime::now calls in kvs.

## What does this change do?

Backports #3131 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
