### PR TITLE
Update CBOR tags

### DIFF
--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -1,7 +1,7 @@
 use crate::sql::duration::Duration;
 use crate::sql::strand::Strand;
 use crate::syn;
-use chrono::{DateTime, LocalResult, SecondsFormat, TimeZone, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
@@ -63,16 +63,6 @@ impl TryFrom<&str> for Datetime {
 	fn try_from(v: &str) -> Result<Self, Self::Error> {
 		match syn::datetime_raw(v) {
 			Ok(v) => Ok(v),
-			_ => Err(()),
-		}
-	}
-}
-
-impl TryFrom<i64> for Datetime {
-	type Error = ();
-	fn try_from(v: i64) -> Result<Self, Self::Error> {
-		match Utc.timestamp_opt(v, 0) {
-			LocalResult::Single(v) => Ok(Self(v)),
 			_ => Err(()),
 		}
 	}

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -72,7 +72,7 @@ impl TryFrom<i64> for Datetime {
 	type Error = ();
 	fn try_from(v: i64) -> Result<Self, Self::Error> {
 		match Utc.timestamp_opt(v, 0) {
-			LocalResult::Single(v) => Ok(Self(v.into())),
+			LocalResult::Single(v) => Ok(Self(v)),
 			_ => Err(()),
 		}
 	}

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -1,7 +1,7 @@
 use crate::sql::duration::Duration;
 use crate::sql::strand::Strand;
 use crate::syn;
-use chrono::{DateTime, TimeZone, SecondsFormat, Utc, LocalResult};
+use chrono::{DateTime, LocalResult, SecondsFormat, TimeZone, Utc};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
@@ -73,7 +73,7 @@ impl TryFrom<i64> for Datetime {
 	fn try_from(v: i64) -> Result<Self, Self::Error> {
 		match Utc.timestamp_opt(v, 0) {
 			LocalResult::Single(v) => Ok(Self(v.into())),
-			_ => Err(())
+			_ => Err(()),
 		}
 	}
 }

--- a/lib/src/sql/datetime.rs
+++ b/lib/src/sql/datetime.rs
@@ -1,7 +1,7 @@
 use crate::sql::duration::Duration;
 use crate::sql::strand::Strand;
 use crate::syn;
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, TimeZone, SecondsFormat, Utc, LocalResult};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
@@ -64,6 +64,16 @@ impl TryFrom<&str> for Datetime {
 		match syn::datetime_raw(v) {
 			Ok(v) => Ok(v),
 			_ => Err(()),
+		}
+	}
+}
+
+impl TryFrom<i64> for Datetime {
+	type Error = ();
+	fn try_from(v: i64) -> Result<Self, Self::Error> {
+		match Utc.timestamp_opt(v, 0) {
+			LocalResult::Single(v) => Ok(Self(v.into())),
+			_ => Err(())
 		}
 	}
 }

--- a/src/rpc/format/cbor/convert.rs
+++ b/src/rpc/format/cbor/convert.rs
@@ -8,12 +8,13 @@ use surrealdb::sql::Thing;
 use surrealdb::sql::Uuid;
 use surrealdb::sql::Value;
 
-const TAG_NONE: u64 = 78_773_250;
-const TAG_UUID: u64 = 78_773_251;
-const TAG_DECIMAL: u64 = 78_773_252;
-const TAG_DURATION: u64 = 78_773_253;
-const TAG_DATETIME: u64 = 78_773_254;
-const TAG_RECORDID: u64 = 78_773_255;
+const TAG_DATETIME: u64 = 0;
+const TAG_DATETIME_EPOCH: u64 = 1;
+const TAG_NONE: u64 = 6;
+const TAG_UUID: u64 = 7;
+const TAG_DECIMAL: u64 = 8;
+const TAG_DURATION: u64 = 9;
+const TAG_RECORDID: u64 = 10;
 
 #[derive(Debug)]
 pub struct Cbor(pub Data);
@@ -74,6 +75,17 @@ impl TryFrom<Cbor> for Value {
 							_ => Err("Expected a valid Datetime value"),
 						},
 						_ => Err("Expected a CBOR text data type"),
+					},
+					// A literal datetime, represented as the number of seconds since EPOCH
+					TAG_DATETIME_EPOCH => match *v {
+						Data::Integer(v) => match i64::try_from(i128::from(v)) {
+							Ok(v) => match Datetime::try_from(v) {
+								Ok(v) => Ok(v.into()),
+								_ => Err("Expected a valid Datetime value"),
+							},
+							_ => Err("Expected a i64 number"),
+						},
+						_ => Err("Expected a CBOR number data type"),
 					},
 					// A literal recordid
 					TAG_RECORDID => match *v {

--- a/src/rpc/format/cbor/convert.rs
+++ b/src/rpc/format/cbor/convert.rs
@@ -9,7 +9,6 @@ use surrealdb::sql::Uuid;
 use surrealdb::sql::Value;
 
 const TAG_DATETIME: u64 = 0;
-const TAG_DATETIME_EPOCH: u64 = 1;
 const TAG_NONE: u64 = 6;
 const TAG_UUID: u64 = 7;
 const TAG_DECIMAL: u64 = 8;
@@ -49,17 +48,6 @@ impl TryFrom<Cbor> for Value {
 							_ => Err("Expected a valid Datetime value"),
 						},
 						_ => Err("Expected a CBOR text data type"),
-					},
-					// A datetime, represented as the number of seconds since EPOCH
-					TAG_DATETIME_EPOCH => match *v {
-						Data::Integer(v) => match i64::try_from(i128::from(v)) {
-							Ok(v) => match Datetime::try_from(v) {
-								Ok(v) => Ok(v.into()),
-								_ => Err("Expected a valid Datetime value"),
-							},
-							_ => Err("Expected a i64 number"),
-						},
-						_ => Err("Expected a CBOR number data type"),
 					},
 					// A literal NONE
 					TAG_NONE => Ok(Value::None),

--- a/src/rpc/format/cbor/convert.rs
+++ b/src/rpc/format/cbor/convert.rs
@@ -42,6 +42,25 @@ impl TryFrom<Cbor> for Value {
 				.collect::<Result<Value, &str>>(),
 			Data::Tag(t, v) => {
 				match t {
+					// A literal datetime
+					TAG_DATETIME => match *v {
+						Data::Text(v) => match Datetime::try_from(v) {
+							Ok(v) => Ok(v.into()),
+							_ => Err("Expected a valid Datetime value"),
+						},
+						_ => Err("Expected a CBOR text data type"),
+					},
+					// A datetime, represented as the number of seconds since EPOCH
+					TAG_DATETIME_EPOCH => match *v {
+						Data::Integer(v) => match i64::try_from(i128::from(v)) {
+							Ok(v) => match Datetime::try_from(v) {
+								Ok(v) => Ok(v.into()),
+								_ => Err("Expected a valid Datetime value"),
+							},
+							_ => Err("Expected a i64 number"),
+						},
+						_ => Err("Expected a CBOR number data type"),
+					},
 					// A literal NONE
 					TAG_NONE => Ok(Value::None),
 					// A literal uuid
@@ -67,25 +86,6 @@ impl TryFrom<Cbor> for Value {
 							_ => Err("Expected a valid Duration value"),
 						},
 						_ => Err("Expected a CBOR text data type"),
-					},
-					// A literal datetime
-					TAG_DATETIME => match *v {
-						Data::Text(v) => match Datetime::try_from(v) {
-							Ok(v) => Ok(v.into()),
-							_ => Err("Expected a valid Datetime value"),
-						},
-						_ => Err("Expected a CBOR text data type"),
-					},
-					// A literal datetime, represented as the number of seconds since EPOCH
-					TAG_DATETIME_EPOCH => match *v {
-						Data::Integer(v) => match i64::try_from(i128::from(v)) {
-							Ok(v) => match Datetime::try_from(v) {
-								Ok(v) => Ok(v.into()),
-								_ => Err("Expected a valid Datetime value"),
-							},
-							_ => Err("Expected a i64 number"),
-						},
-						_ => Err("Expected a CBOR number data type"),
 					},
 					// A literal recordid
 					TAG_RECORDID => match *v {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The current custom CBOR tags increase the size of encoded messages, which I think is not worth it being a nice easter egg.

Additionally, one custom tag is implemented in the official specification published by IANA.

## What does this change do?

The `NONE`, `UUID`, `DECIMAL`, `DURATION` and `RECORDID` values now use tags 6 to 10 respectively.

The `DATETIME` value is moved to CBOR tag `0`, which represent ISO 8601. See IANA spec for CBOR tags: https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
