### PR TITLE
Enable `sql2` and `jwks` in shipped binaries

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -60,7 +60,7 @@ jobs:
 
   bump-version:
     name: Bump main version
-    if: ${{ needs.checks.outputs.branch == 'main' }}
+    if: ${{ inputs.publish }}
     needs: [checks, release]
     runs-on: ubuntu-latest
     steps:
@@ -75,37 +75,47 @@ jobs:
           toolchain: stable
 
       - name: Install a TOML parser
-        run: cargo install --force --locked --version 0.8.1 taplo-cli
+        run: |
+          curl -L https://github.com/tamasfe/taplo/releases/download/0.8.1/taplo-full-linux-x86_64.gz | gunzip - > taplo
+          chmod +x taplo
+          sudo mv taplo /usr/bin/taplo
 
-      - name: Create version bump branch
+      - name: Get version info
         id: bump
         run: |
           set -x
 
           # Retrieve just released version
-          betaVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
+          betaVersion=$(taplo get -f lib/Cargo.toml "package.version")
           major=$(echo $betaVersion | tr "." "\n" | sed -n 1p)
           minor=$(echo $betaVersion | tr "." "\n" | sed -n 2p)
+          betaNum=$(echo $betaVersion | tr "." "\n" | sed -n 4p)
           nightlyVersion=${major}.$(($minor + 1)).0
           echo "version=${nightlyVersion}" >> $GITHUB_OUTPUT
+          echo "beta-num=${betaNum}"  >> $GITHUB_OUTPUT
+
+      - name: Create version bump branch
+        if: ${{ steps.bump.outputs.beta-num == '1' }}
+        run: |
+          set -x
 
           # Checkout the main branch
           git fetch origin main
           git checkout main
 
           # Switch to version bump branch
-          git checkout -b version-bump/v${nightlyVersion}
+          git checkout -b version-bump/v${{ steps.bump.outputs.version }}
 
           # Bump the crate version
-          sed -i "s#^version = \".*\"#version = \"${nightlyVersion}\"#" Cargo.toml
-          sed -i "s#^version = \".*\"#version = \"${nightlyVersion}\"#" lib/Cargo.toml
-          sed -i "s#^version = \".*\"#version = \"${nightlyVersion}\"#" core/Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${{ steps.bump.outputs.version }}\"#" Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${{ steps.bump.outputs.version }}\"#" lib/Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${{ steps.bump.outputs.version }}\"#" core/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem
 
       - name: Push the branch
-        if: ${{ inputs.publish }}
+        if: ${{ steps.bump.outputs.beta-num == '1' }}
         run: |
           # Configure git
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -117,8 +127,8 @@ jobs:
           git push
 
       - name: Create a PR
+        if: ${{ steps.bump.outputs.beta-num == '1' }}
         id: pr
-        if: ${{ inputs.publish }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -127,7 +137,7 @@ jobs:
           echo "url=${url}" >> $GITHUB_OUTPUT
 
       - name: Merge the PR
-        if: ${{ inputs.publish }}
+        if: ${{ steps.bump.outputs.beta-num == '1' }}
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }} # Need the custom user token here so we can approve and merge the PR
         run: |

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -142,13 +142,17 @@ jobs:
             git checkout -b releases/beta
             major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
             minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
-            betaVersion=${major}.$(($minor + 1)).0-beta.1
+            betaVersion=${major}.${minor}.0-beta.1
           fi
 
           # Bump the crate version
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" core/Cargo.toml
+
+          # Update dependency versions
+          sed -i "s#surrealdb = { version = \"1\"#surrealdb = { version = \"=${betaVersion}\"#" Cargo.toml
+          sed -i "s#surrealdb-core = { version = \"1\"#surrealdb-core = { version = \"=${betaVersion}\"#" lib/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem
@@ -339,7 +343,7 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv
+              features=storage-tikv,sql2,jwks
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -373,7 +377,7 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv
+              features=storage-tikv,sql2,jwks
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -401,7 +405,7 @@ jobs:
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
               # Build
-              features=storage-tikv
+              features=storage-tikv,sql2,jwks
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -421,6 +425,7 @@ jobs:
                 --pull always \
                 -v $(pwd):/surrealdb \
                 -e SURREAL_BUILD_METADATA=$SURREAL_BUILD_METADATA \
+                -e RUSTFLAGS="${RUSTFLAGS}" \
                 -e ORT_STRATEGY=$ORT_STRATEGY \
                 -e ORT_LIB_LOCATION=$ORT_LIB_LOCATION \
                 -v $ORT_LIB_LOCATION:$ORT_LIB_LOCATION \
@@ -445,7 +450,7 @@ jobs:
               set -x
 
               # Build
-              features=storage-tikv
+              features=storage-tikv,sql2,jwks
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -465,6 +470,7 @@ jobs:
                 --pull always \
                 -v $(pwd):/surrealdb \
                 -e SURREAL_BUILD_METADATA=$SURREAL_BUILD_METADATA \
+                -e RUSTFLAGS="${RUSTFLAGS}" \
                 -e ORT_STRATEGY=$ORT_STRATEGY \
                 -e ORT_LIB_LOCATION=$ORT_LIB_LOCATION \
                 -v $ORT_LIB_LOCATION:$ORT_LIB_LOCATION \
@@ -492,7 +498,7 @@ jobs:
               vcpkg integrate install
 
               # Build
-              features=storage-tikv
+              features=storage-tikv,sql2,jwks
               if [[ "${{ inputs.http-compression }}" == "true" ]]; then
                 features=${features},http-compression
               fi
@@ -549,6 +555,7 @@ jobs:
       - name: Build step
         env:
           SURREAL_BUILD_METADATA: ${{ needs.prepare-vars.outputs.build-metadata }}
+          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: ${{ matrix.build-step }}
 
       - name: Upload artifacts
@@ -584,7 +591,7 @@ jobs:
           sudo chmod +x /usr/bin/release-plz
 
       - name: Install a TOML parser
-        if: ${{ inputs.environment == 'beta' }}
+        if: ${{ inputs.environment == 'nightly' || inputs.environment == 'beta' }}
         run: |
           curl -L https://github.com/tamasfe/taplo/releases/download/0.8.1/taplo-full-linux-x86_64.gz | gunzip - > taplo
           chmod +x taplo
@@ -618,6 +625,7 @@ jobs:
           # Update crate version
           sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
+          sed -i "s#surrealdb-core = { version = \"=${currentVersion}\"#surrealdb-core = { version = \"=${version}\"#" lib/Cargo.toml
 
       - name: Patch nightly crate version
         if: ${{ inputs.environment == 'nightly' }}
@@ -635,6 +643,7 @@ jobs:
           # Update the version to a nightly one
           sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
+          sed -i "s#surrealdb-core = { version = \"1\"#surrealdb-core = { version = \"=${version}\"#" lib/Cargo.toml
 
       - name: Patch crate name and description
         if: ${{ inputs.environment == 'nightly' || inputs.environment == 'beta' }}


### PR DESCRIPTION
## What is the motivation?

The old workflows do not enable those features.

## What does this change do?

Backports #3445 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

None.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
