### PR TITLE
Fix a bug where a non-empty list parser would parse empty lists

### DIFF
--- a/lib/src/syn/v1/common.rs
+++ b/lib/src/syn/v1/common.rs
@@ -285,8 +285,27 @@ where
 {
 	move |i| {
 		let (i, s) = prefix.parse(i)?;
-		let mut res = Vec::new();
 		let mut input = i;
+		let (i, v) = value.parse(input)?;
+		let mut res = vec![v];
+
+		match separator.parse(i.clone()) {
+			Ok((i, _)) => {
+				input = i;
+			}
+			Err(Err::Error(_)) => match terminator.parse(i.clone()) {
+				Ok((i, _)) => return Ok((i, res)),
+				Result::Err(Err::Error(_)) => {
+					return Err(Err::Failure(ParseError::MissingDelimiter {
+						opened: s,
+						tried: i,
+					}))
+				}
+				Result::Err(e) => return Err(e),
+			},
+			Err(e) => return Err(e),
+		}
+
 		loop {
 			match terminator.parse(input.clone()) {
 				Err(Err::Error(_)) => {}
@@ -296,8 +315,8 @@ where
 					break;
 				}
 			}
-			let (i, value) = value.parse(input)?;
-			res.push(value);
+			let (i, v) = value.parse(input)?;
+			res.push(v);
 			match separator.parse(i.clone()) {
 				Ok((i, _)) => {
 					input = i;

--- a/lib/src/syn/v1/value/geometry.rs
+++ b/lib/src/syn/v1/value/geometry.rs
@@ -391,4 +391,15 @@ mod tests {
 		let out = res.unwrap().1;
 		assert_eq!("{ type: 'Polygon', coordinates: [[[-0.38314819, 51.37692386], [0.1785278, 51.37692386], [0.1785278, 51.6146057], [-0.38314819, 51.6146057], [-0.38314819, 51.37692386]], [[[-0.38314819, 51.37692386], [0.1785278, 51.37692386], [0.1785278, 51.6146057], [-0.38314819, 51.6146057], [-0.38314819, 51.37692386]]]] }", format!("{}", out));
 	}
+
+	#[test]
+	fn invalid_polygon() {
+		// a polygon must have atleast a single item.
+		let sql = r#"{
+			coordinates: []
+			type: 'Polygon',
+		}"#;
+		let res = geometry(sql);
+		res.unwrap_err();
+	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The composable parser `delimited_list1` has the same implementation as `delimited_list0` meaning that it match empty lists when it shouldn't

## What does this change do?

Fix the function to reject empty lists.

## What is your testing strategy?

Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

I added a test for the reproduction which was caused by this bug.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
