### PR TITLE
Remove 3rd party `serde_cbor` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4878,16 +4878,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5312,7 +5302,6 @@ dependencies = [
  "rustyline",
  "semver",
  "serde",
- "serde_cbor",
  "serde_json",
  "serial_test",
  "surrealdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ reqwest = { version = "0.11.22", default-features = false, features = ["blocking
 rmpv = "1.0.1"
 rustyline = { version = "12.0.0", features = ["derive"] }
 serde = { version = "1.0.193", features = ["derive"] }
-serde_cbor = "0.11.2"
 serde_json = "1.0.108"
 serde_pack = { version = "1.1.2", package = "rmp-serde" }
 surrealdb = { path = "lib", features = ["protocol-http", "protocol-ws", "rustls"] }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

`serde_cbor` is unmaintained, and no longer used. It should have been removed previously.

## What does this change do?

Removes the `serde_cbor` dependency.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
