### PR TITLE
Simplify CLI output and eliminate concurrency bugs

### DIFF
--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -5,8 +5,7 @@ use crate::cli::abstraction::{
 use crate::cnf::PKG_VERSION;
 use crate::err::Error;
 use clap::Args;
-use futures::channel::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use futures_util::{SinkExt, StreamExt};
+use futures::StreamExt;
 use rustyline::error::ReadlineError;
 use rustyline::validate::{ValidationContext, ValidationResult, Validator};
 use rustyline::{Completer, Editor, Helper, Highlighter, Hinter};
@@ -151,10 +150,6 @@ pub async fn init(
 		);
 	}
 
-	// Set up the print job
-	let (tx, rx) = mpsc::unbounded();
-	let print_task = tokio::spawn(printer(rx));
-
 	// Loop over each command-line input
 	loop {
 		// Prompt the user to input SQL and check the input.
@@ -179,6 +174,10 @@ pub async fn init(
 				break;
 			}
 		};
+		// Move on if the line is empty
+		if line.trim().is_empty() {
+			continue;
+		}
 		// Complete the request
 		match sql::parse(&line) {
 			Ok(query) => {
@@ -213,9 +212,9 @@ pub async fn init(
 				}
 				// Run the query provided
 				let result = client.query(query).with_stats().await;
-				let result = process(pretty, json, result, tx.clone());
+				let result = process(pretty, json, result);
 				let result_is_error = result.is_err();
-				tx.clone().send(result).await.expect("print job terminated unexpectedly");
+				print(result);
 				if result_is_error {
 					continue;
 				}
@@ -246,10 +245,6 @@ pub async fn init(
 			}
 		}
 	}
-	// drop the printer channel so the printer task will quit.
-	std::mem::drop(tx);
-	// print task shouldn't panic or be cancelled so this unwrap should never trigger.
-	print_task.await.unwrap();
 	// Save the inputs to the history
 	let _ = rl.save_history("history.txt");
 	// Everything OK
@@ -260,7 +255,6 @@ fn process(
 	pretty: bool,
 	json: bool,
 	res: surrealdb::Result<WithStats<Response>>,
-	mut tx: UnboundedSender<Result<String, Error>>,
 ) -> Result<String, Error> {
 	// Check query response for an error
 	let mut response = res?;
@@ -283,7 +277,7 @@ fn process(
 		let mut stream = match response.into_inner().stream::<Value>(()) {
 			Ok(stream) => stream,
 			Err(error) => {
-				tx.send(Err(error.into())).await.ok();
+				print(Err(error.into()));
 				return;
 			}
 		};
@@ -329,9 +323,7 @@ fn process(
 					format!("-- Notification (action: {action:?}, live query ID: {query_id})\n{output:#}")
 				}
 			};
-			if tx.send(Ok(format!("\n{message}"))).await.is_err() {
-				return;
-			}
+			print(Ok(format!("\n{message}")));
 		}
 	});
 
@@ -378,15 +370,13 @@ fn process(
 	})
 }
 
-async fn printer(mut rx: UnboundedReceiver<Result<String, Error>>) {
-	while let Some(result) = rx.next().await {
-		match result {
-			Ok(v) => {
-				println!("{v}\n");
-			}
-			Err(e) => {
-				eprintln!("{e}\n");
-			}
+fn print(result: Result<String, Error>) {
+	match result {
+		Ok(v) => {
+			println!("{v}\n");
+		}
+		Err(e) => {
+			eprintln!("{e}\n");
 		}
 	}
 }
@@ -412,6 +402,8 @@ impl Validator for InputValidator {
 			Incomplete // The line was empty and we are in multi mode
 		} else if input.ends_with('\\') {
 			Incomplete // The line ends with a backslash
+		} else if input.is_empty() {
+			Valid(None) // Ignore empty lines
 		} else if let Err(e) = sql::parse(input) {
 			Invalid(Some(format!(" --< {e}")))
 		} else {


### PR DESCRIPTION
## What is the motivation?

CLI output is sometimes printed out of order. This is due to printing being done concurrently.

## What does this change do?

It prints results sequentially.

## What is your testing strategy?

Tested the CLI manually.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
