### PR TITLE
Bump rquickjs version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,9 +4543,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78e717c7530616265e1f85e06d661c8822fb499631d734d3c5a8b6dfb6c12cc"
+checksum = "0db265d331ae1b1a9fdb68466a8359bc9dcc5e78a9c323f790322f8442e005ac"
 dependencies = [
  "rquickjs-core",
  "rquickjs-macro",
@@ -4553,9 +4553,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-core"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0820b0537fc3f6d7b822dc667bb17cc59aa5a57562537d70aca40ea988f523"
+checksum = "48e51f2fc99917699385bfa290b776e712e414b222d7c2a9b2cd67b8e93585f3"
 dependencies = [
  "async-lock 2.8.0",
  "relative-path",
@@ -4564,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-macro"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77bbce6775bb5fa9978e1e66d7dc64d1e237c6330c4199c0b80445d3621760de"
+checksum = "5c508ce83e3f9daaa91e63ffcd0e2df71cbf46c52246cb45ce410a2d8fdc04df"
 dependencies = [
  "convert_case 0.6.0",
  "fnv",
@@ -4582,9 +4582,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c21ace559d5c911ffb741d33d9ac2eb2e59fbdc1ff313e3b8169b236c37715"
+checksum = "86b6865056bc4154c49bc8b2babd9232a8ba55dee4860fc74c789633aecad3ca"
 dependencies = [
  "bindgen 0.66.1",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,9 +4543,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de83ea57beee293520e2f93ac6d34a5596411e7841846a8e179a3623ea17e4e2"
+checksum = "b78e717c7530616265e1f85e06d661c8822fb499631d734d3c5a8b6dfb6c12cc"
 dependencies = [
  "rquickjs-core",
  "rquickjs-macro",
@@ -4553,9 +4553,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-core"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0af23e8116333509584b539f0cb65bcdbe5db019abe86e1159ad4f87f27f5e"
+checksum = "dc0820b0537fc3f6d7b822dc667bb17cc59aa5a57562537d70aca40ea988f523"
 dependencies = [
  "async-lock 2.8.0",
  "relative-path",
@@ -4564,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-macro"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6966220d9aba3fa0474a4c990e6104a7f38eb50016d7a336d32f49601d34546c"
+checksum = "77bbce6775bb5fa9978e1e66d7dc64d1e237c6330c4199c0b80445d3621760de"
 dependencies = [
  "convert_case 0.6.0",
  "fnv",
@@ -4582,9 +4582,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb4766d7b7b291041d458ce3d587c61c365ddc6dc27e6827786e0daef2fd61b"
+checksum = "69c21ace559d5c911ffb741d33d9ac2eb2e59fbdc1ff313e3b8169b236c37715"
 dependencies = [
  "bindgen 0.66.1",
  "cc",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -82,7 +82,7 @@ hex = { version = "0.4.3", optional = false }
 indexmap = { version = "2.1.0", features = ["serde"] }
 indxdb = { version = "0.4.0", optional = true }
 ipnet = "2.9.0"
-js = { version = "0.4.1", package = "rquickjs", features = ["array-buffer", "bindgen", "classes", "futures", "loader", "macro", "parallel", "properties","rust-alloc"], optional = true }
+js = { version = "0.4.2", package = "rquickjs", features = ["array-buffer", "bindgen", "classes", "futures", "loader", "macro", "parallel", "properties","rust-alloc"], optional = true }
 jsonwebtoken = { version = "8.3.0-surreal.1", package = "surrealdb-jsonwebtoken" }
 lexicmp = "0.1.0"
 md-5 = "0.10.6"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -82,7 +82,7 @@ hex = { version = "0.4.3", optional = false }
 indexmap = { version = "2.1.0", features = ["serde"] }
 indxdb = { version = "0.4.0", optional = true }
 ipnet = "2.9.0"
-js = { version = "0.4.0", package = "rquickjs", features = ["array-buffer", "bindgen", "classes", "futures", "loader", "macro", "parallel", "properties","rust-alloc"], optional = true }
+js = { version = "0.4.1", package = "rquickjs", features = ["array-buffer", "bindgen", "classes", "futures", "loader", "macro", "parallel", "properties","rust-alloc"], optional = true }
 jsonwebtoken = { version = "8.3.0-surreal.1", package = "surrealdb-jsonwebtoken" }
 lexicmp = "0.1.0"
 md-5 = "0.10.6"


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

There is a rather severe bug in rquickjs v0.4.0.

## What does this change do?

Bumps rquickjs version to v0.4.1

## What is your testing strategy?

Existing test should continue to work.

## Is this related to any issues?

Fixes #3327 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
