### PR TITLE
Datastore: remove the global static datastore

### DIFF
--- a/core/src/cf/gc.rs
+++ b/core/src/cf/gc.rs
@@ -1,7 +1,5 @@
 use crate::err::Error;
 use crate::key::change;
-#[cfg(debug_assertions)]
-use crate::key::debug::sprint_key;
 use crate::kvs::Transaction;
 use crate::vs;
 use crate::vs::Versionstamp;
@@ -29,19 +27,10 @@ pub async fn gc_ns(
 	let dbs = tx.all_db(ns).await?;
 	let dbs = dbs.as_ref();
 	for db in dbs {
-		// We get the expiration of the change feed defined on the database
 		let db_cf_expiry = match &db.changefeed {
 			None => 0,
 			Some(cf) => cf.expiry.as_secs(),
 		};
-		#[cfg(debug_assertions)]
-		trace!(
-			"Performing garbage collection on ns {} db {} for ts {}. The cf expiration is {}",
-			ns,
-			db.name,
-			ts,
-			db_cf_expiry
-		);
 		let tbs = tx.all_tb(ns, db.name.as_str()).await?;
 		let tbs = tbs.as_ref();
 		let max_tb_cf_expiry = tbs.iter().fold(0, |acc, tb| match &tb.changefeed {
@@ -58,10 +47,7 @@ pub async fn gc_ns(
 		if ts < cf_expiry {
 			continue;
 		}
-		// We only want to retain the expiry window, so we are going to delete everything before
 		let watermark_ts = ts - cf_expiry;
-		#[cfg(debug_assertions)]
-		trace!("The watermark is {} after removing {cf_expiry} from {ts}", watermark_ts);
 		let watermark_vs =
 			tx.get_versionstamp_from_timestamp(watermark_ts, ns, db.name.as_str(), true).await?;
 		if let Some(watermark_vs) = watermark_vs {
@@ -81,15 +67,6 @@ pub async fn gc_db(
 ) -> Result<(), Error> {
 	let beg: Vec<u8> = change::prefix_ts(ns, db, vs::u64_to_versionstamp(0));
 	let end = change::prefix_ts(ns, db, watermark);
-	#[cfg(debug_assertions)]
-	trace!(
-		"DB GC: ns: {}, db: {}, watermark: {:?}, prefix: {}, end: {}",
-		ns,
-		db,
-		watermark,
-		sprint_key(&beg),
-		sprint_key(&end)
-	);
 
 	let limit = limit.unwrap_or(100);
 

--- a/core/src/cf/mutations.rs
+++ b/core/src/cf/mutations.rs
@@ -3,7 +3,7 @@ use crate::sql::object::Object;
 use crate::sql::statements::DefineTableStatement;
 use crate::sql::thing::Thing;
 use crate::sql::value::Value;
-use crate::vs::versionstamp_to_u64;
+use crate::vs::to_u128_be;
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -104,7 +104,7 @@ impl DatabaseMutation {
 impl ChangeSet {
 	pub fn into_value(self) -> Value {
 		let mut m = BTreeMap::<String, Value>::new();
-		let vs = versionstamp_to_u64(&self.0);
+		let vs = to_u128_be(self.0);
 		m.insert("versionstamp".to_string(), Value::from(vs));
 		m.insert("changes".to_string(), self.1.into_value());
 		let so: Object = m.into();
@@ -174,7 +174,7 @@ mod tests {
 		use super::*;
 		use std::collections::HashMap;
 		let cs = ChangeSet(
-			[0, 0, 0, 0, 0, 0, 0, 1, 0, 0],
+			[0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
 			DatabaseMutation(vec![TableMutations(
 				"mytb".to_string(),
 				vec![
@@ -209,7 +209,7 @@ mod tests {
 		use super::*;
 		use std::collections::HashMap;
 		let cs = ChangeSet(
-			[0, 0, 0, 0, 0, 0, 0, 1, 0, 0],
+			[0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
 			DatabaseMutation(vec![TableMutations(
 				"mytb".to_string(),
 				vec![

--- a/core/src/cf/reader.rs
+++ b/core/src/cf/reader.rs
@@ -1,8 +1,6 @@
 use crate::cf::{ChangeSet, DatabaseMutation, TableMutations};
 use crate::err::Error;
 use crate::key::change;
-#[cfg(debug_assertions)]
-use crate::key::debug::sprint_key;
 use crate::kvs::{Limit, ScanPage, Transaction};
 use crate::sql::statements::show::ShowSince;
 use crate::vs;
@@ -58,8 +56,7 @@ pub async fn read(
 	let mut r = Vec::<ChangeSet>::new();
 	// iterate over _x and put decoded elements to r
 	for (k, v) in scan.values {
-		#[cfg(debug_assertions)]
-		trace!("read change feed; {}", sprint_key(&k));
+		trace!("read change feed; {k:?}");
 
 		let dec = crate::key::change::Cf::decode(&k).unwrap();
 

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -835,7 +835,6 @@ impl Datastore {
 	// It is handy for testing, because it allows you to specify the timestamp,
 	// without depending on a system clock.
 	pub async fn tick_at(&self, ts: u64) -> Result<(), Error> {
-		trace!("Ticking at timestamp {}", ts);
 		let _vs = self.save_timestamp_for_versionstamp(ts).await?;
 		self.garbage_collect_stale_change_feeds(ts).await?;
 		// TODO Add LQ GC
@@ -844,7 +843,6 @@ impl Datastore {
 	}
 
 	// save_timestamp_for_versionstamp saves the current timestamp for the each database's current versionstamp.
-	// Note: the returned VS is flawed, as there are multiple {ts: vs} mappings per (ns, db)
 	pub(crate) async fn save_timestamp_for_versionstamp(
 		&self,
 		ts: u64,
@@ -904,7 +902,7 @@ impl Datastore {
 				trace!(
 					"There were no changes in the change feed for {:?} from versionstamp {:?}",
 					selector,
-					conv::versionstamp_to_u64(vs)
+					vs
 				)
 			}
 			if let Some(change_set) = res.last() {
@@ -1147,7 +1145,6 @@ impl Datastore {
 			let dbs = dbs.as_ref();
 			for db in dbs {
 				let db = db.name.as_str();
-				// TODO(SUR-341): This is incorrect, it's a [ns,db] to vs pair
 				vs = Some(tx.set_timestamp_for_versionstamp(ts, ns, db, true).await?);
 			}
 		}

--- a/core/src/kvs/mem/mod.rs
+++ b/core/src/kvs/mem/mod.rs
@@ -1,12 +1,10 @@
 #![cfg(feature = "kv-mem")]
 
 use crate::err::Error;
-#[cfg(debug_assertions)]
-use crate::key::debug::sprint_key;
 use crate::kvs::Check;
 use crate::kvs::Key;
 use crate::kvs::Val;
-use crate::vs::{u64_to_versionstamp, versionstamp_to_u64, Versionstamp};
+use crate::vs::{try_to_u64_be, u64_to_versionstamp, Versionstamp};
 use std::ops::Range;
 
 pub struct Datastore {
@@ -170,19 +168,11 @@ impl Transaction {
 			Some(prev) => {
 				let slice = prev.as_slice();
 				let res: Result<[u8; 10], Error> = match slice.try_into() {
-					Ok(ba) => {
-						#[cfg(debug_assertions)]
-						trace!(
-							"Previous timestamp for key {} is {}",
-							sprint_key(&k),
-							sprint_key(&ba)
-						);
-						Ok(ba)
-					}
+					Ok(ba) => Ok(ba),
 					Err(e) => Err(Error::Ds(e.to_string())),
 				};
 				let array = res?;
-				let prev = versionstamp_to_u64(&array);
+				let prev = try_to_u64_be(array)?;
 				prev + 1
 			}
 			None => 1,
@@ -214,22 +204,15 @@ impl Transaction {
 		}
 
 		let ts_key: Key = ts_key.into();
-		#[cfg(debug_assertions)]
-		let dbg_ts = sprint_key(&ts_key);
 		let prefix: Key = prefix.into();
-		#[cfg(debug_assertions)]
-		let dbg_prefix = sprint_key(&prefix);
-		let mut suffix: Key = suffix.into();
-		#[cfg(debug_assertions)]
-		let dbg_suffix = sprint_key(&suffix);
+		let suffix: Key = suffix.into();
 
-		let ts = self.get_timestamp(ts_key)?;
-		let mut k: Vec<u8> = prefix;
+		let ts = self.get_timestamp(ts_key.clone())?;
+		let mut k: Vec<u8> = prefix.clone();
 		k.append(&mut ts.to_vec());
-		k.append(&mut suffix);
+		k.append(&mut suffix.clone());
 
-		#[cfg(debug_assertions)]
-		trace!("get_versionstamped_key; prefix={dbg_prefix} ts={dbg_ts} suff={dbg_suffix}");
+		trace!("get_versionstamped_key; {ts_key:?} {prefix:?} {ts:?} {suffix:?} {k:?}",);
 
 		Ok(k)
 	}

--- a/core/src/kvs/tests/tx_test.rs
+++ b/core/src/kvs/tests/tx_test.rs
@@ -1,7 +1,4 @@
-use crate::key::debug::sprint_key;
-use crate::key::error::KeyCategory;
 use crate::kvs::lq_structs::{KillEntry, LqEntry, TrackedResult};
-use crate::sql::Strand;
 
 #[tokio::test]
 #[serial]
@@ -60,83 +57,4 @@ async fn kill_queries_sent_to_tx_are_received() {
 	let live_queries = tx.consume_pending_live_queries();
 	assert_eq!(live_queries.len(), 1);
 	assert_eq!(live_queries[0], TrackedResult::KillQuery(kill_entry));
-}
-
-#[tokio::test]
-#[serial]
-async fn delr_range_correct() {
-	let node_id = uuid::uuid!("d0f1a200-e24e-44fe-98c1-2271a5781da7");
-	let clock = Arc::new(SizedClock::Fake(FakeClock::new(Timestamp::default())));
-	let test = init(node_id, clock).await.unwrap();
-
-	// Create some data
-	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
-	tx.putc(b"hugh\x00\x10", Value::Strand(Strand::from("0010")), None).await.unwrap();
-	tx.put(KeyCategory::ChangeFeed, b"hugh\x00\x10\x10", Value::Strand(Strand::from("001010")))
-		.await
-		.unwrap();
-	tx.putc(b"hugh\x00\x20", Value::Strand(Strand::from("0020")), None).await.unwrap();
-	tx.commit().await.unwrap();
-
-	// Check we have all data
-	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
-	let vals = tx.scan(b"hugh\x00".to_vec()..b"hugh\xff".to_vec(), 100).await.unwrap();
-	assert_eq!(vals.len(), 3);
-	tx.cancel().await.unwrap();
-
-	// Delete first range, inclusive of next key, without deleting next key
-	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
-	tx.delr(b"hugh\x00".to_vec()..b"hugh\x00\x10\x10".to_vec(), 100).await.unwrap();
-	tx.commit().await.unwrap();
-
-	// Scan results
-	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
-	let vals = tx.scan(b"hugh\x00"..b"hugh\xff", 100).await.unwrap();
-	assert_eq!(vals.len(), 2);
-	tx.cancel().await.unwrap();
-
-	// Delete second range, beyond next key but beyond limit
-	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
-	tx.delr(b"hugh\x00\x20".to_vec()..b"hugh\xff".to_vec(), 1).await.unwrap();
-	tx.commit().await.unwrap();
-
-	// Scan results
-	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
-	let vals = tx.scan(b"hugh\x00"..b"hugh\xff", 100).await.unwrap();
-	assert_eq!(vals.len(), 1);
-	tx.cancel().await.unwrap();
-}
-
-#[tokio::test]
-#[serial]
-async fn set_versionstamp_is_incremental() {
-	let node_id = uuid::uuid!("3988b179-6212-4a45-a496-4d9ee4cbd639");
-	let clock = Arc::new(SizedClock::Fake(FakeClock::new(Timestamp::default())));
-	let test = init(node_id, clock).await.unwrap();
-
-	// Create the first timestamped key
-	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
-	tx.set_versionstamped_key(b"ts_key", b"prefix", b"suffix", Value::from("'value'"))
-		.await
-		.unwrap();
-	tx.commit().await.unwrap();
-
-	// Create the second timestamped key
-	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
-	tx.set_versionstamped_key(b"ts_key", b"prefix", b"suffix", Value::from("'value'"))
-		.await
-		.unwrap();
-	tx.commit().await.unwrap();
-
-	// Scan the keys and validate versionstamps match expected
-	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
-	let found = tx.scan(b"prefix".to_vec()..b"prefix\xff".to_vec(), 1000).await.unwrap();
-	tx.cancel().await.unwrap();
-	assert_eq!(found.len(), 2);
-	let expected_keys = [
-		b"prefix\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00suffix",
-		b"prefix\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00suffix",
-	];
-	assert_eq!(found[0].0, expected_keys[0], "key was {}", sprint_key(&found[0].0));
-	assert_eq!(found[1].0, expected_keys[1], "key was {}", sprint_key(&found[1].0));
 }

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -29,7 +29,6 @@ use crate::dbs::node::ClusterMembership;
 use crate::dbs::node::Timestamp;
 use crate::err::Error;
 use crate::idg::u32::U32;
-#[cfg(debug_assertions)]
 use crate::key::debug::sprint_key;
 use crate::key::error::KeyCategory;
 use crate::key::key_req::KeyRequirements;
@@ -46,8 +45,8 @@ use crate::sql::paths::OUT;
 use crate::sql::thing::Thing;
 use crate::sql::Strand;
 use crate::sql::Value;
+use crate::vs::Oracle;
 use crate::vs::Versionstamp;
-use crate::vs::{conv, Oracle};
 
 use super::kv::Add;
 use super::kv::Convert;
@@ -364,7 +363,7 @@ impl Transaction {
 	{
 		let key = key.into();
 		#[cfg(debug_assertions)]
-		trace!("Del {}", sprint_key(&key));
+		trace!("Del {:?}", sprint_key(&key));
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -413,7 +412,7 @@ impl Transaction {
 		K: Into<Key> + Debug + AsRef<[u8]>,
 	{
 		#[cfg(debug_assertions)]
-		trace!("Exi {}", sprint_key(&key));
+		trace!("Exi {:?}", sprint_key(&key));
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -463,7 +462,7 @@ impl Transaction {
 	{
 		let key = key.into();
 		#[cfg(debug_assertions)]
-		trace!("Get {}", sprint_key(&key));
+		trace!("Get {:?}", sprint_key(&key));
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -514,7 +513,7 @@ impl Transaction {
 	{
 		let key = key.into();
 		#[cfg(debug_assertions)]
-		trace!("Set {} => {:?}", sprint_key(&key), val);
+		trace!("Set {:?} => {:?}", sprint_key(&key), val);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -569,7 +568,7 @@ impl Transaction {
 		// We convert to byte slice as its easier at this level
 		let key = key.into();
 		#[cfg(debug_assertions)]
-		trace!("Get Timestamp {}", sprint_key(&key));
+		trace!("Get Timestamp {:?}", sprint_key(&key));
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -647,16 +646,6 @@ impl Transaction {
 		K: Into<Key> + Debug,
 		V: Into<Val> + Debug,
 	{
-		let ts_key = ts_key.into();
-		let prefix = prefix.into();
-		let suffix = suffix.into();
-		#[cfg(debug_assertions)]
-		trace!(
-			"Set Versionstamped Key ts={} prefix={} suffix={}",
-			sprint_key(&prefix),
-			sprint_key(&ts_key),
-			sprint_key(&suffix)
-		);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -777,7 +766,7 @@ impl Transaction {
 			end: rng.end.into(),
 		};
 		#[cfg(debug_assertions)]
-		trace!("Scan {} - {}", sprint_key(&rng.start), sprint_key(&rng.end));
+		trace!("Scan {:?} - {:?}", sprint_key(&rng.start), sprint_key(&rng.end));
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -832,7 +821,7 @@ impl Transaction {
 		K: Into<Key> + From<Vec<u8>> + AsRef<[u8]> + Debug + Clone,
 	{
 		#[cfg(debug_assertions)]
-		trace!("Scan paged {} - {}", sprint_key(&page.range.start), sprint_key(&page.range.end));
+		trace!("Scan {:?} - {:?}", sprint_key(&page.range.start), sprint_key(&page.range.end));
 		let range = page.range.clone();
 		let res = match self {
 			#[cfg(feature = "kv-mem")]
@@ -906,7 +895,7 @@ impl Transaction {
 	{
 		let key = key.into();
 		#[cfg(debug_assertions)]
-		trace!("Putc {} if {:?} => {:?}", sprint_key(&key), chk, val);
+		trace!("Putc {:?} if {:?} => {:?}", sprint_key(&key), chk, val);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -957,7 +946,7 @@ impl Transaction {
 	{
 		let key = key.into();
 		#[cfg(debug_assertions)]
-		trace!("Delc {} if {:?}", sprint_key(&key), chk);
+		trace!("Delc {:?} if {:?}", sprint_key(&key), chk);
 		match self {
 			#[cfg(feature = "kv-mem")]
 			Transaction {
@@ -1013,7 +1002,7 @@ impl Transaction {
 		let beg: Key = rng.start.into();
 		let end: Key = rng.end.into();
 		#[cfg(debug_assertions)]
-		trace!("Getr {}..{} (limit: {limit})", sprint_key(&beg), sprint_key(&end));
+		trace!("Getr {:?}..{:?} (limit: {limit})", sprint_key(&beg), sprint_key(&end));
 		let mut out: Vec<(Key, Val)> = vec![];
 		let mut next_page = Some(ScanPage {
 			range: beg..end,
@@ -1049,7 +1038,7 @@ impl Transaction {
 			end: rng.end.into(),
 		};
 		#[cfg(debug_assertions)]
-		trace!("Delr {}..{} (limit: {limit})", sprint_key(&rng.start), sprint_key(&rng.end));
+		trace!("Delr {:?}..{:?} (limit: {limit})", sprint_key(&rng.start), sprint_key(&rng.end));
 		match self {
 			#[cfg(feature = "kv-tikv")]
 			Transaction {
@@ -1087,14 +1076,11 @@ impl Transaction {
 			let res = res.values;
 			// Exit when settled
 			if res.is_empty() {
-				trace!("Delr page was empty");
 				break;
 			}
 			// Loop over results
 			for (k, _) in res.into_iter() {
 				// Delete
-				#[cfg(debug_assertions)]
-				trace!("Delr key {}", sprint_key(&k));
 				self.del(k).await?;
 			}
 		}
@@ -1110,7 +1096,7 @@ impl Transaction {
 		let beg: Key = key.into();
 		let end: Key = beg.clone().add(0xff);
 		#[cfg(debug_assertions)]
-		trace!("Getp {}-{} (limit: {limit})", sprint_key(&beg), sprint_key(&end));
+		trace!("Getp {:?}-{:?} (limit: {limit})", sprint_key(&beg), sprint_key(&end));
 		let mut out: Vec<(Key, Val)> = vec![];
 		// Start processing
 		let mut next_page = Some(ScanPage {
@@ -1144,7 +1130,7 @@ impl Transaction {
 		let beg: Key = key.into();
 		let end: Key = beg.clone().add(0xff);
 		#[cfg(debug_assertions)]
-		trace!("Delp {}-{} (limit: {limit})", sprint_key(&beg), sprint_key(&end));
+		trace!("Delp {:?}-{:?} (limit: {limit})", sprint_key(&beg), sprint_key(&end));
 		let min = beg.clone();
 		let max = end.clone();
 		self.delr(min..max, limit).await?;
@@ -2036,7 +2022,7 @@ impl Transaction {
 	) -> Result<LiveStatement, Error> {
 		let key = crate::key::table::lq::new(ns, db, tb, *lv);
 		let key_enc = crate::key::table::lq::Lq::encode(&key)?;
-		trace!("Getting lv ({:?}) {}", lv, sprint_key(&key_enc));
+		trace!("Getting lv ({:?}) {:?}", lv, sprint_key(&key_enc));
 		let val = self.get(key_enc).await?.ok_or(Error::LvNotFound {
 			value: lv.to_string(),
 		})?;
@@ -2054,7 +2040,7 @@ impl Transaction {
 	) -> Result<DefineEventStatement, Error> {
 		let key = crate::key::table::ev::new(ns, db, tb, ev);
 		let key_enc = crate::key::table::ev::Ev::encode(&key)?;
-		trace!("Getting ev ({:?}) {}", ev, sprint_key(&key_enc));
+		trace!("Getting ev ({:?}) {:?}", ev, sprint_key(&key_enc));
 		let val = self.get(key_enc).await?.ok_or(Error::EvNotFound {
 			value: ev.to_string(),
 		})?;
@@ -2072,7 +2058,7 @@ impl Transaction {
 	) -> Result<DefineFieldStatement, Error> {
 		let key = crate::key::table::fd::new(ns, db, tb, fd);
 		let key_enc = crate::key::table::fd::Fd::encode(&key)?;
-		trace!("Getting fd ({:?}) {}", fd, sprint_key(&key_enc));
+		trace!("Getting fd ({:?}) {:?}", fd, sprint_key(&key_enc));
 		let val = self.get(key_enc).await?.ok_or(Error::FdNotFound {
 			value: fd.to_string(),
 		})?;
@@ -2090,7 +2076,7 @@ impl Transaction {
 	) -> Result<DefineIndexStatement, Error> {
 		let key = crate::key::table::ix::new(ns, db, tb, ix);
 		let key_enc = crate::key::table::ix::Ix::encode(&key)?;
-		trace!("Getting ix ({:?}) {}", ix, sprint_key(&key_enc));
+		trace!("Getting ix ({:?}) {:?}", ix, sprint_key(&key_enc));
 		let val = self.get(key_enc).await?.ok_or(Error::IxNotFound {
 			value: ix.to_string(),
 		})?;
@@ -2901,14 +2887,6 @@ impl Transaction {
 		// This also works as an advisory lock on the ts keys so that there is
 		// on other concurrent transactions that can write to the ts_key or the keys after it.
 		let vs = self.get_timestamp(crate::key::database::vs::new(ns, db), lock).await?;
-		#[cfg(debug_assertions)]
-		trace!(
-			"Setting timestamp {} for versionstamp {:?} in ns: {}, db: {}",
-			ts,
-			conv::versionstamp_to_u64(&vs),
-			ns,
-			db
-		);
 
 		// Ensure there are no keys after the ts_key
 		// Otherwise we can go back in time!
@@ -2918,13 +2896,6 @@ impl Transaction {
 		let ts_pairs: Vec<(Vec<u8>, Vec<u8>)> = self.getr(begin..end, u32::MAX).await?;
 		let latest_ts_pair = ts_pairs.last();
 		if let Some((k, _)) = latest_ts_pair {
-			trace!(
-				"There already was a greater committed timestamp {} in ns: {}, db: {} found: {}",
-				ts,
-				ns,
-				db,
-				sprint_key(k)
-			);
 			let k = crate::key::database::ts::Ts::decode(k)?;
 			let latest_ts = k.ts;
 			if latest_ts >= ts {
@@ -3007,23 +2978,6 @@ impl Transaction {
 			#[allow(unreachable_patterns)]
 			_ => unreachable!(),
 		}
-	}
-
-	#[cfg(debug_assertions)]
-	#[allow(unused)]
-	#[doc(hidden)]
-	pub async fn print_all(&mut self) {
-		let mut next_page =
-			Some(ScanPage::from(crate::key::root::ns::prefix()..b"\xff\xff\xff".to_vec()));
-		println!("Start print all");
-		while next_page.is_some() {
-			let res = self.scan_paged(next_page.unwrap(), 1000).await.unwrap();
-			for (k, _) in res.values {
-				println!("{}", sprint_key(&k));
-			}
-			next_page = res.next_page;
-		}
-		println!("End print all");
 	}
 }
 

--- a/core/src/sql/v1/statements/show.rs
+++ b/core/src/sql/v1/statements/show.rs
@@ -70,8 +70,8 @@ impl ShowStatement {
 		.await?;
 		// Return the changes
 		let mut a = Vec::<Value>::new();
-		for r in r.into_iter() {
-			let v: Value = r.into_value();
+		for r in r.iter() {
+			let v: Value = r.clone().into_value();
 			a.push(v);
 		}
 		let v: Value = Value::Array(crate::sql::array::Array(a));

--- a/core/src/vs/conv.rs
+++ b/core/src/vs/conv.rs
@@ -75,14 +75,11 @@ pub fn try_u128_to_versionstamp(v: u128) -> Result<[u8; 10], Error> {
 	Ok(buf)
 }
 
-/// Take the most significant, time-based bytes and ignores the last 2 bytes
-#[doc(hidden)]
 pub fn versionstamp_to_u64(vs: &Versionstamp) -> u64 {
 	u64::from_be_bytes(vs[..8].try_into().unwrap())
 }
 // to_u128_be converts a 10-byte versionstamp to a u128 assuming big-endian.
 // This is handy for human comparing versionstamps.
-// This is not the same as timestamp u64 representation as the tailing bytes are included
 #[allow(unused)]
 pub fn to_u128_be(vs: [u8; 10]) -> u128 {
 	let mut buf = [0; 16];
@@ -138,10 +135,7 @@ pub fn to_u128_le(vs: [u8; 10]) -> u128 {
 	u128::from_be_bytes(buf)
 }
 
-#[cfg(test)]
 mod tests {
-	use crate::vs::{u64_to_versionstamp, versionstamp_to_u64};
-
 	#[test]
 	fn try_to_u64_be() {
 		use super::*;
@@ -166,21 +160,5 @@ mod tests {
 		let v = u128::MAX >> 48;
 		let res = try_u128_to_versionstamp(v).unwrap();
 		assert_eq!(res, [255, 255, 255, 255, 255, 255, 255, 255, 255, 255]);
-	}
-
-	#[test]
-	fn can_add_u64_conversion() {
-		let start = 5u64;
-		let vs = u64_to_versionstamp(start);
-		// The last 2 bytes are empty
-		assert_eq!("00000000000000050000", hex::encode(vs));
-		let mid = versionstamp_to_u64(&vs);
-		assert_eq!(start, mid);
-		let mid = mid + 1;
-		let vs = u64_to_versionstamp(mid);
-		// The last 2 bytes are empty
-		assert_eq!("00000000000000060000", hex::encode(vs));
-		let end = versionstamp_to_u64(&vs);
-		assert_eq!(end, 6);
 	}
 }

--- a/core/src/vs/oracle.rs
+++ b/core/src/vs/oracle.rs
@@ -153,9 +153,10 @@ fn secs_since_unix_epoch() -> u64 {
 	}
 }
 
-#[cfg(test)]
 mod tests {
+	#[allow(unused)]
 	use super::*;
+	#[allow(unused)]
 	use crate::vs::to_u128_be;
 
 	#[test]

--- a/lib/tests/bootstrap.rs
+++ b/lib/tests/bootstrap.rs
@@ -49,7 +49,7 @@ async fn bootstrap_removes_unreachable_nodes() -> Result<(), Error> {
 	dbs.bootstrap().await.unwrap();
 
 	// Declare a function that will assert
-	async fn try_validate(tx: &mut Transaction, bad_node: &uuid::Uuid) -> Result<(), String> {
+	async fn try_validate(mut tx: &mut Transaction, bad_node: &uuid::Uuid) -> Result<(), String> {
 		let res = tx.scan_nd(1000).await.map_err(|e| e.to_string())?;
 		tx.commit().await.map_err(|e| e.to_string())?;
 		for node in &res {

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -1,13 +1,9 @@
 use crate::cli::CF;
 use crate::err::Error;
 use clap::Args;
-use std::sync::OnceLock;
 use std::time::Duration;
 use surrealdb::dbs::capabilities::{Capabilities, FuncTarget, NetTarget, Targets};
 use surrealdb::kvs::Datastore;
-
-pub static DB: OnceLock<Datastore> = OnceLock::new();
-
 #[derive(Args, Debug)]
 pub struct StartCommandDbsOptions {
 	#[arg(help = "Whether strict mode is enabled on this database instance")]
@@ -215,7 +211,7 @@ pub async fn init(
 		auth_level_enabled,
 		caps,
 	}: StartCommandDbsOptions,
-) -> Result<(), Error> {
+) -> Result<Datastore, Error> {
 	// Get local copy of options
 	let opt = CF.get().unwrap();
 	// Log specified strict mode
@@ -265,11 +261,8 @@ pub async fn init(
 		dbs.setup_initial_creds(user, opt.pass.as_ref().unwrap()).await?;
 	}
 
-	// Store database instance
-	let _ = DB.set(dbs);
-
 	// All ok
-	Ok(())
+	Ok(dbs)
 }
 
 #[cfg(test)]

--- a/src/net/ml.rs
+++ b/src/net/ml.rs
@@ -21,6 +21,8 @@ use surrealdb::ml::storage::surml_file::SurMlFile;
 use surrealdb::sql::statements::{DefineModelStatement, DefineStatement};
 use tower_http::limit::RequestBodyLimitLayer;
 
+use super::AppState;
+
 const MAX: usize = 1024 * 1024 * 1024 * 4; // 4 GiB
 
 /// The router definition for the ML API endpoints.

--- a/src/net/signin.rs
+++ b/src/net/signin.rs
@@ -1,4 +1,3 @@
-use crate::dbs::DB;
 use crate::err::Error;
 use crate::net::input::bytes_to_utf8;
 use crate::net::output;
@@ -16,6 +15,7 @@ use surrealdb::sql::Value;
 use tower_http::limit::RequestBodyLimitLayer;
 
 use super::headers::Accept;
+use super::AppState;
 
 const MAX: usize = 1024; // 1 KiB
 
@@ -50,19 +50,20 @@ where
 }
 
 async fn handler(
+	Extension(state): Extension<AppState>,
 	Extension(mut session): Extension<Session>,
 	accept: Option<TypedHeader<Accept>>,
 	body: Bytes,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
-	// Get a database reference
-	let kvs = DB.get().unwrap();
 	// Convert the HTTP body into text
 	let data = bytes_to_utf8(&body)?;
 	// Parse the provided data as JSON
 	match surrealdb::sql::json(data) {
 		// The provided value was an object
 		Ok(Value::Object(vars)) => {
-			match surrealdb::iam::signin::signin(kvs, &mut session, vars).await.map_err(Error::from)
+			match surrealdb::iam::signin::signin(&state.datastore, &mut session, vars)
+				.await
+				.map_err(Error::from)
 			{
 				// Authentication was successful
 				Ok(v) => match accept.as_deref() {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use surrealdb::dbs::Options;
@@ -5,6 +6,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use surrealdb::fflags::FFLAGS;
+use surrealdb::kvs::Datastore;
 
 use crate::cli::CF;
 
@@ -14,19 +16,14 @@ const LOG: &str = "surrealdb::node";
 // Datastore.tick is responsible for running garbage collection and other
 // background tasks.
 //
-// This function needs to be called before after the dbs::init and before the net::init functions.
-// It needs to be before net::init because the net::init function blocks until the web server stops.
-pub fn init(ct: CancellationToken) -> JoinHandle<()> {
+pub fn init(ds: Arc<Datastore>, ct: CancellationToken) -> JoinHandle<()> {
 	let opt = CF.get().unwrap();
 	let tick_interval = opt.tick_interval;
 	info!(target: LOG, "Started node agent");
 
-	// This requires the nodes::init function to be called after the dbs::init function.
-	let dbs = crate::dbs::DB.get().unwrap();
-
 	tokio::spawn(async move {
 		loop {
-			if let Err(e) = dbs.tick().await {
+			if let Err(e) = ds.tick().await {
 				error!("Error running node agent tick: {}", e);
 			}
 			tokio::select! {
@@ -43,19 +40,18 @@ pub fn init(ct: CancellationToken) -> JoinHandle<()> {
 }
 
 // Start live query on change feeds notification processing
-pub fn live_query_change_feed(ct: CancellationToken) -> JoinHandle<()> {
+pub fn live_query_change_feed(ds: Arc<Datastore>, ct: CancellationToken) -> JoinHandle<()> {
 	tokio::spawn(async move {
 		if !FFLAGS.change_feed_live_queries.enabled() {
 			return;
 		}
 		// Spawn the live query change feed consumer, which is used for catching up on relevant change feeds
 		tokio::spawn(async move {
-			let kvs = crate::dbs::DB.get().unwrap();
 			let tick_interval = Duration::from_secs(1);
 
 			let opt = Options::default();
 			loop {
-				if let Err(e) = kvs.process_lq_notifications(&opt).await {
+				if let Err(e) = ds.process_lq_notifications(&opt).await {
 					error!("Error running node agent live query tick: {}", e);
 				}
 				tokio::select! {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -5,7 +5,6 @@ pub mod format;
 pub mod request;
 pub mod response;
 
-use crate::dbs::DB;
 use crate::rpc::connection::Connection;
 use crate::rpc::response::success;
 use crate::telemetry::metrics::ws::NotificationContext;
@@ -14,6 +13,7 @@ use opentelemetry::Context as TelemetryContext;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+use surrealdb::kvs::Datastore;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -32,9 +32,9 @@ pub(crate) static WEBSOCKETS: Lazy<WebSockets> = Lazy::new(WebSockets::default);
 pub(crate) static LIVE_QUERIES: Lazy<LiveQueries> = Lazy::new(LiveQueries::default);
 
 /// Performs notification delivery to the WebSockets
-pub(crate) async fn notifications(canceller: CancellationToken) {
+pub(crate) async fn notifications(ds: Arc<Datastore>, canceller: CancellationToken) {
 	// Listen to the notifications channel
-	if let Some(channel) = DB.get().unwrap().notifications() {
+	if let Some(channel) = ds.notifications() {
 		// Loop continuously
 		loop {
 			tokio::select! {

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -665,39 +665,23 @@ mod cli_integration {
 					.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
 					.output()
 					.unwrap();
-				let output = remove_debug_info(output).replace('\n', "");
-				let allowed = [
-					"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 1 }, { changes: [{ create: { id: thing:one } }], versionstamp: 2 }]]",
-					"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 1 }, { changes: [{ create: { id: thing:one } }], versionstamp: 3 }]]",
-					"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 2 }, { changes: [{ create: { id: thing:one } }], versionstamp: 3 }]]",
-					"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 2 }, { changes: [{ create: { id: thing:one } }], versionstamp: 4 }]]",
-				];
-				allowed
-					.into_iter()
-					.find(|case| *case == output)
-					.ok_or(format!("Output didnt match an example output: {output}"))
-					.unwrap();
+				let output = remove_debug_info(output);
+				assert_eq!(
+					output,
+						"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 65536 }, { changes: [{ create: { id: thing:one } }], versionstamp: 131072 }]]\n\n"
+							.to_owned(),
+						"failed to send sql: {args}");
 			} else {
 				let output = common::run(&args)
 					.input("SHOW CHANGES FOR TABLE thing SINCE 0 LIMIT 10;\n")
 					.output()
 					.unwrap();
-				let output = remove_debug_info(output).replace('\n', "");
-				let allowed = [
-					"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 1 }, { changes: [{ update: { id: thing:one } }], versionstamp: 2 }]]",
-					"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 1 }, { changes: [{ update: { id: thing:one } }], versionstamp: 3 }]]",
-					"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 2 }, { changes: [{ update: { id: thing:one } }], versionstamp: 3 }]]",
-					"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 2 }, { changes: [{ update: { id: thing:one } }], versionstamp: 4 }]]",
-				];
-				allowed
-					.into_iter()
-					.find(|case| {
-						let a = *case == output;
-						println!("Comparing\n{case}\n{output}\n{a}");
-						a
-					})
-					.ok_or(format!("Output didnt match an example output: {output}"))
-					.unwrap();
+				let output = remove_debug_info(output);
+				assert_eq!(
+					output,
+						"[[{ changes: [{ define_table: { name: 'thing' } }], versionstamp: 65536 }, { changes: [{ update: { id: thing:one } }], versionstamp: 131072 }]]\n\n"
+							.to_owned(),
+						"failed to send sql: {args}" );
 			}
 		};
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The global static Datastore lifecycle is independent from the Tokio Runtime.

SurrealKV leverages Tokio to trigger a graceful shutdown when the object is dropped, but given the Datastore object may outlive the Tokio Runtime or be dropped outside a Tokio Runtime context, the cleanup may not be executed.

Besides, we prefer non-global variables in order to have more control over the object's lifecycle.

## What does this change do?

It leverages the Axum state extension to pass around a reference to the Datastore created during the `start` command.

## What is your testing strategy?

CI is green

## Is this related to any issues?

Refs https://github.com/surrealdb/surrealkv/pull/31

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
