### PR TITLE
Fix documentation builds on docs.rs

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,10 +54,9 @@ sql2 = []
 kv-fdb = ["tokio/time"]
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs,surrealdb_unstable"]
 features = [
     "kv-mem",
-    "kv-indxdb",
     "kv-rocksdb",
     "http",
     "scripting",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -60,12 +60,11 @@ parser2 = ["surrealdb-core/experimental-parser"]
 kv-fdb = ["tokio/time"]
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs,surrealdb_unstable"]
 features = [
     "protocol-ws",
     "protocol-http",
     "kv-mem",
-    "kv-indxdb",
     "kv-rocksdb",
     "rustls",
     "native-tls",


### PR DESCRIPTION
## What is the motivation?

Documentation is currently broken on docs.rs.

## What does this change do?

It disables building `kv-indxdb` and allows building documentation for unstable features.

## What is your testing strategy?

"Trust me bro" 🤣 

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
