### PR TITLE
Fix mtree benchmark build

### DIFF
--- a/lib/src/sql/mod.rs
+++ b/lib/src/sql/mod.rs
@@ -29,7 +29,6 @@ pub(crate) mod group;
 pub(crate) mod id;
 pub(crate) mod ident;
 pub(crate) mod idiom;
-pub(crate) mod index;
 pub(crate) mod kind;
 pub(crate) mod language;
 pub(crate) mod limit;
@@ -64,6 +63,9 @@ pub(crate) mod value;
 pub(crate) mod version;
 pub(crate) mod view;
 pub(crate) mod with;
+
+#[doc(hidden)]
+pub mod index;
 
 pub mod serde;
 pub mod statements;


### PR DESCRIPTION
## What is the motivation?

Making the sql::index module private broke the MTree benchmark.

## What does this change do?

Backports #3283 to v1.1.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
