### PR TITLE
Bugfix: Make integration tests more consistent

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -26,25 +26,25 @@ args = ["clippy", "--all-targets", "--features", "storage-mem,storage-rocksdb,st
 [tasks.ci-cli-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "cli_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http,scripting,jwks", "--workspace", "--test", "cli_integration", "--", "cli_integration", "--nocapture"]
+env = { RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "cli_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http,scripting,jwks", "--workspace", "--test", "cli_integration", "--", "cli_integration"]
 
 [tasks.ci-http-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks", "--workspace", "--test", "http_integration", "--", "http_integration", "--nocapture"]
+env = { RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks", "--workspace", "--test", "http_integration", "--", "http_integration"]
 
 [tasks.ci-ws-integration]
 category = "WS - INTEGRATION TESTS"
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "ws_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,sql2", "--workspace", "--test", "ws_integration", "--", "ws_integration", "--nocapture"]
+env = { RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "ws_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,sql2", "--workspace", "--test", "ws_integration", "--", "ws_integration"]
 
 [tasks.ci-ml-integration]
 category = "ML - INTEGRATION TESTS"
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "cli_integration::common=debug", condition = { env_not_set = ["RUST_LOG"] } } }
+env = { RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG={ value = "cli_integration::common=debug", condition = { env_not_set = ["RUST_LOG"] } } }
 args = ["test", "--locked", "--features", "storage-mem,ml,sql2", "--workspace", "--test", "ml_integration", "--", "ml_integration", "--nocapture"]
 
 [tasks.ci-workspace-coverage]
@@ -63,7 +63,7 @@ args = [
 [tasks.test-experimental-parser]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUSTDOCFLAGS="--cfg surrealdb_unstable" }
+env = { RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable", RUSTDOCFLAGS="--cfg surrealdb_unstable" }
 args = [
 	"test", "--locked", "--no-default-features", "--features", "storage-mem,scripting,http,parser2", "--workspace", "--",
 	"--skip", "api_integration",
@@ -90,18 +90,18 @@ run_task = { name = ["start-surrealdb", "test-workspace-coverage-complete", "sto
 [tasks.test-kvs]
 private = true
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable" }
+env = {RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable" }
 args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--lib", "kvs"]
 
 
 [tasks.test-api-integration]
 private = true
 command = "cargo"
-env = { RUSTFLAGS = "--cfg surrealdb_unstable" }
+env = {RUST_BACKTRACE=1, RUSTFLAGS = "--cfg surrealdb_unstable" }
 args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--test", "api", "api_integration::${_TEST_API_ENGINE}"]
 
 [tasks.ci-api-integration]
-env = { _START_SURREALDB_PATH = "memory", RUSTFLAGS = "--cfg surrealdb_unstable" }
+env = {RUST_BACKTRACE=1, _START_SURREALDB_PATH = "memory", RUSTFLAGS = "--cfg surrealdb_unstable" }
 private = true
 run_task = { name = ["start-surrealdb", "test-api-integration", "stop-surrealdb"], fork = true }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -5,6 +5,7 @@ mod cli_integration {
 	use assert_fs::prelude::{FileTouch, FileWriteStr, PathChild};
 	use common::Format;
 	use common::Socket;
+	use serde_json::json;
 	use std::fs;
 	use std::fs::File;
 	use std::time;
@@ -256,7 +257,7 @@ mod cli_integration {
 	#[test(tokio::test)]
 	async fn with_root_auth() {
 		// Commands with credentials when auth is enabled, should succeed
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, server) = common::start_server_with_defaults().await.unwrap();
 		let creds = format!("--user {USER} --pass {PASS}");
 		let sql_args = format!("sql --conn http://{addr} --multi --pretty");
 
@@ -306,12 +307,13 @@ mod cli_integration {
 			// TODO: Once backups are functional, update this test.
 			assert_eq!(fs::read_to_string(file).unwrap(), "Save");
 		}
+		server.finish()
 	}
 
 	#[test(tokio::test)]
 	async fn with_auth_level() {
 		// Commands with credentials for different auth levels
-		let (addr, _server) = common::start_server_with_auth_level().await.unwrap();
+		let (addr, server) = common::start_server_with_auth_level().await.unwrap();
 		let creds = format!("--user {USER} --pass {PASS}");
 		let ns = Ulid::new();
 		let db = Ulid::new();
@@ -490,13 +492,14 @@ mod cli_integration {
 				output
 			);
 		}
+		server.finish();
 	}
 
 	#[test(tokio::test)]
 	// TODO(gguillemas): Remove this test once the legacy authentication is deprecated in v2.0.0
 	async fn without_auth_level() {
 		// Commands with credentials for different auth levels
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, server) = common::start_server_with_defaults().await.unwrap();
 		let creds = format!("--user {USER} --pass {PASS}");
 		let ns = Ulid::new();
 		let db = Ulid::new();
@@ -556,12 +559,13 @@ mod cli_integration {
 				output
 			);
 		}
+		server.finish()
 	}
 
 	#[test(tokio::test)]
 	async fn with_anon_auth() {
 		// Commands without credentials when auth is enabled, should fail
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, server) = common::start_server_with_defaults().await.unwrap();
 		let creds = ""; // Anonymous user
 		let sql_args = format!("sql --conn http://{addr} --multi --pretty");
 
@@ -623,12 +627,13 @@ mod cli_integration {
 			// );
 			assert!(output.is_ok(), "anonymous user can do backups: {:?}", output);
 		}
+		server.finish();
 	}
 
 	#[test(tokio::test)]
 	async fn node() {
 		// Commands without credentials when auth is disabled, should succeed
-		let (addr, _server) = common::start_server(StartServerArguments {
+		let (addr, server) = common::start_server(StartServerArguments {
 			auth: false,
 			tls: false,
 			wait_is_ready: true,
@@ -696,6 +701,7 @@ mod cli_integration {
 				"failed to send sql: {args}"
 			);
 		}
+		server.finish()
 	}
 
 	#[test]
@@ -774,66 +780,67 @@ mod cli_integration {
 		let (addr, mut server) = common::start_server_without_auth().await.unwrap();
 
 		// Create a long-lived WS connection so the server don't shutdown gracefully
-		let mut socket = Socket::connect(&addr, None).await.expect("Failed to connect to server");
-		let json = serde_json::json!({
-			"id": "1",
-			"method": "query",
-			"params": ["SLEEP 30s;"],
-		});
-		socket.send_message(Format::Json, json).await.expect("Failed to send WS message");
+		let socket =
+			Socket::connect(&addr, None, Format::Json).await.expect("Failed to connect to server");
 
-		// Make sure the SLEEP query is being executed
-		tokio::select! {
-			_ = async {
+		let send_future = socket.send_request("query", json!(["SLEEP 30s;"]));
+
+		let signal_send_fut = async {
+			// Make sure the SLEEP query is being executed
+			tokio::time::timeout(time::Duration::from_secs(10), async {
 				loop {
-					if server.stderr().contains("Executing: SLEEP 30s") {
+					let err = server.stderr();
+					if err.contains("SLEEP 30s") {
 						break;
 					}
 					tokio::time::sleep(time::Duration::from_secs(1)).await;
 				}
-			} => {},
-			// Timeout after 10 seconds
-			_ = tokio::time::sleep(time::Duration::from_secs(10)) => panic!("Server didn't start executing the SLEEP query"),
-		}
+			})
+			.await
+			.expect("Server didn't start executing the SLEEP query");
 
-		info!("* Send first SIGINT signal");
-		server
-			.send_signal(nix::sys::signal::Signal::SIGINT)
-			.expect("Failed to send SIGINT to server");
+			info!("* Send first SIGINT signal");
+			server
+				.send_signal(nix::sys::signal::Signal::SIGINT)
+				.expect("Failed to send SIGINT to server");
 
-		tokio::select! {
-			_ = async {
+			tokio::time::timeout(time::Duration::from_secs(10), async {
 				loop {
 					if let Ok(Some(exit)) = server.status() {
-						panic!("Server unexpectedly exited after receiving first SIGINT: {:?}", exit);
+						panic!(
+							"Server unexpectedly exited after receiving first SIGINT: {:?}",
+							exit
+						);
 					}
-					tokio::time::sleep(time::Duration::from_secs(1)).await;
+					tokio::time::sleep(time::Duration::from_millis(100)).await;
 				}
-			} => {},
-			// Timeout after 5 seconds
-			_ = tokio::time::sleep(time::Duration::from_secs(5)) => ()
-		}
+			})
+			.await
+			.unwrap_err();
 
-		info!("* Send second SIGINT signal");
-		server
-			.send_signal(nix::sys::signal::Signal::SIGINT)
-			.expect("Failed to send SIGINT to server");
+			info!("* Send second SIGINT signal");
 
-		tokio::select! {
-			_ = async {
+			server
+				.send_signal(nix::sys::signal::Signal::SIGINT)
+				.expect("Failed to send SIGINT to server");
+
+			tokio::time::timeout(time::Duration::from_secs(5), async {
 				loop {
 					if let Ok(Some(exit)) = server.status() {
 						assert!(exit.success(), "Server shutted down successfully");
 						break;
 					}
-					tokio::time::sleep(time::Duration::from_secs(1)).await;
+					tokio::time::sleep(time::Duration::from_millis(100)).await;
 				}
-			} => {},
-			// Timeout after 5 seconds
-			_ = tokio::time::sleep(time::Duration::from_secs(5)) => {
-				panic!("Server didn't exit after receiving two SIGINT signals");
-			}
-		}
+			})
+			.await
+			.expect("Server didn't exit after receiving two SIGINT signals");
+		};
+
+		let _ =
+			futures::future::join(async { send_future.await.unwrap_err() }, signal_send_fut).await;
+
+		server.finish()
 	}
 
 	#[test(tokio::test)]
@@ -842,7 +849,7 @@ mod cli_integration {
 		// Default capabilities only allow functions
 		info!("* When default capabilities");
 		{
-			let (addr, _server) = common::start_server(StartServerArguments {
+			let (addr, server) = common::start_server(StartServerArguments {
 				args: "".to_owned(),
 				..Default::default()
 			})
@@ -868,12 +875,14 @@ mod cli_integration {
 					|| output.contains("Embedded functions are not enabled"),
 				"unexpected output: {output:?}"
 			);
+
+			server.finish();
 		}
 
 		// Deny all, denies all users to execute functions and access any network address
 		info!("* When all capabilities are denied");
 		{
-			let (addr, _server) = common::start_server(StartServerArguments {
+			let (addr, server) = common::start_server(StartServerArguments {
 				args: "--deny-all".to_owned(),
 				..Default::default()
 			})
@@ -899,12 +908,13 @@ mod cli_integration {
 					|| output.contains("Embedded functions are not enabled"),
 				"unexpected output: {output:?}"
 			);
+			server.finish()
 		}
 
 		// When all capabilities are allowed, anyone (including non-authenticated users) can execute functions and access any network address
 		info!("* When all capabilities are allowed");
 		{
-			let (addr, _server) = common::start_server(StartServerArguments {
+			let (addr, server) = common::start_server(StartServerArguments {
 				args: "--allow-all".to_owned(),
 				..Default::default()
 			})
@@ -923,11 +933,13 @@ mod cli_integration {
 			let query = "RETURN function() { return '1' };";
 			let output = common::run(&cmd).input(query).output().unwrap();
 			assert!(output.starts_with("['1']"), "unexpected output: {output:?}");
+
+			server.finish()
 		}
 
 		info!("* When scripting is denied");
 		{
-			let (addr, _server) = common::start_server(StartServerArguments {
+			let (addr, server) = common::start_server(StartServerArguments {
 				args: "--deny-scripting".to_owned(),
 				..Default::default()
 			})
@@ -946,11 +958,12 @@ mod cli_integration {
 					|| output.contains("Embedded functions are not enabled"),
 				"unexpected output: {output:?}"
 			);
+			server.finish()
 		}
 
 		info!("* When net is denied and function is enabled");
 		{
-			let (addr, _server) = common::start_server(StartServerArguments {
+			let (addr, server) = common::start_server(StartServerArguments {
 				args: "--deny-net 127.0.0.1 --allow-funcs http::get".to_owned(),
 				..Default::default()
 			})
@@ -971,11 +984,12 @@ mod cli_integration {
 				),
 				"unexpected output: {output:?}"
 			);
+			server.finish()
 		}
 
 		info!("* When net is enabled for an IP and also denied for a specific port that doesn't match");
 		{
-			let (addr, _server) = common::start_server(StartServerArguments {
+			let (addr, server) = common::start_server(StartServerArguments {
 				args: "--allow-net 127.0.0.1 --deny-net 127.0.0.1:80 --allow-funcs http::get"
 					.to_owned(),
 				..Default::default()
@@ -991,11 +1005,12 @@ mod cli_integration {
 			let query = format!("RETURN http::get('http://{}/version');\n\n", addr);
 			let output = common::run(&cmd).input(&query).output().unwrap();
 			assert!(output.starts_with("['surrealdb"), "unexpected output: {output:?}");
+			server.finish()
 		}
 
 		info!("* When a function family is denied");
 		{
-			let (addr, _server) = common::start_server(StartServerArguments {
+			let (addr, server) = common::start_server(StartServerArguments {
 				args: "--deny-funcs http".to_owned(),
 				..Default::default()
 			})
@@ -1013,11 +1028,12 @@ mod cli_integration {
 				output.contains("Function 'http::get' is not allowed"),
 				"unexpected output: {output:?}"
 			);
+			server.finish()
 		}
 
 		info!("* When auth is enabled and guest access is allowed");
 		{
-			let (addr, _server) = common::start_server(StartServerArguments {
+			let (addr, server) = common::start_server(StartServerArguments {
 				auth: true,
 				args: "--allow-guests".to_owned(),
 				..Default::default()
@@ -1033,11 +1049,12 @@ mod cli_integration {
 			let query = "RETURN 1;\n\n";
 			let output = common::run(&cmd).input(query).output().unwrap();
 			assert!(output.contains("[1]"), "unexpected output: {output:?}");
+			server.finish()
 		}
 
 		info!("* When auth is enabled and guest access is denied");
 		{
-			let (addr, _server) = common::start_server(StartServerArguments {
+			let (addr, server) = common::start_server(StartServerArguments {
 				auth: true,
 				args: "--deny-guests".to_owned(),
 				..Default::default()
@@ -1056,11 +1073,12 @@ mod cli_integration {
 				output.contains("Not enough permissions to perform this action"),
 				"unexpected output: {output:?}"
 			);
+			server.finish()
 		}
 
 		info!("* When auth is disabled, guest access is always allowed");
 		{
-			let (addr, _server) = common::start_server(StartServerArguments {
+			let (addr, server) = common::start_server(StartServerArguments {
 				auth: false,
 				args: "--deny-guests".to_owned(),
 				..Default::default()
@@ -1076,6 +1094,7 @@ mod cli_integration {
 			let query = "RETURN 1;\n\n";
 			let output = common::run(&cmd).input(query).output().unwrap();
 			assert!(output.contains("[1]"), "unexpected output: {output:?}");
+			server.finish()
 		}
 	}
 }

--- a/tests/common/socket.rs
+++ b/tests/common/socket.rs
@@ -1,17 +1,28 @@
 use super::format::Format;
 use crate::common::error::TestError;
+use futures::channel::oneshot::channel;
 use futures_util::{SinkExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::collections::HashMap;
 use std::error::Error;
+use std::result::Result as StdResult;
 use std::time::Duration;
 use surrealdb::sql::Value;
 use tokio::net::TcpStream;
+use tokio::sync::{
+	mpsc::{self, Receiver, Sender},
+	oneshot,
+};
 use tokio::time;
+use tokio_stream::StreamExt;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 use tracing::{debug, error};
+
+type Result<T> = StdResult<T, Box<dyn Error>>;
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 #[derive(Serialize, Deserialize)]
 struct UseParams<'a> {
@@ -33,42 +44,69 @@ struct SigninParams<'a> {
 	sc: Option<&'a str>,
 }
 
+enum SocketMsg {
+	SendAwait {
+		method: String,
+		args: serde_json::Value,
+		channel: oneshot::Sender<serde_json::Value>,
+	},
+	Send {
+		method: String,
+		args: serde_json::Value,
+	},
+	Close {
+		channel: oneshot::Sender<()>,
+	},
+}
+
 pub struct Socket {
-	pub stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+	sender: mpsc::Sender<SocketMsg>,
+	other_messages: mpsc::Receiver<serde_json::Value>,
 }
 
 // pub struct Socket(pub WebSocketStream<MaybeTlsStream<TcpStream>>);
 
 impl Socket {
 	/// Close the connection with the WebSocket server
-	pub async fn close(&mut self) -> Result<(), Box<dyn Error>> {
-		Ok(self.stream.close(None).await?)
+	pub async fn close(&mut self) -> Result<()> {
+		let (send, recv) = oneshot::channel();
+		self.sender
+			.send(SocketMsg::Close {
+				channel: send,
+			})
+			.await?;
+		if (recv.await).is_err() {
+			return Err("Ws task stoped unexpectedly".to_string().into());
+		}
+		Ok(())
 	}
 
 	/// Connect to a WebSocket server using a specific format
-	pub async fn connect(addr: &str, format: Option<Format>) -> Result<Self, Box<dyn Error>> {
+	pub async fn connect(addr: &str, format: Option<Format>, msg_format: Format) -> Result<Self> {
 		let url = format!("ws://{}/rpc", addr);
 		let mut req = url.into_client_request().unwrap();
 		if let Some(v) = format.map(|v| v.to_string()) {
 			req.headers_mut().insert("Sec-WebSocket-Protocol", v.parse().unwrap());
 		}
 		let (stream, _) = connect_async(req).await?;
+		let (send, recv) = mpsc::channel(16);
+		let (send_other, recv_other) = mpsc::channel(16);
+
+		tokio::spawn(async move {
+			if let Err(e) = Self::ws_task(recv, stream, send_other, msg_format).await {
+				eprintln!("error in websocket task: {e}")
+			}
+		});
+
 		Ok(Self {
-			stream,
+			sender: send,
+			other_messages: recv_other,
 		})
 	}
 
-	/// Send a text or binary message to the WebSocket server
-	pub async fn send_message(
-		&mut self,
-		format: Format,
-		message: serde_json::Value,
-	) -> Result<(), Box<dyn Error>> {
-		let now = time::Instant::now();
-		debug!("Sending message: {message}");
-		// Format the message
-		let msg = match format {
-			Format::Json => Message::Text(serde_json::to_string(&message)?),
+	fn to_msg(format: Format, message: &serde_json::Value) -> Result<Message> {
+		match format {
+			Format::Json => Ok(Message::Text(serde_json::to_string(message)?)),
 			Format::Cbor => {
 				pub mod try_from_impls {
 					include!("../../src/rpc/format/cbor/convert.rs");
@@ -86,7 +124,7 @@ impl Socket {
 				let mut output = Vec::new();
 				ciborium::into_writer(&cbor.0, &mut output).unwrap();
 				// THen output the message.
-				Message::Binary(output)
+				Ok(Message::Binary(output))
 			}
 			Format::Pack => {
 				pub mod try_from_impls {
@@ -105,165 +143,202 @@ impl Socket {
 				let mut output = Vec::new();
 				rmpv::encode::write_value(&mut output, &pack.0).unwrap();
 				// THen output the message.
-				Message::Binary(output)
-			}
-		};
-		// Send the message
-		tokio::select! {
-			_ = time::sleep(time::Duration::from_millis(500)) => {
-				return Err("timeout after 500ms waiting for the request to be sent".into());
-			}
-			res = self.stream.send(msg) => {
-				debug!("Message sent in {:?}", now.elapsed());
-					if let Err(err) = res {
-						return Err(format!("Error sending the message: {}", err).into());
-					}
+				Ok(Message::Binary(output))
 			}
 		}
-		Ok(())
 	}
 
-	/// Receive a text or binary message from the WebSocket server
-	pub async fn receive_message(
-		&mut self,
+	fn from_msg(format: Format, msg: Message) -> Result<Option<serde_json::Value>> {
+		match msg {
+			Message::Text(msg) => {
+				debug!("Response {msg:?}");
+				match format {
+					Format::Json => {
+						let msg = serde_json::from_str(&msg)?;
+						debug!("Received message: {msg}");
+						Ok(Some(msg))
+					}
+					_ => Err("Expected to receive a binary message".to_string().into()),
+				}
+			}
+			Message::Binary(msg) => {
+				debug!("Response {msg:?}");
+				match format {
+					Format::Cbor => {
+						pub mod try_from_impls {
+							include!("../../src/rpc/format/cbor/convert.rs");
+						}
+						// For tests we need to convert the binary data to
+						// a serde_json::Value so that test assertions work.
+						// First of all we deserialize the CBOR data.
+						let msg: ciborium::Value = ciborium::from_reader(&mut msg.as_slice())?;
+						// Then we convert it to a SurrealQL Value.
+						let msg: Value = try_from_impls::Cbor(msg).try_into()?;
+						// Then we convert the SurrealQL to JSON.
+						let msg = msg.into_json();
+						// Then output the response.
+						debug!("Received message: {msg:?}");
+						Ok(Some(msg))
+					}
+					Format::Pack => {
+						pub mod try_from_impls {
+							include!("../../src/rpc/format/msgpack/convert.rs");
+						}
+						// For tests we need to convert the binary data to
+						// a serde_json::Value so that test assertions work.
+						// First of all we deserialize the MessagePack data.
+						let msg: rmpv::Value = rmpv::decode::read_value(&mut msg.as_slice())?;
+						// Then we convert it to a SurrealQL Value.
+						let msg: Value = try_from_impls::Pack(msg).try_into()?;
+						// Then we convert the SurrealQL to JSON.
+						let msg = msg.into_json();
+						// Then output the response.
+						debug!("Received message: {msg:?}");
+						Ok(Some(msg))
+					}
+					_ => Err("Expected to receive a text message".to_string().into()),
+				}
+			}
+			Message::Close(_) => Err("Socket closed unexpectedly".to_string().into()),
+			_ => Ok(None),
+		}
+	}
+
+	async fn send_msg(
+		stream: &mut WsStream,
+		id: u64,
 		format: Format,
-	) -> Result<serde_json::Value, Box<dyn Error>> {
-		let now = time::Instant::now();
-		debug!("Receiving response...");
+		method: &str,
+		args: serde_json::Value,
+	) -> Result<()> {
+		let msg = json!({
+			"id": id,
+			"method": method,
+			"params": args,
+		});
+
+		let msg = Self::to_msg(format, &msg)?;
+
+		match tokio::time::timeout(Duration::from_millis(500), stream.send(msg)).await {
+			Ok(Ok(_)) => Ok(()),
+			Ok(Err(e)) => Err(format!("error sending message: {e}").into()),
+			Err(_) => Err("sending message timed-out".to_string().into()),
+		}
+	}
+
+	async fn ws_task(
+		mut recv: Receiver<SocketMsg>,
+		mut stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+		other: Sender<serde_json::Value>,
+		format: Format,
+	) -> Result<()> {
+		let mut next_id: u64 = 0;
+
+		let mut awaiting = HashMap::new();
+
 		loop {
 			tokio::select! {
-				_ = time::sleep(time::Duration::from_millis(5000)) => {
-					return Err(Box::new(TestError::NetworkError {message: "timeout after 5s waiting for the response".to_string()}))
-				}
-				res = self.stream.try_next() => {
-					match res {
-						Ok(res) => match res {
-							Some(Message::Text(msg)) => {
-								debug!("Response {msg:?} received in {:?}", now.elapsed());
-								match format {
-									Format::Json => {
-										let msg = serde_json::from_str(&msg)?;
-										debug!("Received message: {msg}");
-										return Ok(msg);
-									},
-									_ => {
-										return Err("Expected to receive a binary message".to_string().into());
-									}
-								}
-							},
-							Some(Message::Binary(msg)) => {
-								debug!("Response {msg:?} received in {:?}", now.elapsed());
-								match format {
-									Format::Cbor => {
-										pub mod try_from_impls {
-											include!("../../src/rpc/format/cbor/convert.rs");
-										}
-										// For tests we need to convert the binary data to
-										// a serde_json::Value so that test assertions work.
-										// First of all we deserialize the CBOR data.
-										let msg: ciborium::Value = ciborium::from_reader(&mut msg.as_slice())?;
-										// Then we convert it to a SurrealQL Value.
-										let msg: Value = try_from_impls::Cbor(msg).try_into()?;
-										// Then we convert the SurrealQL to JSON.
-										let msg = msg.into_json();
-										// Then output the response.
-										debug!("Received message: {msg:?}");
-										return Ok(msg);
-									},
-									Format::Pack => {
-										pub mod try_from_impls {
-											include!("../../src/rpc/format/msgpack/convert.rs");
-										}
-										// For tests we need to convert the binary data to
-										// a serde_json::Value so that test assertions work.
-										// First of all we deserialize the MessagePack data.
-										let msg: rmpv::Value = rmpv::decode::read_value(&mut msg.as_slice())?;
-										// Then we convert it to a SurrealQL Value.
-										let msg: Value = try_from_impls::Pack(msg).try_into()?;
-										// Then we convert the SurrealQL to JSON.
-										let msg = msg.into_json();
-										// Then output the response.
-										debug!("Received message: {msg:?}");
-										return Ok(msg);
-									},
-									_ => {
-										return Err("Expected to receive a text message".to_string().into());
-									}
-								}
-							},
-							Some(_) => {
-								continue;
-							}
-							None => {
-								return Err("Expected to receive a message".to_string().into());
-							}
+				msg = recv.recv() => {
+					let Some(msg) = msg else {
+						return Ok(());
+					};
+					match msg{
+						SocketMsg::SendAwait { method, args, channel } => {
+							let id = next_id;
+							next_id += 1;
+							awaiting.insert(id,channel);
+							Self::send_msg(&mut stream,id,format,&method, args).await?;
 						},
-						Err(err) => {
-							return Err(format!("Error receiving the message: {}", err).into());
+						SocketMsg::Send { method, args } => {
+							let id = next_id;
+							next_id += 1;
+							Self::send_msg(&mut stream,id,format,&method, args).await?;
+						},
+						SocketMsg::Close{ channel } => {
+							stream.close(None).await?;
+							let _ = channel.send(());
+							return Ok(());
 						}
 					}
+				}
+				res = stream.next() => {
+					let Some(res) = res else {
+						return Ok(());
+					};
+					let res = res?;
+					let Some(res) = Self::from_msg(format,res)? else {
+						continue;
+					};
+
+					// does the response have an id.
+					if let Some(sender) = res.get("id").and_then(|x| x.as_u64()).and_then(|x| awaiting.remove(&x)){
+						let _ = sender.send(res);
+					}else if (other.send(res).await).is_err(){
+						 return Err("main thread quit unexpectedly".to_string().into())
+					 }
 				}
 			}
 		}
 	}
 
 	/// Send a text or binary message and receive a reponse from the WebSocket server
-	pub async fn send_and_receive_message(
-		&mut self,
-		format: Format,
-		message: serde_json::Value,
-	) -> Result<serde_json::Value, Box<dyn Error>> {
-		self.send_message(format, message).await?;
-		self.receive_message(format).await
+	pub async fn send_request(
+		&self,
+		method: &str,
+		params: serde_json::Value,
+	) -> Result<serde_json::Value> {
+		let (send, recv) = oneshot::channel();
+		if (self
+			.sender
+			.send(SocketMsg::SendAwait {
+				method: method.to_string(),
+				args: params,
+				channel: send,
+			})
+			.await)
+			.is_err()
+		{
+			return Err("websocket task quit unexpectedly".to_string().into());
+		}
+
+		match recv.await {
+			Ok(x) => Ok(x),
+			Err(_) => Err("websocket task dropped request unexpectedly".to_string().into()),
+		}
 	}
 
 	/// When testing Live Queries, we may receive multiple messages unordered.
 	/// This method captures all the expected messages before the given timeout. The result can be inspected later on to find the desired message.
-	pub async fn receive_all_messages(
-		&mut self,
-		format: Format,
-		expected: usize,
-		timeout: Duration,
-	) -> Result<Vec<serde_json::Value>, Box<dyn Error>> {
-		let mut res = Vec::new();
-		let deadline = time::Instant::now() + timeout;
-		loop {
-			tokio::select! {
-				_ = time::sleep_until(deadline) => {
-					debug!("Waited for {:?} and received {} messages", timeout, res.len());
-					if res.len() != expected {
-						return Err(format!("Expected {} messages but got {} after {:?}: {:?}", expected, res.len(), timeout, res).into());
-					}
-				}
-				msg = self.receive_message(format) => {
-					res.push(msg?);
-				}
-			}
-			if res.len() == expected {
-				return Ok(res);
-			}
+	pub async fn receive_other_message(&mut self) -> Result<serde_json::Value> {
+		match self.other_messages.recv().await {
+			Some(x) => Ok(x),
+			None => Err("websocket task quit unexpectedly".to_string().into()),
 		}
+	}
+
+	pub async fn receive_all_other_messages(
+		&mut self,
+		amount: usize,
+		timeout: Duration,
+	) -> Result<Vec<serde_json::Value>> {
+		tokio::time::timeout(timeout, async {
+			let mut res = Vec::with_capacity(amount);
+			for _ in 0..amount {
+				res.push(self.receive_other_message().await?)
+			}
+			Ok(res)
+		})
+		.await?
 	}
 
 	/// Send a USE message to the server and check the response
 	pub async fn send_message_use(
 		&mut self,
-		format: Format,
 		ns: Option<&str>,
 		db: Option<&str>,
-	) -> Result<serde_json::Value, Box<dyn Error>> {
-		// Generate an ID
-		let id = uuid::Uuid::new_v4().to_string();
-		// Construct message
-		let msg = json!({
-			"id": id,
-			"method": "use",
-			"params": [
-				ns, db
-			],
-		});
+	) -> Result<serde_json::Value> {
 		// Send message and receive response
-		let msg = self.send_and_receive_message(format, msg).await?;
+		let msg = self.send_request("use", json!([ns, db])).await?;
 		// Check response message structure
 		match msg.as_object() {
 			Some(obj) if obj.keys().all(|k| ["id", "error"].contains(&k.as_str())) => {
@@ -286,21 +361,9 @@ impl Socket {
 	}
 
 	/// Send a generic query message to the server and check the response
-	pub async fn send_message_query(
-		&mut self,
-		format: Format,
-		query: &str,
-	) -> Result<Vec<serde_json::Value>, Box<dyn Error>> {
-		// Generate an ID
-		let id = uuid::Uuid::new_v4().to_string();
-		// Construct message
-		let msg = json!({
-			"id": id,
-			"method": "query",
-			"params": [query],
-		});
+	pub async fn send_message_query(&mut self, query: &str) -> Result<Vec<serde_json::Value>> {
 		// Send message and receive response
-		let msg = self.send_and_receive_message(format, msg).await?;
+		let msg = self.send_request("query", json!([query])).await?;
 		// Check response message structure
 		match msg.as_object() {
 			Some(obj) if obj.keys().all(|k| ["id", "error"].contains(&k.as_str())) => {
@@ -326,25 +389,25 @@ impl Socket {
 	/// Send a signin authentication query message to the server and check the response
 	pub async fn send_message_signin(
 		&mut self,
-		format: Format,
 		user: &str,
 		pass: &str,
 		ns: Option<&str>,
 		db: Option<&str>,
 		sc: Option<&str>,
-	) -> Result<String, Box<dyn Error>> {
-		// Generate an ID
-		let id = uuid::Uuid::new_v4().to_string();
-		// Construct message
-		let msg = json!({
-			"id": id,
-			"method": "signin",
-			"params": [
-				SigninParams { user, pass, ns, db, sc }
-			],
-		});
+	) -> Result<String> {
 		// Send message and receive response
-		let msg = self.send_and_receive_message(format, msg).await?;
+		let msg = self
+			.send_request(
+				"signin",
+				json!([SigninParams {
+					user,
+					pass,
+					ns,
+					db,
+					sc
+				}]),
+			)
+			.await?;
 		// Check response message structure
 		match msg.as_object() {
 			Some(obj) if obj.keys().all(|k| ["id", "error"].contains(&k.as_str())) => {

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -1,50 +1,43 @@
 use super::common::{self, Format, Socket, DB, NS, PASS, USER};
 use serde_json::json;
+use std::future::Future;
+use std::pin::Pin;
 use std::time::Duration;
 use test_log::test;
-use ulid::Ulid;
 
 #[test(tokio::test)]
 async fn ping() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Send INFO command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "ping",
-			}),
-		)
-		.await;
+	let res = socket.send_request("ping", json!([])).await;
 	assert!(res.is_ok(), "result: {:?}", res);
 	let res = res.unwrap();
 	assert!(res.is_object(), "result: {:?}", res);
 	let res = res.as_object().unwrap();
 	assert!(res.keys().all(|k| ["id", "result"].contains(&k.as_str())), "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn info() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Define a user table
-	socket.send_message_query(FORMAT, "DEFINE TABLE user PERMISSIONS FULL").await?;
+	socket.send_message_query("DEFINE TABLE user PERMISSIONS FULL").await?;
 	// Define a user scope
 	socket
 		.send_message_query(
-			FORMAT,
 			r#"
 			DEFINE SCOPE scope SESSION 24h
 				SIGNUP ( CREATE user SET user = $user, pass = crypto::argon2::generate($pass) )
@@ -56,7 +49,6 @@ async fn info() -> Result<(), Box<dyn std::error::Error>> {
 	// Create a user record
 	socket
 		.send_message_query(
-			FORMAT,
 			r#"
 			CREATE user CONTENT {
 				user: 'user',
@@ -66,38 +58,30 @@ async fn info() -> Result<(), Box<dyn std::error::Error>> {
 		)
 		.await?;
 	// Sign in as scope user
-	socket.send_message_signin(FORMAT, "user", "pass", Some(NS), Some(DB), Some("scope")).await?;
+	socket.send_message_signin("user", "pass", Some(NS), Some(DB), Some("scope")).await?;
 	// Send INFO command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "info",
-			}),
-		)
-		.await?;
+	let res = socket.send_request("info", json!([])).await?;
 	assert!(res["result"].is_object(), "result: {:?}", res);
 	let res = res["result"].as_object().unwrap();
 	assert_eq!(res["user"], "user", "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn signup() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Setup the scope
 	socket
 		.send_message_query(
-			FORMAT,
 			r#"
 			DEFINE SCOPE scope SESSION 24h
 				SIGNUP ( CREATE user SET email = $email, pass = crypto::argon2::generate($pass) )
@@ -107,19 +91,15 @@ async fn signup() -> Result<(), Box<dyn std::error::Error>> {
 		.await?;
 	// Send SIGNUP command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "signup",
-				"params": [{
-					"ns": NS,
-					"db": DB,
-					"sc": "scope",
-					"email": "email@email.com",
-					"pass": "pass",
-				}],
-			}),
+		.send_request(
+			"signup",
+			json!([{
+				"ns": NS,
+				"db": DB,
+				"sc": "scope",
+				"email": "email@email.com",
+				"pass": "pass",
+			}]),
 		)
 		.await;
 	assert!(res.is_ok(), "result: {:?}", res);
@@ -133,23 +113,23 @@ async fn signup() -> Result<(), Box<dyn std::error::Error>> {
 	let res = res["result"].as_str().unwrap();
 	assert!(res.starts_with("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9"), "result: {}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Setup the scope
 	socket
 		.send_message_query(
-			FORMAT,
 			r#"
 			DEFINE SCOPE scope SESSION 24h
 				SIGNUP ( CREATE user SET email = $email, pass = crypto::argon2::generate($pass) )
@@ -159,19 +139,17 @@ async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 		.await?;
 	// Send SIGNUP command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "signup",
-				"params": [{
+		.send_request(
+			"signup",
+			json!(
+				[{
 					"ns": NS,
 					"db": DB,
 					"sc": "scope",
 					"email": "email@email.com",
 					"pass": "pass",
-				}],
-			}),
+				}]
+			),
 		)
 		.await;
 	assert!(res.is_ok(), "result: {:?}", res);
@@ -186,19 +164,16 @@ async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res.starts_with("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9"), "result: {}", res);
 	// Send SIGNIN command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "signin",
-				"params": [{
-					"ns": NS,
-					"db": DB,
-					"sc": "scope",
-					"email": "email@email.com",
-					"pass": "pass",
-				}],
-			}),
+		.send_request(
+			"signin",
+			json!(
+			[{
+				"ns": NS,
+				"db": DB,
+				"sc": "scope",
+				"email": "email@email.com",
+				"pass": "pass",
+			}]),
 		)
 		.await;
 	assert!(res.is_ok(), "result: {:?}", res);
@@ -212,34 +187,27 @@ async fn signin() -> Result<(), Box<dyn std::error::Error>> {
 	let res = res["result"].as_str().unwrap();
 	assert!(res.starts_with("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9"), "result: {}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn invalidate() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Verify we have an authenticated session
-	let res = socket.send_message_query(FORMAT, "DEFINE NAMESPACE test").await?;
+	let res = socket.send_message_query("DEFINE NAMESPACE test").await?;
 	assert_eq!(res[0]["status"], "OK", "result: {:?}", res);
 	// Send INVALIDATE command
-	socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "invalidate",
-			}),
-		)
-		.await?;
+	socket.send_request("invalidate", json!([])).await?;
 	// Verify we have an invalidated session
-	let res = socket.send_message_query(FORMAT, "DEFINE NAMESPACE test").await?;
+	let res = socket.send_message_query("DEFINE NAMESPACE test").await?;
 	assert_eq!(res[0]["status"], "ERR", "result: {:?}", res);
 	assert_eq!(
 		res[0]["result"], "IAM error: Not enough permissions to perform this action",
@@ -247,154 +215,92 @@ async fn invalidate() -> Result<(), Box<dyn std::error::Error>> {
 		res
 	);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn authenticate() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	let token = socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	let token = socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Disconnect the connection
 	socket.close().await?;
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Send AUTHENTICATE command
-	socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "authenticate",
-				"params": [
-					token,
-				],
-			}),
-		)
-		.await?;
+	socket.send_request("authenticate", json!([token,])).await?;
 	// Verify we have an authenticated session
-	let res = socket.send_message_query(FORMAT, "DEFINE NAMESPACE test").await?;
+	let res = socket.send_message_query("DEFINE NAMESPACE test").await?;
 	assert_eq!(res[0]["status"], "OK", "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn letset() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Send LET command
-	socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "let",
-				"params": [
-					"let_var", "let_value",
-				],
-			}),
-		)
-		.await?;
+	socket.send_request("let", json!(["let_var", "let_value",])).await?;
 	// Send SET command
-	socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "set",
-				"params": [
-					"set_var", "set_value",
-				],
-			}),
-		)
-		.await?;
+	socket.send_request("set", json!(["set_var", "set_value",])).await?;
 	// Verify the variables are set
-	let res = socket.send_message_query(FORMAT, "SELECT * FROM $let_var, $set_var").await?;
+	let res = socket.send_message_query("SELECT * FROM $let_var, $set_var").await?;
 	assert_eq!(res[0]["result"], json!(["let_value", "set_value"]), "result: {:?}", res);
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn unset() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Send LET command
-	socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "let",
-				"params": [
-					"let_var", "let_value",
-				],
-			}),
-		)
-		.await?;
+	socket.send_request("let", json!(["let_var", "let_value",])).await?;
 	// Verify the variable is set
-	let res = socket.send_message_query(FORMAT, "SELECT * FROM $let_var").await?;
+	let res = socket.send_message_query("SELECT * FROM $let_var").await?;
 	assert_eq!(res[0]["result"], json!(["let_value"]), "result: {:?}", res);
 	// Send UNSET command
-	socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "unset",
-				"params": [
-					"let_var",
-				],
-			}),
-		)
-		.await?;
+	socket.send_request("unset", json!(["let_var",])).await?;
 	// Verify the variable is unset
-	let res = socket.send_message_query(FORMAT, "SELECT * FROM $let_var").await?;
+	let res = socket.send_message_query("SELECT * FROM $let_var").await?;
 	assert_eq!(res[0]["result"], json!([null]), "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn select() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Create a test record
-	socket.send_message_query(FORMAT, "CREATE tester SET name = 'foo', value = 'bar'").await?;
+	socket.send_message_query("CREATE tester SET name = 'foo', value = 'bar'").await?;
 	// Send SELECT command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "select",
-				"params": [
-					"tester",
-				],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("select", json!(["tester",])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
@@ -402,34 +308,31 @@ async fn select() -> Result<(), Box<dyn std::error::Error>> {
 	assert_eq!(res[0]["name"], "foo", "result: {:?}", res);
 	assert_eq!(res[0]["value"], "bar", "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn insert() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Send INSERT command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "insert",
-				"params": [
-					"tester",
-					{
-						"name": "foo",
-						"value": "bar",
-					}
-				],
-			}),
+		.send_request(
+			"insert",
+			json!([
+				"tester",
+				{
+					"name": "foo",
+					"value": "bar",
+				}
+			]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -439,40 +342,37 @@ async fn insert() -> Result<(), Box<dyn std::error::Error>> {
 	assert_eq!(res[0]["name"], "foo", "result: {:?}", res);
 	assert_eq!(res[0]["value"], "bar", "result: {:?}", res);
 	// Verify the data was inserted and can be queried
-	let res = socket.send_message_query(FORMAT, "SELECT * FROM tester").await?;
+	let res = socket.send_message_query("SELECT * FROM tester").await?;
 	assert!(res[0]["result"].is_array(), "result: {:?}", res);
 	let res = res[0]["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	assert_eq!(res[0]["name"], "foo", "result: {:?}", res);
 	assert_eq!(res[0]["value"], "bar", "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn create() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Send CREATE command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "create",
-				"params": [
-					"tester",
-					{
-						"value": "bar",
-					}
-				],
-			}),
+		.send_request(
+			"create",
+			json!([
+				"tester",
+				{
+					"value": "bar",
+				}
+			]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -481,41 +381,38 @@ async fn create() -> Result<(), Box<dyn std::error::Error>> {
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	assert_eq!(res[0]["value"], "bar", "result: {:?}", res);
 	// Verify the data was created
-	let res = socket.send_message_query(FORMAT, "SELECT * FROM tester").await?;
+	let res = socket.send_message_query("SELECT * FROM tester").await?;
 	assert!(res[0]["result"].is_array(), "result: {:?}", res);
 	let res = res[0]["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	assert_eq!(res[0]["value"], "bar", "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn update() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Create a test record
-	socket.send_message_query(FORMAT, "CREATE tester SET name = 'foo'").await?;
+	socket.send_message_query("CREATE tester SET name = 'foo'").await?;
 	// Send UPDATE command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "update",
-				"params": [
-					"tester",
-					{
-						"value": "bar",
-					}
-				],
-			}),
+		.send_request(
+			"update",
+			json!([
+				"tester",
+				{
+					"value": "bar",
+				}
+			]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -524,42 +421,39 @@ async fn update() -> Result<(), Box<dyn std::error::Error>> {
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	assert_eq!(res[0]["value"], "bar", "result: {:?}", res);
 	// Verify the data was updated
-	let res = socket.send_message_query(FORMAT, "SELECT * FROM tester").await?;
+	let res = socket.send_message_query("SELECT * FROM tester").await?;
 	assert!(res[0]["result"].is_array(), "result: {:?}", res);
 	let res = res[0]["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	assert_eq!(res[0]["name"], json!(null), "result: {:?}", res);
 	assert_eq!(res[0]["value"], "bar", "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn merge() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Create a test record
-	socket.send_message_query(FORMAT, "CREATE tester SET name = 'foo'").await?;
+	socket.send_message_query("CREATE tester SET name = 'foo'").await?;
 	// Send UPDATE command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "merge",
-				"params": [
-					"tester",
-					{
-						"value": "bar",
-					}
-				],
-			}),
+		.send_request(
+			"merge",
+			json!([
+				"tester",
+				{
+					"value": "bar",
+				}
+			]),
 		)
 		.await?;
 	assert!(res.is_object(), "result: {:?}", res);
@@ -569,180 +463,141 @@ async fn merge() -> Result<(), Box<dyn std::error::Error>> {
 	assert_eq!(res[0]["name"], "foo", "result: {:?}", res);
 	assert_eq!(res[0]["value"], "bar", "result: {:?}", res);
 	// Verify the data was merged
-	let res = socket.send_message_query(FORMAT, "SELECT * FROM tester").await?;
+	let res = socket.send_message_query("SELECT * FROM tester").await?;
 	assert!(res[0]["result"].is_array(), "result: {:?}", res);
 	let res = res[0]["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	assert_eq!(res[0]["name"], "foo", "result: {:?}", res);
 	assert_eq!(res[0]["value"], "bar", "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn patch() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Create a test record
-	socket.send_message_query(FORMAT, "CREATE tester:id SET name = 'foo'").await?;
+	socket.send_message_query("CREATE tester:id SET name = 'foo'").await?;
 	// Send PATCH command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "patch",
-				"params": [
-					"tester:id",
-					[
-						{
-							"op": "add",
-							"path": "value",
-							"value": "bar"
-						},
-						{
-							"op": "remove",
-							"path": "name",
-						}
-					]
+		.send_request(
+			"patch",
+			json!([
+				"tester:id",
+				[
+					{
+						"op": "add",
+						"path": "value",
+						"value": "bar"
+					},
+					{
+						"op": "remove",
+						"path": "name",
+					}
 				]
-			}),
+			]),
 		)
 		.await?;
 	assert!(res["result"].is_object(), "result: {:?}", res);
 	let res = res["result"].as_object().unwrap();
 	assert_eq!(res.get("value"), Some(json!("bar")).as_ref(), "result: {:?}", res);
 	// Verify the data was patched
-	let res = socket.send_message_query(FORMAT, "SELECT * FROM tester").await?;
+	let res = socket.send_message_query("SELECT * FROM tester").await?;
 	assert!(res[0]["result"].is_array(), "result: {:?}", res);
 	let res = res[0]["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	assert_eq!(res[0]["name"], json!(null), "result: {:?}", res);
 	assert_eq!(res[0]["value"], "bar", "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn delete() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Create a test record
-	socket.send_message_query(FORMAT, "CREATE tester:id").await?;
+	socket.send_message_query("CREATE tester:id").await?;
 	// Send DELETE command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "delete",
-				"params": [
-					"tester"
-				]
-			}),
-		)
-		.await?;
+	let res = socket.send_request("delete", json!(["tester"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	assert_eq!(res[0]["id"], "tester:id", "result: {:?}", res);
 	// Create a test record
-	socket.send_message_query(FORMAT, "CREATE tester:id").await?;
+	socket.send_message_query("CREATE tester:id").await?;
 	// Send DELETE command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "delete",
-				"params": [
-					"tester:id"
-				]
-			}),
-		)
-		.await?;
+	let res = socket.send_request("delete", json!(["tester:id"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_object(), "result: {:?}", res);
 	let res = res["result"].as_object().unwrap();
 	assert_eq!(res["id"], "tester:id", "result: {:?}", res);
 	// Verify the data was merged
-	let res = socket.send_message_query(FORMAT, "SELECT * FROM tester").await?;
+	let res = socket.send_message_query("SELECT * FROM tester").await?;
 	assert!(res[0]["result"].is_array(), "result: {:?}", res);
 	let res = res[0]["result"].as_array().unwrap();
 	assert_eq!(res.len(), 0, "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn query() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Send QUERY command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": [
-					"CREATE tester; SELECT * FROM tester;",
-				]
-			}),
-		)
-		.await?;
+	let res =
+		socket.send_request("query", json!(["CREATE tester; SELECT * FROM tester;",])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
 	assert_eq!(res.len(), 2, "result: {:?}", res);
 	// Verify the data was created
-	let res = socket.send_message_query(FORMAT, "SELECT * FROM tester").await?;
+	let res = socket.send_message_query("SELECT * FROM tester").await?;
 	assert!(res[0]["result"].is_array(), "result: {:?}", res);
 	let res = res[0]["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn version() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Send version command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "version",
-			}),
-		)
-		.await?;
+	let res = socket.send_request("version", json!([])).await?;
 	assert!(res["result"].is_string(), "result: {:?}", res);
 	let res = res["result"].as_str().unwrap();
 	assert!(res.starts_with("surrealdb-"), "result: {}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
@@ -750,68 +605,58 @@ async fn version() -> Result<(), Box<dyn std::error::Error>> {
 #[test(tokio::test)]
 async fn concurrency() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Send 5 long-running queries and verify they run concurrently
+
+	let mut futures = Vec::<Pin<Box<dyn Future<Output = _>>>>::new();
 	for i in 0..5 {
-		socket
-			.send_message(
-				FORMAT,
-				json!({
-					"id": Ulid::new(),
-					"method": "query",
-					"params": [format!("SLEEP 3s; RETURN {i};")],
-				}),
-			)
-			.await?;
+		let future = socket.send_request("query", json!([format!("SLEEP 3s; RETURN {i};")]));
+		futures.push(Box::pin(future))
 	}
-	// Verify the queries all completed concurrently within 5 seconds
-	let res = socket.receive_all_messages(FORMAT, 5, Duration::from_secs(5)).await?;
+
+	let res =
+		tokio::time::timeout(Duration::from_secs(5), futures::future::join_all(futures)).await;
+	let Ok(res) = res else {
+		panic!("future timed-out");
+	};
+
+	let res = res.into_iter().try_fold(
+		Vec::new(),
+		|mut acc, x| -> Result<_, Box<dyn std::error::Error>> {
+			acc.push(x?);
+			Ok(acc)
+		},
+	)?;
+
 	assert!(res.iter().all(|v| v["error"].is_null()), "Unexpected error received: {:#?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Send LIVE command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "live",
-				"params": ["tester"],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("live", json!(["tester"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_string(), "result: {:?}", res);
 	let live1 = res["result"].as_str().unwrap();
 	// Send QUERY command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["LIVE SELECT * FROM tester"],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("query", json!(["LIVE SELECT * FROM tester"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
@@ -819,22 +664,18 @@ async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res[0]["result"].is_string(), "result: {:?}", res);
 	let live2 = res[0]["result"].as_str().unwrap();
 	// Create a new test record
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:id SET name = 'foo'"],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("query", json!(["CREATE tester:id SET name = 'foo'"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	// Wait some time for all messages to arrive, and then search for the notification message
-	let msgs = socket.receive_all_messages(FORMAT, 2, Duration::from_secs(1)).await?;
+	let msgs: Result<_, Box<dyn std::error::Error>> =
+		tokio::time::timeout(Duration::from_secs(1), async {
+			Ok(vec![socket.receive_other_message().await?, socket.receive_other_message().await?])
+		})
+		.await?;
+	let msgs = msgs?;
 	assert!(msgs.iter().all(|v| v["error"].is_null()), "Unexpected error received: {:?}", msgs);
 	// Check for first live query notifcation
 	let res = msgs.iter().find(|v| common::is_notification_from_lq(v, live1));
@@ -862,44 +703,27 @@ async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	let res = res["result"].as_object().unwrap();
 	assert_eq!(res["id"], "tester:id", "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Send LIVE command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "live",
-				"params": ["tester"],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("live", json!(["tester"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_string(), "result: {:?}", res);
 	let live1 = res["result"].as_str().unwrap();
 	// Send QUERY command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["LIVE SELECT * FROM tester"],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("query", json!(["LIVE SELECT * FROM tester"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
@@ -907,22 +731,13 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	assert!(res[0]["result"].is_string(), "result: {:?}", res);
 	let live2 = res[0]["result"].as_str().unwrap();
 	// Create a new test record
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:one SET name = 'one'"],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("query", json!(["CREATE tester:one SET name = 'one'"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	// Wait some time for all messages to arrive, and then search for the notification message
-	let msgs = socket.receive_all_messages(FORMAT, 2, Duration::from_secs(1)).await?;
+	let msgs = socket.receive_all_other_messages(2, Duration::from_secs(1)).await?;
 	assert!(msgs.iter().all(|v| v["error"].is_null()), "Unexpected error received: {:?}", msgs);
 	// Check for first live query notifcation
 	let res = msgs.iter().find(|v| common::is_notification_from_lq(v, live1));
@@ -950,35 +765,17 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	let res = res["result"].as_object().unwrap();
 	assert_eq!(res["id"], "tester:one", "result: {:?}", res);
 	// Send KILL command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "kill",
-				"params": [live1],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("kill", json!([live1])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_null(), "result: {:?}", res);
 	// Create a new test record
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:two SET name = 'two'"],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("query", json!(["CREATE tester:two SET name = 'two'"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	// Wait some time for all messages to arrive, and then search for the notification message
-	let msgs = socket.receive_all_messages(FORMAT, 1, Duration::from_secs(1)).await?;
+	let msgs = socket.receive_all_other_messages(1, Duration::from_secs(1)).await?;
 	assert!(msgs.iter().all(|v| v["error"].is_null()), "Unexpected error received: {:?}", msgs);
 	// Check for second live query notifcation
 	let res = msgs.iter().find(|v| common::is_notification_from_lq(v, live2));
@@ -993,90 +790,55 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	let res = res["result"].as_object().unwrap();
 	assert_eq!(res["id"], "tester:two", "result: {:?}", res);
 	// Send QUERY command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": [format!("KILL '{live2}'")],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("query", json!([format!("KILL '{live2}'")])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	assert!(res[0]["result"].is_null(), "result: {:?}", res);
 	// Create a new test record
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:tre SET name = 'two'"],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("query", json!(["CREATE tester:tre SET name = 'two'"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	// Wait some time for all messages to arrive, and then search for the notification message
-	let msgs = socket.receive_all_messages(FORMAT, 0, Duration::from_secs(1)).await?;
+	let msgs = socket.receive_all_other_messages(0, Duration::from_secs(1)).await?;
 	assert!(msgs.iter().all(|v| v["error"].is_null()), "Unexpected error received: {:?}", msgs);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn live_second_connection() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket1 = Socket::connect(&addr, SERVER).await?;
+	let mut socket1 = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket1.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket1.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket1.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket1.send_message_use(Some(NS), Some(DB)).await?;
 	// Send LIVE command
-	let res = socket1
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "live",
-				"params": ["tester"],
-			}),
-		)
-		.await?;
+	let res = socket1.send_request("live", json!(["tester"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_string(), "result: {:?}", res);
 	let liveid = res["result"].as_str().unwrap();
 	// Connect to WebSocket
-	let mut socket2 = Socket::connect(&addr, SERVER).await?;
+	let mut socket2 = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket2.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket2.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket2.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket2.send_message_use(Some(NS), Some(DB)).await?;
 	// Create a new test record
-	let res = socket2
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:id SET name = 'foo'"],
-			}),
-		)
-		.await?;
+	let res = socket2.send_request("query", json!(["CREATE tester:id SET name = 'foo'"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	// Wait some time for all messages to arrive, and then search for the notification message
-	let msgs = socket1.receive_all_messages(FORMAT, 1, Duration::from_secs(1)).await?;
+	let msgs = socket1.receive_all_other_messages(1, Duration::from_secs(1)).await?;
 	assert!(msgs.iter().all(|v| v["error"].is_null()), "Unexpected error received: {:?}", msgs);
 	// Check for live query notifcation
 	let res = msgs.iter().find(|v| common::is_notification_from_lq(v, liveid));
@@ -1092,23 +854,23 @@ async fn live_second_connection() -> Result<(), Box<dyn std::error::Error>> {
 	let res = res["result"].as_object().unwrap();
 	assert_eq!(res["id"], "tester:id", "result: {:?}", res);
 	// Test passed
+	server.finish();
 	Ok(())
 }
 
 #[test(tokio::test)]
 async fn variable_auth_live_query() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
-	let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
 	// Connect to WebSocket
-	let mut socket = Socket::connect(&addr, SERVER).await?;
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
 	// Authenticate the connection
-	socket.send_message_signin(FORMAT, USER, PASS, None, None, None).await?;
+	socket.send_message_signin(USER, PASS, None, None, None).await?;
 	// Specify a namespace and database
-	socket.send_message_use(FORMAT, Some(NS), Some(DB)).await?;
+	socket.send_message_use(Some(NS), Some(DB)).await?;
 	// Setup the scope
 	socket
 		.send_message_query(
-			FORMAT,
 			r#"
 			DEFINE SCOPE scope SESSION 1s
 				SIGNUP ( CREATE user SET email = $email, pass = crypto::argon2::generate($pass) )
@@ -1118,19 +880,15 @@ async fn variable_auth_live_query() -> Result<(), Box<dyn std::error::Error>> {
 		.await?;
 	// Send SIGNUP command
 	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "signup",
-				"params": [{
-					"ns": NS,
-					"db": DB,
-					"sc": "scope",
-					"email": "email@email.com",
-					"pass": "pass",
-				}],
-			}),
+		.send_request(
+			"signup",
+			json!([{
+				"ns": NS,
+				"db": DB,
+				"sc": "scope",
+				"email": "email@email.com",
+				"pass": "pass",
+			}]),
 		)
 		.await;
 	assert!(res.is_ok(), "result: {:?}", res);
@@ -1140,38 +898,21 @@ async fn variable_auth_live_query() -> Result<(), Box<dyn std::error::Error>> {
 	// Verify response contains no error
 	assert!(res.keys().all(|k| ["id", "result"].contains(&k.as_str())), "result: {:?}", res);
 	// Send LIVE command
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "live",
-				"params": ["tester"],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("live", json!(["tester"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_string(), "result: {:?}", res);
 	// Wait 2 seconds for auth to expire
 	tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 	// Create a new test record
-	let res = socket
-		.send_and_receive_message(
-			FORMAT,
-			json!({
-				"id": Ulid::new(),
-				"method": "query",
-				"params": ["CREATE tester:id SET name = 'foo'"],
-			}),
-		)
-		.await?;
+	let res = socket.send_request("query", json!(["CREATE tester:id SET name = 'foo'"])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();
 	assert_eq!(res.len(), 1, "result: {:?}", res);
 	// Wait some time for all messages to arrive, and then search for the notification message
-	let msgs = socket.receive_all_messages(FORMAT, 0, Duration::from_secs(1)).await?;
+	let msgs = socket.receive_all_other_messages(0, Duration::from_secs(1)).await?;
 	assert!(msgs.iter().all(|v| v["error"].is_null()), "Unexpected error received: {:?}", msgs);
 	// Test passed
+	server.finish();
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

Experimentation around the integration tests showed that a lot of the integration tests failures are due to live messages appearing in an unexpected but still valid order.

## What does this change do?

Backports #3487 to v1.2.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
