### PR TITLE
Bugfix: Fix cli occasionally not printing results

### DIFF
--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -153,7 +153,7 @@ pub async fn init(
 
 	// Set up the print job
 	let (tx, rx) = mpsc::unbounded();
-	tokio::spawn(printer(rx));
+	let print_task = tokio::spawn(printer(rx));
 
 	// Loop over each command-line input
 	loop {
@@ -246,6 +246,10 @@ pub async fn init(
 			}
 		}
 	}
+	// drop the printer channel so the printer task will quit.
+	std::mem::drop(tx);
+	// print task shouldn't panic or be cancelled so this unwrap should never trigger.
+	print_task.await.unwrap();
 	// Save the inputs to the history
 	let _ = rl.save_history("history.txt");
 	// Everything OK


### PR DESCRIPTION
## What is the motivation?

There is a bug where the CLI will sometimes not print the results of a ran query if the process is supposed to quit after.

## What does this change do?

Backports #3509 to v1.2.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
