### PR TITLE
Bug fix: Restore cosine distance on MTree indexes

### DIFF
--- a/core/src/fnc/util/math/mod.rs
+++ b/core/src/fnc/util/math/mod.rs
@@ -17,3 +17,37 @@ pub mod top;
 pub mod trimean;
 pub mod variance;
 pub mod vector;
+
+pub(crate) trait ToFloat {
+	fn to_float(&self) -> f64;
+}
+
+impl ToFloat for f64 {
+	fn to_float(&self) -> f64 {
+		*self
+	}
+}
+
+impl ToFloat for f32 {
+	fn to_float(&self) -> f64 {
+		*self as f64
+	}
+}
+
+impl ToFloat for i64 {
+	fn to_float(&self) -> f64 {
+		*self as f64
+	}
+}
+
+impl ToFloat for i32 {
+	fn to_float(&self) -> f64 {
+		*self as f64
+	}
+}
+
+impl ToFloat for i16 {
+	fn to_float(&self) -> f64 {
+		*self as f64
+	}
+}


### PR DESCRIPTION
## What is the motivation?

The cosine distance has been removed from MTree indexes in the v.1.2 branch.

## What does this change do?

Backports #3614 to v1.2.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
