### PR TITLE
Drop `sql2` from the build tooling

### DIFF
--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -54,6 +54,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  RUSTFLAGS: "--cfg surrealdb_unstable"
+
 jobs:
   prepare-vars:
     name: Prepare vars
@@ -524,7 +527,6 @@ jobs:
       - name: Build step
         env:
           SURREAL_BUILD_METADATA: ${{ needs.prepare-vars.outputs.build-metadata }}
-          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: ${{ matrix.build-step }}
 
       - name: Upload artifacts

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -346,7 +346,7 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv,http-compression,sql2,jwks,${{ inputs.extra-features }}
+              features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}
 
               # Download libonnxruntime's static library and tell ORT crate to use it
               mkdir /tmp/onnxruntime
@@ -373,7 +373,7 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv,http-compression,sql2,jwks,${{ inputs.extra-features }}
+              features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}
 
               # Download libonnxruntime's static library and tell ORT crate to use it
               mkdir /tmp/onnxruntime
@@ -395,7 +395,7 @@ jobs:
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
               # Build
-              features=storage-tikv,http-compression,sql2,jwks,${{ inputs.extra-features }}
+              features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}
 
               # Download libonnxruntime's static library and tell ORT crate to use it
               tmpdir=$(mktemp -d)
@@ -433,7 +433,7 @@ jobs:
               set -x
 
               # Build
-              features=storage-tikv,http-compression,sql2,jwks,${{ inputs.extra-features }}
+              features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}
 
               # Download libonnxruntime's static library and tell ORT crate to use it
               tmpdir=$(mktemp -d)
@@ -474,7 +474,7 @@ jobs:
               vcpkg integrate install
 
               # Build
-              features=storage-tikv,http-compression,sql2,jwks,${{ inputs.extra-features }}
+              features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}
 
               # Download libonnxruntime's static library and tell ORT crate to use it
               tmp_dir=$(mktemp -d)


### PR DESCRIPTION
## What is the motivation?

The `sql2` feature no longer has any effect on the binary.

## What does this change do?

It removes it from the build commands.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
