### PR TITLE
Bugfix: fix a panic in span rendering

### DIFF
--- a/core/src/sql/v1/value/value.rs
+++ b/core/src/sql/v1/value/value.rs
@@ -2848,16 +2848,20 @@ mod tests {
 
 	#[test]
 	fn check_size() {
-		assert!(64 <= std::mem::size_of::<Value>());
-		assert_eq!(104, std::mem::size_of::<Error>());
-		assert_eq!(104, std::mem::size_of::<Result<Value, Error>>());
+		assert!(
+			64 >= std::mem::size_of::<Value>(),
+			"expected Value to be smaller then 64 bytes found {:?}",
+			std::mem::size_of::<Value>()
+		);
+		assert!(112 >= std::mem::size_of::<Error>());
+		assert!(112 >= std::mem::size_of::<Result<Value, Error>>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::number::Number>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::strand::Strand>());
 		assert_eq!(16, std::mem::size_of::<crate::sql::duration::Duration>());
 		assert_eq!(12, std::mem::size_of::<crate::sql::datetime::Datetime>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::array::Array>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::object::Object>());
-		assert_eq!(56, std::mem::size_of::<crate::sql::geometry::Geometry>());
+		assert!(56 >= std::mem::size_of::<crate::sql::geometry::Geometry>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::param::Param>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::idiom::Idiom>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::table::Table>());

--- a/core/src/syn/mod.rs
+++ b/core/src/syn/mod.rs
@@ -20,3 +20,17 @@ pub use v2::{
 pub trait Parse<T> {
 	fn parse(val: &str) -> T;
 }
+
+#[cfg(test)]
+mod test {
+	use super::parse;
+
+	#[test]
+	fn test_error_in_lineterminator() {
+		let q = r#"
+select * from person
+CREATE person CONTENT { foo:'bar'};
+"#;
+		parse(q).unwrap_err();
+	}
+}


### PR DESCRIPTION
## What is the motivation?

The span rendering code can panic whenever a error happens within the line terminator of a line.

## What does this change do?

Backports #3527 to v1.2.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
