### PR TITLE
Fix lints for Rust v1.75.0

### DIFF
--- a/lib/src/ctx/mod.rs
+++ b/lib/src/ctx/mod.rs
@@ -22,7 +22,6 @@
 
 pub use self::canceller::*;
 pub use self::context::*;
-pub use self::reason::*;
 
 pub mod cancellation;
 pub mod canceller;

--- a/lib/src/fnc/object.rs
+++ b/lib/src/fnc/object.rs
@@ -21,7 +21,7 @@ pub fn from_entries((array,): (Array,)) -> Result<Value, Error> {
 	for v in array.iter() {
 		match v {
 			Value::Array(Array(entry)) if entry.len() == 2 => {
-				let key = match entry.get(0) {
+				let key = match entry.first() {
 					Some(v) => match v {
 						Value::Strand(v) => v.to_owned().to_raw(),
 						v => v.to_string(),

--- a/lib/src/fnc/script/fetch/classes/request.rs
+++ b/lib/src/fnc/script/fetch/classes/request.rs
@@ -364,8 +364,6 @@ impl<'js> FromJs<'js> for RequestInit<'js> {
 	}
 }
 
-pub use request::Request as RequestClass;
-
 pub use super::*;
 
 use bytes::Bytes;

--- a/lib/src/fnc/util/math/spread.rs
+++ b/lib/src/fnc/util/math/spread.rs
@@ -9,7 +9,7 @@ pub trait Spread {
 impl Spread for Vec<Number> {
 	fn spread(self) -> Number {
 		// Get the initial number
-		let init = self.get(0);
+		let init = self.first();
 		// Get the minimum and the maximum
 		let min_max = self.iter().fold((init, init), |(mut min, mut max), val| {
 			min = std::cmp::min(min, Some(val));

--- a/lib/src/iam/entities/roles.rs
+++ b/lib/src/iam/entities/roles.rs
@@ -37,18 +37,6 @@ impl FromStr for Role {
 	}
 }
 
-impl std::convert::From<&str> for Role {
-	fn from(s: &str) -> Self {
-		Self::from_str(s).unwrap()
-	}
-}
-
-impl std::convert::From<String> for Role {
-	fn from(s: String) -> Self {
-		Self::from_str(&s).unwrap()
-	}
-}
-
 impl std::convert::From<&Ident> for Role {
 	fn from(id: &Ident) -> Self {
 		Role::from_str(id).unwrap()

--- a/lib/src/sql/number.rs
+++ b/lib/src/sql/number.rs
@@ -318,6 +318,7 @@ impl Number {
 
 	pub fn to_decimal(&self) -> Decimal {
 		match self {
+			#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
 			Number::Int(v) => Decimal::try_from(*v).unwrap_or_default(),
 			Number::Float(v) => Decimal::try_from(*v).unwrap_or_default(),
 			Number::Decimal(v) => *v,

--- a/lib/src/sql/number.rs
+++ b/lib/src/sql/number.rs
@@ -318,7 +318,9 @@ impl Number {
 
 	pub fn to_decimal(&self) -> Decimal {
 		match self {
-			#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+			// #[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+			// `clippy::unnecessary_fallible_conversions` not available on Rust < v1.75
+			#[allow(warnings)]
 			Number::Int(v) => Decimal::try_from(*v).unwrap_or_default(),
 			Number::Float(v) => Decimal::try_from(*v).unwrap_or_default(),
 			Number::Decimal(v) => *v,

--- a/lib/src/sql/value/serde/ser/number/mod.rs
+++ b/lib/src/sql/value/serde/ser/number/mod.rs
@@ -44,7 +44,9 @@ impl ser::Serializer for Serializer {
 
 	fn serialize_i128(self, value: i128) -> Result<Self::Ok, Error> {
 		// TODO: Replace with native 128-bit integer support.
-		#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+		// #[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+		// `clippy::unnecessary_fallible_conversions` not available on Rust < v1.75
+		#[allow(warnings)]
 		match Decimal::try_from(value) {
 			Ok(decimal) => Ok(decimal.into()),
 			_ => Err(Error::TryFrom(value.to_string(), "Decimal")),
@@ -73,7 +75,9 @@ impl ser::Serializer for Serializer {
 
 	fn serialize_u128(self, value: u128) -> Result<Self::Ok, Error> {
 		// TODO: Replace with native 128-bit integer support.
-		#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+		// #[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+		// `clippy::unnecessary_fallible_conversions` not available on Rust < v1.75
+		#[allow(warnings)]
 		match Decimal::try_from(value) {
 			Ok(decimal) => Ok(decimal.into()),
 			_ => Err(Error::TryFrom(value.to_string(), "Decimal")),

--- a/lib/src/sql/value/serde/ser/number/mod.rs
+++ b/lib/src/sql/value/serde/ser/number/mod.rs
@@ -44,6 +44,7 @@ impl ser::Serializer for Serializer {
 
 	fn serialize_i128(self, value: i128) -> Result<Self::Ok, Error> {
 		// TODO: Replace with native 128-bit integer support.
+		#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
 		match Decimal::try_from(value) {
 			Ok(decimal) => Ok(decimal.into()),
 			_ => Err(Error::TryFrom(value.to_string(), "Decimal")),
@@ -72,6 +73,7 @@ impl ser::Serializer for Serializer {
 
 	fn serialize_u128(self, value: u128) -> Result<Self::Ok, Error> {
 		// TODO: Replace with native 128-bit integer support.
+		#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
 		match Decimal::try_from(value) {
 			Ok(decimal) => Ok(decimal.into()),
 			_ => Err(Error::TryFrom(value.to_string(), "Decimal")),

--- a/lib/src/sql/value/serde/ser/value/mod.rs
+++ b/lib/src/sql/value/serde/ser/value/mod.rs
@@ -99,6 +99,7 @@ impl ser::Serializer for Serializer {
 
 	fn serialize_i128(self, value: i128) -> Result<Self::Ok, Error> {
 		// TODO: Replace with native 128-bit integer support.
+		#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
 		match Decimal::try_from(value) {
 			Ok(decimal) => Ok(decimal.into()),
 			_ => Err(Error::TryFrom(value.to_string(), "Decimal")),
@@ -127,6 +128,7 @@ impl ser::Serializer for Serializer {
 
 	fn serialize_u128(self, value: u128) -> Result<Self::Ok, Error> {
 		// TODO: replace with native 128-bit integer support.
+		#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
 		match Decimal::try_from(value) {
 			Ok(decimal) => Ok(decimal.into()),
 			_ => Err(Error::TryFrom(value.to_string(), "Decimal")),

--- a/lib/src/sql/value/serde/ser/value/mod.rs
+++ b/lib/src/sql/value/serde/ser/value/mod.rs
@@ -99,7 +99,9 @@ impl ser::Serializer for Serializer {
 
 	fn serialize_i128(self, value: i128) -> Result<Self::Ok, Error> {
 		// TODO: Replace with native 128-bit integer support.
-		#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+		// #[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+		// `clippy::unnecessary_fallible_conversions` not available on Rust < v1.75
+		#[allow(warnings)]
 		match Decimal::try_from(value) {
 			Ok(decimal) => Ok(decimal.into()),
 			_ => Err(Error::TryFrom(value.to_string(), "Decimal")),
@@ -128,7 +130,9 @@ impl ser::Serializer for Serializer {
 
 	fn serialize_u128(self, value: u128) -> Result<Self::Ok, Error> {
 		// TODO: replace with native 128-bit integer support.
-		#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+		// #[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+		// `clippy::unnecessary_fallible_conversions` not available on Rust < v1.75
+		#[allow(warnings)]
 		match Decimal::try_from(value) {
 			Ok(decimal) => Ok(decimal.into()),
 			_ => Err(Error::TryFrom(value.to_string(), "Decimal")),

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -1868,7 +1868,9 @@ impl Value {
 			// Allow any decimal number
 			Value::Number(v) if v.is_decimal() => Ok(v),
 			// Attempt to convert an int number
-			#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+			// #[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
+			// `clippy::unnecessary_fallible_conversions` not available on Rust < v1.75
+			#[allow(warnings)]
 			Value::Number(Number::Int(ref v)) => match Decimal::try_from(*v) {
 				// The Int can be represented as a Decimal
 				Ok(v) => Ok(Number::Decimal(v)),

--- a/lib/src/sql/value/value.rs
+++ b/lib/src/sql/value/value.rs
@@ -1868,6 +1868,7 @@ impl Value {
 			// Allow any decimal number
 			Value::Number(v) if v.is_decimal() => Ok(v),
 			// Attempt to convert an int number
+			#[allow(clippy::unnecessary_fallible_conversions)] // `Decimal::from` can panic
 			Value::Number(Number::Int(ref v)) => match Decimal::try_from(*v) {
 				// The Int can be represented as a Decimal
 				Ok(v) => Ok(Number::Decimal(v)),

--- a/lib/src/syn/v1/error/mod.rs
+++ b/lib/src/syn/v1/error/mod.rs
@@ -15,7 +15,6 @@ use thiserror::Error;
 mod utils;
 pub use utils::*;
 mod render;
-pub use render::*;
 
 pub type IResult<I, O, E = ParseError<I>> = Result<(I, O), Err<E>>;
 

--- a/lib/src/syn/v1/part/mod.rs
+++ b/lib/src/syn/v1/part/mod.rs
@@ -34,7 +34,7 @@ pub mod view;
 pub mod with;
 
 pub use data::data;
-pub use field::{field, fields};
+pub use field::fields;
 pub use split::split;
 pub use start::start;
 pub use timeout::timeout;

--- a/lib/src/syn/v1/stmt/define/user.rs
+++ b/lib/src/syn/v1/stmt/define/user.rs
@@ -112,7 +112,7 @@ fn user_roles(i: &str) -> IResult<&str, DefineUserOption> {
 	let (i, roles) = separated_list1(commas, |i| {
 		let (i, v) = cut(ident)(i)?;
 		// Verify the role is valid
-		Role::try_from(v.as_str()).map_err(|_| Err::Failure(ParseError::Role(i, v.to_string())))?;
+		v.as_str().parse::<Role>().map_err(|_| Err::Failure(ParseError::Role(i, v.to_string())))?;
 
 		Ok((i, v))
 	})(i)?;

--- a/lib/src/syn/v1/test.rs
+++ b/lib/src/syn/v1/test.rs
@@ -4,5 +4,5 @@ pub use super::{
 	idiom::plain as idiom,
 	literal::param,
 	thing::thing,
-	value::{array, object, value},
+	value::{array, value},
 };

--- a/src/net/client_ip.rs
+++ b/src/net/client_ip.rs
@@ -27,9 +27,11 @@ pub enum ClientIp {
 	CfConnectingIp,
 	/// Fly.io client IP
 	#[clap(name = "Fly-Client-IP")]
+	#[allow(clippy::enum_variant_names)]
 	FlyClientIp,
 	/// Akamai, Cloudflare true client IP
 	#[clap(name = "True-Client-IP")]
+	#[allow(clippy::enum_variant_names)]
 	TrueClientIP,
 	/// Nginx real IP
 	#[clap(name = "X-Real-IP")]

--- a/tests/ws_integration.rs
+++ b/tests/ws_integration.rs
@@ -494,7 +494,7 @@ mod ws_integration {
 			"Unexpected error received: {:#?}",
 			msgs
 		);
-		let msg = msgs.get(0).unwrap();
+		let msg = msgs.first().unwrap();
 		assert!(msg["status"].is_null(), "unexpected status: {:?}", msg);
 
 		// Create some data for notification
@@ -571,7 +571,7 @@ mod ws_integration {
 			"Unexpected error received: {:#?}",
 			msgs
 		);
-		let msg = msgs.get(0).unwrap();
+		let msg = msgs.first().unwrap();
 		assert!(msg["status"].is_null(), "unexpected status: {:?}", msg);
 
 		// Create some data for notification


### PR DESCRIPTION
## What is the motivation?

Running `make check` with Rust v1.75.0 emits some warnings.

## What does this change do?

Fixes the warnings.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
