### PR TITLE
Assign Cargo dependency files to `surrealdb/security`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,11 @@ build.rs @surrealdb/ci
 Makefile @surrealdb/ci
 Makefile.* @surrealdb/ci
 
+# Configuration for Rust dependencies
+Cargo.lock @surrealdb/security
+Cargo.toml @surrealdb/security
+lib/Cargo.toml @surrealdb/security
+
 # General owners for the database
 /doc/ @surrealdb/db
 /lib/ @surrealdb/db


### PR DESCRIPTION
## What is the motivation?

Changes to `Cargo.lock` and `Cargo.toml` files is one area that still requires Tobie's approval.

## What does this change do?

It assigns ownership for those files to the security team.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
