### PR TITLE
Unpin rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,12 +4684,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring 0.16.20",
+ "ring 0.17.7",
  "rustls-webpki",
  "sct",
 ]
@@ -5043,9 +5043,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5393,6 +5393,7 @@ dependencies = [
  "regex-syntax 0.8.2",
  "reqwest",
  "revision",
+ "ring 0.17.7",
  "roaring",
  "rocksdb",
  "rquickjs",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -106,7 +106,7 @@ roaring = { version = "0.10.2", features = ["serde"] }
 rocksdb = { version = "0.21.0", features = ["lz4", "snappy"], optional = true }
 rust_decimal = { version = "1.33.1", features = ["maths", "serde-str"] }
 rust-stemmers = "1.2.0"
-rustls = { version = "=0.21.7", optional = true }
+rustls = { version = "0.21.10", optional = true }
 scrypt = "0.11.0"
 semver = { version = "1.0.20", features = ["serde"] }
 serde = { version = "1.0.193", features = ["derive"] }
@@ -144,6 +144,7 @@ wiremock = "0.5.22"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pharos = "0.5.3"
+ring = { version = "0.17.7", features = ["wasm32_unknown_unknown_js"] } # Make ring-based dependencies work on Wasm
 tokio = { version = "1.34.0", default-features = false, features = ["rt", "sync"] }
 uuid = { version = "1.6.1", features = ["serde", "js", "v4", "v7"] }
 wasm-bindgen-futures = "0.4.39"


### PR DESCRIPTION
## What is the motivation?

`rustls` is currently pinned, causing dependency hell in some cases.

## What does this change do?

It unpins it and makes sure `ring` compiles fine on Wasm.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

It's related to this [Discord issue](https://discord.com/channels/902568124350599239/1014970959461105664/1198935644064448562).

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
