### PR TITLE
Prepare v1.2.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "addr",
  "any_ascii",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surrealdb-core"
 publish = true
 edition = "2021"
-version = "1.2.0"
+version = "1.2.1"
 rust-version = "1.70.0"
 readme = "../lib/CARGO.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]


### PR DESCRIPTION
## What is the motivation?

The core library has some patches that need to be published.

## What does this change do?

It bumps the version of `surrealdb-core` to `v1.2.1`.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
