### PR TITLE
Implement missing errors for missing clauses on `DEFINE`-statements

### DIFF
--- a/lib/src/syn/v1/stmt/define/event.rs
+++ b/lib/src/syn/v1/stmt/define/event.rs
@@ -4,8 +4,7 @@ use super::super::super::{
 	error::{expect_tag_no_case, expected},
 	literal::{ident, strand},
 	value::{value, values},
-	IResult,
-	ParseError
+	IResult, ParseError,
 };
 use crate::sql::{statements::DefineEventStatement, Strand, Value, Values};
 use nom::{

--- a/lib/src/syn/v1/stmt/define/event.rs
+++ b/lib/src/syn/v1/stmt/define/event.rs
@@ -5,6 +5,7 @@ use super::super::super::{
 	literal::{ident, strand},
 	value::{value, values},
 	IResult,
+	ParseError
 };
 use crate::sql::{statements::DefineEventStatement, Strand, Value, Values};
 use nom::{
@@ -13,6 +14,7 @@ use nom::{
 	combinator::{cut, opt},
 	multi::many0,
 	sequence::tuple,
+	Err,
 };
 
 pub fn event(i: &str) -> IResult<&str, DefineEventStatement> {
@@ -52,7 +54,11 @@ pub fn event(i: &str) -> IResult<&str, DefineEventStatement> {
 	}
 	// Check necessary options
 	if res.then.is_empty() {
-		// TODO throw error
+		return Err(Err::Failure(ParseError::ExplainedExpected {
+			tried: i,
+			expected: "a THEN clause",
+			explained: "An event requires a THEN clause to be defined.",
+		}));
 	}
 	// Return the statement
 	Ok((i, res))
@@ -90,4 +96,18 @@ fn event_comment(i: &str) -> IResult<&str, DefineEventOption> {
 	let (i, _) = shouldbespace(i)?;
 	let (i, v) = cut(strand)(i)?;
 	Ok((i, DefineEventOption::Comment(v)))
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+
+	#[test]
+	fn define_event_without_then_clause() {
+		let sql = "EVENT test ON test";
+		let res = event(sql);
+
+		assert_eq!(res.is_err(), true)
+	}
 }

--- a/lib/src/syn/v1/stmt/define/index.rs
+++ b/lib/src/syn/v1/stmt/define/index.rs
@@ -58,8 +58,8 @@ pub fn index(i: &str) -> IResult<&str, DefineIndexStatement> {
 	if res.cols.is_empty() {
 		return Err(Err::Failure(ParseError::ExplainedExpected {
 			tried: i,
-			expected: "a COLUMNS clause",
-			explained: "An index requires a COLUMNS clause to be defined.",
+			expected: "a COLUMNS or FIELDS clause",
+			explained: "An index requires a COLUMNS or FIELDS clause to be defined.",
 		}));
 	}
 	// Return the statement

--- a/lib/src/syn/v1/stmt/define/index.rs
+++ b/lib/src/syn/v1/stmt/define/index.rs
@@ -7,13 +7,17 @@ use super::super::super::{
 	part::index,
 	IResult,
 };
-use crate::sql::{statements::DefineIndexStatement, Idioms, Index, Strand};
+use crate::{
+	sql::{statements::DefineIndexStatement, Idioms, Index, Strand},
+	syn::v1::ParseError,
+};
 use nom::{
 	branch::alt,
 	bytes::complete::tag_no_case,
 	combinator::{cut, opt},
 	multi::many0,
 	sequence::tuple,
+	Err,
 };
 
 pub fn index(i: &str) -> IResult<&str, DefineIndexStatement> {
@@ -52,7 +56,11 @@ pub fn index(i: &str) -> IResult<&str, DefineIndexStatement> {
 	}
 	// Check necessary options
 	if res.cols.is_empty() {
-		// TODO throw error
+		return Err(Err::Failure(ParseError::ExplainedExpected {
+			tried: i,
+			expected: "a COLUMNS clause",
+			explained: "An index requires a COLUMNS clause to be defined.",
+		}));
 	}
 	// Return the statement
 	Ok((i, res))
@@ -230,5 +238,13 @@ mod tests {
 			idx.to_string(),
 			"DEFINE INDEX my_index ON my_table FIELDS my_col MTREE DIMENSION 4 DIST EUCLIDEAN TYPE F64 CAPACITY 40 DOC_IDS_ORDER 100 DOC_IDS_CACHE 100 MTREE_CACHE 100"
 		);
+	}
+
+	#[test]
+	fn define_index_without_columns_clause() {
+		let sql = "INDEX test ON test";
+		let res = index(sql);
+
+		assert_eq!(res.is_err(), true)
 	}
 }

--- a/lib/src/syn/v1/stmt/define/token.rs
+++ b/lib/src/syn/v1/stmt/define/token.rs
@@ -12,7 +12,6 @@ use crate::{
 	sql::{statements::DefineTokenStatement, Algorithm, Strand},
 	syn::v1::ParseError,
 };
-#[cfg(not(feature = "jwks"))]
 use nom::Err;
 use nom::{branch::alt, bytes::complete::tag_no_case, combinator::cut, multi::many0};
 

--- a/lib/src/syn/v1/stmt/define/token.rs
+++ b/lib/src/syn/v1/stmt/define/token.rs
@@ -8,7 +8,10 @@ use super::super::super::{
 	part::base_or_scope,
 	IResult,
 };
-use crate::sql::{statements::DefineTokenStatement, Algorithm, Strand};
+use crate::{
+	sql::{statements::DefineTokenStatement, Algorithm, Strand},
+	syn::v1::ParseError,
+};
 #[cfg(not(feature = "jwks"))]
 use nom::Err;
 use nom::{branch::alt, bytes::complete::tag_no_case, combinator::cut, multi::many0};
@@ -55,7 +58,11 @@ pub fn token(i: &str) -> IResult<&str, DefineTokenStatement> {
 	}
 	// Check necessary options
 	if res.code.is_empty() {
-		// TODO throw error
+		return Err(Err::Failure(ParseError::ExplainedExpected {
+			tried: i,
+			expected: "a VALUE clause",
+			explained: "A token requires a VALUE clause to be defined.",
+		}));
 	}
 	// Return the statement
 	Ok((i, res))
@@ -93,4 +100,18 @@ fn token_comment(i: &str) -> IResult<&str, DefineTokenOption> {
 	let (i, _) = shouldbespace(i)?;
 	let (i, v) = cut(strand)(i)?;
 	Ok((i, DefineTokenOption::Comment(v)))
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+
+	#[test]
+	fn define_token_without_value_clause() {
+		let sql = "TOKEN test ON test";
+		let res = token(sql);
+
+		assert_eq!(res.is_err(), true)
+	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

See #3354

## What does this change do?

It implements throwing an error in various places with todo comments, for missing clauses on `DEFINE`-statements

## What is your testing strategy?

Added tests

## Is this related to any issues?

fixes #3354

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
