### PR TITLE
Fix a panic when invalid builtin function names are passed to the executor

### DIFF
--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -71,7 +71,12 @@ macro_rules! dispatch {
 					#[allow(clippy::redundant_closure_call)]
 					$($wrapper)*(|| $($function_path)::+($($ctx_arg,)* args))()$(.$await)*
 				},)+
-				_ => unreachable!()
+				_ => {
+					return Err($crate::err::Error::InvalidFunction{
+						name: String::from($name),
+						message: "no such builtin function".to_string()
+					})
+				}
 			}
 		}
 	};


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently the executor panics whenever it encounters a call to a builtin function with an invalid name. This can cause panics when newer clients are used on an older database or when hand-crafted queries are passed to the database.

## What does this change do?

Make the executor return an error instead of a panic.

## What is your testing strategy?

Added a test to ensure the executor doesn't panic anymore

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
