### PR TITLE
Fix the modulo operator on sql2 and parser1

### DIFF
--- a/core/src/syn/v1/operator.rs
+++ b/core/src/syn/v1/operator.rs
@@ -76,6 +76,8 @@ pub fn binary_symbols(i: &str) -> IResult<&str, Operator> {
 			value(Operator::Mul, char('∙')),
 			value(Operator::Div, char('/')),
 			value(Operator::Div, char('÷')),
+			#[cfg(feature = "sql2")]
+			value(Operator::Rem, char('%')),
 		)),
 		alt((
 			value(Operator::Contain, char('∋')),


### PR DESCRIPTION
## What is the motivation?

#3433 wrongfully removed the modulo operator from parser1 instead of feature gating it behind sql2.

## What does this change do?

Backport #3477 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
