### PR TITLE
Fix string::is::longitude regex, more test coverage

### DIFF
--- a/core/src/fnc/string.rs
+++ b/core/src/fnc/string.rs
@@ -179,7 +179,7 @@ pub mod is {
 	use uuid::Uuid;
 
 	#[rustfmt::skip] static LATITUDE_RE: Lazy<Regex> = Lazy::new(|| Regex::new("^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$").unwrap());
-	#[rustfmt::skip] static LONGITUDE_RE: Lazy<Regex> = Lazy::new(|| Regex::new("^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$").unwrap());
+	#[rustfmt::skip] static LONGITUDE_RE: Lazy<Regex> = Lazy::new(|| Regex::new("^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$").unwrap());
 
 	pub fn alphanum((arg,): (String,)) -> Result<Value, Error> {
 		Ok(arg.chars().all(char::is_alphanumeric).into())
@@ -520,8 +520,23 @@ mod tests {
 
 	#[test]
 	fn is_longitude() {
-		let value = super::is::longitude((String::from("51.509865"),)).unwrap();
+		let value = super::is::longitude((String::from("91.509865"),)).unwrap();
 		assert_eq!(value, Value::Bool(true));
+
+		let value = super::is::longitude((String::from("-91.509865"),)).unwrap();
+		assert_eq!(value, Value::Bool(true));
+
+		let value = super::is::longitude((String::from("-180.00000"),)).unwrap();
+		assert_eq!(value, Value::Bool(true));
+
+		let value = super::is::longitude((String::from("-180.00001"),)).unwrap();
+		assert_eq!(value, Value::Bool(false));
+
+		let value = super::is::longitude((String::from("180.00000"),)).unwrap();
+		assert_eq!(value, Value::Bool(true));
+
+		let value = super::is::longitude((String::from("180.00001"),)).unwrap();
+		assert_eq!(value, Value::Bool(false));
 
 		let value = super::is::longitude((String::from("12345"),)).unwrap();
 		assert_eq!(value, Value::Bool(false));

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -3693,7 +3693,7 @@ async fn function_parse_is_latitude() -> Result<(), Error> {
 #[tokio::test]
 async fn function_parse_is_longitude() -> Result<(), Error> {
 	let sql = r#"
-		RETURN string::is::longitude("-0.136439");
+		RETURN string::is::longitude("-90.136439");
 		RETURN string::is::longitude("this is a test!");
 	"#;
 	let dbs = new_ds().await?;


### PR DESCRIPTION
Resolves https://github.com/surrealdb/surrealdb/issues/3666

## What is the motivation?

https://github.com/surrealdb/surrealdb/issues/3666 where the same regex is being used for both latitude and longitude. Latitude varies between -90 and 90 degrees, but longitude is twice that.

## What does this change do?

Changes the regex to allow for numbers between -180 and 180.

## What is your testing strategy?

Change the existing tests to check for numbers that are correct longitude but too large or too small to be latitude.

## Is this related to any issues?

Yes, as above.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

No, the current documentation assumes that the function is correct.

- [X ] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

- [X ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
