### PR TITLE
function to check if any item in the array contains the needle

### DIFF
--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -31,6 +31,20 @@ pub fn add((mut array, value): (Array, Value)) -> Result<Value, Error> {
 	}
 }
 
+pub fn like((array, value): (Array, Value)) -> Result<Value, Error> {
+	Ok(array.iter().any(|v| v.contains(&value)).into())
+}
+
+pub fn ilike((array, value): (Array, Value)) -> Result<Value, Error> {
+	Ok(array
+		.iter()
+		.any(|v| match v {
+			Value::Strand(v) => Value::from(v.to_lowercase()).contains(&value),
+			_ => value.contains(&value),
+		})
+		.into())
+}
+
 pub fn all((array,): (Array,)) -> Result<Value, Error> {
 	Ok(array.iter().all(Value::is_truthy).into())
 }

--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -129,6 +129,8 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"array::union" => array::union,
 		"array::sort::asc" => array::sort::asc,
 		"array::sort::desc" => array::sort::desc,
+		"array::ilike" => array::ilike,
+		"array::like" => array::like,
 		//
 		"bytes::len" => bytes::len,
 		//

--- a/core/src/fnc/script/modules/surrealdb/functions/array.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/array.rs
@@ -45,6 +45,8 @@ impl_module_def!(
 	"remove" => run,
 	"reverse" => run,
 	"slice" => run,
+	"like" => run,
+	"ilike" => run,
 	"sort" => (sort::Package),
 	"transpose" => run,
 	"union" => run

--- a/core/src/syn/v1/builtin.rs
+++ b/core/src/syn/v1/builtin.rs
@@ -172,6 +172,8 @@ pub(crate) fn builtin_name(i: &str) -> IResult<&str, BuiltinName<&str>, ParseErr
 			remove => { fn },
 			reverse => { fn },
 			slice => { fn },
+			like => { fn },
+			ilike => { fn },
 			// says that sort is also itself a function
 			sort(func) => {
 				asc => {fn },

--- a/core/src/syn/v2/parser/builtin.rs
+++ b/core/src/syn/v2/parser/builtin.rs
@@ -119,6 +119,8 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("array::union") => PathKind::Function,
 		UniCase::ascii("array::sort::asc") => PathKind::Function,
 		UniCase::ascii("array::sort::desc") => PathKind::Function,
+		UniCase::ascii("array::ilike") => PathKind::Function,
+		UniCase::ascii("array::like") => PathKind::Function,
 		//
 		UniCase::ascii("object::entries") => PathKind::Function,
 		UniCase::ascii("object::from_entries") => PathKind::Function,

--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -190,6 +190,8 @@
 "array::sort::desc("
 "array::transpose("
 "array::union("
+"array::like("
+"array::ilike("
 "count("
 "crypto"
 "crypto::"

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -190,6 +190,8 @@
 "array::sort::desc("
 "array::transpose("
 "array::union("
+"array::like("
+"array::ilike("
 "count("
 "crypto"
 "crypto::"


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

This is useful if there is a field like titles: array<string> or urls: array<string> to search for entries or the base of the url

## What does this change do?

added array::like and array::ilike. 
It checks if a string is a part of the strings in the array:`.iter().any(|v|v.contains(needle)`
`ilike` converts the strings in the array to lowercase strings

## What is your testing strategy?

I tested it manually with the compiled binary. I didn't see a need to write an extra test, because of its simplicity.

## Is this related to any issues?

No

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

```
array::like
The array:: like returns a boolean
its true if the needle is a part of any string in the array

API DEFINITION
array:: like(Array,value) -> boolean

The following example shows this function, and its output, when used in a [RETURN](https://surrealdb.com/docs/surrealdb/surrealql/statements/return) statement:

RETURN array:: like(["abc", "def"], "a");

true
```
- [X] surrealdb/docs.surrealdb.com

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
