### PR TITLE
Fix leaking module and re-add lost documentation

### DIFF
--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod group;
 pub(crate) mod id;
 pub(crate) mod ident;
 pub(crate) mod idiom;
-pub mod index;
+pub(crate) mod index;
 pub(crate) mod kind;
 pub(crate) mod language;
 pub(crate) mod limit;

--- a/lib/src/syn/v1/mod.rs
+++ b/lib/src/syn/v1/mod.rs
@@ -99,6 +99,7 @@ pub fn range(input: &str) -> Result<Range, Error> {
 	parse_impl(input, literal::range)
 }
 
+/// Parses a SurrealQL [`Thing`]
 pub fn thing(input: &str) -> Result<Thing, Error> {
 	parse_impl(input, thing::thing)
 }


### PR DESCRIPTION
## What is the motivation?

The index module is leaking and documentation for `sql::thing` was lost during a refactor.

## What does this change do?

Backports  #3280 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
