### PR TITLE
Add define relation

### DIFF
--- a/lib/src/doc/create.rs
+++ b/lib/src/doc/create.rs
@@ -13,6 +13,8 @@ impl<'a> Document<'a> {
 		txn: &Transaction,
 		stm: &Statement<'_>,
 	) -> Result<Value, Error> {
+		// Check if table has corrent relation status
+		self.relation(ctx, opt, txn, stm).await?;
 		// Alter record data
 		self.alter(ctx, opt, txn, stm).await?;
 		// Merge fields data

--- a/lib/src/doc/insert.rs
+++ b/lib/src/doc/insert.rs
@@ -50,6 +50,8 @@ impl<'a> Document<'a> {
 		txn: &Transaction,
 		stm: &Statement<'_>,
 	) -> Result<Value, Error> {
+		// Check if table has corrent relation status
+		self.relation(ctx, opt, txn, stm).await?;
 		// Merge record data
 		self.merge(ctx, opt, txn, stm).await?;
 		// Merge fields data

--- a/lib/src/doc/mod.rs
+++ b/lib/src/doc/mod.rs
@@ -37,3 +37,5 @@ mod purge; // Deletes this document, and any edges or indexes
 mod reset; // Resets internal fields which were set for this document
 mod store; // Writes the document content to the storage engine
 mod table; // Processes any foreign tables relevant for this document
+
+mod relation;

--- a/lib/src/doc/relate.rs
+++ b/lib/src/doc/relate.rs
@@ -13,6 +13,8 @@ impl<'a> Document<'a> {
 		txn: &Transaction,
 		stm: &Statement<'_>,
 	) -> Result<Value, Error> {
+		// Check if table has corrent relation status
+		self.relation(ctx, opt, txn, stm).await?;
 		// Check current record
 		match self.current.doc.is_some() {
 			// Create new edge

--- a/lib/src/doc/relation.rs
+++ b/lib/src/doc/relation.rs
@@ -18,8 +18,6 @@ impl<'a> Document<'a> {
 		};
 		let tb = self.tb_with_rel(opt, txn, relation).await?;
 
-		// panic!("{:?}", tb);
-		// panic!("{:?}", stm);
 		let rid = self.id.as_ref().unwrap();
 		match stm {
 			Statement::Create(_) | Statement::Insert(_) => {

--- a/lib/src/doc/relation.rs
+++ b/lib/src/doc/relation.rs
@@ -1,0 +1,39 @@
+use crate::ctx::Context;
+use crate::dbs::Statement;
+use crate::dbs::{Options, Transaction};
+use crate::doc::Document;
+use crate::err::Error;
+
+impl<'a> Document<'a> {
+	pub async fn relation(
+		&mut self,
+		_ctx: &Context<'_>,
+		opt: &Options,
+		txn: &Transaction,
+		stm: &Statement<'_>,
+	) -> Result<(), Error> {
+		let tb = self.tb(opt, txn).await?;
+		let rid = self.id.as_ref().unwrap();
+		match stm {
+			Statement::Create(_) | Statement::Insert(_) => {
+				if tb.relation {
+					return Err(Error::TableCheck {
+						thing: rid.to_string(),
+						relation: false,
+					});
+				}
+			}
+			Statement::Relate(_) => {
+				if !tb.relation {
+					return Err(Error::TableCheck {
+						thing: rid.to_string(),
+						relation: true,
+					});
+				}
+			}
+			_ => {}
+		}
+		// Carry on
+		Ok(())
+	}
+}

--- a/lib/src/doc/relation.rs
+++ b/lib/src/doc/relation.rs
@@ -12,7 +12,14 @@ impl<'a> Document<'a> {
 		txn: &Transaction,
 		stm: &Statement<'_>,
 	) -> Result<(), Error> {
-		let tb = self.tb(opt, txn).await?;
+		let relation = match stm {
+			Statement::Relate(_) => true,
+			_ => false,
+		};
+		let tb = self.tb_with_rel(opt, txn, relation).await?;
+
+		// panic!("{:?}", tb);
+		// panic!("{:?}", stm);
 		let rid = self.id.as_ref().unwrap();
 		match stm {
 			Statement::Create(_) | Statement::Insert(_) => {

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -511,6 +511,13 @@ pub enum Error {
 		value: String,
 	},
 
+	/// The specified table is not configured for the type of record being added
+	#[error("Table is {}a relation, but record {thing} is {}a relation", if *relation { "not " } else { "" }, if *relation { "" } else { "not " })]
+	TableCheck {
+		thing: String,
+		relation: bool,
+	},
+
 	/// The specified field did not conform to the field type check
 	#[error("Found {value} for field `{field}`, with record `{thing}`, but expected a {check}")]
 	FieldCheck {

--- a/lib/src/kvs/tests/tb.rs
+++ b/lib/src/kvs/tests/tb.rs
@@ -25,6 +25,7 @@ async fn table_definitions_can_be_scanned() {
 		permissions: Default::default(),
 		changefeed: None,
 		comment: None,
+		relation: false,
 	};
 	tx.set(&key, &value).await.unwrap();
 
@@ -63,6 +64,7 @@ async fn table_definitions_can_be_deleted() {
 		permissions: Default::default(),
 		changefeed: None,
 		comment: None,
+		relation: false,
 	};
 	tx.set(&key, &value).await.unwrap();
 

--- a/lib/src/kvs/tx.rs
+++ b/lib/src/kvs/tx.rs
@@ -2319,6 +2319,7 @@ impl Transaction {
 		db: &str,
 		tb: &str,
 		strict: bool,
+		relation: bool,
 	) -> Result<Arc<DefineTableStatement>, Error> {
 		match self.get_and_cache_tb(ns, db, tb).await {
 			Err(Error::TbNotFound {
@@ -2329,6 +2330,7 @@ impl Transaction {
 					let val = DefineTableStatement {
 						name: tb.to_owned().into(),
 						permissions: Permissions::none(),
+						relation,
 						..Default::default()
 					};
 					self.put(key.key_category(), key, &val).await?;

--- a/lib/src/sql/statements/define/table.rs
+++ b/lib/src/sql/statements/define/table.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Write};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
-#[revisioned(revision = 1)]
+#[revisioned(revision = 2)]
 pub struct DefineTableStatement {
 	pub id: Option<u32>,
 	pub name: Ident,
@@ -25,6 +25,8 @@ pub struct DefineTableStatement {
 	pub permissions: Permissions,
 	pub changefeed: Option<ChangeFeed>,
 	pub comment: Option<Strand>,
+	#[revision(start = 2)]
+	pub relation: bool,
 }
 
 impl DefineTableStatement {

--- a/lib/src/sql/statements/define/table.rs
+++ b/lib/src/sql/statements/define/table.rs
@@ -103,6 +103,9 @@ impl Display for DefineTableStatement {
 		if self.drop {
 			f.write_str(" DROP")?;
 		}
+		if self.relation {
+			f.write_str(" RELATION")?;
+		}
 		f.write_str(if self.full {
 			" SCHEMAFULL"
 		} else {

--- a/lib/src/sql/value/serde/ser/statement/define/table.rs
+++ b/lib/src/sql/value/serde/ser/statement/define/table.rs
@@ -47,6 +47,7 @@ pub struct SerializeDefineTableStatement {
 	permissions: Permissions,
 	changefeed: Option<ChangeFeed>,
 	comment: Option<Strand>,
+	relation: bool,
 }
 
 impl serde::ser::SerializeStruct for SerializeDefineTableStatement {
@@ -82,6 +83,9 @@ impl serde::ser::SerializeStruct for SerializeDefineTableStatement {
 			"comment" => {
 				self.comment = value.serialize(ser::strand::opt::Serializer.wrap())?;
 			}
+			"relation" => {
+				self.relation = value.serialize(ser::primitive::bool::Serializer.wrap())?;
+			}
 			key => {
 				return Err(Error::custom(format!(
 					"unexpected field `DefineTableStatement::{key}`"
@@ -101,6 +105,7 @@ impl serde::ser::SerializeStruct for SerializeDefineTableStatement {
 			permissions: self.permissions,
 			changefeed: self.changefeed,
 			comment: self.comment,
+			relation: self.relation,
 		})
 	}
 }

--- a/lib/src/syn/v1/stmt/define/table.rs
+++ b/lib/src/syn/v1/stmt/define/table.rs
@@ -23,7 +23,7 @@ pub fn table(i: &str) -> IResult<&str, DefineTableStatement> {
 	let (i, name) = cut(ident)(i)?;
 	let (i, opts) = many0(table_opts)(i)?;
 	let (i, _) = expected(
-		"DROP, SCHEMALESS, SCHEMAFUL(L), VIEW, CHANGEFEED, PERMISSIONS, or COMMENT",
+		"RELATION, DROP, SCHEMALESS, SCHEMAFUL(L), VIEW, CHANGEFEED, PERMISSIONS, or COMMENT",
 		ending::query,
 	)(i)?;
 	// Create the base statement

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -2081,3 +2081,31 @@ async fn define_statement_table_permissions() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn define_table_relation() -> Result<(), Error> {
+	let sql = "
+		DEFINE TABLE likes RELATION;
+		CREATE person:raphael, person:tobie;
+		RELATE person:raphael->likes->person:tobie;
+		CREATE likes:1;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 4);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_err());
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently there is no distinction in the schema between tables that contain regular records or relations, when each table should only contain one type.

## What does this change do?

This pr adds checks for this and new syntax in the DEFINE statement.

## What is your testing strategy?

Rely on existing tests for regressions, some tests already added, more will be added for the parser and overall behaviour.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
