### PR TITLE
Bug fix: Implements the union strategy on unique indexes

### DIFF
--- a/core/src/dbs/processor.rs
+++ b/core/src/dbs/processor.rs
@@ -605,6 +605,10 @@ impl<'a> Processor<'a> {
 				}
 				// Everything ok
 				return Ok(());
+			} else {
+				return Err(Error::QueryNotExecutedDetail {
+					message: "No Iterator has been found.".to_string(),
+				});
 			}
 		}
 		Err(Error::QueryNotExecutedDetail {

--- a/core/src/idx/planner/executor.rs
+++ b/core/src/idx/planner/executor.rs
@@ -10,6 +10,7 @@ use crate::idx::ft::{FtIndex, MatchRef};
 use crate::idx::planner::iterators::{
 	DocIdsIterator, IndexEqualThingIterator, IndexRangeThingIterator, IndexUnionThingIterator,
 	MatchesThingIterator, ThingIterator, UniqueEqualThingIterator, UniqueRangeThingIterator,
+	UniqueUnionThingIterator,
 };
 use crate::idx::planner::knn::KnnPriorityList;
 use crate::idx::planner::plan::IndexOperator::Matches;
@@ -337,6 +338,9 @@ impl QueryExecutor {
 		match io.op() {
 			IndexOperator::Equality(value) => {
 				Some(ThingIterator::UniqueEqual(UniqueEqualThingIterator::new(opt, ix, value)))
+			}
+			IndexOperator::Union(value) => {
+				Some(ThingIterator::UniqueUnion(UniqueUnionThingIterator::new(opt, ix, value)))
 			}
 			_ => None,
 		}

--- a/core/src/idx/planner/iterators.rs
+++ b/core/src/idx/planner/iterators.rs
@@ -18,6 +18,7 @@ pub(crate) enum ThingIterator {
 	IndexUnion(IndexUnionThingIterator),
 	UniqueEqual(UniqueEqualThingIterator),
 	UniqueRange(UniqueRangeThingIterator),
+	UniqueUnion(UniqueUnionThingIterator),
 	Matches(MatchesThingIterator),
 	Knn(DocIdsIterator),
 }
@@ -34,6 +35,7 @@ impl ThingIterator {
 			ThingIterator::IndexRange(i) => i.next_batch(tx, size).await,
 			ThingIterator::UniqueRange(i) => i.next_batch(tx, size).await,
 			ThingIterator::IndexUnion(i) => i.next_batch(tx, size).await,
+			ThingIterator::UniqueUnion(i) => i.next_batch(tx, size).await,
 			ThingIterator::Matches(i) => i.next_batch(tx, size).await,
 			ThingIterator::Knn(i) => i.next_batch(tx, size).await,
 		}
@@ -365,6 +367,45 @@ impl UniqueRangeThingIterator {
 		}
 		self.done = true;
 		Ok(r)
+	}
+}
+
+pub(crate) struct UniqueUnionThingIterator {
+	keys: VecDeque<Key>,
+}
+
+impl UniqueUnionThingIterator {
+	pub(super) fn new(opt: &Options, ix: &DefineIndexStatement, a: &Array) -> Self {
+		// We create a VecDeque to hold the key for each value in the array.
+		let keys: VecDeque<Key> =
+			a.0.iter()
+				.map(|v| {
+					let a = Array::from(v.clone());
+					let key = Index::new(opt.ns(), opt.db(), &ix.what, &ix.name, &a, None).into();
+					key
+				})
+				.collect();
+		Self {
+			keys,
+		}
+	}
+
+	async fn next_batch(
+		&mut self,
+		txn: &Transaction,
+		limit: u32,
+	) -> Result<Vec<(Thing, Option<DocId>)>, Error> {
+		let mut run = txn.lock().await;
+		let mut res = vec![];
+		while let Some(key) = self.keys.pop_front() {
+			if let Some(val) = run.get(key).await? {
+				res.push((val.into(), None));
+			}
+			if res.len() >= limit as usize {
+				return Ok(res);
+			}
+		}
+		Ok(res)
 	}
 }
 

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -1323,27 +1323,52 @@ async fn select_with_in_operator_uniq_index() -> Result<(), Error> {
 	let sql = r#"
 		DEFINE INDEX apprenantUid ON apprenants FIELDS apprenantUid UNIQUE;
 		CREATE apprenants:1 CONTENT { apprenantUid: "00013483-fedd-43e3-a94e-80728d896f6e" };
-		SELECT * FROM apprenants WHERE apprenantUid in [];
+		SELECT apprenantUid FROM apprenants WHERE apprenantUid in [];
 		SELECT apprenantUid FROM apprenants WHERE apprenantUid IN ["00013483-fedd-43e3-a94e-80728d896f6e"];
+		SELECT apprenantUid FROM apprenants WHERE apprenantUid IN ["99999999-aaaa-1111-8888-abcdef012345", "00013483-fedd-43e3-a94e-80728d896f6e"];
+		SELECT apprenantUid FROM apprenants WHERE apprenantUid IN ["00013483-fedd-43e3-a94e-80728d896f6e", "99999999-aaaa-1111-8888-abcdef012345"];
+		SELECT apprenantUid FROM apprenants WHERE apprenantUid IN ["99999999-aaaa-1111-8888-abcdef012345", "00013483-fedd-43e3-a94e-80728d896f6e", "99999999-aaaa-1111-8888-abcdef012345"];
+		SELECT apprenantUid FROM apprenants WHERE apprenantUid IN ["00013483-fedd-43e3-a94e-80728d896f6e"] EXPLAIN;
 	"#;
 	let mut res = dbs.execute(&sql, &ses, None).await?;
 
-	assert_eq!(res.len(), 4);
+	assert_eq!(res.len(), 8);
 	skip_ok(&mut res, 2)?;
 
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(r#"[]"#);
 	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
 
-	let tmp = res.remove(0).result?;
-	let val = Value::parse(
-		r#"[
+	for _ in 0..4 {
+		let tmp = res.remove(0).result?;
+		let val = Value::parse(
+			r#"[
 			{
 				apprenantUid: '00013483-fedd-43e3-a94e-80728d896f6e'
 			}
 		]"#,
+		);
+		assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	}
+
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+			{
+				detail: {
+					plan: {
+						index: 'apprenantUid',
+						operator: 'union',
+						value: [
+							'00013483-fedd-43e3-a94e-80728d896f6e'
+						]
+					},
+					table: 'apprenants'
+				},
+				operation: 'Iterate Index'
+			}
+		]"#,
 	);
 	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
-
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

The query executor didn't have any iterator implementation for the union strategy with unique indexes.

## What does this change do?

Implement the missing iterator.

## What is your testing strategy?

A test as been written.

## Is this related to any issues?

Fixes #3671 

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
