### PR TITLE
Implement Basic Supply Chain Security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,8 @@ Makefile.* @surrealdb/ci
 Cargo.lock @surrealdb/security
 Cargo.toml @surrealdb/security
 lib/Cargo.toml @surrealdb/security
+cackle.toml @surrealdb/security
+supply-chain/* @surrealdb/security
 
 # General owners for the database
 /doc/ @surrealdb/db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,8 @@ jobs:
       - name: Dependency check failure
         if: failure()
         run: |
-          echo "Dependency check failed. See instructions in the [supply chain security process](./supply-chain/README.md#Process)."
-          echo "##[set-output name=failure_message]::Dependency check failed. See instructions in the [supply chain security process](./supply-chain/README.md#Process)."
+          echo "## :warning: Dependency check failed" >> $GITHUB_STEP_SUMMARY
+          echo "See instructions in the [supply chain security process](https://github.com/surrealdb/surrealdb/blob/main/supply-chain/README.md#Process)." >> $GITHUB_STEP_SUMMARY
 
   check-wasm:
     name: Check Wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         run: cargo vet
 
       - name: Check dependencies for unauthorized access
-        run: cargo acl
+        run: cargo acl -n
 
   check-wasm:
     name: Check Wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,22 @@ jobs:
       - name: Install cargo-deny
         run: cargo install --debug --locked cargo-deny
 
-      - name: Check dependencies
+      - name: Install cargo-vet
+        run: cargo install --debug --locked cargo-vet
+
+      - name: Install cargo-acl
+        run: |
+          cargo install --debug --locked cargo-acl
+          apt install -y bubblewrap
+
+      - name: Check dependencies for known issues
         run: cargo deny check
+
+      - name: Check dependencies for untrusted sources
+        run: cargo vet
+
+      - name: Check dependencies for unauthorized access
+        run: cargo acl
 
   check-wasm:
     name: Check Wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install cargo-acl
         run: |
           cargo install --debug --locked cargo-acl
-          apt-get install -y bubblewrap
+          sudo apt-get install -y bubblewrap
 
       - name: Check dependencies for known issues
         run: cargo deny check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,11 @@ jobs:
       - name: Check dependencies for unauthorized access
         run: cargo acl -n
 
+      - name: Dependency check failure
+        run: |
+          echo "Dependency check failed. See instructions in the [supply chain security process](./supply-chain/README.md#Process)."
+          echo "##[set-output name=failure_message]::Dependency check failed. See instructions in the [supply chain security process](./supply-chain/README.md#Process)."
+
   check-wasm:
     name: Check Wasm
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
         run: cargo acl -n
 
       - name: Dependency check failure
+        if: failure()
         run: |
           echo "Dependency check failed. See instructions in the [supply chain security process](./supply-chain/README.md#Process)."
           echo "##[set-output name=failure_message]::Dependency check failed. See instructions in the [supply chain security process](./supply-chain/README.md#Process)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install cargo-acl
         run: |
           cargo install --debug --locked cargo-acl
-          apt install -y bubblewrap
+          apt-get install -y bubblewrap
 
       - name: Check dependencies for known issues
         run: cargo deny check

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-# <img height="25" src="/img/security.svg">&nbsp;&nbsp;Security Policy
+# <img height="25" src="/img/security.svg">&nbsp;&nbsp;Open Source Security Policy
 
 ## Supported Versions
 
@@ -85,6 +85,12 @@ replace or acknowledge vulnerable dependencies found during the approval process
 SurrealDB makes use of Github's [Dependabot
 alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts) to continuously
 monitor its dependencies for security issues.
+
+SurrealDB also [implements basic supply chain security practices](https://github.com/surrealdb/surrealdb/pull/3395)
+using [`cargo-vet`](https://mozilla.github.io/cargo-vet/index.html) and [`cargo-acl` (i.e.
+Cackle)](https://github.com/cackle-rs/cackle) to mitigate the impact of attackers introducing malicious code into
+third-party dependencies. These tools are executed as part of the CI process to ensure that significant changes in
+dependencies are considered. More details about these practices can be found [here](supply-chain/README.md).
 
 ### Fuzzing
 

--- a/cackle.toml
+++ b/cackle.toml
@@ -128,6 +128,25 @@ build.allow_build_instructions = [
     "cargo:rustc-link-search=native=*",
 ]
 
+[pkg.librocksdb-sys]
+allow_unsafe = true
+build.sandbox.allow_network = true
+build.sandbox.make_writable = [
+    "target",
+]
+build.allow_apis = [
+    "fs",
+    "process",
+]
+build.allow_build_instructions = [
+    "cargo:rustc-link-lib=static=rocksdb",
+    "cargo:rustc-link-search=native=*",
+    "cargo:rustc-link-lib=stdc++",
+    "cargo:rustc-link-lib=static=snappy",
+    "cargo:cargo_manifest_dir=*",
+    "cargo:out_dir=*",
+]
+
 #
 # Other (e.g. Unsafe, Filesystem, Network, Procedural Macros...)
 #
@@ -818,16 +837,6 @@ allow_unsafe = true
 
 [pkg.stacker]
 allow_unsafe = true
-
-[pkg.librocksdb-sys]
-build.allow_apis = [
-    "fs",
-    "process",
-]
-allow_unsafe = true
-
-[pkg.librocksdb-sys.build.sandbox]
-allow_network = true
 
 [pkg.brotli]
 allow_unsafe = true

--- a/cackle.toml
+++ b/cackle.toml
@@ -1,0 +1,1267 @@
+#
+# General Configuration
+#
+
+[common]
+version = 2
+import_std = [
+    "fs",
+    "net",
+    "process",
+]
+features = ["default"]
+build_flags = ["--tests"]
+
+[sandbox]
+kind = "Bubblewrap"
+
+[api.fs]
+include = [
+    "rustix::fs",
+    "tokio::fs",
+]
+
+[api.net]
+include = [
+    "connect",
+    "futures_util",
+    "hashbrown",
+    "mio::net",
+    "surreal::net",
+    "surrealdb",
+    "tokio::net",
+    "tracing",
+    "tracing_core",
+]
+
+#
+# Crates Linking to Libraries
+#
+
+[pkg.ring]
+build.allow_apis = [
+    "process",
+]
+build.allow_build_instructions = [
+    "cargo:rustc-env=RING_CORE_PREFIX=*",
+    "cargo:rustc-link-lib=static=ring",
+    "cargo:rustc-link-lib=static=ring-core",
+    "cargo:rustc-link-lib=static=ring-test",
+    "cargo:rustc-link-lib=static=ring_core_0_17_7_",
+    "cargo:rustc-link-lib=static=ring_core_0_17_7_test",
+    "cargo:rustc-link-search=native=*",
+]
+allow_unsafe = true
+allow_apis = [
+    "fs",
+]
+
+[pkg.zstd-sys]
+build.allow_apis = [
+    "fs",
+]
+build.allow_build_instructions = [
+    "cargo:include=*",
+    "cargo:root=*",
+    "cargo:rustc-link-lib=static=zstd",
+    "cargo:rustc-link-search=native=*",
+]
+
+[pkg.libz-sys]
+build.allow_apis = [
+    "fs",
+    "process",
+]
+build.allow_build_instructions = [
+    "cargo:include=*",
+    "cargo:root=*",
+    "cargo:rustc-link-lib=static=z",
+    "cargo:rustc-link-search=native=*",
+]
+allow_unsafe = true
+
+[pkg.bzip2-sys]
+build.allow_apis = [
+    "fs",
+]
+build.allow_build_instructions = [
+    "cargo:include=*",
+    "cargo:root=*",
+    "cargo:rustc-link-lib=static=bz2",
+    "cargo:rustc-link-search=native=*",
+]
+
+[pkg.lz4-sys]
+build.allow_apis = [
+    "fs",
+]
+build.allow_build_instructions = [
+    "cargo:include=*",
+    "cargo:root=*",
+    "cargo:rustc-link-lib=static=lz4",
+    "cargo:rustc-link-search=native=*",
+]
+allow_unsafe = true
+
+[pkg.psm]
+allow_unsafe = true
+build.allow_build_instructions = [
+    "cargo:rustc-link-lib=static=psm_s",
+    "cargo:rustc-link-search=native=*",
+]
+
+[pkg.rquickjs-sys]
+build.allow_apis = [
+    "fs",
+    "process",
+]
+build.allow_build_instructions = [
+    "cargo:rustc-link-lib=static=quickjs",
+    "cargo:rustc-link-search=native=*",
+]
+allow_unsafe = true
+
+[pkg.libmimalloc-sys]
+allow_unsafe = true
+build.allow_build_instructions = [
+    "cargo:rustc-link-lib=static=mimalloc",
+    "cargo:rustc-link-search=native=*",
+]
+
+#
+# Other (e.g. Unsafe, Filesystem, Network, Procedural Macros...)
+#
+
+[pkg.thiserror-impl]
+allow_proc_macro = true
+
+[pkg.pin-project-internal]
+allow_proc_macro = true
+allow_unsafe = true
+
+[pkg.ptr_meta_derive]
+allow_proc_macro = true
+
+[pkg.derive_more]
+allow_proc_macro = true
+
+[pkg.actix-web-codegen]
+allow_proc_macro = true
+
+[pkg.test-log-macros]
+allow_proc_macro = true
+
+[pkg.rkyv_derive]
+allow_proc_macro = true
+
+[pkg.syn_derive]
+allow_proc_macro = true
+
+[pkg.miette-derive]
+allow_proc_macro = true
+
+[pkg.borsh-derive]
+allow_proc_macro = true
+
+[pkg.serial_test_derive]
+allow_proc_macro = true
+
+[pkg.time-macros]
+allow_proc_macro = true
+allow_unsafe = true
+
+[pkg.futures-macro]
+allow_proc_macro = true
+allow_unsafe = true
+
+[pkg.snafu-derive]
+allow_proc_macro = true
+
+[pkg.tracing-attributes]
+allow_proc_macro = true
+
+[pkg.wasm-bindgen-macro]
+allow_proc_macro = true
+
+[pkg.axum-macros]
+allow_proc_macro = true
+
+[pkg.serde_with_macros]
+allow_proc_macro = true
+
+[pkg.async-trait]
+allow_proc_macro = true
+build.allow_apis = [
+    "process",
+]
+allow_unsafe = true
+
+[pkg.clap_derive]
+allow_proc_macro = true
+
+[pkg.serde_derive]
+allow_proc_macro = true
+
+[pkg.prost-derive]
+allow_proc_macro = true
+
+[pkg.zerocopy-derive]
+allow_proc_macro = true
+
+[pkg.revision-derive]
+allow_proc_macro = true
+
+[pkg.ref-cast-impl]
+allow_proc_macro = true
+allow_unsafe = true
+
+[pkg.rustversion]
+allow_proc_macro = true
+build.allow_apis = [
+    "fs",
+    "process",
+]
+
+[pkg.bytecheck_derive]
+allow_proc_macro = true
+
+[pkg.actix-macros]
+allow_proc_macro = true
+
+[pkg.rquickjs-macro]
+allow_proc_macro = true
+allow_apis = [
+    "fs",
+]
+allow_unsafe = true
+
+[pkg.async-stream-impl]
+allow_proc_macro = true
+allow_unsafe = true
+
+[pkg.rustyline-derive]
+allow_proc_macro = true
+
+[pkg.async-recursion]
+allow_proc_macro = true
+
+[pkg.proc-macro-error-attr]
+allow_proc_macro = true
+
+[pkg.paste]
+allow_proc_macro = true
+build.allow_apis = [
+    "process",
+]
+
+[pkg.surrealdb-derive]
+allow_proc_macro = true
+
+[pkg.tokio-macros]
+allow_proc_macro = true
+
+[pkg.darling_macro]
+allow_proc_macro = true
+
+[pkg.pin-project-lite]
+allow_unsafe = true
+
+[pkg.unicode-ident]
+allow_unsafe = true
+
+[pkg.itoa]
+allow_unsafe = true
+
+[pkg.futures-core]
+allow_unsafe = true
+
+[pkg.once_cell]
+allow_unsafe = true
+
+[pkg.serde]
+build.allow_apis = [
+    "process",
+]
+allow_unsafe = true
+
+[pkg.proc-macro2]
+build.allow_apis = [
+    "fs",
+    "process",
+]
+allow_unsafe = true
+
+[pkg.libc]
+build.allow_apis = [
+    "process",
+]
+allow_unsafe = true
+
+[pkg.memchr]
+allow_unsafe = true
+
+[pkg.log]
+allow_unsafe = true
+
+[pkg.bytes]
+allow_unsafe = true
+
+[pkg.autocfg]
+from.build.allow_apis = [
+    "fs",
+    "process",
+]
+
+[pkg.scopeguard]
+allow_unsafe = true
+
+[pkg.version_check]
+from.build.allow_apis = [
+    "process",
+]
+
+[pkg.zerocopy]
+allow_unsafe = true
+
+[pkg.futures-sink]
+allow_unsafe = true
+
+[pkg.futures-task]
+allow_unsafe = true
+
+[pkg.allocator-api2]
+allow_unsafe = true
+
+[pkg.pin-utils]
+allow_unsafe = true
+
+[pkg.slab]
+allow_unsafe = true
+
+[pkg.smallvec]
+allow_unsafe = true
+
+[pkg.lock_api]
+allow_unsafe = true
+
+[pkg.bitflags]
+allow_unsafe = true
+
+[pkg.either]
+allow_unsafe = true
+
+[pkg.futures-channel]
+allow_unsafe = true
+
+[pkg.jobserver]
+allow_unsafe = true
+from.build.allow_apis = [
+    "fs",
+]
+
+[pkg.getrandom]
+allow_unsafe = true
+
+[pkg.syn]
+allow_unsafe = true
+build.allow_apis = [
+    "process",
+]
+
+[pkg.mio]
+allow_unsafe = true
+allow_apis = [
+    "fs",
+    "net",
+]
+
+[pkg.num_cpus]
+allow_unsafe = true
+allow_apis = [
+    "fs",
+]
+
+[pkg.socket2]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.signal-hook-registry]
+allow_unsafe = true
+
+[pkg.rustix]
+build.allow_apis = [
+    "fs",
+    "process",
+]
+allow_unsafe = true
+
+[pkg.tracing-core]
+allow_unsafe = true
+
+[pkg.linux-raw-sys]
+allow_unsafe = true
+
+[pkg.lazy_static]
+allow_unsafe = true
+
+[pkg.thiserror]
+build.allow_apis = [
+    "process",
+]
+allow_apis = [
+    "fs",
+]
+
+[pkg.ahash]
+allow_unsafe = true
+
+[pkg.cc]
+allow_unsafe = true
+from.build.allow_apis = [
+    "fs",
+    "process",
+]
+
+[pkg.typenum]
+build.allow_apis = [
+    "fs",
+]
+
+[pkg.rand_core]
+allow_unsafe = true
+
+[pkg.spin]
+allow_unsafe = true
+
+[pkg.ppv-lite86]
+allow_unsafe = true
+
+[pkg.percent-encoding]
+allow_unsafe = true
+
+[pkg.hashbrown]
+allow_unsafe = true
+
+[pkg.tracing]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.tokio]
+allow_unsafe = true
+allow_apis = [
+    "net",
+    "process",
+]
+
+[pkg.regex-automata]
+allow_unsafe = true
+
+[pkg.generic-array]
+allow_unsafe = true
+
+[pkg.byteorder]
+allow_unsafe = true
+
+[pkg.clang-sys]
+allow_unsafe = true
+from.build.allow_apis = [
+    "fs",
+    "process",
+]
+
+[pkg.http]
+allow_unsafe = true
+
+[pkg.crossbeam-utils]
+allow_unsafe = true
+
+[pkg.subtle]
+allow_unsafe = true
+
+[pkg.minimal-lexical]
+allow_unsafe = true
+
+[pkg.libm]
+allow_unsafe = true
+
+[pkg.futures-util]
+allow_unsafe = true
+
+[pkg.indexmap]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.httparse]
+allow_unsafe = true
+
+[pkg.block-buffer]
+allow_unsafe = true
+
+[pkg.rand_chacha]
+allow_unsafe = true
+
+[pkg.libloading]
+allow_unsafe = true
+
+[pkg.ryu]
+allow_unsafe = true
+
+[pkg.tokio-util]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.nom]
+allow_unsafe = true
+
+[pkg.num-traits]
+allow_unsafe = true
+
+[pkg.unicode-normalization]
+allow_unsafe = true
+
+[pkg.prettyplease]
+allow_unsafe = true
+build.allow_build_instructions = [
+    "cargo:VERSION=*",
+]
+
+[pkg.lazycell]
+allow_unsafe = true
+
+[pkg.aho-corasick]
+allow_unsafe = true
+
+[pkg.rand]
+allow_unsafe = true
+
+[pkg.shlex]
+allow_unsafe = true
+
+[pkg.form_urlencoded]
+allow_unsafe = true
+
+[pkg.http-body]
+allow_unsafe = true
+
+[pkg.cpufeatures]
+allow_unsafe = true
+
+[pkg.serde_json]
+allow_unsafe = true
+
+[pkg.semver]
+build.allow_apis = [
+    "process",
+]
+allow_unsafe = true
+
+[pkg.unicode-bidi]
+allow_unsafe = true
+
+[pkg.try-lock]
+allow_unsafe = true
+
+[pkg.bindgen]
+allow_unsafe = true
+from.build.allow_apis = [
+    "fs",
+    "process",
+]
+
+[pkg.pkg-config]
+from.build.allow_apis = [
+    "fs",
+    "process",
+]
+
+[pkg.parking_lot_core]
+allow_unsafe = true
+
+[pkg.wasm-bindgen-shared]
+build.allow_apis = [
+    "fs",
+    "process",
+]
+build.allow_build_instructions = [
+    "cargo:rustc-env=SCHEMA_FILE_HASH=*",
+]
+
+[pkg.dirs-sys-next]
+allow_unsafe = true
+from.build.allow_apis = [
+    "fs",
+]
+
+[pkg.crunchy]
+build.allow_apis = [
+    "fs",
+]
+
+[pkg.is-terminal]
+allow_unsafe = true
+
+[pkg.sha1]
+allow_unsafe = true
+
+[pkg.pin-project]
+allow_unsafe = true
+
+[pkg.anyhow]
+build.allow_apis = [
+    "fs",
+    "process",
+]
+allow_unsafe = true
+
+[pkg.siphasher]
+allow_unsafe = true
+
+[pkg.parking_lot]
+allow_unsafe = true
+
+[pkg.rustc_version]
+from.build.allow_apis = [
+    "process",
+]
+
+[pkg.concurrent-queue]
+allow_unsafe = true
+
+[pkg.h2]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.fixedbitset]
+allow_unsafe = true
+
+[pkg.sync_wrapper]
+allow_unsafe = true
+
+[pkg.bumpalo]
+allow_unsafe = true
+
+[pkg.data-encoding]
+allow_unsafe = true
+
+[pkg.utf-8]
+allow_unsafe = true
+
+[pkg.urlencoding]
+allow_unsafe = true
+
+[pkg.bit-vec]
+allow_unsafe = true
+
+[pkg.string_cache]
+allow_unsafe = true
+
+[pkg.tiny-keccak]
+allow_unsafe = true
+
+[pkg.hash32]
+allow_unsafe = true
+
+[pkg.petgraph]
+allow_unsafe = true
+
+[pkg.bit-set]
+allow_unsafe = true
+
+[pkg.alloc-no-stdlib]
+allow_unsafe = true
+
+[pkg.event-listener]
+allow_unsafe = true
+
+[pkg.stable_deref_trait]
+allow_unsafe = true
+
+[pkg.matchit]
+allow_unsafe = true
+
+[pkg.powerfmt]
+allow_unsafe = true
+
+[pkg.wasm-bindgen-backend]
+allow_unsafe = true
+allow_apis = [
+    "fs",
+]
+
+[pkg.alloc-stdlib]
+allow_unsafe = true
+
+[pkg.crc32fast]
+build.allow_apis = [
+    "process",
+]
+allow_unsafe = true
+
+[pkg.heapless]
+allow_unsafe = true
+
+[pkg.vcpkg]
+from.build.allow_apis = [
+    "fs",
+]
+
+[pkg.inout]
+allow_unsafe = true
+
+[pkg.dashmap]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.tokio-stream]
+allow_unsafe = true
+from.test.allow_apis = [
+    "net",
+]
+
+[pkg.deranged]
+allow_unsafe = true
+
+
+[pkg.same-file]
+allow_unsafe = true
+
+[pkg.doc-comment]
+build.allow_apis = [
+    "process",
+]
+
+[pkg.itertools]
+allow_unsafe = true
+
+[pkg.cipher]
+allow_unsafe = true
+
+[pkg.headers]
+allow_unsafe = true
+
+[pkg.hyper]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.brotli-decompressor]
+allow_unsafe = true
+
+[pkg.time]
+allow_unsafe = true
+
+[pkg.crossbeam-channel]
+allow_unsafe = true
+
+[pkg.thread_local]
+allow_unsafe = true
+
+[pkg.num-bigint]
+build.allow_apis = [
+    "fs",
+]
+allow_unsafe = true
+
+[pkg.utf8parse]
+allow_unsafe = true
+
+[pkg.retain_mut]
+allow_unsafe = true
+
+[pkg.base64ct]
+allow_unsafe = true
+
+[pkg.arbitrary]
+allow_unsafe = true
+
+[pkg.winnow]
+allow_unsafe = true
+
+[pkg.anstyle]
+allow_unsafe = true
+
+[pkg.relative-path]
+allow_unsafe = true
+
+[pkg.miette]
+allow_unsafe = true
+
+
+[pkg.glob]
+allow_apis = [
+    "fs",
+]
+
+[pkg.which]
+from.build.allow_apis = [
+    "fs",
+]
+
+[pkg.geo-types]
+allow_unsafe = true
+
+[pkg.serde_with]
+allow_unsafe = true
+
+[pkg.stacker]
+allow_unsafe = true
+
+[pkg.librocksdb-sys]
+build.allow_apis = [
+    "fs",
+    "process",
+]
+allow_unsafe = true
+
+[pkg.librocksdb-sys.build.sandbox]
+allow_network = true
+kind = "Disabled"
+
+[pkg.brotli]
+allow_unsafe = true
+
+[pkg.flate2]
+allow_unsafe = true
+
+[pkg.wasm-bindgen]
+allow_unsafe = true
+
+[pkg.toml_edit]
+allow_unsafe = true
+
+[pkg.mime_guess]
+build.allow_apis = [
+    "fs",
+]
+
+[pkg.term]
+from.build.allow_apis = [
+    "fs",
+]
+
+[pkg.lalrpop]
+from.build.allow_apis = [
+    "fs",
+]
+
+[pkg.smol_str]
+allow_unsafe = true
+
+[pkg.rust_decimal]
+build.allow_apis = [
+    "fs",
+]
+
+[pkg.ref-cast]
+build.allow_apis = [
+    "process",
+]
+allow_unsafe = true
+
+[pkg.atomic]
+allow_unsafe = true
+
+[pkg.iana-time-zone]
+allow_unsafe = true
+allow_apis = [
+    "fs",
+]
+
+[pkg.bitmaps]
+allow_unsafe = true
+
+[pkg.wyz]
+allow_unsafe = true
+
+[pkg.nu-ansi-term]
+allow_unsafe = true
+
+[pkg.event-listener-strategy]
+allow_unsafe = true
+
+[pkg.async-stream]
+allow_unsafe = true
+
+[pkg.prost]
+allow_unsafe = true
+
+[pkg.matchers]
+allow_unsafe = true
+
+[pkg.uuid]
+allow_unsafe = true
+
+[pkg.imbl-sized-chunks]
+allow_unsafe = true
+
+[pkg.chrono]
+allow_unsafe = true
+allow_apis = [
+    "fs",
+]
+
+[pkg.anstyle-parse]
+allow_unsafe = true
+
+[pkg.http-body-util]
+allow_unsafe = true
+
+[pkg.async-lock]
+allow_unsafe = true
+
+[pkg.sha2]
+allow_unsafe = true
+
+[pkg.crossbeam-epoch]
+allow_unsafe = true
+
+[pkg.sharded-slab]
+allow_unsafe = true
+
+[pkg.tracing-log]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.arrayvec]
+allow_unsafe = true
+
+[pkg.bstr]
+allow_unsafe = true
+
+[pkg.fst]
+build.allow_apis = [
+    "fs",
+]
+
+[pkg.anstyle-query]
+allow_unsafe = true
+
+[pkg.endian-type]
+allow_unsafe = true
+
+[pkg.snap]
+build.allow_apis = [
+    "fs",
+]
+allow_unsafe = true
+
+[pkg.arc-swap]
+allow_unsafe = true
+
+[pkg.bytemuck]
+allow_unsafe = true
+
+[pkg.crossbeam-deque]
+allow_unsafe = true
+
+[pkg.anstream]
+allow_unsafe = true
+
+[pkg.bitvec]
+allow_unsafe = true
+
+[pkg.tracing-subscriber]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.imbl]
+allow_unsafe = true
+
+[pkg.rmp]
+allow_unsafe = true
+
+[pkg.hyper-util]
+allow_unsafe = true
+
+[pkg.terminal_size]
+allow_unsafe = true
+
+[pkg.bincode]
+allow_unsafe = true
+
+[pkg.blake2]
+allow_unsafe = true
+
+[pkg.roaring]
+allow_unsafe = true
+
+[pkg.geo]
+allow_unsafe = true
+
+[pkg.nanorand]
+allow_unsafe = true
+
+[pkg.futures-lite]
+allow_unsafe = true
+
+[pkg.half]
+allow_unsafe = true
+
+[pkg.http-types]
+build.allow_apis = [
+    "fs",
+    "process",
+]
+allow_unsafe = true
+
+[pkg.any_ascii]
+allow_unsafe = true
+
+[pkg.zeroize]
+allow_unsafe = true
+
+[pkg.encoding_rs]
+allow_unsafe = true
+
+[pkg.clap_lex]
+allow_unsafe = true
+
+[pkg.async-task]
+allow_unsafe = true
+
+[pkg.argon2]
+allow_unsafe = true
+
+[pkg.futures-concurrency]
+allow_unsafe = true
+
+[pkg.quick_cache]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.surreal]
+allow_apis = [
+    "fs",
+    "net",
+    "process",
+]
+build.allow_build_instructions = [
+    "cargo:rustc-env=*",
+]
+
+[pkg.surreal.build.sandbox]
+allow_network = true
+
+[pkg.nix]
+allow_unsafe = true
+
+[pkg.ulid]
+allow_unsafe = true
+
+[pkg.serde_html_form]
+allow_unsafe = true
+
+[pkg.md-5]
+allow_unsafe = true
+
+[pkg.async-executor]
+allow_unsafe = true
+
+[pkg.fd-lock]
+allow_unsafe = true
+
+[pkg.deunicode]
+allow_unsafe = true
+
+[pkg.mimalloc]
+allow_unsafe = true
+
+[pkg.tracing-opentelemetry]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.predicates]
+allow_unsafe = true
+
+[pkg.futures-timer]
+allow_unsafe = true
+
+[pkg.rustyline]
+allow_unsafe = true
+allow_apis = [
+    "fs",
+]
+
+[pkg.zstd-safe]
+allow_unsafe = true
+
+[pkg.zstd]
+allow_unsafe = true
+
+[pkg.async-compression]
+allow_unsafe = true
+
+[pkg.rquickjs-core]
+allow_unsafe = true
+
+[pkg.tungstenite]
+allow_unsafe = true
+
+[pkg.reqwest]
+allow_unsafe = true
+allow_apis = [
+    "fs",
+    "net",
+]
+
+[pkg.proc-macro-crate]
+allow_apis = [
+    "fs",
+]
+
+[pkg.tonic]
+allow_unsafe = true
+allow_apis = [
+    "net",
+]
+
+[pkg.rocksdb]
+allow_unsafe = true
+allow_apis = [
+    "fs",
+]
+
+[pkg.surrealdb]
+allow_unsafe = true
+allow_apis = [
+    "fs",
+]
+
+[pkg.assert_fs]
+from.test.allow_apis = [
+    "fs",
+]
+
+[pkg.tempfile]
+allow_apis = [
+    "fs",
+]
+
+[pkg.object_store]
+allow_apis = [
+    "fs",
+]
+
+[pkg.hyper-rustls]
+allow_apis = [
+    "net",
+]
+
+[pkg.wiremock]
+from.test.allow_apis = [
+    "net",
+]
+
+[pkg.tokio-tungstenite]
+allow_apis = [
+    "net",
+]
+
+[pkg.path-clean]
+allow_apis = [
+    "fs",
+]
+
+[pkg.axum-server]
+allow_apis = [
+    "net",
+]
+
+[pkg.clap_builder]
+allow_apis = [
+    "fs",
+]
+
+[pkg.axum]
+allow_apis = [
+    "net",
+]
+
+[pkg.tower]
+allow_apis = [
+    "net",
+]
+
+[pkg.opentelemetry_sdk]
+allow_apis = [
+    "net",
+]
+
+[pkg.tower-http]
+allow_apis = [
+    "net",
+]
+
+[pkg.axum-core]
+allow_apis = [
+    "net",
+]
+
+[pkg.cpp_demangle]
+allow_unsafe = true
+
+[pkg.memmap2]
+allow_unsafe = true
+
+[pkg.rayon-core]
+allow_unsafe = true
+
+[pkg.gimli]
+allow_unsafe = true
+
+[pkg.backtrace]
+allow_unsafe = true
+
+[pkg.rayon]
+allow_unsafe = true
+
+[pkg.symbolic-common]
+allow_unsafe = true
+
+[pkg.addr2line]
+allow_unsafe = true
+
+[pkg.rgb]
+allow_unsafe = true
+
+[pkg.num-format]
+allow_unsafe = true
+
+[pkg.str_stack]
+allow_unsafe = true
+
+[pkg.object]
+allow_unsafe = true
+
+[pkg.findshlibs]
+allow_unsafe = true
+
+[pkg.symbolic-demangle]
+allow_unsafe = true
+
+[pkg.criterion]
+allow_unsafe = true
+
+[pkg.pprof]
+allow_unsafe = true

--- a/cackle.toml
+++ b/cackle.toml
@@ -829,8 +829,8 @@ allow_unsafe = true
 [pkg.librocksdb-sys.build.sandbox]
 allow_network = true
 
-[pkg.brotli]
-allow_unsafe = true
+#[pkg.brotli]
+#allow_unsafe = true
 
 [pkg.flate2]
 allow_unsafe = true

--- a/cackle.toml
+++ b/cackle.toml
@@ -828,7 +828,6 @@ allow_unsafe = true
 
 [pkg.librocksdb-sys.build.sandbox]
 allow_network = true
-kind = "Disabled"
 
 [pkg.brotli]
 allow_unsafe = true

--- a/cackle.toml
+++ b/cackle.toml
@@ -829,8 +829,8 @@ allow_unsafe = true
 [pkg.librocksdb-sys.build.sandbox]
 allow_network = true
 
-#[pkg.brotli]
-#allow_unsafe = true
+[pkg.brotli]
+allow_unsafe = true
 
 [pkg.flate2]
 allow_unsafe = true

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -2,11 +2,11 @@
 
 ## Goal
 
-The goal of supply chain security is to mitigate the impact of attackers introducing malicious code into dependencies that SurrealDB relies on. At this stage, our aim is to introduce a basic mechanism by which dependency source and access is at least considered as part of the CI process, to reduce the attack surface of SurrealDB by limiting the number of dependencies completely exposed to supply chain attacks and to raise the bar for the effort needed to perform a successful supply chain attack against many of the current SurrealDB dependencies.
+Our main goal with supply chain security is to mitigate the impact of attackers introducing malicious code into dependencies that SurrealDB relies on. At this stage, our aim is to introduce a basic mechanism by which dependency source and access is at least considered as part of the CI process, to reduce the attack surface of SurrealDB by limiting the number of dependencies completely exposed to supply chain attacks and to raise the bar for the effort needed to perform a successful supply chain attack against many of the current SurrealDB dependencies.
 
 ## Mechanism
 
-Currently, supply chain security is implemented through a basic configuration of [`cargo-vet`](https://mozilla.github.io/cargo-vet/index.html) and [`cargo-acl` (i.e. Cackle)](https://github.com/cackle-rs/cackle) for the main SurrealDB repository. These tools are executed as part of the CI process. Ownership of the configuration files for these tools is assigned to @surrealdb/security group in the [`.github/CODEOWNERS`](https://github.com/surrealdb/surrealdb/blob/main/.github/CODEOWNERS) file.
+Currently, supply chain security is implemented through a basic configuration of [`cargo-vet`](https://mozilla.github.io/cargo-vet/index.html) and [`cargo-acl` (i.e. Cackle)](https://github.com/cackle-rs/cackle) for the main SurrealDB repository. These tools are executed as part of the CI process. Ownership of the configuration files for these tools is assigned to **@surrealdb/security** group in the [`.github/CODEOWNERS`](https://github.com/surrealdb/surrealdb/blob/main/.github/CODEOWNERS) file.
 
 ### Security Compromises
 
@@ -54,7 +54,7 @@ The following process can be followed whenever the dependency checking action fa
       - Add an [exception to the `deny.toml`](https://github.com/surrealdb/surrealdb/blob/main/deny.toml#L64) file.
       - Add a comment to the exception with its rationale and the conditions for it to be removed.
   - Request the changes on a separate PR. Paste the vulnerability details provided by `cargo-deny`.
-  - The PR containing the dependency update will be approved by @surrealdb/security.
+  - The PR containing the dependency update will be approved by **@surrealdb/security**.
   - Rebase your original branch so that the dependency is updated.
 - If the action fails due to `cargo-vet`:
   - This means that the dependency has not yet been trusted, audited nor exempted.
@@ -65,7 +65,7 @@ The following process can be followed whenever the dependency checking action fa
       - `cargo vet trust <PACKAGE>`
     - Otherwise, it can be (for now) exempted from the vetting process.
       - `cargo vet add-exemption <PACKAGE>`
-  - The changes will be approved by @surrealdb/security.
+  - The changes will be approved by **@surrealdb/security**.
 - If the action fails due to `cargo-acl`:
   - The newly required access (e.g. `unsafe`, `fs`, `net`...) should be understood by the author of the PR.
   - If an audit is present in [`supply-chain/audits.toml`](https://github.com/surrealdb/surrealdb/blob/main/supply-chain/audit.toml), you may review it to understand the required access.
@@ -75,4 +75,4 @@ The following process can be followed whenever the dependency checking action fa
     - Select the minimum access that you believe the dependency should be granted.
     - Commit and push the changes to the config files to your PR.
     - In your PR add a brief explanation of the granted access.
-    - The changes will be approved by @surrealdb/security.
+    - The changes will be approved by **@surrealdb/security**.

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -1,0 +1,78 @@
+# Supply Chain Security
+
+## Goal
+
+The goal of supply chain security is to mitigate the impact of attackers introducing malicious code into dependencies that SurrealDB relies on. At this stage, our aim is to introduce a basic mechanism by which dependency source and access is at least considered as part of the CI process, to reduce the attack surface of SurrealDB by limiting the number of dependencies completely exposed to supply chain attacks and to raise the bar for the effort needed to perform a successful supply chain attack against many of the current SurrealDB dependencies.
+
+## Mechanism
+
+Currently, supply chain security is implemented through a basic configuration of [`cargo-vet`](https://mozilla.github.io/cargo-vet/index.html) and [`cargo-acl` (i.e. Cackle)](https://github.com/cackle-rs/cackle) for the main SurrealDB repository. These tools are executed as part of the CI process. Ownership of the configuration files for these tools is assigned to @surrealdb/security group in the [`.github/CODEOWNERS`](https://github.com/surrealdb/surrealdb/blob/main/.github/CODEOWNERS) file.
+
+### Security Compromises
+
+At this stage, the following compromises are made due to lack of dedicated resources to audit dependencies:
+- Dependencies published by SurrealDB employees are trusted by default when they are the only publisher.
+- Dependencies audited directly (i.e. not transitively) by [some trusted organizations](https://raw.githubusercontent.com/bholley/cargo-vet/main/registry.toml) are trusted by default.
+- Any dependencies that have not yet been audited are exempt from the vetting process.
+
+In this implementation, it is important to note that `cargo-vet` is only used as an informational tool and that no significant security review will be performed by SurrealDB for third-party dependencies. The `cargo-vet` tool will be used to collect information from third-party audits that can be used to inform the decision of allowing or denying newly required access through `cargo-acl` as well as inventory which dependencies are published by trusted developers.
+
+Using `cargo-acl`, the minimum required permissions for each existing dependency (from a total of 594 dependencies, only 272 required no special permissions) at the time of implementation have been granted without any significant review. This limits the exposure to supply chain attacks that require additional access (e.g. a dependency only granted `net` would not be able to suddenly read files and exfiltrate them over the network), but would still allow for dependencies that have been granted some level of access (specially `unsafe`, `fs` and procedural macros) to leverage this access to conduct significant supply chain attacks. Ideally, dependencies granted higher level of access should be reviewed in the future by leveraging `cargo-vet`. As [acknowledged by the Cackle project](https://github.com/cackle-rs/cackle/blob/main/SECURITY.md), we recognize that access limitations can be overcome by determined attackers.
+
+### Process
+
+The following is a simplified lightweight process to support contributors in passing dependency checking.
+
+Using the dependency tools locally requires installing the following software:
+
+```bash
+cargo install --locked cargo-deny
+cargo install --locked cargo-vet
+
+# Linux
+cargo install --locked cargo-acl
+sudo apt install -y bubblewrap # Adapt as required
+
+# Other Systems (Docker)
+# You will need to build the following image at least once:
+docker build -t surrealdb-local/builder --target builder -f docker/Dockerfile .
+# Disable the sandboxing configuration in favor of Docker.
+sed -i 's/kind = "Bubblewrap"/kind = "Disabled"/g' cackle.toml
+# Run Cackle interactively inside the Docker image.
+docker run --entrypoint /bin/bash -it --rm -v $(pwd):/app -w /app surrealdb-local/builder \
+  -c "cargo install cargo-acl && cargo acl"
+# Revert the sandboxing configuration before committing your changes.
+sed -i 's/kind = "Disabled"/kind = "Bubblewrap"/g' cackle.toml
+```
+
+The following process can be followed whenever the dependency checking action fails:
+
+- If the action fails due to `cargo-deny`:
+  - Identify the affected dependency.
+  - In a separate branch, run `cargo update <PACKAGE>`.
+    - If there is no fix or an update is not possible:
+      - Add an [exception to the `deny.toml`](https://github.com/surrealdb/surrealdb/blob/main/deny.toml#L64) file.
+      - Add a comment to the exception with its rationale and the conditions for it to be removed.
+  - Request the changes on a separate PR. Paste the vulnerability details provided by `cargo-deny`.
+  - The PR containing the dependency update will be approved by @surrealdb/security.
+  - Rebase your original branch so that the dependency is updated.
+- If the action fails due to `cargo-vet`:
+  - This means that the dependency has not yet been trusted, audited nor exempted.
+  - If this is a new dependency, think about whether or not it needs to be introduced to SurrealDB.
+  - If the dependency should be introduced:
+    - If published by [a SurrealDB employee](https://github.com/orgs/surrealdb/people), it can be trusted as `safe-to-deploy`.
+      - Ensure that all publishers of the dependency are SurrealDB employees.
+      - `cargo vet trust <PACKAGE>`
+    - Otherwise, it can be (for now) exempted from the vetting process.
+      - `cargo vet add-exemption <PACKAGE>`
+  - The changes will be approved by @surrealdb/security.
+- If the action fails due to `cargo-acl`:
+  - The newly required access (e.g. `unsafe`, `fs`, `net`...) should be understood by the author of the PR.
+  - If an audit is present in [`supply-chain/audits.toml`](https://github.com/surrealdb/surrealdb/blob/main/supply-chain/audit.toml), you may review it to understand the required access.
+  - If the newly required permissions are understood and accepted.
+    - Locally run `cargo acl`. When the required access dialog appears, press `f`.
+      - Alternatively, you can directly edit the [`cackle.toml`](https://github.com/surrealdb/surrealdb/blob/main/cackle.toml) file to add the necessary permissions.
+    - Select the minimum access that you believe the dependency should be granted.
+    - Commit and push the changes to the config files to your PR.
+    - In your PR add a brief explanation of the granted access.
+    - The changes will be approved by @surrealdb/security.

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Our main goal with supply chain security is to mitigate the impact of attackers introducing malicious code into dependencies that SurrealDB relies on. At this stage, our aim is to introduce a basic mechanism by which dependency source and access is at least considered as part of the CI process, to reduce the attack surface of SurrealDB by limiting the number of dependencies completely exposed to supply chain attacks and to raise the bar for the effort needed to perform a successful supply chain attack against many of the current SurrealDB dependencies.
+Our main goal with supply chain security is to mitigate the impact of attackers introducing malicious code into third-party dependencies that SurrealDB relies on. At this stage, our aim is to introduce a basic mechanism by which dependency source and access is at least considered as part of the CI process, to reduce the attack surface of SurrealDB by limiting the number of dependencies completely exposed to supply chain attacks and to raise the bar for the effort needed to perform a successful supply chain attack against many of the current SurrealDB dependencies.
 
 ## Mechanism
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,0 +1,88 @@
+
+# cargo-vet audits file
+
+[audits]
+
+[[trusted.addr]]
+criteria = "safe-to-deploy"
+user-id = 3987 # Rushmore Mushambi (rushmorem)
+start = "2021-02-25"
+end = "2025-01-24"
+
+[[trusted.dmp]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2022-01-27"
+end = "2025-01-24"
+
+[[trusted.echodb]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2022-01-27"
+end = "2025-01-24"
+
+[[trusted.indxdb]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2022-02-19"
+end = "2025-01-24"
+
+[[trusted.lexicmp]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2023-03-26"
+end = "2025-01-24"
+
+[[trusted.psl-types]]
+criteria = "safe-to-deploy"
+user-id = 3987 # Rushmore Mushambi (rushmorem)
+start = "2021-03-12"
+end = "2025-01-24"
+
+[[trusted.revision]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2023-08-09"
+end = "2025-01-24"
+
+[[trusted.revision-derive]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2023-08-09"
+end = "2025-01-24"
+
+[[trusted.storekey]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2022-03-16"
+end = "2025-01-24"
+
+[[trusted.surrealdb]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2022-07-19"
+end = "2025-01-24"
+
+[[trusted.surrealdb-derive]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2022-02-26"
+end = "2025-01-24"
+
+[[trusted.surrealdb-jsonwebtoken]]
+criteria = "safe-to-deploy"
+user-id = 3987 # Rushmore Mushambi (rushmorem)
+start = "2023-08-29"
+end = "2025-01-24"
+
+[[trusted.surrealml-core]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2023-10-31"
+end = "2025-01-24"
+
+[[trusted.trice]]
+criteria = "safe-to-deploy"
+user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
+start = "2022-02-17"
+end = "2025-01-24"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,0 +1,2057 @@
+
+# cargo-vet config file
+
+[cargo-vet]
+version = "0.9"
+
+[imports.bytecode-alliance]
+url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
+
+[imports.embark-studios]
+url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
+
+[imports.fermyon]
+url = "https://raw.githubusercontent.com/fermyon/spin/main/supply-chain/audits.toml"
+
+[imports.google]
+url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
+
+[imports.isrg]
+url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/audits.toml"
+
+[imports.mozilla]
+url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
+
+[imports.zcash]
+url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
+
+[policy.surrealdb]
+audit-as-crates-io = true
+
+[[exemptions.actix-codec]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.actix-http]]
+version = "3.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.actix-macros]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.actix-router]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.actix-rt]]
+version = "2.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.actix-server]]
+version = "2.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.actix-service]]
+version = "2.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.actix-utils]]
+version = "3.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.actix-web]]
+version = "4.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.actix-web-codegen]]
+version = "4.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.addr2line]]
+version = "0.21.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ahash]]
+version = "0.7.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.ahash]]
+version = "0.8.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.aho-corasick]]
+version = "1.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.alloc-no-stdlib]]
+version = "2.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.alloc-stdlib]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.allocator-api2]]
+version = "0.2.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.android-tzdata]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstream]]
+version = "0.6.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstyle]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstyle-parse]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstyle-query]]
+version = "1.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.anstyle-wincon]]
+version = "3.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.any_ascii]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.approx]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.arc-swap]]
+version = "1.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.argon2]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.arrayvec]]
+version = "0.7.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.ascii-canvas]]
+version = "3.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.assert_fs]]
+version = "1.1.1"
+criteria = "safe-to-run"
+
+[[exemptions.async-channel]]
+version = "1.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-compression]]
+version = "0.4.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-executor]]
+version = "1.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-lock]]
+version = "2.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-lock]]
+version = "3.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-recursion]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-recursion]]
+version = "1.0.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-task]]
+version = "4.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-trait]]
+version = "0.1.77"
+criteria = "safe-to-deploy"
+
+[[exemptions.async_io_stream]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.atomic]]
+version = "0.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.atomic-polyfill]]
+version = "1.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.axum]]
+version = "0.6.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.axum]]
+version = "0.7.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.axum-client-ip]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.axum-core]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.axum-core]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.axum-extra]]
+version = "0.7.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.axum-macros]]
+version = "0.3.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.axum-server]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.backtrace]]
+version = "0.3.69"
+criteria = "safe-to-deploy"
+
+[[exemptions.base64]]
+version = "0.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.base64]]
+version = "0.21.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.base64ct]]
+version = "1.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.bcrypt]]
+version = "0.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.bincode]]
+version = "1.3.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bindgen]]
+version = "0.65.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bitflags]]
+version = "1.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.bitflags]]
+version = "2.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.bitmaps]]
+version = "3.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.bitvec]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.blake2]]
+version = "0.10.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.blowfish]]
+version = "0.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.borsh]]
+version = "1.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.borsh-derive]]
+version = "1.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.brotli]]
+version = "3.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.brotli-decompressor]]
+version = "2.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bstr]]
+version = "1.9.0"
+criteria = "safe-to-run"
+
+[[exemptions.bytecheck]]
+version = "0.6.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytecheck_derive]]
+version = "0.6.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytemuck]]
+version = "1.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.byteorder]]
+version = "1.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytes]]
+version = "1.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytestring]]
+version = "1.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bzip2-sys]]
+version = "0.1.11+1.0.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.cast]]
+version = "0.3.0"
+criteria = "safe-to-run"
+
+[[exemptions.cedar-policy]]
+version = "2.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.cedar-policy-core]]
+version = "2.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.cedar-policy-validator]]
+version = "2.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.chrono]]
+version = "0.4.31"
+criteria = "safe-to-deploy"
+
+[[exemptions.ciborium]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ciborium-io]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ciborium-ll]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.cipher]]
+version = "0.4.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.clang-sys]]
+version = "1.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap]]
+version = "4.4.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_builder]]
+version = "4.4.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_derive]]
+version = "4.4.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_lex]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.clipboard-win]]
+version = "4.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.concurrent-queue]]
+version = "2.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.console_error_panic_hook]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.const-oid]]
+version = "0.9.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.convert_case]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cookie]]
+version = "0.16.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.core-foundation]]
+version = "0.9.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.cpp_demangle]]
+version = "0.4.3"
+criteria = "safe-to-run"
+
+[[exemptions.cpufeatures]]
+version = "0.2.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.crc32fast]]
+version = "1.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.criterion]]
+version = "0.5.1"
+criteria = "safe-to-run"
+
+[[exemptions.criterion-plot]]
+version = "0.5.0"
+criteria = "safe-to-run"
+
+[[exemptions.critical-section]]
+version = "1.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-channel]]
+version = "0.5.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-deque]]
+version = "0.8.5"
+criteria = "safe-to-run"
+
+[[exemptions.crossbeam-epoch]]
+version = "0.9.18"
+criteria = "safe-to-run"
+
+[[exemptions.crossbeam-utils]]
+version = "0.8.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling]]
+version = "0.20.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling_core]]
+version = "0.20.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling_macro]]
+version = "0.20.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.dashmap]]
+version = "5.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.data-encoding]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.deadpool]]
+version = "0.9.5"
+criteria = "safe-to-run"
+
+[[exemptions.deadpool-runtime]]
+version = "0.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.der]]
+version = "0.7.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.deranged]]
+version = "0.3.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.deunicode]]
+version = "1.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.diff]]
+version = "0.1.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.digest]]
+version = "0.10.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.dirs-next]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.dirs-sys-next]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.earcutr]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.ena]]
+version = "0.14.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.endian-type]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.env_logger]]
+version = "0.10.2"
+criteria = "safe-to-run"
+
+[[exemptions.error-code]]
+version = "2.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.event-listener]]
+version = "2.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.event-listener]]
+version = "4.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.event-listener-strategy]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.fail]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.fd-lock]]
+version = "3.0.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.filetime]]
+version = "0.2.23"
+criteria = "safe-to-deploy"
+
+[[exemptions.findshlibs]]
+version = "0.10.2"
+criteria = "safe-to-run"
+
+[[exemptions.fixedbitset]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.flate2]]
+version = "1.0.28"
+criteria = "safe-to-deploy"
+
+[[exemptions.float_next_after]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.flume]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.forwarded-header-value]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.foundationdb]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.foundationdb-gen]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.foundationdb-macros]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.foundationdb-sys]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.fst]]
+version = "0.4.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.funty]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures]]
+version = "0.3.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-concurrency]]
+version = "7.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-executor]]
+version = "0.3.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-io]]
+version = "0.3.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-lite]]
+version = "1.13.0"
+criteria = "safe-to-run"
+
+[[exemptions.futures-lite]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-macro]]
+version = "0.3.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-sink]]
+version = "0.3.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-task]]
+version = "0.3.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-timer]]
+version = "3.0.2"
+criteria = "safe-to-run"
+
+[[exemptions.futures-util]]
+version = "0.3.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.fuzzy-matcher]]
+version = "0.3.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.generic-array]]
+version = "0.14.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.geo]]
+version = "0.26.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.geo]]
+version = "0.27.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.geo-types]]
+version = "0.7.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.geographiclib-rs]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.getrandom]]
+version = "0.1.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.getrandom]]
+version = "0.2.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.gimli]]
+version = "0.28.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.globset]]
+version = "0.4.14"
+criteria = "safe-to-run"
+
+[[exemptions.globwalk]]
+version = "0.9.1"
+criteria = "safe-to-run"
+
+[[exemptions.h2]]
+version = "0.3.24"
+criteria = "safe-to-deploy"
+
+[[exemptions.h2]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.half]]
+version = "2.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hash32]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hashbrown]]
+version = "0.14.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.headers]]
+version = "0.3.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.heapless]]
+version = "0.7.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.hermit-abi]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.home]]
+version = "0.5.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.http]]
+version = "0.2.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.http]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.http-body]]
+version = "0.4.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.http-types]]
+version = "2.12.0"
+criteria = "safe-to-run"
+
+[[exemptions.httparse]]
+version = "1.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.humantime]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyper]]
+version = "0.14.28"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyper]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyper-rustls]]
+version = "0.24.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyper-timeout]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyper-tls]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hyper-util]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ignore]]
+version = "0.4.22"
+criteria = "safe-to-run"
+
+[[exemptions.imbl]]
+version = "2.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.imbl-sized-chunks]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.indexmap]]
+version = "1.9.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.indexmap]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.infer]]
+version = "0.2.3"
+criteria = "safe-to-run"
+
+[[exemptions.inferno]]
+version = "0.11.19"
+criteria = "safe-to-run"
+
+[[exemptions.ipnet]]
+version = "2.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.is-terminal]]
+version = "0.4.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.itertools]]
+version = "0.10.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.itertools]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.itoa]]
+version = "1.0.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.jemalloc-sys]]
+version = "0.5.4+5.3.0-patched"
+criteria = "safe-to-deploy"
+
+[[exemptions.jemallocator]]
+version = "0.5.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.jobserver]]
+version = "0.1.27"
+criteria = "safe-to-deploy"
+
+[[exemptions.js-sys]]
+version = "0.3.67"
+criteria = "safe-to-deploy"
+
+[[exemptions.lalrpop]]
+version = "0.20.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.lalrpop-util]]
+version = "0.20.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.language-tags]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.lazycell]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.libc]]
+version = "0.2.152"
+criteria = "safe-to-deploy"
+
+[[exemptions.libloading]]
+version = "0.7.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.libloading]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.libm]]
+version = "0.2.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.libmimalloc-sys]]
+version = "0.1.35"
+criteria = "safe-to-deploy"
+
+[[exemptions.libredox]]
+version = "0.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.librocksdb-sys]]
+version = "0.11.0+8.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.libspeedb-sys]]
+version = "0.0.4+2.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.libz-sys]]
+version = "1.1.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.linux-raw-sys]]
+version = "0.4.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.local-channel]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.local-waker]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.lock_api]]
+version = "0.4.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.lz4-sys]]
+version = "1.9.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.matchit]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.matrixmultiply]]
+version = "0.3.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.md-5]]
+version = "0.10.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.memchr]]
+version = "2.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.memmap2]]
+version = "0.9.3"
+criteria = "safe-to-run"
+
+[[exemptions.miette]]
+version = "5.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.miette-derive]]
+version = "5.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.mimalloc]]
+version = "0.1.39"
+criteria = "safe-to-deploy"
+
+[[exemptions.mime]]
+version = "0.3.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.mime_guess]]
+version = "2.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.minimal-lexical]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.mio]]
+version = "0.8.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.nanoid]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.nanorand]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ndarray]]
+version = "0.15.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.nibble_vec]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.nix]]
+version = "0.26.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.nix]]
+version = "0.27.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.nom]]
+version = "7.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.nonempty]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-bigint-dig]]
+version = "0.8.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-complex]]
+version = "0.4.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-format]]
+version = "0.4.4"
+criteria = "safe-to-run"
+
+[[exemptions.num_cpus]]
+version = "1.16.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.object]]
+version = "0.32.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.object_store]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.once_cell]]
+version = "1.19.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl]]
+version = "0.10.62"
+criteria = "safe-to-deploy"
+
+[[exemptions.openssl-sys]]
+version = "0.9.98"
+criteria = "safe-to-deploy"
+
+[[exemptions.opentelemetry]]
+version = "0.19.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.opentelemetry-otlp]]
+version = "0.12.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.opentelemetry-proto]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.opentelemetry_api]]
+version = "0.19.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.opentelemetry_sdk]]
+version = "0.19.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ort]]
+version = "1.16.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking_lot]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking_lot_core]]
+version = "0.9.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.password-hash]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.paste]]
+version = "1.0.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.path-clean]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pbkdf2]]
+version = "0.12.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pem]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.pem]]
+version = "3.0.3"
+criteria = "safe-to-run"
+
+[[exemptions.pem-rfc7468]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.petgraph]]
+version = "0.6.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.pharos]]
+version = "0.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.phf]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.phf_generator]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.phf_macros]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.phf_shared]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pico-args]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pin-project]]
+version = "1.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.pin-project-internal]]
+version = "1.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkcs1]]
+version = "0.7.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkcs8]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkg-config]]
+version = "0.3.29"
+criteria = "safe-to-deploy"
+
+[[exemptions.plotters]]
+version = "0.3.5"
+criteria = "safe-to-run"
+
+[[exemptions.plotters-backend]]
+version = "0.3.5"
+criteria = "safe-to-run"
+
+[[exemptions.plotters-svg]]
+version = "0.3.5"
+criteria = "safe-to-run"
+
+[[exemptions.powerfmt]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.pprof]]
+version = "0.13.0"
+criteria = "safe-to-run"
+
+[[exemptions.ppv-lite86]]
+version = "0.2.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.predicates]]
+version = "3.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.prettyplease]]
+version = "0.2.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro-crate]]
+version = "1.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro-crate]]
+version = "3.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro-error]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro2]]
+version = "1.0.76"
+criteria = "safe-to-deploy"
+
+[[exemptions.prometheus]]
+version = "0.13.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.prost]]
+version = "0.11.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.prost-derive]]
+version = "0.11.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.psm]]
+version = "0.1.21"
+criteria = "safe-to-deploy"
+
+[[exemptions.ptr_meta]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.ptr_meta_derive]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.quick-xml]]
+version = "0.26.0"
+criteria = "safe-to-run"
+
+[[exemptions.quick_cache]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.radium]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.radix_trie]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_chacha]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_core]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_hc]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_xoshiro]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rawpointer]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rayon]]
+version = "1.8.1"
+criteria = "safe-to-run"
+
+[[exemptions.rayon-core]]
+version = "1.12.1"
+criteria = "safe-to-run"
+
+[[exemptions.rcgen]]
+version = "0.11.3"
+criteria = "safe-to-run"
+
+[[exemptions.redox_syscall]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.redox_users]]
+version = "0.4.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.ref-cast]]
+version = "1.0.22"
+criteria = "safe-to-deploy"
+
+[[exemptions.ref-cast-impl]]
+version = "1.0.22"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex]]
+version = "1.10.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex-automata]]
+version = "0.1.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex-automata]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex-syntax]]
+version = "0.6.29"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex-syntax]]
+version = "0.7.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.relative-path]]
+version = "1.9.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rend]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.reqwest]]
+version = "0.11.23"
+criteria = "safe-to-deploy"
+
+[[exemptions.retain_mut]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.rexie]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rgb]]
+version = "0.8.37"
+criteria = "safe-to-run"
+
+[[exemptions.ring]]
+version = "0.16.20"
+criteria = "safe-to-deploy"
+
+[[exemptions.ring]]
+version = "0.17.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.rkyv]]
+version = "0.7.43"
+criteria = "safe-to-deploy"
+
+[[exemptions.rkyv_derive]]
+version = "0.7.43"
+criteria = "safe-to-deploy"
+
+[[exemptions.rmp]]
+version = "0.8.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.rmp-serde]]
+version = "1.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rmpv]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.roaring]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.robust]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rocksdb]]
+version = "0.21.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rquickjs]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rquickjs-core]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rquickjs-macro]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rquickjs-sys]]
+version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rsa]]
+version = "0.9.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.rstar]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rust-stemmers]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rust_decimal]]
+version = "1.33.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustc_lexer]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustix]]
+version = "0.38.30"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls]]
+version = "0.21.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-pemfile]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-webpki]]
+version = "0.101.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustyline]]
+version = "12.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustyline-derive]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ryu]]
+version = "1.0.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.salsa20]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.same-file]]
+version = "1.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.schannel]]
+version = "0.1.23"
+criteria = "safe-to-deploy"
+
+[[exemptions.scopeguard]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.scrypt]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.sct]]
+version = "0.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.seahash]]
+version = "4.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.security-framework]]
+version = "2.9.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.security-framework-sys]]
+version = "2.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.send_wrapper]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde]]
+version = "1.0.193"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_bytes]]
+version = "0.11.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_derive]]
+version = "1.0.193"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_html_form]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_json]]
+version = "1.0.108"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_path_to_error]]
+version = "0.1.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_qs]]
+version = "0.8.5"
+criteria = "safe-to-run"
+
+[[exemptions.serde_urlencoded]]
+version = "0.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_with]]
+version = "3.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_with_macros]]
+version = "3.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha1]]
+version = "0.10.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha2]]
+version = "0.10.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.shlex]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.simdutf8]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.simple_asn1]]
+version = "0.6.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.siphasher]]
+version = "0.3.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.slab]]
+version = "0.4.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.smallvec]]
+version = "1.12.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.smol_str]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.snafu]]
+version = "0.7.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.snafu-derive]]
+version = "0.7.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.snap]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.socket2]]
+version = "0.5.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.spade]]
+version = "2.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.speedb]]
+version = "0.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.spin]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.spin]]
+version = "0.9.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.spki]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.stable_deref_trait]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.stacker]]
+version = "0.1.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.static_assertions]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.str-buf]]
+version = "1.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.str_stack]]
+version = "0.1.0"
+criteria = "safe-to-run"
+
+[[exemptions.string_cache]]
+version = "0.8.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.strsim]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.surrealdb-tikv-client]]
+version = "0.2.0-surreal.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.symbolic-common]]
+version = "12.8.0"
+criteria = "safe-to-run"
+
+[[exemptions.symbolic-demangle]]
+version = "12.8.0"
+criteria = "safe-to-run"
+
+[[exemptions.syn]]
+version = "1.0.109"
+criteria = "safe-to-deploy"
+
+[[exemptions.syn]]
+version = "2.0.48"
+criteria = "safe-to-deploy"
+
+[[exemptions.syn_derive]]
+version = "0.1.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.sync_wrapper]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.system-configuration]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.system-configuration-sys]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tar]]
+version = "0.4.40"
+criteria = "safe-to-deploy"
+
+[[exemptions.temp-dir]]
+version = "0.1.12"
+criteria = "safe-to-run"
+
+[[exemptions.temp-env]]
+version = "0.3.6"
+criteria = "safe-to-run"
+
+[[exemptions.tempfile]]
+version = "3.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.term]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.termcolor]]
+version = "1.4.1"
+criteria = "safe-to-run"
+
+[[exemptions.terminal_size]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.test-log]]
+version = "0.2.14"
+criteria = "safe-to-run"
+
+[[exemptions.test-log-macros]]
+version = "0.2.14"
+criteria = "safe-to-run"
+
+[[exemptions.time]]
+version = "0.3.31"
+criteria = "safe-to-deploy"
+
+[[exemptions.time-macros]]
+version = "0.2.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.tiny-keccak]]
+version = "2.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.tinytemplate]]
+version = "1.2.1"
+criteria = "safe-to-run"
+
+[[exemptions.tokio]]
+version = "1.35.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-io-timeout]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-macros]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-rustls]]
+version = "0.24.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-tungstenite]]
+version = "0.20.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-util]]
+version = "0.7.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml_datetime]]
+version = "0.6.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml_edit]]
+version = "0.19.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml_edit]]
+version = "0.21.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tonic]]
+version = "0.8.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.tonic]]
+version = "0.9.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.tower]]
+version = "0.4.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.tower-http]]
+version = "0.4.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.tower-layer]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.tower-service]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing]]
+version = "0.1.40"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-attributes]]
+version = "0.1.27"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-core]]
+version = "0.1.32"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-futures]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-log]]
+version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-log]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-opentelemetry]]
+version = "0.19.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.try_map]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.tungstenite]]
+version = "0.20.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.typenum]]
+version = "1.17.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ulid]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicase]]
+version = "2.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-bidi]]
+version = "0.3.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-script]]
+version = "0.5.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-security]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.untrusted]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ureq]]
+version = "2.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.urlencoding]]
+version = "2.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.utf-8]]
+version = "0.7.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.uuid]]
+version = "1.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.vswhom]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.vswhom-sys]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.waker-fn]]
+version = "1.1.1"
+criteria = "safe-to-run"
+
+[[exemptions.walkdir]]
+version = "2.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi]]
+version = "0.9.0+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi]]
+version = "0.11.0+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen]]
+version = "0.2.90"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-backend]]
+version = "0.2.90"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-futures]]
+version = "0.4.40"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-macro]]
+version = "0.2.90"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-macro-support]]
+version = "0.2.90"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-shared]]
+version = "0.2.90"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-streams]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmtimer]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.web-sys]]
+version = "0.3.67"
+criteria = "safe-to-deploy"
+
+[[exemptions.webpki-roots]]
+version = "0.25.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.which]]
+version = "4.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi]]
+version = "0.3.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-i686-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-util]]
+version = "0.1.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-x86_64-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-core]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.48.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-targets]]
+version = "0.48.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-targets]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.48.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_gnullvm]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.48.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.48.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.48.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.48.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.48.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnullvm]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.48.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.52.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.winnow]]
+version = "0.5.34"
+criteria = "safe-to-deploy"
+
+[[exemptions.winreg]]
+version = "0.50.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wiremock]]
+version = "0.5.22"
+criteria = "safe-to-run"
+
+[[exemptions.ws_stream_wasm]]
+version = "0.7.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.wyz]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.xattr]]
+version = "1.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.xml-rs]]
+version = "0.8.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.yasna]]
+version = "0.5.2"
+criteria = "safe-to-run"
+
+[[exemptions.zerocopy]]
+version = "0.7.32"
+criteria = "safe-to-deploy"
+
+[[exemptions.zerocopy-derive]]
+version = "0.7.32"
+criteria = "safe-to-deploy"
+
+[[exemptions.zeroize]]
+version = "1.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zip]]
+version = "0.6.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd-safe]]
+version = "7.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd-sys]]
+version = "2.0.9+zstd.1.5.5"
+criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,0 +1,1585 @@
+
+# cargo-vet imports lock
+
+[[publisher.addr]]
+version = "0.15.6"
+when = "2022-08-31"
+user-id = 3987
+user-login = "rushmorem"
+user-name = "Rushmore Mushambi"
+
+[[publisher.arbitrary]]
+version = "1.3.2"
+when = "2023-10-30"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
+[[publisher.bumpalo]]
+version = "3.14.0"
+when = "2023-09-14"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
+[[publisher.cexpr]]
+version = "0.6.0"
+when = "2021-10-11"
+user-id = 3788
+user-login = "emilio"
+user-name = "Emilio Cobos Álvarez"
+
+[[publisher.core-foundation-sys]]
+version = "0.8.4"
+when = "2023-04-03"
+user-id = 5946
+user-login = "jrmuizel"
+user-name = "Jeff Muizelaar"
+
+[[publisher.derive_arbitrary]]
+version = "1.3.2"
+when = "2023-10-30"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
+[[publisher.dmp]]
+version = "0.2.0"
+when = "2023-05-19"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.echodb]]
+version = "0.4.0"
+when = "2023-03-26"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.encoding_rs]]
+version = "0.8.33"
+when = "2023-08-23"
+user-id = 4484
+user-login = "hsivonen"
+user-name = "Henri Sivonen"
+
+[[publisher.indxdb]]
+version = "0.4.0"
+when = "2023-06-13"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.lexicmp]]
+version = "0.1.0"
+when = "2023-03-26"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.psl-types]]
+version = "2.0.11"
+when = "2022-08-10"
+user-id = 3987
+user-login = "rushmorem"
+user-name = "Rushmore Mushambi"
+
+[[publisher.revision]]
+version = "0.5.0"
+when = "2023-08-29"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.revision-derive]]
+version = "0.5.0"
+when = "2023-08-29"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.storekey]]
+version = "0.5.0"
+when = "2023-04-28"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.surrealdb]]
+version = "1.1.1"
+when = "2024-01-16"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.surrealdb-derive]]
+version = "0.12.0"
+when = "2023-08-14"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.surrealdb-jsonwebtoken]]
+version = "8.3.0-surreal.1"
+when = "2023-08-29"
+user-id = 3987
+user-login = "rushmorem"
+user-name = "Rushmore Mushambi"
+
+[[publisher.surrealml-core]]
+version = "0.0.7"
+when = "2024-01-22"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.trice]]
+version = "0.4.0"
+when = "2024-01-04"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.unicode-normalization]]
+version = "0.1.22"
+when = "2022-09-16"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-segmentation]]
+version = "1.10.1"
+when = "2023-01-31"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[publisher.unicode-width]]
+version = "0.1.11"
+when = "2023-09-19"
+user-id = 1139
+user-login = "Manishearth"
+user-name = "Manish Goregaokar"
+
+[[audits.bytecode-alliance.wildcard-audits.arbitrary]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2020-01-14"
+end = "2024-04-21"
+notes = "I am an author of this crate."
+
+[[audits.bytecode-alliance.wildcard-audits.bumpalo]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2019-03-16"
+end = "2024-03-10"
+
+[[audits.bytecode-alliance.wildcard-audits.derive_arbitrary]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2020-01-14"
+end = "2024-04-27"
+notes = "I am an author of this crate"
+
+[[audits.bytecode-alliance.audits.adler]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.0.2"
+notes = "This is a small crate which forbids unsafe code and is a straightforward implementation of the adler hashing algorithm."
+
+[[audits.bytecode-alliance.audits.anes]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.6"
+notes = "Contains no unsafe code, no IO, no build.rs."
+
+[[audits.bytecode-alliance.audits.anyhow]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.69 -> 1.0.71"
+
+[[audits.bytecode-alliance.audits.block-buffer]]
+who = "Benjamin Bouvier <public@benj.me>"
+criteria = "safe-to-deploy"
+delta = "0.9.0 -> 0.10.2"
+
+[[audits.bytecode-alliance.audits.cc]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.0.73"
+notes = "I am the author of this crate."
+
+[[audits.bytecode-alliance.audits.cfg-if]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "I am the author of this crate."
+
+[[audits.bytecode-alliance.audits.core-foundation-sys]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+delta = "0.8.4 -> 0.8.6"
+notes = """
+The changes here are all typical bindings updates: new functions, types, and
+constants. I have not audited all the bindings for ABI conformance.
+"""
+
+[[audits.bytecode-alliance.audits.crypto-common]]
+who = "Benjamin Bouvier <public@benj.me>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+
+[[audits.bytecode-alliance.audits.errno]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+notes = "This crate uses libc and windows-sys APIs to get and set the raw OS error value."
+
+[[audits.bytecode-alliance.audits.errno]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.3.1"
+notes = "Just a dependency version bump and a bug fix for redox"
+
+[[audits.bytecode-alliance.audits.fastrand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0 -> 2.0.1"
+notes = """
+This update had a few doc updates but no otherwise-substantial source code
+updates.
+"""
+
+[[audits.bytecode-alliance.audits.foreign-types]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = "This crate defined a macro-rules which creates wrappers working with FFI types. The implementation of this crate appears to be safe, but each use of this macro would need to be vetted for correctness as well."
+
+[[audits.bytecode-alliance.audits.foreign-types-shared]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+
+[[audits.bytecode-alliance.audits.futures-channel]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.27"
+notes = "build.rs is just detecting the target and setting cfg. unsafety is for implementing a concurrency primitives using atomics and unsafecell, and is not obviously incorrect (this is the sort of thing I wouldn't certify as correct without formal methods)"
+
+[[audits.bytecode-alliance.audits.futures-core]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.27"
+notes = "Unsafe used to implement a concurrency primitive AtomicWaker. Well-commented and not obviously incorrect. Like my other audits of these concurrency primitives inside the futures family, I couldn't certify that it is correct without formal methods, but that is out of scope for this vetting."
+
+[[audits.bytecode-alliance.audits.heck]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = "Contains `forbid_unsafe` and only uses `std::fmt` from the standard library. Otherwise only contains string manipulation."
+
+[[audits.bytecode-alliance.audits.http-body]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0-rc.2"
+
+[[audits.bytecode-alliance.audits.http-body]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.0-rc.2 -> 1.0.0"
+notes = "Only minor changes made for a stable release."
+
+[[audits.bytecode-alliance.audits.http-body-util]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0-rc.2"
+notes = "only one use of unsafe related to pin projection. unclear to me why pin_project! is used in many modules of the project, but the expanded output of that macro is inlined in either.rs"
+
+[[audits.bytecode-alliance.audits.http-body-util]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0-rc.2 -> 0.1.0"
+notes = "Minor documentation updates an additions, nothing major."
+
+[[audits.bytecode-alliance.audits.iana-time-zone]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+version = "0.1.59"
+notes = """
+I also manually ran windows-bindgen and confirmed that the output matches
+the bindings checked into the repo.
+"""
+
+[[audits.bytecode-alliance.audits.iana-time-zone-haiku]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+
+[[audits.bytecode-alliance.audits.idna]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+notes = """
+This is a crate without unsafe code or usage of the standard library. The large
+size of this crate comes from the large generated unicode tables file. This
+crate is broadly used throughout the ecosystem and does not contain anything
+suspicious.
+"""
+
+[[audits.bytecode-alliance.audits.matchers]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
+[[audits.bytecode-alliance.audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+notes = """
+This crate is a Rust implementation of zlib compression/decompression and has
+been used by default by the Rust standard library for quite some time. It's also
+a default dependency of the popular `backtrace` crate for decompressing debug
+information. This crate forbids unsafe code and does not otherwise access system
+resources. It's originally a port of the `miniz.c` library as well, and given
+its own longevity should be relatively hardened against some of the more common
+compression-related issues.
+"""
+
+[[audits.bytecode-alliance.audits.native-tls]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.2.11"
+notes = "build is only looking for environment variables to set cfg. only two minor uses of unsafe,on macos, with ffi bindings to digest primitives and libc atexit. otherwise, this is an abstraction over three very complex systems (schannel, security-framework, and openssl) which may end up having subtle differences, but none of those are apparent from the implementation of this crate"
+
+[[audits.bytecode-alliance.audits.nu-ansi-term]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.46.0"
+notes = "one use of unsafe to call windows specific api to get console handle."
+
+[[audits.bytecode-alliance.audits.openssl-macros]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
+[[audits.bytecode-alliance.audits.openssl-probe]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.5"
+notes = "IO is only checking for the existence of paths in the filesystem"
+
+[[audits.bytecode-alliance.audits.overload]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "small crate, only defines macro-rules!, nicely documented as well"
+
+[[audits.bytecode-alliance.audits.peeking_take_while]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "I am the author of this crate."
+
+[[audits.bytecode-alliance.audits.percent-encoding]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "2.2.0"
+notes = """
+This crate is a single-file crate that does what it says on the tin. There are
+a few `unsafe` blocks related to utf-8 validation which are locally verifiable
+as correct and otherwise this crate is good to go.
+"""
+
+[[audits.bytecode-alliance.audits.pin-utils]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
+[[audits.bytecode-alliance.audits.quote]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.23 -> 1.0.27"
+
+[[audits.bytecode-alliance.audits.rustc-demangle]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.21"
+notes = "I am the author of this crate."
+
+[[audits.bytecode-alliance.audits.semver]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.0.17"
+notes = "plenty of unsafe pointer and vec tricks, but in well-structured and commented code that appears to be correct"
+
+[[audits.bytecode-alliance.audits.sharded-slab]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.4"
+notes = "I always really enjoy reading eliza's code, she left perfect comments at every use of unsafe."
+
+[[audits.bytecode-alliance.audits.signal-hook-registry]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.4.1"
+
+[[audits.bytecode-alliance.audits.thread_local]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.1.4"
+notes = "uses unsafe to implement thread local storage of objects"
+
+[[audits.bytecode-alliance.audits.tinyvec]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.6.0"
+notes = """
+This crate, while it implements collections, does so without `std::*` APIs and
+without `unsafe`. Skimming the crate everything looks reasonable and what one
+would expect from idiomatic safe collections in Rust.
+"""
+
+[[audits.bytecode-alliance.audits.tinyvec_macros]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = """
+This is a trivial crate which only contains a singular macro definition which is
+intended to multiplex across the internal representation of a tinyvec,
+presumably. This trivially doesn't contain anything bad.
+"""
+
+[[audits.bytecode-alliance.audits.tokio-native-tls]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+notes = "unsafety is used for smuggling std::task::Context as a raw pointer. Lifetime and type safety appears to be taken care of correctly."
+
+[[audits.bytecode-alliance.audits.tracing-subscriber]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.17"
+
+[[audits.bytecode-alliance.audits.try-lock]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.2.4"
+notes = "Implements a concurrency primitive with atomics, and is not obviously incorrect"
+
+[[audits.bytecode-alliance.audits.unicode-ident]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.0.8"
+
+[[audits.bytecode-alliance.audits.vcpkg]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.2.15"
+notes = "no build.rs, no macros, no unsafe. It reads the filesystem and makes copies of DLLs into OUT_DIR."
+
+[[audits.bytecode-alliance.audits.want]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+
+[[audits.embark-studios.audits.anyhow]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.58"
+
+[[audits.embark-studios.audits.assert-json-diff]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-run"
+version = "2.0.2"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.cfg_aliases]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.colorchoice]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.convert_case]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.derive-new]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.5.9"
+notes = "Proc macro. No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.derive_more]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.99.17"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.ident_case]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.idna]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.4.0"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.tap]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.thiserror]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.40"
+notes = "Wrapper over implementation crate, found no unsafe or ambient capabilities used"
+
+[[audits.embark-studios.audits.thiserror-impl]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.40"
+notes = "Found no unsafe or ambient capabilities used"
+
+[[audits.embark-studios.audits.utf8parse]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.2.1"
+notes = "Single unsafe usage that looks sound, no ambient capabilities"
+
+[[audits.embark-studios.audits.valuable]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "No unsafe usage or ambient capabilities, sane build script"
+
+[[audits.fermyon.audits.oorandom]]
+who = "Radu Matei <radu.matei@fermyon.com>"
+criteria = "safe-to-run"
+version = "11.1.3"
+
+[[audits.google.audits.async-stream]]
+who = "Tyler Mandry <tmandry@google.com>"
+criteria = "safe-to-deploy"
+version = "0.3.4"
+notes = "Reviewed on https://fxrev.dev/761470"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.async-stream]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.3.5"
+notes = "Reviewed on https://fxrev.dev/906795"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.async-stream-impl]]
+who = "Tyler Mandry <tmandry@google.com>"
+criteria = "safe-to-deploy"
+version = "0.3.4"
+notes = "Reviewed on https://fxrev.dev/761470"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.async-stream-impl]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.3.5"
+notes = "Reviewed on https://fxrev.dev/906795"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.difflib]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "0.4.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.equivalent]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.fastrand]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.9.0"
+notes = """
+`does-not-implement-crypto` is certified because this crate explicitly says
+that the RNG here is not cryptographically secure.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.glob]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.http-range-header]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.httpdate]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.3"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.instant]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.1.12"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.openssl-macros]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.pin-project-lite]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+version = "0.2.9"
+notes = "Reviewed on https://fxrev.dev/824504"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.pin-project-lite]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.9 -> 0.2.13"
+notes = "Audited at https://fxrev.dev/946396"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.predicates-core]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "1.0.6"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.predicates-tree]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "1.0.9"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro-error-attr]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.0.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.serial_test]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "2.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.serial_test_derive]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "2.0.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.termtree]]
+who = "Max Lee <endlesspring@google.com>"
+criteria = "safe-to-run"
+version = "0.4.1"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.tokio-stream]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+version = "0.1.11"
+notes = "Reviewed on https://fxrev.dev/804724"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.tokio-stream]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.11 -> 0.1.14"
+notes = "Reviewed on https://fxrev.dev/907732."
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.unicode-xid]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.2.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.version_check]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.9.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.isrg.audits.block-buffer]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.9.0"
+
+[[audits.isrg.audits.crunchy]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.2.2"
+
+[[audits.isrg.audits.either]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "1.6.1"
+
+[[audits.isrg.audits.hmac]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.12.1"
+
+[[audits.isrg.audits.num-bigint]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.3 -> 0.4.4"
+
+[[audits.isrg.audits.num-traits]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.15 -> 0.2.16"
+
+[[audits.isrg.audits.num-traits]]
+who = "Ameer Ghani <inahga@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.16 -> 0.2.17"
+
+[[audits.isrg.audits.rand_chacha]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+
+[[audits.isrg.audits.rand_core]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.6.3"
+
+[[audits.isrg.audits.thiserror]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.40 -> 1.0.43"
+
+[[audits.isrg.audits.thiserror-impl]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.40 -> 1.0.43"
+
+[[audits.isrg.audits.untrusted]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+
+[[audits.mozilla.wildcard-audits.cexpr]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+user-id = 3788 # Emilio Cobos Álvarez (emilio)
+start = "2021-06-21"
+end = "2024-04-21"
+notes = "No unsafe code, rather straight-forward parser."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.core-foundation-sys]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 5946 # Jeff Muizelaar (jrmuizel)
+start = "2020-10-14"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.encoding_rs]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+user-id = 4484 # Henri Sivonen (hsivonen)
+start = "2019-02-26"
+end = "2024-08-28"
+notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-normalization]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-11-06"
+end = "2024-05-03"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-segmentation]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-05-15"
+end = "2024-05-03"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.unicode-width]]
+who = "Manish Goregaokar <manishsmail@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 1139 # Manish Goregaokar (Manishearth)
+start = "2019-12-05"
+end = "2024-05-03"
+notes = "All code written or reviewed by Manish"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.android_system_properties]]
+who = "Nicolas Silva <nical@fastmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.2"
+notes = "I wrote this crate, reviewed by jimb. It is mostly a Rust port of some C++ code we already ship."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.android_system_properties]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.android_system_properties]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.5"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.57 -> 1.0.61"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.58 -> 1.0.57"
+notes = "No functional differences, just CI config and docs."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.61 -> 1.0.62"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.62 -> 1.0.68"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.anyhow]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.68 -> 1.0.69"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.autocfg]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "All code written or reviewed by Josh Stone."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+version = "0.59.2"
+notes = "I'm the primary author and maintainer of the crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+delta = "0.59.2 -> 0.63.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.63.0 -> 0.64.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bindgen]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.64.0 -> 0.66.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Aria Beingessner <a.beingessner@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.5.2"
+notes = "Another crate I own via contain-rs that is ancient and maintenance mode, no known issues."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.5.2 -> 0.5.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Aria Beingessner <a.beingessner@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.6.3"
+notes = "Another crate I own via contain-rs that is ancient and in maintenance mode but otherwise perfectly fine."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.block-buffer]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.2 -> 0.10.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cc]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.73 -> 1.0.78"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cc]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.78 -> 1.0.83"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crypto-common]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.3 -> 0.1.6"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.debugid]]
+who = "Gabriele Svelto <gsvelto@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.8.0"
+notes = "This crates was written by Sentry and I've fully audited it as Firefox crash reporting machinery relies on it."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.doc-comment]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "0.3.3"
+notes = """
+Trivial macro crate implementing a trick for expanding macros within doc
+comments on older versions of rustc.
+"""
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.6.1 -> 1.7.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.7.0 -> 1.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.8.0 -> 1.8.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.errno]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.3.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.9.0 -> 2.0.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fnv]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.7"
+notes = "Simple hasher implementation with no unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.form_urlencoded]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.2.0 -> 1.2.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.futures-channel]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.27 -> 0.3.28"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.futures-core]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.27 -> 0.3.28"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.half]]
+who = "John M. Schanck <jschanck@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.8.2"
+notes = """
+This crate contains unsafe code for bitwise casts to/from binary16 floating-point
+format. I've reviewed these and found no issues. There are no uses of ambient
+capabilities.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hashbrown]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+version = "0.12.3"
+notes = "This version is used in rust's libstd, so effectively we're already trusting it"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.headers-core]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+notes = "Trivial crate, no unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.heck]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hex]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.idna]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.lazy_static]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "1.4.0"
+notes = "I have read over the macros, and audited the unsafe code."
+aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.17"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.17 -> 0.4.18"
+notes = "One dependency removed, others updated (which we don't rely on), some APIs (which we don't use) changed."
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Kagami Sascha Rosylight <krosylight@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.18 -> 0.4.20"
+notes = "Only cfg attribute and internal macro changes and module refactorings"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.new_debug_unreachable]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.4"
+notes = "This is a trivial crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-bigint]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "0.4.3"
+notes = "All code written or reviewed by Josh Stone."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-integer]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "0.1.45"
+notes = "All code written or reviewed by Josh Stone."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-iter]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "0.1.43"
+notes = "All code written or reviewed by Josh Stone."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-traits]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "0.2.15"
+notes = "All code written or reviewed by Josh Stone."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.peeking_take_while]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.0 -> 0.1.2"
+notes = "Small refactor of some simple iterator logic, no unsafe code or capabilities."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.0 -> 2.3.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.percent-encoding]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.0 -> 2.3.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.phf_shared]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.11.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.precomputed-hash]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "This is a trivial crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.quote]]
+who = "Nika Layzell <nika@thelayzells.com>"
+criteria = "safe-to-deploy"
+version = "1.0.18"
+notes = """
+`quote` is a utility crate used by proc-macros to generate TokenStreams
+conveniently from source code. The bulk of the logic is some complex
+interlocking `macro_rules!` macros which are used to parse and build the
+`TokenStream` within the proc-macro.
+
+This crate contains no unsafe code, and the internal logic, while difficult to
+read, is generally straightforward. I have audited the the quote macros, ident
+formatter, and runtime logic.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.quote]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.18 -> 1.0.21"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.quote]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.21 -> 1.0.23"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.quote]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.27 -> 1.0.28"
+notes = "Enabled on wasm targets"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.quote]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.28 -> 1.0.31"
+notes = "Minimal changes and removal of the build.rs"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rand_core]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.6.3 -> 0.6.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rustc-hash]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "Straightforward crate with no unsafe code, does what it says on the tin."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rustversion]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.0.9"
+notes = """
+This crate has a build-time component and procedural macro logic, which I looked
+at enough to convince myself it wasn't going to do anything dramatically wrong.
+I don't think logic bugs in the version parsing etc can realistically introduce
+a security vulnerability.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.rustversion]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.9 -> 1.0.14"
+notes = "Doc updates, minimal CI changes and a fix to build-script reruns"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.subtle]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "2.5.0"
+notes = "The goal is to provide some constant-time correctness for cryptographic implementations. The approach is reasonable, it is known to be insufficient but this is pointed out in the documentation."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.unicode-ident]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.8 -> 1.0.9"
+notes = "Dependency updates only"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+version = "2.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.0 -> 2.4.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.url]]
+who = "Valentin Gosu <valentin.gosu@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.1 -> 2.5.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.zcash.audits.anyhow]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.71 -> 1.0.75"
+notes = """
+`unsafe` changes are migrating from `core::any::Demand` to `std::error::Request` when the
+nightly features are available.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.anyhow]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.75 -> 1.0.77"
+notes = """
+- Build script changes are to rerun cargo if the `RUSTC_BOOTSTRAP` env variable
+  changes, and enable a few more `rustc` config flags.
+- Some `unsafe fn`s were altered to add `unsafe` blocks, to make the safety
+  contracts in the code clearer (instead of using the `unsafe fn`'s implicit
+  `unsafe` block); no actual `unsafe` changes were made.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.anyhow]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.77 -> 1.0.79"
+notes = """
+Build script changes are to refactor the existing probe into a separate file
+(which removes a filesystem write), and adjust how it gets rerun in response to
+changes in the build environment.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.block-buffer]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.10.3 -> 0.10.4"
+notes = "Adds panics to prevent a block size of zero from causing unsoundness."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.either]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.8.1 -> 1.9.0"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.errno]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.3 -> 0.3.8"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.futures-channel]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.28 -> 0.3.29"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.futures-channel]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.29 -> 0.3.30"
+notes = "Removes `build.rs` now that it can rely on the `target_has_atomic` attribute."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.futures-core]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.28 -> 0.3.29"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.futures-core]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.29 -> 0.3.30"
+notes = "Removes `build.rs` now that it can rely on the `target_has_atomic` attribute."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.inout]]
+who = "Daira Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+version = "0.1.3"
+notes = "Reviewed in full."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.quote]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.31 -> 1.0.33"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.quote]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.33 -> 1.0.35"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.regex-syntax]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.7.5 -> 0.8.2"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.rustc-demangle]]
+who = "Sean Bowe <ewillbefull@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.21 -> 0.1.22"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.rustc-demangle]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.1.22 -> 0.1.23"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.rustc_version]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+notes = """
+Most of the crate is code to parse and validate the output of `rustc -vV`. The caller can
+choose which `rustc` to use, or can use `rustc_version::{version, version_meta}` which will
+try `$RUSTC` followed by `rustc`.
+
+If an adversary can arbitrarily set the `$RUSTC` environment variable then this crate will
+execute arbitrary code. But when this crate is used within a build script, `$RUSTC` should
+be set correctly by `cargo`.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.semver]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.17 -> 1.0.18"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.semver]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.18 -> 1.0.19"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.semver]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.19 -> 1.0.20"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.sharded-slab]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.7"
+notes = "Only change to an `unsafe` block is to fix a clippy lint."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.signature]]
+who = "Daira Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+version = "2.1.0"
+notes = """
+This crate uses `#![forbid(unsafe_code)]`, has no build script, and only provides traits with some trivial default implementations.
+I did not review whether implementing these APIs would present any undocumented cryptographic hazards.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.signature]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "2.1.0 -> 2.2.0"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.43 -> 1.0.48"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.48 -> 1.0.51"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.51 -> 1.0.52"
+notes = "Reruns the build script if the `RUSTC_BOOTSTRAP` env variable changes."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.52 -> 1.0.56"
+notes = """
+Build script changes are to refactor the existing probe into a separate file
+(which removes a filesystem write), and adjust how it gets rerun in response to
+changes in the build environment.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.43 -> 1.0.48"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.48 -> 1.0.51"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.51 -> 1.0.52"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.52 -> 1.0.56"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thread_local]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "1.1.4 -> 1.1.7"
+notes = """
+New `unsafe` usage:
+- An extra `deallocate_bucket`, to replace a `Mutex::lock` with a `compare_exchange`.
+- Setting and getting a `#[thread_local] static mut Option<Thread>` on nightly.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.time-core]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.1.2"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.tinyvec_macros]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+notes = "Adds `#![forbid(unsafe_code)]` and license files."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.tracing-subscriber]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.17 -> 0.3.18"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.try-lock]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.4 -> 0.2.5"
+notes = "Bumps MSRV to remove unsafe code block."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.unicode-ident]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.9 -> 1.0.12"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.want]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.3.1"
+notes = """
+Migrates to `try-lock 0.2.4` to replace some unsafe APIs that were not marked
+`unsafe` (but that were being used safely).
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

This PR aims to implement basic supply chain security to mitigate the impact of attackers introducing malicious code into dependencies that SurrealDB relies on. At this stage, our aim is to introduce a basic mechanism by which dependency source and access is at least considered as part of the CI process, to reduce the attack surface of SurrealDB by limiting the number of dependencies completely exposed to supply chain attacks and to raise the bar for the effort needed to perform a successful supply chain attack against many of the current SurrealDB dependencies.

## What does this change do?

This change implements a basic configuration of [`cargo-vet`](https://mozilla.github.io/cargo-vet/index.html) and [`cargo-acl` (i.e. Cackle)](https://github.com/cackle-rs/cackle) for the main SurrealDB repository. Ownership of the configuration files for these tools is assigned to @surrealdb/security group in the `.github/CODEOWNERS` file. It also ensures that those tools are executed as part of the CI process. When the CI process fails, a message point the user to the supply chain security README file. The contents of this PR description can also be found in this dedicated README file under `supply-chain/README.md`.

**Important**: Due to `cargo-acl` having to build the SurrealDB binary, the whole dependency checking action will take about a minute more (totaling almost 20 minutes) as the currently longest running action, which is "Test workspace". This will improve as we improve build times in general, but will currently increase total CI build times by about one minute.

Our current implementation of supply chain security has been added to our Open Source Security Policy (now renamed from just "Security Policy"), which links to the aforementioned README file.

### Security Compromises

At this stage, the following compromises are made due to lack of dedicated resources to audit dependencies:
- Dependencies published by SurrealDB employees are trusted by default when they are the only publisher.
- Dependencies audited directly (i.e. not transitively) by [some trusted organizations](https://raw.githubusercontent.com/bholley/cargo-vet/main/registry.toml) are trusted by default.
- Any dependencies that have not yet been audited are exempt from the vetting process.

In this implementation, it is important to note that `cargo-vet` is only used as an informational tool and that no significant security review will be performed by SurrealDB for third-party dependencies. The `cargo-vet` tool will be used to collect information from third-party audits that can be used to inform the decision of allowing or denying newly required access through `cargo-acl` as well as inventory which dependencies are published by trusted developers.

Using `cargo-acl`, the minimum required permissions for each existing dependency (from a total of 594 dependencies, only 272 required no special permissions) have been granted without any significant review. This limits the exposure to supply chain attacks that require additional access (e.g. a dependency only granted `net` would not be able to suddenly read files and exfiltrate them over the network), but would still allow for dependencies that have been granted some level of access (specially `unsafe`, `fs` and procedural macros) to leverage this access to conduct significant supply chain attacks. Ideally, dependencies granted higher level of access should be reviewed in the future by leveraging `cargo-vet`.

### Process

The following is a simplified lightweight process to support contributors in passing dependency checking.

Using the dependency tools locally requires installing the following software:

```bash
cargo install --locked cargo-deny
cargo install --locked cargo-vet

# Linux
cargo install --locked cargo-acl
sudo apt install -y bubblewrap # Adapt as required

# Other Systems (Docker)
# You will need to build the following image at least once:
docker build -t surrealdb-local/builder --target builder -f docker/Dockerfile .
# Disable the sandboxing configuration in favor of Docker.
sed -i 's/kind = "Bubblewrap"/kind = "Disabled"/g' cackle.toml
# Run Cackle interactively inside the Docker image.
docker run --entrypoint /bin/bash -it --rm -v $(pwd):/app -w /app surrealdb-local/builder \
  -c "cargo install cargo-acl && cargo acl"
# Revert the sandboxing configuration before committing your changes.
sed -i 's/kind = "Disabled"/kind = "Bubblewrap"/g' cackle.toml
```

The following process can be followed whenever the dependency checking action fails:

- If the action fails due to `cargo-deny`:
  - Identify the affected dependency.
  - In a separate branch, run `cargo update <PACKAGE>`.
    - If there is no fix or an update is not possible:
      - Add an [exception to the `deny.toml`](https://github.com/surrealdb/surrealdb/blob/main/deny.toml#L64) file.
      - Add a comment to the exception with its rationale and the conditions for it to be removed.
  - Request the changes on a separate PR. Paste the vulnerability details provided by `cargo-deny`.
  - The PR containing the dependency update will be approved by @surrealdb/security.
  - Rebase your original branch so that the dependency is updated.
- If the action fails due to `cargo-vet`:
  - This means that the dependency has not yet been trusted, audited nor exempted.
  - If this is a new dependency, think about whether or not it needs to be introduced to SurrealDB.
  - If the dependency should be introduced:
    - If published by [a SurrealDB employee](https://github.com/orgs/surrealdb/people), it can be trusted as `safe-to-deploy`.
      - Ensure that all publishers of the dependency are SurrealDB employees.
      - `cargo vet trust <PACKAGE>`
    - Otherwise, it can be (for now) exempted from the vetting process.
      - `cargo vet add-exemption <PACKAGE>`
  - The changes will be approved by @surrealdb/security.
- If the action fails due to `cargo-acl`:
  - The newly required access (e.g. `unsafe`, `fs`, `net`...) should be understood by the author of the PR.
  - If an audit is present in [`supply-chain/audits.toml`](https://github.com/surrealdb/surrealdb/blob/main/supply-chain/audit.toml), you may review it to understand the required access.
  - If the newly required permissions are understood and accepted.
    - Locally run `cargo acl`. When the required access dialog appears, press `f`.
      - Alternatively, you can directly edit the [`cackle.toml`](https://github.com/surrealdb/surrealdb/blob/main/cackle.toml) file to add the necessary permissions.
    - Select the minimum access that you believe the dependency should be granted.
    - Commit and push the changes to the config files to your PR.
    - In your PR add a brief explanation of the granted access.
    - The changes will be approved by @surrealdb/security.

## What is your testing strategy?

Ensure that the Github actions pass at their current state. 

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
