### PR TITLE
[Documentation] Add example of .take() for error handling to query method

### DIFF
--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -639,7 +639,7 @@ where
 	///
 	/// #[derive(serde::Deserialize)]
 	/// struct Country {
-	/// 	name: String
+	///     name: String
 	/// }
 	///
 	/// // The .take() method can be used for error handling
@@ -647,13 +647,13 @@ where
 	/// // If the table has no defined schema, this query will
 	/// // create a `country` on the SurrealDB side, but...
 	/// let mut result = db
-	/// 	.query("CREATE country")
-	/// 	.await?;
+	///     .query("CREATE country")
+	///     .await?;
 	///
 	/// // It won't deserialize into a Country struct
 	/// if let Err(e) = result.take::<Option<Country>>(0) {
-	/// 	println!("Failed to make a country: {e:#?}");
-	/// 	assert!(e.to_string().contains("missing field `name`"));
+	///     println!("Failed to make a country: {e:#?}");
+	///     assert!(e.to_string().contains("missing field `name`"));
 	/// }
 	/// #
 	/// # Ok(())

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -635,7 +635,26 @@ where
 	/// let created: Option<Person> = result.take(0)?;
 	///
 	/// // Get all of the results from the second query
-	/// let people: Vec<Person> = result.take(1)?;
+	/// let people: Vec<Person> = result.take(1)?; 
+	///
+	/// #[derive(serde::Deserialize)]
+	/// struct Country {
+	/// 	name: String
+	/// }
+	///
+	/// // The .take() method can be used for error handling
+	///
+	/// // If the table has no defined schema, this query will 
+	/// // create a `country` on the SurrealDB side, but...
+	/// let mut result = db
+	/// 	.query("CREATE country")
+	/// 	.await?;
+	///
+	/// // It won't deserialize into a Country struct
+	/// if let Err(e) = result.take::<Option<Country>>(0) {
+	/// 	println!("Failed to make a country: {e:#?}");
+	/// 	assert!(e.to_string().contains("missing field `name`"));
+	/// }
 	/// #
 	/// # Ok(())
 	/// # }

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -635,7 +635,7 @@ where
 	/// let created: Option<Person> = result.take(0)?;
 	///
 	/// // Get all of the results from the second query
-	/// let people: Vec<Person> = result.take(1)?; 
+	/// let people: Vec<Person> = result.take(1)?;
 	///
 	/// #[derive(serde::Deserialize)]
 	/// struct Country {
@@ -644,7 +644,7 @@ where
 	///
 	/// // The .take() method can be used for error handling
 	///
-	/// // If the table has no defined schema, this query will 
+	/// // If the table has no defined schema, this query will
 	/// // create a `country` on the SurrealDB side, but...
 	/// let mut result = db
 	/// 	.query("CREATE country")


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Issue https://github.com/orgs/surrealdb/discussions/3576 where user could have used a more up front example of .take() to validate output

## What does this change do?

Adds an example of using the .take() method to validate the output from .query()

## What is your testing strategy?

NA, just documentation

## Is this related to any issues?

Yes, as above. (May not outright close the issue if the user isn't satisfied with .take() as a solution)

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

This change is documentation.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
