### PR TITLE
Drop `--conn` and `--multi` from `make sql`

### DIFF
--- a/Makefile.local.toml
+++ b/Makefile.local.toml
@@ -93,7 +93,7 @@ args = ["run", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "
 category = "LOCAL USAGE"
 command = "cargo"
 env = { RUSTFLAGS = "--cfg surrealdb_unstable" }
-args = ["run", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "sql", "--conn", "ws://0.0.0.0:8000", "--multi", "--pretty", "${@}"]
+args = ["run", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "sql", "--pretty", "${@}"]
 
 # Quick
 [tasks.quick]


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

- The `--conn` flag was set to an already default value, thus not needed. Dropping it also gives the benefit of being able to do `make sql --conn memory`.
- With the `--multi` flag set by default, I just spent an hour or two figuring out why queries stopped working on the CLI, only to find out I needed to suffix them with `;` because of the `--multi` flag.

## What does this change do?

It drops `--conn` and `--multi` from the `make sql` command for reasons stated above

## What is your testing strategy?

N/A

## Is this related to any issues?

N/A

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
