### PR TITLE
Reduce scope of some tick functions in ds RE change feeds

### DIFF
--- a/lib/src/kvs/ds.rs
+++ b/lib/src/kvs/ds.rs
@@ -829,7 +829,7 @@ impl Datastore {
 	}
 
 	// save_timestamp_for_versionstamp saves the current timestamp for the each database's current versionstamp.
-	pub async fn save_timestamp_for_versionstamp(&self, ts: u64) -> Result<(), Error> {
+	pub(crate) async fn save_timestamp_for_versionstamp(&self, ts: u64) -> Result<(), Error> {
 		let mut tx = self.transaction(Write, Optimistic).await?;
 		if let Err(e) = self.save_timestamp_for_versionstamp_impl(ts, &mut tx).await {
 			return match tx.cancel().await {
@@ -865,7 +865,7 @@ impl Datastore {
 	}
 
 	// garbage_collect_stale_change_feeds deletes all change feed entries that are older than the watermarks.
-	pub async fn garbage_collect_stale_change_feeds(&self, ts: u64) -> Result<(), Error> {
+	pub(crate) async fn garbage_collect_stale_change_feeds(&self, ts: u64) -> Result<(), Error> {
 		let mut tx = self.transaction(Write, Optimistic).await?;
 		if let Err(e) = self.garbage_collect_stale_change_feeds_impl(ts, &mut tx).await {
 			return match tx.cancel().await {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Have unnecessary scope exposure on the ds struct for some internal tick functionality. The ticks aren't being tested externally, so can be set to pub(crate) instead. We could hypothetically reduce the scope of all such methods.

## What does this change do?

Reduce scope, before people start relying on the existence of these functions.

## What is your testing strategy?

make serve

## Is this related to any issues?

LQ on CF changes signatures #3392 which would be a breaking change as well, but it demonstrates that these functions shouldn't be exposed.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
