### PR TITLE
SUR-347 - Live Queries error when no change feed

### DIFF
--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1044,7 +1044,7 @@ impl Serialize for Error {
 
 #[derive(Error, Debug)]
 #[non_exhaustive]
-pub(crate) enum LiveQueryCause {
+pub enum LiveQueryCause {
 	#[doc(hidden)]
 	#[error("The Live Query must have a change feed for it it work")]
 	MissingChangeFeed,

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -923,6 +923,10 @@ pub enum Error {
 	/// A node task has failed
 	#[error("A node task has failed: {0}")]
 	NodeAgent(&'static str),
+
+	/// An error related to live query occurred
+	#[error("Failed to process Live Query: {0}")]
+	LiveQueryError(LiveQueryCause),
 }
 
 impl From<Error> for String {
@@ -1036,4 +1040,15 @@ impl Serialize for Error {
 	{
 		serializer.serialize_str(self.to_string().as_str())
 	}
+}
+
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub(crate) enum LiveQueryCause {
+	#[doc(hidden)]
+	#[error("The Live Query must have a change feed for it it work")]
+	MissingChangeFeed,
+	#[doc(hidden)]
+	#[error("The Live Query must have a change feed that includes relative changes")]
+	ChangeFeedNoOriginal,
 }

--- a/core/src/sql/statements/live.rs
+++ b/core/src/sql/statements/live.rs
@@ -150,14 +150,14 @@ impl LiveStatement {
 	async fn validate_change_feed_valid(
 		&self,
 		tx: &mut MutexGuard<'_, crate::kvs::Transaction>,
-		ns: &String,
-		db: &String,
+		ns: &str,
+		db: &str,
 		tb: &Table,
 	) -> Result<(), Error> {
 		// Find the table definition
 		let tb_definition = tx.get_and_cache_tb(ns, db, tb).await.map_err(|e| match e {
 			Error::TbNotFound {
-				value,
+				value: _tb,
 			} => Error::LiveQueryError(LiveQueryCause::MissingChangeFeed),
 			_ => e,
 		})?;

--- a/lib/tests/live.rs
+++ b/lib/tests/live.rs
@@ -8,12 +8,34 @@ use surrealdb::fflags::FFLAGS;
 use surrealdb::sql::Value;
 
 #[tokio::test]
+async fn live_query_fails_if_no_change_feed() -> Result<(), Error> {
+	if !FFLAGS.change_feed_live_queries.enabled() {
+		return Ok(());
+	}
+	let sql = "
+		LIVE SELECT * FROM lq_test_123;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test").with_rt(true);
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 1);
+	let res = res.remove(0).result;
+	assert!(res.is_err(), "{:?}", res);
+	let err = res.as_ref().err().unwrap();
+	assert_eq!(
+		format!("{}", err),
+		"Failed to process Live Query: The Live Query must have a change feed for it it work"
+	);
+	Ok(())
+}
+
+#[tokio::test]
 async fn live_query_sends_registered_lq_details() -> Result<(), Error> {
 	if !FFLAGS.change_feed_live_queries.enabled() {
 		return Ok(());
 	}
 	let sql = "
-		DEFINE TABLE lq_test_123 CHANGEFEED 10m;
+		DEFINE TABLE lq_test_123 CHANGEFEED 10m INCLUDE ORIGINAL;
 		LIVE SELECT * FROM lq_test_123;
 	";
 	let dbs = new_ds().await?;
@@ -26,7 +48,7 @@ async fn live_query_sends_registered_lq_details() -> Result<(), Error> {
 	assert!(tmp.is_ok());
 
 	// Live query returned a valid uuid
-	let actual = res.remove(0).result?;
+	let actual = res.remove(0).result.unwrap();
 	let live_id = match actual {
 		Value::Uuid(live_id) => live_id,
 		_ => panic!("Expected a UUID"),


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Live Queries require change feeds to correctly function. They should error in that case, when a change feed does not exist or is mis-configured

## What does this change do?

Adds errors to live queries when badly configured

## What is your testing strategy?

Local against fflag

## Is this related to any issues?

SUR-347, lq v2

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

- [ ] No documentation needed
- [x] https://github.com/surrealdb/docs.surrealdb.com/issues/445

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
