### PR TITLE
Fix: Allow legacy headers in CORS

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -35,7 +35,7 @@ use http::header;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use surrealdb::headers::{DB, ID, NS};
+use surrealdb::headers::{AUTH_DB, AUTH_NS, DB, DB_LEGACY, ID, ID_LEGACY, NS, NS_LEGACY};
 use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
 use tower_http::add_extension::AddExtensionLayer;
@@ -106,6 +106,12 @@ pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 		NS.clone(),
 		DB.clone(),
 		ID.clone(),
+		AUTH_NS.clone(),
+		AUTH_DB.clone(),
+		// TODO(gguillemas): Remove these headers once the legacy authentication is deprecated in v2.0.0
+		NS_LEGACY.clone(),
+		DB_LEGACY.clone(),
+		ID_LEGACY.clone(),
 	];
 
 	#[cfg(not(feature = "http-compression"))]
@@ -117,6 +123,12 @@ pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 		NS.clone(),
 		DB.clone(),
 		ID.clone(),
+		AUTH_NS.clone(),
+		AUTH_DB.clone(),
+		// TODO(gguillemas): Remove these headers once the legacy authentication is deprecated in v2.0.0
+		NS_LEGACY.clone(),
+		DB_LEGACY.clone(),
+		ID_LEGACY.clone(),
 	];
 
 	let service = service


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

After mergin #2985, the list of allowed headers by CORS via the `Access-Control-Allow-Headers` header started referencing the new headers introduced in the PR instead of the legacy headers. This was not the intended behavior, as legacy headers should be supported until the breaking change is introduced in `2.0.0`. This was causing issues with web clients like Surrealist when using the legacy headers to perform cross-origin HTTP requests to SurrealDB.

## What does this change do?

This change adds the legacy to the array of allowed headers, as well as the new authentication headers introduced in #2985. A comment marks the legacy headers for deletion on the `2.0.0` release.

## What is your testing strategy?

Ensure that existing tests continue passing.

## Is this related to any issues?

No.

## Does this change need documentation?

Not this specific change, but documentation should be prepared for the eventual breaking change in `2.0.0`.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
