### PR TITLE
bugfix: fix DEFINE .. TYPE parsing in parser 2

### DIFF
--- a/core/src/syn/v2/parser/stmt/define.rs
+++ b/core/src/syn/v2/parser/stmt/define.rs
@@ -800,12 +800,12 @@ impl Parser<'_> {
 		};
 		loop {
 			match self.peek_kind() {
-				t!("FROM") => {
+				t!("FROM") | t!("IN") => {
 					self.pop_peek();
 					let from = self.parse_tables()?;
 					res.from = Some(from);
 				}
-				t!("TO") => {
+				t!("TO") | t!("OUT") => {
 					self.pop_peek();
 					let to = self.parse_tables()?;
 					res.to = Some(to);


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

There was a bug in the parser2 code where it would not accept IN or OUT in a TYPE RELATION clause when it should

## What does this change do?

parse IN and OUT as well as FROM and TO

## What is your testing strategy?

#3759

## Is this related to any issues?

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
