### PR TITLE
Don't include `jwks` in docs.rs features

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,13 +54,12 @@ sql2 = []
 kv-fdb = ["tokio/time"]
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docsrs,surrealdb_unstable"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = [
     "kv-mem",
     "kv-rocksdb",
     "http",
     "scripting",
-    "jwks",
 ]
 targets = []
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -60,7 +60,7 @@ parser2 = ["surrealdb-core/experimental-parser"]
 kv-fdb = ["tokio/time"]
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docsrs,surrealdb_unstable"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = [
     "protocol-ws",
     "protocol-http",
@@ -70,7 +70,6 @@ features = [
     "native-tls",
     "http",
     "scripting",
-    "jwks",
 ]
 targets = []
 


### PR DESCRIPTION
## What is the motivation?

This feature currently activates the `sql2` feature, which is unstable. Having the unstable features show up in documentation will be confusing, unless they were properly marked as such in the documentation as well.

## What does this change do?

It removes the feature from documented features.

## What is your testing strategy?

Will see if the nightly documentation builds on docs.rs 😄 

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
