### PR TITLE
bugfix: Ensure an attempt to set a protected variable returns an error

### DIFF
--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -765,9 +765,11 @@ async fn router(
 				[Value::Strand(Strand(key)), value] => (mem::take(key), mem::take(value)),
 				_ => unreachable!(),
 			};
-			let mut new_vars = vars.clone();
-			new_vars.insert(key.clone(), value.clone());
-			match kvs.compute(value, &*session, Some(new_vars)).await? {
+			let var = Some(map! {
+				key.clone() => Value::None,
+				=> &vars
+			});
+			match kvs.compute(value, &*session, var).await? {
 				Value::None => vars.remove(&key),
 				v => vars.insert(key, v),
 			};

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -767,7 +767,7 @@ async fn router(
 			};
 			let var = Some(map! {
 				key.clone() => Value::None,
-				=> &vars
+				=> vars
 			});
 			match kvs.compute(value, &*session, var).await? {
 				Value::None => vars.remove(&key),

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -765,7 +765,9 @@ async fn router(
 				[Value::Strand(Strand(key)), value] => (mem::take(key), mem::take(value)),
 				_ => unreachable!(),
 			};
-			match kvs.compute(value, &*session, Some(vars.clone())).await? {
+			let mut new_vars = vars.clone();
+			new_vars.insert(key.clone(), value.clone());
+			match kvs.compute(value, &*session, Some(new_vars)).await? {
 				Value::None => vars.remove(&key),
 				v => vars.insert(key, v),
 			};

--- a/lib/src/api/engine/remote/ws/wasm.rs
+++ b/lib/src/api/engine/remote/ws/wasm.rs
@@ -155,6 +155,7 @@ pub(crate) fn router(
 			Message::Binary(value)
 		};
 
+		let mut var_stash = IndexMap::new();
 		let mut vars = IndexMap::new();
 		let mut replay = IndexMap::new();
 
@@ -201,7 +202,7 @@ pub(crate) fn router(
 						match method {
 							Method::Set => {
 								if let [Value::Strand(Strand(key)), value] = &params[..2] {
-									vars.insert(key.to_owned(), value.clone());
+									var_stash.insert(id, (key.clone(), value.clone()));
 								}
 							}
 							Method::Unset => {
@@ -296,8 +297,14 @@ pub(crate) fn router(
 										Some(id) => {
 											if let Ok(id) = id.coerce_to_i64() {
 												// We can only route responses with IDs
-												if let Some((_method, sender)) = routes.remove(&id)
-												{
+												if let Some((method, sender)) = routes.remove(&id) {
+													if matches!(method, Method::Set) {
+														if let Some((key, value)) =
+															var_stash.remove(&id)
+														{
+															vars.insert(key, value);
+														}
+													}
 													// Send the response back to the caller
 													let _res = sender
 														.into_send_async(DbResponse::from(

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -148,7 +148,7 @@ pub enum Error {
 	HttpDisabled,
 
 	/// it is not possible to set a variable with the specified name
-	#[error("Found '{name}' but it is not possible to set a variable with this name")]
+	#[error("'{name}' is a protected variable and cannot be set")]
 	InvalidParam {
 		name: String,
 	},

--- a/lib/src/mac/mod.rs
+++ b/lib/src/mac/mod.rs
@@ -7,10 +7,11 @@ macro_rules! bytes {
 
 /// Creates a new b-tree map of key-value pairs
 macro_rules! map {
-    ($($k:expr => $v:expr),* $(,)?) => {{
-        ::std::collections::BTreeMap::from([
-            $(($k, $v),)+
-        ])
+    ($($k:expr => $v:expr),* $(,)? $( => $x:expr )?) => {{
+        let mut m = ::std::collections::BTreeMap::new();
+        $(m.extend($x.iter().map(|(k, v)| (k.clone(), v.clone())));)?
+        $(m.insert($k, $v);)+
+        m
     }};
 }
 

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -1067,6 +1067,10 @@ async fn set_unset() {
 		panic!("record not found");
 	};
 	assert_eq!(name, value);
+	// `token` is a reserved variable
+	db.set("token", value).await.unwrap_err();
+	// make sure we can still run queries after trying to set a protected variable
+	db.query("RETURN true").await.unwrap().check().unwrap();
 	db.unset(key).await.unwrap();
 	let mut response = db.query(sql).await.unwrap();
 	let name: Option<String> = response.take(0).unwrap();

--- a/lib/tests/param.rs
+++ b/lib/tests/param.rs
@@ -81,7 +81,7 @@ async fn define_protected_param() -> Result<(), Error> {
 	let tmp = res.remove(0).result;
 	assert!(matches!(
 		tmp.err(),
-		Some(e) if e.to_string() == r#"Found 'auth' but it is not possible to set a variable with this name"#
+		Some(e) if e.to_string() == "'auth' is a protected variable and cannot be set"
 	));
 	//
 	Ok(())

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -587,7 +587,9 @@ impl Connection {
 		// Get a database reference
 		let kvs = DB.get().unwrap();
 		// Specify the query parameters
-		let var = Some(self.vars.to_owned());
+		let mut new_vars = self.vars.to_owned();
+		new_vars.insert(key.0.clone(), val.clone());
+		let var = Some(new_vars);
 		// Compute the specified parameter
 		match kvs.compute(val, &self.session, var).await? {
 			// Remove the variable if undefined

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -587,9 +587,10 @@ impl Connection {
 		// Get a database reference
 		let kvs = DB.get().unwrap();
 		// Specify the query parameters
-		let mut new_vars = self.vars.to_owned();
-		new_vars.insert(key.0.clone(), val.clone());
-		let var = Some(new_vars);
+		let var = Some(map! {
+			key.0.clone() => Value::None,
+			=> &self.vars
+		});
 		// Compute the specified parameter
 		match kvs.compute(val, &self.session, var).await? {
 			// Remove the variable if undefined


### PR DESCRIPTION
## What is the motivation?

Setting a protected variable appears to succeed but causes an error to be returned for all subsequent queries.

## What does this change do?

It returns an error when trying to set a protected variable. It also improves the error message returned to the user.

## What is your testing strategy?

Updated the `set_unset` test to catch this.

## Is this related to any issues?

It closes https://github.com/surrealdb/surrealdb/issues/2478.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
