### PR TITLE
Fix: Ensure path idioms are correct when looping over

### DIFF
--- a/lib/src/sql/idiom.rs
+++ b/lib/src/sql/idiom.rs
@@ -130,6 +130,12 @@ impl Idiom {
 	pub(crate) fn split_multi_yield(v: &Part) -> bool {
 		matches!(v, Part::Graph(g) if g.alias.is_some())
 	}
+	/// Check if the path part is a yield in a multi-yield expression
+	pub(crate) fn remove_trailing_all(&mut self) {
+		if self.ends_with(&[Part::All]) {
+			self.0.truncate(self.len() - 1);
+		}
+	}
 }
 
 impl Idiom {

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -929,7 +929,7 @@ async fn field_definition_flexible_array_any() -> Result<(), Error> {
 		DEFINE FIELD custom.* ON user FLEXIBLE TYPE any;
 		CREATE user:one CONTENT { custom: ['sometext'] };
 		CREATE user:two CONTENT { custom: [ ['sometext'] ] };
-		CREATE user:three CONTENT { custom: [ { key: 'sometext' } };
+		CREATE user:three CONTENT { custom: [ { key: 'sometext' } ] };
 	";
 	let dbs = new_ds().await?.with_auth_enabled(true);
 	let ses = Session::owner().with_ns("test").with_db("test");

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -920,3 +920,73 @@ async fn field_definition_readonly() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn field_definition_flexible_array_any() -> Result<(), Error> {
+	let sql = "
+		DEFINE TABLE user SCHEMAFULL;
+		DEFINE FIELD custom ON user TYPE option<array>;
+		DEFINE FIELD custom.* ON user FLEXIBLE TYPE any;
+		CREATE user:one CONTENT { custom: ['sometext'] };
+		CREATE user:two CONTENT { custom: [ ['sometext'] ] };
+		CREATE user:three CONTENT { custom: [ { key: 'sometext' } };
+	";
+	let dbs = new_ds().await?.with_auth_enabled(true);
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 6);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				custom: [
+					'sometext'
+				],
+				id: user:one
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				custom: [
+					[
+						'sometext'
+					]
+				],
+				id: user:two
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				custom: [
+					{
+						key: 'sometext'
+					}
+				],
+				id: user:three
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Content in `FLEXIBLE` array fields on a `SCHEMAFULL` table could sometimes be removed.

## What does this change do?

Ensures that `FLEXIBLE` `array.*` fields are looped over correctly on a `SCHEMAFULL` table, ensuring that the content within the fields is correct and not removed.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #3048.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
