### PR TITLE
Remove `parser2` and `ml2` from nightly binaries

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/reusable_publish_version.yml
     with:
       environment: nightly
-      extra-features: ml2,storage-surrealkv
+      extra-features: storage-surrealkv
       git-ref: ${{ inputs.git-ref || github.ref_name }}
       publish: ${{ inputs.publish || github.event_name == 'schedule' }}
     secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/reusable_publish_version.yml
     with:
       environment: nightly
-      extra-features: parser2,ml2,storage-surrealkv
+      extra-features: ml2,storage-surrealkv
       git-ref: ${{ inputs.git-ref || github.ref_name }}
       publish: ${{ inputs.publish || github.event_name == 'schedule' }}
     secrets: inherit


### PR DESCRIPTION
## What is the motivation?

Backwards incompatible changes in features already stable can be confusing even on nightly.

## What does this change do?

It removes those features from the nightly binary.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
