### PR TITLE
Avoid bumping the SDK version when checking out a patch branch

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -36,18 +36,16 @@ jobs:
     needs: [tag-check]
     runs-on: ubuntu-latest
     steps:
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-tag }}
 
       - name: Install a TOML parser
-        run: cargo install --force --locked --version 0.8.1 taplo-cli
+        run: |
+          curl -L https://github.com/tamasfe/taplo/releases/download/0.8.1/taplo-full-linux-x86_64.gz | gunzip - > taplo
+          chmod +x taplo
+          sudo mv taplo /usr/bin/taplo
 
       - name: Prepare patch branch
         run: |
@@ -59,7 +57,7 @@ jobs:
           git config --add --bool push.autoSetupRemote true
 
           # Calculate new version
-          currentVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
+          currentVersion=$(taplo get -f lib/Cargo.toml "package.version")
           major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
           minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
           patch=$(echo $currentVersion | tr "." "\n" | sed -n 3p)
@@ -67,7 +65,6 @@ jobs:
 
           # Bump the crate version
           sed -i "s#^version = \".*\"#version = \"${version}\"#" Cargo.toml
-          sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem


### PR DESCRIPTION
## What is the motivation?

Now that the core library lives in separate crate from the SDK, we don't know which library we will be patching.

## What does this change do?

It avoids automatically bumping the version of the SDK and ensures only the binary is bumped. We know we will need to bump that one anyway regardless of the library we end up patching.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
