### PR TITLE
The query planner should accept Datetime and Uuid values

### DIFF
--- a/core/src/idx/planner/tree.rs
+++ b/core/src/idx/planner/tree.rs
@@ -97,9 +97,15 @@ impl<'a> TreeBuilder<'a> {
 		match v {
 			Value::Expression(e) => self.eval_expression(e).await,
 			Value::Idiom(i) => self.eval_idiom(i).await,
-			Value::Strand(_) | Value::Number(_) | Value::Bool(_) | Value::Thing(_) => {
-				Ok(Node::Computed(Arc::new(v.to_owned())))
-			}
+			Value::Strand(_)
+			| Value::Number(_)
+			| Value::Bool(_)
+			| Value::Thing(_)
+			| Value::Duration(_)
+			| Value::Uuid(_)
+			| Value::Constant(_)
+			| Value::Geometry(_)
+			| Value::Datetime(_) => Ok(Node::Computed(Arc::new(v.to_owned()))),
 			Value::Array(a) => self.eval_array(a).await,
 			Value::Subquery(s) => self.eval_subquery(s).await,
 			Value::Param(p) => {

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -1145,3 +1145,104 @@ async fn select_unique_contains() -> Result<(), Error> {
 
 	test_contains(&dbs, SQL, INDEX_EXPLAIN, RESULT).await
 }
+
+#[tokio::test]
+async fn select_with_datetime_value() -> Result<(), Error> {
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	let sql = "
+		DEFINE FIELD created_at ON TABLE test_user TYPE datetime;
+		DEFINE INDEX createdAt ON TABLE test_user COLUMNS created_at;
+		LET $now = d'2023-12-25T17:13:01.940183014Z';
+		CREATE test_user:1 CONTENT { created_at: $now };
+		SELECT * FROM test_user WHERE created_at = $now EXPLAIN;
+		SELECT * FROM test_user WHERE created_at = d'2023-12-25T17:13:01.940183014Z' EXPLAIN;
+		SELECT * FROM test_user WHERE created_at = $now;
+		SELECT * FROM test_user WHERE created_at = d'2023-12-25T17:13:01.940183014Z';";
+	let mut res = dbs.execute(&sql, &ses, None).await?;
+
+	assert_eq!(res.len(), 8);
+	skip_ok(&mut res, 4)?;
+
+	for _ in 0..2 {
+		let tmp = res.remove(0).result?;
+		let val = Value::parse(
+			r#"[
+				{
+					detail: {
+						plan: {
+							index: 'createdAt',
+							operator: '=',
+							value: '2023-12-25T17:13:01.940183014Z'
+						},
+						table: 'test_user'
+					},
+					operation: 'Iterate Index'
+				}
+			]"#,
+		);
+		assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	}
+
+	for _ in 0..2 {
+		let tmp = res.remove(0).result?;
+		let val = Value::parse(
+			r#"[
+				{
+        			"created_at": "2023-12-25T17:13:01.940183014Z",
+        			"id": test_user:1
+    			}
+			]"#,
+		);
+		assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	}
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_with_uuid_value() -> Result<(), Error> {
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	let sql = "
+		DEFINE INDEX sessionUid ON sessions FIELDS sessionUid;
+		CREATE sessions:1 CONTENT { sessionUid: u'00ad70db-f435-442e-9012-1cd853102084' };
+		SELECT * FROM sessions WHERE sessionUid = u'00ad70db-f435-442e-9012-1cd853102084' EXPLAIN;
+		SELECT * FROM sessions WHERE sessionUid = u'00ad70db-f435-442e-9012-1cd853102084';";
+	let mut res = dbs.execute(&sql, &ses, None).await?;
+
+	assert_eq!(res.len(), 4);
+	skip_ok(&mut res, 2)?;
+
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+				{
+					detail: {
+						plan: {
+							index: 'sessionUid',
+							operator: '=',
+							value: '00ad70db-f435-442e-9012-1cd853102084'
+						},
+						table: 'sessions'
+					},
+					operation: 'Iterate Index'
+				}
+			]"#,
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+				{
+               		"id": sessions:1,
+ 					"sessionUid": "00ad70db-f435-442e-9012-1cd853102084"
+    			}
+			]"#,
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+
+	Ok(())
+}


### PR DESCRIPTION
## What is the motivation?

The query planner does not trigger indexes in the presence of Datetime and UUID types in the query.

## What does this change do?

Backports #3626 to v1.2.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
