### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@ cackle.toml @surrealdb/security
 supply-chain/* @surrealdb/security
 
 # General owners for the database
+/core/ @surrealdb/db
 /doc/ @surrealdb/db
 /lib/ @surrealdb/db
 /src/ @surrealdb/db
@@ -35,26 +36,26 @@ SECURITY.md @surrealdb/security
 /lib/CARGO.md @surrealdb/api
 /lib/README.md @surrealdb/api
 /lib/examples/ @surrealdb/api
-/lib/src/api/ @surrealdb/api
+/lib/src/ @surrealdb/api
 /lib/src/tests/api/ @surrealdb/api
 /lib/src/tests/api.rs @surrealdb/api
 
 # Code and tests for indexing
-/lib/src/idx/ @surrealdb/ix
+/core/src/idx/ @surrealdb/ix
 
 # Code and tests for changefeeds
-/lib/src/cf/ @surrealdb/cf
-/lib/src/idg/ @surrealdb/cf
-/lib/src/vs/ @surrealdb/cf
+/core/src/cf/ @surrealdb/cf
+/core/src/idg/ @surrealdb/cf
+/core/src/vs/ @surrealdb/cf
 
 # Tests related to the storage
-/lib/src/key/ @surrealdb/kv
-/lib/src/kvs/ @surrealdb/kv
+/core/src/key/ @surrealdb/kv
+/core/src/kvs/ @surrealdb/kv
 
 # Code and tests for querying
-/lib/src/sql/ @surrealdb/ql
-/lib/src/syn/ @surrealdb/ql
-/lib/src/fnc/ @surrealdb/ql
+/core/src/sql/ @surrealdb/ql
+/core/src/syn/ @surrealdb/ql
+/core/src/fnc/ @surrealdb/ql
 
 # Code and tests for the server
 /src/* @surrealdb/net
@@ -74,4 +75,4 @@ SECURITY.md @surrealdb/security
 /tests/cli_integration.rs @surrealdb/cli
 
 # Code and tests for authentication
-/lib/src/iam/ @surrealdb/api @surrealdb/security
+/core/src/iam/ @surrealdb/api @surrealdb/security

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@ Makefile.* @surrealdb/ci
 # Configuration for Rust dependencies
 Cargo.lock @surrealdb/security
 Cargo.toml @surrealdb/security
+core/Cargo.toml @surrealdb/security
 lib/Cargo.toml @surrealdb/security
 cackle.toml @surrealdb/security
 supply-chain/* @surrealdb/security


### PR DESCRIPTION
## What is the motivation?

With the introduction of the `core` crate, the `CODEOWNERS` file is now out of date.

## What does this change do?

It updates the file.

## What is your testing strategy?

Github. It says "This CODEOWNERS file is valid".

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
