### PR TITLE
Fix deserialisation and HTTP engine regressions

### DIFF
--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -395,7 +395,7 @@ fn process(responses: Vec<Response>) -> QueryResponse {
 	let mut map = IndexMap::with_capacity(responses.len());
 	for (index, response) in responses.into_iter().enumerate() {
 		let stats = Stats {
-			execution_time: response.time,
+			execution_time: Some(response.time),
 		};
 		match response.result {
 			Ok(value) => map.insert(index, (stats, Ok(value))),

--- a/lib/src/api/engine/remote/mod.rs
+++ b/lib/src/api/engine/remote/mod.rs
@@ -7,3 +7,62 @@ pub mod http;
 #[cfg(feature = "protocol-ws")]
 #[cfg_attr(docsrs, doc(cfg(feature = "protocol-ws")))]
 pub mod ws;
+
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use std::time::Duration;
+
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+const NANOS_PER_MILLI: i64 = 1_000_000;
+const NANOS_PER_MICRO: i64 = 1_000;
+
+// Converts a debug representation of `std::time::Duration` back
+fn duration_from_str(duration: &str) -> Option<std::time::Duration> {
+	let nanos = if let Some(duration) = duration.strip_suffix("ns") {
+		duration.parse().ok()?
+	} else if let Some(duration) = duration.strip_suffix("µs") {
+		let micros = duration.parse::<Decimal>().ok()?;
+		let multiplier = Decimal::try_new(NANOS_PER_MICRO, 0).ok()?;
+		micros.checked_mul(multiplier)?.to_u128()?
+	} else if let Some(duration) = duration.strip_suffix("ms") {
+		let millis = duration.parse::<Decimal>().ok()?;
+		let multiplier = Decimal::try_new(NANOS_PER_MILLI, 0).ok()?;
+		millis.checked_mul(multiplier)?.to_u128()?
+	} else {
+		let duration = duration.strip_suffix('s')?;
+		let secs = duration.parse::<Decimal>().ok()?;
+		let multiplier = Decimal::try_new(NANOS_PER_SEC, 0).ok()?;
+		secs.checked_mul(multiplier)?.to_u128()?
+	};
+	let secs = nanos.checked_div(NANOS_PER_SEC as u128)?;
+	let nanos = nanos % (NANOS_PER_SEC as u128);
+	Some(Duration::new(secs.try_into().ok()?, nanos.try_into().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+	use std::time::Duration;
+
+	#[test]
+	fn duration_from_str() {
+		let durations = vec![
+			Duration::ZERO,
+			Duration::from_nanos(1),
+			Duration::from_nanos(u64::MAX),
+			Duration::from_micros(1),
+			Duration::from_micros(u64::MAX),
+			Duration::from_millis(1),
+			Duration::from_millis(u64::MAX),
+			Duration::from_secs(1),
+			Duration::from_secs(u64::MAX),
+			Duration::MAX,
+		];
+
+		for duration in durations {
+			let string = format!("{duration:?}");
+			let parsed = super::duration_from_str(&string)
+				.expect(&format!("Duration {string} failed to parse"));
+			assert_eq!(duration, parsed, "Duration {string} not parsed correctly");
+		}
+	}
+}

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -87,7 +87,7 @@ use std::time::Duration;
 #[non_exhaustive]
 pub struct Stats {
 	/// The time taken to execute the query
-	pub execution_time: Duration,
+	pub execution_time: Option<Duration>,
 }
 
 /// Machine learning model marker type for import and export types

--- a/lib/src/dbs/response.rs
+++ b/lib/src/dbs/response.rs
@@ -31,6 +31,7 @@ impl Response {
 	pub fn speed(&self) -> String {
 		format!("{:?}", self.time)
 	}
+
 	/// Retrieve the response as a normal result
 	pub fn output(self) -> Result<Value, Error> {
 		self.result
@@ -39,7 +40,7 @@ impl Response {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
-pub enum Status {
+pub(crate) enum Status {
 	Ok,
 	Err,
 }
@@ -50,7 +51,7 @@ impl Serialize for Response {
 		S: serde::Serializer,
 	{
 		let mut val = serializer.serialize_struct(TOKEN, 3)?;
-		val.serialize_field("time", &self.time)?;
+		val.serialize_field("time", self.speed().as_str())?;
 		match &self.result {
 			Ok(v) => {
 				val.serialize_field("status", &Status::Ok)?;
@@ -62,28 +63,5 @@ impl Serialize for Response {
 			}
 		}
 		val.end()
-	}
-}
-
-// User facing response sent to WS and HTTP connections directly
-#[derive(Serialize)]
-pub struct ApiResponse {
-	time: String,
-	status: Status,
-	result: Value,
-}
-
-impl From<Response> for ApiResponse {
-	fn from(r: Response) -> Self {
-		let time = r.speed();
-		let (status, result) = match r.result {
-			Ok(value) => (Status::Ok, value),
-			Err(error) => (Status::Err, error.to_string().into()),
-		};
-		Self {
-			time,
-			status,
-			result,
-		}
 	}
 }

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -190,10 +190,7 @@ async fn scope_throws_error() {
 		.await
 	{
 		Err(Error::Db(surrealdb::err::Error::Thrown(e))) => assert_eq!(e, "signup_thrown_error"),
-		Err(Error::Api(surrealdb::error::Api::Query(e))) => assert_eq!(
-			e,
-			"There was a problem with the database: An error occurred: signup_thrown_error"
-		),
+		Err(Error::Api(surrealdb::error::Api::Query(e))) => assert!(e.contains("signup")),
 		Err(Error::Api(surrealdb::error::Api::Http(e))) => assert_eq!(
 			e,
 			"HTTP status client error (400 Bad Request) for url (http://127.0.0.1:8000/signup)"
@@ -214,10 +211,7 @@ async fn scope_throws_error() {
 		.await
 	{
 		Err(Error::Db(surrealdb::err::Error::Thrown(e))) => assert_eq!(e, "signin_thrown_error"),
-		Err(Error::Api(surrealdb::error::Api::Query(e))) => assert_eq!(
-			e,
-			"There was a problem with the database: An error occurred: signin_thrown_error"
-		),
+		Err(Error::Api(surrealdb::error::Api::Query(e))) => assert!(e.contains("signin")),
 		Err(Error::Api(surrealdb::error::Api::Http(e))) => assert_eq!(
 			e,
 			"HTTP status client error (400 Bad Request) for url (http://127.0.0.1:8000/signin)"
@@ -391,11 +385,11 @@ async fn query_with_stats() {
 	let mut response = db.query(sql).with_stats().await.unwrap();
 	// First query statement
 	let (stats, result) = response.take(0).unwrap();
-	assert!(stats.execution_time > Duration::ZERO);
+	assert!(stats.execution_time > Some(Duration::ZERO));
 	let _: Value = result.unwrap();
 	// Second query statement
 	let (stats, result) = response.take(1).unwrap();
-	assert!(stats.execution_time > Duration::ZERO);
+	assert!(stats.execution_time > Some(Duration::ZERO));
 	let _: Vec<RecordId> = result.unwrap();
 }
 

--- a/src/net/output.rs
+++ b/src/net/output.rs
@@ -3,7 +3,6 @@ use http::header::{HeaderValue, CONTENT_TYPE};
 use http::StatusCode;
 use serde::Serialize;
 use serde_json::Value as Json;
-use surrealdb::dbs;
 use surrealdb::sql;
 
 use super::headers::Accept;
@@ -67,9 +66,8 @@ where
 }
 
 /// Convert and simplify the value into JSON
-pub fn simplify(vec: Vec<dbs::Response>) -> Json {
-	let responses: Vec<_> = vec.into_iter().map(dbs::ApiResponse::from).collect();
-	sql::to_value(responses).unwrap().into()
+pub fn simplify<T: Serialize>(v: T) -> Json {
+	sql::to_value(v).unwrap().into()
 }
 
 impl IntoResponse for Output {

--- a/src/rpc/response.rs
+++ b/src/rpc/response.rs
@@ -71,11 +71,7 @@ impl Response {
 		let mut value = match self.result {
 			Ok(data) => {
 				let value = match data {
-					Data::Query(vec) => {
-						let responses: Vec<_> =
-							vec.into_iter().map(dbs::ApiResponse::from).collect();
-						sql::to_value(responses).unwrap()
-					}
+					Data::Query(vec) => sql::to_value(vec).unwrap(),
 					Data::Live(notification) => sql::to_value(notification).unwrap(),
 					Data::Other(value) => value,
 				};


### PR DESCRIPTION
## What is the motivation?

`v1.1.0-beta.1` has some regressions in deserialisation and HTTP engine headers.

## What does this change do?

Backports #3180 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
