### PR TITLE
Fix Nix flake builds

### DIFF
--- a/pkg/nix/drv/binary.nix
+++ b/pkg/nix/drv/binary.nix
@@ -24,4 +24,6 @@ let
 in craneLib.buildPackage (buildSpec // {
   inherit cargoArtifacts;
   inherit (util) version SURREAL_BUILD_METADATA;
+
+  RUSTFLAGS = "--cfg surrealdb_unstable";
 })


### PR DESCRIPTION
## What is the motivation?

Nix flake is broken after making `sql2` mandatory in the binary.

## What does this change do?

It defines `RUSTFLAGS` in the Nix flake.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
