### PR TITLE
Assign `deny.toml` to the security team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@ core/Cargo.toml @surrealdb/security
 lib/Cargo.toml @surrealdb/security
 cackle.toml @surrealdb/security
 supply-chain/* @surrealdb/security
+deny.toml @surrealdb/security
 
 # General owners for the database
 /core/ @surrealdb/db


### PR DESCRIPTION
## What is the motivation?

`deny.toml` is not currently assigned to any group.

## What does this change do?

It assigns it to the security team.

## What is your testing strategy?

Github says the code owners' file is valid.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
