### PR TITLE
Bugfix: check if update version is already installed

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -110,7 +110,11 @@ pub async fn init(args: UpgradeCommandArguments) -> Result<(), Error> {
 	let old_version = PKG_VERSION.deref().clone();
 	let new_version = args.version().await?;
 
-	if old_version == new_version {
+	// Parsed version numbers follow semver format (major.minor.patch)
+	let old_version_parsed = parse_version(&old_version)?;
+	let new_version_parsed = parse_version(&new_version)?;
+
+	if old_version_parsed == new_version_parsed {
 		println!("{old_version} is already installed");
 		return Ok(());
 	}


### PR DESCRIPTION
## What does this change do?

Fixes the check for the installed version versus the version that's being upgraded to, to avoid the unnecessary waste of resources of upgrading to the same version.

## What is your testing strategy?

Checked out to the latest stable release (at the time of writing, v1.3.1), built the project, then ran the `upgrade` command from the CLI. Nothing was downloaded as a result of my change and the program correctly displayed that version 1.3.1 was already installed.

## Is this related to any issues?

Issue https://github.com/surrealdb/surrealdb/issues/3618

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [X] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
