### PR TITLE
Add instruction to run `cargo vet prune` when updating crate audits

### DIFF
--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -65,6 +65,8 @@ The following process can be followed whenever the dependency checking action fa
       - `cargo vet trust <PACKAGE>`
     - Otherwise, it can be (for now) exempted from the vetting process.
       - `cargo vet add-exemption <PACKAGE>`
+  - Afterwards, prune the list of audits to remove outdated entries.
+  	- `cargo vet prune`
   - The changes will be approved by **@surrealdb/security**.
 - If the action fails due to `cargo-acl`:
   - The newly required access (e.g. `unsafe`, `fs`, `net`...) should be understood by the author of the PR.


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

To ensure that old entries are removed from the crate audit files managed by `cargo vet`.

## What does this change do?

Updates supply chain security process to add instruction to run `cargo vet prune` when updating crate audits.

## What is your testing strategy?

None needed.

## Is this related to any issues?

Comment left on #3451.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
