### PR TITLE
Release the core crate together with the SDK crate and binaries

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -57,3 +57,80 @@ jobs:
       publish: ${{ inputs.publish }}
       create-release: ${{ inputs.publish }}
     secrets: inherit
+
+  bump-version:
+    name: Bump main version
+    if: ${{ needs.checks.outputs.branch == 'main' }}
+    needs: [checks, release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: releases/beta
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Install a TOML parser
+        run: cargo install --force --locked --version 0.8.1 taplo-cli
+
+      - name: Create version bump branch
+        id: bump
+        run: |
+          set -x
+
+          # Retrieve just released version
+          betaVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
+          major=$(echo $betaVersion | tr "." "\n" | sed -n 1p)
+          minor=$(echo $betaVersion | tr "." "\n" | sed -n 2p)
+          nightlyVersion=${major}.$(($minor + 1)).0
+          echo "version=${nightlyVersion}" >> $GITHUB_OUTPUT
+
+          # Checkout the main branch
+          git fetch origin main
+          git checkout main
+
+          # Switch to version bump branch
+          git checkout -b version-bump/v${nightlyVersion}
+
+          # Bump the crate version
+          sed -i "s#^version = \".*\"#version = \"${nightlyVersion}\"#" Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${nightlyVersion}\"#" lib/Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${nightlyVersion}\"#" core/Cargo.toml
+
+          # Update Cargo.lock without updating dependency versions
+          cargo check --no-default-features --features storage-mem
+
+      - name: Push the branch
+        if: ${{ inputs.publish }}
+        run: |
+          # Configure git
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config --add --bool push.autoSetupRemote true
+
+          # Commit changes
+          git commit -am "Bump version to v${{ steps.bump.outputs.version }}"
+          git push
+
+      - name: Create a PR
+        id: pr
+        if: ${{ inputs.publish }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          url=$(gh pr create --base main --title "Bump version to v${{ steps.bump.outputs.version }}" --body "Update main version")
+          echo "url=${url}" >> $GITHUB_OUTPUT
+
+      - name: Merge the PR
+        if: ${{ inputs.publish }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can approve and merge the PR
+        run: |
+          set -x
+          gh pr review ${{ steps.pr.outputs.url }} --approve
+          gh pr merge ${{ steps.pr.outputs.url }} --delete-branch --admin --squash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,89 +70,16 @@ jobs:
       ml: ${{ inputs.ml }}
     secrets: inherit
 
-  release-branch:
+  delete-branches:
     name: Bump main version
+    if: ${{ inputs.publish }}
     needs: [release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
-
-      - name: Install stable toolchain
-        if: ${{ inputs.branch == 'releases/beta' || inputs.latest }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: Install a TOML parser
-        if: ${{ inputs.branch == 'releases/beta' || inputs.latest }}
-        run: cargo install --force --locked --version 0.8.1 taplo-cli
-
-      - name: Create version bump branch
-        id: bump
-        if: ${{ inputs.branch == 'releases/beta' || inputs.latest }}
-        run: |
-          set -x
-
-          # When moving from beta we are going to pull the version from the stable branch
-          if [[ "${{ inputs.branch }}" == "releases/beta" ]]; then
-            git fetch origin releases/stable
-            git checkout releases/stable
-          fi
-
-          # Retrieve just released version
-          version=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
-          echo "version=${version}" >> $GITHUB_OUTPUT
-
-          # Checkout the main branch
-          git fetch origin main
-          git checkout main
-
-          # Switch to version bump branch
-          git checkout -b version-bump/v${version}
-
-          # Bump the crate version
-          sed -i "s#^version = \".*\"#version = \"${version}\"#" Cargo.toml
-          sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
-
-          # Update Cargo.lock without updating dependency versions
-          cargo check --no-default-features --features storage-mem
-
-      - name: Push the branch
-        if: ${{ inputs.publish && (inputs.branch == 'releases/beta' || inputs.latest) }}
-        run: |
-          # Configure git
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          git config --add --bool push.autoSetupRemote true
-
-          # Commit changes
-          git commit -am "Bump version to v${{ steps.bump.outputs.version }}"
-          git push
-
-      - name: Create a PR
-        id: pr
-        if: ${{ inputs.publish && (inputs.branch == 'releases/beta' || inputs.latest) }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -x
-          url=$(gh pr create --base main --title "Bump version to v${{ steps.bump.outputs.version }}" --body "Update main version")
-          echo "url=${url}" >> $GITHUB_OUTPUT
-
-      - name: Merge the PR
-        if: ${{ inputs.publish && (inputs.branch == 'releases/beta' || inputs.latest) }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can approve and merge the PR
-        run: |
-          set -x
-          gh pr review ${{ steps.pr.outputs.url }} --approve
-          gh pr merge ${{ steps.pr.outputs.url }} --delete-branch --admin --squash
 
       - name: Delete the release branch
-        if: ${{ inputs.publish }}
         run: |
           set -x
           git push origin --delete ${{ inputs.branch }} || true

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -107,6 +107,7 @@ jobs:
             # Bump the crate version
             sed -i "s#^version = \".*\"#version = \"${version}\"#" Cargo.toml
             sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
+            sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
 
             # Update Cargo.lock without updating dependency versions
             cargo check --no-default-features --features storage-mem
@@ -147,6 +148,7 @@ jobs:
           # Bump the crate version
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" lib/Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" core/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem
@@ -615,6 +617,7 @@ jobs:
 
           # Update crate version
           sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
 
       - name: Patch nightly crate version
         if: ${{ inputs.environment == 'nightly' }}
@@ -627,6 +630,7 @@ jobs:
           # This sets the nightly version to something like `1.20231117.1130416`
           # The 1 at the beginning of the patch number is just so it never starts with zero
           sed -i "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${date}.1${time}\"#" lib/Cargo.toml
+          sed -i "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${date}.1${time}\"#" core/Cargo.toml
 
       - name: Patch crate name and description
         if: ${{ inputs.environment == 'nightly' || inputs.environment == 'beta' }}
@@ -635,9 +639,11 @@ jobs:
 
           # Patch crate name
           sed -i "0,/surrealdb/s//surrealdb-${{ inputs.environment }}/" lib/Cargo.toml
+          sed -i "0,/surrealdb-core/s//surrealdb-core-${{ inputs.environment }}/" core/Cargo.toml
 
           # Patch the description
           sed -i "s#^description = \".*\"#description = \"A ${{ inputs.environment }} release of the surrealdb crate\"#" lib/Cargo.toml
+          sed -i "s#^description = \".*\"#description = \"A ${{ inputs.environment }} release of the surrealdb-core crate\"#" core/Cargo.toml
 
           # Temporarily commit patches
           # These should not be pushed back to the repo

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -624,13 +624,17 @@ jobs:
         run: |
           # Get the date and time of the last commit
           date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
-          time=$(git show --no-patch --format=%ad --date=format:%H%M%S)
+
+          # Derive crate version
+          currentVersion=$(taplo get -f lib/Cargo.toml "package.version")
+          major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
+          minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
+          # This sets the nightly version to something like `1.3.20231117`
+          version=${major}.${minor}.${date}
 
           # Update the version to a nightly one
-          # This sets the nightly version to something like `1.20231117.1130416`
-          # The 1 at the beginning of the patch number is just so it never starts with zero
-          sed -i "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${date}.1${time}\"#" lib/Cargo.toml
-          sed -i "s#^version = \"\([[:digit:]]*\)\..*\"#version = \"\1.${date}.1${time}\"#" core/Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
 
       - name: Patch crate name and description
         if: ${{ inputs.environment == 'nightly' || inputs.environment == 'beta' }}

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -645,6 +645,9 @@ jobs:
           sed -i "0,/surrealdb/s//surrealdb-${{ inputs.environment }}/" lib/Cargo.toml
           sed -i "0,/surrealdb-core/s//surrealdb-core-${{ inputs.environment }}/" core/Cargo.toml
 
+          # Patch lib dependency
+          sed -i "s#package = \"surrealdb-core\"#package = \"surrealdb-core-${{ inputs.environment }}\"#" lib/Cargo.toml
+
           # Patch the description
           sed -i "s#^description = \".*\"#description = \"A ${{ inputs.environment }} release of the surrealdb crate\"#" lib/Cargo.toml
           sed -i "s#^description = \".*\"#description = \"A ${{ inputs.environment }} release of the surrealdb-core crate\"#" core/Cargo.toml

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -185,3 +185,6 @@ tokio = { version = "1.34.0", default-features = false, features = [
 ] }
 tokio-tungstenite = { version = "0.20.1", optional = true }
 uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }
+
+[lib]
+name = "surrealdb_core"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -98,7 +98,7 @@ rustls = { version = "0.21.10", optional = true }
 semver = { version = "1.0.20", features = ["serde"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
-surrealdb-core = { version = "1", default-features = false, path = "../core" }
+surrealdb-core = { version = "1", default-features = false, path = "../core", package = "surrealdb-core" }
 thiserror = "1.0.50"
 tokio-util = { version = "0.7.10", optional = true, features = ["compat"] }
 tracing = "0.1.40"


### PR DESCRIPTION
## What is the motivation?

Currently the core crate is not factored in when doing a release.

## What does this change do?

It makes sure the core crate is also released. It also simplifies versioning for nightly crates and main.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
