### PR TITLE
Revert "Bugfix: Compute futures in query conditions"

### DIFF
--- a/core/src/doc/check.rs
+++ b/core/src/doc/check.rs
@@ -15,11 +15,7 @@ impl<'a> Document<'a> {
 		// Check where condition
 		if let Some(cond) = stm.conds() {
 			// Check if the expression is truthy
-			if !cond
-				.compute(ctx, &opt.new_with_futures(true), txn, Some(&self.current))
-				.await?
-				.is_truthy()
-			{
+			if !cond.compute(ctx, opt, txn, Some(&self.current)).await?.is_truthy() {
 				// Ignore this document
 				return Err(Error::Ignore);
 			}

--- a/core/src/doc/lives.rs
+++ b/core/src/doc/lives.rs
@@ -167,8 +167,7 @@ impl<'a> Document<'a> {
 		// Check where condition
 		if let Some(cond) = stm.conds() {
 			// Check if the expression is truthy
-
-			if !cond.compute(ctx, &opt.new_with_futures(true), txn, Some(doc)).await?.is_truthy() {
+			if !cond.compute(ctx, opt, txn, Some(doc)).await?.is_truthy() {
 				// Ignore this document
 				return Err(Error::Ignore);
 			}

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -1074,32 +1074,3 @@ async fn select_only() -> Result<(), Error> {
 	//
 	Ok(())
 }
-
-#[tokio::test]
-async fn select_on_future() -> Result<(), Error> {
-	let insert_query = "
-		CREATE person SET name = \"Hana\", age = 10, can_drive = <future>{ age > 17 };
-		CREATE person SET name = \"Hendrick\", age = 18, can_drive = <future>{ age > 17 };
-	";
-	let dbs = new_ds().await?;
-	let ses = Session::owner().with_ns("test").with_db("test");
-	dbs.execute(insert_query, &ses, None).await?;
-
-	let select_query_true = "
-		SELECT name FROM person WHERE can_drive
-	";
-	let mut res = dbs.execute(select_query_true, &ses, None).await?;
-	let tmp = res.remove(0).result?;
-	let val = Value::parse("[{ name: \"Hendrick\" }]");
-	assert_eq!(tmp, val);
-
-	let select_query_false = "
-		SELECT name FROM person WHERE !can_drive
-	";
-	let mut res = dbs.execute(select_query_false, &ses, None).await?;
-	let tmp = res.remove(0).result?;
-	let val = Value::parse("[{ name: \"Hana\" }]");
-	assert_eq!(tmp, val);
-
-	Ok(())
-}


### PR DESCRIPTION
## What is the motivation?

Unfortunately #3118 caused a regression which is being tracked in #3211.

## What does this change do?

It reverts the PR until the regression is fixed.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
