### PR TITLE
Fix crate dependency patching

### DIFF
--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -109,6 +109,10 @@ jobs:
             sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
             sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
 
+            # Update dependency versions
+            sed -i "s#surrealdb = { version = \"=${currentVersion}\"#surrealdb = { version = \"${major}\"#" Cargo.toml
+            sed -i "s#surrealdb-core = { version = \"=${currentVersion}\"#surrealdb-core = { version = \"${major}\"#" lib/Cargo.toml
+
             # Update Cargo.lock without updating dependency versions
             cargo check --no-default-features --features storage-mem
 
@@ -138,21 +142,25 @@ jobs:
             else
               betaVersion=$currentVersion
             fi
+
+            # Update dependency versions
+            sed -i "s#surrealdb = { version = \"=${currentVersion}\"#surrealdb = { version = \"=${betaVersion}\"#" Cargo.toml
+            sed -i "s#surrealdb-core = { version = \"=${currentVersion}\"#surrealdb-core = { version = \"=${betaVersion}\"#" lib/Cargo.toml
           else
             git checkout -b releases/beta
             major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
             minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
             betaVersion=${major}.${minor}.0-beta.1
+
+            # Update dependency versions
+            sed -i "s#surrealdb = { version = \"${major}\"#surrealdb = { version = \"=${betaVersion}\"#" Cargo.toml
+            sed -i "s#surrealdb-core = { version = \"${major}\"#surrealdb-core = { version = \"=${betaVersion}\"#" lib/Cargo.toml
           fi
 
           # Bump the crate version
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${betaVersion}\"#" core/Cargo.toml
-
-          # Update dependency versions
-          sed -i "s#surrealdb = { version = \"1\"#surrealdb = { version = \"=${betaVersion}\"#" Cargo.toml
-          sed -i "s#surrealdb-core = { version = \"1\"#surrealdb-core = { version = \"=${betaVersion}\"#" lib/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem
@@ -643,7 +651,7 @@ jobs:
           # Update the version to a nightly one
           sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"${version}\"#" core/Cargo.toml
-          sed -i "s#surrealdb-core = { version = \"1\"#surrealdb-core = { version = \"=${version}\"#" lib/Cargo.toml
+          sed -i "s#surrealdb-core = { version = \"${major}\"#surrealdb-core = { version = \"=${version}\"#" lib/Cargo.toml
 
       - name: Patch crate name and description
         if: ${{ inputs.environment == 'nightly' || inputs.environment == 'beta' }}


### PR DESCRIPTION
## What is the motivation?

After modularisation, patching for `surrealdb` and `surrealdb-core` dependencies was not robust enough to cover both beta and stable releases.

## What does this change do?

It makes it more robust.

## What is your testing strategy?

Released v1.2.0-beta.2 using this changeset.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
