### PR TITLE
Add JWT ID claim to tokens issued by SurrealDB

### DIFF
--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -11,6 +11,7 @@ use crate::sql::Value;
 use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey};
 use std::sync::Arc;
+use uuid::Uuid;
 
 pub async fn signin(
 	kvs: &Datastore,
@@ -155,6 +156,7 @@ pub async fn sc(
 									iat: Some(Utc::now().timestamp()),
 									nbf: Some(Utc::now().timestamp()),
 									exp,
+									jti: Some(Uuid::new_v4().to_string()),
 									ns: Some(ns.to_owned()),
 									db: Some(db.to_owned()),
 									sc: Some(sc.to_owned()),
@@ -228,6 +230,7 @@ pub async fn db(
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp,
+				jti: Some(Uuid::new_v4().to_string()),
 				ns: Some(ns.to_owned()),
 				db: Some(db.to_owned()),
 				id: Some(user),
@@ -281,6 +284,7 @@ pub async fn ns(
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp,
+				jti: Some(Uuid::new_v4().to_string()),
 				ns: Some(ns.to_owned()),
 				id: Some(user),
 				..Claims::default()
@@ -332,6 +336,7 @@ pub async fn root(
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp,
+				jti: Some(Uuid::new_v4().to_string()),
 				id: Some(user),
 				..Claims::default()
 			};

--- a/core/src/iam/signup.rs
+++ b/core/src/iam/signup.rs
@@ -10,6 +10,7 @@ use crate::sql::Value;
 use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey};
 use std::sync::Arc;
+use uuid::Uuid;
 
 pub async fn signup(
 	kvs: &Datastore,
@@ -73,6 +74,7 @@ pub async fn sc(
 									iss: Some(SERVER_NAME.to_owned()),
 									iat: Some(Utc::now().timestamp()),
 									nbf: Some(Utc::now().timestamp()),
+									jti: Some(Uuid::new_v4().to_string()),
 									exp: Some(
 										match sv.session {
 											Some(v) => {

--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -89,7 +89,7 @@ impl From<Claims> for Value {
 			out.insert("exp".to_string(), exp.into());
 		}
 		// Add jti field if set
-		if let Some(jti) = v.exp {
+		if let Some(jti) = v.jti {
 			out.insert("jti".to_string(), jti.into());
 		}
 		// Add NS field if set

--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -18,6 +18,8 @@ pub struct Claims {
 	pub exp: Option<i64>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub iss: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub jti: Option<String>,
 	#[serde(alias = "ns")]
 	#[serde(alias = "NS")]
 	#[serde(rename = "NS")]
@@ -85,6 +87,10 @@ impl From<Claims> for Value {
 		// Add exp field if set
 		if let Some(exp) = v.exp {
 			out.insert("exp".to_string(), exp.into());
+		}
+		// Add jti field if set
+		if let Some(jti) = v.exp {
+			out.insert("jti".to_string(), jti.into());
 		}
 		// Add NS field if set
 		if let Some(ns) = v.ns {


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The motivation for this PR is to support use cases where developers may want to uniquely identify tokens issued by SurrealDB. This can be leveraged in SurrealDB and other backends to prevent token replay, audit token usage or disallow (i.e. revoke) specific tokens by referencing the unique token identifier.

This claim can currently only be validated in SurrealDB via `PERMISSIONS` clauses, as the `SIGNIN` clause does not have access to the token. However, if we merge #3659, it will be possible to process the JWT ID more naturally as part of scope authentication, which will allow better performance and security than doing so in `PERMISSIONS` clauses.

## What does this change do?

Introduces the optional `jti` claim following the requirements specified in [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7). The claim is added to every JWT generated by SurrealDB and contains a randomly generated UUIDv4 string, which ensures that the possibility of collisions is negligible. The use of this claim is optional and not enforced when verifying tokens.

## What is your testing strategy?

Rely on the existing tests to verify that tokens continue working as expected.

## Is this related to any issues?

Not directly.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

Not for now.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
