### PR TITLE
Remove `make check-wasm` in favour of `cargo make ci-check-wasm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,6 @@ test: check-deps
 check: check-deps
 	cargo make check
 
-.PHONY: check-wasm
-check-wasm: check-deps
-	cargo make check-wasm
-
 .PHONY: clean
 clean: check-deps
 	cargo make clean


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

We don't need the shortcut for `make check-wasm`

## What does this change do?

Remove the makefile task

## What is your testing strategy?

Terminal

## Is this related to any issues?

None. Redundant code

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
