### PR TITLE
Bug fix: In some conditions iteration stages would avoid iterating

### DIFF
--- a/core/src/dbs/iterator.rs
+++ b/core/src/dbs/iterator.rs
@@ -308,15 +308,12 @@ impl Iterator {
 				while let Some(s) = qp.next_iteration_stage().await {
 					let is_last = matches!(s, IterationStage::Iterate(_));
 					cancel_ctx.set_iteration_stage(s);
-					if is_last {
-						self.iterate(&cancel_ctx, opt, txn, stm).await?;
-					} else {
+					if !is_last {
 						self.clone().iterate(&cancel_ctx, opt, txn, stm).await?;
 					};
 				}
-			} else {
-				self.iterate(&cancel_ctx, opt, txn, stm).await?;
 			}
+			self.iterate(&cancel_ctx, opt, txn, stm).await?;
 			// Return any document errors
 			if let Some(e) = self.error.take() {
 				return Err(e);

--- a/lib/tests/select.rs
+++ b/lib/tests/select.rs
@@ -1074,3 +1074,36 @@ async fn select_only() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn select_issue_3510() -> Result<(), Error> {
+	let sql: &str = "
+		CREATE a:1;
+		CREATE b:1 SET link = a:1, num = 1;
+		SELECT link.* FROM b;
+		SELECT link.* FROM b WHERE num = 1;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 4);
+	//
+	let _ = res.remove(0).result?;
+	let _ = res.remove(0).result?;
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+				{
+					link: {
+						id: a:1
+					}
+				}
+			]",
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	//
+	let tmp = res.remove(0).result?;
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	Ok(())
+}


### PR DESCRIPTION
## What is the motivation?

When no iteration stage is defined, but a query planner is installed, no iteration occurs.

## What does this change do?

Backports #3513 to v1.2.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
