### PR TITLE
Bug fix: empty array on index

### DIFF
--- a/core/src/doc/index.rs
+++ b/core/src/doc/index.rs
@@ -132,11 +132,7 @@ impl Combinator {
 			if !f {
 				// Iterator for not flattened values
 				if let Value::Array(v) = v {
-					iterators.push(Box::new(MultiValuesIterator {
-						vals: v.0,
-						done: false,
-						current: 0,
-					}));
+					iterators.push(Box::new(MultiValuesIterator::new(v.0)));
 					continue;
 				}
 			}
@@ -182,6 +178,28 @@ struct MultiValuesIterator {
 	vals: Vec<Value>,
 	done: bool,
 	current: usize,
+	end: usize,
+}
+
+impl MultiValuesIterator {
+	fn new(vals: Vec<Value>) -> Self {
+		let len = vals.len();
+		if len == 0 {
+			Self {
+				vals,
+				done: true,
+				current: 0,
+				end: 0,
+			}
+		} else {
+			Self {
+				vals,
+				done: false,
+				current: 0,
+				end: len - 1,
+			}
+		}
+	}
 }
 
 impl ValuesIterator for MultiValuesIterator {
@@ -189,7 +207,7 @@ impl ValuesIterator for MultiValuesIterator {
 		if self.done {
 			return false;
 		}
-		if self.current == self.vals.len() - 1 {
+		if self.current == self.end {
 			self.done = true;
 			return false;
 		}

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -2672,3 +2672,23 @@ async fn define_table_relation() -> Result<(), Error> {
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn define_statement_index_empty_array() -> Result<(), Error> {
+	let sql = r"
+		DEFINE TABLE indexTest;
+		INSERT INTO indexTest { arr: [] };
+		DEFINE INDEX idx_arr ON TABLE indexTest COLUMNS arr;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 3);
+	//
+	for _ in 0..3 {
+		let tmp = res.remove(0).result;
+		assert!(tmp.is_ok());
+	}
+	//
+	Ok(())
+}


### PR DESCRIPTION
## What is the motivation?

```sql
DEFINE TABLE indexTest;
INSERT INTO indexTest { arr: [] };
DEFINE INDEX idx_arr ON TABLE indexTest COLUMNS arr;
```

This fails with the following error:

```
attempt to subtract with overflow
thread 'define_statement_index_empty_array' panicked at core/src/doc/index.rs:192:28:
attempt to subtract with overflow
```



Bug reported here: https://discord.com/channels/902568124350599239/1018618253695795261/1220322230328889426

## What does this change do?

Fixes the bug.

## What is your testing strategy?

A test has been written.

## Is this related to any issues?

No

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
