### PR TITLE
Refactor: In MTree large vector improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5326,6 +5326,7 @@ dependencies = [
  "path-clean",
  "pharos",
  "pprof",
+ "radix_trie",
  "rand 0.8.5",
  "regex",
  "reqwest",

--- a/core/src/fnc/util/math/vector.rs
+++ b/core/src/fnc/util/math/vector.rs
@@ -9,7 +9,7 @@ pub trait Add {
 	fn add(&self, other: &Self) -> Result<Vec<Number>, Error>;
 }
 
-fn check_same_dimension(fnc: &str, a: &Vec<Number>, b: &Vec<Number>) -> Result<(), Error> {
+fn check_same_dimension(fnc: &str, a: &[Number], b: &[Number]) -> Result<(), Error> {
 	if a.len() != b.len() {
 		Err(Error::InvalidArguments {
 			name: String::from(fnc),

--- a/core/src/idx/trees/vector.rs
+++ b/core/src/idx/trees/vector.rs
@@ -4,7 +4,6 @@ use crate::sql::Number;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 /// In the context of a Symmetric MTree index, the term object refers to a vector, representing the indexed item.
@@ -23,44 +22,6 @@ pub enum Vector {
 /// However, because we are running in an async context, and because we are using cache structures that use the Arc as a key,
 /// the cached objects has to be Sent, which then requires the use of Arc (rather than just Rc).
 pub(crate) type SharedVector = Arc<Vector>;
-
-impl Hash for Vector {
-	fn hash<H: Hasher>(&self, state: &mut H) {
-		use Vector::*;
-		match self {
-			F64(v) => {
-				0.hash(state);
-				for item in v {
-					state.write_u64(item.to_bits());
-				}
-			}
-			F32(v) => {
-				1.hash(state);
-				for item in v {
-					state.write_u32(item.to_bits());
-				}
-			}
-			I64(v) => {
-				2.hash(state);
-				for item in v {
-					state.write_i64(*item);
-				}
-			}
-			I32(v) => {
-				3.hash(state);
-				for item in v {
-					state.write_i32(*item);
-				}
-			}
-			I16(v) => {
-				4.hash(state);
-				for item in v {
-					state.write_i16(*item);
-				}
-			}
-		}
-	}
-}
 
 impl PartialEq for Vector {
 	fn eq(&self, other: &Self) -> bool {

--- a/core/src/key/table/ix.rs
+++ b/core/src/key/table/ix.rs
@@ -4,7 +4,7 @@ use crate::key::key_req::KeyRequirements;
 use derive::Key;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Key)]
 pub struct Ix<'a> {
 	__: u8,
 	_a: u8,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -109,6 +109,7 @@ criterion = { version = "0.5.1", features = ["async_tokio"] }
 env_logger = "0.10.1"
 pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
 rand = "0.8.5"
+radix_trie = "0.2.1"
 regex = "1.10.2"
 serial_test = "2.0.0"
 temp-dir = "0.1.11"
@@ -157,6 +158,10 @@ harness = false
 
 [[bench]]
 name = "processor"
+harness = false
+
+[[bench]]
+name = "hash_trie_btree"
 harness = false
 
 [[bench]]

--- a/lib/benches/hash_trie_btree.rs
+++ b/lib/benches/hash_trie_btree.rs
@@ -1,0 +1,200 @@
+use criterion::measurement::WallTime;
+use criterion::{criterion_group, criterion_main, BenchmarkGroup, Criterion, Throughput};
+use radix_trie::{Trie, TrieCommon, TrieKey};
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
+use std::time::Duration;
+use surrealdb::key::table::ix;
+use surrealdb_core::sql::{value, Array, Id, Thing};
+
+// Common use case: VectorSearch
+fn bench_hash_trie_btree_large_vector(c: &mut Criterion) {
+	const N: usize = 10_000;
+	let mut samples = Vec::with_capacity(N);
+	for i in 0..N {
+		let key = vec![i as u64; 1536];
+		samples.push((key, i));
+	}
+
+	let mut g = new_group(c, "bench_hash_trie_btree_large_vector", N);
+	bench_hash(&mut g, &samples);
+	bench_trie(&mut g, &samples);
+	bench_btree(&mut g, &samples);
+	g.finish();
+}
+
+fn bench_hash_trie_btree_ix_key(c: &mut Criterion) {
+	const N: usize = 100_000;
+	let mut samples = Vec::with_capacity(N);
+	for i in 0..N {
+		let key = ix::new("test", "test", "test", &format!("test{i}")).encode().unwrap();
+		samples.push((key, i));
+	}
+
+	let mut g = new_group(c, "bench_hash_trie_btree_ix_key", N);
+	bench_hash(&mut g, &samples);
+	bench_trie(&mut g, &samples);
+	bench_btree(&mut g, &samples);
+	g.finish();
+}
+
+fn bench_hash_trie_btree_small_string(c: &mut Criterion) {
+	const N: usize = 100_000;
+	let mut samples = Vec::with_capacity(N);
+	for i in 0..N {
+		let key = format!("test{i}");
+		samples.push((key, i));
+	}
+
+	let mut g = new_group(c, "bench_hash_trie_btree_string", N);
+	bench_hash(&mut g, &samples);
+	bench_trie(&mut g, &samples);
+	bench_btree(&mut g, &samples);
+	g.finish();
+}
+
+fn bench_hash_trie_btree_value(c: &mut Criterion) {
+	const N: usize = 100_000;
+	let mut samples = Vec::with_capacity(N);
+	for i in 0..N {
+		let key = value(&format!("{{ test: {{ something: [1, 'two', null, test:{i}, {{ trueee: false, noneee: nulll }}] }} }}")).unwrap();
+		samples.push((key, i));
+	}
+
+	let mut g = new_group(c, "bench_hash_trie_btree_value", N);
+	bench_hash(&mut g, &samples);
+	bench_btree(&mut g, &samples);
+	g.finish();
+}
+
+fn bench_hash_trie_btree_thing(c: &mut Criterion) {
+	const N: usize = 50_000;
+	let mut samples = Vec::with_capacity(N);
+	for i in 0..N {
+		let key = Thing::from(("test", Id::Array(Array::from(vec![i as i32; 5]))));
+		samples.push((key, i));
+	}
+
+	let mut g = new_group(c, "bench_hash_trie_btree_thing", N);
+	bench_hash(&mut g, &samples);
+	bench_btree(&mut g, &samples);
+	g.finish();
+}
+
+fn new_group<'a>(c: &'a mut Criterion, group: &str, n: usize) -> BenchmarkGroup<'a, WallTime> {
+	let mut group = c.benchmark_group(group);
+	group.throughput(Throughput::Elements(n as u64));
+	group.sample_size(10);
+	group.measurement_time(Duration::from_secs(10));
+	group
+}
+
+fn bench_hash<K: Hash + Eq + Clone, V: Clone>(
+	group: &mut BenchmarkGroup<WallTime>,
+	samples: &[(K, V)],
+) {
+	group.bench_function("hash_insert", |b| {
+		b.iter(|| bench_hash_insert(&samples));
+	});
+	group.bench_function("hash_get", |b| {
+		let map = build_hash(&samples);
+		b.iter(|| bench_hash_get(&samples, &map));
+	});
+}
+
+fn bench_trie<K: TrieKey + Clone, V: Clone>(
+	group: &mut BenchmarkGroup<WallTime>,
+	samples: &[(K, V)],
+) {
+	group.bench_function("trie_insert", |b| {
+		b.iter(|| bench_trie_insert(&samples));
+	});
+
+	group.bench_function("trie_get", |b| {
+		let map = build_trie(&samples);
+		b.iter(|| bench_trie_get(&samples, &map));
+	});
+}
+
+fn bench_btree<K: Eq + Ord + Clone, V: Clone>(
+	group: &mut BenchmarkGroup<WallTime>,
+	samples: &[(K, V)],
+) {
+	group.bench_function("btree_insert", |b| {
+		b.iter(|| bench_btree_insert(&samples));
+	});
+
+	group.bench_function("btree_get", |b| {
+		let map = build_btree(&samples);
+		b.iter(|| bench_btree_get(&samples, &map));
+	});
+}
+
+fn build_hash<K: Hash + Eq + Clone, V: Clone>(samples: &[(K, V)]) -> HashMap<K, V> {
+	let mut map = HashMap::default();
+	for (key, val) in samples {
+		map.insert(key.clone(), val.clone());
+	}
+	map
+}
+fn bench_hash_insert<K: Hash + Eq + Clone, V: Clone>(samples: &[(K, V)]) {
+	let map = build_hash(samples);
+	assert_eq!(map.len(), samples.len());
+}
+
+fn bench_hash_get<K: Hash + Eq, V>(samples: &[(K, V)], map: &HashMap<K, V>) {
+	for (key, _) in samples {
+		assert!(map.get(key).is_some());
+	}
+	assert_eq!(map.len(), samples.len());
+}
+
+fn build_trie<K: TrieKey + Clone, V: Clone>(samples: &[(K, V)]) -> Trie<K, V> {
+	let mut map = Trie::default();
+	for (key, val) in samples {
+		map.insert(key.clone(), val.clone());
+	}
+	map
+}
+
+fn bench_trie_insert<K: TrieKey + Clone, V: Clone>(samples: &[(K, V)]) {
+	let map = build_trie(samples);
+	assert_eq!(map.len(), samples.len());
+}
+
+fn bench_trie_get<K: TrieKey, V>(samples: &[(K, V)], map: &Trie<K, V>) {
+	for (key, _) in samples {
+		assert!(map.get(key).is_some());
+	}
+	assert_eq!(map.len(), samples.len());
+}
+
+fn build_btree<K: Ord + Clone, V: Clone>(samples: &[(K, V)]) -> BTreeMap<K, V> {
+	let mut map = BTreeMap::default();
+	for (key, val) in samples {
+		map.insert(key.clone(), val.clone());
+	}
+	map
+}
+
+fn bench_btree_insert<K: Ord + Clone, V: Clone>(samples: &[(K, V)]) {
+	let map = build_btree(samples);
+	assert_eq!(map.len(), samples.len());
+}
+
+fn bench_btree_get<K: Ord, V>(samples: &[(K, V)], map: &BTreeMap<K, V>) {
+	for (key, _) in samples {
+		assert!(map.get(key).is_some());
+	}
+	assert_eq!(map.len(), samples.len());
+}
+
+criterion_group!(
+	benches,
+	bench_hash_trie_btree_large_vector,
+	bench_hash_trie_btree_ix_key,
+	bench_hash_trie_btree_small_string,
+	bench_hash_trie_btree_thing,
+	bench_hash_trie_btree_value
+);
+criterion_main!(benches);


### PR DESCRIPTION
## What is the motivation?

It is common with Vector Search to use Vector with large dimensions (thousands). Storing such Vectors in a HashMap is slower than a BTreeMap due to the hash computation.

## What does this change do?

Backports #3466 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
