### PR TITLE
Support pre-release servers

### DIFF
--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -26,7 +26,7 @@ use std::sync::OnceLock;
 /// A specialized `Result` type
 pub type Result<T> = std::result::Result<T, crate::Error>;
 
-const SUPPORTED_VERSIONS: (&str, &str) = (">=1.0.0-beta.9, <2.0.0", "20230701.55918b7c");
+const SUPPORTED_VERSIONS: (&str, &str) = (">=1.0.0, <2.0.0", "20230701.55918b7c");
 
 /// Connection trait implemented by supported engines
 pub trait Connection: conn::Connection {}
@@ -140,7 +140,9 @@ where
 		// invalid version requirements should be caught during development
 		let req = VersionReq::parse(versions).expect("valid supported versions");
 		let build_meta = BuildMetadata::new(build_meta).expect("valid supported build metadata");
-		let version = self.version().await?;
+		let mut version = self.version().await?;
+		// we would like to be able to connect to pre-releases too
+		version.pre = Default::default();
 		let server_build = &version.build;
 		if !req.matches(&version) {
 			return Err(Error::VersionMismatch {


### PR DESCRIPTION
## What is the motivation?

The current version check doesn't support some pre-releases.

## What does this change do?

Backports #3094 to v1.0.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
