### PR TITLE
Fix build metadata in beta and stable binaries

### DIFF
--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -169,7 +169,7 @@ jobs:
             echo "build-metadata=${date}.${rev}" >> $GITHUB_OUTPUT
           else
             echo "name=v${version}" >> $GITHUB_OUTPUT
-            echo "build-metadata=\"\"" >> $GITHUB_OUTPUT
+            echo "build-metadata=" >> $GITHUB_OUTPUT
           fi
 
   test:
@@ -280,10 +280,10 @@ jobs:
 
               # Build
               features=storage-tikv
-              if [[ "${{ inputs.http-compression}}" == "true" ]]; then
+              if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
-              if [[ "${{ inputs.ml}}" == "true" ]]; then
+              if [[ "${{ inputs.ml }}" == "true" ]]; then
                 features=${features},ml
               fi
               cargo build --features $features --release --locked --target x86_64-apple-darwin
@@ -291,6 +291,7 @@ jobs:
               # Package
               cp target/x86_64-apple-darwin/release/surreal surreal
               chmod +x surreal
+              ./surreal version
               tar -zcvf surreal-${{ needs.prepare-vars.outputs.name }}.darwin-amd64.tgz surreal
               echo $(shasum -a 256 surreal-${{ needs.prepare-vars.outputs.name }}.darwin-amd64.tgz | cut -f1 -d' ') > surreal-${{ needs.prepare-vars.outputs.name }}.darwin-amd64.txt
 
@@ -306,10 +307,10 @@ jobs:
 
               # Build
               features=storage-tikv
-              if [[ "${{ inputs.http-compression}}" == "true" ]]; then
+              if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
-              if [[ "${{ inputs.ml}}" == "true" ]]; then
+              if [[ "${{ inputs.ml }}" == "true" ]]; then
                 features=${features},ml
               fi
               cargo build --features $features --release --locked --target aarch64-apple-darwin
@@ -329,10 +330,10 @@ jobs:
 
               # Build
               features=storage-tikv
-              if [[ "${{ inputs.http-compression}}" == "true" ]]; then
+              if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
-              if [[ "${{ inputs.ml}}" == "true" ]]; then
+              if [[ "${{ inputs.ml }}" == "true" ]]; then
                 features=${features},ml
               fi
               docker build \
@@ -347,6 +348,7 @@ jobs:
               
               # Package
               chmod +x surreal
+              ./surreal version
               tar -zcvf surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64.tgz surreal
               echo $(shasum -a 256 surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64.tgz | cut -f1 -d' ') > surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64.txt
 
@@ -359,10 +361,10 @@ jobs:
 
               # Build
               features=storage-tikv
-              if [[ "${{ inputs.http-compression}}" == "true" ]]; then
+              if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
-              if [[ "${{ inputs.ml}}" == "true" ]]; then
+              if [[ "${{ inputs.ml }}" == "true" ]]; then
                 features=${features},ml
               fi
               docker build \
@@ -377,6 +379,7 @@ jobs:
 
               # Package
               chmod +x surreal
+              ./surreal version
               tar -zcvf surreal-${{ needs.prepare-vars.outputs.name }}.linux-arm64.tgz surreal
               echo $(shasum -a 256 surreal-${{ needs.prepare-vars.outputs.name }}.linux-arm64.tgz | cut -f1 -d' ') > surreal-${{ needs.prepare-vars.outputs.name }}.linux-arm64.txt
 
@@ -392,15 +395,16 @@ jobs:
 
               # Build
               features=storage-tikv
-              if [[ "${{ inputs.http-compression}}" == "true" ]]; then
+              if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
-              if [[ "${{ inputs.ml}}" == "true" ]]; then
+              if [[ "${{ inputs.ml }}" == "true" ]]; then
                 features=${features},ml
               fi
               cargo build --features $features --release --locked --target x86_64-pc-windows-msvc
 
               # Package
+              ./target/x86_64-pc-windows-msvc/release/surreal.exe version
               cp target/x86_64-pc-windows-msvc/release/surreal.exe surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe
               echo $(shasum -a 256 surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe | cut -f1 -d' ') > surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.txt
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5258,6 +5258,7 @@ dependencies = [
  "reqwest",
  "rmp-serde",
  "rustyline",
+ "semver",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ tonic = "0.8.3"
 ulid = "1.1.0"
 wiremock = "0.5.22"
 
+[build-dependencies]
+semver = "1.0.20"
+
 [package.metadata.deb]
 maintainer-scripts = "pkg/deb/"
 maintainer = "Tobie Morgan Hitchcock <tobie@surrealdb.com>"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use semver::BuildMetadata;
 use std::process::Command;
 use std::{env, str};
 
@@ -15,8 +16,12 @@ fn main() {
 }
 
 fn build_metadata() -> Option<String> {
-	if let Ok(metadata) = env::var(BUILD_METADATA) {
-		return Some(metadata);
+	if let Ok(input) = env::var(BUILD_METADATA) {
+		let metadata = input.trim();
+		if let Err(error) = BuildMetadata::new(metadata) {
+			panic!("invalid build metadata `{input}`: {error}");
+		}
+		return Some(metadata.to_owned());
 	}
 	let date = git()
 		.args(["show", "--no-patch", "--format=%ad", "--date=format:%Y%m%d"])


### PR DESCRIPTION
## What is the motivation?

Build metadata in beta and stable binaries currently includes empty quotes, which breaks semver parsing.

## What does this change do?

It removes the empty quotes and makes sure we validate build metadata in `build.rs`.

## What is your testing strategy?

Used this changeset to re-deploy beta.2 binaries.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
