### PR TITLE
Fix a bug where the kind parser would eat whitespace

### DIFF
--- a/lib/src/syn/v1/kind.rs
+++ b/lib/src/syn/v1/kind.rs
@@ -62,14 +62,15 @@ fn option(i: &str) -> IResult<&str, Kind> {
 
 fn record(i: &str) -> IResult<&str, Kind> {
 	let (i, _) = tag("record")(i)?;
-	let (i, _) = mightbespace(i)?;
-	let (i, v) =
-		opt(alt((delimited_list1(openparentheses, commas, cut(table), closeparentheses), |i| {
+	let (i, v) = opt(|i| {
+		let (i, _) = mightbespace(i)?;
+		alt((delimited_list1(openparentheses, commas, cut(table), closeparentheses), |i| {
 			let (i, s) = tag("<")(i)?;
 			let (i, v) = separated_list1(verbar, table)(i)?;
 			let (i, _) = expect_terminator(s, char('>'))(i)?;
 			Ok((i, v))
-		})))(i)?;
+		}))(i)
+	})(i)?;
 	Ok((i, Kind::Record(v.unwrap_or_default())))
 }
 
@@ -89,6 +90,7 @@ fn geometry(i: &str) -> IResult<&str, Kind> {
 fn array(i: &str) -> IResult<&str, Kind> {
 	let (i, _) = tag("array")(i)?;
 	let (i, v) = opt(|i| {
+		let (i, _) = mightbespace(i)?;
 		let (i, s) = tag("<")(i)?;
 		let (i, _) = mightbespace(i)?;
 		let (i, k) = kind(i)?;

--- a/lib/src/syn/v1/stmt/define/field.rs
+++ b/lib/src/syn/v1/stmt/define/field.rs
@@ -144,3 +144,20 @@ fn field_permissions(i: &str) -> IResult<&str, DefineFieldOption> {
 	let (i, v) = permissions(i, Permission::Full)?;
 	Ok((i, DefineFieldOption::Permissions(v)))
 }
+
+#[cfg(test)]
+mod test {
+	use super::field;
+
+	fn assert_parsable(sql: &str) {
+		let res = field(sql);
+		assert!(res.is_ok());
+		let (_, out) = res.unwrap();
+		assert_eq!(format!("DEFINE {}", sql), format!("{}", out))
+	}
+
+	#[test]
+	fn define_field_record_type_permissions() {
+		assert_parsable("FIELD attributes[*] ON listing TYPE record PERMISSIONS FULL")
+	}
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

When parsing a kind/type the sub parser, when parsing a record type, will eat the next white space. This will cause certain correct queries to fail to parse as some parsers rely on the existence of white space to parse the next statement.

An example is `DEFINE FIELD attributes[*] ON listing TYPE record PERMISSIONS FULL`

The parser fails to parser `PERMISSIONS FULL` because `record ` already ate the white space before it.

## What does this change do?

Make the type parser not eat white space.

## What is your testing strategy?

I added a test testing that the example statement above parses correctly.

## Is this related to any issues?

fixes #3217 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
