### PR TITLE
Fix: Consistently enforce session expiration

### DIFF
--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -244,7 +244,8 @@ pub async fn db(
 			session.tk = Some(val.into());
 			session.ns = Some(ns.to_owned());
 			session.db = Some(db.to_owned());
-			session.exp = exp;
+			// TODO(gguillemas): Enforce session expiration once token expiration is configurable.
+			session.exp = None;
 			session.au = Arc::new((&u, Level::Database(ns.to_owned(), db.to_owned())).into());
 			// Check the authentication token
 			match enc {
@@ -296,7 +297,8 @@ pub async fn ns(
 			// Set the authentication on the session
 			session.tk = Some(val.into());
 			session.ns = Some(ns.to_owned());
-			session.exp = exp;
+			// TODO(gguillemas): Enforce session expiration once token expiration is configurable.
+			session.exp = None;
 			session.au = Arc::new((&u, Level::Namespace(ns.to_owned())).into());
 			// Check the authentication token
 			match enc {
@@ -346,7 +348,8 @@ pub async fn root(
 			let enc = encode(&HEADER, &val, &key);
 			// Set the authentication on the session
 			session.tk = Some(val.into());
-			session.exp = exp;
+			// TODO(gguillemas): Enforce session expiration once token expiration is configurable.
+			session.exp = None;
 			session.au = Arc::new((&u, Level::Root).into());
 			// Check the authentication token
 			match enc {


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The intent of #3561 was to enforce session expiration only for scope users and system users who authenticated via token. Session expiration was meant to be `None` for system users authenticating with username and password regardless of the token expiration until token expiration for those users was configurable. This is the case when performing basic authentication, but not when authenticating using the `signin` method. This PR intends to fix this.

Additionally, the `signin` and `signup` methods did not consistently set session expiration, which is resolved as well. 

## What does this change do?

This change sets session expiration for system users to `None` unless authenticating with a token with a set expiration. It also sets a session expiration for sessions established after `signup`, which was not previously done.

## What is your testing strategy?

I will do a separate PR to implement better testing on sessions after `signin` methods. If this PR is not merged when that PR is done, I may rebase it to include the tests, but I think this fix should go out as soon as possible.

## Is this related to any issues?

This issue was [reported today in Discord](https://discord.com/channels/902568124350599239/902568124350599242/1217208550955159693).

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
