### PR TITLE
Make `surreal upgrade` version parsing more robust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ reqwest = { version = "0.11.22", default-features = false, features = [
 revision = "0.5.0"
 rmpv = "1.0.1"
 rustyline = { version = "12.0.0", features = ["derive"] }
+semver = "1.0.20"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 serde_pack = { version = "1.1.2", package = "rmp-serde" }


### PR DESCRIPTION
## What is the motivation?

`surreal upgrade` currently requires one to include a `v` prefix when specifying a version. Not including it leads to an error.

## What does this change do?

It makes parsing the version more robust and tries to catch some error cases in order to provide a more helpful error message.

## What is your testing strategy?

Tested the binary manually.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
