### PR TITLE
Refactor live query API to improve consistency and code reuse

### DIFF
--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -46,7 +46,6 @@ pub use export::Export;
 pub use health::Health;
 pub use import::Import;
 pub use invalidate::Invalidate;
-pub use live::Live;
 pub use live::Stream;
 pub use merge::Merge;
 pub use patch::Patch;
@@ -92,6 +91,9 @@ pub struct Stats {
 
 /// Machine learning model marker type for import and export types
 pub struct Model;
+
+/// Live query marker type
+pub struct Live;
 
 /// Responses returned with statistics
 #[derive(Debug)]
@@ -684,6 +686,7 @@ where
 			resource: resource.into_resource(),
 			range: None,
 			response_type: PhantomData,
+			query_type: PhantomData,
 		}
 	}
 


### PR DESCRIPTION
## What is the motivation?

The live query API uses a different design approach from `import` and `export` API.

## What does this change do?

Backports #3182 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
