### PR TITLE
Improve the js-surql value conversion for numbers

### DIFF
--- a/core/src/fnc/script/from.rs
+++ b/core/src/fnc/script/from.rs
@@ -24,7 +24,7 @@ fn check_nul(s: &str) -> Result<(), Error> {
 
 impl<'js> FromJs<'js> for Value {
 	fn from_js(ctx: &Ctx<'js>, val: js::Value<'js>) -> Result<Self, Error> {
-		match dbg!(val.type_of()) {
+		match val.type_of() {
 			js::Type::Undefined => Ok(Value::None),
 			js::Type::Null => Ok(Value::Null),
 			js::Type::Bool => Ok(Value::from(val.as_bool().unwrap())),

--- a/core/src/fnc/script/from.rs
+++ b/core/src/fnc/script/from.rs
@@ -6,11 +6,13 @@ use crate::sql::value::Value;
 use crate::sql::Id;
 use chrono::{TimeZone, Utc};
 use js::prelude::This;
+use js::Coerced;
 use js::Ctx;
 use js::Error;
 use js::Exception;
 use js::FromAtom;
 use js::FromJs;
+use rust_decimal::Decimal;
 
 fn check_nul(s: &str) -> Result<(), Error> {
 	if s.contains('\0') {
@@ -22,41 +24,45 @@ fn check_nul(s: &str) -> Result<(), Error> {
 
 impl<'js> FromJs<'js> for Value {
 	fn from_js(ctx: &Ctx<'js>, val: js::Value<'js>) -> Result<Self, Error> {
-		match val {
-			val if val.type_name() == "null" => Ok(Value::Null),
-			val if val.type_name() == "undefined" => Ok(Value::None),
-			val if val.is_bool() => Ok(val.as_bool().unwrap().into()),
-			val if val.is_string() => match val.into_string().unwrap().to_string() {
-				Ok(v) => {
-					check_nul(&v)?;
-					Ok(Value::from(v))
-				}
-				Err(e) => Err(e),
-			},
-			val if val.is_number() => Ok(val.as_number().unwrap().into()),
-			val if val.is_array() => {
+		match val.type_of() {
+			js::Type::Undefined => Ok(Value::None),
+			js::Type::Null => Ok(Value::Null),
+			js::Type::Bool => Ok(Value::from(val.as_bool().unwrap())),
+			js::Type::Int => Ok(Value::from(val.as_int().unwrap())),
+			js::Type::Float => Ok(Value::from(val.as_float().unwrap())),
+			js::Type::String => Ok(Value::from(val.as_string().unwrap().to_string()?)),
+			js::Type::Array => {
 				let v = val.as_array().unwrap();
 				let mut x = Array::with_capacity(v.len());
 				for i in v.iter() {
 					let v = i?;
-					let v = Value::from_js(ctx, v)?;
-					x.push(v);
+					x.push(Value::from_js(ctx, v)?);
 				}
 				Ok(x.into())
 			}
-			val if val.is_object() => {
+			js::Type::BigInt => {
+				let big_int = val.into_big_int().unwrap();
+				if let Ok(i) = big_int.clone().to_i64() {
+					return Ok(Value::from(i));
+				}
+				let str = Coerced::<String>::from_js(ctx, big_int.into())?;
+				match str.parse::<Decimal>() {
+					Ok(x) => Ok(Value::from(x)),
+					Err(e) => Err(Exception::from_message(ctx.clone(), &e.to_string())?.throw()),
+				}
+			}
+			js::Type::Object | js::Type::Exception => {
 				// Extract the value as an object
 				let v = val.into_object().unwrap();
 				// Check to see if this object is an error
 				if v.is_error() {
-					let e: String = v.get("message")?;
+					let e: String = v.get(js::atom::PredefinedAtom::Message)?;
 					let (Ok(e) | Err(e)) =
 						Exception::from_message(ctx.clone(), &e).map(|x| x.throw());
 					return Err(e);
 				}
 				// Check to see if this object is a record
-				if (v).instance_of::<classes::record::Record>() {
-					let v = v.into_class::<classes::record::Record>().unwrap();
+				if let Some(v) = v.as_class::<classes::record::Record>() {
 					let borrow = v.borrow();
 					let v: &classes::record::Record = &borrow;
 					check_nul(&v.value.tb)?;
@@ -66,8 +72,7 @@ impl<'js> FromJs<'js> for Value {
 					return Ok(v.value.clone().into());
 				}
 				// Check to see if this object is a duration
-				if (v).instance_of::<classes::duration::Duration>() {
-					let v = v.into_class::<classes::duration::Duration>().unwrap();
+				if let Some(v) = v.as_class::<classes::duration::Duration>() {
 					let borrow = v.borrow();
 					let v: &classes::duration::Duration = &borrow;
 					return match &v.value {
@@ -76,8 +81,7 @@ impl<'js> FromJs<'js> for Value {
 					};
 				}
 				// Check to see if this object is a uuid
-				if (v).instance_of::<classes::uuid::Uuid>() {
-					let v = v.into_class::<classes::uuid::Uuid>().unwrap();
+				if let Some(v) = v.as_class::<classes::uuid::Uuid>() {
 					let borrow = v.borrow();
 					let v: &classes::uuid::Uuid = &borrow;
 					return match &v.value {
@@ -86,7 +90,7 @@ impl<'js> FromJs<'js> for Value {
 					};
 				}
 				// Check to see if this object is a date
-				let date: js::Object = ctx.globals().get("Date")?;
+				let date: js::Object = ctx.globals().get(js::atom::PredefinedAtom::Date)?;
 				if (v).is_instance_of(&date) {
 					let f: js::Function = v.get("getTime")?;
 					let m: i64 = f.call((This(v),))?;
@@ -118,7 +122,7 @@ impl<'js> FromJs<'js> for Value {
 				}
 				Ok(x.into())
 			}
-			_ => Ok(Value::None),
+			_ => Ok(Value::Null),
 		}
 	}
 }

--- a/core/src/fnc/script/from.rs
+++ b/core/src/fnc/script/from.rs
@@ -28,7 +28,7 @@ impl<'js> FromJs<'js> for Value {
 			js::Type::Undefined => Ok(Value::None),
 			js::Type::Null => Ok(Value::Null),
 			js::Type::Bool => Ok(Value::from(val.as_bool().unwrap())),
-			js::Type::Int => Ok(Value::from(val.as_int().unwrap())),
+			js::Type::Int => Ok(Value::from(val.as_int().unwrap() as f64)),
 			js::Type::Float => Ok(Value::from(val.as_float().unwrap())),
 			js::Type::String => Ok(Value::from(val.as_string().unwrap().to_string()?)),
 			js::Type::Array => {

--- a/core/src/fnc/script/from.rs
+++ b/core/src/fnc/script/from.rs
@@ -24,7 +24,7 @@ fn check_nul(s: &str) -> Result<(), Error> {
 
 impl<'js> FromJs<'js> for Value {
 	fn from_js(ctx: &Ctx<'js>, val: js::Value<'js>) -> Result<Self, Error> {
-		match val.type_of() {
+		match dbg!(val.type_of()) {
 			js::Type::Undefined => Ok(Value::None),
 			js::Type::Null => Ok(Value::Null),
 			js::Type::Bool => Ok(Value::from(val.as_bool().unwrap())),
@@ -41,11 +41,11 @@ impl<'js> FromJs<'js> for Value {
 				Ok(x.into())
 			}
 			js::Type::BigInt => {
-				let big_int = val.into_big_int().unwrap();
-				if let Ok(i) = big_int.clone().to_i64() {
+				// TODO: Optimize this if rquickjs ever supports better conversion methods.
+				let str = Coerced::<String>::from_js(ctx, val)?;
+				if let Ok(i) = str.parse::<i64>() {
 					return Ok(Value::from(i));
 				}
-				let str = Coerced::<String>::from_js(ctx, big_int.into())?;
 				match str.parse::<Decimal>() {
 					Ok(x) => Ok(Value::from(x)),
 					Err(e) => Err(Exception::from_message(ctx.clone(), &e.to_string())?.throw()),

--- a/core/src/fnc/script/into.rs
+++ b/core/src/fnc/script/into.rs
@@ -2,13 +2,19 @@ use super::classes;
 use crate::sql::number::Number;
 use crate::sql::value::Value;
 use js::Array;
+use js::BigInt;
 use js::Class;
 use js::Ctx;
 use js::Error;
+use js::Exception;
 use js::IntoJs;
 use js::Null;
 use js::Object;
 use js::Undefined;
+use rust_decimal::prelude::ToPrimitive;
+
+const F64_INT_MAX: i64 = ((1u64 << f64::MANTISSA_DIGITS) - 1) as i64;
+const F64_INT_MIN: i64 = -F64_INT_MAX - 1;
 
 impl<'js> IntoJs<'js> for Value {
 	fn into_js(self, ctx: &Ctx<'js>) -> Result<js::Value<'js>, Error> {
@@ -18,50 +24,84 @@ impl<'js> IntoJs<'js> for Value {
 
 impl<'js> IntoJs<'js> for &Value {
 	fn into_js(self, ctx: &Ctx<'js>) -> Result<js::Value<'js>, Error> {
-		match self {
+		match *self {
 			Value::Null => Null.into_js(ctx),
 			Value::None => Undefined.into_js(ctx),
-			Value::Bool(boolean) => Ok(js::Value::new_bool(ctx.clone(), *boolean)),
-			Value::Strand(v) => js::String::from_str(ctx.clone(), v)?.into_js(ctx),
-			Value::Number(Number::Int(v)) => Ok(js::Value::new_int(ctx.clone(), *v as i32)),
-			Value::Number(Number::Float(v)) => Ok(js::Value::new_float(ctx.clone(), *v)),
-			&Value::Number(Number::Decimal(v)) => match v.is_integer() {
-				true => Ok(js::Value::new_int(ctx.clone(), v.try_into().unwrap_or_default())),
-				false => Ok(js::Value::new_float(ctx.clone(), v.try_into().unwrap_or_default())),
+			Value::Bool(boolean) => Ok(js::Value::new_bool(ctx.clone(), boolean)),
+			Value::Strand(ref v) => js::String::from_str(ctx.clone(), v)?.into_js(ctx),
+			Value::Number(Number::Int(v)) => {
+				if ((i32::MIN as i64)..=(i32::MAX as i64)).contains(&v) {
+					Ok(js::Value::new_int(ctx.clone(), v as i32))
+				} else if (F64_INT_MIN..=F64_INT_MAX).contains(&v) {
+					Ok(js::Value::new_float(ctx.clone(), v as f64))
+				} else {
+					Ok(js::Value::from(BigInt::from_i64(ctx.clone(), v)?))
+				}
+			}
+			Value::Number(Number::Float(v)) => Ok(js::Value::new_float(ctx.clone(), v)),
+			Value::Number(Number::Decimal(v)) => match v.is_integer() {
+				true => {
+					if let Some(v) = v.to_i64() {
+						if ((i32::MIN as i64)..=(i32::MAX as i64)).contains(&v) {
+							Ok(js::Value::new_int(ctx.clone(), v as i32))
+						} else if (F64_INT_MIN..=F64_INT_MAX).contains(&v) {
+							Ok(js::Value::new_float(ctx.clone(), v as f64))
+						} else {
+							Ok(js::Value::from(BigInt::from_i64(ctx.clone(), v)?))
+						}
+					} else {
+						Err(Exception::from_message(
+							ctx.clone(),
+							"Couldn't convert SurrealQL Decimal to JavaScript number",
+						)?
+						.throw())
+					}
+				}
+				false => {
+					if let Ok(v) = v.try_into() {
+						Ok(js::Value::new_float(ctx.clone(), v))
+					} else {
+						Err(Exception::from_message(
+							ctx.clone(),
+							"Couldn't convert SurrealQL Decimal to a JavaScript number",
+						)?
+						.throw())
+					}
+				}
 			},
-			Value::Datetime(v) => {
+			Value::Datetime(ref v) => {
 				let date: js::function::Constructor = ctx.globals().get("Date")?;
 				date.construct((v.0.timestamp_millis(),))
 			}
-			Value::Thing(v) => Ok(Class::<classes::record::Record>::instance(
+			Value::Thing(ref v) => Ok(Class::<classes::record::Record>::instance(
 				ctx.clone(),
 				classes::record::Record {
 					value: v.to_owned(),
 				},
 			)?
 			.into_value()),
-			Value::Duration(v) => Ok(Class::<classes::duration::Duration>::instance(
+			Value::Duration(ref v) => Ok(Class::<classes::duration::Duration>::instance(
 				ctx.clone(),
 				classes::duration::Duration {
 					value: Some(v.to_owned()),
 				},
 			)?
 			.into_value()),
-			Value::Uuid(v) => Ok(Class::<classes::uuid::Uuid>::instance(
+			Value::Uuid(ref v) => Ok(Class::<classes::uuid::Uuid>::instance(
 				ctx.clone(),
 				classes::uuid::Uuid {
 					value: Some(v.to_owned()),
 				},
 			)?
 			.into_value()),
-			Value::Array(v) => {
+			Value::Array(ref v) => {
 				let x = Array::new(ctx.clone())?;
 				for (i, v) in v.iter().enumerate() {
 					x.set(i, v)?;
 				}
 				x.into_js(ctx)
 			}
-			Value::Object(v) => {
+			Value::Object(ref v) => {
 				let x = Object::new(ctx.clone())?;
 				for (k, v) in v.iter() {
 					x.set(k, v)?;

--- a/lib/tests/script.rs
+++ b/lib/tests/script.rs
@@ -4,9 +4,11 @@ mod parse;
 use parse::Parse;
 mod helpers;
 use helpers::new_ds;
+use rust_decimal::Decimal;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::sql::Value;
+use surrealdb_core::sql::Number;
 
 #[tokio::test]
 async fn script_function_error() -> Result<(), Error> {
@@ -324,5 +326,51 @@ async fn script_value_function_inline_values() -> Result<(), Error> {
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
 	res.remove(0).result?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn script_function_number_conversion_test() -> Result<(), Error> {
+	let sql = r#"
+		RETURN function() {
+			if(await surrealdb.value(`2147483647`) !== 2147483647){
+				throw new Error(1)
+			}
+			if(await surrealdb.value(`9007199254740991`) !== 9007199254740991){
+				throw new Error(2)
+			}
+			if(await surrealdb.value(`9007199254740992`) !== 9007199254740992n){
+				throw new Error(3)
+			}
+			if(await surrealdb.value(`-9007199254740992`) !== -9007199254740992){
+				throw new Error(4)
+			}
+			if(await surrealdb.value(`-9007199254740993`) !== -9007199254740993n){
+				throw new Error(5)
+			}
+			return {
+				a:  9007199254740991,
+				b: -9007199254740992,
+				c: 100000000000000000n,
+				d: 9223372036854775808n
+			}
+		}
+	"#;
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 1);
+
+	let Value::Object(res) = res.remove(0).result? else {
+		panic!("not an object")
+	};
+	assert_eq!(res.get("a").unwrap(), &Value::Number(Number::Float(9007199254740991f64)));
+	assert_eq!(res.get("b").unwrap(), &Value::Number(Number::Float(-9007199254740992f64)));
+	assert_eq!(res.get("c").unwrap(), &Value::Number(Number::Int(100000000000000000i64)));
+	assert_eq!(
+		res.get("d").unwrap(),
+		&Value::Number(Number::Decimal(Decimal::from(9223372036854775808u128)))
+	);
+
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Converting numbers to and from js functions will truncate integers currently. This makes it hard to use js functions for some use-cases.

## What does this change do?

Changes how surrealql values are converted to and from surql.

Previously integers would alsways be truncated to an i32. Now whenever the number is larger than i32 it will be converted to a Quickjs float as long as that can be done without losing precision. This means that any number between `-(1 << 53)` and `(1 << 53) - 1` will be a normal number on the javascript side. Any number larger then these two values will be converted to a js bigint. 

Bigint's returned from javascript will be converted to an i64 now if they can fit without truncating and otherwise will be converted to a decimal. 

## What is your testing strategy?

I added some test to ensure the new behavior works as advertised.

## Is this related to any issues?

Fixes #3311 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
