### PR TITLE
Fix WebSocket notification sending format

### DIFF
--- a/lib/src/dbs/notification.rs
+++ b/lib/src/dbs/notification.rs
@@ -22,8 +22,11 @@ impl Display for Action {
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Notification {
+	/// The id of the LIVE query to which this notification belongs
 	pub id: Uuid,
+	/// The CREATE / UPDATE / DELETE action which caused this notification
 	pub action: Action,
+	/// The resulting notification content, usually the altered record content
 	pub result: Value,
 }
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -5,38 +5,76 @@ pub mod format;
 pub mod request;
 pub mod response;
 
-use axum::extract::ws::Message;
+use crate::dbs::DB;
+use crate::rpc::connection::Connection;
+use crate::rpc::response::success;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
-use surrealdb::channel::Sender;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 static CONN_CLOSED_ERR: &str = "Connection closed normally";
-
-pub struct WebSocketRef(Sender<Message>, CancellationToken);
-// Mapping of WebSocketID to WebSocket
-type WebSockets = RwLock<HashMap<Uuid, WebSocketRef>>;
-// Mapping of LiveQueryID to WebSocketID
+/// A type alias for an RPC Connection
+type WebSocket = Arc<RwLock<Connection>>;
+/// Mapping of WebSocket ID to WebSocket
+type WebSockets = RwLock<HashMap<Uuid, WebSocket>>;
+/// Mapping of LIVE Query ID to WebSocket ID
 type LiveQueries = RwLock<HashMap<Uuid, Uuid>>;
 
+/// Stores the currently connected WebSockets
 pub(crate) static WEBSOCKETS: Lazy<WebSockets> = Lazy::new(WebSockets::default);
+/// Stores the currently initiated LIVE queries
 pub(crate) static LIVE_QUERIES: Lazy<LiveQueries> = Lazy::new(LiveQueries::default);
 
-pub(crate) async fn graceful_shutdown() {
-	// Close all WebSocket connections. Queued messages will still be processed.
-	for (_, WebSocketRef(_, cancel_token)) in WEBSOCKETS.read().await.iter() {
-		cancel_token.cancel();
+/// Performs notification delivery to the WebSockets
+pub(crate) async fn notifications(canceller: CancellationToken) {
+	// Listen to the notifications channel
+	if let Some(channel) = DB.get().unwrap().notifications() {
+		// Loop continuously
+		loop {
+			tokio::select! {
+				//
+				biased;
+				// Check if this has shutdown
+				_ = canceller.cancelled() => break,
+				// Receive a notification on the channel
+				Ok(notification) = channel.recv() => {
+					// Find which WebSocket the notification belongs to
+					if let Some(id) = LIVE_QUERIES.read().await.get(&notification.id) {
+						// Check to see if the WebSocket exists
+						if let Some(rpc) = WEBSOCKETS.read().await.get(id) {
+							// Serialize the message to send
+							let message = success(None, notification);
+							// Get the WebSocket output format
+							let format = rpc.read().await.format;
+							// get the WebSocket sending channel
+							let sender = rpc.read().await.channels.0.clone();
+							// Send the notification to the client
+							message.send(format, &sender).await
+						}
+					}
+				},
+			}
+		}
 	}
+}
 
-	// Wait for all existing WebSocket connections to gracefully close
+/// Closes all WebSocket connections, waiting for graceful shutdown
+pub(crate) async fn graceful_shutdown() {
+	// Close WebSocket connections, ensuring queued messages are processed
+	for (_, rpc) in WEBSOCKETS.read().await.iter() {
+		rpc.read().await.canceller.cancel();
+	}
+	// Wait for all existing WebSocket connections to finish sending
 	while WEBSOCKETS.read().await.len() > 0 {
 		tokio::time::sleep(Duration::from_millis(100)).await;
 	}
 }
 
+/// Forces a fast shutdown of all WebSocket connections
 pub(crate) fn shutdown() {
 	// Close all WebSocket connections immediately
 	if let Ok(mut writer) = WEBSOCKETS.try_write() {


### PR DESCRIPTION
## What is the motivation?

Currently an issue can arise when multiple clients with different protocol formats are connected to the same server. If a binary client, and a text client are connected, then the WebSocket LIVE query notifications can be sent in either binary or text format, at random.

## What does this change do?

Backports #3314 to v1.1.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
