### PR TITLE
Rename `ml1` and `ml2` crate names

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,8 +39,8 @@ kv-fdb-7_0 = ["foundationdb/fdb-7_0", "kv-fdb"]
 kv-fdb-7_1 = ["foundationdb/fdb-7_1", "kv-fdb"]
 scripting = ["dep:js"]
 http = ["dep:reqwest"]
-ml = ["dep:ml1", "dep:ndarray"]
-ml2 = ["dep:ml2", "dep:ndarray"]
+ml = ["dep:surrealml-core1", "dep:ndarray"]
+ml2 = ["dep:surrealml-core2", "dep:ndarray"]
 jwks = ["dep:reqwest", "sql2"]
 arbitrary = [
     "dep:arbitrary",
@@ -136,8 +136,8 @@ sha2 = "0.10.8"
 snap = "1.1.0"
 speedb = { version = "0.0.4", features = ["lz4", "snappy"], optional = true }
 storekey = "0.5.0"
-ml1 = { version = "0.0.7", optional = true, package = "surrealml-core" }
-ml2 = { version = "0.0.8", optional = true, package = "surrealml-core" }
+surrealml-core1 = { version = "0.0.7", optional = true, package = "surrealml-core" }
+surrealml-core2 = { version = "0.0.8", optional = true, package = "surrealml-core" }
 thiserror = "1.0.50"
 tikv = { version = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }
 tracing = "0.1.40"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -51,9 +51,9 @@ pub mod channel {
 #[cfg(all(feature = "ml", not(feature = "ml2")))]
 #[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
-pub use ml1 as ml;
+pub use surrealml_core1 as ml;
 
 #[cfg(feature = "ml2")]
 #[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
-pub use ml2 as ml;
+pub use surrealml_core2 as ml;


### PR DESCRIPTION
## What is the motivation?

@phughk [raised a concern](https://github.com/surrealdb/surrealdb/pull/3385#discussion_r1484418626) about naming crate names the same names as those of the Cargo features that enable them.

## What does this change do?

It renames the crates to `surrealml-core1` and `surrealml-core2`.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
