### PR TITLE
Bugfix: Make integration tests more consistent.

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -27,13 +27,13 @@ args = ["clippy", "--all-targets", "--features", "storage-mem,storage-rocksdb,st
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
 env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "cli_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http,scripting,jwks", "--workspace", "--test", "cli_integration", "--", "cli_integration", "--nocapture"]
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http,scripting,jwks", "--workspace", "--test", "cli_integration", "--", "cli_integration"]
 
 [tasks.ci-http-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
 env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks", "--workspace", "--test", "http_integration", "--", "http_integration", "--nocapture"]
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks", "--workspace", "--test", "http_integration", "--", "http_integration"]
 
 [tasks.ci-ws-integration]
 category = "WS - INTEGRATION TESTS"

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -39,7 +39,7 @@ args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,
 category = "WS - INTEGRATION TESTS"
 command = "cargo"
 env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "ws_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,sql2", "--workspace", "--test", "ws_integration", "--", "ws_integration", "--nocapture"]
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,sql2", "--workspace", "--test", "ws_integration", "--", "ws_integration"]
 
 [tasks.ci-ml-integration]
 category = "ML - INTEGRATION TESTS"

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -26,25 +26,25 @@ args = ["clippy", "--all-targets", "--features", "storage-mem,storage-rocksdb,st
 [tasks.ci-cli-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "cli_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
+env = { RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "cli_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
 args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http,scripting,jwks", "--workspace", "--test", "cli_integration", "--", "cli_integration"]
 
 [tasks.ci-http-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
+env = { RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
 args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks", "--workspace", "--test", "http_integration", "--", "http_integration"]
 
 [tasks.ci-ws-integration]
 category = "WS - INTEGRATION TESTS"
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "ws_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
+env = { RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "ws_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
 args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,sql2", "--workspace", "--test", "ws_integration", "--", "ws_integration"]
 
 [tasks.ci-ml-integration]
 category = "ML - INTEGRATION TESTS"
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "cli_integration::common=debug", condition = { env_not_set = ["RUST_LOG"] } } }
+env = { RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "cli_integration::common=debug", condition = { env_not_set = ["RUST_LOG"] } } }
 args = ["test", "--locked", "--features", "storage-mem,ml,sql2", "--workspace", "--test", "ml_integration", "--", "ml_integration", "--nocapture"]
 
 [tasks.ci-workspace-coverage]
@@ -63,7 +63,7 @@ args = [
 [tasks.test-experimental-parser]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUSTDOCFLAGS="--cfg surrealdb_unstable" }
+env = { RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable", RUSTDOCFLAGS="--cfg surrealdb_unstable" }
 args = [
 	"test", "--locked", "--no-default-features", "--features", "storage-mem,scripting,http,parser2", "--workspace", "--",
 	"--skip", "api_integration",
@@ -90,18 +90,18 @@ run_task = { name = ["start-surrealdb", "test-workspace-coverage-complete", "sto
 [tasks.test-kvs]
 private = true
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable" }
+env = {RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable" }
 args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--lib", "kvs"]
 
 
 [tasks.test-api-integration]
 private = true
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable" }
+env = {RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable" }
 args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--test", "api", "api_integration::${_TEST_API_ENGINE}"]
 
 [tasks.ci-api-integration]
-env = { _START_SURREALDB_PATH = "memory", RUSTFLAGS = "--cfg surrealdb_unstable" }
+env = {RUST_BACKTRACE=1, _START_SURREALDB_PATH = "memory", RUSTFLAGS = "--cfg surrealdb_unstable" }
 private = true
 run_task = { name = ["start-surrealdb", "test-api-integration", "stop-surrealdb"], fork = true }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -780,9 +780,8 @@ mod cli_integration {
 		let (addr, mut server) = common::start_server_without_auth().await.unwrap();
 
 		// Create a long-lived WS connection so the server don't shutdown gracefully
-		let socket = Socket::connect(&addr, None, Format::Json, "cli::second_signal")
-			.await
-			.expect("Failed to connect to server");
+		let socket =
+			Socket::connect(&addr, None, Format::Json).await.expect("Failed to connect to server");
 		socket
 			.send_request("query", json!(["SLEEP 30s;"]))
 			.await

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -5,6 +5,7 @@ mod cli_integration {
 	use assert_fs::prelude::{FileTouch, FileWriteStr, PathChild};
 	use common::Format;
 	use common::Socket;
+	use serde_json::json;
 	use std::fs;
 	use std::fs::File;
 	use std::time;
@@ -775,12 +776,10 @@ mod cli_integration {
 
 		// Create a long-lived WS connection so the server don't shutdown gracefully
 		let mut socket = Socket::connect(&addr, None).await.expect("Failed to connect to server");
-		let json = serde_json::json!({
-			"id": "1",
-			"method": "query",
-			"params": ["SLEEP 30s;"],
-		});
-		socket.send_message(Format::Json, json).await.expect("Failed to send WS message");
+		socket
+			.send_message(Format::Json, json!("1"), json!("query"), json!(["SLEEP 30s;"]))
+			.await
+			.expect("Failed to send WS message");
 
 		// Make sure the SLEEP query is being executed
 		tokio::select! {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -775,7 +775,7 @@ mod cli_integration {
 		let (addr, mut server) = common::start_server_without_auth().await.unwrap();
 
 		// Create a long-lived WS connection so the server don't shutdown gracefully
-		let mut socket =
+		let socket =
 			Socket::connect(&addr, None, Format::Json).await.expect("Failed to connect to server");
 		socket
 			.send_request("query", json!(["SLEEP 30s;"]))

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -775,9 +775,10 @@ mod cli_integration {
 		let (addr, mut server) = common::start_server_without_auth().await.unwrap();
 
 		// Create a long-lived WS connection so the server don't shutdown gracefully
-		let mut socket = Socket::connect(&addr, None).await.expect("Failed to connect to server");
+		let mut socket =
+			Socket::connect(&addr, None, Format::Json).await.expect("Failed to connect to server");
 		socket
-			.send_message(Format::Json, json!("1"), json!("query"), json!(["SLEEP 30s;"]))
+			.send_request("query", json!(["SLEEP 30s;"]))
 			.await
 			.expect("Failed to send WS message");
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -804,7 +804,7 @@ mod cli_integration {
 				.send_signal(nix::sys::signal::Signal::SIGINT)
 				.expect("Failed to send SIGINT to server");
 
-			tokio::time::timeout(time::Duration::from_secs(1), async {
+			tokio::time::timeout(time::Duration::from_secs(10), async {
 				loop {
 					if let Ok(Some(exit)) = server.status() {
 						panic!(

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -15,7 +15,6 @@ pub const DB: &str = "testdb";
 /// Child is a (maybe running) CLI process. It can be killed by dropping it
 pub struct Child {
 	inner: Option<std::process::Child>,
-	output: Option<ExitStatus>,
 	stdout_path: String,
 	stderr_path: String,
 }

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -84,6 +84,8 @@ impl Drop for Child {
 				std::fs::read_to_string(&self.stderr_path).expect("Failed to read the stderr file");
 			println!("Server STDERR: \n{}", stderr);
 		}
+		let _ = std::fs::remove_file(&self.stdout_path);
+		let _ = std::fs::remove_file(&self.stderr_path);
 	}
 }
 

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -220,7 +220,7 @@ pub async fn start_server(
 	}
 
 	'retry: for _ in 0..3 {
-		let port: u16 = rng.gen_range(13000..14000);
+		let port: u16 = rng.gen_range(13000..24000);
 		let addr = format!("127.0.0.1:{port}");
 
 		let start_args = format!("start --bind {addr} memory --no-banner --log trace --user {USER} --pass {PASS} {extra_args}");

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -2,7 +2,7 @@ use rand::{thread_rng, Rng};
 use std::error::Error;
 use std::fs::File;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
 use std::{env, fs};
 use tokio::time;
 use tracing::{debug, error, info};
@@ -15,6 +15,7 @@ pub const DB: &str = "testdb";
 /// Child is a (maybe running) CLI process. It can be killed by dropping it
 pub struct Child {
 	inner: Option<std::process::Child>,
+	output: Option<ExitStatus>,
 	stdout_path: String,
 	stderr_path: String,
 }

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -30,7 +30,7 @@ impl Child {
 	}
 
 	pub fn kill(mut self) -> Self {
-		self.inner.take().unwrap().kill().unwrap();
+		self.inner.as_mut().unwrap().kill().unwrap();
 		self
 	}
 

--- a/tests/common/socket.rs
+++ b/tests/common/socket.rs
@@ -176,7 +176,7 @@ impl Socket {
 						let msg: Value = try_from_impls::Cbor(msg).try_into()?;
 						// Then we convert the SurrealQL to JSON.
 						let msg = msg.into_json();
-						// Then output the response:three: any blockers/issues/question.
+						// Then output the response.
 						debug!("Received message: {msg:?}");
 						Ok(Some(msg))
 					}

--- a/tests/common/socket.rs
+++ b/tests/common/socket.rs
@@ -75,7 +75,7 @@ impl Socket {
 				channel: send,
 			})
 			.await?;
-		if let Err(_) = recv.await {
+		if (recv.await).is_err() {
 			return Err("Ws task stoped unexpectedly".to_string().into());
 		}
 		Ok(())
@@ -156,11 +156,9 @@ impl Socket {
 					Format::Json => {
 						let msg = serde_json::from_str(&msg)?;
 						debug!("Received message: {msg}");
-						return Ok(Some(msg));
+						Ok(Some(msg))
 					}
-					_ => {
-						return Err("Expected to receive a binary message".to_string().into());
-					}
+					_ => Err("Expected to receive a binary message".to_string().into()),
 				}
 			}
 			Message::Binary(msg) => {
@@ -180,7 +178,7 @@ impl Socket {
 						let msg = msg.into_json();
 						// Then output the response:three: any blockers/issues/question.
 						debug!("Received message: {msg:?}");
-						return Ok(Some(msg));
+						Ok(Some(msg))
 					}
 					Format::Pack => {
 						pub mod try_from_impls {
@@ -196,15 +194,13 @@ impl Socket {
 						let msg = msg.into_json();
 						// Then output the response.
 						debug!("Received message: {msg:?}");
-						return Ok(Some(msg));
+						Ok(Some(msg))
 					}
-					_ => {
-						return Err("Expected to receive a text message".to_string().into());
-					}
+					_ => Err("Expected to receive a text message".to_string().into()),
 				}
 			}
-			Message::Close(_) => return Err("Socket closed unexpectedly".to_string().into()),
-			_ => return Ok(None),
+			Message::Close(_) => Err("Socket closed unexpectedly".to_string().into()),
+			_ => Ok(None),
 		}
 	}
 

--- a/tests/common/socket.rs
+++ b/tests/common/socket.rs
@@ -82,7 +82,12 @@ impl Socket {
 	}
 
 	/// Connect to a WebSocket server using a specific format
-	pub async fn connect(addr: &str, format: Option<Format>, msg_format: Format) -> Result<Self> {
+	pub async fn connect(
+		addr: &str,
+		format: Option<Format>,
+		msg_format: Format,
+		_id: &str,
+	) -> Result<Self> {
 		let url = format!("ws://{}/rpc", addr);
 		let mut req = url.into_client_request().unwrap();
 		if let Some(v) = format.map(|v| v.to_string()) {

--- a/tests/common/socket.rs
+++ b/tests/common/socket.rs
@@ -82,12 +82,7 @@ impl Socket {
 	}
 
 	/// Connect to a WebSocket server using a specific format
-	pub async fn connect(
-		addr: &str,
-		format: Option<Format>,
-		msg_format: Format,
-		_id: &str,
-	) -> Result<Self> {
+	pub async fn connect(addr: &str, format: Option<Format>, msg_format: Format) -> Result<Self> {
 		let url = format!("ws://{}/rpc", addr);
 		let mut req = url.into_client_request().unwrap();
 		if let Some(v) = format.map(|v| v.to_string()) {

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -10,7 +10,7 @@ async fn ping() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::ping")).await?;
+	let socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Send INFO command
 	let res = socket.send_request("ping", json!([])).await;
 	assert!(res.is_ok(), "result: {:?}", res);
@@ -28,7 +28,7 @@ async fn info() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::info")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -74,7 +74,7 @@ async fn signup() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::singup")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -122,7 +122,7 @@ async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::signin")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -196,8 +196,7 @@ async fn invalidate() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket =
-		Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::invalidate")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -225,15 +224,13 @@ async fn authenticate() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket =
-		Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::authenticate::1")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	let token = socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Disconnect the connection
 	socket.close().await?;
 	// Connect to WebSocket
-	let mut socket =
-		Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::authenticate::2")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Send AUTHENTICATE command
 	socket.send_request("authenticate", json!([token,])).await?;
 	// Verify we have an authenticated session
@@ -249,7 +246,7 @@ async fn letset() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::letset")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -270,7 +267,7 @@ async fn unset() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::unset")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -295,7 +292,7 @@ async fn select() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::select")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -320,7 +317,7 @@ async fn insert() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::insert")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -361,7 +358,7 @@ async fn create() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::create")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -399,7 +396,7 @@ async fn update() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::update")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -440,7 +437,7 @@ async fn merge() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::merge")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -482,7 +479,7 @@ async fn patch() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::patch")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -529,7 +526,7 @@ async fn delete() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::delete")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -566,7 +563,7 @@ async fn query() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::query")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -593,7 +590,7 @@ async fn version() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::version")).await?;
+	let socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Send version command
 	let res = socket.send_request("version", json!([])).await?;
 	assert!(res["result"].is_string(), "result: {:?}", res);
@@ -610,8 +607,7 @@ async fn concurrency() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket =
-		Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::concurrency")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -649,7 +645,7 @@ async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::live")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -716,7 +712,7 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::kill")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -819,8 +815,7 @@ async fn live_second_connection() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket1 =
-		Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::live_second::1")).await?;
+	let mut socket1 = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket1.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -831,8 +826,7 @@ async fn live_second_connection() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res["result"].is_string(), "result: {:?}", res);
 	let liveid = res["result"].as_str().unwrap();
 	// Connect to WebSocket
-	let mut socket2 =
-		Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::live_second::2")).await?;
+	let mut socket2 = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket2.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
@@ -869,8 +863,7 @@ async fn variable_auth_live_query() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket =
-		Socket::connect(&addr, SERVER, FORMAT, &format!("{FORMAT:?}::variable_auth")).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
 	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -11,15 +11,8 @@ async fn ping() -> Result<(), Box<dyn std::error::Error>> {
 	// Connect to WebSocket
 	let mut socket = Socket::connect(&addr, SERVER).await?;
 	// Send INFO command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "ping",
-			}),
-		)
-		.await;
+	let res =
+		socket.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("ping"), json!([])).await;
 	assert!(res.is_ok(), "result: {:?}", res);
 	let res = res.unwrap();
 	assert!(res.is_object(), "result: {:?}", res);
@@ -69,13 +62,7 @@ async fn info() -> Result<(), Box<dyn std::error::Error>> {
 	socket.send_message_signin(FORMAT, "user", "pass", Some(NS), Some(DB), Some("scope")).await?;
 	// Send INFO command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "info",
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("info"), json!([]))
 		.await?;
 	assert!(res["result"].is_object(), "result: {:?}", res);
 	let res = res["result"].as_object().unwrap();
@@ -109,17 +96,15 @@ async fn signup() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "signup",
-				"params": [{
-					"ns": NS,
-					"db": DB,
-					"sc": "scope",
-					"email": "email@email.com",
-					"pass": "pass",
-				}],
-			}),
+			json!(Ulid::new()),
+			json!("signup"),
+			json!([{
+				"ns": NS,
+				"db": DB,
+				"sc": "scope",
+				"email": "email@email.com",
+				"pass": "pass",
+			}]),
 		)
 		.await;
 	assert!(res.is_ok(), "result: {:?}", res);
@@ -161,17 +146,17 @@ async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "signup",
-				"params": [{
+			json!(Ulid::new()),
+			json!("signup"),
+			json!(
+				[{
 					"ns": NS,
 					"db": DB,
 					"sc": "scope",
 					"email": "email@email.com",
 					"pass": "pass",
-				}],
-			}),
+				}]
+			),
 		)
 		.await;
 	assert!(res.is_ok(), "result: {:?}", res);
@@ -188,17 +173,16 @@ async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "signin",
-				"params": [{
-					"ns": NS,
-					"db": DB,
-					"sc": "scope",
-					"email": "email@email.com",
-					"pass": "pass",
-				}],
-			}),
+			json!(Ulid::new()),
+			json!("signin"),
+			json!(
+			[{
+				"ns": NS,
+				"db": DB,
+				"sc": "scope",
+				"email": "email@email.com",
+				"pass": "pass",
+			}]),
 		)
 		.await;
 	assert!(res.is_ok(), "result: {:?}", res);
@@ -230,13 +214,7 @@ async fn invalidate() -> Result<(), Box<dyn std::error::Error>> {
 	assert_eq!(res[0]["status"], "OK", "result: {:?}", res);
 	// Send INVALIDATE command
 	socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "invalidate",
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("invalidate"), json!([]))
 		.await?;
 	// Verify we have an invalidated session
 	let res = socket.send_message_query(FORMAT, "DEFINE NAMESPACE test").await?;
@@ -266,13 +244,9 @@ async fn authenticate() -> Result<(), Box<dyn std::error::Error>> {
 	socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "authenticate",
-				"params": [
-					token,
-				],
-			}),
+			json!(Ulid::new()),
+			json!("authenticate"),
+			json!([token,]),
 		)
 		.await?;
 	// Verify we have an authenticated session
@@ -296,26 +270,18 @@ async fn letset() -> Result<(), Box<dyn std::error::Error>> {
 	socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "let",
-				"params": [
-					"let_var", "let_value",
-				],
-			}),
+			json!(Ulid::new()),
+			json!("let"),
+			json!(["let_var", "let_value",]),
 		)
 		.await?;
 	// Send SET command
 	socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "set",
-				"params": [
-					"set_var", "set_value",
-				],
-			}),
+			json!(Ulid::new()),
+			json!("set"),
+			json!(["set_var", "set_value",]),
 		)
 		.await?;
 	// Verify the variables are set
@@ -338,13 +304,9 @@ async fn unset() -> Result<(), Box<dyn std::error::Error>> {
 	socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "let",
-				"params": [
-					"let_var", "let_value",
-				],
-			}),
+			json!(Ulid::new()),
+			json!("let"),
+			json!(["let_var", "let_value",]),
 		)
 		.await?;
 	// Verify the variable is set
@@ -352,16 +314,7 @@ async fn unset() -> Result<(), Box<dyn std::error::Error>> {
 	assert_eq!(res[0]["result"], json!(["let_value"]), "result: {:?}", res);
 	// Send UNSET command
 	socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "unset",
-				"params": [
-					"let_var",
-				],
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("unset"), json!(["let_var",]))
 		.await?;
 	// Verify the variable is unset
 	let res = socket.send_message_query(FORMAT, "SELECT * FROM $let_var").await?;
@@ -384,16 +337,7 @@ async fn select() -> Result<(), Box<dyn std::error::Error>> {
 	socket.send_message_query(FORMAT, "CREATE tester SET name = 'foo', value = 'bar'").await?;
 	// Send SELECT command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "select",
-				"params": [
-					"tester",
-				],
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("select"), json!(["tester",]))
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
@@ -419,17 +363,15 @@ async fn insert() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "insert",
-				"params": [
-					"tester",
-					{
-						"name": "foo",
-						"value": "bar",
-					}
-				],
-			}),
+			json!(Ulid::new()),
+			json!("insert"),
+			json!([
+				"tester",
+				{
+					"name": "foo",
+					"value": "bar",
+				}
+			]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -463,16 +405,14 @@ async fn create() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "create",
-				"params": [
-					"tester",
-					{
-						"value": "bar",
-					}
-				],
-			}),
+			json!(Ulid::new()),
+			json!("create"),
+			json!([
+				"tester",
+				{
+					"value": "bar",
+				}
+			]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -506,16 +446,14 @@ async fn update() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "update",
-				"params": [
-					"tester",
-					{
-						"value": "bar",
-					}
-				],
-			}),
+			json!(Ulid::new()),
+			json!("update"),
+			json!([
+				"tester",
+				{
+					"value": "bar",
+				}
+			]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -550,16 +488,14 @@ async fn merge() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "merge",
-				"params": [
-					"tester",
-					{
-						"value": "bar",
-					}
-				],
-			}),
+			json!(Ulid::new()),
+			json!("merge"),
+			json!([
+				"tester",
+				{
+					"value": "bar",
+				}
+			]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -595,24 +531,22 @@ async fn patch() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "patch",
-				"params": [
-					"tester:id",
-					[
-						{
-							"op": "add",
-							"path": "value",
-							"value": "bar"
-						},
-						{
-							"op": "remove",
-							"path": "name",
-						}
-					]
+			json!(Ulid::new()),
+			json!("patch"),
+			json!([
+				"tester:id",
+				[
+					{
+						"op": "add",
+						"path": "value",
+						"value": "bar"
+					},
+					{
+						"op": "remove",
+						"path": "name",
+					}
 				]
-			}),
+			]),
 		)
 		.await?;
 	assert!(res["result"].is_object(), "result: {:?}", res);
@@ -643,16 +577,7 @@ async fn delete() -> Result<(), Box<dyn std::error::Error>> {
 	socket.send_message_query(FORMAT, "CREATE tester:id").await?;
 	// Send DELETE command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "delete",
-				"params": [
-					"tester"
-				]
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("delete"), json!(["tester"]))
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
@@ -663,16 +588,7 @@ async fn delete() -> Result<(), Box<dyn std::error::Error>> {
 	socket.send_message_query(FORMAT, "CREATE tester:id").await?;
 	// Send DELETE command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "delete",
-				"params": [
-					"tester:id"
-				]
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("delete"), json!(["tester:id"]))
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_object(), "result: {:?}", res);
@@ -701,13 +617,9 @@ async fn query() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": [
-					"CREATE tester; SELECT * FROM tester;",
-				]
-			}),
+			json!(Ulid::new()),
+			json!("query"),
+			json!(["CREATE tester; SELECT * FROM tester;",]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -731,13 +643,7 @@ async fn version() -> Result<(), Box<dyn std::error::Error>> {
 	let mut socket = Socket::connect(&addr, SERVER).await?;
 	// Send version command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "version",
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("version"), json!([]))
 		.await?;
 	assert!(res["result"].is_string(), "result: {:?}", res);
 	let res = res["result"].as_str().unwrap();
@@ -762,11 +668,9 @@ async fn concurrency() -> Result<(), Box<dyn std::error::Error>> {
 		socket
 			.send_message(
 				FORMAT,
-				json!({
-					"id": Ulid::new(),
-					"method": "query",
-					"params": [format!("SLEEP 3s; RETURN {i};")],
-				}),
+				json!(Ulid::new()),
+				json!("query"),
+				json!([format!("SLEEP 3s; RETURN {i};")]),
 			)
 			.await?;
 	}
@@ -789,14 +693,7 @@ async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
 	// Send LIVE command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "live",
-				"params": ["tester"],
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("live"), json!(["tester"]))
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_string(), "result: {:?}", res);
@@ -805,11 +702,9 @@ async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["LIVE SELECT * FROM tester"],
-			}),
+			json!(Ulid::new()),
+			json!("query"),
+			json!(["LIVE SELECT * FROM tester"]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -822,11 +717,9 @@ async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:id SET name = 'foo'"],
-			}),
+			json!(Ulid::new()),
+			json!("query"),
+			json!(["CREATE tester:id SET name = 'foo'"]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -877,14 +770,7 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
 	// Send LIVE command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "live",
-				"params": ["tester"],
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("live"), json!(["tester"]))
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_string(), "result: {:?}", res);
@@ -893,11 +779,9 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["LIVE SELECT * FROM tester"],
-			}),
+			json!(Ulid::new()),
+			json!("query"),
+			json!(["LIVE SELECT * FROM tester"]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -910,11 +794,9 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:one SET name = 'one'"],
-			}),
+			json!(Ulid::new()),
+			json!("query"),
+			json!(["CREATE tester:one SET name = 'one'"]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -951,14 +833,7 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	assert_eq!(res["id"], "tester:one", "result: {:?}", res);
 	// Send KILL command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "kill",
-				"params": [live1],
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("kill"), json!([live1]))
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_null(), "result: {:?}", res);
@@ -966,11 +841,9 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:two SET name = 'two'"],
-			}),
+			json!(Ulid::new()),
+			json!("query"),
+			json!(["CREATE tester:two SET name = 'two'"]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -996,11 +869,9 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": [format!("KILL '{live2}'")],
-			}),
+			json!(Ulid::new()),
+			json!("query"),
+			json!([format!("KILL '{live2}'")]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -1012,11 +883,9 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:tre SET name = 'two'"],
-			}),
+			json!(Ulid::new()),
+			json!("query"),
+			json!(["CREATE tester:tre SET name = 'two'"]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -1042,14 +911,7 @@ async fn live_second_connection() -> Result<(), Box<dyn std::error::Error>> {
 	socket1.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
 	// Send LIVE command
 	let res = socket1
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "live",
-				"params": ["tester"],
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("live"), json!(["tester"]))
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_string(), "result: {:?}", res);
@@ -1064,11 +926,9 @@ async fn live_second_connection() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket2
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:id SET name = 'foo'"],
-			}),
+			json!(Ulid::new()),
+			json!("query"),
+			json!(["CREATE tester:id SET name = 'foo'"]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -1120,17 +980,15 @@ async fn variable_auth_live_query() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "signup",
-				"params": [{
-					"ns": NS,
-					"db": DB,
-					"sc": "scope",
-					"email": "email@email.com",
-					"pass": "pass",
-				}],
-			}),
+			json!(Ulid::new()),
+			json!("signup"),
+			json!([{
+				"ns": NS,
+				"db": DB,
+				"sc": "scope",
+				"email": "email@email.com",
+				"pass": "pass",
+			}]),
 		)
 		.await;
 	assert!(res.is_ok(), "result: {:?}", res);
@@ -1141,14 +999,7 @@ async fn variable_auth_live_query() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.keys().all(|k| ["id", "result"].contains(&k.as_str())), "result: {:?}", res);
 	// Send LIVE command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "live",
-				"params": ["tester"],
-			}),
-		)
+		.send_and_receive_message(FORMAT, json!(Ulid::new()), json!("live"), json!(["tester"]))
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_string(), "result: {:?}", res);
@@ -1158,11 +1009,9 @@ async fn variable_auth_live_query() -> Result<(), Box<dyn std::error::Error>> {
 	let res = socket
 		.send_and_receive_message(
 			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:id SET name = 'foo'"],
-			}),
+			json!(Ulid::new()),
+			json!("query"),
+			json!(["CREATE tester:id SET name = 'foo'"]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Experimentation around the integration tests showed that a lot of the integration tests failures are due to live messages appearing in an unexpected but still valid order. This causes test to fail when they shouldn't. This PR changes the web socket tests to handle receiving live query updates in any order.

Other causes of test failures happened do to server port collisions. So this PR also makes the tests retry starting the server, up to three times, if the server failed with an Address already in use error.

This test also adds more checks to see if the server is actually started. 

Previously the test would go ahead if it could connect to the server, but when a port collision happens a server is already running and therefore you can connect to a server on the requested port. This connection to this server would often terminate before the test could complete because the test it actually belonged to completed, causing the test to fail. 

Now we check if the server has printed `Started web server on` message and hasn't yet failed to find a socket. This should make the tests more consistent as it is less likely that a test will connect to a server of a different test.

Furthermore this PR also makes failed tests print the output from the server when an error happens and removes the `--nocapture` argument from the CI tests as they create unnecessary clutter in the test logs.

## What is your testing strategy?

Test should more consistently succeed.

With a somewhat imprecise test of running CI 6 times returned no spurious failures for integration tests. 

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
