### PR TITLE
Fix document not being available to delete permissions clause

### DIFF
--- a/core/src/doc/allow.rs
+++ b/core/src/doc/allow.rs
@@ -37,7 +37,19 @@ impl<'a> Document<'a> {
 						// Disable permissions
 						let opt = &opt.new_with_perms(false);
 						// Process the PERMISSION clause
-						if !e.compute(ctx, opt, txn, Some(&self.current)).await?.is_truthy() {
+						if !e
+							.compute(
+								ctx,
+								opt,
+								txn,
+								Some(match stm.is_delete() {
+									true => &self.initial,
+									false => &self.current,
+								}),
+							)
+							.await?
+							.is_truthy()
+						{
 							return Err(Error::Ignore);
 						}
 					}

--- a/lib/tests/delete.rs
+++ b/lib/tests/delete.rs
@@ -6,7 +6,7 @@ use helpers::new_ds;
 use surrealdb::dbs::{Action, Notification, Session};
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
-use surrealdb::sql::Value;
+use surrealdb::sql::{Thing, Value};
 
 #[tokio::test]
 async fn delete() -> Result<(), Error> {
@@ -424,5 +424,57 @@ async fn delete_filtered_live_notification() -> Result<(), Error> {
 			),
 		}
 	);
+	Ok(())
+}
+
+#[tokio::test]
+async fn delete_with_permissions() -> Result<(), Error> {
+	let sql = "
+		DEFINE TABLE friends_with PERMISSIONS FOR delete WHERE in = $auth;
+		CREATE user:john, user:mary;
+		RELATE user:john->friends_with:1->user:mary;
+		RELATE user:mary->friends_with:2->user:john;
+	";
+	let dbs = new_ds().await?.with_auth_enabled(true);
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 4);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let sql = "
+		DELETE friends_with:1 RETURN BEFORE;
+		DELETE friends_with:2 RETURN BEFORE;
+	";
+	let ses = Session::for_scope("test", "test", "test", Thing::from(("user", "john")).into());
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: friends_with:1,
+				in: user:john,
+				out: user:mary,
+			},
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("[]");
+	assert_eq!(tmp, val);
+	//
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

I encountered this issue while working on an application built with SurrealDB, where the document is not available when processing a delete permissions clause.

## What does this change do?

Instead of passing the current document to the delete permissions clause, it now instead passes the initial document before the deletion. This is added functionality and does not introduce any breaking changes

## What is your testing strategy?

Need to add a test

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
