### PR TITLE
Fix: Panic invoking parameters and functions without a database

### DIFF
--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -174,6 +174,9 @@ impl Function {
 				ctx.check_allowed_function(name.as_str())?;
 				// Get the function definition
 				let val = {
+					// Check that namespace and database are set to prevent a panic
+					opt.valid_for_ns()?;
+					opt.valid_for_db()?;
 					// Claim transaction
 					let mut run = txn.lock().await;
 					// Get the function definition

--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -168,15 +168,15 @@ impl Function {
 				fnc::run(ctx, opt, txn, doc, s, a).await
 			}
 			Self::Custom(s, x) => {
+				// Check that namespace and database are set to prevent a panic
+				opt.valid_for_ns()?;
+				opt.valid_for_db()?;
 				// Get the full name of this function
 				let name = format!("fn::{s}");
 				// Check this function is allowed
 				ctx.check_allowed_function(name.as_str())?;
 				// Get the function definition
 				let val = {
-					// Check that namespace and database are set to prevent a panic
-					opt.valid_for_ns()?;
-					opt.valid_for_db()?;
 					// Claim transaction
 					let mut run = txn.lock().await;
 					// Get the function definition

--- a/lib/src/sql/param.rs
+++ b/lib/src/sql/param.rs
@@ -67,6 +67,9 @@ impl Param {
 				Some(v) => v.compute(ctx, opt, txn, doc).await,
 				// The param has not been set locally
 				None => {
+					// Check that namespace and database are set to prevent a panic
+					opt.valid_for_ns()?;
+					opt.valid_for_db()?;
 					let val = {
 						// Claim transaction
 						let mut run = txn.lock().await;


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

To resolve a panic when a parameter or a function was invoked outside of the context of a database. This would call `unwrap()` on a `None` value as both entities are expected to be defined at database level, leading to a panic. This panic would crash the server process and deny service to its users.

## What does this change do?

It checks that both a namespace and a database are set before calling `opt.ns()` and `opt.db()`.

## What is your testing strategy?

Build the binary and attempt to reproduce the crash following the changes.

## Is this related to any issues?

This is related to the following security report:
- [GHSA-jm4v-58r5-66hj](https://github.com/surrealdb/surrealdb/security/advisories/GHSA-jm4v-58r5-66hj)

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
