### PR TITLE
Backport fix in timeout overflow from #3258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6062,9 +6062,9 @@ dependencies = [
 
 [[package]]
 name = "trice"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61aa4cd1c1dca57255b92cb9e53d5b3ac5a22da6d8a63045337eb3da1a065d43"
+checksum = "d3aaab10ae9fac0b10f392752bf56f0fd20845f39037fec931e8537b105b515a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -118,7 +118,7 @@ thiserror = "1.0.50"
 tikv = { version = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }
 tokio-util = { version = "0.7.10", optional = true, features = ["compat"] }
 tracing = "0.1.40"
-trice = "0.3.1"
+trice = "0.4.0"
 ulid = { version = "1.1.0", features = ["serde"] }
 url = "2.5.0"
 

--- a/lib/src/err/mod.rs
+++ b/lib/src/err/mod.rs
@@ -251,6 +251,10 @@ pub enum Error {
 	#[error("Invalid regular expression: {0:?}")]
 	InvalidRegex(String),
 
+	/// Invalid timeout
+	#[error("Invalid timeout: {0:?} seconds")]
+	InvalidTimeout(u64),
+
 	/// The query timedout
 	#[error("The query was not executed because it exceeded the timeout")]
 	QueryTimedout,

--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -1050,7 +1050,7 @@ impl Datastore {
 		ctx.add_capabilities(self.capabilities.clone());
 		// Set the global query timeout
 		if let Some(timeout) = self.query_timeout {
-			ctx.add_timeout(timeout);
+			ctx.add_timeout(timeout)?;
 		}
 		// Setup the notification channel
 		if let Some(channel) = &self.notification_channel {
@@ -1114,7 +1114,7 @@ impl Datastore {
 		ctx.add_capabilities(self.capabilities.clone());
 		// Set the global query timeout
 		if let Some(timeout) = self.query_timeout {
-			ctx.add_timeout(timeout);
+			ctx.add_timeout(timeout)?;
 		}
 		// Setup the notification channel
 		if let Some(channel) = &self.notification_channel {
@@ -1183,7 +1183,7 @@ impl Datastore {
 		ctx.add_capabilities(self.capabilities.clone());
 		// Set the global query timeout
 		if let Some(timeout) = self.query_timeout {
-			ctx.add_timeout(timeout);
+			ctx.add_timeout(timeout)?;
 		}
 		// Setup the notification channel
 		if let Some(channel) = &self.notification_channel {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When an timeout was provided with statements that support it, an non-checked addition was performed between the current instant and the timeout duration, leading to an overflow when the timeout provided was absurdly large. This overflow would cause a panic which would crash the server.

## What does this change do?

Backports the changes made in #3258 except for the change in `from_ds`, which does not exist here.

## What is your testing strategy?

I have introduced a test to verify the fact that the overflow no longer causes a panic. The test would panic in previous versions of SurrealDB and no longer fails after the fix implemented in this PR.

## Is this related to any issues?

This issue was reported by OSS-Fuzz:

- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64735

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
