### PR TITLE
Fix the SurrealKV scheme in the CLI

### DIFF
--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -15,6 +15,7 @@ pub(crate) fn path_valid(v: &str) -> Result<String, String> {
 		v if v.starts_with("file:") => Ok(v.to_string()),
 		v if v.starts_with("rocksdb:") => Ok(v.to_string()),
 		v if v.starts_with("speedb:") => Ok(v.to_string()),
+		v if v.starts_with("surrealkv:") => Ok(v.to_string()),
 		v if v.starts_with("tikv:") => Ok(v.to_string()),
 		v if v.starts_with("fdb:") => Ok(v.to_string()),
 		_ => Err(String::from("Provide a valid database path parameter")),
@@ -45,9 +46,8 @@ pub(crate) fn endpoint_valid(v: &str) -> Result<String, String> {
 
 	let scheme = split_endpoint(v).0;
 	match scheme {
-		"http" | "https" | "ws" | "wss" | "fdb" | "mem" | "rocksdb" | "file" | "tikv" => {
-			Ok(v.to_string())
-		}
+		"http" | "https" | "ws" | "wss" | "fdb" | "mem" | "rocksdb" | "speedb" | "surrealkv"
+		| "file" | "tikv" => Ok(v.to_string()),
 		_ => Err(String::from("Provide a valid database connection string")),
 	}
 }


### PR DESCRIPTION
## What is the motivation?

`surreal start surrealkv:/path/to/db` and `surreal sql --endpoint surrealkv:/path/to/db` are not working on nightly. This makes it impossible to test SurrealKV using the nightly binary.

## What does this change do?

It adds the `surrealkv` scheme to the functions that validate schemes so that they can also be recognised. It also adds `speedb` which was missing in one of the functions.

## What is your testing strategy?

Tested the binary manually.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
