### PR TITLE
[ci] Fix Docker push

### DIFF
--- a/.github/workflows/reusable_docker.yml
+++ b/.github/workflows/reusable_docker.yml
@@ -116,6 +116,13 @@ jobs:
       - name: Test the Docker image
         run: docker run --platform linux/amd64 --rm surrealdb-local:amd64 version
 
+      - name: Configure DockerHub
+        uses: docker/login-action@v3
+        if: ${{ inputs.push }}
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
       - name: Push to DockerHub
         uses: docker/build-push-action@v5
         if: ${{ inputs.push }}

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -578,8 +578,8 @@ jobs:
 
       - name: Install release-plz
         run: |
-          curl -L https://github.com/MarcoIeni/release-plz/releases/download/release-plz-v0.3.30/release-plz-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C /usr/bin
-          chmod +x /usr/bin/release-plz
+          curl -L https://github.com/MarcoIeni/release-plz/releases/download/release-plz-v0.3.30/release-plz-x86_64-unknown-linux-gnu.tar.gz | sudo tar -xz -C /usr/bin
+          sudo chmod +x /usr/bin/release-plz
 
       - name: Install a TOML parser
         if: ${{ inputs.environment == 'beta' }}

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -648,7 +648,7 @@ jobs:
       - name: Publish the crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: /home/runner/.cargo/bin/release-plz release --config /tmp/release-plz.toml
+        run: release-plz release --config /tmp/release-plz.toml
 
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -577,7 +577,9 @@ jobs:
           toolchain: ${{ inputs.rust_version }}
 
       - name: Install release-plz
-        run: cargo install --force --locked --version 0.3.30 release-plz
+        run: |
+          curl -L https://github.com/MarcoIeni/release-plz/releases/download/release-plz-v0.3.30/release-plz-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C /usr/bin
+          chmod +x /usr/bin/release-plz
 
       - name: Install a TOML parser
         if: ${{ inputs.environment == 'beta' }}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The Docker push is failing after #3382 

## What does this change do?

* It adds the DockerHub login step
* It uses a pre-built release-plz binary, cargo install takes >6mins

## What is your testing strategy?

- [x] Wait for this nightly run with `publish=true` to finish successfully: https://github.com/surrealdb/surrealdb/actions/runs/7624492875

## Is this related to any issues?

No

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
