### PR TITLE
Bump MSRV to 1.75

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -120,7 +120,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
           components: rustfmt
 
       - name: Checkout sources
@@ -59,7 +59,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
           components: rustfmt
 
       - name: Checkout sources
@@ -107,7 +107,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
           targets: wasm32-unknown-unknown
 
       - name: Checkout sources
@@ -132,7 +132,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
           components: clippy
 
       - name: Checkout sources
@@ -161,7 +161,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -199,7 +199,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -227,7 +227,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.74.1
 
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -255,7 +255,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -283,7 +283,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -334,7 +334,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -373,7 +373,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -410,7 +410,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -447,7 +447,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -484,7 +484,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -508,7 +508,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -532,7 +532,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -556,7 +556,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -580,7 +580,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -624,7 +624,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -179,7 +179,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -230,7 +230,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.75.0
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 
@@ -433,7 +433,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.71.1
+          toolchain: 1.74.1
           targets: ${{ matrix.arch }}
 
       - name: Output package versions

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ Temporary Items
 # -----------------------------------
 
 /target/
+/lib/cache/
+/lib/store/
 /lib/target/
 .idea/
 .vscode/


### PR DESCRIPTION
## What is the motivation?

To fix nightly and prepare for more granular modularisation in v1.2. 

## What does this change do?

It updates the MSRV to 1.75.

## What is your testing strategy?

Ran the nightly workflow.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
