### PR TITLE
Backport bugfix tx::depl limit 1000

### DIFF
--- a/lib/src/idx/docids.rs
+++ b/lib/src/idx/docids.rs
@@ -1,8 +1,8 @@
 use crate::err::Error;
 use crate::idx::trees::bkeys::TrieKeys;
-use crate::idx::trees::btree::{BStatistics, BTree, BTreeNodeStore};
+use crate::idx::trees::btree::{BState, BStatistics, BTree, BTreeNodeStore};
 use crate::idx::trees::store::{TreeNodeProvider, TreeNodeStore, TreeStoreType};
-use crate::idx::{trees, IndexKeyBase, VersionedSerdeState};
+use crate::idx::{IndexKeyBase, VersionedSerdeState};
 use crate::kvs::{Key, Transaction};
 use revision::revisioned;
 use roaring::RoaringTreemap;
@@ -155,7 +155,7 @@ impl DocIds {
 #[derive(Serialize, Deserialize)]
 #[revisioned(revision = 1)]
 struct State {
-	btree: trees::btree::BState,
+	btree: BState,
 	available_ids: Option<RoaringTreemap>,
 	next_doc_id: DocId,
 }
@@ -165,7 +165,7 @@ impl VersionedSerdeState for State {}
 impl State {
 	fn new(default_btree_order: u32) -> Self {
 		Self {
-			btree: trees::btree::BState::new(default_btree_order),
+			btree: BState::new(default_btree_order),
 			available_ids: None,
 			next_doc_id: 0,
 		}

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -975,7 +975,7 @@ impl Transaction {
 		let end: Key = beg.clone().add(0xff);
 		let min = beg.clone();
 		let max = end.clone();
-		self.delr(min..max, num).await?;
+		self.delr(min..max, limit).await?;
 		Ok(())
 	}
 

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -975,7 +975,7 @@ impl Transaction {
 		let end: Key = beg.clone().add(0xff);
 		let min = beg.clone();
 		let max = end.clone();
-		self.delr(min..max, limit).await?;
+		self.delr(min..max, num).await?;
 		Ok(())
 	}
 


### PR DESCRIPTION


## What is the motivation?

The REMOVE statement is only removing the first 1000 keys.

## What does this change do?

Backport of the bug fix.

## What is your testing strategy?

A test has been added.

## Is this related to any issues?

#3167 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
