### PR TITLE
Default ownership of `/tests` to the DB team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@ supply-chain/* @surrealdb/security
 /doc/ @surrealdb/db
 /lib/ @surrealdb/db
 /src/ @surrealdb/db
+/tests/ @surrealdb/db
 
 # Code for fuzzing configuration
 /lib/fuzz/ @surrealdb/security


### PR DESCRIPTION
## What is the motivation?

`tests/ml_integration.rs` has no code owner.

## What does this change do?

It makes the DB team assume default ownership for any tests in `/tests`.

## What is your testing strategy?

Github says `This CODEOWNERS file is valid`.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
