### PR TITLE
Backport limit RELATE recursion depth from #3232

### DIFF
--- a/lib/src/syn/v1/depth.rs
+++ b/lib/src/syn/v1/depth.rs
@@ -140,6 +140,28 @@ mod tests {
 	}
 
 	#[test]
+	fn parse_ok_recursion_relate() {
+		let depth = 20;
+		let sql =
+			format!("{} {} {}", "(RELATE ".repeat(depth), "a:1", " -> b:1 -> c:1)".repeat(depth));
+		syn::parse(&sql).unwrap();
+	}
+
+	#[test]
+	fn parse_ko_recursion_relate() {
+		use crate::err::Error;
+		let depth = 2000;
+		let sql =
+			format!("{} {} {}", "(RELATE ".repeat(depth), "a:1", " -> b:1 -> c:1)".repeat(depth));
+		let err = syn::parse(&sql).unwrap_err();
+		assert!(
+			matches!(err, Error::InvalidQuery(_)),
+			"expected invalid query due to computation depth exceeded, got {:?}",
+			err
+		);
+	}
+
+	#[test]
 	fn parse_ok_recursion_basic_idiom() {
 		let depth = 2;
 		let sql = format!("{}{}", "[a".repeat(depth), "]".repeat(depth));

--- a/lib/src/syn/v1/stmt/relate.rs
+++ b/lib/src/syn/v1/stmt/relate.rs
@@ -17,6 +17,9 @@ use nom::{
 };
 
 pub fn relate(i: &str) -> IResult<&str, RelateStatement> {
+	use super::super::depth;
+	// Limit recursion depth.
+	let _diving = depth::dive(i)?;
 	let (i, _) = tag_no_case("RELATE")(i)?;
 	let (i, only) = opt(preceded(shouldbespace, tag_no_case("ONLY")))(i)?;
 	let (i, _) = shouldbespace(i)?;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

To resolve an issue where the stack would overflow in deeply nested `RELATE` statements in `1.1.0`.

## What does this change do?

Checks the computation depth before parsing nested `RELATE` statements.
Introduces two tests to verify that the issue existed and that it has been resolved.

## What is your testing strategy?

Add tests for both `ok` and `ko` recursion in the parsing of the `RELATE` statement.
The `ko` test would fail before the fix was implemented.

## Is this related to any issues?

This issue was reported twice by OSS-Fuzz:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64731
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65277

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)