### PR TITLE
Add ensure-time to tests, to not have spinning-tests

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -27,25 +27,25 @@ args = ["clippy", "--all-targets", "--features", "storage-mem,storage-rocksdb,st
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG = { value = "cli_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http,scripting,jwks,sql2", "--workspace", "--test", "cli_integration", "--", "cli_integration"]
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http,scripting,jwks,sql2", "--workspace", "--ensure-time", "--test", "cli_integration", "--", "cli_integration"]
 
 [tasks.ci-http-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG = { value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks,sql2", "--workspace", "--test", "http_integration", "--", "http_integration"]
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks,sql2", "--workspace", "--ensure-time", "--test", "http_integration", "--", "http_integration"]
 
 [tasks.ci-ws-integration]
 category = "WS - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG = { value = "ws_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,sql2", "--workspace", "--test", "ws_integration", "--", "ws_integration"]
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,sql2", "--workspace", "--ensure-time", "--test", "ws_integration", "--", "ws_integration"]
 
 [tasks.ci-ml-integration]
 category = "ML - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG = { value = "cli_integration::common=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--features", "storage-mem,ml,sql2", "--workspace", "--test", "ml_integration", "--", "ml_integration", "--nocapture"]
+args = ["test", "--locked", "--features", "storage-mem,ml,sql2", "--workspace", "--ensure-time", "--test", "ml_integration", "--", "ml_integration", "--nocapture"]
 
 [tasks.ci-workspace-coverage]
 category = "CI - INTEGRATION TESTS"
@@ -66,7 +66,7 @@ category = "CI - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUSTDOCFLAGS = "--cfg surrealdb_unstable" }
 args = [
-    "test", "--locked", "--no-default-features", "--features", "storage-mem,scripting,http,parser2,sql2", "--workspace", "--",
+    "test", "--locked", "--no-default-features", "--features", "storage-mem,scripting,http,parser2,sql2", "--workspace", "--ensure-time", "--",
     "--skip", "api_integration",
     "--skip", "cli_integration",
     "--skip", "http_integration",
@@ -98,14 +98,14 @@ run_task = { name = ["test-database-upgrade"], fork = true }
 private = true
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable" }
-args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--lib", "kvs"]
+args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--ensure-time", "--features", "${_TEST_FEATURES}", "--lib", "kvs"]
 
 
 [tasks.test-api-integration]
 private = true
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable" }
-args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--test", "api", "api_integration::${_TEST_API_ENGINE}"]
+args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--ensure-time", "--test", "api", "api_integration::${_TEST_API_ENGINE}"]
 
 [tasks.ci-api-integration]
 env = { RUST_BACKTRACE = 1, _START_SURREALDB_PATH = "memory", RUSTFLAGS = "--cfg surrealdb_unstable" }
@@ -116,7 +116,7 @@ run_task = { name = ["start-surrealdb", "test-api-integration", "stop-surrealdb"
 private = true
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUST_LOG = "info", RUSTFLAGS = "--cfg surrealdb_unstable" }
-args = ["test", "--locked", "--no-default-features", "--features", "${_TEST_FEATURES}", "--workspace", "--test", "database_upgrade", "--", "database_upgrade", "--show-output"]
+args = ["test", "--locked", "--no-default-features", "--features", "${_TEST_FEATURES}", "--workspace", "--ensure-time", "--test", "database_upgrade", "--", "database_upgrade", "--show-output"]
 
 
 #

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -27,25 +27,25 @@ args = ["clippy", "--all-targets", "--features", "storage-mem,storage-rocksdb,st
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG = { value = "cli_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http,scripting,jwks,sql2", "--workspace", "--ensure-time", "--test", "cli_integration", "--", "cli_integration"]
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http,scripting,jwks,sql2", "--workspace", "--test", "cli_integration", "--", "cli_integration", "--ensure-time"]
 
 [tasks.ci-http-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG = { value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks,sql2", "--workspace", "--ensure-time", "--test", "http_integration", "--", "http_integration"]
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks,sql2", "--workspace", "--test", "http_integration", "--", "http_integration", "--ensure-time",]
 
 [tasks.ci-ws-integration]
 category = "WS - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG = { value = "ws_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,sql2", "--workspace", "--ensure-time", "--test", "ws_integration", "--", "ws_integration"]
+args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,sql2", "--workspace", "--test", "ws_integration", "--", "ws_integration", "--ensure-time",]
 
 [tasks.ci-ml-integration]
 category = "ML - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUST_LOG = { value = "cli_integration::common=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--features", "storage-mem,ml,sql2", "--workspace", "--ensure-time", "--test", "ml_integration", "--", "ml_integration", "--nocapture"]
+args = ["test", "--locked", "--features", "storage-mem,ml,sql2", "--workspace", "--test", "ml_integration", "--", "ml_integration", "--nocapture", "--ensure-time"]
 
 [tasks.ci-workspace-coverage]
 category = "CI - INTEGRATION TESTS"
@@ -66,7 +66,7 @@ category = "CI - INTEGRATION TESTS"
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUSTDOCFLAGS = "--cfg surrealdb_unstable" }
 args = [
-    "test", "--locked", "--no-default-features", "--features", "storage-mem,scripting,http,parser2,sql2", "--workspace", "--ensure-time", "--",
+    "test", "--locked", "--no-default-features", "--features", "storage-mem,scripting,http,parser2,sql2", "--workspace", "--", "--ensure-time",
     "--skip", "api_integration",
     "--skip", "cli_integration",
     "--skip", "http_integration",
@@ -98,14 +98,14 @@ run_task = { name = ["test-database-upgrade"], fork = true }
 private = true
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable" }
-args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--ensure-time", "--features", "${_TEST_FEATURES}", "--lib", "kvs"]
+args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--lib", "kvs", "--", "--ensure-time"]
 
 
 [tasks.test-api-integration]
 private = true
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable" }
-args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--ensure-time", "--test", "api", "api_integration::${_TEST_API_ENGINE}"]
+args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--test", "api", "api_integration::${_TEST_API_ENGINE}", "--", "--ensure-time"]
 
 [tasks.ci-api-integration]
 env = { RUST_BACKTRACE = 1, _START_SURREALDB_PATH = "memory", RUSTFLAGS = "--cfg surrealdb_unstable" }

--- a/Makefile.local.toml
+++ b/Makefile.local.toml
@@ -25,7 +25,7 @@ args = ["doc", "--open", "--no-deps", "--package", "surrealdb", "--features", "r
 category = "LOCAL USAGE"
 command = "cargo"
 env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUSTDOCFLAGS = "--cfg surrealdb_unstable", RUST_MIN_STACK={ value = "4194304", condition = { env_not_set = ["RUST_MIN_STACK"] } } }
-args = ["test", "--workspace", "--ensure-time", "--no-fail-fast", "--features", "sql2"]
+args = ["test", "--workspace", "--no-fail-fast", "--features", "sql2", "--", "--ensure-time"]
 
 # Check
 [tasks.cargo-check]

--- a/Makefile.local.toml
+++ b/Makefile.local.toml
@@ -25,7 +25,7 @@ args = ["doc", "--open", "--no-deps", "--package", "surrealdb", "--features", "r
 category = "LOCAL USAGE"
 command = "cargo"
 env = { RUSTFLAGS = "--cfg surrealdb_unstable", RUSTDOCFLAGS = "--cfg surrealdb_unstable", RUST_MIN_STACK={ value = "4194304", condition = { env_not_set = ["RUST_MIN_STACK"] } } }
-args = ["test", "--workspace", "--no-fail-fast", "--features", "sql2"]
+args = ["test", "--workspace", "--ensure-time", "--no-fail-fast", "--features", "sql2"]
 
 # Check
 [tasks.cargo-check]


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Tests running a long time can block a build

## What does this change do?

Terminate tests that run too long

## What is your testing strategy?

CI

## Is this related to any issues?

Builds

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
