### PR TITLE
Fix `beta` and `patch` workflows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -87,7 +87,6 @@ jobs:
 
           # Retrieve just released version
           betaVersion=$(taplo get -f Cargo.toml "package.version")
-          echo "current-version=${betaVersion}" >> $GITHUB_OUTPUT
           major=$(echo $betaVersion | tr "." "\n" | sed -n 1p)
           minor=$(echo $betaVersion | tr "." "\n" | sed -n 2p)
           betaNum=$(echo $betaVersion | tr "." "\n" | sed -n 4p)
@@ -115,7 +114,7 @@ jobs:
           sed -i "s#^version = \".*\"#version = \"2.0.0-${{ steps.bump.outputs.version }}\"#" core/Cargo.toml
 
           # Update dependency versions
-          sed -i "s#surrealdb-core2 = { version = \"=2.0.0-${{ steps.bump.outputs.current-version }}\"#surrealdb-core2 = { version = \"=2.0.0-${{ steps.bump.outputs.core-version }}\"#" lib/Cargo.toml
+          sed -i "s#surrealdb-core2 = { version = \".*\", default-features#surrealdb-core2 = { version = \"=2.0.0-${{ steps.bump.outputs.version }}\", default-features#" lib/Cargo.toml
 
           # Update Cargo.lock without updating dependency versions
           cargo check --no-default-features --features storage-mem

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -97,6 +97,8 @@ jobs:
 
       - name: Create version bump branch
         if: ${{ steps.bump.outputs.beta-num == '1' }}
+        env:
+          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: |
           set -x
 

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -48,6 +48,8 @@ jobs:
           sudo mv taplo /usr/bin/taplo
 
       - name: Prepare patch branch
+        env:
+          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: |
           set -x
 


### PR DESCRIPTION
## What is the motivation?

`surrealdb-core2` patching is broken in the beta workflow. Moreover, the beta and patch workflows call `cargo check` in the root workspace. This now requires the `surrealdb_unstable` flag to be set.

## What does this change do?

It fixes the core patching in the beta workflow and makes sure `surrealdb_unstable` is defined before calling `cargo check` in both workflows.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
