### PR TITLE
Bugfix: Fix builtin error pointing to the wrong part

### DIFF
--- a/core/src/syn/v1/builtin.rs
+++ b/core/src/syn/v1/builtin.rs
@@ -85,8 +85,10 @@ macro_rules! impl_builtins {
 			)*
 
 			$(
-				if let Ok((i, x)) = $name($i){
-					return Ok((i,x))
+				match $name($i){
+					Ok((i,x)) => return Ok((i,x)),
+					Err(Err::Failure(x)) => return Err(Err::Failure(x)),
+					_ => {}
 				}
 			)*
 			($i,())


### PR DESCRIPTION
## What is the motivation?

There is a bug in the old parser where the error message pointing out that a certain subpath of builtin functions doesn't exists points to the wrong part:

```
Parse error: Path is not a member of string at line 4 column 16
  |
4 | RETURN string::is::foo();
  |                ^ 
The error should point to foo instead of is.
```

## What does this change do?

Backports #3467 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
