### PR TITLE
[ci] Use self-hosted runners for more CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,22 +15,10 @@ defaults:
     shell: bash
 
 jobs:
-  # TODO: Do not run it on CI because it's very slow right now.
-  # Build the Docker image but don't push it.
-  # docker:
-  #   uses: ./.github/workflows/reusable_docker.yml
-  #   with:
-  #     git-ref: ${{ github.ref }}
-  #     tag-prefix: ${{ github.head_ref || github.ref_name }}
-  #     build: true
-  #     push: false
-  #   secrets: inherit
-
   format:
     name: Check format
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -55,7 +43,6 @@ jobs:
     name: Check workspace
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -83,7 +70,6 @@ jobs:
     name: Check dependencies
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -123,7 +109,6 @@ jobs:
     name: Check Wasm
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -148,7 +133,6 @@ jobs:
     name: Check clippy
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -177,7 +161,6 @@ jobs:
     name: CLI integration tests
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -210,12 +193,10 @@ jobs:
           ps auxf
           cat /tmp/surrealdb.log || true
 
-
   http-server:
     name: HTTP integration tests
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -243,7 +224,6 @@ jobs:
     name: ML integration tests
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -271,7 +251,6 @@ jobs:
     name: WebSocket integration tests
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -297,9 +276,8 @@ jobs:
 
   test:
     name: Test workspace
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "arm64", "builder"]
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -316,17 +294,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y update
-
-      - name: Free up some disk space
-        run: |
-          (set -x; df -h)
-          # Free up some disk space by removing unused files
-          (set -x; sudo rm -rf /imagegeneration || true)
-          (set -x; sudo rm -rf /opt/az || true)
-          (set -x; sudo rm -rf /opt/hostedtoolcache || true)
-          (set -x; sudo rm -rf /opt/google || true)
-          (set -x; sudo rm -rf /opt/pipx || true)
-          (set -x; df -h)
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -348,9 +315,8 @@ jobs:
 
   test-parser:
     name: Test workspace with experimental parser
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "arm64", "builder"]
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -391,7 +357,6 @@ jobs:
     name: WebSocket engine
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -428,7 +393,6 @@ jobs:
     name: HTTP engine
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -465,7 +429,6 @@ jobs:
     name: Any engine
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -502,7 +465,6 @@ jobs:
     name: Memory engine
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -526,7 +488,6 @@ jobs:
     name: File engine
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -550,7 +511,6 @@ jobs:
     name: RocksDB engine
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -574,7 +534,6 @@ jobs:
     name: SpeeDB engine
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -595,10 +554,9 @@ jobs:
         run: cargo make ci-api-integration-speedb
 
   tikv-engine:
-     name: TiKV engine
-     runs-on: ubuntu-latest
-     steps:
-
+    name: TiKV engine
+    runs-on: ubuntu-latest
+    steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -642,7 +600,6 @@ jobs:
     name: FoundationDB engine
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -680,7 +637,6 @@ jobs:
     name: SurrealKV engine
     runs-on: ubuntu-latest
     steps:
-
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

GH Action's managed runners only have 14G of disk space, and that is often not enough when dealing with the Rust cache

## What does this change do?

Use self-hosted runners for heavyweight jobs

## What is your testing strategy?

Check that all jobs are successful

## Is this related to any issues?

Failed CI jobs because of not enough disk space

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
