### PR TITLE
Add timeouts to LQ tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,6 +3464,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntest"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cd16a2e6992865367e7ca50cd6953d09daaed93641421168733a1274afadd6"
+dependencies = [
+ "ntest_test_cases",
+ "ntest_timeout",
+]
+
+[[package]]
+name = "ntest_test_cases"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197eff6c12b80ff5de6173e438fa3c1340a9e708118c1626e690f65aee1e5332"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ntest_timeout"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef492b5cf80f90c050b287e747228a1fa6517e9d754f364b5a7e0e038e49a25f"
+dependencies = [
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5716,6 +5749,7 @@ dependencies = [
  "jemallocator",
  "mimalloc",
  "nix 0.27.1",
+ "ntest",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5770,6 +5804,7 @@ dependencies = [
  "geo 0.27.0",
  "indexmap 2.2.2",
  "native-tls",
+ "ntest",
  "once_cell",
  "path-clean",
  "pharos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ jemallocator = "0.5.4"
 [dev-dependencies]
 assert_fs = "1.0.13"
 env_logger = "0.10.1"
+ntest = "0.9.2"
 opentelemetry-proto = { version = "0.2.0", features = [
 	"gen-tonic",
 	"traces",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -121,6 +121,7 @@ tokio = { version = "1.34.0", features = ["macros", "sync", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 ulid = { version = "1.1.0", features = ["serde"] }
 wiremock = "0.5.22"
+ntest = "0.9.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pharos = "0.5.3"

--- a/lib/tests/api/live.rs
+++ b/lib/tests/api/live.rs
@@ -175,7 +175,7 @@ async fn live_select_record_ranges() {
 	drop(permit);
 }
 
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(timeout = Duration::from_millis(50)))]
 async fn live_select_query() {
 	let (permit, db) = new_db().await;
 

--- a/lib/tests/api/live.rs
+++ b/lib/tests/api/live.rs
@@ -6,7 +6,7 @@ use futures::TryStreamExt;
 use surrealdb::Action;
 use surrealdb::Notification;
 
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(timeout = "10s"))]
 async fn live_select_table() {
 	let (permit, db) = new_db().await;
 
@@ -62,7 +62,7 @@ async fn live_select_table() {
 	drop(permit);
 }
 
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(timeout = "10s"))]
 async fn live_select_record_id() {
 	let (permit, db) = new_db().await;
 
@@ -118,7 +118,7 @@ async fn live_select_record_id() {
 	drop(permit);
 }
 
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(timeout = "10s"))]
 async fn live_select_record_ranges() {
 	let (permit, db) = new_db().await;
 
@@ -175,7 +175,7 @@ async fn live_select_record_ranges() {
 	drop(permit);
 }
 
-#[test_log::test(tokio::test(timeout = Duration::from_millis(50)))]
+#[test_log::test(tokio::test(timeout = "10s"))]
 async fn live_select_query() {
 	let (permit, db) = new_db().await;
 

--- a/lib/tests/api/live.rs
+++ b/lib/tests/api/live.rs
@@ -6,7 +6,8 @@ use futures::TryStreamExt;
 use surrealdb::Action;
 use surrealdb::Notification;
 
-#[test_log::test(tokio::test(timeout = "10s"))]
+#[test_log::test(tokio::test)]
+#[ntest::timeout(10000)]
 async fn live_select_table() {
 	let (permit, db) = new_db().await;
 
@@ -62,7 +63,8 @@ async fn live_select_table() {
 	drop(permit);
 }
 
-#[test_log::test(tokio::test(timeout = "10s"))]
+#[test_log::test(tokio::test)]
+#[ntest::timeout(10000)]
 async fn live_select_record_id() {
 	let (permit, db) = new_db().await;
 
@@ -118,7 +120,8 @@ async fn live_select_record_id() {
 	drop(permit);
 }
 
-#[test_log::test(tokio::test(timeout = "10s"))]
+#[test_log::test(tokio::test)]
+#[ntest::timeout(10000)]
 async fn live_select_record_ranges() {
 	let (permit, db) = new_db().await;
 
@@ -175,7 +178,8 @@ async fn live_select_record_ranges() {
 	drop(permit);
 }
 
-#[test_log::test(tokio::test(timeout = "10s"))]
+#[test_log::test(tokio::test)]
+#[ntest::timeout(10000)]
 async fn live_select_query() {
 	let (permit, db) = new_db().await;
 

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -640,7 +640,8 @@ async fn concurrency() -> Result<(), Box<dyn std::error::Error>> {
 	Ok(())
 }
 
-#[test(tokio::test(timeout = "10s"))]
+#[test(tokio::test)]
+#[ntest::timeout(10000)]
 async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, mut server) = common::start_server_with_defaults().await.unwrap();
@@ -707,7 +708,8 @@ async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	Ok(())
 }
 
-#[test(tokio::test(timeout = "10s"))]
+#[test(tokio::test)]
+#[ntest::timeout(10000)]
 async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, mut server) = common::start_server_with_defaults().await.unwrap();
@@ -810,7 +812,8 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	Ok(())
 }
 
-#[test(tokio::test(timeout = "10s"))]
+#[test(tokio::test)]
+#[ntest::timeout(10000)]
 async fn live_second_connection() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, mut server) = common::start_server_with_defaults().await.unwrap();

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -640,7 +640,7 @@ async fn concurrency() -> Result<(), Box<dyn std::error::Error>> {
 	Ok(())
 }
 
-#[test(tokio::test)]
+#[test(tokio::test(timeout = "10s"))]
 async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, mut server) = common::start_server_with_defaults().await.unwrap();
@@ -707,7 +707,7 @@ async fn live() -> Result<(), Box<dyn std::error::Error>> {
 	Ok(())
 }
 
-#[test(tokio::test)]
+#[test(tokio::test(timeout = "10s"))]
 async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, mut server) = common::start_server_with_defaults().await.unwrap();
@@ -810,7 +810,7 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	Ok(())
 }
 
-#[test(tokio::test)]
+#[test(tokio::test(timeout = "10s"))]
 async fn live_second_connection() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, mut server) = common::start_server_with_defaults().await.unwrap();
@@ -858,7 +858,7 @@ async fn live_second_connection() -> Result<(), Box<dyn std::error::Error>> {
 	Ok(())
 }
 
-#[test(tokio::test)]
+#[test(tokio::test(timeout = "10s"))]
 async fn variable_auth_live_query() -> Result<(), Box<dyn std::error::Error>> {
 	// Setup database server
 	let (addr, mut server) = common::start_server_with_defaults().await.unwrap();


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

When a live query is broken, some of the tests will work indefinitely. Obviously the tests should be re-written to include timeouts at every step, but equally we could have a catch all. Adding the test timeout makes the tests guaranteed to fail-fast instead of block. Using cargo `--ensure-timeout` isnt viable because it is unstable.

## What does this change do?

Add test timeouts to live query tests

## What is your testing strategy?

CICD and other broken builds

## Is this related to any issues?

LQ v2 development

## Does this change need documentation?

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
