### PR TITLE
Bump surrealml version from 0.0.3 to 0.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ Temporary Items
 
 /target/
 /lib/target/
+/lib/cache/
+/lib/store/
 .idea/
 .vscode/
 /result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,7 +1196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 1.8.2",
 ]
 
 [[package]]
@@ -2312,6 +2312,16 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "half"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hash32"
@@ -3554,6 +3564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "889dca4c98efa21b1ba54ddb2bde44fd4920d910f492b618351f839d8428d79d"
 dependencies = [
  "flate2",
+ "half 2.3.1",
  "lazy_static",
  "libc",
  "libloading",
@@ -3561,8 +3572,10 @@ dependencies = [
  "tar",
  "thiserror",
  "tracing",
+ "ureq",
  "vswhom",
  "winapi",
+ "zip",
 ]
 
 [[package]]
@@ -5463,9 +5476,9 @@ dependencies = [
 
 [[package]]
 name = "surrealml-core"
-version = "0.0.3"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cde4ceed0b05a8f512afe7fa1a260e4a67cfbba439eccb858e189f826fc3fff"
+checksum = "224e5e362ae8152566c61384318d1d226e75521d4518c3d63b92264f84fe6465"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6232,6 +6245,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+dependencies = [
+ "base64 0.21.5",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-webpki",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6759,6 +6787,18 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 serde_pack = { version = "1.1.2", package = "rmp-serde" }
 surrealdb = { path = "lib", features = ["protocol-http", "protocol-ws", "rustls"] }
-surrealml-core = { version = "0.0.3", optional = true}
+surrealml-core = { version = "0.0.6", optional = true}
 tempfile = "3.8.1"
 thiserror = "1.0.50"
 tokio = { version = "1.34.0", features = ["macros", "signal"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -115,7 +115,7 @@ sha2 = "0.10.8"
 snap = "1.1.0"
 speedb = { version = "0.0.4", features = ["lz4", "snappy"], optional = true }
 storekey = "0.5.0"
-surrealml-core = { version = "0.0.3", optional = true }
+surrealml-core = { version = "0.0.6", optional = true }
 thiserror = "1.0.50"
 tikv = { version = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }
 tokio-util = { version = "0.7.10", optional = true, features = ["compat"] }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Bump surrealml version to 0.0.6 so that we dont need environment variables pointing at the dynamic library.
```
error: couldn't read /Users/hughkaznowski/.cargo/registry/src/index.crates.io-6f17d22bba15001f/surrealml-core-0.0.3/src/execution/../../onnx_driver/target/debug/libonnxruntime.dylib: No such file or directory (os error 2)
 --> /Users/hughkaznowski/.cargo/registry/src/index.crates.io-6f17d22bba15001f/surrealml-core-0.0.3/src/execution/onnx_environment.rs:9:39
  |
9 | pub static LIB_BYTES: &'static [u8] = include_bytes!("../../onnx_driver/target/debug/libonnxruntime.dylib");
  |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
```

## What does this change do?

Bump surrealml version

## What is your testing strategy?

`make serve`

## Is this related to any issues?

Linked term output 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
