### PR TITLE
Fix stable version patch

### DIFF
--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -84,8 +84,7 @@ jobs:
             git checkout -b releases/stable
             major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
             minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
-            betaNum=$(echo $currentVersion | tr "." "\n" | sed -n 4p)
-            version=${major}.${minor}.$(($betaNum - 1))
+            version=${major}.${minor}.0
 
             # Bump the crate version
             sed -i "s#^version = \".*\"#version = \"${version}\"#" Cargo.toml


### PR DESCRIPTION
## What is the motivation?

Patching the version from a beta to a stable release does not correctly reset the patch to 0.

## What does this change do?

It simply replaces the current beta patch with 0.

## What is your testing strategy?

Used this changeset to release v1.1.0 from v1.1.0-beta.3.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
