### PR TITLE
Support of IN operator in the planner

### DIFF
--- a/core/src/idx/planner/tree.rs
+++ b/core/src/idx/planner/tree.rs
@@ -316,12 +316,11 @@ impl<'a> TreeBuilder<'a> {
 				(Operator::Contain, v, IdiomPosition::Left) => {
 					Some(IndexOperator::Equality(v.clone()))
 				}
-				(Operator::ContainAny, Value::Array(a), IdiomPosition::Left) => {
-					Some(IndexOperator::Union(a.clone()))
-				}
-				(Operator::ContainAll, Value::Array(a), IdiomPosition::Left) => {
-					Some(IndexOperator::Union(a.clone()))
-				}
+				(
+					Operator::ContainAny | Operator::ContainAll | Operator::Inside,
+					Value::Array(a),
+					IdiomPosition::Left,
+				) => Some(IndexOperator::Union(a.clone())),
 				(
 					Operator::LessThan
 					| Operator::LessThanOrEqual

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -1246,3 +1246,51 @@ async fn select_with_uuid_value() -> Result<(), Error> {
 
 	Ok(())
 }
+
+#[tokio::test]
+async fn select_with_in_operator() -> Result<(), Error> {
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	let sql = "
+		DEFINE INDEX user_email_idx ON user FIELDS email;
+		CREATE user:1 CONTENT { email: 'a@b' };
+		CREATE user:2 CONTENT { email: 'c@d' };
+		SELECT * FROM user WHERE email IN ['a@b', 'e@f'] EXPLAIN;
+		SELECT * FROM user WHERE email IN ['a@b', 'e@f'];";
+	let mut res = dbs.execute(&sql, &ses, None).await?;
+
+	assert_eq!(res.len(), 5);
+	skip_ok(&mut res, 3)?;
+
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+				{
+					detail: {
+						plan: {
+							index: 'user_email_idx',
+							operator: 'in',
+							value: ['a@b', 'e@f']
+						},
+						table: 'user'
+					},
+					operation: 'Iterate Index'
+				}
+			]"#,
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+				{
+               		'id': user:1,
+ 					'email': 'a@b'
+    			}
+			]"#,
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+
+	Ok(())
+}


### PR DESCRIPTION
## What is the motivation?

When using IN in a SELECT query any existing index is not triggered.

## What does this change do?

Add the support of IN in the query planner.

## What is your testing strategy?

A test has been created

## Is this related to any issues?

Fixes #3221 

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
