### PR TITLE
Export namespace users 

### DIFF
--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -2841,9 +2841,7 @@ mod tests {
 
 		// Process all chunk values
 		tokio::spawn(async move {
-			let mut expected = String::from("-- ------------------------------");
-			expected.push_str("-- NS USERS");
-			expected.push_str("-- ------------------------------");
+			let expected = String::from("-- NS USERS");
 
 			let mut result = String::new();
 
@@ -2853,8 +2851,9 @@ mod tests {
 			}
 
 			assert_eq!(result.to_string().contains(&expected), true);
-		}).await.unwrap();
-
+		})
+		.await
+		.unwrap();
 
 		txn.commit().await.unwrap();
 	}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -103,9 +103,8 @@ mod cli_integration {
 
 		info!("Export namespace users");
 		{
-			let args = format!(
-				"sql --conn http://{addr} {creds} --ns {ns} --db {db} --multi --pretty",
-			);
+			let args =
+				format!("sql --conn http://{addr} {creds} --ns {ns} --db {db} --multi --pretty",);
 
 			// Create DATABASE and NAMESPACE users
 			common::run(&args)
@@ -119,16 +118,18 @@ mod cli_integration {
 				.output()
 				.unwrap();
 
-			let args = format!(
-				"export --conn http://{addr} {creds} --ns {ns} --db {db}",
+			let args = format!("export --conn http://{addr} {creds} --ns {ns} --db {db}",);
+
+			let output = common::run(&args).output().unwrap();
+
+			assert!(
+				output.contains("DEFINE USER user_ns ON NAMESPACE"),
+				"namespace users were not exported"
 			);
-
-			let output = common::run(&args)
-				.output()
-				.unwrap();
-
-			assert!(output.contains("DEFINE USER user_ns ON NAMESPACE"), "namespace users were not exported");
-			assert!(output.contains("DEFINE USER user_db ON DATABASE"), "database users were not exported");
+			assert!(
+				output.contains("DEFINE USER user_db ON DATABASE"),
+				"database users were not exported"
+			);
 		}
 
 		let db2 = Ulid::new();

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -627,6 +627,27 @@ mod http_integration {
 			assert!(body.contains("DEFINE TABLE foo"), "body: {}", body);
 		}
 
+		// Create some data
+		{
+			let res = client
+				.post(format!("http://{addr}/sql"))
+				.basic_auth(USER, Some(PASS))
+				.body("DEFINE USER user_db ON DATABASE PASSWORD 'user_db' ROLES VIEWER COMMENT 'db user';
+				DEFINE USER user_ns ON NAMESPACE PASSWORD 'user_ns' ROLES VIEWER COMMENT 'ns user';")
+				.send()
+				.await?;
+			assert_eq!(res.status(), 200, "body: {}", res.text().await?);
+		}
+
+		// Namespace user export
+		{
+			let res = client.get(url).basic_auth(USER, Some(PASS)).send().await?;
+			assert_eq!(res.status(), 200, "body: {}", res.text().await?);
+			let body = res.text().await?;
+			assert!(body.contains("DEFINE USER user_db ON DATABASE"), "body: {}", body);
+			assert!(body.contains("DEFINE USER user_ns ON NAMESPACE"), "body: {}", body);
+		}
+
 		Ok(())
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The current exporter does not export namespace users

## What does this change do?

Add the missing namespace users sql to the export file

## What is your testing strategy?

I've added test cases on both `cli` and `http` integration tests for export. 

- Add couple of users 
- export the database.
- Verify that the exported output has the namespace users created above

## Is this related to any issues?

#3430  

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
