### PR TITLE
Make the CI group own flake.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 .dockerignore @surrealdb/ci
 build.rs @surrealdb/ci
 *.nix @surrealdb/ci
+flake.lock @surrealdb/ci
 /.cargo/ @surrealdb/ci
 /.config/ @surrealdb/ci
 /dev/ @surrealdb/ci


### PR DESCRIPTION
## What is the motivation?

`flake.lock` does not currently have a code owner assigned.

## What does this change do?

It assigns it to the CI group, which is what other Nix files are already assigned to.

## What is your testing strategy?

Github says CODEOWNERS is valid.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
