### PR TITLE
Improve the js-surql value conversion for numbers

### DIFF
--- a/core/src/fnc/script/into.rs
+++ b/core/src/fnc/script/into.rs
@@ -2,13 +2,19 @@ use super::classes;
 use crate::sql::number::Number;
 use crate::sql::value::Value;
 use js::Array;
+use js::BigInt;
 use js::Class;
 use js::Ctx;
 use js::Error;
+use js::Exception;
 use js::IntoJs;
 use js::Null;
 use js::Object;
 use js::Undefined;
+use rust_decimal::prelude::ToPrimitive;
+
+const F64_INT_MAX: i64 = ((1u64 << f64::MANTISSA_DIGITS) - 1) as i64;
+const F64_INT_MIN: i64 = -F64_INT_MAX - 1;
 
 impl<'js> IntoJs<'js> for Value {
 	fn into_js(self, ctx: &Ctx<'js>) -> Result<js::Value<'js>, Error> {
@@ -18,50 +24,82 @@ impl<'js> IntoJs<'js> for Value {
 
 impl<'js> IntoJs<'js> for &Value {
 	fn into_js(self, ctx: &Ctx<'js>) -> Result<js::Value<'js>, Error> {
-		match self {
+		match *self {
 			Value::Null => Null.into_js(ctx),
 			Value::None => Undefined.into_js(ctx),
-			Value::Bool(boolean) => Ok(js::Value::new_bool(ctx.clone(), *boolean)),
-			Value::Strand(v) => js::String::from_str(ctx.clone(), v)?.into_js(ctx),
-			Value::Number(Number::Int(v)) => Ok(js::Value::new_int(ctx.clone(), *v as i32)),
-			Value::Number(Number::Float(v)) => Ok(js::Value::new_float(ctx.clone(), *v)),
-			&Value::Number(Number::Decimal(v)) => match v.is_integer() {
-				true => Ok(js::Value::new_int(ctx.clone(), v.try_into().unwrap_or_default())),
-				false => Ok(js::Value::new_float(ctx.clone(), v.try_into().unwrap_or_default())),
-			},
-			Value::Datetime(v) => {
+			Value::Bool(boolean) => Ok(js::Value::new_bool(ctx.clone(), boolean)),
+			Value::Strand(ref v) => js::String::from_str(ctx.clone(), v)?.into_js(ctx),
+			Value::Number(Number::Int(v)) => {
+				if ((i32::MIN as i64)..=(i32::MAX as i64)).contains(&v) {
+					Ok(js::Value::new_int(ctx.clone(), v as i32))
+				} else if (F64_INT_MIN..=F64_INT_MAX).contains(&v) {
+					Ok(js::Value::new_float(ctx.clone(), v as f64))
+				} else {
+					Ok(js::Value::from(BigInt::from_i64(ctx.clone(), v)?))
+				}
+			}
+			Value::Number(Number::Float(v)) => Ok(js::Value::new_float(ctx.clone(), v)),
+			Value::Number(Number::Decimal(v)) => {
+				if v.is_integer() {
+					if let Some(v) = v.to_i64() {
+						if ((i32::MIN as i64)..=(i32::MAX as i64)).contains(&v) {
+							Ok(js::Value::new_int(ctx.clone(), v as i32))
+						} else if (F64_INT_MIN..=F64_INT_MAX).contains(&v) {
+							Ok(js::Value::new_float(ctx.clone(), v as f64))
+						} else {
+							Ok(js::Value::from(BigInt::from_i64(ctx.clone(), v)?))
+						}
+					} else {
+						Err(Exception::from_message(
+							ctx.clone(),
+							"Couldn't convert SurrealQL Decimal to JavaScript number",
+						)?
+						.throw())
+					}
+				} else if let Ok(v) = v.try_into() {
+					Ok(js::Value::new_float(ctx.clone(), v))
+				} else {
+					// FIXME: Add support for larger numbers if rquickjs ever adds support.
+					Err(Exception::from_message(
+						ctx.clone(),
+						"Couldn't convert SurrealQL Decimal to a JavaScript number",
+					)?
+					.throw())
+				}
+			}
+			Value::Datetime(ref v) => {
 				let date: js::function::Constructor = ctx.globals().get("Date")?;
 				date.construct((v.0.timestamp_millis(),))
 			}
-			Value::Thing(v) => Ok(Class::<classes::record::Record>::instance(
+			Value::Thing(ref v) => Ok(Class::<classes::record::Record>::instance(
 				ctx.clone(),
 				classes::record::Record {
 					value: v.to_owned(),
 				},
 			)?
 			.into_value()),
-			Value::Duration(v) => Ok(Class::<classes::duration::Duration>::instance(
+			Value::Duration(ref v) => Ok(Class::<classes::duration::Duration>::instance(
 				ctx.clone(),
 				classes::duration::Duration {
 					value: Some(v.to_owned()),
 				},
 			)?
 			.into_value()),
-			Value::Uuid(v) => Ok(Class::<classes::uuid::Uuid>::instance(
+			Value::Uuid(ref v) => Ok(Class::<classes::uuid::Uuid>::instance(
 				ctx.clone(),
 				classes::uuid::Uuid {
 					value: Some(v.to_owned()),
 				},
 			)?
 			.into_value()),
-			Value::Array(v) => {
+			Value::Array(ref v) => {
 				let x = Array::new(ctx.clone())?;
 				for (i, v) in v.iter().enumerate() {
 					x.set(i, v)?;
 				}
 				x.into_js(ctx)
 			}
-			Value::Object(v) => {
+			Value::Object(ref v) => {
 				let x = Object::new(ctx.clone())?;
 				for (k, v) in v.iter() {
 					x.set(k, v)?;

--- a/lib/tests/script.rs
+++ b/lib/tests/script.rs
@@ -4,9 +4,11 @@ mod parse;
 use parse::Parse;
 mod helpers;
 use helpers::new_ds;
+use rust_decimal::Decimal;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::sql::Value;
+use surrealdb_core::sql::Number;
 
 #[tokio::test]
 async fn script_function_error() -> Result<(), Error> {
@@ -324,5 +326,51 @@ async fn script_value_function_inline_values() -> Result<(), Error> {
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
 	res.remove(0).result?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn script_function_number_conversion_test() -> Result<(), Error> {
+	let sql = r#"
+		RETURN function() {
+			if(await surrealdb.value(`2147483647`) !== 2147483647){
+				throw new Error(1)
+			}
+			if(await surrealdb.value(`9007199254740991`) !== 9007199254740991){
+				throw new Error(2)
+			}
+			if(await surrealdb.value(`9007199254740992`) !== 9007199254740992n){
+				throw new Error(3)
+			}
+			if(await surrealdb.value(`-9007199254740992`) !== -9007199254740992){
+				throw new Error(4)
+			}
+			if(await surrealdb.value(`-9007199254740993`) !== -9007199254740993n){
+				throw new Error(5)
+			}
+			return {
+				a:  9007199254740991,
+				b: -9007199254740992,
+				c: 100000000000000000n,
+				d: 9223372036854775808n
+			}
+		}
+	"#;
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 1);
+
+	let Value::Object(res) = res.remove(0).result? else {
+		panic!("not an object")
+	};
+	assert_eq!(res.get("a").unwrap(), &Value::Number(Number::Float(9007199254740991f64)));
+	assert_eq!(res.get("b").unwrap(), &Value::Number(Number::Float(-9007199254740992f64)));
+	assert_eq!(res.get("c").unwrap(), &Value::Number(Number::Int(100000000000000000i64)));
+	assert_eq!(
+		res.get("d").unwrap(),
+		&Value::Number(Number::Decimal(Decimal::from(9223372036854775808u128)))
+	);
+
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

Converting numbers to and from js functions will truncate integers currently. This makes it hard to use js functions for some use-cases.

## What does this change do?

Backport #3460 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
