### PR TITLE
Use Rust 1.74.1 to build binaries

### DIFF
--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.74.1
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -473,7 +473,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.74.1
 
       - name: Install release-plz
         run: cargo install --force --locked --version 0.3.30 release-plz

--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y curl patch clang gpg build-essential gi
 
 # Install rust
 COPY docker/files/rustup-init.sh /tmp/rustup-init.sh
-RUN /tmp/rustup-init.sh -y
+RUN /tmp/rustup-init.sh -y --default-toolchain 1.74.1
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN mkdir /surrealdb


### PR DESCRIPTION
## What is the motivation?

`surrealml-core` is currently broken on for Rust v1.75 on some systems.

## What does this change do?

Backports  #3279 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
