### PR TITLE
Add `Surreal::wait_for`

### DIFF
--- a/lib/src/api/engine/any/mod.rs
+++ b/lib/src/api/engine/any/mod.rs
@@ -144,6 +144,7 @@ use crate::opt::path_to_string;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use tokio::sync::watch;
 use url::Url;
 
 /// A trait for converting inputs to a server address object
@@ -240,6 +241,7 @@ impl Surreal<Any> {
 			address: address.into_endpoint(),
 			capacity: 0,
 			client: PhantomData,
+			waiter: self.waiter.clone(),
 			response_type: PhantomData,
 		}
 	}
@@ -296,6 +298,7 @@ pub fn connect(address: impl IntoEndpoint) -> Connect<Any, Surreal<Any>> {
 		address: address.into_endpoint(),
 		capacity: 0,
 		client: PhantomData,
+		waiter: Arc::new(watch::channel(None)),
 		response_type: PhantomData,
 	}
 }

--- a/lib/src/api/engine/any/native.rs
+++ b/lib/src/api/engine/any/native.rs
@@ -21,6 +21,7 @@ use crate::api::Result;
 use crate::api::Surreal;
 #[allow(unused_imports)]
 use crate::error::Db as DbError;
+use crate::opt::WaitFor;
 use flume::Receiver;
 #[cfg(feature = "protocol-http")]
 use reqwest::ClientBuilder;
@@ -31,6 +32,7 @@ use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use tokio::sync::watch;
 #[cfg(feature = "protocol-ws")]
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 #[cfg(feature = "protocol-ws")]
@@ -235,6 +237,7 @@ impl Connection for Any {
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
+				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
 				engine: PhantomData,
 			})
 		})

--- a/lib/src/api/engine/any/wasm.rs
+++ b/lib/src/api/engine/any/wasm.rs
@@ -14,6 +14,7 @@ use crate::api::OnceLockExt;
 use crate::api::Result;
 use crate::api::Surreal;
 use crate::error::Db as DbError;
+use crate::opt::WaitFor;
 use flume::Receiver;
 use std::collections::HashSet;
 use std::future::Future;
@@ -22,6 +23,7 @@ use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use tokio::sync::watch;
 
 impl crate::api::Connection for Any {}
 
@@ -188,6 +190,7 @@ impl Connection for Any {
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
+				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
 				engine: PhantomData,
 			})
 		})

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -392,6 +392,7 @@ impl Surreal<Db> {
 			address: address.into_endpoint(),
 			capacity: 0,
 			client: PhantomData,
+			waiter: self.waiter.clone(),
 			response_type: PhantomData,
 		}
 	}

--- a/lib/src/api/engine/local/native.rs
+++ b/lib/src/api/engine/local/native.rs
@@ -17,6 +17,7 @@ use crate::fflags::FFLAGS;
 use crate::iam::Level;
 use crate::kvs::Datastore;
 use crate::opt::auth::Root;
+use crate::opt::WaitFor;
 use flume::Receiver;
 use flume::Sender;
 use futures::future::Either;
@@ -35,6 +36,7 @@ use std::sync::OnceLock;
 use std::task::Poll;
 use std::time::Duration;
 use surrealdb_core::dbs::Options;
+use tokio::sync::watch;
 use tokio::time;
 use tokio::time::MissedTickBehavior;
 
@@ -73,6 +75,7 @@ impl Connection for Db {
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
+				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
 				engine: PhantomData,
 			})
 		})

--- a/lib/src/api/engine/local/wasm.rs
+++ b/lib/src/api/engine/local/wasm.rs
@@ -17,6 +17,7 @@ use crate::fflags::FFLAGS;
 use crate::iam::Level;
 use crate::kvs::Datastore;
 use crate::opt::auth::Root;
+use crate::opt::WaitFor;
 use flume::Receiver;
 use flume::Sender;
 use futures::future::Either;
@@ -35,6 +36,7 @@ use std::sync::OnceLock;
 use std::task::Poll;
 use std::time::Duration;
 use surrealdb_core::dbs::Options;
+use tokio::sync::watch;
 use wasm_bindgen_futures::spawn_local;
 use wasmtimer::tokio as time;
 use wasmtimer::tokio::MissedTickBehavior;
@@ -73,6 +75,7 @@ impl Connection for Db {
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
+				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
 				engine: PhantomData,
 			})
 		})

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -104,6 +104,7 @@ impl Surreal<Client> {
 			address: address.into_endpoint(),
 			capacity: 0,
 			client: PhantomData,
+			waiter: self.waiter.clone(),
 			response_type: PhantomData,
 		}
 	}

--- a/lib/src/api/engine/remote/http/native.rs
+++ b/lib/src/api/engine/remote/http/native.rs
@@ -12,6 +12,7 @@ use crate::api::ExtraFeatures;
 use crate::api::OnceLockExt;
 use crate::api::Result;
 use crate::api::Surreal;
+use crate::opt::WaitFor;
 use flume::Receiver;
 use futures::StreamExt;
 use indexmap::IndexMap;
@@ -24,6 +25,7 @@ use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use tokio::sync::watch;
 use url::Url;
 
 impl crate::api::Connection for Client {}
@@ -77,6 +79,7 @@ impl Connection for Client {
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
+				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
 				engine: PhantomData,
 			})
 		})

--- a/lib/src/api/engine/remote/http/wasm.rs
+++ b/lib/src/api/engine/remote/http/wasm.rs
@@ -9,6 +9,7 @@ use crate::api::opt::Endpoint;
 use crate::api::OnceLockExt;
 use crate::api::Result;
 use crate::api::Surreal;
+use crate::opt::WaitFor;
 use flume::Receiver;
 use flume::Sender;
 use futures::StreamExt;
@@ -22,6 +23,7 @@ use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use tokio::sync::watch;
 use url::Url;
 use wasm_bindgen_futures::spawn_local;
 
@@ -56,6 +58,7 @@ impl Connection for Client {
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
+				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
 				engine: PhantomData,
 			})
 		})

--- a/lib/src/api/engine/remote/ws/mod.rs
+++ b/lib/src/api/engine/remote/ws/mod.rs
@@ -78,6 +78,7 @@ impl Surreal<Client> {
 			address: address.into_endpoint(),
 			capacity: 0,
 			client: PhantomData,
+			waiter: self.waiter.clone(),
 			response_type: PhantomData,
 		}
 	}

--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -20,6 +20,7 @@ use crate::api::Result;
 use crate::api::Surreal;
 use crate::engine::remote::ws::Data;
 use crate::engine::IntervalStream;
+use crate::opt::WaitFor;
 use crate::sql::Strand;
 use crate::sql::Value;
 use flume::Receiver;
@@ -41,6 +42,7 @@ use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use tokio::net::TcpStream;
+use tokio::sync::watch;
 use tokio::time;
 use tokio::time::MissedTickBehavior;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
@@ -154,6 +156,7 @@ impl Connection for Client {
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
+				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
 				engine: PhantomData,
 			})
 		})

--- a/lib/src/api/engine/remote/ws/wasm.rs
+++ b/lib/src/api/engine/remote/ws/wasm.rs
@@ -18,6 +18,7 @@ use crate::api::Result;
 use crate::api::Surreal;
 use crate::engine::remote::ws::Data;
 use crate::engine::IntervalStream;
+use crate::opt::WaitFor;
 use crate::sql::Strand;
 use crate::sql::Value;
 use flume::Receiver;
@@ -42,6 +43,7 @@ use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
+use tokio::sync::watch;
 use trice::Instant;
 use wasm_bindgen_futures::spawn_local;
 use wasmtimer::tokio as time;
@@ -94,6 +96,7 @@ impl Connection for Client {
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
+				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
 				engine: PhantomData,
 			})
 		})

--- a/lib/src/api/method/live.rs
+++ b/lib/src/api/method/live.rs
@@ -97,6 +97,7 @@ macro_rules! into_future {
 					rx: Some(rx),
 					client: Surreal {
 						router: client.router.clone(),
+						waiter: client.waiter.clone(),
 						engine: PhantomData,
 					},
 					response_type: PhantomData,

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -55,6 +55,7 @@ pub use select::Select;
 pub use set::Set;
 pub use signin::Signin;
 pub use signup::Signup;
+use tokio::sync::watch;
 pub use unset::Unset;
 pub use update::Update;
 pub use use_db::UseDb;
@@ -72,6 +73,7 @@ use crate::api::Connection;
 use crate::api::OnceLockExt;
 use crate::api::Surreal;
 use crate::opt::IntoExportDestination;
+use crate::opt::WaitFor;
 use crate::sql::to_value;
 use crate::sql::Value;
 use serde::Serialize;
@@ -228,6 +230,7 @@ where
 	pub fn init() -> Self {
 		Self {
 			router: Arc::new(OnceLock::new()),
+			waiter: Arc::new(watch::channel(None)),
 			engine: PhantomData,
 		}
 	}
@@ -258,6 +261,7 @@ where
 			address: address.into_endpoint(),
 			capacity: 0,
 			client: PhantomData,
+			waiter: Arc::new(watch::channel(None)),
 			response_type: PhantomData,
 		}
 	}
@@ -974,6 +978,21 @@ where
 		Health {
 			client: Cow::Borrowed(self),
 		}
+	}
+
+	/// Wait for the selected event to happen before proceeding
+	pub async fn wait_for(&self, event: WaitFor) {
+		let mut rx = self.waiter.0.subscribe();
+		rx.wait_for(|current| match current {
+			// The connection hasn't been initialised yet.
+			None => false,
+			// The connection has been initialised. Only the connection even matches.
+			Some(WaitFor::Connection) => matches!(event, WaitFor::Connection),
+			// The database has been selected. Connection and database events both match.
+			Some(WaitFor::Database) => matches!(event, WaitFor::Connection | WaitFor::Database),
+		})
+		.await
+		.ok();
 	}
 
 	/// Dumps the database contents to a file

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -106,6 +106,7 @@ where
 											rx: Some(rx),
 											client: Surreal {
 												router: self.client.router.clone(),
+												waiter: self.client.waiter.clone(),
 												engine: PhantomData,
 											},
 											response_type: PhantomData,
@@ -128,6 +129,7 @@ where
 			}
 			response.client = Surreal {
 				router: self.client.router.clone(),
+				waiter: self.client.waiter.clone(),
 				engine: PhantomData,
 			};
 			Ok(response)

--- a/lib/src/api/method/tests/protocol.rs
+++ b/lib/src/api/method/tests/protocol.rs
@@ -20,6 +20,7 @@ use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use tokio::sync::watch;
 use url::Url;
 
 #[derive(Debug)]
@@ -49,6 +50,7 @@ impl Surreal<Client> {
 			address: address.into_endpoint(),
 			capacity: 0,
 			client: PhantomData,
+			waiter: self.waiter.clone(),
 			response_type: PhantomData,
 		}
 	}
@@ -79,6 +81,7 @@ impl Connection for Client {
 			server::mock(route_rx);
 			Ok(Surreal {
 				router: Arc::new(OnceLock::with_value(router)),
+				waiter: Arc::new(watch::channel(None)),
 				engine: PhantomData,
 			})
 		})

--- a/lib/src/api/method/use_db.rs
+++ b/lib/src/api/method/use_db.rs
@@ -3,6 +3,7 @@ use crate::api::conn::Param;
 use crate::api::Connection;
 use crate::api::Result;
 use crate::method::OnceLockExt;
+use crate::opt::WaitFor;
 use crate::sql::Value;
 use crate::Surreal;
 use std::borrow::Cow;
@@ -45,7 +46,9 @@ where
 				self.client.router.extract()?,
 				Param::new(vec![self.ns, self.db.into()]),
 			)
-			.await
+			.await?;
+			self.client.waiter.0.send(Some(WaitFor::Database)).ok();
+			Ok(())
 		})
 	}
 }

--- a/lib/src/api/opt/mod.rs
+++ b/lib/src/api/opt/mod.rs
@@ -138,3 +138,13 @@ impl PatchOp {
 		}))
 	}
 }
+
+/// Makes the client wait for a certain event or call to happen before continuing
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum WaitFor {
+	/// Waits for the connection to succeed
+	Connection,
+	/// Waits for the desired database to be selected
+	Database,
+}

--- a/lib/tests/api.rs
+++ b/lib/tests/api.rs
@@ -128,7 +128,7 @@ mod api_integration {
 			assert_eq!(poll!(pin!(db.wait_for(Connection))), Poll::Ready(()));
 			assert_eq!(poll!(pin!(db.wait_for(Database))), Poll::Pending);
 
-			// Selecting a namespace shouldn't fire the database selection event
+			// Selecting a namespace shouldn't fire the database selection event.
 			db.use_ns("namespace").await.unwrap();
 			assert_eq!(poll!(pin!(db.wait_for(Connection))), Poll::Ready(()));
 			assert_eq!(poll!(pin!(db.wait_for(Database))), Poll::Pending);


### PR DESCRIPTION
## What is the motivation?

On some environments, one may not have access to the main function or an asynchronous main function may not be supported.

## What does this change do?

It makes it possible to initialise the connection and run setup actions like authentication and selecting the database concurrently with other queries by making it possible to wait for the SDK to connect or select the database to use before allowing other queries to execute.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

## Does this change need documentation?

- [x] Yes documentation is needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
