### PR TITLE
WIP: draft 3rd-paty token signin/up

### DIFF
--- a/core/src/dbs/session.rs
+++ b/core/src/dbs/session.rs
@@ -45,9 +45,15 @@ impl Session {
 		self
 	}
 
-	/// Set the selected database for the session
+	/// Set the selected scope for the session
 	pub fn with_sc(mut self, sc: &str) -> Session {
 		self.sc = Some(sc.to_owned());
+		self
+	}
+
+	/// Set the selected token for the session
+	pub fn with_tk(mut self, tk: Option<Value>) -> Session {
+		self.tk = tk.to_owned();
 		self
 	}
 

--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -88,6 +88,9 @@ pub async fn signin(
 					// Attempt to signin to root
 					super::signin::root(kvs, session, user, pass).await
 				}
+				(None, None) => {
+					super::signin::sc(kvs, session, session.ns.clone().unwrap(), session.db.clone().unwrap(), session.sc.clone().unwrap(), vars).await
+				}
 				_ => Err(Error::MissingUserOrPass),
 			}
 		}
@@ -118,7 +121,7 @@ pub async fn sc(
 					// Setup the query params
 					let vars = Some(vars.0);
 					// Setup the system session for finding the signin record
-					let mut sess = Session::editor().with_ns(&ns).with_db(&db);
+					let mut sess = Session::editor().with_ns(&ns).with_db(&db).with_tk(session.tk.clone());
 					sess.ip.clone_from(&session.ip);
 					sess.or.clone_from(&session.or);
 					// Compute the value with the params

--- a/core/src/iam/signup.rs
+++ b/core/src/iam/signup.rs
@@ -31,6 +31,9 @@ pub async fn signup(
 			// Attempt to signup to specified scope
 			super::signup::sc(kvs, session, ns, db, sc, vars).await
 		}
+		(None, None, None) => {
+			super::signup::sc(kvs, session, session.ns.clone().unwrap(), session.db.clone().unwrap(), session.sc.clone().unwrap(), vars).await
+	    }
 		_ => Err(Error::InvalidSignup),
 	}
 }
@@ -58,7 +61,7 @@ pub async fn sc(
 					// Setup the query params
 					let vars = Some(vars.0);
 					// Setup the system session for creating the signup record
-					let mut sess = Session::editor().with_ns(&ns).with_db(&db);
+					let mut sess = Session::editor().with_ns(&ns).with_db(&db).with_tk(session.tk.clone());
 					sess.ip.clone_from(&session.ip);
 					sess.or.clone_from(&session.or);
 					// Compute the value with the params


### PR DESCRIPTION
## What is the motivation?

Wonder if singup/signin could honor info coming inside 3rd-party jwks token (I believe in session' tk field)? There are email/name/preferred_username/sub that could be re-used in scope' [signup/signin hooks](https://github.com/surrealdb/surrealdb/blob/main/core/src/iam/signup.rs#L61) thus allowing for local/external login parity plus user' record auto-creation for new users.

## What does this change do?

It adds `tk` field to session, sets it to incoming token and make `$token` available in signin/up hooks:
```surql
DEFINE SCOPE web SESSION 7d
    SIGNUP (
        INSERT IGNORE INTO user {
            id: $token.sub,
            email: $token.email,
            name: $token.name,
            username: $token.preferred_username,
        }
    )
    SIGNIN (
        UPDATE type::thing("user", $token.sub) MERGE {
            email: $token.email,
            name: $token.name,
            username: $token.preferred_username,
        }
    );

DEFINE TOKEN web_token ON SCOPE web TYPE JWKS VALUE "https://idm.example.com/oauth2/openid/app/public_key.jwk";
```

If this is welcome I'd appreciate someone to extend the idea and make actual right changes to the original code. I don't speak rust and have just monkey-patched it to compile.

## What is your testing strategy?

None.

## Is this related to any issues?

Inspired by #2817
