### PR TITLE
Remove a forgotten println

### DIFF
--- a/core/src/syn/v2/parser/mac.rs
+++ b/core/src/syn/v2/parser/mac.rs
@@ -114,8 +114,6 @@ macro_rules! enter_object_recursion {
 #[macro_export]
 macro_rules! enter_query_recursion {
 	($name:ident = $this:expr => { $($t:tt)* }) => {{
-
-        println!("{} = {}",$this.query_recursion, std::backtrace::Backtrace::force_capture());
 		if $this.query_recursion == 0 {
 			return Err($crate::syn::v2::parser::ParseError::new(
 				$crate::syn::v2::parser::ParseErrorKind::ExceededQueryDepthLimit,


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

I left in a println in my PR which I used for debugging. 

## What does this change do?

remove the println

## What is your testing strategy?

no tests required

## Is this related to any issues?

None

## Does this change need documentation?

No

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
