### PR TITLE
Implement session expiration

### DIFF
--- a/core/src/dbs/session.rs
+++ b/core/src/dbs/session.rs
@@ -2,6 +2,7 @@ use crate::ctx::Context;
 use crate::iam::Auth;
 use crate::iam::{Level, Role};
 use crate::sql::value::Value;
+use chrono::Utc;
 use std::sync::Arc;
 
 /// Specifies the current session information when processing a query.
@@ -27,6 +28,8 @@ pub struct Session {
 	pub tk: Option<Value>,
 	/// The current scope authentication data
 	pub sd: Option<Value>,
+	/// The current expiration time of the session
+	pub exp: Option<i64>,
 }
 
 impl Session {
@@ -69,6 +72,14 @@ impl Session {
 		self.rt
 	}
 
+	/// Checks if the session has expired
+	pub(crate) fn expired(&self) -> bool {
+		match self.exp {
+			Some(exp) => Utc::now().timestamp() > exp,
+			None => false,
+		}
+	}
+
 	/// Convert a session into a runtime
 	pub(crate) fn context<'a>(&self, mut ctx: Context<'a>) -> Context<'a> {
 		// Add scope auth data
@@ -90,6 +101,7 @@ impl Session {
 			"sc".to_string() => self.sc.to_owned().into(),
 			"sd".to_string() => self.sd.to_owned().into(),
 			"tk".to_string() => self.tk.to_owned().into(),
+			"exp".to_string() => self.exp.to_owned().into(),
 		});
 		ctx.add_value("session", val);
 		// Output context
@@ -132,6 +144,7 @@ impl Session {
 			sc: Some(sc.to_owned()),
 			tk: None,
 			sd: Some(rid),
+			exp: None,
 		}
 	}
 

--- a/core/src/dbs/session.rs
+++ b/core/src/dbs/session.rs
@@ -76,6 +76,9 @@ impl Session {
 	pub(crate) fn expired(&self) -> bool {
 		match self.exp {
 			Some(exp) => Utc::now().timestamp() > exp,
+			// Sessions for system users using basic authentication have no expiration.
+			// TODO(gguillemas): Change this to "true" once session lifetime is configurable
+			// for system users and a default expiration is always set in their session.
 			None => false,
 		}
 	}

--- a/core/src/dbs/session.rs
+++ b/core/src/dbs/session.rs
@@ -76,9 +76,7 @@ impl Session {
 	pub(crate) fn expired(&self) -> bool {
 		match self.exp {
 			Some(exp) => Utc::now().timestamp() > exp,
-			// Sessions for system users using basic authentication have no expiration.
-			// TODO(gguillemas): Change this to "true" once session lifetime is configurable
-			// for system users and a default expiration is always set in their session.
+			// It is currently possible to have sessions without expiration.
 			None => false,
 		}
 	}

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -758,6 +758,14 @@ pub enum Error {
 	#[error("The session has expired")]
 	ExpiredSession,
 
+	/// The session has an invalid duration
+	#[error("The session has an invalid duration")]
+	InvalidSessionDuration,
+
+	/// The session has an invalid expiration
+	#[error("The session has an invalid expiration")]
+	InvalidSessionExpiration,
+
 	/// There was an error with authentication
 	#[error("There was a problem with authentication")]
 	InvalidAuth,

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -752,6 +752,12 @@ pub enum Error {
 	#[error("The password did not verify")]
 	InvalidPass,
 
+	/// The session has expired either because the token used
+	/// to establish it has expired or because an expiration
+	/// was explicitly defined when establishing it
+	#[error("The session has expired")]
+	ExpiredSession,
+
 	/// There was an error with authentication
 	#[error("There was a problem with authentication")]
 	InvalidAuth,
@@ -763,10 +769,6 @@ pub enum Error {
 	/// Auth was expected to be set but was unknown
 	#[error("Auth was expected to be set but was unknown")]
 	UnknownAuth,
-
-	/// The authenticated session has expired
-	#[error("The authenticated session has expired")]
-	ExpiredAuth,
 
 	/// Auth requires a token header which is missing
 	#[error("Auth token is missing the '{0}' header")]

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -752,12 +752,6 @@ pub enum Error {
 	#[error("The password did not verify")]
 	InvalidPass,
 
-	/// The session has expired either because the token used
-	/// to establish it has expired or because an expiration
-	/// was explicitly defined when establishing it
-	#[error("The session has expired")]
-	ExpiredSession,
-
 	/// There was an error with authentication
 	#[error("There was a problem with authentication")]
 	InvalidAuth,
@@ -785,6 +779,12 @@ pub enum Error {
 	/// The db is running without an available storage engine
 	#[error("The db is running without an available storage engine")]
 	MissingStorageEngine,
+
+	/// The session has expired either because the token used
+	/// to establish it has expired or because an expiration
+	/// was explicitly defined when establishing it
+	#[error("The session has expired")]
+	ExpiredSession,
 
 	/// The session has an invalid duration
 	#[error("The session has an invalid duration")]

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -764,6 +764,10 @@ pub enum Error {
 	#[error("Auth was expected to be set but was unknown")]
 	UnknownAuth,
 
+	/// The authenticated session has expired
+	#[error("The authenticated session has expired")]
+	ExpiredAuth,
+
 	/// Auth requires a token header which is missing
 	#[error("Auth token is missing the '{0}' header")]
 	MissingTokenHeader(String),

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -758,14 +758,6 @@ pub enum Error {
 	#[error("The session has expired")]
 	ExpiredSession,
 
-	/// The session has an invalid duration
-	#[error("The session has an invalid duration")]
-	InvalidSessionDuration,
-
-	/// The session has an invalid expiration
-	#[error("The session has an invalid expiration")]
-	InvalidSessionExpiration,
-
 	/// There was an error with authentication
 	#[error("There was a problem with authentication")]
 	InvalidAuth,
@@ -793,6 +785,14 @@ pub enum Error {
 	/// The db is running without an available storage engine
 	#[error("The db is running without an available storage engine")]
 	MissingStorageEngine,
+
+	/// The session has an invalid duration
+	#[error("The session has an invalid duration")]
+	InvalidSessionDuration,
+
+	/// The session has an invalid expiration
+	#[error("The session has an invalid expiration")]
+	InvalidSessionExpiration,
 }
 
 impl From<Error> for String {

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -461,6 +461,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			trace!("Authenticated to root level with user `{}`", id);
 			// Set the session
 			session.tk = Some(value);
+			session.exp = token_data.claims.exp;
 			session.au = Arc::new(Auth::new(Actor::new(
 				id.to_string(),
 				de.roles.iter().map(|r| r.into()).collect(),

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -127,6 +127,8 @@ pub async fn basic(
 		(Some(ns), Some(db)) => match verify_db_creds(kvs, ns, db, user, pass).await {
 			Ok(u) => {
 				debug!("Authenticated as database user '{}'", user);
+				// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
+				session.exp = None;
 				session.au = Arc::new((&u, Level::Database(ns.to_owned(), db.to_owned())).into());
 				Ok(())
 			}
@@ -136,6 +138,8 @@ pub async fn basic(
 		(Some(ns), None) => match verify_ns_creds(kvs, ns, user, pass).await {
 			Ok(u) => {
 				debug!("Authenticated as namespace user '{}'", user);
+				// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
+				session.exp = None;
 				session.au = Arc::new((&u, Level::Namespace(ns.to_owned())).into());
 				Ok(())
 			}
@@ -145,6 +149,8 @@ pub async fn basic(
 		(None, None) => match verify_root_creds(kvs, user, pass).await {
 			Ok(u) => {
 				debug!("Authenticated as root user '{}'", user);
+				// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
+				session.exp = None;
 				session.au = Arc::new((&u, Level::Root).into());
 				Ok(())
 			}
@@ -167,16 +173,22 @@ pub async fn basic_legacy(
 	match verify_creds_legacy(kvs, session.ns.as_ref(), session.db.as_ref(), user, pass).await {
 		Ok((au, _)) if au.is_root() => {
 			debug!("Authenticated as root user '{}'", user);
+			// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
+			session.exp = None;
 			session.au = Arc::new(au);
 			Ok(())
 		}
 		Ok((au, _)) if au.is_ns() => {
 			debug!("Authenticated as namespace user '{}'", user);
+			// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
+			session.exp = None;
 			session.au = Arc::new(au);
 			Ok(())
 		}
 		Ok((au, _)) if au.is_db() => {
 			debug!("Authenticated as database user '{}'", user);
+			// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
+			session.exp = None;
 			session.au = Arc::new(au);
 			Ok(())
 		}

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -240,6 +240,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			session.ns = Some(ns.to_owned());
 			session.db = Some(db.to_owned());
 			session.sc = Some(sc.to_owned());
+			session.exp = token_data.claims.exp;
 			session.au = Arc::new(Auth::new(Actor::new(
 				de.name.to_string(),
 				Default::default(),
@@ -274,6 +275,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			session.db = Some(db.to_owned());
 			session.sc = Some(sc.to_owned());
 			session.sd = Some(Value::from(id.to_owned()));
+			session.exp = token_data.claims.exp;
 			session.au = Arc::new(Auth::new(Actor::new(
 				id.to_string(),
 				Default::default(),
@@ -316,6 +318,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			session.tk = Some(value);
 			session.ns = Some(ns.to_owned());
 			session.db = Some(db.to_owned());
+			session.exp = token_data.claims.exp;
 			session.au = Arc::new(Auth::new(Actor::new(
 				de.name.to_string(),
 				roles,
@@ -348,6 +351,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			session.tk = Some(value);
 			session.ns = Some(ns.to_owned());
 			session.db = Some(db.to_owned());
+			session.exp = token_data.claims.exp;
 			session.au = Arc::new(Auth::new(Actor::new(
 				id.to_string(),
 				de.roles.iter().map(|r| r.into()).collect(),
@@ -388,6 +392,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Set the session
 			session.tk = Some(value);
 			session.ns = Some(ns.to_owned());
+			session.exp = token_data.claims.exp;
 			session.au =
 				Arc::new(Auth::new(Actor::new(de.name.to_string(), roles, Level::Namespace(ns))));
 			Ok(())
@@ -415,6 +420,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Set the session
 			session.tk = Some(value);
 			session.ns = Some(ns.to_owned());
+			session.exp = token_data.claims.exp;
 			session.au = Arc::new(Auth::new(Actor::new(
 				id.to_string(),
 				de.roles.iter().map(|r| r.into()).collect(),

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -603,6 +603,7 @@ mod tests {
 			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
 			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
 			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
 		}
 
 		//
@@ -630,6 +631,7 @@ mod tests {
 			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
 			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
 			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
+			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
 		}
 
 		// Test invalid password
@@ -673,6 +675,7 @@ mod tests {
 			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
 			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
 			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
 		}
 
 		//
@@ -701,6 +704,7 @@ mod tests {
 			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
 			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
 			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
+			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
 		}
 
 		// Test invalid password
@@ -745,6 +749,7 @@ mod tests {
 			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
 			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
 			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
 		}
 
 		//
@@ -774,6 +779,7 @@ mod tests {
 			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
 			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
 			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
+			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
 		}
 
 		// Test invalid password
@@ -837,6 +843,7 @@ mod tests {
 			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
 			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
 			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert_eq!(sess.exp, claims.exp, "Session expiration is expected to match token");
 		}
 
 		//
@@ -861,6 +868,7 @@ mod tests {
 			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
 			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
 			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
+			assert_eq!(sess.exp, claims.exp, "Session expiration is expected to match token");
 		}
 
 		//
@@ -944,6 +952,7 @@ mod tests {
 			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
 			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
 			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert_eq!(sess.exp, claims.exp, "Session expiration is expected to match token");
 		}
 
 		//
@@ -969,6 +978,7 @@ mod tests {
 			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
 			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
 			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
+			assert_eq!(sess.exp, claims.exp, "Session expiration is expected to match token");
 		}
 
 		//
@@ -1055,6 +1065,7 @@ mod tests {
 			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
 			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
 			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert_eq!(sess.exp, claims.exp, "Session expiration is expected to match token");
 		}
 
 		//
@@ -1082,6 +1093,7 @@ mod tests {
 			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
 			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
 			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert_eq!(sess.exp, claims.exp, "Session expiration is expected to match token");
 		}
 
 		//
@@ -1339,6 +1351,7 @@ mod tests {
 			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
 			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
 			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert_eq!(sess.exp, claims.exp, "Session expiration is expected to match token");
 			let tk = match sess.tk {
 				Some(Value::Object(tk)) => tk,
 				_ => panic!("Session token is not an object"),
@@ -1481,6 +1494,7 @@ mod tests {
 			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
 			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
 			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert_eq!(sess.exp, claims.exp, "Session expiration is expected to match token");
 		}
 
 		//

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -1133,7 +1133,7 @@ impl Datastore {
 	) -> Result<Vec<Response>, Error> {
 		// Check if the session has expired
 		if sess.expired() {
-			return Err(Error::ExpiredAuth);
+			return Err(Error::ExpiredSession);
 		}
 		// Check if anonymous actors can execute queries when auth is enabled
 		// TODO(sgirones): Check this as part of the authorisation layer
@@ -1201,7 +1201,7 @@ impl Datastore {
 	) -> Result<Value, Error> {
 		// Check if the session has expired
 		if sess.expired() {
-			return Err(Error::ExpiredAuth);
+			return Err(Error::ExpiredSession);
 		}
 		// Check if anonymous actors can compute values when auth is enabled
 		// TODO(sgirones): Check this as part of the authorisation layer
@@ -1284,7 +1284,7 @@ impl Datastore {
 	) -> Result<Value, Error> {
 		// Check if the session has expired
 		if sess.expired() {
-			return Err(Error::ExpiredAuth);
+			return Err(Error::ExpiredSession);
 		}
 		// Create a new query options
 		let opt = Options::default()
@@ -1366,7 +1366,7 @@ impl Datastore {
 	) -> Result<impl Future<Output = Result<(), Error>>, Error> {
 		// Check if the session has expired
 		if sess.expired() {
-			return Err(Error::ExpiredAuth);
+			return Err(Error::ExpiredSession);
 		}
 		// Retrieve the provided NS and DB
 		let (ns, db) = crate::iam::check::check_ns_db(sess)?;
@@ -1386,7 +1386,7 @@ impl Datastore {
 	pub fn check(&self, sess: &Session, action: Action, resource: Resource) -> Result<(), Error> {
 		// Check if the session has expired
 		if sess.expired() {
-			return Err(Error::ExpiredAuth);
+			return Err(Error::ExpiredSession);
 		}
 		// Skip auth for Anonymous users if auth is disabled
 		let skip_auth = !self.is_auth_enabled() && sess.au.is_anon();

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -1131,6 +1131,10 @@ impl Datastore {
 		sess: &Session,
 		vars: Variables,
 	) -> Result<Vec<Response>, Error> {
+		// Check if the session has expired
+		if sess.expired() {
+			return Err(Error::ExpiredAuth);
+		}
 		// Check if anonymous actors can execute queries when auth is enabled
 		// TODO(sgirones): Check this as part of the authorisation layer
 		if self.auth_enabled && sess.au.is_anon() && !self.capabilities.allows_guest_access() {

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -1199,6 +1199,10 @@ impl Datastore {
 		sess: &Session,
 		vars: Variables,
 	) -> Result<Value, Error> {
+		// Check if the session has expired
+		if sess.expired() {
+			return Err(Error::ExpiredAuth);
+		}
 		// Check if anonymous actors can compute values when auth is enabled
 		// TODO(sgirones): Check this as part of the authorisation layer
 		if self.auth_enabled && !self.capabilities.allows_guest_access() {
@@ -1278,6 +1282,10 @@ impl Datastore {
 		sess: &Session,
 		vars: Variables,
 	) -> Result<Value, Error> {
+		// Check if the session has expired
+		if sess.expired() {
+			return Err(Error::ExpiredAuth);
+		}
 		// Create a new query options
 		let opt = Options::default()
 			.with_id(self.id.0)
@@ -1356,6 +1364,10 @@ impl Datastore {
 		sess: &Session,
 		chn: Sender<Vec<u8>>,
 	) -> Result<impl Future<Output = Result<(), Error>>, Error> {
+		// Check if the session has expired
+		if sess.expired() {
+			return Err(Error::ExpiredAuth);
+		}
 		// Retrieve the provided NS and DB
 		let (ns, db) = crate::iam::check::check_ns_db(sess)?;
 		// Create a new readonly transaction
@@ -1372,6 +1384,10 @@ impl Datastore {
 	/// Checks the required permissions level for this session
 	#[instrument(level = "debug", skip(self, sess))]
 	pub fn check(&self, sess: &Session, action: Action, resource: Resource) -> Result<(), Error> {
+		// Check if the session has expired
+		if sess.expired() {
+			return Err(Error::ExpiredAuth);
+		}
 		// Skip auth for Anonymous users if auth is disabled
 		let skip_auth = !self.is_auth_enabled() && sess.au.is_anon();
 		if !skip_auth {

--- a/core/src/sql/v1/value/value.rs
+++ b/core/src/sql/v1/value/value.rs
@@ -502,6 +502,15 @@ impl From<Option<String>> for Value {
 	}
 }
 
+impl From<Option<i64>> for Value {
+	fn from(v: Option<i64>) -> Self {
+		match v {
+			Some(v) => Value::from(v),
+			None => Value::None,
+		}
+	}
+}
+
 impl From<Id> for Value {
 	fn from(v: Id) -> Self {
 		match v {

--- a/core/src/sql/v2/value/value.rs
+++ b/core/src/sql/v2/value/value.rs
@@ -502,6 +502,15 @@ impl From<Option<String>> for Value {
 	}
 }
 
+impl From<Option<i64>> for Value {
+	fn from(v: Option<i64>) -> Self {
+		match v {
+			Some(v) => Value::from(v),
+			None => Value::None,
+		}
+	}
+}
+
 impl From<Id> for Value {
 	fn from(v: Id) -> Self {
 		match v {

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -1182,6 +1182,7 @@ async fn session_expiration_operations() -> Result<(), Box<dyn std::error::Error
 
 	// Test operations that SHOULD work with an expired session
 	let operations_ok = vec![
+		socket.send_request("use", json!([NS, DB])).await,
 		socket.send_request("ping", json!([])).await,
 		socket.send_request("version", json!([])).await,
 		socket
@@ -1238,6 +1239,92 @@ async fn session_expiration_operations() -> Result<(), Box<dyn std::error::Error
 		}
 	}
 
+	// Test passed
+	server.finish();
+	Ok(())
+}
+
+#[test(tokio::test)]
+async fn session_reauthentication() -> Result<(), Box<dyn std::error::Error>> {
+	// Setup database server
+	let (addr, server) = common::start_server_with_defaults().await.unwrap();
+	// Connect to WebSocket
+	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await?;
+	// Authenticate the connection and store the root level token
+	let root_token = socket.send_message_signin(USER, PASS, None, None, None).await?;
+	// Check that we have root access
+	socket.send_message_query("INFO FOR ROOT").await?;
+	// Specify a namespace and database
+	socket.send_message_use(Some(NS), Some(DB)).await?;
+	// Setup the scope
+	socket
+		.send_message_query(
+			r#"
+			DEFINE SCOPE scope SESSION 1h
+				SIGNUP ( CREATE user SET email = $email, pass = crypto::argon2::generate($pass) )
+				SIGNIN ( SELECT * FROM user WHERE email = $email AND crypto::argon2::compare(pass, $pass) )
+			;"#,
+		)
+		.await?;
+	// Create resource that requires a scope session to query
+	socket
+		.send_message_query(
+			r#"
+			DEFINE TABLE test SCHEMALESS
+				PERMISSIONS FOR select, create, update, delete WHERE $scope = "scope"
+			;"#,
+		)
+		.await?;
+	socket
+		.send_message_query(
+			r#"
+			CREATE test:1 SET working = "yes"
+			;"#,
+		)
+		.await?;
+	// Send SIGNUP command
+	let res = socket
+		.send_request(
+			"signup",
+			json!(
+				[{
+					"ns": NS,
+					"db": DB,
+					"sc": "scope",
+					"email": "email@email.com",
+					"pass": "pass",
+				}]
+			),
+		)
+		.await;
+	assert!(res.is_ok(), "result: {:?}", res);
+	let res = res.unwrap();
+	assert!(res.is_object(), "result: {:?}", res);
+	let res = res.as_object().unwrap();
+	// Verify response contains no error
+	assert!(res.keys().all(|k| ["id", "result"].contains(&k.as_str())), "result: {:?}", res);
+	// Verify it returns a token
+	assert!(res["result"].is_string(), "result: {:?}", res);
+	let res = res["result"].as_str().unwrap();
+	assert!(res.starts_with("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9"), "result: {}", res);
+	// Authenticate using the scope token
+	socket.send_request("authenticate", json!([res,])).await?;
+	// Check that we do not have root access
+	let res = socket.send_message_query("INFO FOR ROOT").await?;
+	assert_eq!(res[0]["status"], "ERR", "result: {:?}", res);
+	assert_eq!(
+		res[0]["result"], "IAM error: Not enough permissions to perform this action",
+		"result: {:?}",
+		res
+	);
+	// Check if the session is authenticated for the scope
+	let res = socket.send_message_query("SELECT VALUE working FROM test:1").await?;
+	assert_eq!(res[0]["result"], json!(["yes"]), "result: {:?}", res);
+	// Authenticate using the root token
+	socket.send_request("authenticate", json!([root_token,])).await?;
+	// Check that we have root access again
+	let res = socket.send_message_query("INFO FOR ROOT").await?;
+	assert_eq!(res[0]["status"], "OK", "result: {:?}", res);
 	// Test passed
 	server.finish();
 	Ok(())


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

Currently, authenticated WebSocket sessions do not expire. This means that a WS session established with a valid token will persist even after the token has expired. This is far from ideal from a security perspective, as it allows a user to effectively use a token to perform authenticated actions beyond its intended lifetime as long as the WS connection is kept open. The motivation for this PR is to implement expiration for sessions so that an authenticated session established with a token can only be used to perform authenticated actions until the expiration of the token that was used to establish it.

## What does this change do?

It introduces the `exp` session attribute, which will currently match the expiration time of the token used to establish the session. It also introduces the `expired` session method, which checks if the current time exceeds the session expiration time. The `expired` method will be called whenever any datastore operation is going to be executed, before any other permission checks are performed. If a session is expired, a dedicated `ExpiredSession` error will be returned and the operation will not be executed. Despite the error, the session will not be terminated to allow clients to handle the error and re-authenticate with a currently valid token reusing the same connection.

With this implementation, sessions for system users established with username and password will not have a set expiration and, as a consequence, will not expire. This could be easily enforced but would require that users are allowed to configure this session lifetime like it can be done in the case of tokens via `DEFINE SCOPE` or through token claims. Otherwise, users that require a longer session lifetime would not be able to work with system users. Our plan is to support this customization in the future, at which point we will be able to enforce expiration for all sessions. 

## What is your testing strategy?

I implemented the following new tests in WebSocket sessions:

- Check that sessions expire when they are supposed to.
- Check which operations an expired session can and cannot perform.
- Check the behavior of calling `authenticate` within a session.
- Check the behavior of calling `authenticate` within an expired session.

Besides that, I rely on existing tests to ensure that nothing else breaks.

## Is this related to any issues?

This is related to issue #3543.

## Does this change need documentation?

- [x] Yes documentation is needed

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
