### PR TITLE
feature-2924: Add an option to suppress server identification headers

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -18,5 +18,5 @@ pub struct Config {
 	pub key: Option<PathBuf>,
 	pub tick_interval: Duration,
 	pub engine: Option<EngineOptions>,
-	pub hide_server_id_headers: bool,
+	pub no_identification_headers: bool,
 }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -18,4 +18,5 @@ pub struct Config {
 	pub key: Option<PathBuf>,
 	pub tick_interval: Duration,
 	pub engine: Option<EngineOptions>,
+	pub hide_server_id_headers: bool,
 }

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -96,7 +96,7 @@ pub struct StartCommandArguments {
 	#[arg(env = "SURREAL_BIND", short = 'b', long = "bind")]
 	#[arg(default_value = "127.0.0.1:8000")]
 	listen_addresses: Vec<SocketAddr>,
-	#[arg(help = "Whether to suppress the server name and version header")]
+	#[arg(help = "Whether to suppress the server name and version headers")]
 	#[arg(env = "SURREAL_NO_IDENTIFICATION_HEADERS", long)]
 	#[arg(default_value_t = false)]
 	no_identification_headers: bool,

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -96,7 +96,10 @@ pub struct StartCommandArguments {
 	#[arg(env = "SURREAL_BIND", short = 'b', long = "bind")]
 	#[arg(default_value = "127.0.0.1:8000")]
 	listen_addresses: Vec<SocketAddr>,
-
+	#[arg(help = "Whether to suppress the server name and version header")]
+	#[arg(env = "SURREAL_NO_SERVER_ID_HEADERS", long)]
+	#[arg(default_value_t = false)]
+	hide_server_id_headers: bool,
 	//
 	// Database options
 	//
@@ -142,6 +145,7 @@ pub async fn init(
 		log,
 		tick_interval,
 		no_banner,
+		hide_server_id_headers,
 		..
 	}: StartCommandArguments,
 ) -> Result<(), Error> {
@@ -171,6 +175,7 @@ pub async fn init(
 		user,
 		pass,
 		tick_interval,
+		hide_server_id_headers,
 		crt: web.as_ref().and_then(|x| x.web_crt.clone()),
 		key: web.as_ref().and_then(|x| x.web_key.clone()),
 		engine: None,

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -99,7 +99,7 @@ pub struct StartCommandArguments {
 	#[arg(help = "Whether to suppress the server name and version header")]
 	#[arg(env = "SURREAL_NO_IDENTIFICATION_HEADERS", long)]
 	#[arg(default_value_t = false)]
-	hide_server_id_headers: bool,
+	no_identification_headers: bool,
 	//
 	// Database options
 	//
@@ -145,7 +145,7 @@ pub async fn init(
 		log,
 		tick_interval,
 		no_banner,
-		hide_server_id_headers,
+		no_identification_headers,
 		..
 	}: StartCommandArguments,
 ) -> Result<(), Error> {
@@ -175,7 +175,7 @@ pub async fn init(
 		user,
 		pass,
 		tick_interval,
-		hide_server_id_headers,
+		no_identification_headers,
 		crt: web.as_ref().and_then(|x| x.web_crt.clone()),
 		key: web.as_ref().and_then(|x| x.web_key.clone()),
 		engine: None,

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -97,7 +97,7 @@ pub struct StartCommandArguments {
 	#[arg(default_value = "127.0.0.1:8000")]
 	listen_addresses: Vec<SocketAddr>,
 	#[arg(help = "Whether to suppress the server name and version header")]
-	#[arg(env = "SURREAL_NO_SERVER_ID_HEADERS", long)]
+	#[arg(env = "SURREAL_NO_IDENTIFICATION_HEADERS", long)]
 	#[arg(default_value_t = false)]
 	hide_server_id_headers: bool,
 	//

--- a/src/net/headers/mod.rs
+++ b/src/net/headers/mod.rs
@@ -27,22 +27,22 @@ pub use db::SurrealDatabase;
 pub use id::SurrealId;
 pub use ns::SurrealNamespace;
 
-pub fn add_version_header(disabled: bool) -> SetResponseHeaderLayer<Option<HeaderValue>> {
-	let header_value = if disabled {
-		None
-	} else {
+pub fn add_version_header(enabled: bool) -> SetResponseHeaderLayer<Option<HeaderValue>> {
+	let header_value = if enabled {
 		let val = format!("{PKG_NAME}-{}", *PKG_VERSION);
 		Some(HeaderValue::try_from(val).unwrap())
+	} else {
+		None
 	};
 
 	SetResponseHeaderLayer::if_not_present(VERSION.to_owned(), header_value)
 }
 
-pub fn add_server_header(disabled: bool) -> SetResponseHeaderLayer<Option<HeaderValue>> {
-	let header_value = if disabled {
-		None
-	} else {
+pub fn add_server_header(enabled: bool) -> SetResponseHeaderLayer<Option<HeaderValue>> {
+	let header_value = if enabled {
 		Some(HeaderValue::try_from(SERVER_NAME).unwrap())
+	} else {
+		None
 	};
 
 	SetResponseHeaderLayer::if_not_present(SERVER, header_value)

--- a/src/net/headers/mod.rs
+++ b/src/net/headers/mod.rs
@@ -27,13 +27,25 @@ pub use db::SurrealDatabase;
 pub use id::SurrealId;
 pub use ns::SurrealNamespace;
 
-pub fn add_version_header() -> SetResponseHeaderLayer<HeaderValue> {
-	let val = format!("{PKG_NAME}-{}", *PKG_VERSION);
-	SetResponseHeaderLayer::if_not_present(VERSION.to_owned(), HeaderValue::try_from(val).unwrap())
+pub fn add_version_header(disabled: bool) -> SetResponseHeaderLayer<Option<HeaderValue>> {
+	let header_value = if disabled {
+		None
+	} else {
+		let val = format!("{PKG_NAME}-{}", *PKG_VERSION);
+		Some(HeaderValue::try_from(val).unwrap())
+	};
+
+	SetResponseHeaderLayer::if_not_present(VERSION.to_owned(), header_value)
 }
 
-pub fn add_server_header() -> SetResponseHeaderLayer<HeaderValue> {
-	SetResponseHeaderLayer::if_not_present(SERVER, HeaderValue::try_from(SERVER_NAME).unwrap())
+pub fn add_server_header(disabled: bool) -> SetResponseHeaderLayer<Option<HeaderValue>> {
+	let header_value = if disabled {
+		None
+	} else {
+		Some(HeaderValue::try_from(SERVER_NAME).unwrap())
+	};
+
+	SetResponseHeaderLayer::if_not_present(SERVER, header_value)
 }
 
 // Parse a TypedHeader, returning None if the header is missing and an error if the header is invalid.

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -137,8 +137,8 @@ pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 		.layer(HttpMetricsLayer)
 		.layer(SetSensitiveResponseHeadersLayer::from_shared(headers))
 		.layer(AsyncRequireAuthorizationLayer::new(auth::SurrealAuth))
-		.layer(headers::add_server_header(opt.hide_server_id_headers))
-		.layer(headers::add_version_header(opt.hide_server_id_headers))
+		.layer(headers::add_server_header(opt.no_identification_headers))
+		.layer(headers::add_version_header(opt.no_identification_headers))
 		.layer(
 			CorsLayer::new()
 				.allow_methods([

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -137,8 +137,8 @@ pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 		.layer(HttpMetricsLayer)
 		.layer(SetSensitiveResponseHeadersLayer::from_shared(headers))
 		.layer(AsyncRequireAuthorizationLayer::new(auth::SurrealAuth))
-		.layer(headers::add_server_header(opt.no_identification_headers))
-		.layer(headers::add_version_header(opt.no_identification_headers))
+		.layer(headers::add_server_header(!opt.no_identification_headers))
+		.layer(headers::add_version_header(!opt.no_identification_headers))
 		.layer(
 			CorsLayer::new()
 				.allow_methods([

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -137,8 +137,8 @@ pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 		.layer(HttpMetricsLayer)
 		.layer(SetSensitiveResponseHeadersLayer::from_shared(headers))
 		.layer(AsyncRequireAuthorizationLayer::new(auth::SurrealAuth))
-		.layer(headers::add_server_header())
-		.layer(headers::add_version_header())
+		.layer(headers::add_server_header(opt.hide_server_id_headers))
+		.layer(headers::add_version_header(opt.hide_server_id_headers))
 		.layer(
 			CorsLayer::new()
 				.allow_methods([

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -11,7 +11,7 @@ mod http_integration {
 	use test_log::test;
 	use ulid::Ulid;
 
-	use super::common::{self, PASS, StartServerArguments, USER};
+	use super::common::{self, StartServerArguments, PASS, USER};
 
 	#[test(tokio::test)]
 	async fn basic_auth() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -379,7 +379,6 @@ mod http_integration {
 		Ok(())
 	}
 
-
 	#[test(tokio::test)]
 	async fn import_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 		let (addr, _server) = common::start_server_with_defaults().await.unwrap();

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -11,7 +11,7 @@ mod http_integration {
 	use test_log::test;
 	use ulid::Ulid;
 
-	use super::common::{self, PASS, USER};
+	use super::common::{self, PASS, StartServerArguments, USER};
 
 	#[test(tokio::test)]
 	async fn basic_auth() -> Result<(), Box<dyn std::error::Error>> {
@@ -351,6 +351,34 @@ mod http_integration {
 
 		Ok(())
 	}
+
+	#[test(tokio::test)]
+	async fn no_server_id_headers() -> Result<(), Box<dyn std::error::Error>> {
+		// default server has the id headers
+		{
+			let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+			let url = &format!("http://{addr}/health");
+
+			let res = Client::default().get(url).send().await?;
+			assert!(res.headers().contains_key("server"));
+			assert!(res.headers().contains_key("surreal-version"));
+		}
+
+		// turn on the no-identification-headers option to suppress headers
+		{
+			let mut start_server_arguments = StartServerArguments::default();
+			start_server_arguments.args.push_str(" --no-identification-headers");
+			let (addr, _server) = common::start_server(start_server_arguments).await.unwrap();
+			let url = &format!("http://{addr}/health");
+
+			let res = Client::default().get(url).send().await?;
+			assert!(!res.headers().contains_key("server"));
+			assert!(!res.headers().contains_key("surreal-version"));
+		}
+
+		Ok(())
+	}
+
 
 	#[test(tokio::test)]
 	async fn import_endpoint() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
remove-version-and-server-headers had recent pushes 29 minutes ago Add a hide_server_id_headers option that suppresses the `surreal-version` and `server` headers

Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Offering up information such as server running and the particular version can make it easier for bad actors to exploit known vulnerabilities. 

## What does this change do?

This adds a CLI option to not emit the `server` and `surreal-version` headers. By setting this flag, the server no longer emits this information.

## What is your testing strategy?

Integration test added.

Also tested manually. Starting the server without the flag set, curl and check the headers are present. Start the server again with the flag set - use curl to confirm the headers are not present. 


## Is this related to any issues?

Closes #2924 

## Does this change need documentation?

Server options need updating e.g. https://github.com/surrealdb/docs.surrealdb.com/blob/main/doc-surrealdb_versioned_docs/version-1.x/cli/start.mdx?plain=1#L196

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
