### PR TITLE
Feature: Add short alias `v` for `surreal version` command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod validator;
 mod version;
 
 use crate::cnf::LOGO;
+use crate::env::RELEASE;
 use backup::BackupCommandArguments;
 use clap::{Parser, Subcommand};
 pub use config::CF;
@@ -42,8 +43,8 @@ We would love it if you could star the repository (https://github.com/surrealdb/
 
 #[derive(Parser, Debug)]
 #[command(name = "SurrealDB command-line interface and server", bin_name = "surreal")]
-#[command(about = INFO, before_help = LOGO)]
-#[command(disable_version_flag = true, arg_required_else_help = true)]
+#[command(version = RELEASE.as_str(), about = INFO, before_help = LOGO)]
+#[command(disable_version_flag = false, arg_required_else_help = true)]
 struct Cli {
 	#[command(subcommand)]
 	command: Commands,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -62,7 +62,6 @@ enum Commands {
 	#[command(about = "Export an existing database as a SurrealQL script")]
 	Export(ExportCommandArguments),
 	#[command(about = "Output the command-line tool and remote server version information")]
-	#[command(alias = "v")]
 	Version(VersionCommandArguments),
 	#[command(about = "Upgrade to the latest stable version")]
 	Upgrade(UpgradeCommandArguments),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -61,6 +61,7 @@ enum Commands {
 	#[command(about = "Export an existing database as a SurrealQL script")]
 	Export(ExportCommandArguments),
 	#[command(about = "Output the command-line tool and remote server version information")]
+	#[command(alias = "v")]
 	Version(VersionCommandArguments),
 	#[command(about = "Upgrade to the latest stable version")]
 	Upgrade(UpgradeCommandArguments),

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -1,5 +1,5 @@
 use crate::cli::abstraction::OptionalDatabaseConnectionArguments;
-use crate::env::release;
+use crate::env::RELEASE;
 use crate::err::Error;
 use clap::Args;
 use surrealdb::engine::any::connect;
@@ -25,7 +25,7 @@ pub async fn init(
 		println!("{}", get_server_version_string(e).await?);
 	} else {
 		// Print local CLI version
-		println!("{}", release());
+		println!("{}", *RELEASE);
 	}
 	Ok(())
 }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,15 +1,15 @@
 use crate::cnf::PKG_VERSION;
 use crate::err::Error;
+use once_cell::sync::Lazy;
 use surrealdb::env::{arch, os};
+
+/// Stores the current release identifier
+pub static RELEASE: Lazy<String> =
+	Lazy::new(|| format!("{} for {} on {}", *PKG_VERSION, os(), arch()));
 
 pub async fn init() -> Result<(), Error> {
 	// Log version
-	info!("Running {}", release());
+	info!("Running {}", *RELEASE);
 	// All ok
 	Ok(())
-}
-
-/// Get the current release identifier
-pub fn release() -> String {
-	format!("{} for {} on {}", *PKG_VERSION, os(), arch())
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -24,6 +24,11 @@ mod cli_integration {
 	}
 
 	#[test]
+	fn version_short() {
+		assert!(common::run("v").output().is_ok());
+	}
+
+	#[test]
 	fn help() {
 		assert!(common::run("help").output().is_ok());
 	}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -19,18 +19,33 @@ mod cli_integration {
 	const TWO_SECS: time::Duration = time::Duration::new(2, 0);
 
 	#[test]
-	fn version() {
+	fn version_command() {
 		assert!(common::run("version").output().is_ok());
 	}
 
 	#[test]
-	fn version_short() {
-		assert!(common::run("v").output().is_ok());
+	fn version_flag_short() {
+		assert!(common::run("-V").output().is_ok());
 	}
 
 	#[test]
-	fn help() {
+	fn version_flag_long() {
+		assert!(common::run("--version").output().is_ok());
+	}
+
+	#[test]
+	fn help_command() {
 		assert!(common::run("help").output().is_ok());
+	}
+
+	#[test]
+	fn help_flag_short() {
+		assert!(common::run("-h").output().is_ok());
+	}
+
+	#[test]
+	fn help_flag_long() {
+		assert!(common::run("--help").output().is_ok());
 	}
 
 	#[test]


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The motivation is to make the version command more intuitive and to run with the short form.

## What does this change do?

Adds an alias command to the original surreal version command. 

## What is your testing strategy?
Before:
<img width="526" alt="Screenshot 2024-01-16 at 3 18 17 PM" src="https://github.com/surrealdb/surrealdb/assets/32492961/2464c26c-b150-40f4-891b-de6b0bf1818f">

After:
<img width="565" alt="Screenshot 2024-01-16 at 3 16 04 PM" src="https://github.com/surrealdb/surrealdb/assets/32492961/9d8808b9-982d-493b-823c-2bb0eb9bb499">


## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
