### PR TITLE
Bugfix: Fix builtin error pointing to the wrong part

### DIFF
--- a/core/src/syn/v1/builtin.rs
+++ b/core/src/syn/v1/builtin.rs
@@ -85,6 +85,11 @@ macro_rules! impl_builtins {
 			)*
 
 			$(
+				match $name($i){
+					Ok((i,x)) => return Ok((i,x)),
+					Err(Err::Failure(x)) => return Err(Err::Failure(x)),
+					_ => {}
+				}
 				if let Ok((i, x)) = $name($i){
 					return Ok((i,x))
 				}

--- a/core/src/syn/v1/builtin.rs
+++ b/core/src/syn/v1/builtin.rs
@@ -90,9 +90,6 @@ macro_rules! impl_builtins {
 					Err(Err::Failure(x)) => return Err(Err::Failure(x)),
 					_ => {}
 				}
-				if let Ok((i, x)) = $name($i){
-					return Ok((i,x))
-				}
 			)*
 			($i,())
 		}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

There is a bug in the old parser where the error message pointing out that a certain subpath  of builtin functions doesn't exists points to the wrong part:

```
Parse error: Path is not a member of string at line 4 column 16
  |
4 | RETURN string::is::foo();
  |                ^ 
```
The error should point to foo instead of is.

## What does this change do?

Fixes the error message.
