### PR TITLE
Infer current version from the binary, not the SDK

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -86,7 +86,7 @@ jobs:
           set -x
 
           # Retrieve just released version
-          betaVersion=$(taplo get -f lib/Cargo.toml "package.version")
+          betaVersion=$(taplo get -f Cargo.toml "package.version")
           major=$(echo $betaVersion | tr "." "\n" | sed -n 1p)
           minor=$(echo $betaVersion | tr "." "\n" | sed -n 2p)
           betaNum=$(echo $betaVersion | tr "." "\n" | sed -n 4p)

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -59,7 +59,7 @@ jobs:
           git config --add --bool push.autoSetupRemote true
 
           # Calculate new version
-          currentVersion=$(/home/runner/.cargo/bin/taplo get -f lib/Cargo.toml "package.version")
+          currentVersion=$(/home/runner/.cargo/bin/taplo get -f Cargo.toml "package.version")
           major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
           minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
           patch=$(echo $currentVersion | tr "." "\n" | sed -n 3p)

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           set -x
 
-          currentVersion=$(taplo get -f lib/Cargo.toml "package.version")
+          currentVersion=$(taplo get -f Cargo.toml "package.version")
 
           if [[ $currentVersion == *"-beta"* ]]; then
             git push origin --delete releases/stable || true
@@ -130,7 +130,7 @@ jobs:
         run: |
           set -x
 
-          currentVersion=$(taplo get -f lib/Cargo.toml "package.version")
+          currentVersion=$(taplo get -f Cargo.toml "package.version")
 
           if [[ $currentVersion == *"-beta"* ]]; then
             if [[ "${{ inputs.bump-version }}" == "true" ]]; then
@@ -184,7 +184,7 @@ jobs:
         run: |
           set -x
 
-          version=$(taplo get -f lib/Cargo.toml "package.version")
+          version=$(taplo get -f Cargo.toml "package.version")
 
           if [[ "${{ inputs.publish }}" == "true" && ("${{ inputs.environment }}" == "beta" || "${{ inputs.environment }}" == "stable")  ]]; then
             echo "git-ref=v${version}" >> $GITHUB_OUTPUT
@@ -624,7 +624,7 @@ jobs:
           set -x
 
           # Derive crate version
-          currentVersion=$(taplo get -f lib/Cargo.toml "package.version")
+          currentVersion=$(taplo get -f Cargo.toml "package.version")
           major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
           minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
           betaNum=$(echo $currentVersion | tr "." "\n" | sed -n 4p)
@@ -642,7 +642,7 @@ jobs:
           date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
 
           # Derive crate version
-          currentVersion=$(taplo get -f lib/Cargo.toml "package.version")
+          currentVersion=$(taplo get -f Cargo.toml "package.version")
           major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
           minor=$(echo $currentVersion | tr "." "\n" | sed -n 2p)
           # This sets the nightly version to something like `1.3.20231117`


### PR DESCRIPTION
## What is the motivation?

We currently infer the version from the SDK. This is not always up to date. If the SDK has no patches, its version won't change when the core library and/or binary crates are patched.

## What does this change do?

It infers the version from the binary crate instead. 

## What is your testing strategy?

Used this changeset to deploy v1.2.1.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
