### PR TITLE
Update rquickjs version

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -91,7 +91,7 @@ geo = { version = "0.27.0", features = ["use-serde"] }
 hex = { version = "0.4.3" }
 indxdb = { version = "0.4.0", optional = true }
 ipnet = "2.9.0"
-js = { version = "0.4.3", package = "rquickjs", features = [
+js = { version = "0.5.1", package = "rquickjs", features = [
     "array-buffer",
     "bindgen",
     "classes",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1344,19 +1344,19 @@ version = "0.21.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rquickjs]]
-version = "0.4.3"
+version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rquickjs-core]]
-version = "0.4.3"
+version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rquickjs-macro]]
-version = "0.4.3"
+version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rquickjs-sys]]
-version = "0.4.3"
+version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rsa]]


### PR DESCRIPTION
## What is the motivation?

There was a bug in rquickjs which caused builds to stall on macos. This is fixed in the newest version.

## What does this change do?

Backports #3557 to v1.2.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
