### PR TITLE
Add tests for the `signin` and `signup` methods

### DIFF
--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -484,14 +484,9 @@ mod tests {
 				ns: Some("test".to_string()),
 				..Default::default()
 			};
-			let res = ns(
-				&ds,
-				&mut sess,
-				"test".to_string(),
-				"user".to_string(),
-				"pass".to_string(),
-			)
-			.await;
+			let res =
+				ns(&ds, &mut sess, "test".to_string(), "user".to_string(), "pass".to_string())
+					.await;
 
 			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
 			assert_eq!(sess.ns, Some("test".to_string()));
@@ -519,14 +514,9 @@ mod tests {
 				ns: Some("test".to_string()),
 				..Default::default()
 			};
-			let res = ns(
-				&ds,
-				&mut sess,
-				"test".to_string(),
-				"user".to_string(),
-				"pass".to_string(),
-			)
-			.await;
+			let res =
+				ns(&ds, &mut sess, "test".to_string(), "user".to_string(), "pass".to_string())
+					.await;
 
 			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
 			assert_eq!(sess.ns, Some("test".to_string()));
@@ -548,14 +538,9 @@ mod tests {
 			let mut sess = Session {
 				..Default::default()
 			};
-			let res = ns(
-				&ds,
-				&mut sess,
-				"test".to_string(),
-				"user".to_string(),
-				"invalid".to_string(),
-			)
-			.await;
+			let res =
+				ns(&ds, &mut sess, "test".to_string(), "user".to_string(), "invalid".to_string())
+					.await;
 
 			assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
 		}
@@ -575,13 +560,7 @@ mod tests {
 			let mut sess = Session {
 				..Default::default()
 			};
-			let res = root(
-				&ds,
-				&mut sess,
-				"user".to_string(),
-				"pass".to_string(),
-			)
-			.await;
+			let res = root(&ds, &mut sess, "user".to_string(), "pass".to_string()).await;
 
 			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
 			assert_eq!(sess.au.id(), "user");
@@ -606,13 +585,7 @@ mod tests {
 			let mut sess = Session {
 				..Default::default()
 			};
-			let res = root(
-				&ds,
-				&mut sess,
-				"user".to_string(),
-				"pass".to_string(),
-			)
-			.await;
+			let res = root(&ds, &mut sess, "user".to_string(), "pass".to_string()).await;
 
 			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
 			assert_eq!(sess.au.id(), "user");
@@ -632,13 +605,7 @@ mod tests {
 			let mut sess = Session {
 				..Default::default()
 			};
-			let res = root(
-				&ds,
-				&mut sess,
-				"user".to_string(),
-				"invalid".to_string(),
-			)
-			.await;
+			let res = root(&ds, &mut sess, "user".to_string(), "invalid".to_string()).await;
 
 			assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
 		}

--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -367,6 +367,127 @@ pub async fn root(
 mod tests {
 	use super::*;
 	use crate::iam::Role;
+	use std::collections::HashMap;
+
+	#[tokio::test]
+	async fn test_signin_scope() {
+		// Test with correct credentials
+		{
+			let ds = Datastore::new("memory").await.unwrap();
+			let sess = Session::owner().with_ns("test").with_db("test");
+			ds.execute(
+				r#"
+				DEFINE SCOPE user SESSION 1h
+					SIGNIN (
+						SELECT * FROM user WHERE name = $user AND crypto::argon2::compare(pass, $pass)
+					)
+					SIGNUP (
+						CREATE user CONTENT {
+							name: $user,
+							pass: crypto::argon2::generate($pass)
+						}
+					);
+					CREATE user:test CONTENT {
+						name: 'user',
+						pass: crypto::argon2::generate('pass')
+					}
+			"#,
+				&sess,
+				None,
+			)
+			.await
+			.unwrap();
+
+			// Signin with the user
+			let mut sess = Session {
+				ns: Some("test".to_string()),
+				db: Some("test".to_string()),
+				..Default::default()
+			};
+			let mut vars: HashMap<&str, Value> = HashMap::new();
+			vars.insert("user", "user".into());
+			vars.insert("pass", "pass".into());
+			let res = sc(
+				&ds,
+				&mut sess,
+				"test".to_string(),
+				"test".to_string(),
+				"user".to_string(),
+				vars.into(),
+			)
+			.await;
+
+			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
+			assert_eq!(sess.ns, Some("test".to_string()));
+			assert_eq!(sess.db, Some("test".to_string()));
+			assert_eq!(sess.au.id(), "user:test");
+			assert!(sess.au.is_scope());
+			assert_eq!(sess.au.level().ns(), Some("test"));
+			assert_eq!(sess.au.level().db(), Some("test"));
+			// Scope users should not have roles
+			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			// Expiration should always be set for tokens issued by SurrealDB
+			let exp = sess.exp.unwrap();
+			// Expiration should match the current time plus session duration with some margin
+			let min_exp = (Utc::now() + Duration::hours(1) - Duration::seconds(10)).timestamp();
+			let max_exp = (Utc::now() + Duration::hours(1) + Duration::seconds(10)).timestamp();
+			assert!(
+				exp > min_exp && exp < max_exp,
+				"Session expiration is expected to follow scope duration"
+			);
+		}
+
+		// Test with incorrect credentials
+		{
+			let ds = Datastore::new("memory").await.unwrap();
+			let sess = Session::owner().with_ns("test").with_db("test");
+			ds.execute(
+				r#"
+				DEFINE SCOPE user SESSION 1h
+					SIGNIN (
+						SELECT * FROM user WHERE name = $user AND crypto::argon2::compare(pass, $pass)
+					)
+					SIGNUP (
+						CREATE user CONTENT {
+							name: $user,
+							pass: crypto::argon2::generate($pass)
+						}
+					);
+					CREATE user:test CONTENT {
+						name: 'user',
+						pass: crypto::argon2::generate('pass')
+					}
+			"#,
+				&sess,
+				None,
+			)
+			.await
+			.unwrap();
+
+			// Signin with the user
+			let mut sess = Session {
+				ns: Some("test".to_string()),
+				db: Some("test".to_string()),
+				..Default::default()
+			};
+			let mut vars: HashMap<&str, Value> = HashMap::new();
+			vars.insert("user", "user".into());
+			vars.insert("pass", "incorrect".into());
+			let res = sc(
+				&ds,
+				&mut sess,
+				"test".to_string(),
+				"test".to_string(),
+				"user".to_string(),
+				vars.into(),
+			)
+			.await;
+
+			assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
+		}
+	}
 
 	#[tokio::test]
 	async fn test_signin_db() {

--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -387,11 +387,12 @@ mod tests {
 							pass: crypto::argon2::generate($pass)
 						}
 					);
-					CREATE user:test CONTENT {
-						name: 'user',
-						pass: crypto::argon2::generate('pass')
-					}
-			"#,
+
+				CREATE user:test CONTENT {
+					name: 'user',
+					pass: crypto::argon2::generate('pass')
+				}
+				"#,
 				&sess,
 				None,
 			)
@@ -455,11 +456,12 @@ mod tests {
 							pass: crypto::argon2::generate($pass)
 						}
 					);
-					CREATE user:test CONTENT {
-						name: 'user',
-						pass: crypto::argon2::generate('pass')
-					}
-			"#,
+
+				CREATE user:test CONTENT {
+					name: 'user',
+					pass: crypto::argon2::generate('pass')
+				}
+				"#,
 				&sess,
 				None,
 			)

--- a/core/src/iam/signup.rs
+++ b/core/src/iam/signup.rs
@@ -166,7 +166,7 @@ mod tests {
 							pass: crypto::argon2::generate($pass)
 						}
 					);
-			"#,
+				"#,
 				&sess,
 				None,
 			)
@@ -230,7 +230,7 @@ mod tests {
 							pass: crypto::argon2::generate($pass)
 						}
 					);
-			"#,
+				"#,
 				&sess,
 				None,
 			)

--- a/core/src/iam/signup.rs
+++ b/core/src/iam/signup.rs
@@ -141,3 +141,122 @@ pub async fn sc(
 		_ => Err(Error::NoScopeFound),
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::iam::Role;
+	use std::collections::HashMap;
+
+	#[tokio::test]
+	async fn test_scope_signup() {
+		// Test with valid parameters
+		{
+			let ds = Datastore::new("memory").await.unwrap();
+			let sess = Session::owner().with_ns("test").with_db("test");
+			ds.execute(
+				r#"
+				DEFINE SCOPE user SESSION 1h
+					SIGNIN (
+						SELECT * FROM user WHERE name = $user AND crypto::argon2::compare(pass, $pass)
+					)
+					SIGNUP (
+						CREATE user CONTENT {
+							name: $user,
+							pass: crypto::argon2::generate($pass)
+						}
+					);
+			"#,
+				&sess,
+				None,
+			)
+			.await
+			.unwrap();
+
+			// Signin with the user
+			let mut sess = Session {
+				ns: Some("test".to_string()),
+				db: Some("test".to_string()),
+				..Default::default()
+			};
+			let mut vars: HashMap<&str, Value> = HashMap::new();
+			vars.insert("user", "user".into());
+			vars.insert("pass", "pass".into());
+			let res = sc(
+				&ds,
+				&mut sess,
+				"test".to_string(),
+				"test".to_string(),
+				"user".to_string(),
+				vars.into(),
+			)
+			.await;
+
+			assert!(res.is_ok(), "Failed to signup: {:?}", res);
+			assert_eq!(sess.ns, Some("test".to_string()));
+			assert_eq!(sess.db, Some("test".to_string()));
+			assert!(sess.au.id().starts_with("user:"));
+			assert!(sess.au.is_scope());
+			assert_eq!(sess.au.level().ns(), Some("test"));
+			assert_eq!(sess.au.level().db(), Some("test"));
+			// Scope users should not have roles.
+			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			// Expiration should always be set for tokens issued by SurrealDB
+			let exp = sess.exp.unwrap();
+			// Expiration should match the current time plus session duration with some margin
+			let min_exp = (Utc::now() + Duration::hours(1) - Duration::seconds(10)).timestamp();
+			let max_exp = (Utc::now() + Duration::hours(1) + Duration::seconds(10)).timestamp();
+			assert!(
+				exp > min_exp && exp < max_exp,
+				"Session expiration is expected to follow scope duration"
+			);
+		}
+
+		// Test with invalid parameters
+		{
+			let ds = Datastore::new("memory").await.unwrap();
+			let sess = Session::owner().with_ns("test").with_db("test");
+			ds.execute(
+				r#"
+				DEFINE SCOPE user SESSION 1h
+					SIGNIN (
+						SELECT * FROM user WHERE name = $user AND crypto::argon2::compare(pass, $pass)
+					)
+					SIGNUP (
+						CREATE user CONTENT {
+							name: $user,
+							pass: crypto::argon2::generate($pass)
+						}
+					);
+			"#,
+				&sess,
+				None,
+			)
+			.await
+			.unwrap();
+
+			// Signin with the user
+			let mut sess = Session {
+				ns: Some("test".to_string()),
+				db: Some("test".to_string()),
+				..Default::default()
+			};
+			let mut vars: HashMap<&str, Value> = HashMap::new();
+			// Password is missing
+			vars.insert("user", "user".into());
+			let res = sc(
+				&ds,
+				&mut sess,
+				"test".to_string(),
+				"test".to_string(),
+				"user".to_string(),
+				vars.into(),
+			)
+			.await;
+
+			assert!(res.is_err(), "Unexpected successful signup: {:?}", res);
+		}
+	}
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The motivation for this PR is to ensure that we catch errors like those fixed in #3686 early on during testing. These tests will provide some basic assurance when modifying the authentication logic and provide a basis to implement additional testing whenever new authentication features are introduced.

## What does this change do?

Implements tests for the `signin` and `signup` methods in `signin.rs` and `signup.rs`. These tests are similar to those implemented in `verify.rs` for the `basic` and `token` authentication methods. This will allow us to further improve tests in all available authentication methods at the same time.

## What is your testing strategy?

Test `signin` and `signup` methods in the same way that `basic` and `token` methods are tested.

## Is this related to any issues?

This is related to #3686.

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
