### PR TITLE
Ensure advanced `DEFINE PARAM` parameters are computed correctly

### DIFF
--- a/lib/src/sql/param.rs
+++ b/lib/src/sql/param.rs
@@ -100,8 +100,8 @@ impl Param {
 									}
 								}
 							}
-							// Return the value
-							Ok(val.value.to_owned())
+							// Return the computed value
+							val.value.compute(ctx, opt, txn, doc).await
 						}
 						// The param has not been set globally
 						Err(_) => Ok(Value::None),

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -112,6 +112,24 @@ mod cli_integration {
 			assert_eq!(fs::read_to_string(file).unwrap(), "Save");
 		}
 
+		info!("* Advanced uncomputed variable to be computed before saving");
+		{
+			let args = format!(
+				"sql --conn ws://{addr} {creds} --ns {throwaway} --db {throwaway} --multi",
+				throwaway = Ulid::new()
+			);
+			let output = common::run(&args)
+				.input(
+					"DEFINE PARAM $something VALUE <set>[1, 2, 3]; \
+				$something;
+				",
+				)
+				.output()
+				.unwrap();
+
+			assert!(output.contains("[1, 2, 3]"), "missing success in {output}");
+		}
+
 		info!("* Multi-statement (and multi-line) query including error(s) over WS");
 		{
 			let args = format!(


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Advanced parameters can sometimes be output without being computed correctly (see #3339). In addition, parameters which reference local parameters can be `NONE` on other new database connections (see #2689).

## What does this change do?

Ensures that parameters created with `DEFINE PARAM` are computed on insertion in to the database.
## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #2689.
Closes #3339.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
