### PR TITLE
Bugfix: Fix a panic when invalid builtin function names are passed to the executor

### DIFF
--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -71,7 +71,12 @@ macro_rules! dispatch {
 					#[allow(clippy::redundant_closure_call)]
 					$($wrapper)*(|| $($function_path)::+($($ctx_arg,)* args))()$(.$await)*
 				},)+
-				_ => unreachable!()
+				_ => {
+					return Err($crate::err::Error::InvalidFunction{
+						name: String::from($name),
+						message: "no such builtin function".to_string()
+					})
+				}
 			}
 		}
 	};


### PR DESCRIPTION
## What is the motivation?

Currently the executor panics whenever it encounters a call to a builtin function with an invalid name. This can cause panics when newer clients are used on an older database or when hand-crafted queries are passed to the database.

## What does this change do?

It backports #3454 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
