### PR TITLE
Fix: Consistently enforce session expiration

### DIFF
--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -244,7 +244,8 @@ pub async fn db(
 			session.tk = Some(val.into());
 			session.ns = Some(ns.to_owned());
 			session.db = Some(db.to_owned());
-			session.exp = exp;
+			// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
+			session.exp = None;
 			session.au = Arc::new((&u, Level::Database(ns.to_owned(), db.to_owned())).into());
 			// Check the authentication token
 			match enc {
@@ -296,7 +297,8 @@ pub async fn ns(
 			// Set the authentication on the session
 			session.tk = Some(val.into());
 			session.ns = Some(ns.to_owned());
-			session.exp = exp;
+			// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
+			session.exp = None;
 			session.au = Arc::new((&u, Level::Namespace(ns.to_owned())).into());
 			// Check the authentication token
 			match enc {
@@ -346,7 +348,8 @@ pub async fn root(
 			let enc = encode(&HEADER, &val, &key);
 			// Set the authentication on the session
 			session.tk = Some(val.into());
-			session.exp = exp;
+			// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
+			session.exp = None;
 			session.au = Arc::new((&u, Level::Root).into());
 			// Check the authentication token
 			match enc {

--- a/core/src/iam/signup.rs
+++ b/core/src/iam/signup.rs
@@ -70,20 +70,33 @@ pub async fn sc(
 								// Create the authentication key
 								let key = EncodingKey::from_secret(sv.code.as_ref());
 								// Create the authentication claim
+								let exp = Some(
+									match sv.session {
+										Some(v) => {
+											// The defined session duration must be valid
+											match Duration::from_std(v.0) {
+												// The resulting session expiration must be valid
+												Ok(d) => match Utc::now().checked_add_signed(d) {
+													Some(exp) => exp,
+													None => {
+														return Err(Error::InvalidSessionExpiration)
+													}
+												},
+												Err(_) => {
+													return Err(Error::InvalidSessionDuration)
+												}
+											}
+										}
+										_ => Utc::now() + Duration::hours(1),
+									}
+									.timestamp(),
+								);
 								let val = Claims {
 									iss: Some(SERVER_NAME.to_owned()),
 									iat: Some(Utc::now().timestamp()),
 									nbf: Some(Utc::now().timestamp()),
 									jti: Some(Uuid::new_v4().to_string()),
-									exp: Some(
-										match sv.session {
-											Some(v) => {
-												Utc::now() + Duration::from_std(v.0).unwrap()
-											}
-											_ => Utc::now() + Duration::hours(1),
-										}
-										.timestamp(),
-									),
+									exp,
 									ns: Some(ns.to_owned()),
 									db: Some(db.to_owned()),
 									sc: Some(sc.to_owned()),
@@ -100,6 +113,7 @@ pub async fn sc(
 								session.db = Some(db.to_owned());
 								session.sc = Some(sc.to_owned());
 								session.sd = Some(Value::from(rid.to_owned()));
+								session.exp = exp;
 								session.au = Arc::new(Auth::new(Actor::new(
 									rid.to_string(),
 									Default::default(),


### PR DESCRIPTION
## What is the motivation?

The intent of https://github.com/surrealdb/surrealdb/pull/3561 was to enforce session expiration only for scope users and system users who authenticated via token. Session expiration was meant to be None for system users authenticating with username and password regardless of the token expiration until token expiration for those users was configurable. This is the case when performing basic authentication, but not when authenticating using the signin method. This PR intends to fix this.

Additionally, the signin and signup methods did not consistently set session expiration, which is resolved as well.

## What does this change do?

Backports #3686 to v1.3.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
