### PR TITLE
Fix surrealdb-core dependency patching

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -113,7 +113,7 @@ jobs:
           sed -i "s#^version = \".*\"#version = \"2.0.0-${{ steps.bump.outputs.version }}\"#" core/Cargo.toml
 
           # Update dependency versions
-          sed -i "s#surrealdb-core = { version = \"=2.0.0-${{ steps.bump.outputs.current-version }}\"#surrealdb-core = { version = \"=2.0.0-${{ steps.bump.outputs.core-version }}\"#" lib/Cargo.toml
+          sed -i "s#surrealdb-core2 = { version = \"=2.0.0-${{ steps.bump.outputs.current-version }}\"#surrealdb-core2 = { version = \"=2.0.0-${{ steps.bump.outputs.core-version }}\"#" lib/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -69,7 +69,7 @@ jobs:
           sed -i "s#^version = \".*\"#version = \"2.0.0-${version}\"#" core/Cargo.toml
 
           # Update dependency versions
-          sed -i "s#surrealdb-core = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core = { version = \"=2.0.0-${version}\"#" lib/Cargo.toml
+          sed -i "s#surrealdb-core2 = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core2 = { version = \"=2.0.0-${version}\"#" lib/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -106,7 +106,7 @@ jobs:
 
             # Update dependency versions
             sed -i "s#surrealdb = { version = \"=${currentVersion}\"#surrealdb = { version = \"${major}\"#" Cargo.toml
-            sed -i "s#surrealdb-core = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core = { version = \"=2.0.0-${version}\"#" lib/Cargo.toml
+            sed -i "s#surrealdb-core2 = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core2 = { version = \"=2.0.0-${version}\"#" lib/Cargo.toml
 
             # Update Cargo.lock without updating dependency versions
             cargo check --no-default-features --features storage-mem
@@ -140,7 +140,7 @@ jobs:
 
             # Update dependency versions
             sed -i "s#surrealdb = { version = \"=${currentVersion}\"#surrealdb = { version = \"=${betaVersion}\"#" Cargo.toml
-            sed -i "s#surrealdb-core = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core = { version = \"=2.0.0-${betaVersion}\"#" lib/Cargo.toml
+            sed -i "s#surrealdb-core2 = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core2 = { version = \"=2.0.0-${betaVersion}\"#" lib/Cargo.toml
           else
             git checkout -b releases/beta
             major=$(echo $currentVersion | tr "." "\n" | sed -n 1p)
@@ -149,7 +149,7 @@ jobs:
 
             # Update dependency versions
             sed -i "s#surrealdb = { version = \"${major}\"#surrealdb = { version = \"=${betaVersion}\"#" Cargo.toml
-            sed -i "s#surrealdb-core = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core = { version = \"=2.0.0-${betaVersion}\"#" lib/Cargo.toml
+            sed -i "s#surrealdb-core2 = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core2 = { version = \"=2.0.0-${betaVersion}\"#" lib/Cargo.toml
           fi
 
           # Bump the crate version
@@ -594,12 +594,12 @@ jobs:
           # Update crate version
           sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"2.0.0-${version}\"#" core/Cargo.toml
-          sed -i "s#surrealdb-core = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core = { version = \"=2.0.0-${version}\"#" lib/Cargo.toml
+          sed -i "s#surrealdb-core2 = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core2 = { version = \"=2.0.0-${version}\"#" lib/Cargo.toml
 
       - name: Patch nightly crate version
         if: ${{ inputs.environment == 'nightly' }}
         run: |
-          # Get the date and time of the last commit
+          # Get the date of the last commit
           date=$(git show --no-patch --format=%ad --date=format:%Y%m%d)
 
           # Derive crate version
@@ -612,7 +612,7 @@ jobs:
           # Update the version to a nightly one
           sed -i "s#^version = \".*\"#version = \"${version}\"#" lib/Cargo.toml
           sed -i "s#^version = \".*\"#version = \"2.0.0-${version}\"#" core/Cargo.toml
-          sed -i "s#surrealdb-core = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core = { version = \"=2.0.0-${version}\"#" lib/Cargo.toml
+          sed -i "s#surrealdb-core2 = { version = \"=2.0.0-${currentVersion}\"#surrealdb-core2 = { version = \"=2.0.0-${version}\"#" lib/Cargo.toml
 
       - name: Patch crate name and description
         if: ${{ inputs.environment == 'nightly' || inputs.environment == 'beta' }}


### PR DESCRIPTION
## What is the motivation?

The crate publish job is currently broken.

## What does this change do?

It updates the `surrealdb-core` dependency in the workflows to `surrealdb-core2`.

## What is your testing strategy?

Published a nightly release with this changeset.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
