### PR TITLE
Bugfix: Fix MATH::SQRT_2 not parsing

### DIFF
--- a/core/src/syn/v1/builtin.rs
+++ b/core/src/syn/v1/builtin.rs
@@ -85,7 +85,7 @@ macro_rules! impl_builtins {
 			)*
 
 			$(
-				match dbg!($name(dbg!($i))){
+				match $name($i){
 					Ok((i,x)) => return Ok((i,x)),
 					Err(Err::Failure(x)) => return Err(Err::Failure(x)),
 					_ => {}

--- a/core/src/syn/v1/builtin.rs
+++ b/core/src/syn/v1/builtin.rs
@@ -85,7 +85,7 @@ macro_rules! impl_builtins {
 			)*
 
 			$(
-				match $name($i){
+				match dbg!($name(dbg!($i))){
 					Ok((i,x)) => return Ok((i,x)),
 					Err(Err::Failure(x)) => return Err(Err::Failure(x)),
 					_ => {}
@@ -269,6 +269,7 @@ pub(crate) fn builtin_name(i: &str) -> IResult<&str, BuiltinName<&str>, ParseErr
 			product => { fn },
 			round => { fn },
 			spread => { fn },
+			SQRT_2 => { const = constant::Constant::MathSqrt2 },
 			sqrt => { fn },
 			stddev => { fn },
 			sum => { fn },
@@ -293,7 +294,6 @@ pub(crate) fn builtin_name(i: &str) -> IResult<&str, BuiltinName<&str>, ParseErr
 			LOG2_10 => { const = constant::Constant::MathLog210 },
 			LOG2_E => { const = constant::Constant::MathLog2E },
 			PI => { const = constant::Constant::MathPi },
-			SQRT_2 => { const = constant::Constant::MathSqrt2 },
 			TAU => { const = constant::Constant::MathTau },
 		},
 		meta => {
@@ -547,5 +547,14 @@ mod tests {
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
 		assert_eq!(out, BuiltinName::Constant(Constant::MathPi));
+	}
+
+	#[test]
+	fn constant_sqrt_2() {
+		let sql = "math::SqRt_2";
+		let res = builtin_name(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!(out, BuiltinName::Constant(Constant::MathSqrt2));
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

MATH::SQRT_2 constant didn't parse because an ordering mistake in the parser

## What does this change do?

Fixes the problem

## What is your testing strategy?

Added a test for this specific problem

## Is this related to any issues?

Fixes #3511

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
