### PR TITLE
Enable parser2, ml2 and surrealkv in nightly binaries

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,6 +33,7 @@ jobs:
     uses: ./.github/workflows/reusable_publish_version.yml
     with:
       environment: nightly
+      extra-features: parser2,ml2,storage-surrealkv
       git-ref: ${{ inputs.git-ref || github.ref_name }}
       publish: ${{ inputs.publish || github.event_name == 'schedule' }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 
 name: Stable release
 
-run-name: "Stable release '${{ inputs.branch }}' (publish: ${{ inputs.publish }}, latest: ${{ inputs.branch == 'releases/beta' || inputs.latest }}, HTTP compression: ${{ inputs.http-compression }}, ML: ${{ inputs.ml }})"
+run-name: "Stable release '${{ inputs.branch }}' (publish: ${{ inputs.publish }}, latest: ${{ inputs.branch == 'releases/beta' || inputs.latest }})"
 
 on:
   workflow_dispatch:
@@ -22,16 +22,6 @@ on:
         type: boolean
         default: false
         description: "Publish the release"
-      http-compression:
-        required: false
-        type: boolean
-        default: true
-        description: "Enable HTTP compression in binaries"
-      ml:
-        required: false
-        type: boolean
-        default: true
-        description: "Enable ML support in binaries"
 
 defaults:
   run:
@@ -66,8 +56,6 @@ jobs:
       latest: ${{ inputs.branch == 'releases/beta' || inputs.latest }}
       publish: ${{ inputs.publish }}
       create-release: ${{ inputs.publish }}
-      http-compression: ${{ inputs.http-compression }}
-      ml: ${{ inputs.ml }}
     secrets: inherit
 
   delete-branches:

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -29,16 +29,6 @@ on:
         type: boolean
         default: false
         description: "Create a GitHub release"
-      http-compression:
-        required: false
-        type: boolean
-        default: true
-        description: "Enable HTTP compression in binaries"
-      ml:
-        required: false
-        type: boolean
-        default: true
-        description: "Enable ML support in binaries"
       rust_version:
         required: false
         type: string
@@ -49,6 +39,11 @@ on:
         type: string
         default: "1.16.3"
         description: "The ONNX library version"
+      extra-features:
+        required: false
+        type: string
+        default: "ml"
+        description: "Extra features enabled in the binary"
     secrets:
       AWS_CI_ACCESS_KEY_ID:
         description: "AWS access key ID"
@@ -351,20 +346,13 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv,sql2,jwks
-              if [[ "${{ inputs.http-compression }}" == "true" ]]; then
-                features=${features},http-compression
-              fi
+              features=storage-tikv,http-compression,sql2,jwks,${{ inputs.extra-features }}
 
-              if [[ "${{ inputs.ml }}" == "true" ]]; then
-                features=${features},ml
-
-                # Download libonnxruntime's static library and tell ORT crate to use it
-                mkdir /tmp/onnxruntime
-                curl -sSL https://github.com/surrealdb/onnxruntime-build/releases/download/v${{ inputs.onnx_version }}/onnxruntime-osx-x86_64-static_lib-${{ inputs.onnx_version }}.tgz | \
-                  tar -xz -C /tmp/onnxruntime/
-                export ORT_STRATEGY=system ORT_LIB_LOCATION=/tmp/onnxruntime/lib
-              fi
+              # Download libonnxruntime's static library and tell ORT crate to use it
+              mkdir /tmp/onnxruntime
+              curl -sSL https://github.com/surrealdb/onnxruntime-build/releases/download/v${{ inputs.onnx_version }}/onnxruntime-osx-x86_64-static_lib-${{ inputs.onnx_version }}.tgz | \
+                tar -xz -C /tmp/onnxruntime/
+              export ORT_STRATEGY=system ORT_LIB_LOCATION=/tmp/onnxruntime/lib
 
               cargo build --features $features --release --locked --target x86_64-apple-darwin
 
@@ -385,20 +373,14 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv,sql2,jwks
-              if [[ "${{ inputs.http-compression }}" == "true" ]]; then
-                features=${features},http-compression
-              fi
+              features=storage-tikv,http-compression,sql2,jwks,${{ inputs.extra-features }}
 
-              if [[ "${{ inputs.ml }}" == "true" ]]; then
-                features=${features},ml
+              # Download libonnxruntime's static library and tell ORT crate to use it
+              mkdir /tmp/onnxruntime
+              curl -sSL https://github.com/surrealdb/onnxruntime-build/releases/download/v${{ inputs.onnx_version }}/onnxruntime-osx-arm64-static_lib-${{ inputs.onnx_version }}.tgz | \
+                tar -xz -C /tmp/onnxruntime/
+              export ORT_STRATEGY=system ORT_LIB_LOCATION=/tmp/onnxruntime/lib
 
-                # Download libonnxruntime's static library and tell ORT crate to use it
-                mkdir /tmp/onnxruntime
-                curl -sSL https://github.com/surrealdb/onnxruntime-build/releases/download/v${{ inputs.onnx_version }}/onnxruntime-osx-arm64-static_lib-${{ inputs.onnx_version }}.tgz | \
-                  tar -xz -C /tmp/onnxruntime/
-                export ORT_STRATEGY=system ORT_LIB_LOCATION=/tmp/onnxruntime/lib
-              fi
               cargo build --features $features --release --locked --target aarch64-apple-darwin
 
               # Package
@@ -413,20 +395,13 @@ jobs:
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
               # Build
-              features=storage-tikv,sql2,jwks
-              if [[ "${{ inputs.http-compression }}" == "true" ]]; then
-                features=${features},http-compression
-              fi
+              features=storage-tikv,http-compression,sql2,jwks,${{ inputs.extra-features }}
 
-              if [[ "${{ inputs.ml }}" == "true" ]]; then
-                features=${features},ml
-
-                # Download libonnxruntime's static library and tell ORT crate to use it
-                tmpdir=$(mktemp -d)
-                curl -sSL https://github.com/surrealdb/onnxruntime-build/releases/download/v${{ inputs.onnx_version }}/onnxruntime-linux-x64-static_lib-${{ inputs.onnx_version }}.tgz | \
-                  tar -xz -C $tmpdir
-                export ORT_STRATEGY=system ORT_LIB_LOCATION=$tmpdir/lib
-              fi
+              # Download libonnxruntime's static library and tell ORT crate to use it
+              tmpdir=$(mktemp -d)
+              curl -sSL https://github.com/surrealdb/onnxruntime-build/releases/download/v${{ inputs.onnx_version }}/onnxruntime-linux-x64-static_lib-${{ inputs.onnx_version }}.tgz | \
+                tar -xz -C $tmpdir
+              export ORT_STRATEGY=system ORT_LIB_LOCATION=$tmpdir/lib
 
               docker run \
                 --rm -t \
@@ -458,20 +433,13 @@ jobs:
               set -x
 
               # Build
-              features=storage-tikv,sql2,jwks
-              if [[ "${{ inputs.http-compression }}" == "true" ]]; then
-                features=${features},http-compression
-              fi
+              features=storage-tikv,http-compression,sql2,jwks,${{ inputs.extra-features }}
 
-              if [[ "${{ inputs.ml }}" == "true" ]]; then
-                features=${features},ml
-
-                # Download libonnxruntime's static library and tell ORT crate to use it
-                tmpdir=$(mktemp -d)
-                curl -sSL https://github.com/surrealdb/onnxruntime-build/releases/download/v${{ inputs.onnx_version }}/onnxruntime-linux-aarch64-static_lib-${{ inputs.onnx_version }}.tgz | \
-                  tar -xz -C $tmpdir
-                export ORT_STRATEGY=system ORT_LIB_LOCATION=$tmpdir/lib
-              fi
+              # Download libonnxruntime's static library and tell ORT crate to use it
+              tmpdir=$(mktemp -d)
+              curl -sSL https://github.com/surrealdb/onnxruntime-build/releases/download/v${{ inputs.onnx_version }}/onnxruntime-linux-aarch64-static_lib-${{ inputs.onnx_version }}.tgz | \
+                tar -xz -C $tmpdir
+              export ORT_STRATEGY=system ORT_LIB_LOCATION=$tmpdir/lib
 
               docker run \
                 --rm -t \
@@ -506,20 +474,13 @@ jobs:
               vcpkg integrate install
 
               # Build
-              features=storage-tikv,sql2,jwks
-              if [[ "${{ inputs.http-compression }}" == "true" ]]; then
-                features=${features},http-compression
-              fi
+              features=storage-tikv,http-compression,sql2,jwks,${{ inputs.extra-features }}
 
-              if [[ "${{ inputs.ml }}" == "true" ]]; then
-                features=${features},ml
-
-                # Download libonnxruntime's static library and tell ORT crate to use it
-                tmp_dir=$(mktemp -d)
-                curl -sSL https://github.com/surrealdb/onnxruntime-build/releases/download/v${{ inputs.onnx_version }}/onnxruntime-win-x64-static_lib-${{ inputs.onnx_version }}.zip -o $tmp_dir/onnxruntime.zip
-                unzip -d $tmp_dir $tmp_dir/onnxruntime.zip
-                export ORT_STRATEGY=system ORT_LIB_LOCATION=$tmp_dir/lib
-              fi
+              # Download libonnxruntime's static library and tell ORT crate to use it
+              tmp_dir=$(mktemp -d)
+              curl -sSL https://github.com/surrealdb/onnxruntime-build/releases/download/v${{ inputs.onnx_version }}/onnxruntime-win-x64-static_lib-${{ inputs.onnx_version }}.zip -o $tmp_dir/onnxruntime.zip
+              unzip -d $tmp_dir $tmp_dir/onnxruntime.zip
+              export ORT_STRATEGY=system ORT_LIB_LOCATION=$tmp_dir/lib
 
               cargo build --features $features --release --locked --target x86_64-pc-windows-msvc
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5553,9 +5553,9 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb36f58183b82fe47f0d2a3d2565ec3f6192ff9638482a8084a91f9f06b409d"
+checksum = "111e9b259dc5ef69db5c159ed9a2857a072b56e282f690610d7cbc1d27a6ca0b"
 dependencies = [
  "async-channel 2.1.1",
  "bytes",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -139,7 +139,7 @@ speedb = { version = "0.0.4", features = ["lz4", "snappy"], optional = true }
 storekey = "0.5.0"
 surrealml-core1 = { version = "0.0.7", optional = true, package = "surrealml-core" }
 surrealml-core2 = { version = "0.0.8", optional = true, package = "surrealml-core" }
-surrealkv = { version = "0.1.1", optional = true }
+surrealkv = { version = "0.1.2", optional = true }
 thiserror = "1.0.50"
 tikv = { version = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }
 tracing = "0.1.40"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -3,11 +3,11 @@
 
 [[unpublished.surrealdb]]
 version = "1.3.0"
-audited_as = "1.1.1"
+audited_as = "1.2.0"
 
 [[unpublished.surrealdb-core]]
 version = "1.3.0"
-audited_as = "1.1.5"
+audited_as = "1.2.1"
 
 [[publisher.addr]]
 version = "0.15.6"
@@ -115,15 +115,15 @@ user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb]]
-version = "1.1.1"
-when = "2024-01-16"
+version = "1.2.0"
+when = "2024-02-13"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb-core]]
-version = "1.1.5"
-when = "2024-01-31"
+version = "1.2.1"
+when = "2024-02-16"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -143,8 +143,8 @@ user-login = "rushmorem"
 user-name = "Rushmore Mushambi"
 
 [[publisher.surrealkv]]
-version = "0.1.1"
-when = "2024-02-10"
+version = "0.1.2"
+when = "2024-02-17"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"


### PR DESCRIPTION
## What is the motivation?

To make it easier to test these unstable features.

## What does this change do?

It enables those features in the release workflows when building nightly binaries.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
