### PR TITLE
Re-export `surrealdb::sql::ParseError`

### DIFF
--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -145,4 +145,4 @@ mod parser {
 	pub use crate::syn::*;
 }
 
-pub use self::parser::{idiom, json, parse, subquery, thing, value};
+pub use self::parser::{idiom, json, parse, subquery, thing, v1::ParseError, value};


### PR DESCRIPTION
## What is the motivation?

It was previously publicly visible but was lost in a refactor.

## What does this change do?

It re-exports it.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
