### PR TITLE
Improve debug experience on debug builds

### DIFF
--- a/core/src/key/debug.rs
+++ b/core/src/key/debug.rs
@@ -1,5 +1,4 @@
 /// Debug purposes only. It may be used in logs. Not for key handling in implementation code.
-use crate::kvs::Key;
 
 /// Helpers for debugging keys
 

--- a/core/src/key/debug.rs
+++ b/core/src/key/debug.rs
@@ -5,8 +5,13 @@ use crate::kvs::Key;
 
 /// sprint_key converts a key to an escaped string.
 /// This is used for logging and debugging tests and should not be used in implementation code.
-pub fn sprint_key(key: &Key) -> String {
-	key.iter()
+#[doc(hidden)]
+pub fn sprint_key<T>(key: &T) -> String
+where
+	T: AsRef<[u8]>,
+{
+	key.as_ref()
+		.iter()
 		.flat_map(|&byte| std::ascii::escape_default(byte))
 		.map(|byte| byte as char)
 		.collect::<String>()

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -359,6 +359,7 @@ impl Transaction {
 	where
 		K: Into<Key> + Debug,
 	{
+		let key = key.into();
 		#[cfg(debug_assertions)]
 		trace!("Del {:?}", sprint_key(&key));
 		match self {
@@ -457,6 +458,7 @@ impl Transaction {
 	where
 		K: Into<Key> + Debug,
 	{
+		let key = key.into();
 		#[cfg(debug_assertions)]
 		trace!("Get {:?}", sprint_key(&key));
 		match self {
@@ -507,6 +509,7 @@ impl Transaction {
 		K: Into<Key> + Debug,
 		V: Into<Val> + Debug,
 	{
+		let key = key.into();
 		#[cfg(debug_assertions)]
 		trace!("Set {:?} => {:?}", sprint_key(&key), val);
 		match self {
@@ -558,8 +561,10 @@ impl Transaction {
 	#[allow(unused)]
 	pub async fn get_timestamp<K>(&mut self, key: K, lock: bool) -> Result<Versionstamp, Error>
 	where
-		K: Into<Key> + Debug + AsRef<[u8]>,
+		K: Into<Key> + Debug,
 	{
+		// We convert to byte slice as its easier at this level
+		let key = key.into();
 		#[cfg(debug_assertions)]
 		trace!("Get Timestamp {:?}", sprint_key(&key));
 		match self {
@@ -639,8 +644,6 @@ impl Transaction {
 		K: Into<Key> + Debug,
 		V: Into<Val> + Debug,
 	{
-		#[cfg(debug_assertions)]
-		trace!("Set {:?} <ts> {:?} => {:?}", sprint_key(&prefix), sprint_key(&suffix), val);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -813,7 +816,7 @@ impl Transaction {
 		batch_limit: u32,
 	) -> Result<ScanResult<K>, Error>
 	where
-		K: Into<Key> + From<Vec<u8>> + Debug + Clone,
+		K: Into<Key> + From<Vec<u8>> + AsRef<[u8]> + Debug + Clone,
 	{
 		#[cfg(debug_assertions)]
 		trace!("Scan {:?} - {:?}", sprint_key(&page.range.start), sprint_key(&page.range.end));
@@ -888,6 +891,7 @@ impl Transaction {
 		K: Into<Key> + Debug,
 		V: Into<Val> + Debug,
 	{
+		let key = key.into();
 		#[cfg(debug_assertions)]
 		trace!("Putc {:?} if {:?} => {:?}", sprint_key(&key), chk, val);
 		match self {
@@ -938,6 +942,7 @@ impl Transaction {
 		K: Into<Key> + Debug,
 		V: Into<Val> + Debug,
 	{
+		let key = key.into();
 		#[cfg(debug_assertions)]
 		trace!("Delc {:?} if {:?}", sprint_key(&key), chk);
 		match self {
@@ -992,10 +997,10 @@ impl Transaction {
 	where
 		K: Into<Key> + Debug,
 	{
-		#[cfg(debug_assertions)]
-		trace!("Getr {:?}..{:?} (limit: {limit})", sprint_key(&rng.start), sprint_key(&rng.end));
 		let beg: Key = rng.start.into();
 		let end: Key = rng.end.into();
+		#[cfg(debug_assertions)]
+		trace!("Getr {:?}..{:?} (limit: {limit})", sprint_key(&beg), sprint_key(&end));
 		let mut out: Vec<(Key, Val)> = vec![];
 		let mut next_page = Some(ScanPage {
 			range: beg..end,
@@ -1026,6 +1031,10 @@ impl Transaction {
 	where
 		K: Into<Key> + Debug,
 	{
+		let rng = Range {
+			start: rng.start.into(),
+			end: rng.end.into(),
+		};
 		#[cfg(debug_assertions)]
 		trace!("Delr {:?}..{:?} (limit: {limit})", sprint_key(&rng.start), sprint_key(&rng.end));
 		match self {
@@ -1083,9 +1092,9 @@ impl Transaction {
 		K: Into<Key> + Debug,
 	{
 		let beg: Key = key.into();
-		#[cfg(debug_assertions)]
-		trace!("Getp {:?} (limit: {limit})", sprint_key(&beg));
 		let end: Key = beg.clone().add(0xff);
+		#[cfg(debug_assertions)]
+		trace!("Getp {:?}-{:?} (limit: {limit})", sprint_key(&beg), sprint_key(&end));
 		let mut out: Vec<(Key, Val)> = vec![];
 		// Start processing
 		let mut next_page = Some(ScanPage {
@@ -1116,10 +1125,10 @@ impl Transaction {
 	where
 		K: Into<Key> + Debug,
 	{
-		#[cfg(debug_assertions)]
-		trace!("Delp {:?} (limit: {limit})", sprint_key(&key));
 		let beg: Key = key.into();
 		let end: Key = beg.clone().add(0xff);
+		#[cfg(debug_assertions)]
+		trace!("Delp {:?}-{:?} (limit: {limit})", sprint_key(&beg), sprint_key(&end));
 		let min = beg.clone();
 		let max = end.clone();
 		self.delr(min..max, limit).await?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -97,10 +97,12 @@ pub async fn init() -> ExitCode {
 		.blocklist(&["libc", "libgcc", "pthread", "vdso"])
 		.build()
 		.unwrap();
-	#[cfg(debug_assertions)]
-	println!("{DEBUG_BUILD_WARNING}",);
 	// Parse the CLI arguments
 	let args = Cli::parse();
+
+	#[cfg(debug_assertions)]
+	println!("{DEBUG_BUILD_WARNING}");
+
 	// After parsing arguments, we check the version online
 	if args.online_version_check {
 		let client = version_client::new(Some(Duration::from_millis(500))).unwrap();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,7 +15,7 @@ mod version;
 mod version_client;
 
 use crate::cli::version_client::VersionClient;
-use crate::cnf::{LOGO, PKG_VERSION};
+use crate::cnf::{DEBUG_BUILD_WARNING, LOGO, PKG_VERSION};
 use crate::env::RELEASE;
 use clap::{Parser, Subcommand};
 pub use config::CF;
@@ -97,6 +97,8 @@ pub async fn init() -> ExitCode {
 		.blocklist(&["libc", "libgcc", "pthread", "vdso"])
 		.build()
 		.unwrap();
+	#[cfg(debug_assertions)]
+	println!("{DEBUG_BUILD_WARNING}",);
 	// Parse the CLI arguments
 	let args = Cli::parse();
 	// After parsing arguments, we check the version online

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -13,6 +13,14 @@ Y88b  d88P Y88b 888 888     888     Y8b.     888  888 888 888  .d88P 888   d88P
 
 ";
 
+pub const DEBUG_BUILD_WARNING: &str = "\
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        !!! THIS IS A DEBUG BUILD !!!                        │
+│        Debug builds are not intended for production use and include         │
+│       tooling and features that we would not recommend people run on        │
+│                                  live data.                                 │
+└─────────────────────────────────────────────────────────────────────────────┘";
+
 /// The publicly visible name of the server
 pub const PKG_NAME: &str = "surrealdb";
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -2,6 +2,7 @@
 mod common;
 
 mod cli_integration {
+	use crate::remove_debug_info;
 	use assert_fs::prelude::{FileTouch, FileWriteStr, PathChild};
 	use common::Format;
 	use common::Socket;
@@ -59,6 +60,14 @@ mod cli_integration {
 		assert!(common::run("version --turbo").output().is_err());
 	}
 
+	fn debug_builds_contain_debug_message(addr: &str, creds: &str, ns: &Ulid, db: &Ulid) {
+		info!("* Debug builds contain debug message");
+		let args =
+			format!("sql --conn http://{addr} {creds} --ns {ns} --db {db} --multi --hide-welcome");
+		let res = common::run(&args).input("CREATE not_a_table:not_a_record;\n").output().unwrap();
+		assert!(res.contains("Debug builds are not intended for production use"));
+	}
+
 	#[test(tokio::test)]
 	async fn all_commands() {
 		// Commands without credentials when auth is disabled, should succeed
@@ -73,22 +82,16 @@ mod cli_integration {
 		let ns = Ulid::new();
 		let db = Ulid::new();
 
+		#[cfg(debug_assertions)]
+		debug_builds_contain_debug_message(&addr, creds, &ns, &db);
+
 		info!("* Create a record");
 		{
 			let args = format!(
 				"sql --conn http://{addr} {creds} --ns {ns} --db {db} --multi --hide-welcome"
 			);
-			assert_eq!(
-				common::run(&args)
-					.input("CREATE thing:one;\n")
-					.output()
-					.unwrap()
-					.replace("^┌.*$", "")
-					.replace("^└.*$", "")
-					.replace("│", ""),
-				Ok("[[{ id: thing:one }]]\n\n".to_owned()),
-				"failed to send sql: {args}"
-			);
+			let output = common::run(&args).input("CREATE thing:one;\n").output().unwrap();
+			assert!(output.contains("[[{ id: thing:one }]]\n\n"), "failed to send sql: {args}");
 		}
 
 		info!("* Export to stdout");
@@ -123,8 +126,9 @@ mod cli_integration {
 				"sql --conn http://{addr} {creds} --ns {ns} --db {db2} --pretty --hide-welcome"
 			);
 			let output = common::run(&args).input("SELECT * FROM thing;\n").output().unwrap();
+			let output = remove_debug_info(output);
 			let (line1, rest) = output.split_once('\n').expect("response to have multiple lines");
-			assert!(line1.starts_with("-- Query 1"));
+			assert!(line1.starts_with("-- Query 1"), "Expected on {line1}, and rest was {rest}");
 			assert!(line1.contains("execution time"));
 			assert_eq!(rest, "[\n\t{\n\t\tid: thing:one\n\t}\n]\n\n", "failed to send sql: {args}");
 		}
@@ -488,8 +492,9 @@ mod cli_integration {
 		// Commands with credentials for different auth levels
 		let (addr, server) = common::start_server_with_defaults().await.unwrap();
 		let creds = format!("--user {USER} --pass {PASS}");
-		let ns = Ulid::new();
-		let db = Ulid::new();
+		// Prefix with 'a' so that we don't start with a number and cause a parsing error
+		let ns = format!("a{}", Ulid::new());
+		let db = format!("a{}", Ulid::new());
 
 		info!("* Create users with identical credentials at ROOT, NS and DB levels");
 		{
@@ -627,11 +632,10 @@ mod cli_integration {
 			let args = format!(
 				"sql --conn http://{addr} {creds} --ns {ns} --db {db} --multi --hide-welcome"
 			);
-			assert_eq!(
-				common::run(&args).input("DEFINE TABLE thing CHANGEFEED 1s;\n").output(),
-				Ok("[NONE]\n\n".to_owned()),
-				"failed to send sql: {args}"
-			);
+			let output =
+				common::run(&args).input("DEFINE TABLE thing CHANGEFEED 1s;\n").output().unwrap();
+			let output = remove_debug_info(output);
+			assert_eq!(output, "[NONE]\n\n".to_owned(), "failed to send sql: {args}");
 		}
 
 		info!("* Create a record");
@@ -639,9 +643,14 @@ mod cli_integration {
 			let args = format!(
 				"sql --conn http://{addr} {creds} --ns {ns} --db {db} --multi --hide-welcome"
 			);
+			let output = common::run(&args)
+				.input("BEGIN TRANSACTION; CREATE thing:one; COMMIT;\n")
+				.output()
+				.unwrap();
+			let output = remove_debug_info(output);
 			assert_eq!(
-				common::run(&args).input("BEGIN TRANSACTION; CREATE thing:one; COMMIT;\n").output(),
-				Ok("[[{ id: thing:one }]]\n\n".to_owned()),
+				output,
+				"[[{ id: thing:one }]]\n\n".to_owned(),
 				"failed to send sql: {args}"
 			);
 		}
@@ -652,20 +661,26 @@ mod cli_integration {
 				"sql --conn http://{addr} {creds} --ns {ns} --db {db} --multi --hide-welcome"
 			);
 			if FFLAGS.change_feed_live_queries.enabled() {
+				let output = common::run(&args)
+					.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
+					.output()
+					.unwrap();
+				let output = remove_debug_info(output);
 				assert_eq!(
-						common::run(&args)
-							.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
-							.output(),
-						Ok("[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 65536 }, { changes: [{ create: { id: thing:one } }], versionstamp: 131072 }]]\n\n"
-							.to_owned()),
+					output,
+						"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 65536 }, { changes: [{ create: { id: thing:one } }], versionstamp: 131072 }]]\n\n"
+							.to_owned(),
 						"failed to send sql: {args}");
 			} else {
+				let output = common::run(&args)
+					.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
+					.output()
+					.unwrap();
+				let output = remove_debug_info(output);
 				assert_eq!(
-						common::run(&args)
-							.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
-							.output(),
-						Ok("[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 65536 }, { changes: [{ update: { id: thing:one } }], versionstamp: 131072 }]]\n\n"
-							.to_owned()),
+					output,
+						"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 65536 }, { changes: [{ update: { id: thing:one } }], versionstamp: 131072 }]]\n\n"
+							.to_owned(),
 						"failed to send sql: {args}" );
 			}
 		};
@@ -677,13 +692,12 @@ mod cli_integration {
 			let args = format!(
 				"sql --conn http://{addr} {creds} --ns {ns} --db {db} --multi --hide-welcome"
 			);
-			assert_eq!(
-				common::run(&args)
-					.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
-					.output(),
-				Ok("[[]]\n\n".to_owned()),
-				"failed to send sql: {args}"
-			);
+			let output = common::run(&args)
+				.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
+				.output()
+				.unwrap();
+			let output = remove_debug_info(output);
+			assert_eq!(output, "[[]]\n\n".to_owned(), "failed to send sql: {args}");
 		}
 		server.finish()
 	}
@@ -1081,4 +1095,18 @@ mod cli_integration {
 			server.finish()
 		}
 	}
+}
+
+fn remove_debug_info(output: String) -> String {
+	// Look... sometimes you just gotta copy paste
+	let output_warning = "\
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        !!! THIS IS A DEBUG BUILD !!!                        │
+│        Debug builds are not intended for production use and include         │
+│       tooling and features that we would not recommend people run on        │
+│                                  live data.                                 │
+└─────────────────────────────────────────────────────────────────────────────┘
+";
+	// The last line in the above is important
+	output.replace(output_warning, "")
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -79,7 +79,13 @@ mod cli_integration {
 				"sql --conn http://{addr} {creds} --ns {ns} --db {db} --multi --hide-welcome"
 			);
 			assert_eq!(
-				common::run(&args).input("CREATE thing:one;\n").output(),
+				common::run(&args)
+					.input("CREATE thing:one;\n")
+					.output()
+					.unwrap()
+					.replace("^┌.*$", "")
+					.replace("^└.*$", "")
+					.replace("│", ""),
 				Ok("[[{ id: thing:one }]]\n\n".to_owned()),
 				"failed to send sql: {args}"
 			);


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Debugging can be inconvenient. This adds a warning message about debug builds in CLI start and improves log messages.

## What does this change do?

- Add CLI start warning about debug builds
- Change trace messages in tx to pretty print ascii
- Shuffle around types a bit. I wanted to use AsRef everywhere, but this would only work if the struct is backed by a slice. That isn't the case for structs annotated by Key from surrealdb-derive crate. And adding that to the macro there might not make sense, because that would be a hidden allocation. We should not rely on struct Keys at such calls - that is something beyond this PR.

## What is your testing strategy?

Manual

## Is this related to any issues?

Debugging a bunch of lq2 stuff

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
