### PR TITLE
Fix the five second delay in Wasm after initial connection

### DIFF
--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -198,8 +198,6 @@ pub(crate) fn router(
 				let mut interval = time::interval(PING_INTERVAL);
 				// don't bombard the server with pings if we miss some ticks
 				interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-				// Delay sending the first ping
-				interval.tick().await;
 
 				let pinger = IntervalStream::new(interval);
 

--- a/lib/src/api/engine/remote/ws/wasm.rs
+++ b/lib/src/api/engine/remote/ws/wasm.rs
@@ -171,8 +171,6 @@ pub(crate) fn router(
 			let mut interval = time::interval(PING_INTERVAL);
 			// don't bombard the server with pings if we miss some ticks
 			interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-			// Delay sending the first ping
-			interval.tick().await;
 
 			let pinger = IntervalStream::new(interval);
 


### PR DESCRIPTION
## What is the motivation?

There is a five second delay on Wasm after connecting before queries are processed.

## What does this change do?

The delay is caused by the initial ping tick. The tick awaits for as long as the tick interval, which is 5 seconds. The delay did not just happen on Wasm. It only manifested there because Wasm is single threaded. The higher concurrency on native masked the issue there.

## What is your testing strategy?

Tested this changeset manually in a web browser.

## Is this related to any issues?

Closes https://github.com/surrealdb/surrealdb/issues/3067.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
