### PR TITLE
Fix: Panic invoking parameters and functions without a database

### DIFF
--- a/lib/src/sql/function.rs
+++ b/lib/src/sql/function.rs
@@ -167,6 +167,8 @@ impl Function {
 				fnc::run(ctx, opt, txn, doc, s, a).await
 			}
 			Self::Custom(s, x) => {
+				// Check that a database is set to prevent a panic
+				opt.valid_for_db()?;
 				// Get the full name of this function
 				let name = format!("fn::{s}");
 				// Check this function is allowed

--- a/lib/src/sql/param.rs
+++ b/lib/src/sql/param.rs
@@ -66,6 +66,8 @@ impl Param {
 				Some(v) => v.compute(ctx, opt, txn, doc).await,
 				// The param has not been set locally
 				None => {
+					// Check that a database is set to prevent a panic
+					opt.valid_for_db()?;
 					let val = {
 						// Claim transaction
 						let mut run = txn.lock().await;

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -6328,3 +6328,19 @@ async fn function_custom_optional_args() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn function_outside_database() -> Result<(), Error> {
+	let sql = "RETURN fn::does_not_exist();";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 1);
+
+	match res.remove(0).result {
+		Err(Error::DbEmpty) => (),
+		_ => panic!("Query should have failed with error: Specify a database to use"),
+	}
+
+	Ok(())
+}

--- a/lib/tests/param.rs
+++ b/lib/tests/param.rs
@@ -86,3 +86,19 @@ async fn define_protected_param() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn parameter_outside_database() -> Result<(), Error> {
+	let sql = "RETURN $does_not_exist;";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 1);
+
+	match res.remove(0).result {
+		Err(Error::DbEmpty) => (),
+		_ => panic!("Query should have failed with error: Specify a database to use"),
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
## What is the motivation?

To resolve a panic when a parameter or a function was invoked outside of the context of a database. This would call `unwrap()` on a `None` value as both entities are expected to be defined at database level, leading to a panic. This panic would crash the server process and deny service to its users.

## What does this change do?

Backports #3297 to v1.1.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
