### PR TITLE
Make `sql2` mandatory in the binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
         run: cargo vet
 
       - name: Check dependencies for unauthorized access
+        env:
+          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: cargo acl -n
 
       - name: Dependency check failure

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ http = ["surrealdb/http"]
 http-compression = []
 ml = ["surrealdb/ml"]
 jwks = ["surrealdb/jwks"]
-sql2 = ["surrealdb/sql2"]
+sql2 = [] # Deprecated since v1.4
 parser2 = ["surrealdb/parser2"]
 performance-profiler = ["dep:pprof"]
 
@@ -83,6 +83,7 @@ surrealdb = { version = "1", path = "lib", features = [
 	"protocol-http",
 	"protocol-ws",
 	"rustls",
+	"sql2"
 ] }
 tempfile = "3.8.1"
 thiserror = "1.0.50"

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -184,7 +184,6 @@ pub async fn init(
 	dbs::init(dbs).await?;
 	// Start the node agent
 	let (tasks, task_chans) = start_tasks(
-		#[cfg(feature = "sql2")]
 		&config::CF.get().unwrap().engine.unwrap_or_default(),
 		DB.get().unwrap().clone(),
 	);


### PR DESCRIPTION
## What is the motivation?

`sql2` is already being used in official binaries.

## What does this change do?

It always activates `sql2` for binaries.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
