### PR TITLE
The query planner should accept Datetime and Uuid values

### DIFF
--- a/core/src/idx/planner/tree.rs
+++ b/core/src/idx/planner/tree.rs
@@ -97,9 +97,15 @@ impl<'a> TreeBuilder<'a> {
 		match v {
 			Value::Expression(e) => self.eval_expression(e).await,
 			Value::Idiom(i) => self.eval_idiom(i).await,
-			Value::Strand(_) | Value::Number(_) | Value::Bool(_) | Value::Thing(_) => {
-				Ok(Node::Computed(Arc::new(v.to_owned())))
-			}
+			Value::Strand(_)
+			| Value::Number(_)
+			| Value::Bool(_)
+			| Value::Thing(_)
+			| Value::Duration(_)
+			| Value::Uuid(_)
+			| Value::Constant(_)
+			| Value::Geometry(_)
+			| Value::Datetime(_) => Ok(Node::Computed(Arc::new(v.to_owned()))),
 			Value::Array(a) => self.eval_array(a).await,
 			Value::Subquery(s) => self.eval_subquery(s).await,
 			Value::Param(p) => {

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -1154,20 +1154,18 @@ async fn select_with_datetime_value() -> Result<(), Error> {
 	let sql = "
 		DEFINE FIELD created_at ON TABLE test_user TYPE datetime;
 		DEFINE INDEX createdAt ON TABLE test_user COLUMNS created_at;
-		LET $now = '2023-12-25T17:13:01.940183014Z';
+		LET $now = d'2023-12-25T17:13:01.940183014Z';
 		CREATE test_user:1 CONTENT { created_at: $now };
 		SELECT * FROM test_user WHERE created_at = $now EXPLAIN;
-		SELECT * FROM test_user WHERE created_at ='2023-12-25T17:13:01.940183014Z' EXPLAIN;
 		SELECT * FROM test_user WHERE created_at = d'2023-12-25T17:13:01.940183014Z' EXPLAIN;
 		SELECT * FROM test_user WHERE created_at = $now;
-		SELECT * FROM test_user WHERE created_at = '2023-12-25T17:13:01.940183014Z';
 		SELECT * FROM test_user WHERE created_at = d'2023-12-25T17:13:01.940183014Z';";
 	let mut res = dbs.execute(&sql, &ses, None).await?;
 
-	assert_eq!(res.len(), 10);
+	assert_eq!(res.len(), 8);
 	skip_ok(&mut res, 4)?;
 
-	for _ in 0..3 {
+	for _ in 0..2 {
 		let tmp = res.remove(0).result?;
 		let val = Value::parse(
 			r#"[
@@ -1187,13 +1185,13 @@ async fn select_with_datetime_value() -> Result<(), Error> {
 		assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
 	}
 
-	for _ in 0..3 {
+	for _ in 0..2 {
 		let tmp = res.remove(0).result?;
 		let val = Value::parse(
 			r#"[
 				{
         			"created_at": "2023-12-25T17:13:01.940183014Z",
-        			"id": "test_user:1"
+        			"id": test_user:1
     			}
 			]"#,
 		);
@@ -1210,19 +1208,16 @@ async fn select_with_uuid_value() -> Result<(), Error> {
 	let sql = "
 		DEFINE INDEX sessionUid ON sessions FIELDS sessionUid;
 		CREATE sessions:1 CONTENT { sessionUid: u'00ad70db-f435-442e-9012-1cd853102084' };
-		SELECT * FROM sessions WHERE sessionUid = '00ad70db-f435-442e-9012-1cd853102084' EXPLAIN;
 		SELECT * FROM sessions WHERE sessionUid = u'00ad70db-f435-442e-9012-1cd853102084' EXPLAIN;
-		SELECT * FROM sessions WHERE sessionUid = '00ad70db-f435-442e-9012-1cd853102084';
 		SELECT * FROM sessions WHERE sessionUid = u'00ad70db-f435-442e-9012-1cd853102084';";
 	let mut res = dbs.execute(&sql, &ses, None).await?;
 
-	assert_eq!(res.len(), 6);
+	assert_eq!(res.len(), 4);
 	skip_ok(&mut res, 2)?;
 
-	for _ in 0..2 {
-		let tmp = res.remove(0).result?;
-		let val = Value::parse(
-			r#"[
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
 				{
 					detail: {
 						plan: {
@@ -1235,21 +1230,19 @@ async fn select_with_uuid_value() -> Result<(), Error> {
 					operation: 'Iterate Index'
 				}
 			]"#,
-		);
-		assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
-	}
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
 
-	for _ in 0..2 {
-		let tmp = res.remove(0).result?;
-		let val = Value::parse(
-			r#"[
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
 				{
-               		"id": "sessions:1",
+               		"id": sessions:1,
  					"sessionUid": "00ad70db-f435-442e-9012-1cd853102084"
     			}
 			]"#,
-		);
-		assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
-	}
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

The query planner does not trigger indexes in the presence of Datetime and UUID types in the query.

## What does this change do?

Type support has been extended to Datetime, UUID, Constant, Duration and Geometry.

## What is your testing strategy?

Tests have been implemented.

## Is this related to any issues?


Fixes #3223 
Fixes #3524

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
