### PR TITLE
Enable `sql2` and `jwks` in shipped binaries

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -75,7 +75,10 @@ jobs:
           toolchain: stable
 
       - name: Install a TOML parser
-        run: cargo install --force --locked --version 0.8.1 taplo-cli
+        run: |
+          curl -L https://github.com/tamasfe/taplo/releases/download/0.8.1/taplo-full-linux-x86_64.gz | gunzip - > taplo
+          chmod +x taplo
+          sudo mv taplo /usr/bin/taplo
 
       - name: Create version bump branch
         id: bump
@@ -83,7 +86,7 @@ jobs:
           set -x
 
           # Retrieve just released version
-          betaVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
+          betaVersion=$(taplo get -f lib/Cargo.toml "package.version")
           major=$(echo $betaVersion | tr "." "\n" | sed -n 1p)
           minor=$(echo $betaVersion | tr "." "\n" | sed -n 2p)
           nightlyVersion=${major}.$(($minor + 1)).0

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -60,7 +60,7 @@ jobs:
 
   bump-version:
     name: Bump main version
-    if: ${{ inputs.publish && needs.checks.outputs.branch == 'main' }}
+    if: ${{ inputs.publish }}
     needs: [checks, release]
     runs-on: ubuntu-latest
     steps:
@@ -80,7 +80,7 @@ jobs:
           chmod +x taplo
           sudo mv taplo /usr/bin/taplo
 
-      - name: Create version bump branch
+      - name: Get version info
         id: bump
         run: |
           set -x
@@ -89,25 +89,33 @@ jobs:
           betaVersion=$(taplo get -f lib/Cargo.toml "package.version")
           major=$(echo $betaVersion | tr "." "\n" | sed -n 1p)
           minor=$(echo $betaVersion | tr "." "\n" | sed -n 2p)
+          betaNum=$(echo $betaVersion | tr "." "\n" | sed -n 4p)
           nightlyVersion=${major}.$(($minor + 1)).0
           echo "version=${nightlyVersion}" >> $GITHUB_OUTPUT
+          echo "beta-num=${betaNum}"  >> $GITHUB_OUTPUT
+
+      - name: Create version bump branch
+        if: ${{ steps.bump.outputs.beta-num == '1' }}
+        run: |
+          set -x
 
           # Checkout the main branch
           git fetch origin main
           git checkout main
 
           # Switch to version bump branch
-          git checkout -b version-bump/v${nightlyVersion}
+          git checkout -b version-bump/v${{ steps.bump.outputs.version }}
 
           # Bump the crate version
-          sed -i "s#^version = \".*\"#version = \"${nightlyVersion}\"#" Cargo.toml
-          sed -i "s#^version = \".*\"#version = \"${nightlyVersion}\"#" lib/Cargo.toml
-          sed -i "s#^version = \".*\"#version = \"${nightlyVersion}\"#" core/Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${{ steps.bump.outputs.version }}\"#" Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${{ steps.bump.outputs.version }}\"#" lib/Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${{ steps.bump.outputs.version }}\"#" core/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem
 
       - name: Push the branch
+        if: ${{ steps.bump.outputs.beta-num == '1' }}
         run: |
           # Configure git
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -119,6 +127,7 @@ jobs:
           git push
 
       - name: Create a PR
+        if: ${{ steps.bump.outputs.beta-num == '1' }}
         id: pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -128,6 +137,7 @@ jobs:
           echo "url=${url}" >> $GITHUB_OUTPUT
 
       - name: Merge the PR
+        if: ${{ steps.bump.outputs.beta-num == '1' }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can approve and merge the PR
         run: |

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -60,7 +60,7 @@ jobs:
 
   bump-version:
     name: Bump main version
-    if: ${{ needs.checks.outputs.branch == 'main' }}
+    if: ${{ inputs.publish && needs.checks.outputs.branch == 'main' }}
     needs: [checks, release]
     runs-on: ubuntu-latest
     steps:
@@ -108,7 +108,6 @@ jobs:
           cargo check --no-default-features --features storage-mem
 
       - name: Push the branch
-        if: ${{ inputs.publish }}
         run: |
           # Configure git
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -121,7 +120,6 @@ jobs:
 
       - name: Create a PR
         id: pr
-        if: ${{ inputs.publish }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -130,7 +128,6 @@ jobs:
           echo "url=${url}" >> $GITHUB_OUTPUT
 
       - name: Merge the PR
-        if: ${{ inputs.publish }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can approve and merge the PR
         run: |

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -142,7 +142,7 @@ jobs:
             git checkout -b releases/beta
             major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
             minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
-            betaVersion=${major}.$(($minor + 1)).0-beta.1
+            betaVersion=${major}.${minor}.0-beta.1
           fi
 
           # Bump the crate version

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -425,6 +425,7 @@ jobs:
                 --pull always \
                 -v $(pwd):/surrealdb \
                 -e SURREAL_BUILD_METADATA=$SURREAL_BUILD_METADATA \
+                -e RUSTFLAGS=$RUSTFLAGS \
                 -e ORT_STRATEGY=$ORT_STRATEGY \
                 -e ORT_LIB_LOCATION=$ORT_LIB_LOCATION \
                 -v $ORT_LIB_LOCATION:$ORT_LIB_LOCATION \
@@ -469,6 +470,7 @@ jobs:
                 --pull always \
                 -v $(pwd):/surrealdb \
                 -e SURREAL_BUILD_METADATA=$SURREAL_BUILD_METADATA \
+                -e RUSTFLAGS=$RUSTFLAGS \
                 -e ORT_STRATEGY=$ORT_STRATEGY \
                 -e ORT_LIB_LOCATION=$ORT_LIB_LOCATION \
                 -v $ORT_LIB_LOCATION:$ORT_LIB_LOCATION \

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -425,7 +425,7 @@ jobs:
                 --pull always \
                 -v $(pwd):/surrealdb \
                 -e SURREAL_BUILD_METADATA=$SURREAL_BUILD_METADATA \
-                -e RUSTFLAGS=$RUSTFLAGS \
+                -e RUSTFLAGS="${RUSTFLAGS}" \
                 -e ORT_STRATEGY=$ORT_STRATEGY \
                 -e ORT_LIB_LOCATION=$ORT_LIB_LOCATION \
                 -v $ORT_LIB_LOCATION:$ORT_LIB_LOCATION \
@@ -470,7 +470,7 @@ jobs:
                 --pull always \
                 -v $(pwd):/surrealdb \
                 -e SURREAL_BUILD_METADATA=$SURREAL_BUILD_METADATA \
-                -e RUSTFLAGS=$RUSTFLAGS \
+                -e RUSTFLAGS="${RUSTFLAGS}" \
                 -e ORT_STRATEGY=$ORT_STRATEGY \
                 -e ORT_LIB_LOCATION=$ORT_LIB_LOCATION \
                 -v $ORT_LIB_LOCATION:$ORT_LIB_LOCATION \
@@ -555,7 +555,7 @@ jobs:
       - name: Build step
         env:
           SURREAL_BUILD_METADATA: ${{ needs.prepare-vars.outputs.build-metadata }}
-          RUSTFLAGS: '"--cfg surrealdb_unstable"'
+          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: ${{ matrix.build-step }}
 
       - name: Upload artifacts

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -591,7 +591,7 @@ jobs:
           sudo chmod +x /usr/bin/release-plz
 
       - name: Install a TOML parser
-        if: ${{ inputs.environment == 'beta' }}
+        if: ${{ inputs.environment == 'nightly' || inputs.environment == 'beta' }}
         run: |
           curl -L https://github.com/tamasfe/taplo/releases/download/0.8.1/taplo-full-linux-x86_64.gz | gunzip - > taplo
           chmod +x taplo

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -625,7 +625,7 @@ jobs:
           # Update crate version
           sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
-          sed -i "s#surrealdb-core = { version = \"=${currentVersion}\"#surrealdb-core = { version = \"1\"#" lib/Cargo.toml
+          sed -i "s#surrealdb-core = { version = \"=${currentVersion}\"#surrealdb-core = { version = \"=${version}\"#" lib/Cargo.toml
 
       - name: Patch nightly crate version
         if: ${{ inputs.environment == 'nightly' }}
@@ -643,6 +643,7 @@ jobs:
           # Update the version to a nightly one
           sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
+          sed -i "s#surrealdb-core = { version = \"1\"#surrealdb-core = { version = \"=${version}\"#" lib/Cargo.toml
 
       - name: Patch crate name and description
         if: ${{ inputs.environment == 'nightly' || inputs.environment == 'beta' }}

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -343,7 +343,7 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv
+              features=storage-tikv,sql2
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -377,7 +377,7 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv
+              features=storage-tikv,sql2
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -405,7 +405,7 @@ jobs:
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
               # Build
-              features=storage-tikv
+              features=storage-tikv,sql2
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -449,7 +449,7 @@ jobs:
               set -x
 
               # Build
-              features=storage-tikv
+              features=storage-tikv,sql2
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -496,7 +496,7 @@ jobs:
               vcpkg integrate install
 
               # Build
-              features=storage-tikv
+              features=storage-tikv,sql2
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -553,6 +553,7 @@ jobs:
       - name: Build step
         env:
           SURREAL_BUILD_METADATA: ${{ needs.prepare-vars.outputs.build-metadata }}
+          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: ${{ matrix.build-step }}
 
       - name: Upload artifacts

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -625,8 +625,7 @@ jobs:
           # Update crate version
           sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
-          sed -i "s#surrealdb = { version = \".*\"#surrealdb = { version = \"1\"#" Cargo.toml
-          sed -i "s#surrealdb-core = { version = \".*\"#surrealdb-core = { version = \"1\"#" lib/Cargo.toml
+          sed -i "s#surrealdb-core = { version = \"=${currentVersion}\"#surrealdb-core = { version = \"1\"#" lib/Cargo.toml
 
       - name: Patch nightly crate version
         if: ${{ inputs.environment == 'nightly' }}

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -555,7 +555,7 @@ jobs:
       - name: Build step
         env:
           SURREAL_BUILD_METADATA: ${{ needs.prepare-vars.outputs.build-metadata }}
-          RUSTFLAGS: "--cfg surrealdb_unstable"
+          RUSTFLAGS: '"--cfg surrealdb_unstable"'
         run: ${{ matrix.build-step }}
 
       - name: Upload artifacts

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -149,7 +149,10 @@ jobs:
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" core/Cargo.toml
-          sed -i "s#surrealdb-core = { version = \"1\"#surrealdb-core = { version = \"${betaVersion}\"#" lib/Cargo.toml
+
+          # Update dependency versions
+          sed -i "s#surrealdb = { version = \"1\"#surrealdb = { version = \"=${betaVersion}\"#" Cargo.toml
+          sed -i "s#surrealdb-core = { version = \"1\"#surrealdb-core = { version = \"=${betaVersion}\"#" lib/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem
@@ -619,6 +622,8 @@ jobs:
           # Update crate version
           sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
+          sed -i "s#surrealdb = { version = \".*\"#surrealdb = { version = \"1\"#" Cargo.toml
+          sed -i "s#surrealdb-core = { version = \".*\"#surrealdb-core = { version = \"1\"#" lib/Cargo.toml
 
       - name: Patch nightly crate version
         if: ${{ inputs.environment == 'nightly' }}

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -343,7 +343,7 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv,sql2
+              features=storage-tikv,sql2,jwks
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -377,7 +377,7 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv,sql2
+              features=storage-tikv,sql2,jwks
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -405,7 +405,7 @@ jobs:
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
               # Build
-              features=storage-tikv,sql2
+              features=storage-tikv,sql2,jwks
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -450,7 +450,7 @@ jobs:
               set -x
 
               # Build
-              features=storage-tikv,sql2
+              features=storage-tikv,sql2,jwks
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -498,7 +498,7 @@ jobs:
               vcpkg integrate install
 
               # Build
-              features=storage-tikv,sql2
+              features=storage-tikv,sql2,jwks
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -149,6 +149,7 @@ jobs:
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" core/Cargo.toml
+          sed -i "s#surrealdb-core = { version = \"1\"#surrealdb-core = { version = \"${betaVersion}\"#" lib/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem


### PR DESCRIPTION
## What is the motivation?

The current workflows do not enable those features.

## What does this change do?

It enables the features when building the binaries and fixes some bugs in the workflows.

## What is your testing strategy?

Used this changeset to deploy `v1.2.0-beta.1`.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
