### PR TITLE
Add `#[non_exhaustive]` to core structs and enums

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -125,7 +125,7 @@ args = ["test", "--locked", "--no-default-features", "--features", "${_TEST_FEAT
 
 [tasks.ci-api-integration-http]
 category = "CI - INTEGRATION TESTS"
-env = { _TEST_API_ENGINE = "http", _TEST_FEATURES = "protocol-http" }
+env = { _TEST_API_ENGINE = "http", _TEST_FEATURES = "protocol-http,sql2", RUSTFLAGS = "--cfg surrealdb_unstable" }
 run_task = "ci-api-integration"
 
 [tasks.ci-api-integration-ws]
@@ -135,7 +135,7 @@ run_task = "ci-api-integration"
 
 [tasks.ci-api-integration-any]
 category = "CI - INTEGRATION TESTS"
-env = { _TEST_API_ENGINE = "any", _TEST_FEATURES = "protocol-http" }
+env = { _TEST_API_ENGINE = "any", _TEST_FEATURES = "protocol-http,sql2", RUSTFLAGS = "--cfg surrealdb_unstable" }
 run_task = "ci-api-integration"
 
 #

--- a/core/src/cf/mutations.rs
+++ b/core/src/cf/mutations.rs
@@ -15,6 +15,7 @@ use std::fmt::{self, Display, Formatter};
 // Mutation is a single mutation to a table.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub enum TableMutation {
 	// Although the Value is supposed to contain a field "id" of Thing,
 	// we do include it in the first field for convenience.
@@ -43,6 +44,7 @@ impl From<DefineTableStatement> for Value {
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct TableMutations(pub String, pub Vec<TableMutation>);
 
 impl TableMutations {
@@ -53,6 +55,7 @@ impl TableMutations {
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct DatabaseMutation(pub Vec<TableMutations>);
 
 impl DatabaseMutation {
@@ -70,6 +73,7 @@ impl Default for DatabaseMutation {
 // Change is a set of mutations made to a table at the specific timestamp.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct ChangeSet(pub [u8; 10], pub DatabaseMutation);
 
 impl TableMutation {
@@ -180,6 +184,7 @@ impl Display for ChangeSet {
 // WriteMutationSet is a set of mutations to be to a table at the specific timestamp.
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
+#[non_exhaustive]
 pub struct WriteMutationSet(pub Vec<TableMutations>);
 
 impl WriteMutationSet {

--- a/core/src/cf/writer.rs
+++ b/core/src/cf/writer.rs
@@ -16,15 +16,18 @@ use std::collections::HashMap;
 // value = serialized table mutations
 type PreparedWrite = (Vec<u8>, Vec<u8>, Vec<u8>, crate::kvs::Val);
 
+#[non_exhaustive]
 pub struct Writer {
 	buf: Buffer,
 }
 
+#[non_exhaustive]
 pub struct Buffer {
 	pub b: HashMap<ChangeKey, TableMutations>,
 }
 
 #[derive(Hash, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub struct ChangeKey {
 	pub ns: String,
 	pub db: String,

--- a/core/src/ctx/cancellation.rs
+++ b/core/src/ctx/cancellation.rs
@@ -6,6 +6,7 @@ use trice::Instant;
 
 /// A 'static view into the cancellation status of a Context.
 #[derive(Clone, Debug, Default)]
+#[non_exhaustive]
 pub struct Cancellation {
 	deadline: Option<Instant>,
 	cancellations: Vec<Arc<AtomicBool>>,

--- a/core/src/ctx/canceller.rs
+++ b/core/src/ctx/canceller.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 #[derive(Default, Clone)]
+#[non_exhaustive]
 pub struct Canceller {
 	/// A reference to the canceled value of a context.
 	cancelled: Arc<AtomicBool>,

--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -50,6 +50,7 @@ impl<'a> From<&'a Value> for Cow<'a, Value> {
 		Cow::Borrowed(v)
 	}
 }
+#[non_exhaustive]
 pub struct Context<'a> {
 	// An optional parent context.
 	parent: Option<&'a Context<'a>>,

--- a/core/src/ctx/reason.rs
+++ b/core/src/ctx/reason.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::io;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum Reason {
 	Timedout,
 	Canceled,

--- a/core/src/dbs/capabilities.rs
+++ b/core/src/dbs/capabilities.rs
@@ -10,6 +10,7 @@ pub trait Target {
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct FuncTarget(pub String, pub Option<String>);
 
 impl std::fmt::Display for FuncTarget {
@@ -48,6 +49,7 @@ impl std::str::FromStr for FuncTarget {
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum NetTarget {
 	Host(url::Host<String>, Option<u16>),
 	IPNet(ipnet::IpNet),
@@ -123,6 +125,7 @@ impl std::str::FromStr for NetTarget {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Targets<T: Target + Hash + Eq + PartialEq> {
 	None,
 	Some(HashSet<T>),
@@ -154,6 +157,7 @@ impl<T: Target + Hash + Eq + PartialEq + std::fmt::Display> std::fmt::Display fo
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Capabilities {
 	scripting: bool,
 	guest_access: bool,

--- a/core/src/dbs/lifecycle.rs
+++ b/core/src/dbs/lifecycle.rs
@@ -1,5 +1,6 @@
 /// LoggingLifecycle is used to create log messages upon creation, and log messages when it is dropped
 #[doc(hidden)]
+#[non_exhaustive]
 pub struct LoggingLifecycle {
 	identifier: String,
 }

--- a/core/src/dbs/node.rs
+++ b/core/src/dbs/node.rs
@@ -10,6 +10,7 @@ use std::ops::{Add, Sub};
 // have a better structure.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, PartialOrd, Hash, Store)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct ClusterMembership {
 	pub name: String,
 	// TiKV = TiKV TSO Timestamp as u64
@@ -23,6 +24,7 @@ pub struct ClusterMembership {
 	Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Ord, PartialOrd, Hash, Store, Default,
 )]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Timestamp {
 	pub value: u64,
 }
@@ -39,6 +41,7 @@ impl From<u64> for Timestamp {
 // conflicts when you have Store and Key derive macros.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, PartialOrd, Hash, Key)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct KeyTimestamp {
 	pub value: u64,
 }

--- a/core/src/dbs/notification.rs
+++ b/core/src/dbs/notification.rs
@@ -46,3 +46,14 @@ impl Display for Notification {
 		write!(f, "{}", obj)
 	}
 }
+
+impl Notification {
+	/// Construct a new notification
+	pub const fn new(id: Uuid, action: Action, result: Value) -> Self {
+		Self {
+			id,
+			action,
+			result,
+		}
+	}
+}

--- a/core/src/dbs/notification.rs
+++ b/core/src/dbs/notification.rs
@@ -6,6 +6,7 @@ use std::fmt::{self, Debug, Display};
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Action {
 	Create,
 	Update,
@@ -24,6 +25,7 @@ impl Display for Action {
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Notification {
 	/// The id of the LIVE query to which this notification belongs
 	pub id: Uuid,

--- a/core/src/dbs/options.rs
+++ b/core/src/dbs/options.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 /// whether field/event/table queries should be processed (useful
 /// when importing data, where these queries might fail).
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Options {
 	/// Current Node ID
 	id: Option<Uuid>,
@@ -51,6 +52,7 @@ pub struct Options {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum Force {
 	All,
 	None,

--- a/core/src/dbs/response.rs
+++ b/core/src/dbs/response.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Response";
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum QueryType {
 	// Any kind of query
 	Other,
@@ -21,6 +22,7 @@ pub enum QueryType {
 
 /// The return value when running a query set on the database.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct Response {
 	pub time: Duration,
 	pub result: Result<Value, Error>,
@@ -44,6 +46,7 @@ impl Response {
 #[serde(rename_all = "UPPERCASE")]
 #[revisioned(revision = 1)]
 #[doc(hidden)]
+#[non_exhaustive]
 pub enum Status {
 	Ok,
 	Err,
@@ -73,6 +76,7 @@ impl Serialize for Response {
 #[derive(Debug, Serialize, Deserialize)]
 #[revisioned(revision = 1)]
 #[doc(hidden)]
+#[non_exhaustive]
 pub struct QueryMethodResponse {
 	pub time: String,
 	pub status: Status,

--- a/core/src/dbs/session.rs
+++ b/core/src/dbs/session.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 /// Specifies the current session information when processing a query.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct Session {
 	/// The current session [`Auth`] information
 	pub au: Arc<Auth>,

--- a/core/src/doc/document.rs
+++ b/core/src/doc/document.rs
@@ -25,6 +25,7 @@ pub(crate) struct Document<'a> {
 	pub(super) current: CursorDoc<'a>,
 }
 
+#[non_exhaustive]
 pub struct CursorDoc<'a> {
 	pub(crate) ir: Option<IteratorRef>,
 	pub(crate) rid: Option<&'a Thing>,

--- a/core/src/exe/try_join_all_buffered.rs
+++ b/core/src/exe/try_join_all_buffered.rs
@@ -10,7 +10,7 @@ use std::task::{Context, Poll};
 pin_project! {
 	/// Future for the [`try_join_all_buffered`] function.
 	#[must_use = "futures do nothing unless you `.await` or poll them"]
-	pub struct TryJoinAllBuffered<F, I>
+	#[non_exhaustive] pub struct TryJoinAllBuffered<F, I>
 	where
 		F: TryFuture,
 		I: Iterator<Item = F>,

--- a/core/src/fflags.rs
+++ b/core/src/fflags.rs
@@ -23,8 +23,8 @@ pub static FFLAGS: FFlags = FFlags {
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[non_exhaustive]
 #[allow(dead_code)]
+#[non_exhaustive]
 pub struct FFlags {
 	pub change_feed_live_queries: FFlagEnabledStatus,
 }
@@ -33,6 +33,7 @@ pub struct FFlags {
 /// All the fields are here as information for people investigating the feature flag.
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[non_exhaustive]
 pub struct FFlagEnabledStatus {
 	pub(crate) enabled_release: bool,
 	pub(crate) enabled_debug: bool,

--- a/core/src/fnc/script/classes/duration.rs
+++ b/core/src/fnc/script/classes/duration.rs
@@ -4,6 +4,7 @@ use crate::sql::duration;
 
 #[derive(Clone, Trace)]
 #[js::class]
+#[non_exhaustive]
 pub struct Duration {
 	#[qjs(skip_trace)]
 	pub(crate) value: Option<duration::Duration>,

--- a/core/src/fnc/script/classes/record.rs
+++ b/core/src/fnc/script/classes/record.rs
@@ -4,6 +4,7 @@ use js::class::Trace;
 
 #[derive(Clone, Trace)]
 #[js::class]
+#[non_exhaustive]
 pub struct Record {
 	#[qjs(skip_trace)]
 	pub(crate) value: thing::Thing,

--- a/core/src/fnc/script/classes/uuid.rs
+++ b/core/src/fnc/script/classes/uuid.rs
@@ -3,6 +3,7 @@ use js::class::Trace;
 
 #[derive(Clone, Trace)]
 #[js::class]
+#[non_exhaustive]
 pub struct Uuid {
 	#[qjs(skip_trace)]
 	pub(crate) value: Option<uuid::Uuid>,

--- a/core/src/fnc/script/fetch/body.rs
+++ b/core/src/fnc/script/fetch/body.rs
@@ -12,12 +12,14 @@ use super::classes::Blob;
 pub type StreamItem = StdResult<Bytes, RequestError>;
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub enum BodyKind {
 	Buffer,
 	String,
 	Blob(String),
 }
 
+#[non_exhaustive]
 pub enum BodyData {
 	Buffer(Bytes),
 	Stream(RefCell<ReadableStream<StreamItem>>),
@@ -28,6 +30,7 @@ pub enum BodyData {
 /// A struct representing the body mixin.
 ///
 /// Implements [`FromJs`] for conversion from `Blob`, `ArrayBuffer`, any `TypedBuffer` and `String`.
+#[non_exhaustive]
 pub struct Body {
 	/// The type of body
 	pub kind: BodyKind,

--- a/core/src/fnc/script/fetch/classes/blob.rs
+++ b/core/src/fnc/script/fetch/classes/blob.rs
@@ -8,6 +8,7 @@ use js::{
 };
 
 #[derive(Clone, Copy)]
+#[non_exhaustive]
 pub enum EndingType {
 	Transparent,
 	Native,
@@ -78,6 +79,7 @@ fn normalize_type(mut ty: String) -> String {
 
 #[derive(Clone, Trace)]
 #[js::class]
+#[non_exhaustive]
 pub struct Blob {
 	pub(crate) mime: String,
 	// TODO: make bytes?

--- a/core/src/fnc/script/fetch/classes/form_data.rs
+++ b/core/src/fnc/script/fetch/classes/form_data.rs
@@ -12,6 +12,7 @@ use std::{collections::HashMap, string::String as StdString};
 use crate::fnc::script::fetch::classes::Blob;
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub enum FormDataValue<'js> {
 	String(String<'js>),
 	Blob {
@@ -47,6 +48,7 @@ impl<'js> FormDataValue<'js> {
 
 #[js::class]
 #[derive(Clone, Trace)]
+#[non_exhaustive]
 pub struct FormData<'js> {
 	#[qjs(skip_trace)]
 	pub(crate) values: HashMap<StdString, Vec<FormDataValue<'js>>>,

--- a/core/src/fnc/script/fetch/classes/headers.rs
+++ b/core/src/fnc/script/fetch/classes/headers.rs
@@ -11,6 +11,7 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
 #[derive(Clone, Trace)]
 #[js::class]
+#[non_exhaustive]
 pub struct Headers {
 	#[qjs(skip_trace)]
 	pub(crate) inner: HeaderMap,

--- a/core/src/fnc/script/fetch/classes/request.rs
+++ b/core/src/fnc/script/fetch/classes/request.rs
@@ -6,6 +6,7 @@ use reqwest::Method;
 use crate::fnc::script::fetch::{body::Body, RequestError};
 
 #[derive(Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum RequestMode {
 	Navigate,
 	SameOrigin,
@@ -43,6 +44,7 @@ impl<'js> FromJs<'js> for RequestMode {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum RequestCredentials {
 	Omit,
 	SameOrigin,
@@ -77,6 +79,7 @@ impl<'js> FromJs<'js> for RequestCredentials {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum RequestCache {
 	Default,
 	NoStore,
@@ -120,6 +123,7 @@ impl<'js> FromJs<'js> for RequestCache {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum RequestRedirect {
 	Follow,
 	Error,
@@ -154,6 +158,7 @@ impl<'js> FromJs<'js> for RequestRedirect {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ReferrerPolicy {
 	Empty,
 	NoReferrer,
@@ -204,6 +209,7 @@ impl<'js> FromJs<'js> for ReferrerPolicy {
 	}
 }
 
+#[non_exhaustive]
 pub struct RequestInit<'js> {
 	pub method: Method,
 	pub headers: Class<'js, Headers>,
@@ -374,6 +380,7 @@ use reqwest::{header::HeaderName, Url};
 #[allow(dead_code)]
 #[js::class]
 #[derive(Trace)]
+#[non_exhaustive]
 pub struct Request<'js> {
 	#[qjs(skip_trace)]
 	pub(crate) url: Url,

--- a/core/src/fnc/script/fetch/classes/response/init.rs
+++ b/core/src/fnc/script/fetch/classes/response/init.rs
@@ -10,6 +10,7 @@ use crate::fnc::script::fetch::{classes::Headers, util};
 
 /// Struct containing data from the init argument from the Response constructor.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct ResponseInit<'js> {
 	// u16 instead of reqwest::StatusCode since javascript allows non valid status codes in some
 	// circumstances.

--- a/core/src/fnc/script/fetch/classes/response/mod.rs
+++ b/core/src/fnc/script/fetch/classes/response/mod.rs
@@ -8,6 +8,7 @@ use js::{class::Trace, prelude::Opt, ArrayBuffer, Class, Ctx, Exception, Result,
 
 #[allow(dead_code)]
 #[derive(Clone, Copy)]
+#[non_exhaustive]
 pub enum ResponseType {
 	Basic,
 	Cors,
@@ -29,6 +30,7 @@ use super::{Blob, Headers};
 #[allow(dead_code)]
 #[derive(Trace)]
 #[js::class]
+#[non_exhaustive]
 pub struct Response<'js> {
 	#[qjs(skip_trace)]
 	pub(crate) body: Body,

--- a/core/src/fnc/script/fetch/mod.rs
+++ b/core/src/fnc/script/fetch/mod.rs
@@ -15,6 +15,7 @@ use func::js_fetch;
 // But with how we implement streams RequestError must be clone.
 /// Error returned by the request.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum RequestError {
 	Reqwest(Arc<reqwest::Error>),
 }

--- a/core/src/fnc/script/fetch/stream.rs
+++ b/core/src/fnc/script/fetch/stream.rs
@@ -4,6 +4,7 @@ use channel::Receiver;
 use futures::{FutureExt, Stream, StreamExt};
 
 /// A newtype struct over receiver implementing the [`Stream`] trait.
+#[non_exhaustive]
 pub struct ChannelStream<R>(Receiver<R>);
 
 impl<R> Stream for ChannelStream<R> {
@@ -17,6 +18,7 @@ impl<R> Stream for ChannelStream<R> {
 }
 
 /// A struct representing a Javascript `ReadableStream`.
+#[non_exhaustive]
 pub struct ReadableStream<R>(Pin<Box<dyn Stream<Item = R> + Send + Sync>>);
 
 impl<R> ReadableStream<R> {

--- a/core/src/fnc/script/fetch_stub/mod.rs
+++ b/core/src/fnc/script/fetch_stub/mod.rs
@@ -33,7 +33,7 @@ macro_rules! impl_stub_class {
 			mod $module{
 				use super::*;
 
-				pub struct $name;
+				#[non_exhaustive] pub struct $name;
 
 				impl<'js> Trace<'js> for $name{
 					fn trace<'a>(&self, _tracer: Tracer<'a, 'js>){}

--- a/core/src/fnc/script/modules/os.rs
+++ b/core/src/fnc/script/modules/os.rs
@@ -14,6 +14,7 @@ pub fn platform() -> &'static str {
 	crate::env::os()
 }
 
+#[non_exhaustive]
 pub struct Package;
 
 impl ModuleDef for Package {

--- a/core/src/fnc/script/modules/surrealdb/functions/array.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/array.rs
@@ -2,6 +2,7 @@ use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
 mod sort;
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/array/sort.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/array/sort.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/bytes.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/bytes.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/crypto.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/crypto.rs
@@ -6,6 +6,7 @@ mod bcrypt;
 mod pbkdf2;
 mod scrypt;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/crypto/argon2.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/crypto/argon2.rs
@@ -2,6 +2,7 @@ use super::super::fut;
 use crate::fnc::script::modules::impl_module_def;
 use js::prelude::Async;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/crypto/bcrypt.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/crypto/bcrypt.rs
@@ -2,6 +2,7 @@ use super::super::fut;
 use crate::fnc::script::modules::impl_module_def;
 use js::prelude::Async;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/crypto/pbkdf2.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/crypto/pbkdf2.rs
@@ -2,6 +2,7 @@ use super::super::fut;
 use crate::fnc::script::modules::impl_module_def;
 use js::prelude::Async;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/crypto/scrypt.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/crypto/scrypt.rs
@@ -2,6 +2,7 @@ use super::super::fut;
 use crate::fnc::script::modules::impl_module_def;
 use js::prelude::Async;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/duration.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/duration.rs
@@ -3,6 +3,7 @@ use crate::fnc::script::modules::impl_module_def;
 
 mod from;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/duration/from.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/duration/from.rs
@@ -1,6 +1,7 @@
 use super::super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/encoding.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/encoding.rs
@@ -2,6 +2,7 @@ use crate::fnc::script::modules::impl_module_def;
 
 mod base64;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/encoding/base64.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/encoding/base64.rs
@@ -1,6 +1,7 @@
 use super::super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/geo.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/geo.rs
@@ -3,6 +3,7 @@ use crate::fnc::script::modules::impl_module_def;
 
 mod hash;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/geo/hash.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/geo/hash.rs
@@ -1,6 +1,7 @@
 use super::super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/http.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/http.rs
@@ -2,6 +2,7 @@ use super::fut;
 use crate::fnc::script::modules::impl_module_def;
 use js::prelude::Async;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/math.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/math.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/meta.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/meta.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/mod.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/mod.rs
@@ -26,6 +26,7 @@ mod time;
 mod r#type;
 mod vector;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/object.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/object.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/parse.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/parse.rs
@@ -3,6 +3,7 @@ use crate::fnc::script::modules::impl_module_def;
 mod email;
 mod url;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/parse/email.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/parse/email.rs
@@ -1,6 +1,7 @@
 use super::super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/parse/url.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/parse/url.rs
@@ -1,6 +1,7 @@
 use super::super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/rand.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/rand.rs
@@ -5,6 +5,7 @@ use crate::sql::value::Value;
 
 mod uuid;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl js::module::ModuleDef for Package {

--- a/core/src/fnc/script/modules/surrealdb/functions/rand/uuid.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/rand/uuid.rs
@@ -3,6 +3,7 @@ use js::{prelude::Rest, Ctx};
 use super::super::run;
 use crate::sql::value::Value;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl js::module::ModuleDef for Package {

--- a/core/src/fnc/script/modules/surrealdb/functions/search.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/search.rs
@@ -2,6 +2,7 @@ use super::fut;
 use crate::fnc::script::modules::impl_module_def;
 use js::prelude::Async;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/session.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/session.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/string.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/string.rs
@@ -6,6 +6,7 @@ mod is;
 mod semver;
 mod similarity;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/string/distance.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/string/distance.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/string/is.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/string/is.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/string/semver.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/string/semver.rs
@@ -3,6 +3,7 @@ use crate::fnc::script::modules::impl_module_def;
 
 mod inc;
 mod set;
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/string/semver/inc.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/string/semver/inc.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/string/semver/set.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/string/semver/set.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/string/similarity.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/string/similarity.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/time.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/time.rs
@@ -3,6 +3,7 @@ use crate::fnc::script::modules::impl_module_def;
 
 mod from;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/time/from.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/time/from.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/type.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/type.rs
@@ -5,6 +5,7 @@ use js::prelude::Async;
 
 mod is;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/type/is.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/type/is.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/vector.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/vector.rs
@@ -4,6 +4,7 @@ use crate::fnc::script::modules::impl_module_def;
 mod distance;
 mod similarity;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/vector/distance.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/vector/distance.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/functions/vector/similarity.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/vector/similarity.rs
@@ -1,6 +1,7 @@
 use super::run;
 use crate::fnc::script::modules::impl_module_def;
 
+#[non_exhaustive]
 pub struct Package;
 
 impl_module_def!(

--- a/core/src/fnc/script/modules/surrealdb/mod.rs
+++ b/core/src/fnc/script/modules/surrealdb/mod.rs
@@ -9,6 +9,7 @@ use self::query::{QueryContext, QUERY_DATA_PROP_NAME};
 mod functions;
 pub mod query;
 
+#[non_exhaustive]
 pub struct Package;
 
 #[js::function]

--- a/core/src/fnc/script/modules/surrealdb/query/classes.rs
+++ b/core/src/fnc/script/modules/surrealdb/query/classes.rs
@@ -10,6 +10,7 @@ use js::{
 
 #[js::class]
 #[derive(Trace, Clone)]
+#[non_exhaustive]
 pub struct Query {
 	#[qjs(skip_trace)]
 	pub(crate) query: Subquery,
@@ -18,6 +19,7 @@ pub struct Query {
 }
 
 #[derive(Default, Clone)]
+#[non_exhaustive]
 pub struct QueryVariables(pub BTreeMap<String, SurValue>);
 
 impl QueryVariables {

--- a/core/src/fnc/script/modules/surrealdb/query/mod.rs
+++ b/core/src/fnc/script/modules/surrealdb/query/mod.rs
@@ -19,6 +19,7 @@ pub use classes::Query;
 pub const QUERY_DATA_PROP_NAME: &str = "__query_context__";
 
 /// A class to carry the data to run subqueries.
+#[non_exhaustive]
 pub struct QueryContext<'js> {
 	pub context: &'js Context<'js>,
 	pub opt: &'js Options,

--- a/core/src/iam/auth.rs
+++ b/core/src/iam/auth.rs
@@ -8,6 +8,7 @@ use super::{is_allowed, Action, Actor, Error, Level, Resource, Role};
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Auth {
 	actor: Actor,
 }

--- a/core/src/iam/entities/action.rs
+++ b/core/src/iam/entities/action.rs
@@ -6,6 +6,7 @@ use crate::dbs::Statement;
 
 // TODO(sgirones): For now keep it simple. In the future, we will allow for custom roles and policies using a more exhaustive list of actions and resources.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd)]
+#[non_exhaustive]
 pub enum Action {
 	View,
 	Edit,

--- a/core/src/iam/entities/resources/actor.rs
+++ b/core/src/iam/entities/resources/actor.rs
@@ -16,6 +16,7 @@ use crate::sql::statements::{DefineTokenStatement, DefineUserStatement};
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Actor {
 	res: Resource,
 	roles: Vec<Role>,

--- a/core/src/iam/entities/resources/level.rs
+++ b/core/src/iam/entities/resources/level.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Deserialize, Serialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Level {
 	#[default]
 	No,

--- a/core/src/iam/entities/resources/resource.rs
+++ b/core/src/iam/entities/resources/resource.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum ResourceKind {
 	#[default]
 	Any,
@@ -81,6 +82,7 @@ impl ResourceKind {
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Resource(String, ResourceKind, Level);
 
 impl std::fmt::Display for Resource {

--- a/core/src/iam/entities/roles.rs
+++ b/core/src/iam/entities/roles.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 #[derive(Hash, Clone, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Role {
 	#[default]
 	Viewer,

--- a/core/src/iam/mod.rs
+++ b/core/src/iam/mod.rs
@@ -19,6 +19,7 @@ pub use self::auth::*;
 pub use self::entities::*;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
 	#[error("Invalid role '{0}'")]
 	InvalidRole(String),

--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 pub static HEADER: Lazy<Header> = Lazy::new(|| Header::new(Algorithm::HS512));
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[non_exhaustive]
 pub struct Claims {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub iat: Option<i64>,

--- a/core/src/idg/u32.rs
+++ b/core/src/idg/u32.rs
@@ -12,6 +12,7 @@ pub(crate) type Id = u32;
 // This doesn't do any variable-length encoding, so it's not as space efficient as it could be.
 // It is used to generate ids for any SurrealDB objects that need aliases (e.g. namespaces, databases, tables, indexes, etc.)
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct U32 {
 	state_key: Key,
 	available_ids: Option<RoaringBitmap>,

--- a/core/src/idx/mod.rs
+++ b/core/src/idx/mod.rs
@@ -28,6 +28,7 @@ use serde::Serialize;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct IndexKeyBase {
 	inner: Arc<Inner>,
 }

--- a/core/src/idx/trees/bkeys.rs
+++ b/core/src/idx/trees/bkeys.rs
@@ -32,6 +32,7 @@ pub trait BKeys: Default + Debug + Display + Sized {
 	fn compile(&mut self) {}
 }
 
+#[non_exhaustive]
 pub struct SplitKeys<BK>
 where
 	BK: BKeys,
@@ -44,6 +45,7 @@ where
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct FstKeys {
 	i: Inner,
 }
@@ -285,6 +287,7 @@ impl Display for FstKeys {
 }
 
 #[derive(Default, Debug, Clone)]
+#[non_exhaustive]
 pub struct TrieKeys {
 	keys: Trie<Key, Payload>,
 }

--- a/core/src/idx/trees/btree.rs
+++ b/core/src/idx/trees/btree.rs
@@ -18,6 +18,7 @@ pub type Payload = u64;
 type BStoredNode<BK> = StoredNode<BTreeNode<BK>>;
 pub(in crate::idx) type BTreeStore<BK> = TreeStore<BTreeNode<BK>>;
 
+#[non_exhaustive]
 pub struct BTree<BK>
 where
 	BK: BKeys,
@@ -29,6 +30,7 @@ where
 
 #[derive(Clone, Serialize, Deserialize)]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct BState {
 	minimum_degree: u32,
 	root: Option<NodeId>,
@@ -143,6 +145,7 @@ impl From<BStatistics> for Value {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum BTreeNode<BK>
 where
 	BK: BKeys + Clone,

--- a/core/src/idx/trees/mtree.rs
+++ b/core/src/idx/trees/mtree.rs
@@ -279,6 +279,7 @@ impl KnnResultBuilder {
 	}
 }
 
+#[non_exhaustive]
 pub struct KnnResult {
 	docs: VecDeque<DocId>,
 	#[cfg(debug_assertions)]
@@ -288,6 +289,7 @@ pub struct KnnResult {
 
 // https://en.wikipedia.org/wiki/M-tree
 // https://arxiv.org/pdf/1004.4216.pdf
+#[non_exhaustive]
 pub struct MTree {
 	state: MState,
 	distance: Distance,
@@ -1336,6 +1338,7 @@ type LeafMap = BTreeMap<SharedVector, ObjectProperties>;
 /// Both LeafNodes and InternalNodes are implemented as a map.
 /// In this map, the key is an object, and the values correspond to its properties.
 /// In essence, an entry can be visualized as a tuple of the form (object, properties).
+#[non_exhaustive]
 pub enum MTreeNode {
 	Internal(InternalNode),
 	Leaf(LeafNode),
@@ -1549,6 +1552,7 @@ impl From<MtStatistics> for Value {
 
 #[derive(Clone, Serialize, Deserialize)]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct MState {
 	capacity: u16,
 	root: Option<NodeId>,
@@ -1570,6 +1574,7 @@ impl MState {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
+#[non_exhaustive]
 pub struct RoutingProperties {
 	// Reference to the node
 	node: NodeId,
@@ -1580,6 +1585,7 @@ pub struct RoutingProperties {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct ObjectProperties {
 	// Distance to its parent object
 	parent_dist: f64,

--- a/core/src/idx/trees/store/cache.rs
+++ b/core/src/idx/trees/store/cache.rs
@@ -79,6 +79,7 @@ where
 }
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub enum TreeCache<N>
 where
 	N: TreeNode + Debug + Clone + Display,
@@ -117,6 +118,7 @@ where
 	}
 }
 
+#[non_exhaustive]
 pub struct TreeLruCache<N>
 where
 	N: TreeNode + Debug + Clone + Display,
@@ -165,6 +167,7 @@ where
 	}
 }
 
+#[non_exhaustive]
 pub struct TreeFullCache<N>
 where
 	N: TreeNode + Debug + Clone,

--- a/core/src/idx/trees/store/mod.rs
+++ b/core/src/idx/trees/store/mod.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 pub type NodeId = u64;
 
+#[non_exhaustive]
 pub enum TreeStore<N>
 where
 	N: TreeNode + Debug + Clone,
@@ -98,6 +99,7 @@ where
 }
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub enum TreeNodeProvider {
 	DocIds(IndexKeyBase),
 	DocLengths(IndexKeyBase),
@@ -143,6 +145,7 @@ impl TreeNodeProvider {
 	}
 }
 
+#[non_exhaustive]
 pub struct StoredNode<N>
 where
 	N: Clone + Display,
@@ -184,6 +187,7 @@ pub trait TreeNode: Debug + Clone + Display {
 }
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct IndexStores(Arc<Inner>);
 
 struct Inner {

--- a/core/src/idx/trees/store/tree.rs
+++ b/core/src/idx/trees/store/tree.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
+#[non_exhaustive]
 pub struct TreeWrite<N>
 where
 	N: TreeNode + Debug + Clone,
@@ -147,6 +148,7 @@ where
 	}
 }
 
+#[non_exhaustive]
 pub struct TreeRead<N>
 where
 	N: TreeNode + Debug + Clone,

--- a/core/src/idx/trees/vector.rs
+++ b/core/src/idx/trees/vector.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 /// In the context of a Symmetric MTree index, the term object refers to a vector, representing the indexed item.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Vector {
 	F64(Vec<f64>),
 	F32(Vec<f32>),

--- a/core/src/key/change/mod.rs
+++ b/core/src/key/change/mod.rs
@@ -10,6 +10,7 @@ use std::str;
 
 // Cf stands for change feeds
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Cf<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/all.rs
+++ b/core/src/key/database/all.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct All<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/az.rs
+++ b/core/src/key/database/az.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Az<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/fc.rs
+++ b/core/src/key/database/fc.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Fc<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/ml.rs
+++ b/core/src/key/database/ml.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Ml<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/pa.rs
+++ b/core/src/key/database/pa.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Pa<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/sc.rs
+++ b/core/src/key/database/sc.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Sc<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/tb.rs
+++ b/core/src/key/database/tb.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Tb<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/ti.rs
+++ b/core/src/key/database/ti.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 // Table ID generator
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Ti {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/tk.rs
+++ b/core/src/key/database/tk.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Tk<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/ts.rs
+++ b/core/src/key/database/ts.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 // Each Ts key is suffixed by a timestamp.
 // The value is the versionstamp that corresponds to the timestamp.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Ts<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/us.rs
+++ b/core/src/key/database/us.rs
@@ -4,6 +4,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Us<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/database/vs.rs
+++ b/core/src/key/database/vs.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 // Vs stands for Database Versionstamp
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Vs<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/error.rs
+++ b/core/src/key/error.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum KeyCategory {
 	/// This category is reserved for cases when we do not know the category
 	/// It should be caught and re-populated with the correct category where appropriate

--- a/core/src/key/graph/mod.rs
+++ b/core/src/key/graph/mod.rs
@@ -101,6 +101,7 @@ impl<'a> PrefixFt<'a> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Graph<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/all.rs
+++ b/core/src/key/index/all.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct All<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bc.rs
+++ b/core/src/key/index/bc.rs
@@ -6,6 +6,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bc<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bd.rs
+++ b/core/src/key/index/bd.rs
@@ -6,6 +6,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bd<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bf.rs
+++ b/core/src/key/index/bf.rs
@@ -7,6 +7,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bf<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bi.rs
+++ b/core/src/key/index/bi.rs
@@ -6,6 +6,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bi<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bk.rs
+++ b/core/src/key/index/bk.rs
@@ -6,6 +6,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bk<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bl.rs
+++ b/core/src/key/index/bl.rs
@@ -6,6 +6,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bl<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bo.rs
+++ b/core/src/key/index/bo.rs
@@ -7,6 +7,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bo<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bp.rs
+++ b/core/src/key/index/bp.rs
@@ -6,6 +6,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bp<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bs.rs
+++ b/core/src/key/index/bs.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bs<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bt.rs
+++ b/core/src/key/index/bt.rs
@@ -6,6 +6,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bt<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/bu.rs
+++ b/core/src/key/index/bu.rs
@@ -6,6 +6,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Bu<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/mod.rs
+++ b/core/src/key/index/mod.rs
@@ -87,6 +87,7 @@ impl<'a> PrefixIds<'a> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Index<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/index/vm.rs
+++ b/core/src/key/index/vm.rs
@@ -4,6 +4,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Vm<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/namespace/all.rs
+++ b/core/src/key/namespace/all.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct All<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/namespace/db.rs
+++ b/core/src/key/namespace/db.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Db<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/namespace/di.rs
+++ b/core/src/key/namespace/di.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Di {
 	__: u8,
 	_a: u8,

--- a/core/src/key/namespace/tk.rs
+++ b/core/src/key/namespace/tk.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Tk<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/namespace/us.rs
+++ b/core/src/key/namespace/us.rs
@@ -4,6 +4,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Us<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/node/all.rs
+++ b/core/src/key/node/all.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct All {
 	__: u8,
 	_a: u8,

--- a/core/src/key/node/lq.rs
+++ b/core/src/key/node/lq.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 ///
 /// The value is just the table of the live query as a Strand, which is the missing information from the key path
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Lq<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/root/all.rs
+++ b/core/src/key/root/all.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Kv {
 	__: u8,
 }

--- a/core/src/key/root/hb.rs
+++ b/core/src/key/root/hb.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Hb {
 	__: u8,
 	_a: u8,

--- a/core/src/key/root/nd.rs
+++ b/core/src/key/root/nd.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 // Represents cluster information.
 // In the future, this could also include broadcast addresses and other information.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Nd {
 	__: u8,
 	_a: u8,

--- a/core/src/key/root/ni.rs
+++ b/core/src/key/root/ni.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Ni {
 	__: u8,
 	_a: u8,

--- a/core/src/key/root/ns.rs
+++ b/core/src/key/root/ns.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Ns<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/root/us.rs
+++ b/core/src/key/root/us.rs
@@ -4,6 +4,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Us<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/scope/all.rs
+++ b/core/src/key/scope/all.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Scope<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/scope/tk.rs
+++ b/core/src/key/scope/tk.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Tk<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/table/all.rs
+++ b/core/src/key/table/all.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Table<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/table/ev.rs
+++ b/core/src/key/table/ev.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Ev<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/table/fd.rs
+++ b/core/src/key/table/fd.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Fd<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/table/ft.rs
+++ b/core/src/key/table/ft.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Ft<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/table/ix.rs
+++ b/core/src/key/table/ix.rs
@@ -5,6 +5,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Ix<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/table/lq.rs
+++ b/core/src/key/table/lq.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 ///
 /// The value of the lv is the statement.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Lq<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/key/thing/mod.rs
+++ b/core/src/key/thing/mod.rs
@@ -6,6 +6,7 @@ use derive::Key;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
 pub struct Thing<'a> {
 	__: u8,
 	_a: u8,

--- a/core/src/kvs/cache.rs
+++ b/core/src/kvs/cache.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub enum Entry {
 	// Single definitions
 	Db(Arc<DefineDatabaseStatement>),
@@ -51,6 +52,7 @@ pub enum Entry {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct Cache(pub HashMap<Key, Entry>);
 
 impl Cache {

--- a/core/src/kvs/clock.rs
+++ b/core/src/kvs/clock.rs
@@ -11,6 +11,7 @@ use wasmtimer::std::{SystemTime, UNIX_EPOCH};
 // Traits cannot have async and we need sized structs for Clone + Send + Sync
 #[allow(dead_code)]
 #[derive(Clone)]
+#[non_exhaustive]
 pub enum SizedClock {
 	System(SystemClock),
 	#[cfg(test)]
@@ -34,6 +35,7 @@ impl SizedClock {
 /// FakeClock is a clock that is fully controlled externally.
 /// Use this clock for when you are testing timestamps.
 
+#[non_exhaustive]
 pub struct FakeClock {
 	// Locks necessary for Send
 	now: AtomicU64,
@@ -70,6 +72,7 @@ impl FakeClock {
 /// This is useful when you need unique and partially deterministic timestamps for tests.
 /// Partially deterministic, because you do not have direct control over how many times a clock
 /// is accessed, and due to the nature of async - you neither have order guarantee.
+#[non_exhaustive]
 pub struct IncFakeClock {
 	now: AtomicU64,
 	increment: Duration,
@@ -104,6 +107,7 @@ impl IncFakeClock {
 /// SystemClock is a clock that uses the system time.
 /// Use this when there are no other alternatives.
 #[derive(Clone, Copy)]
+#[non_exhaustive]
 pub struct SystemClock;
 
 impl SystemClock {

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -74,6 +74,7 @@ const NON_PAGED_BATCH_SIZE: u32 = 100_000;
 
 /// The underlying datastore instance which stores the dataset.
 #[allow(dead_code)]
+#[non_exhaustive]
 pub struct Datastore {
 	// The inner datastore type
 	inner: Inner,

--- a/core/src/kvs/fdb/mod.rs
+++ b/core/src/kvs/fdb/mod.rs
@@ -26,11 +26,13 @@ use once_cell::sync::Lazy;
 // run a few queries via surrealdb-sql or via the REST API, and
 // run the following command to what have been saved to FDB:
 //   fdbcli --exec 'getrangekeys \x00 \xff'
+#[non_exhaustive]
 pub struct Datastore {
 	db: foundationdb::Database,
 	_fdbnet: Arc<foundationdb::api::NetworkAutoStop>,
 }
 
+#[non_exhaustive]
 pub struct Transaction {
 	/// Is the transaction complete?
 	done: bool,

--- a/core/src/kvs/indxdb/mod.rs
+++ b/core/src/kvs/indxdb/mod.rs
@@ -7,10 +7,12 @@ use crate::kvs::Val;
 use crate::vs::{try_to_u64_be, u64_to_versionstamp, Versionstamp};
 use std::ops::Range;
 
+#[non_exhaustive]
 pub struct Datastore {
 	db: indxdb::Db,
 }
 
+#[non_exhaustive]
 pub struct Transaction {
 	/// Is the transaction complete?
 	done: bool,

--- a/core/src/kvs/lq_structs.rs
+++ b/core/src/kvs/lq_structs.rs
@@ -10,6 +10,7 @@ use std::cmp::Ordering;
 /// This struct is public because it is used in Live Query errors for v1.
 /// V1 is now deprecated and the struct can be made non-public
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub struct LqValue {
 	pub nd: Uuid,
 	pub ns: String,

--- a/core/src/kvs/mem/mod.rs
+++ b/core/src/kvs/mem/mod.rs
@@ -9,10 +9,12 @@ use crate::kvs::Val;
 use crate::vs::{try_to_u64_be, u64_to_versionstamp, Versionstamp};
 use std::ops::Range;
 
+#[non_exhaustive]
 pub struct Datastore {
 	db: echodb::Db<Key, Val>,
 }
 
+#[non_exhaustive]
 pub struct Transaction {
 	/// Is the transaction complete?
 	done: bool,

--- a/core/src/kvs/rocksdb/mod.rs
+++ b/core/src/kvs/rocksdb/mod.rs
@@ -18,10 +18,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct Datastore {
 	db: Pin<Arc<OptimisticTransactionDB>>,
 }
 
+#[non_exhaustive]
 pub struct Transaction {
 	/// Is the transaction complete?
 	done: bool,

--- a/core/src/kvs/speedb/mod.rs
+++ b/core/src/kvs/speedb/mod.rs
@@ -18,10 +18,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct Datastore {
 	db: Pin<Arc<OptimisticTransactionDB>>,
 }
 
+#[non_exhaustive]
 pub struct Transaction {
 	// Is the transaction complete?
 	done: bool,

--- a/core/src/kvs/surrealkv/mod.rs
+++ b/core/src/kvs/surrealkv/mod.rs
@@ -12,10 +12,12 @@ use surrealkv::Options;
 use surrealkv::Store;
 use surrealkv::Transaction as Tx;
 
+#[non_exhaustive]
 pub struct Datastore {
 	db: Store,
 }
 
+#[non_exhaustive]
 pub struct Transaction {
 	/// Is the transaction complete?
 	done: bool,

--- a/core/src/kvs/tests/helper.rs
+++ b/core/src/kvs/tests/helper.rs
@@ -2,7 +2,8 @@ use crate::dbs::node::Timestamp;
 use crate::err::Error;
 use crate::kvs::clock::{FakeClock, SizedClock};
 
-#[non_exhaustive] pub struct TestContext {
+#[non_exhaustive]
+pub struct TestContext {
 	pub(crate) db: Datastore,
 	pub(crate) kvs: Kvs,
 	// A string identifier for this context.

--- a/core/src/kvs/tests/helper.rs
+++ b/core/src/kvs/tests/helper.rs
@@ -2,7 +2,7 @@ use crate::dbs::node::Timestamp;
 use crate::err::Error;
 use crate::kvs::clock::{FakeClock, SizedClock};
 
-pub struct TestContext {
+#[non_exhaustive] pub struct TestContext {
 	pub(crate) db: Datastore,
 	pub(crate) kvs: Kvs,
 	// A string identifier for this context.

--- a/core/src/kvs/tikv/mod.rs
+++ b/core/src/kvs/tikv/mod.rs
@@ -11,10 +11,12 @@ use tikv::CheckLevel;
 use tikv::TimestampExt;
 use tikv::TransactionOptions;
 
+#[non_exhaustive]
 pub struct Datastore {
 	db: tikv::TransactionClient,
 }
 
+#[non_exhaustive]
 pub struct Transaction {
 	// Is the transaction complete?
 	done: bool,

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -54,11 +54,13 @@ use super::Key;
 use super::Val;
 
 #[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
 pub enum Limit {
 	Unlimited,
 	Limited(u32),
 }
 
+#[non_exhaustive]
 pub struct ScanPage<K>
 where
 	K: Into<Key> + Debug,
@@ -76,6 +78,7 @@ impl From<Range<Vec<u8>>> for ScanPage<Vec<u8>> {
 	}
 }
 
+#[non_exhaustive]
 pub struct ScanResult<K>
 where
 	K: Into<Key> + Debug,
@@ -86,6 +89,7 @@ where
 
 /// A set of undoable updates and requests against a dataset.
 #[allow(dead_code)]
+#[non_exhaustive]
 pub struct Transaction {
 	pub(super) inner: Inner,
 	pub(super) cache: Cache,
@@ -115,6 +119,7 @@ pub(super) enum Inner {
 }
 
 #[derive(Copy, Clone)]
+#[non_exhaustive]
 pub enum TransactionType {
 	Read,
 	Write,
@@ -129,6 +134,7 @@ impl From<bool> for TransactionType {
 	}
 }
 
+#[non_exhaustive]
 pub enum LockType {
 	Pessimistic,
 	Optimistic,

--- a/core/src/options.rs
+++ b/core/src/options.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 /// The defaults are optimal so please only modify these if you know deliberately why you are modifying them.
 #[derive(Clone, Copy, Debug)]
 #[doc(hidden)]
+#[non_exhaustive]
 pub struct EngineOptions {
 	/// The maximum number of live queries that can be created in a single transaction
 	pub new_live_queries_per_transaction: u32,

--- a/core/src/rpc/basic_context.rs
+++ b/core/src/rpc/basic_context.rs
@@ -9,6 +9,7 @@ use crate::{
 
 use super::{args::Take, Data, RpcError};
 
+#[non_exhaustive]
 pub struct BasicRpcContext<'a> {
 	pub kvs: &'a Datastore,
 	pub session: Session,

--- a/core/src/rpc/response.rs
+++ b/core/src/rpc/response.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 // In future, they will possibly be merged to avoid having to keep them in sync.
 #[derive(Debug, Serialize)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Data {
 	/// Generally methods return a `sql::Value`
 	Other(Value),

--- a/core/src/sql/algorithm.rs
+++ b/core/src/sql/algorithm.rs
@@ -5,6 +5,7 @@ use std::fmt;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Algorithm {
 	EdDSA,
 	Es256,

--- a/core/src/sql/array.rs
+++ b/core/src/sql/array.rs
@@ -20,6 +20,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Array";
 #[serde(rename = "$surrealdb::private::sql::Array")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Array(pub Vec<Value>);
 
 impl From<Value> for Array {

--- a/core/src/sql/base.rs
+++ b/core/src/sql/base.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Base {
 	Root,
 	Ns,

--- a/core/src/sql/block.rs
+++ b/core/src/sql/block.rs
@@ -21,6 +21,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Block";
 #[serde(rename = "$surrealdb::private::sql::Block")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Block(pub Vec<Entry>);
 
 impl Deref for Block {
@@ -168,6 +169,7 @@ impl Display for Block {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Entry {
 	Value(Value),
 	Set(SetStatement),

--- a/core/src/sql/bytes.rs
+++ b/core/src/sql/bytes.rs
@@ -10,6 +10,7 @@ use std::ops::Deref;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Bytes(pub(crate) Vec<u8>);
 
 impl Bytes {

--- a/core/src/sql/cast.rs
+++ b/core/src/sql/cast.rs
@@ -15,6 +15,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Cast";
 #[serde(rename = "$surrealdb::private::sql::Cast")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Cast(pub Kind, pub Value);
 
 impl PartialOrd for Cast {

--- a/core/src/sql/change_feed_include.rs
+++ b/core/src/sql/change_feed_include.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
 /// ChangeFeedInclude statements are an appendix
+#[non_exhaustive]
 pub enum ChangeFeedInclude {
 	Original,
 }

--- a/core/src/sql/changefeed.rs
+++ b/core/src/sql/changefeed.rs
@@ -7,6 +7,7 @@ use std::time;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct ChangeFeed {
 	pub expiry: time::Duration,
 	#[revision(start = 2)]

--- a/core/src/sql/cond.rs
+++ b/core/src/sql/cond.rs
@@ -7,6 +7,7 @@ use std::ops::Deref;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Cond(pub Value);
 
 impl Deref for Cond {

--- a/core/src/sql/constant.rs
+++ b/core/src/sql/constant.rs
@@ -17,6 +17,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Constant";
 #[serde(rename = "$surrealdb::private::sql::Constant")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Constant {
 	MathE,
 	MathFrac1Pi,

--- a/core/src/sql/data.rs
+++ b/core/src/sql/data.rs
@@ -12,6 +12,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Data {
 	EmptyExpression,
 	SetExpression(Vec<(Idiom, Operator, Value)>),

--- a/core/src/sql/datetime.rs
+++ b/core/src/sql/datetime.rs
@@ -17,6 +17,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Datetime";
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Datetime")]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Datetime(pub DateTime<Utc>);
 
 impl Default for Datetime {

--- a/core/src/sql/dir.rs
+++ b/core/src/sql/dir.rs
@@ -5,6 +5,7 @@ use std::fmt;
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Dir {
 	In,
 	Out,

--- a/core/src/sql/duration.rs
+++ b/core/src/sql/duration.rs
@@ -23,6 +23,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Duration";
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Duration")]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Duration(pub time::Duration);
 
 impl From<time::Duration> for Duration {

--- a/core/src/sql/edges.rs
+++ b/core/src/sql/edges.rs
@@ -11,6 +11,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Edges";
 #[serde(rename = "$surrealdb::private::sql::Edges")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Edges {
 	pub dir: Dir,
 	pub from: Thing,

--- a/core/src/sql/explain.rs
+++ b/core/src/sql/explain.rs
@@ -5,6 +5,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Explain(pub bool);
 
 impl fmt::Display for Explain {

--- a/core/src/sql/expression.rs
+++ b/core/src/sql/expression.rs
@@ -17,6 +17,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Expression";
 #[serde(rename = "$surrealdb::private::sql::Expression")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Expression {
 	Unary {
 		o: Operator,

--- a/core/src/sql/fetch.rs
+++ b/core/src/sql/fetch.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Fetchs(pub Vec<Fetch>);
 
 impl Deref for Fetchs {
@@ -34,6 +35,7 @@ impl fmt::Display for Fetchs {
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Fetch(pub Idiom);
 
 impl Deref for Fetch {

--- a/core/src/sql/field.rs
+++ b/core/src/sql/field.rs
@@ -13,6 +13,7 @@ use std::ops::Deref;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Fields(pub Vec<Field>, pub bool);
 
 impl Fields {
@@ -238,6 +239,7 @@ impl Fields {
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Field {
 	/// The `*` in `SELECT * FROM ...`
 	#[default]

--- a/core/src/sql/filter.rs
+++ b/core/src/sql/filter.rs
@@ -7,6 +7,7 @@ use std::fmt::Display;
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Filter {
 	Ascii,
 	EdgeNgram(u16, u16),

--- a/core/src/sql/function.rs
+++ b/core/src/sql/function.rs
@@ -24,6 +24,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Function";
 #[serde(rename = "$surrealdb::private::sql::Function")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Function {
 	Normal(String, Vec<Value>),
 	Custom(String, Vec<Value>),

--- a/core/src/sql/future.rs
+++ b/core/src/sql/future.rs
@@ -14,6 +14,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Future";
 #[serde(rename = "$surrealdb::private::sql::Future")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Future(pub Block);
 
 impl From<Value> for Future {

--- a/core/src/sql/geometry.rs
+++ b/core/src/sql/geometry.rs
@@ -19,6 +19,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Geometry";
 #[serde(rename = "$surrealdb::private::sql::Geometry")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Geometry {
 	Point(Point<f64>),
 	Line(LineString<f64>),

--- a/core/src/sql/graph.rs
+++ b/core/src/sql/graph.rs
@@ -15,6 +15,7 @@ use std::fmt::{self, Display, Formatter, Write};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Graph {
 	pub dir: Dir,
 	pub expr: Fields,

--- a/core/src/sql/group.rs
+++ b/core/src/sql/group.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Groups(pub Vec<Group>);
 
 impl Deref for Groups {
@@ -38,6 +39,7 @@ impl Display for Groups {
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Group(pub Idiom);
 
 impl Deref for Group {

--- a/core/src/sql/id.rs
+++ b/core/src/sql/id.rs
@@ -14,6 +14,7 @@ use ulid::Ulid;
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Gen {
 	Rand,
 	Ulid,
@@ -23,6 +24,7 @@ pub enum Gen {
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Id {
 	Number(i64),
 	String(String),

--- a/core/src/sql/ident.rs
+++ b/core/src/sql/ident.rs
@@ -8,6 +8,7 @@ use std::str;
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Ident(#[serde(with = "no_nul_bytes")] pub String);
 
 impl From<String> for Ident {

--- a/core/src/sql/idiom.rs
+++ b/core/src/sql/idiom.rs
@@ -20,6 +20,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Idiom";
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Idioms(pub Vec<Idiom>);
 
 impl Deref for Idioms {
@@ -47,6 +48,7 @@ impl Display for Idioms {
 #[serde(rename = "$surrealdb::private::sql::Idiom")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Idiom(pub Vec<Part>);
 
 impl Deref for Idiom {

--- a/core/src/sql/index.rs
+++ b/core/src/sql/index.rs
@@ -14,6 +14,7 @@ use std::fmt::{Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Index {
 	/// (Basic) non unique
 	#[default]
@@ -29,6 +30,7 @@ pub enum Index {
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct SearchParams {
 	pub az: Ident,
 	pub hl: bool,
@@ -50,6 +52,7 @@ pub struct SearchParams {
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct MTreeParams {
 	pub dimension: u16,
 	#[revision(start = 1, end = 2, convert_fn = "convert_old_distance")]
@@ -85,6 +88,7 @@ impl MTreeParams {
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Distance1 {
 	#[default]
 	Euclidean,
@@ -97,6 +101,7 @@ pub enum Distance1 {
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Distance {
 	Chebyshev,
 	Cosine,
@@ -142,6 +147,7 @@ impl Display for Distance {
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum VectorType {
 	#[default]
 	F64,

--- a/core/src/sql/kind.rs
+++ b/core/src/sql/kind.rs
@@ -6,6 +6,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Kind {
 	Any,
 	Null,

--- a/core/src/sql/language.rs
+++ b/core/src/sql/language.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Language {
 	Arabic,
 	Danish,

--- a/core/src/sql/limit.rs
+++ b/core/src/sql/limit.rs
@@ -11,6 +11,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Limit(pub Value);
 
 impl Limit {

--- a/core/src/sql/mock.rs
+++ b/core/src/sql/mock.rs
@@ -5,6 +5,7 @@ use std::fmt;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Mock";
 
+#[non_exhaustive]
 pub struct IntoIter {
 	model: Mock,
 	index: u64,
@@ -47,6 +48,7 @@ impl Iterator for IntoIter {
 #[serde(rename = "$surrealdb::private::sql::Mock")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Mock {
 	Count(String, u64),
 	Range(String, u64, u64),

--- a/core/src/sql/model.rs
+++ b/core/src/sql/model.rs
@@ -29,6 +29,7 @@ const ARGUMENTS: &str = "The model expects 1 argument. The argument can be eithe
 #[derive(Clone, Debug, Default, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Model {
 	pub name: String,
 	pub version: String,

--- a/core/src/sql/number.rs
+++ b/core/src/sql/number.rs
@@ -17,6 +17,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Number";
 #[serde(rename = "$surrealdb::private::sql::Number")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Number {
 	Int(i64),
 	Float(f64),
@@ -722,6 +723,7 @@ impl<'a> Product<&'a Self> for Number {
 	}
 }
 
+#[non_exhaustive]
 pub struct Sorted<T>(pub T);
 
 pub trait Sort {

--- a/core/src/sql/object.rs
+++ b/core/src/sql/object.rs
@@ -22,6 +22,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Object";
 #[serde(rename = "$surrealdb::private::sql::Object")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Object(#[serde(with = "no_nul_bytes_in_keys")] pub BTreeMap<String, Value>);
 
 impl From<BTreeMap<&str, Value>> for Object {

--- a/core/src/sql/operation.rs
+++ b/core/src/sql/operation.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "op")]
 #[serde(rename_all = "lowercase")]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Operation {
 	Add {
 		path: Idiom,

--- a/core/src/sql/operator.rs
+++ b/core/src/sql/operator.rs
@@ -9,6 +9,7 @@ use std::fmt::Write;
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Operator {
 	//
 	Neg, // -

--- a/core/src/sql/order.rs
+++ b/core/src/sql/order.rs
@@ -10,6 +10,7 @@ use std::ops::Deref;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Orders(pub Vec<Order>);
 
 impl Orders {
@@ -63,6 +64,7 @@ impl fmt::Display for Orders {
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Order {
 	pub order: Idiom,
 	pub random: bool,

--- a/core/src/sql/output.rs
+++ b/core/src/sql/output.rs
@@ -6,6 +6,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Output {
 	None,
 	Null,

--- a/core/src/sql/param.rs
+++ b/core/src/sql/param.rs
@@ -16,6 +16,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Param";
 #[serde(rename = "$surrealdb::private::sql::Param")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Param(pub Ident);
 
 impl From<Ident> for Param {

--- a/core/src/sql/part.rs
+++ b/core/src/sql/part.rs
@@ -7,6 +7,7 @@ use std::str;
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum Part {
 	All,
 	Flatten,

--- a/core/src/sql/permission.rs
+++ b/core/src/sql/permission.rs
@@ -11,6 +11,7 @@ use std::str;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Permissions {
 	pub select: Permission,
 	pub create: Permission,
@@ -133,6 +134,7 @@ impl PermissionKind {
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Permission {
 	None,
 	Full,

--- a/core/src/sql/query.rs
+++ b/core/src/sql/query.rs
@@ -15,6 +15,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Query";
 #[revisioned(revision = 1)]
 #[serde(rename = "$surrealdb::private::sql::Query")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Query(pub Statements);
 
 impl From<DefineStatement> for Query {

--- a/core/src/sql/range.rs
+++ b/core/src/sql/range.rs
@@ -17,6 +17,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Range";
 #[serde(rename = "$surrealdb::private::sql::Range")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Range {
 	#[serde(with = "no_nul_bytes")]
 	pub tb: String,

--- a/core/src/sql/regex.rs
+++ b/core/src/sql/regex.rs
@@ -17,6 +17,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Regex";
 
 #[derive(Clone)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Regex(pub regex::Regex);
 
 impl Regex {

--- a/core/src/sql/scoring.rs
+++ b/core/src/sql/scoring.rs
@@ -6,6 +6,7 @@ use std::hash::{Hash, Hasher};
 #[derive(Clone, Debug, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Scoring {
 	Bm {
 		k1: f32,

--- a/core/src/sql/script.rs
+++ b/core/src/sql/script.rs
@@ -8,6 +8,7 @@ use std::str;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Script(#[serde(with = "no_nul_bytes")] pub String);
 
 impl From<String> for Script {

--- a/core/src/sql/split.rs
+++ b/core/src/sql/split.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Splits(pub Vec<Split>);
 
 impl Deref for Splits {
@@ -34,6 +35,7 @@ impl fmt::Display for Splits {
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Split(pub Idiom);
 
 impl Deref for Split {

--- a/core/src/sql/start.rs
+++ b/core/src/sql/start.rs
@@ -11,6 +11,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Start(pub Value);
 
 impl Start {

--- a/core/src/sql/statement.rs
+++ b/core/src/sql/statement.rs
@@ -25,6 +25,7 @@ use std::{
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Statements(pub Vec<Statement>);
 
 impl Deref for Statements {
@@ -54,6 +55,7 @@ impl Display for Statements {
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Statement {
 	Value(Value),
 	Analyze(AnalyzeStatement),

--- a/core/src/sql/statements/analyze.rs
+++ b/core/src/sql/statements/analyze.rs
@@ -21,6 +21,7 @@ use std::fmt::{Display, Formatter};
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum AnalyzeStatement {
 	Idx(Ident, Ident),
 }

--- a/core/src/sql/statements/begin.rs
+++ b/core/src/sql/statements/begin.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct BeginStatement;
 
 impl fmt::Display for BeginStatement {

--- a/core/src/sql/statements/break.rs
+++ b/core/src/sql/statements/break.rs
@@ -11,6 +11,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct BreakStatement;
 
 impl BreakStatement {

--- a/core/src/sql/statements/cancel.rs
+++ b/core/src/sql/statements/cancel.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct CancelStatement;
 
 impl fmt::Display for CancelStatement {

--- a/core/src/sql/statements/commit.rs
+++ b/core/src/sql/statements/commit.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct CommitStatement;
 
 impl fmt::Display for CommitStatement {

--- a/core/src/sql/statements/continue.rs
+++ b/core/src/sql/statements/continue.rs
@@ -11,6 +11,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct ContinueStatement;
 
 impl ContinueStatement {

--- a/core/src/sql/statements/create.rs
+++ b/core/src/sql/statements/create.rs
@@ -11,6 +11,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct CreateStatement {
 	#[revision(start = 2)]
 	pub only: bool,

--- a/core/src/sql/statements/define/analyzer.rs
+++ b/core/src/sql/statements/define/analyzer.rs
@@ -12,6 +12,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 3)]
+#[non_exhaustive]
 pub struct DefineAnalyzerStatement {
 	pub name: Ident,
 	#[revision(start = 2)]

--- a/core/src/sql/statements/define/database.rs
+++ b/core/src/sql/statements/define/database.rs
@@ -12,6 +12,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DefineDatabaseStatement {
 	pub id: Option<u32>,
 	pub name: Ident,

--- a/core/src/sql/statements/define/event.rs
+++ b/core/src/sql/statements/define/event.rs
@@ -12,6 +12,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DefineEventStatement {
 	pub name: Ident,
 	pub what: Ident,

--- a/core/src/sql/statements/define/field.rs
+++ b/core/src/sql/statements/define/field.rs
@@ -17,6 +17,7 @@ use std::fmt::{self, Display, Write};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 3)]
+#[non_exhaustive]
 pub struct DefineFieldStatement {
 	pub name: Idiom,
 	pub what: Ident,

--- a/core/src/sql/statements/define/function.rs
+++ b/core/src/sql/statements/define/function.rs
@@ -15,6 +15,7 @@ use std::fmt::{self, Display, Write};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DefineFunctionStatement {
 	pub name: Ident,
 	pub args: Vec<(Ident, Kind)>,

--- a/core/src/sql/statements/define/index.rs
+++ b/core/src/sql/statements/define/index.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DefineIndexStatement {
 	pub name: Ident,
 	pub what: Ident,

--- a/core/src/sql/statements/define/mod.rs
+++ b/core/src/sql/statements/define/mod.rs
@@ -40,6 +40,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum DefineStatement {
 	Namespace(DefineNamespaceStatement),
 	Database(DefineDatabaseStatement),

--- a/core/src/sql/statements/define/model.rs
+++ b/core/src/sql/statements/define/model.rs
@@ -15,6 +15,7 @@ use std::fmt::{self, Write};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DefineModelStatement {
 	pub hash: String,
 	pub name: Ident,

--- a/core/src/sql/statements/define/namespace.rs
+++ b/core/src/sql/statements/define/namespace.rs
@@ -12,6 +12,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DefineNamespaceStatement {
 	pub id: Option<u32>,
 	pub name: Ident,

--- a/core/src/sql/statements/define/param.rs
+++ b/core/src/sql/statements/define/param.rs
@@ -13,6 +13,7 @@ use std::fmt::{self, Display, Write};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DefineParamStatement {
 	pub name: Ident,
 	pub value: Value,

--- a/core/src/sql/statements/define/scope.rs
+++ b/core/src/sql/statements/define/scope.rs
@@ -14,6 +14,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DefineScopeStatement {
 	pub name: Ident,
 	pub code: String,

--- a/core/src/sql/statements/define/table.rs
+++ b/core/src/sql/statements/define/table.rs
@@ -22,6 +22,7 @@ use super::DefineFieldStatement;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 3)]
+#[non_exhaustive]
 pub struct DefineTableStatement {
 	pub id: Option<u32>,
 	pub name: Ident,

--- a/core/src/sql/statements/define/token.rs
+++ b/core/src/sql/statements/define/token.rs
@@ -12,6 +12,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DefineTokenStatement {
 	pub name: Ident,
 	pub base: Base,

--- a/core/src/sql/statements/define/user.rs
+++ b/core/src/sql/statements/define/user.rs
@@ -17,6 +17,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DefineUserStatement {
 	pub name: Ident,
 	pub base: Base,

--- a/core/src/sql/statements/delete.rs
+++ b/core/src/sql/statements/delete.rs
@@ -11,6 +11,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct DeleteStatement {
 	#[revision(start = 2)]
 	pub only: bool,

--- a/core/src/sql/statements/foreach.rs
+++ b/core/src/sql/statements/foreach.rs
@@ -12,6 +12,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct ForeachStatement {
 	pub param: Param,
 	pub range: Value,

--- a/core/src/sql/statements/ifelse.rs
+++ b/core/src/sql/statements/ifelse.rs
@@ -12,6 +12,7 @@ use std::fmt::{self, Display, Write};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct IfelseStatement {
 	/// The first if condition followed by a body, followed by any number of else if's
 	pub exprs: Vec<(Value, Value)>,

--- a/core/src/sql/statements/info.rs
+++ b/core/src/sql/statements/info.rs
@@ -13,6 +13,7 @@ use std::fmt;
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum InfoStatement {
 	Root,
 	Ns,

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -11,6 +11,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct InsertStatement {
 	pub into: Value,
 	pub data: Data,

--- a/core/src/sql/statements/kill.rs
+++ b/core/src/sql/statements/kill.rs
@@ -16,6 +16,7 @@ use crate::sql::Value;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct KillStatement {
 	// Uuid of Live Query
 	// or Param resolving to Uuid of Live Query

--- a/core/src/sql/statements/live.rs
+++ b/core/src/sql/statements/live.rs
@@ -15,6 +15,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct LiveStatement {
 	pub id: Uuid,
 	pub node: Uuid,

--- a/core/src/sql/statements/option.rs
+++ b/core/src/sql/statements/option.rs
@@ -7,6 +7,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct OptionStatement {
 	pub name: Ident,
 	pub what: bool,

--- a/core/src/sql/statements/output.rs
+++ b/core/src/sql/statements/output.rs
@@ -12,6 +12,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct OutputStatement {
 	pub what: Value,
 	pub fetch: Option<Fetchs>,

--- a/core/src/sql/statements/relate.rs
+++ b/core/src/sql/statements/relate.rs
@@ -11,6 +11,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct RelateStatement {
 	#[revision(start = 2)]
 	pub only: bool,

--- a/core/src/sql/statements/remove/analyzer.rs
+++ b/core/src/sql/statements/remove/analyzer.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct RemoveAnalyzerStatement {
 	pub name: Ident,
 	#[revision(start = 2)]

--- a/core/src/sql/statements/remove/database.rs
+++ b/core/src/sql/statements/remove/database.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct RemoveDatabaseStatement {
 	pub name: Ident,
 	#[revision(start = 2)]

--- a/core/src/sql/statements/remove/event.rs
+++ b/core/src/sql/statements/remove/event.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct RemoveEventStatement {
 	pub name: Ident,
 	pub what: Ident,

--- a/core/src/sql/statements/remove/field.rs
+++ b/core/src/sql/statements/remove/field.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct RemoveFieldStatement {
 	pub name: Idiom,
 	pub what: Ident,

--- a/core/src/sql/statements/remove/function.rs
+++ b/core/src/sql/statements/remove/function.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct RemoveFunctionStatement {
 	pub name: Ident,
 	#[revision(start = 2)]

--- a/core/src/sql/statements/remove/index.rs
+++ b/core/src/sql/statements/remove/index.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct RemoveIndexStatement {
 	pub name: Ident,
 	pub what: Ident,

--- a/core/src/sql/statements/remove/mod.rs
+++ b/core/src/sql/statements/remove/mod.rs
@@ -39,6 +39,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum RemoveStatement {
 	Namespace(RemoveNamespaceStatement),
 	Database(RemoveDatabaseStatement),

--- a/core/src/sql/statements/remove/model.rs
+++ b/core/src/sql/statements/remove/model.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct RemoveModelStatement {
 	pub name: Ident,
 	pub version: String,

--- a/core/src/sql/statements/remove/namespace.rs
+++ b/core/src/sql/statements/remove/namespace.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct RemoveNamespaceStatement {
 	pub name: Ident,
 	#[revision(start = 2)]

--- a/core/src/sql/statements/remove/param.rs
+++ b/core/src/sql/statements/remove/param.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct RemoveParamStatement {
 	pub name: Ident,
 	#[revision(start = 2)]

--- a/core/src/sql/statements/remove/scope.rs
+++ b/core/src/sql/statements/remove/scope.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct RemoveScopeStatement {
 	pub name: Ident,
 	#[revision(start = 2)]

--- a/core/src/sql/statements/remove/table.rs
+++ b/core/src/sql/statements/remove/table.rs
@@ -12,6 +12,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct RemoveTableStatement {
 	pub name: Ident,
 	#[revision(start = 2)]

--- a/core/src/sql/statements/remove/token.rs
+++ b/core/src/sql/statements/remove/token.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 2)]
+#[non_exhaustive]
 pub struct RemoveTokenStatement {
 	pub name: Ident,
 	pub base: Base,

--- a/core/src/sql/statements/remove/user.rs
+++ b/core/src/sql/statements/remove/user.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct RemoveUserStatement {
 	pub name: Ident,
 	pub base: Base,

--- a/core/src/sql/statements/select.rs
+++ b/core/src/sql/statements/select.rs
@@ -15,6 +15,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct SelectStatement {
 	pub expr: Fields,
 	pub omit: Option<Idioms>,

--- a/core/src/sql/statements/set.rs
+++ b/core/src/sql/statements/set.rs
@@ -12,6 +12,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct SetStatement {
 	pub name: String,
 	pub what: Value,

--- a/core/src/sql/statements/show.rs
+++ b/core/src/sql/statements/show.rs
@@ -13,6 +13,7 @@ use std::fmt;
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum ShowSince {
 	Timestamp(Datetime),
 	Versionstamp(u64),
@@ -36,6 +37,7 @@ impl ShowSince {
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct ShowStatement {
 	pub table: Option<Table>,
 	pub since: ShowSince,

--- a/core/src/sql/statements/sleep.rs
+++ b/core/src/sql/statements/sleep.rs
@@ -11,6 +11,7 @@ use std::fmt;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct SleepStatement {
 	pub(crate) duration: Duration,
 }

--- a/core/src/sql/statements/throw.rs
+++ b/core/src/sql/statements/throw.rs
@@ -11,6 +11,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct ThrowStatement {
 	pub error: Value,
 }

--- a/core/src/sql/statements/update.rs
+++ b/core/src/sql/statements/update.rs
@@ -11,6 +11,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct UpdateStatement {
 	#[revision(start = 2)]
 	pub only: bool,

--- a/core/src/sql/statements/use.rs
+++ b/core/src/sql/statements/use.rs
@@ -8,6 +8,7 @@ use crate::sql::escape::escape_ident;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct UseStatement {
 	pub ns: Option<String>,
 	pub db: Option<String>,

--- a/core/src/sql/strand.rs
+++ b/core/src/sql/strand.rs
@@ -13,6 +13,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Strand";
 #[serde(rename = "$surrealdb::private::sql::Strand")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Strand(#[serde(with = "no_nul_bytes")] pub String);
 
 impl From<String> for Strand {

--- a/core/src/sql/subquery.rs
+++ b/core/src/sql/subquery.rs
@@ -18,6 +18,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Subquery";
 #[serde(rename = "$surrealdb::private::sql::Subquery")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Subquery {
 	Value(Value),
 	Ifelse(IfelseStatement),

--- a/core/src/sql/table.rs
+++ b/core/src/sql/table.rs
@@ -10,6 +10,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Table";
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Tables(pub Vec<Table>);
 
 impl From<Table> for Tables {
@@ -35,6 +36,7 @@ impl Display for Tables {
 #[serde(rename = "$surrealdb::private::sql::Table")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Table(#[serde(with = "no_nul_bytes")] pub String);
 
 impl From<String> for Table {

--- a/core/src/sql/table_type.rs
+++ b/core/src/sql/table_type.rs
@@ -8,6 +8,7 @@ use super::{Kind, Table};
 /// The type of records stored by a table
 #[derive(Debug, Default, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum TableType {
 	#[default]
 	Any,
@@ -44,6 +45,7 @@ fn get_tables_from_kind(tables: &[Table]) -> String {
 
 #[derive(Debug, Default, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct Relation {
 	pub from: Option<Kind>,
 	pub to: Option<Kind>,

--- a/core/src/sql/thing.rs
+++ b/core/src/sql/thing.rs
@@ -16,6 +16,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Thing";
 #[serde(rename = "$surrealdb::private::sql::Thing")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Thing {
 	/// Table name
 	pub tb: String,

--- a/core/src/sql/timeout.rs
+++ b/core/src/sql/timeout.rs
@@ -7,6 +7,7 @@ use std::ops::Deref;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Timeout(pub Duration);
 
 impl Deref for Timeout {

--- a/core/src/sql/tokenizer.rs
+++ b/core/src/sql/tokenizer.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Tokenizer {
 	Blank,
 	Camel,

--- a/core/src/sql/uuid.rs
+++ b/core/src/sql/uuid.rs
@@ -14,6 +14,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Uuid";
 #[serde(rename = "$surrealdb::private::sql::Uuid")]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Uuid(pub uuid::Uuid);
 
 impl From<uuid::Uuid> for Uuid {

--- a/core/src/sql/value/serde/ser/base/opt.rs
+++ b/core/src/sql/value/serde/ser/base/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Base;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/block/entry/vec.rs
+++ b/core/src/sql/value/serde/ser/block/entry/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeEntryVec(Vec<Entry>);
 
 impl serde::ser::SerializeSeq for SerializeEntryVec {

--- a/core/src/sql/value/serde/ser/changefeed/mod.rs
+++ b/core/src/sql/value/serde/ser/changefeed/mod.rs
@@ -9,6 +9,7 @@ use serde::ser::Impossible;
 use serde::ser::Serialize;
 use std::time::Duration;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -36,6 +37,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeChangeFeed {
 	expiry: Duration,
 	store_original: bool,

--- a/core/src/sql/value/serde/ser/changefeed/opt.rs
+++ b/core/src/sql/value/serde/ser/changefeed/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/cond/opt.rs
+++ b/core/src/sql/value/serde/ser/cond/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Cond;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/data/opt.rs
+++ b/core/src/sql/value/serde/ser/data/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Data;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/duration/opt.rs
+++ b/core/src/sql/value/serde/ser/duration/opt.rs
@@ -4,6 +4,7 @@ use serde::ser::Impossible;
 use serde::ser::Serialize;
 use std::time::Duration;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/explain/opt.rs
+++ b/core/src/sql/value/serde/ser/explain/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Explain;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/fetch/vec/mod.rs
+++ b/core/src/sql/value/serde/ser/fetch/vec/mod.rs
@@ -8,6 +8,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -41,6 +42,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeFetchVec(Vec<Fetch>);
 
 impl serde::ser::SerializeSeq for SerializeFetchVec {

--- a/core/src/sql/value/serde/ser/fetch/vec/opt.rs
+++ b/core/src/sql/value/serde/ser/fetch/vec/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Fetch;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/fetchs/opt.rs
+++ b/core/src/sql/value/serde/ser/fetchs/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Fetchs;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/field/vec.rs
+++ b/core/src/sql/value/serde/ser/field/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeFieldVec(Vec<Field>);
 
 impl serde::ser::SerializeSeq for SerializeFieldVec {

--- a/core/src/sql/value/serde/ser/filter/vec/mod.rs
+++ b/core/src/sql/value/serde/ser/filter/vec/mod.rs
@@ -7,6 +7,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -40,6 +41,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeFilterVec(Vec<Filter>);
 
 impl serde::ser::SerializeSeq for SerializeFilterVec {

--- a/core/src/sql/value/serde/ser/filter/vec/opt.rs
+++ b/core/src/sql/value/serde/ser/filter/vec/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/geometry/coord/vec.rs
+++ b/core/src/sql/value/serde/ser/geometry/coord/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeCoordVec(Vec<Coord<f64>>);
 
 impl serde::ser::SerializeSeq for SerializeCoordVec {

--- a/core/src/sql/value/serde/ser/geometry/line_string/vec.rs
+++ b/core/src/sql/value/serde/ser/geometry/line_string/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeLineStringVec(Vec<LineString<f64>>);
 
 impl serde::ser::SerializeSeq for SerializeLineStringVec {

--- a/core/src/sql/value/serde/ser/geometry/point/vec.rs
+++ b/core/src/sql/value/serde/ser/geometry/point/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializePointVec(Vec<Point<f64>>);
 
 impl serde::ser::SerializeSeq for SerializePointVec {

--- a/core/src/sql/value/serde/ser/geometry/polygon/vec.rs
+++ b/core/src/sql/value/serde/ser/geometry/polygon/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializePolygonVec(Vec<Polygon<f64>>);
 
 impl serde::ser::SerializeSeq for SerializePolygonVec {

--- a/core/src/sql/value/serde/ser/geometry/vec.rs
+++ b/core/src/sql/value/serde/ser/geometry/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -26,6 +27,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeGeometryVec(pub(super) Vec<Geometry>);
 
 impl serde::ser::SerializeSeq for SerializeGeometryVec {

--- a/core/src/sql/value/serde/ser/group/vec/mod.rs
+++ b/core/src/sql/value/serde/ser/group/vec/mod.rs
@@ -8,6 +8,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -41,6 +42,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeGroupVec(Vec<Group>);
 
 impl serde::ser::SerializeSeq for SerializeGroupVec {

--- a/core/src/sql/value/serde/ser/group/vec/opt.rs
+++ b/core/src/sql/value/serde/ser/group/vec/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Group;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/ident/vec.rs
+++ b/core/src/sql/value/serde/ser/ident/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -26,6 +27,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeIdentVec(Vec<Ident>);
 
 impl serde::ser::SerializeSeq for SerializeIdentVec {

--- a/core/src/sql/value/serde/ser/idiom/vec/mod.rs
+++ b/core/src/sql/value/serde/ser/idiom/vec/mod.rs
@@ -7,6 +7,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -40,6 +41,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeIdiomVec(Vec<Idiom>);
 
 impl serde::ser::SerializeSeq for SerializeIdiomVec {

--- a/core/src/sql/value/serde/ser/idiom/vec/opt.rs
+++ b/core/src/sql/value/serde/ser/idiom/vec/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Idiom;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/kind/opt.rs
+++ b/core/src/sql/value/serde/ser/kind/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Kind;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/kind/vec.rs
+++ b/core/src/sql/value/serde/ser/kind/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeKindVec(Vec<Kind>);
 
 impl serde::ser::SerializeSeq for SerializeKindVec {

--- a/core/src/sql/value/serde/ser/limit/opt.rs
+++ b/core/src/sql/value/serde/ser/limit/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Limit;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/order/vec/mod.rs
+++ b/core/src/sql/value/serde/ser/order/vec/mod.rs
@@ -7,6 +7,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -40,6 +41,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeOrderVec(Vec<Order>);
 
 impl serde::ser::SerializeSeq for SerializeOrderVec {

--- a/core/src/sql/value/serde/ser/order/vec/opt.rs
+++ b/core/src/sql/value/serde/ser/order/vec/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Order;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/output/opt.rs
+++ b/core/src/sql/value/serde/ser/output/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Output;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/part/vec/mod.rs
+++ b/core/src/sql/value/serde/ser/part/vec/mod.rs
@@ -7,6 +7,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -40,6 +41,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializePartVec(Vec<Part>);
 
 impl serde::ser::SerializeSeq for SerializePartVec {

--- a/core/src/sql/value/serde/ser/part/vec/opt.rs
+++ b/core/src/sql/value/serde/ser/part/vec/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Part;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/permissions/mod.rs
+++ b/core/src/sql/value/serde/ser/permissions/mod.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializePermissions {
 	select: Permission,
 	create: Permission,

--- a/core/src/sql/value/serde/ser/primitive/bool.rs
+++ b/core/src/sql/value/serde/ser/primitive/bool.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/primitive/f32.rs
+++ b/core/src/sql/value/serde/ser/primitive/f32.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/primitive/f64.rs
+++ b/core/src/sql/value/serde/ser/primitive/f64.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/primitive/i64.rs
+++ b/core/src/sql/value/serde/ser/primitive/i64.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/primitive/opt/u32.rs
+++ b/core/src/sql/value/serde/ser/primitive/opt/u32.rs
@@ -3,6 +3,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/primitive/opt/u64.rs
+++ b/core/src/sql/value/serde/ser/primitive/opt/u64.rs
@@ -3,6 +3,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/primitive/u16.rs
+++ b/core/src/sql/value/serde/ser/primitive/u16.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/primitive/u32.rs
+++ b/core/src/sql/value/serde/ser/primitive/u32.rs
@@ -4,6 +4,7 @@ use crate::err::Error;
 use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/primitive/u64.rs
+++ b/core/src/sql/value/serde/ser/primitive/u64.rs
@@ -4,6 +4,7 @@ use crate::err::Error;
 use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/primitive/u8.rs
+++ b/core/src/sql/value/serde/ser/primitive/u8.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/relation/mod.rs
+++ b/core/src/sql/value/serde/ser/relation/mod.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRelation {
 	from: Option<Kind>,
 	to: Option<Kind>,

--- a/core/src/sql/value/serde/ser/split/vec/mod.rs
+++ b/core/src/sql/value/serde/ser/split/vec/mod.rs
@@ -8,6 +8,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -41,6 +42,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeSplitVec(Vec<Split>);
 
 impl serde::ser::SerializeSeq for SerializeSplitVec {

--- a/core/src/sql/value/serde/ser/split/vec/opt.rs
+++ b/core/src/sql/value/serde/ser/split/vec/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Split;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/start/opt.rs
+++ b/core/src/sql/value/serde/ser/start/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Start;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/statement/begin.rs
+++ b/core/src/sql/value/serde/ser/statement/begin.rs
@@ -4,6 +4,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Error as _;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/statement/break.rs
+++ b/core/src/sql/value/serde/ser/statement/break.rs
@@ -4,6 +4,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Error as _;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/statement/cancel.rs
+++ b/core/src/sql/value/serde/ser/statement/cancel.rs
@@ -4,6 +4,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Error as _;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/statement/commit.rs
+++ b/core/src/sql/value/serde/ser/statement/commit.rs
@@ -4,6 +4,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Error as _;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/statement/continue.rs
+++ b/core/src/sql/value/serde/ser/statement/continue.rs
@@ -4,6 +4,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Error as _;
 use serde::ser::Impossible;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/statement/create.rs
+++ b/core/src/sql/value/serde/ser/statement/create.rs
@@ -11,6 +11,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeCreateStatement {
 	only: Option<bool>,
 	what: Option<Values>,

--- a/core/src/sql/value/serde/ser/statement/define/analyzer.rs
+++ b/core/src/sql/value/serde/ser/statement/define/analyzer.rs
@@ -10,6 +10,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineAnalyzerStatement {
 	name: Ident,
 	function: Option<Strand>,

--- a/core/src/sql/value/serde/ser/statement/define/database.rs
+++ b/core/src/sql/value/serde/ser/statement/define/database.rs
@@ -9,6 +9,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -36,6 +37,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineDatabaseStatement {
 	name: Ident,
 	changefeed: Option<ChangeFeed>,

--- a/core/src/sql/value/serde/ser/statement/define/event.rs
+++ b/core/src/sql/value/serde/ser/statement/define/event.rs
@@ -10,6 +10,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineEventStatement {
 	name: Ident,
 	what: Ident,

--- a/core/src/sql/value/serde/ser/statement/define/field.rs
+++ b/core/src/sql/value/serde/ser/statement/define/field.rs
@@ -12,6 +12,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -39,6 +40,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineFieldStatement {
 	name: Idiom,
 	what: Ident,

--- a/core/src/sql/value/serde/ser/statement/define/function.rs
+++ b/core/src/sql/value/serde/ser/statement/define/function.rs
@@ -11,6 +11,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineFunctionStatement {
 	name: Ident,
 	args: Vec<(Ident, Kind)>,

--- a/core/src/sql/value/serde/ser/statement/define/index.rs
+++ b/core/src/sql/value/serde/ser/statement/define/index.rs
@@ -10,6 +10,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineIndexStatement {
 	name: Ident,
 	what: Ident,

--- a/core/src/sql/value/serde/ser/statement/define/mod.rs
+++ b/core/src/sql/value/serde/ser/statement/define/mod.rs
@@ -18,6 +18,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/statement/define/namespace.rs
+++ b/core/src/sql/value/serde/ser/statement/define/namespace.rs
@@ -8,6 +8,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -35,6 +36,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineNamespaceStatement {
 	name: Ident,
 	id: Option<u32>,

--- a/core/src/sql/value/serde/ser/statement/define/param.rs
+++ b/core/src/sql/value/serde/ser/statement/define/param.rs
@@ -10,6 +10,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineParamStatement {
 	name: Ident,
 	value: Value,

--- a/core/src/sql/value/serde/ser/statement/define/scope.rs
+++ b/core/src/sql/value/serde/ser/statement/define/scope.rs
@@ -10,6 +10,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineScopeStatement {
 	name: Ident,
 	code: String,

--- a/core/src/sql/value/serde/ser/statement/define/table.rs
+++ b/core/src/sql/value/serde/ser/statement/define/table.rs
@@ -12,6 +12,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -39,6 +40,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineTableStatement {
 	name: Ident,
 	drop: bool,

--- a/core/src/sql/value/serde/ser/statement/define/token.rs
+++ b/core/src/sql/value/serde/ser/statement/define/token.rs
@@ -10,6 +10,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineTokenStatement {
 	name: Ident,
 	base: Base,

--- a/core/src/sql/value/serde/ser/statement/define/user.rs
+++ b/core/src/sql/value/serde/ser/statement/define/user.rs
@@ -9,6 +9,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -36,6 +37,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDefineUserStatement {
 	name: Ident,
 	base: Base,

--- a/core/src/sql/value/serde/ser/statement/delete.rs
+++ b/core/src/sql/value/serde/ser/statement/delete.rs
@@ -10,6 +10,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeDeleteStatement {
 	only: Option<bool>,
 	what: Option<Values>,

--- a/core/src/sql/value/serde/ser/statement/ifelse.rs
+++ b/core/src/sql/value/serde/ser/statement/ifelse.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -36,6 +37,7 @@ impl ser::Serializer for Serializer {
 type ValueValueTuple = (Value, Value);
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeIfelseStatement {
 	exprs: Vec<ValueValueTuple>,
 	close: Option<Value>,
@@ -71,6 +73,7 @@ impl serde::ser::SerializeStruct for SerializeIfelseStatement {
 	}
 }
 
+#[non_exhaustive]
 pub struct ValueValueVecSerializer;
 
 impl ser::Serializer for ValueValueVecSerializer {
@@ -92,6 +95,7 @@ impl ser::Serializer for ValueValueVecSerializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeValueValueVec(Vec<ValueValueTuple>);
 
 impl serde::ser::SerializeSeq for SerializeValueValueVec {

--- a/core/src/sql/value/serde/ser/statement/insert.rs
+++ b/core/src/sql/value/serde/ser/statement/insert.rs
@@ -10,6 +10,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeInsertStatement {
 	into: Option<Value>,
 	data: Option<Data>,

--- a/core/src/sql/value/serde/ser/statement/kill.rs
+++ b/core/src/sql/value/serde/ser/statement/kill.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeKillStatement {
 	id: Option<Value>,
 }

--- a/core/src/sql/value/serde/ser/statement/live.rs
+++ b/core/src/sql/value/serde/ser/statement/live.rs
@@ -12,6 +12,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -39,6 +40,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeLiveStatement {
 	id: Uuid,
 	node: Uuid,

--- a/core/src/sql/value/serde/ser/statement/option.rs
+++ b/core/src/sql/value/serde/ser/statement/option.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeOptionStatement {
 	name: Ident,
 	what: bool,

--- a/core/src/sql/value/serde/ser/statement/output.rs
+++ b/core/src/sql/value/serde/ser/statement/output.rs
@@ -8,6 +8,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -35,6 +36,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeOutputStatement {
 	what: Option<Value>,
 	fetch: Option<Fetchs>,

--- a/core/src/sql/value/serde/ser/statement/relate.rs
+++ b/core/src/sql/value/serde/ser/statement/relate.rs
@@ -10,6 +10,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRelateStatement {
 	only: Option<bool>,
 	kind: Option<Value>,

--- a/core/src/sql/value/serde/ser/statement/remove/analyzer.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/analyzer.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveAnalyzerStatement {
 	name: Ident,
 	if_exists: bool,

--- a/core/src/sql/value/serde/ser/statement/remove/database.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/database.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveDatabaseStatement {
 	name: Ident,
 	if_exists: bool,

--- a/core/src/sql/value/serde/ser/statement/remove/event.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/event.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveEventStatement {
 	name: Ident,
 	what: Ident,

--- a/core/src/sql/value/serde/ser/statement/remove/field.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/field.rs
@@ -8,6 +8,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -35,6 +36,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveFieldStatement {
 	name: Idiom,
 	what: Ident,

--- a/core/src/sql/value/serde/ser/statement/remove/function.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/function.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveFunctionStatement {
 	name: Ident,
 	if_exists: bool,

--- a/core/src/sql/value/serde/ser/statement/remove/index.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/index.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveIndexStatement {
 	name: Ident,
 	what: Ident,

--- a/core/src/sql/value/serde/ser/statement/remove/mod.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/mod.rs
@@ -18,6 +18,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/statement/remove/namespace.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/namespace.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveNamespaceStatement {
 	name: Ident,
 	if_exists: bool,

--- a/core/src/sql/value/serde/ser/statement/remove/param.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/param.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveParamStatement {
 	name: Ident,
 	if_exists: bool,

--- a/core/src/sql/value/serde/ser/statement/remove/scope.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/scope.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveScopeStatement {
 	name: Ident,
 	if_exists: bool,

--- a/core/src/sql/value/serde/ser/statement/remove/table.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/table.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveTableStatement {
 	name: Ident,
 	if_exists: bool,

--- a/core/src/sql/value/serde/ser/statement/remove/token.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/token.rs
@@ -8,6 +8,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -35,6 +36,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveTokenStatement {
 	name: Ident,
 	base: Base,

--- a/core/src/sql/value/serde/ser/statement/remove/user.rs
+++ b/core/src/sql/value/serde/ser/statement/remove/user.rs
@@ -8,6 +8,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -35,6 +36,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeRemoveUserStatement {
 	name: Ident,
 	base: Base,

--- a/core/src/sql/value/serde/ser/statement/select.rs
+++ b/core/src/sql/value/serde/ser/statement/select.rs
@@ -20,6 +20,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -47,6 +48,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeSelectStatement {
 	expr: Option<Fields>,
 	omit: Option<Idioms>,

--- a/core/src/sql/value/serde/ser/statement/set.rs
+++ b/core/src/sql/value/serde/ser/statement/set.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeSetStatement {
 	name: Option<String>,
 	what: Option<Value>,

--- a/core/src/sql/value/serde/ser/statement/show/mod.rs
+++ b/core/src/sql/value/serde/ser/statement/show/mod.rs
@@ -10,6 +10,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeShowStatement {
 	table: Option<Table>,
 	since: Option<ShowSince>,

--- a/core/src/sql/value/serde/ser/statement/sleep.rs
+++ b/core/src/sql/value/serde/ser/statement/sleep.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeSleepStatement {
 	duration: Duration,
 }

--- a/core/src/sql/value/serde/ser/statement/throw.rs
+++ b/core/src/sql/value/serde/ser/statement/throw.rs
@@ -7,6 +7,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -34,6 +35,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeThrowStatement {
 	error: Value,
 }

--- a/core/src/sql/value/serde/ser/statement/update.rs
+++ b/core/src/sql/value/serde/ser/statement/update.rs
@@ -12,6 +12,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -39,6 +40,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeUpdateStatement {
 	only: Option<bool>,
 	what: Option<Values>,

--- a/core/src/sql/value/serde/ser/statement/vec.rs
+++ b/core/src/sql/value/serde/ser/statement/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeStatementVec(Vec<Statement>);
 
 impl serde::ser::SerializeSeq for SerializeStatementVec {

--- a/core/src/sql/value/serde/ser/statement/yuse.rs
+++ b/core/src/sql/value/serde/ser/statement/yuse.rs
@@ -6,6 +6,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -33,6 +34,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeUseStatement {
 	ns: Option<String>,
 	db: Option<String>,

--- a/core/src/sql/value/serde/ser/strand/opt.rs
+++ b/core/src/sql/value/serde/ser/strand/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Strand;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/string/opt.rs
+++ b/core/src/sql/value/serde/ser/string/opt.rs
@@ -3,6 +3,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/string/vec.rs
+++ b/core/src/sql/value/serde/ser/string/vec.rs
@@ -4,6 +4,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -37,6 +38,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeStringVec(Vec<String>);
 
 impl serde::ser::SerializeSeq for SerializeStringVec {

--- a/core/src/sql/value/serde/ser/table/opt.rs
+++ b/core/src/sql/value/serde/ser/table/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Table;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/table/vec.rs
+++ b/core/src/sql/value/serde/ser/table/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -38,6 +39,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeTableVec(Vec<Table>);
 
 impl serde::ser::SerializeSeq for SerializeTableVec {

--- a/core/src/sql/value/serde/ser/table_type/mod.rs
+++ b/core/src/sql/value/serde/ser/table_type/mod.rs
@@ -5,6 +5,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/timeout/opt.rs
+++ b/core/src/sql/value/serde/ser/timeout/opt.rs
@@ -5,6 +5,7 @@ use crate::sql::Timeout;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/tokenizer/vec/mod.rs
+++ b/core/src/sql/value/serde/ser/tokenizer/vec/mod.rs
@@ -7,6 +7,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -40,6 +41,7 @@ impl ser::Serializer for Serializer {
 	}
 }
 
+#[non_exhaustive]
 pub struct SerializeTokenizerVec(Vec<Tokenizer>);
 
 impl serde::ser::SerializeSeq for SerializeTokenizerVec {

--- a/core/src/sql/value/serde/ser/tokenizer/vec/opt.rs
+++ b/core/src/sql/value/serde/ser/tokenizer/vec/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::value::serde::ser;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/uuid/opt.rs
+++ b/core/src/sql/value/serde/ser/uuid/opt.rs
@@ -4,6 +4,7 @@ use serde::ser::Impossible;
 use serde::ser::Serialize;
 use uuid::Uuid;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/value/map.rs
+++ b/core/src/sql/value/serde/ser/value/map.rs
@@ -7,6 +7,7 @@ use serde::ser::Impossible;
 use serde::ser::Serialize;
 use std::collections::BTreeMap;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -41,6 +42,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeValueMap {
 	map: BTreeMap<String, Value>,
 	next_key: Option<String>,

--- a/core/src/sql/value/serde/ser/value/opt.rs
+++ b/core/src/sql/value/serde/ser/value/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::Value;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/value/vec.rs
+++ b/core/src/sql/value/serde/ser/value/vec.rs
@@ -5,6 +5,7 @@ use ser::Serializer as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -39,6 +40,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeValueVec(pub Vec<Value>);
 
 impl serde::ser::SerializeSeq for SerializeValueVec {

--- a/core/src/sql/value/serde/ser/version/opt.rs
+++ b/core/src/sql/value/serde/ser/version/opt.rs
@@ -5,6 +5,7 @@ use crate::sql::Version;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/view/mod.rs
+++ b/core/src/sql/value/serde/ser/view/mod.rs
@@ -12,6 +12,7 @@ use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {
@@ -39,6 +40,7 @@ impl ser::Serializer for Serializer {
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct SerializeView {
 	expr: Fields,
 	what: Tables,

--- a/core/src/sql/value/serde/ser/view/opt.rs
+++ b/core/src/sql/value/serde/ser/view/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::View;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/serde/ser/with/opt.rs
+++ b/core/src/sql/value/serde/ser/with/opt.rs
@@ -4,6 +4,7 @@ use crate::sql::with::With;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
 
+#[non_exhaustive]
 pub struct Serializer;
 
 impl ser::Serializer for Serializer {

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -33,6 +33,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Value";
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Values(pub Vec<Value>);
 
 impl Deref for Values {
@@ -60,6 +61,7 @@ impl Display for Values {
 #[serde(rename = "$surrealdb::private::sql::Value")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub enum Value {
 	// These value types are simple values which
 	// can be used in query responses sent to

--- a/core/src/sql/version.rs
+++ b/core/src/sql/version.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub struct Version(pub Datetime);
 
 impl fmt::Display for Version {

--- a/core/src/sql/view.rs
+++ b/core/src/sql/view.rs
@@ -6,6 +6,7 @@ use std::fmt;
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[revisioned(revision = 1)]
+#[non_exhaustive]
 pub struct View {
 	pub expr: Fields,
 	pub what: Tables,

--- a/core/src/sql/with.rs
+++ b/core/src/sql/with.rs
@@ -5,6 +5,7 @@ use std::fmt::{Display, Formatter, Result};
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[non_exhaustive]
 pub enum With {
 	NoIndex,
 	Index(Vec<String>),

--- a/core/src/syn/common.rs
+++ b/core/src/syn/common.rs
@@ -7,6 +7,7 @@ use std::ops::Range;
 ///
 /// Locations are 1 indexed, the first character on the first line being on line 1 column 1.
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub struct Location {
 	pub line: usize,
 	/// In chars.

--- a/core/src/syn/error/mod.rs
+++ b/core/src/syn/error/mod.rs
@@ -6,6 +6,7 @@ mod nom_error;
 pub use nom_error::ParseError;
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct RenderedError {
 	pub text: String,
 	pub snippets: Vec<Snippet>,
@@ -23,6 +24,7 @@ impl fmt::Display for RenderedError {
 
 /// Whether the snippet was truncated.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum Truncation {
 	/// The snippet wasn't truncated
 	None,
@@ -36,6 +38,7 @@ pub enum Truncation {
 
 /// A piece of the source code with a location and an optional explanation.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Snippet {
 	/// The part of the original source code,
 	source: String,

--- a/core/src/syn/error/nom_error.rs
+++ b/core/src/syn/error/nom_error.rs
@@ -12,6 +12,7 @@ use std::ops::Bound;
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone)]
+#[non_exhaustive]
 pub enum ParseError<I> {
 	Base(I),
 	Expected {

--- a/core/src/syn/v1/builtin.rs
+++ b/core/src/syn/v1/builtin.rs
@@ -7,6 +7,7 @@ use nom::{
 };
 
 #[derive(Clone, Eq, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum BuiltinName<I> {
 	Function(I),
 	Constant(constant::Constant),

--- a/core/src/syn/v2/lexer/datetime.rs
+++ b/core/src/syn/v2/lexer/datetime.rs
@@ -11,6 +11,7 @@ use crate::{
 use super::{Error as LexError, Lexer};
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum PartError {
 	#[error("value outside of allowed range")]
 	OutsideRange,
@@ -21,6 +22,7 @@ pub enum PartError {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
 	#[error("invalid year, {0}")]
 	Year(PartError),

--- a/core/src/syn/v2/lexer/duration.rs
+++ b/core/src/syn/v2/lexer/duration.rs
@@ -12,6 +12,7 @@ use crate::{
 use super::{Error as LexError, Lexer};
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
 	#[error("invalid duration suffix")]
 	InvalidSuffix,

--- a/core/src/syn/v2/lexer/mod.rs
+++ b/core/src/syn/v2/lexer/mod.rs
@@ -27,6 +27,7 @@ pub use reader::{BytesReader, CharError};
 /// Can be retrieved from the `Lexer::error` field whenever it returned a [`TokenKind::Invalid`]
 /// token.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
 	#[error("Lexer encountered unexpected character {0:?}")]
 	UnexpectedCharacter(char),
@@ -71,6 +72,7 @@ impl From<CharError> for Error {
 /// Note that SurrealQL syntax cannot be lexed in advance. For example, record strings and regexes,
 /// both cannot be parsed correctly without knowledge of previous tokens as they are both ambigious
 /// with other tokens.
+#[non_exhaustive]
 pub struct Lexer<'a> {
 	/// The reader for reading the source bytes.
 	pub reader: BytesReader<'a>,

--- a/core/src/syn/v2/lexer/number.rs
+++ b/core/src/syn/v2/lexer/number.rs
@@ -6,6 +6,7 @@ use std::mem;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
 	#[error("invalid number suffix")]
 	InvalidSuffix,

--- a/core/src/syn/v2/lexer/reader.rs
+++ b/core/src/syn/v2/lexer/reader.rs
@@ -4,6 +4,7 @@ use crate::syn::v2::token::Span;
 use std::fmt;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum CharError {
 	#[error("found eof inside multi byte character")]
 	Eof,
@@ -12,6 +13,7 @@ pub enum CharError {
 }
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct BytesReader<'a> {
 	data: &'a [u8],
 	current: usize,

--- a/core/src/syn/v2/lexer/uuid.rs
+++ b/core/src/syn/v2/lexer/uuid.rs
@@ -7,6 +7,7 @@ use super::{Error as LexError, Lexer};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
 	#[error("missing digits")]
 	MissingDigits,

--- a/core/src/syn/v2/parser/builtin.rs
+++ b/core/src/syn/v2/parser/builtin.rs
@@ -71,6 +71,7 @@ fn levenshtein(a: &[u8], b: &[u8], cut_off: u8) -> u8 {
 }
 
 /// The kind of a parsed path.
+#[non_exhaustive]
 pub enum PathKind {
 	Constant(Constant),
 	Function,

--- a/core/src/syn/v2/parser/error.rs
+++ b/core/src/syn/v2/parser/error.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum IntErrorKind {
 	FloatToInt,
 	DecimalToInt,
@@ -19,6 +20,7 @@ pub enum IntErrorKind {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum MissingKind {
 	Group,
 	Split,
@@ -26,6 +28,7 @@ pub enum MissingKind {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ParseErrorKind {
 	/// The parser encountered an unexpected token.
 	Unexpected {
@@ -81,6 +84,7 @@ pub enum ParseErrorKind {
 
 /// A parsing error.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct ParseError {
 	pub kind: ParseErrorKind,
 	pub at: Span,

--- a/core/src/syn/v2/parser/mod.rs
+++ b/core/src/syn/v2/parser/mod.rs
@@ -51,6 +51,7 @@ pub type ParseResult<T> = Result<T, ParseError>;
 
 /// A result of trying to parse a possibly partial query.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum PartialResult<T> {
 	/// The parser couldn't be sure that it has finished a full value.
 	Pending {
@@ -71,6 +72,7 @@ pub enum PartialResult<T> {
 }
 
 /// The SurrealQL parser.
+#[non_exhaustive]
 pub struct Parser<'a> {
 	lexer: Lexer<'a>,
 	last_span: Span,

--- a/core/src/syn/v2/parser/token_buffer.rs
+++ b/core/src/syn/v2/parser/token_buffer.rs
@@ -1,5 +1,6 @@
 use crate::syn::v2::token::Token;
 
+#[non_exhaustive]
 pub struct TokenBuffer<const S: usize> {
 	buffer: [Token; S],
 	write: u8,

--- a/core/src/syn/v2/token/keyword.rs
+++ b/core/src/syn/v2/token/keyword.rs
@@ -3,7 +3,7 @@ macro_rules! keyword {
 
 		#[repr(u8)]
 		#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
-		pub enum Keyword{
+		#[non_exhaustive] pub enum Keyword{
 			$($name,)*
 		}
 

--- a/core/src/syn/v2/token/mod.rs
+++ b/core/src/syn/v2/token/mod.rs
@@ -13,6 +13,7 @@ use crate::sql::{language::Language, Algorithm};
 
 /// A location in the source passed to the lexer.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub struct Span {
 	/// Offset in bytes.
 	pub offset: u32,
@@ -55,6 +56,7 @@ impl Span {
 
 #[repr(u8)]
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum Operator {
 	/// `!`
 	Not,
@@ -181,6 +183,7 @@ impl Operator {
 
 /// A delimiting token, denoting the start or end of a certain production.
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum Delim {
 	/// `()`
 	Paren,
@@ -191,6 +194,7 @@ pub enum Delim {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum DistanceKind {
 	Chebyshev,
 	Cosine,
@@ -218,6 +222,7 @@ impl DistanceKind {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum NumberKind {
 	// A plain integer number.
 	Integer,
@@ -238,6 +243,7 @@ pub enum NumberKind {
 
 /// The type of token
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum TokenKind {
 	Keyword(Keyword),
 	Algorithm(Algorithm),
@@ -406,6 +412,7 @@ impl TokenKind {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub struct Token {
 	pub kind: TokenKind,
 	pub span: Span,

--- a/core/src/vs/conv.rs
+++ b/core/src/vs/conv.rs
@@ -97,6 +97,7 @@ pub fn to_u128_be(vs: [u8; 10]) -> u128 {
 }
 
 #[derive(Error)]
+#[non_exhaustive]
 pub enum Error {
 	#[error("invalid versionstamp")]
 	// InvalidVersionstamp is returned when a versionstamp has an unexpected length.

--- a/core/src/vs/mod.rs
+++ b/core/src/vs/mod.rs
@@ -32,6 +32,7 @@ pub fn generate_versionstamp_sequences(start: Versionstamp) -> VersionstampSeque
 }
 
 #[doc(hidden)]
+#[non_exhaustive]
 pub struct VersionstampSequence {
 	next_state: Option<Versionstamp>,
 }

--- a/core/src/vs/oracle.rs
+++ b/core/src/vs/oracle.rs
@@ -15,6 +15,7 @@ use super::{u16_u64_to_versionstamp, u64_to_versionstamp, u64_u16_to_versionstam
 // generation strategy, varying in the trade-off between the monotonicity of the versionstamps
 // and the performance of the versionstamp generation.
 #[allow(unused)]
+#[non_exhaustive]
 pub enum Oracle {
 	// SysTimeCounter versionstamp oracle is a HLC based on system time in seconds as the physical time and the
 	// in-memory counter that resets every second as the logical time.
@@ -80,6 +81,7 @@ impl Oracle {
 	}
 }
 
+#[non_exhaustive]
 pub struct SysTimeCounter {
 	// The first element is the saved physical time of the last versionstamp.
 	// The second element is the in-memory counter that resets every second.
@@ -119,6 +121,7 @@ impl SysTimeCounter {
 // The epoch is supposed to be persisted in the underlying KVS and increased by one on each database restart.
 // The in-memory counter resets on each database restart and increased by one on each now() call.
 // TODO: Refer to a paper that describes this concept and use the correct terminology.
+#[non_exhaustive]
 pub struct EpochCounter {
 	// epoch is the first half of the versionstamp that persists
 	// until the database restarts.

--- a/lib/examples/transaction/main.rs
+++ b/lib/examples/transaction/main.rs
@@ -20,7 +20,7 @@ async fn main() -> surrealdb::Result<()> {
     let response = db
 
         // Start transaction
-        .query(BeginStatement)
+        .query(BeginStatement::default())
 
         // Setup accounts
         .query("
@@ -35,7 +35,7 @@ async fn main() -> surrealdb::Result<()> {
         ")
 
         // Finalise
-        .query(CommitStatement)
+        .query(CommitStatement::default())
         .await?;
 
 	// See if any errors were returned

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -72,11 +72,8 @@ use crate::sql::statements::DefineModelStatement;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::sql::statements::DefineStatement;
 use crate::sql::statements::KillStatement;
-use crate::sql::Array;
 use crate::sql::Query;
 use crate::sql::Statement;
-use crate::sql::Statements;
-use crate::sql::Strand;
 use crate::sql::Uuid;
 use crate::sql::Value;
 use channel::Sender;
@@ -423,8 +420,8 @@ async fn take(one: bool, responses: Vec<Response>) -> Result<Value> {
 		let value = result?;
 		match one {
 			true => match value {
-				Value::Array(Array(mut vec)) => {
-					if let [value] = &mut vec[..] {
+				Value::Array(mut array) => {
+					if let [value] = &mut array.0[..] {
 						return Ok(mem::take(value));
 					}
 				}
@@ -436,7 +433,7 @@ async fn take(one: bool, responses: Vec<Response>) -> Result<Value> {
 	}
 	match one {
 		true => Ok(Value::None),
-		false => Ok(Value::Array(Array(vec![]))),
+		false => Ok(Value::Array(Default::default())),
 	}
 }
 
@@ -508,9 +505,10 @@ async fn kill_live_query(
 	session: &Session,
 	vars: BTreeMap<String, Value>,
 ) -> Result<Value> {
-	let query = Query(Statements(vec![Statement::Kill(KillStatement {
-		id: id.into(),
-	})]));
+	let mut query = Query::default();
+	let mut kill = KillStatement::default();
+	kill.id = id.into();
+	query.0 .0 = vec![Statement::Kill(kill)];
 	let response = kvs.process(query, session, Some(vars)).await?;
 	take(true, response).await
 }
@@ -527,15 +525,15 @@ async fn router(
 	match method {
 		Method::Use => {
 			match &mut params[..] {
-				[Value::Strand(Strand(ns)), Value::Strand(Strand(db))] => {
-					session.ns = Some(mem::take(ns));
-					session.db = Some(mem::take(db));
+				[Value::Strand(ns), Value::Strand(db)] => {
+					session.ns = Some(mem::take(&mut ns.0));
+					session.db = Some(mem::take(&mut db.0));
 				}
-				[Value::Strand(Strand(ns)), Value::None] => {
-					session.ns = Some(mem::take(ns));
+				[Value::Strand(ns), Value::None] => {
+					session.ns = Some(mem::take(&mut ns.0));
 				}
-				[Value::None, Value::Strand(Strand(db))] => {
-					session.db = Some(mem::take(db));
+				[Value::None, Value::Strand(db)] => {
+					session.db = Some(mem::take(&mut db.0));
 				}
 				_ => unreachable!(),
 			}
@@ -559,7 +557,7 @@ async fn router(
 		}
 		Method::Authenticate => {
 			let token = match &mut params[..] {
-				[Value::Strand(Strand(token))] => mem::take(token),
+				[Value::Strand(token)] => mem::take(&mut token.0),
 				_ => unreachable!(),
 			};
 			crate::iam::verify::token(kvs, session, &token).await?;
@@ -570,50 +568,57 @@ async fn router(
 			Ok(DbResponse::Other(Value::None))
 		}
 		Method::Create => {
+			let mut query = Query::default();
 			let statement = create_statement(&mut params);
-			let query = Query(Statements(vec![Statement::Create(statement)]));
+			query.0 .0 = vec![Statement::Create(statement)];
 			let response = kvs.process(query, &*session, Some(vars.clone())).await?;
 			let value = take(true, response).await?;
 			Ok(DbResponse::Other(value))
 		}
 		Method::Update => {
+			let mut query = Query::default();
 			let (one, statement) = update_statement(&mut params);
-			let query = Query(Statements(vec![Statement::Update(statement)]));
+			query.0 .0 = vec![Statement::Update(statement)];
 			let response = kvs.process(query, &*session, Some(vars.clone())).await?;
 			let value = take(one, response).await?;
 			Ok(DbResponse::Other(value))
 		}
 		Method::Insert => {
+			let mut query = Query::default();
 			let (one, statement) = insert_statement(&mut params);
-			let query = Query(Statements(vec![Statement::Insert(statement)]));
+			query.0 .0 = vec![Statement::Insert(statement)];
 			let response = kvs.process(query, &*session, Some(vars.clone())).await?;
 			let value = take(one, response).await?;
 			Ok(DbResponse::Other(value))
 		}
 		Method::Patch => {
+			let mut query = Query::default();
 			let (one, statement) = patch_statement(&mut params);
-			let query = Query(Statements(vec![Statement::Update(statement)]));
+			query.0 .0 = vec![Statement::Update(statement)];
 			let response = kvs.process(query, &*session, Some(vars.clone())).await?;
 			let value = take(one, response).await?;
 			Ok(DbResponse::Other(value))
 		}
 		Method::Merge => {
+			let mut query = Query::default();
 			let (one, statement) = merge_statement(&mut params);
-			let query = Query(Statements(vec![Statement::Update(statement)]));
+			query.0 .0 = vec![Statement::Update(statement)];
 			let response = kvs.process(query, &*session, Some(vars.clone())).await?;
 			let value = take(one, response).await?;
 			Ok(DbResponse::Other(value))
 		}
 		Method::Select => {
+			let mut query = Query::default();
 			let (one, statement) = select_statement(&mut params);
-			let query = Query(Statements(vec![Statement::Select(statement)]));
+			query.0 .0 = vec![Statement::Select(statement)];
 			let response = kvs.process(query, &*session, Some(vars.clone())).await?;
 			let value = take(one, response).await?;
 			Ok(DbResponse::Other(value))
 		}
 		Method::Delete => {
+			let mut query = Query::default();
 			let (one, statement) = delete_statement(&mut params);
-			let query = Query(Statements(vec![Statement::Delete(statement)]));
+			query.0 .0 = vec![Statement::Delete(statement)];
 			let response = kvs.process(query, &*session, Some(vars.clone())).await?;
 			let value = take(one, response).await?;
 			Ok(DbResponse::Other(value))
@@ -738,7 +743,7 @@ async fn router(
 						Ok(file) => file,
 						Err(error) => {
 							return Err(Error::FileRead {
-								path: PathBuf::from(path),
+								path,
 								error: io::Error::new(
 									io::ErrorKind::InvalidData,
 									error.message.to_string(),
@@ -754,14 +759,12 @@ async fn router(
 					// Insert the file data in to the store
 					crate::obs::put(&hash, data).await?;
 					// Insert the model in to the database
-					let query = DefineStatement::Model(DefineModelStatement {
-						hash,
-						name: file.header.name.to_string().into(),
-						version: file.header.version.to_string(),
-						comment: Some(file.header.description.to_string().into()),
-						..Default::default()
-					})
-					.into();
+					let mut model = DefineModelStatement::default();
+					model.name = file.header.name.to_string().into();
+					model.version = file.header.version.to_string();
+					model.comment = Some(file.header.description.to_string().into());
+					model.hash = hash;
+					let query = DefineStatement::Model(model).into();
 					kvs.process(query, session, Some(vars.clone())).await?
 				}
 				_ => {
@@ -785,7 +788,7 @@ async fn router(
 		Method::Version => Ok(DbResponse::Other(crate::env::VERSION.into())),
 		Method::Set => {
 			let (key, value) = match &mut params[..2] {
-				[Value::Strand(Strand(key)), value] => (mem::take(key), mem::take(value)),
+				[Value::Strand(key), value] => (mem::take(&mut key.0), mem::take(value)),
 				_ => unreachable!(),
 			};
 			let var = Some(crate::map! {
@@ -799,8 +802,8 @@ async fn router(
 			Ok(DbResponse::Other(Value::None))
 		}
 		Method::Unset => {
-			if let [Value::Strand(Strand(key))] = &params[..1] {
-				vars.remove(key);
+			if let [Value::Strand(key)] = &params[..1] {
+				vars.remove(&key.0);
 			}
 			Ok(DbResponse::Other(Value::None))
 		}

--- a/lib/src/api/engine/local/native.rs
+++ b/lib/src/api/engine/local/native.rs
@@ -163,14 +163,12 @@ pub(crate) fn router(
 
 		#[cfg(feature = "sql2")]
 		let opt = {
-			let tick_interval = address
+			let mut engine_options = EngineOptions::default();
+			engine_options.tick_interval = address
 				.config
 				.tick_interval
 				.unwrap_or(crate::api::engine::local::DEFAULT_TICK_INTERVAL);
-			EngineOptions {
-				tick_interval,
-				..Default::default()
-			}
+			engine_options
 		};
 		let (tasks, task_chans) = start_tasks(
 			#[cfg(feature = "sql2")]

--- a/lib/src/api/engine/local/wasm.rs
+++ b/lib/src/api/engine/local/wasm.rs
@@ -147,11 +147,8 @@ pub(crate) fn router(
 		let mut live_queries = HashMap::new();
 		let mut session = Session::default().with_rt(true);
 
-		let tick_interval = address.config.tick_interval.unwrap_or(DEFAULT_TICK_INTERVAL);
-		let opt = EngineOptions {
-			tick_interval,
-			..Default::default()
-		};
+		let mut opt = EngineOptions::default();
+		opt.tick_interval = address.config.tick_interval.unwrap_or(DEFAULT_TICK_INTERVAL);
 		let (_tasks, task_chans) = start_tasks(&opt, kvs.clone());
 
 		let mut notifications = kvs.notifications();

--- a/lib/src/api/engine/mod.rs
+++ b/lib/src/api/engine/mod.rs
@@ -21,10 +21,8 @@ use crate::sql::statements::DeleteStatement;
 use crate::sql::statements::InsertStatement;
 use crate::sql::statements::SelectStatement;
 use crate::sql::statements::UpdateStatement;
-use crate::sql::Array;
 use crate::sql::Data;
 use crate::sql::Field;
-use crate::sql::Fields;
 use crate::sql::Output;
 use crate::sql::Value;
 use crate::sql::Values;
@@ -51,8 +49,16 @@ fn split_params(params: &mut [Value]) -> (bool, Values, Value) {
 	};
 	let one = what.is_thing();
 	let what = match what {
-		Value::Array(Array(vec)) => Values(vec),
-		value => Values(vec![value]),
+		Value::Array(vec) => {
+			let mut values = Values::default();
+			values.0 = vec.0;
+			values
+		}
+		value => {
+			let mut values = Values::default();
+			values.0 = vec![value];
+			values
+		}
 	};
 	(one, what, data)
 }
@@ -64,12 +70,11 @@ fn create_statement(params: &mut [Value]) -> CreateStatement {
 		Value::None | Value::Null => None,
 		value => Some(Data::ContentExpression(value)),
 	};
-	CreateStatement {
-		what,
-		data,
-		output: Some(Output::After),
-		..Default::default()
-	}
+	let mut stmt = CreateStatement::default();
+	stmt.what = what;
+	stmt.data = data;
+	stmt.output = Some(Output::After);
+	stmt
 }
 
 #[allow(dead_code)] // used by the the embedded database and `http`
@@ -79,15 +84,11 @@ fn update_statement(params: &mut [Value]) -> (bool, UpdateStatement) {
 		Value::None | Value::Null => None,
 		value => Some(Data::ContentExpression(value)),
 	};
-	(
-		one,
-		UpdateStatement {
-			what,
-			data,
-			output: Some(Output::After),
-			..Default::default()
-		},
-	)
+	let mut stmt = UpdateStatement::default();
+	stmt.what = what;
+	stmt.data = data;
+	stmt.output = Some(Output::After);
+	(one, stmt)
 }
 
 #[allow(dead_code)] // used by the the embedded database and `http`
@@ -97,15 +98,11 @@ fn insert_statement(params: &mut [Value]) -> (bool, InsertStatement) {
 		_ => unreachable!(),
 	};
 	let one = !data.is_array();
-	(
-		one,
-		InsertStatement {
-			into: what,
-			data: Data::SingleExpression(data),
-			output: Some(Output::After),
-			..Default::default()
-		},
-	)
+	let mut stmt = InsertStatement::default();
+	stmt.into = what;
+	stmt.data = Data::SingleExpression(data);
+	stmt.output = Some(Output::After);
+	(one, stmt)
 }
 
 #[allow(dead_code)] // used by the the embedded database and `http`
@@ -115,15 +112,11 @@ fn patch_statement(params: &mut [Value]) -> (bool, UpdateStatement) {
 		Value::None | Value::Null => None,
 		value => Some(Data::PatchExpression(value)),
 	};
-	(
-		one,
-		UpdateStatement {
-			what,
-			data,
-			output: Some(Output::After),
-			..Default::default()
-		},
-	)
+	let mut stmt = UpdateStatement::default();
+	stmt.what = what;
+	stmt.data = data;
+	stmt.output = Some(Output::After);
+	(one, stmt)
 }
 
 #[allow(dead_code)] // used by the the embedded database and `http`
@@ -133,41 +126,29 @@ fn merge_statement(params: &mut [Value]) -> (bool, UpdateStatement) {
 		Value::None | Value::Null => None,
 		value => Some(Data::MergeExpression(value)),
 	};
-	(
-		one,
-		UpdateStatement {
-			what,
-			data,
-			output: Some(Output::After),
-			..Default::default()
-		},
-	)
+	let mut stmt = UpdateStatement::default();
+	stmt.what = what;
+	stmt.data = data;
+	stmt.output = Some(Output::After);
+	(one, stmt)
 }
 
 #[allow(dead_code)] // used by the the embedded database and `http`
 fn select_statement(params: &mut [Value]) -> (bool, SelectStatement) {
 	let (one, what, _) = split_params(params);
-	(
-		one,
-		SelectStatement {
-			what,
-			expr: Fields(vec![Field::All], false),
-			..Default::default()
-		},
-	)
+	let mut stmt = SelectStatement::default();
+	stmt.what = what;
+	stmt.expr.0 = vec![Field::All];
+	(one, stmt)
 }
 
 #[allow(dead_code)] // used by the the embedded database and `http`
 fn delete_statement(params: &mut [Value]) -> (bool, DeleteStatement) {
 	let (one, what, _) = split_params(params);
-	(
-		one,
-		DeleteStatement {
-			what,
-			output: Some(Output::Before),
-			..Default::default()
-		},
-	)
+	let mut stmt = DeleteStatement::default();
+	stmt.what = what;
+	stmt.output = Some(Output::Before);
+	(one, stmt)
 }
 
 struct IntervalStream {

--- a/lib/src/api/engine/remote/ws/mod.rs
+++ b/lib/src/api/engine/remote/ws/mod.rs
@@ -135,6 +135,8 @@ impl DbResponse {
 								(stats, Err(Error::Query(response.result.as_raw_string()).into())),
 							);
 						}
+						#[cfg(feature = "sql2")]
+						_ => unreachable!(),
 					}
 				}
 

--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -21,8 +21,6 @@ use crate::api::Surreal;
 use crate::engine::remote::ws::Data;
 use crate::engine::IntervalStream;
 use crate::opt::WaitFor;
-use crate::sql::Array;
-use crate::sql::Strand;
 use crate::sql::Value;
 use flume::Receiver;
 use futures::stream::SplitSink;
@@ -245,13 +243,13 @@ pub(crate) fn router(
 							};
 							match method {
 								Method::Set => {
-									if let [Value::Strand(Strand(key)), value] = &params[..2] {
-										var_stash.insert(id, (key.clone(), value.clone()));
+									if let [Value::Strand(key), value] = &params[..2] {
+										var_stash.insert(id, (key.0.clone(), value.clone()));
 									}
 								}
 								Method::Unset => {
-									if let [Value::Strand(Strand(key))] = &params[..1] {
-										vars.swap_remove(key);
+									if let [Value::Strand(key)] = &params[..1] {
+										vars.swap_remove(&key.0);
 									}
 								}
 								Method::Live => {
@@ -361,11 +359,11 @@ pub(crate) fn router(
 																{
 																	// For insert, we need to flatten single responses in an array
 																	if let Ok(Data::Other(
-																		Value::Array(Array(value)),
+																		Value::Array(value),
 																	)) = &mut response
 																	{
 																		if let [value] =
-																			&mut value[..]
+																			&mut value.0[..]
 																		{
 																			response =
 																				Ok(Data::Other(

--- a/lib/src/api/engine/remote/ws/wasm.rs
+++ b/lib/src/api/engine/remote/ws/wasm.rs
@@ -19,8 +19,6 @@ use crate::api::Surreal;
 use crate::engine::remote::ws::Data;
 use crate::engine::IntervalStream;
 use crate::opt::WaitFor;
-use crate::sql::Array;
-use crate::sql::Strand;
 use crate::sql::Value;
 use flume::Receiver;
 use flume::Sender;
@@ -209,13 +207,13 @@ pub(crate) fn router(
 						};
 						match method {
 							Method::Set => {
-								if let [Value::Strand(Strand(key)), value] = &params[..2] {
-									var_stash.insert(id, (key.clone(), value.clone()));
+								if let [Value::Strand(key), value] = &params[..2] {
+									var_stash.insert(id, (key.0.clone(), value.clone()));
 								}
 							}
 							Method::Unset => {
-								if let [Value::Strand(Strand(key))] = &params[..1] {
-									vars.swap_remove(key);
+								if let [Value::Strand(key)] = &params[..1] {
+									vars.swap_remove(&key.0);
 								}
 							}
 							Method::Live => {
@@ -318,10 +316,10 @@ pub(crate) fn router(
 													if matches!(method, Method::Insert) {
 														// For insert, we need to flatten single responses in an array
 														if let Ok(Data::Other(Value::Array(
-															Array(value),
+															value,
 														))) = &mut response
 														{
-															if let [value] = &mut value[..] {
+															if let [value] = &mut value.0[..] {
 																response = Ok(Data::Other(
 																	mem::take(value),
 																));

--- a/lib/src/api/method/begin.rs
+++ b/lib/src/api/method/begin.rs
@@ -25,7 +25,7 @@ where
 
 	fn into_future(self) -> Self::IntoFuture {
 		Box::pin(async move {
-			self.client.query(BeginStatement).await?;
+			self.client.query(BeginStatement::default()).await?;
 			Ok(Transaction {
 				client: self.client,
 			})

--- a/lib/src/api/method/cancel.rs
+++ b/lib/src/api/method/cancel.rs
@@ -22,7 +22,7 @@ where
 
 	fn into_future(self) -> Self::IntoFuture {
 		Box::pin(async move {
-			self.client.query(CancelStatement).await?;
+			self.client.query(CancelStatement::default()).await?;
 			Ok(self.client)
 		})
 	}

--- a/lib/src/api/method/commit.rs
+++ b/lib/src/api/method/commit.rs
@@ -22,7 +22,7 @@ where
 
 	fn into_future(self) -> Self::IntoFuture {
 		Box::pin(async move {
-			self.client.query(CommitStatement).await?;
+			self.client.query(CommitStatement::default()).await?;
 			Ok(self.client)
 		})
 	}

--- a/lib/src/api/method/insert.rs
+++ b/lib/src/api/method/insert.rs
@@ -52,10 +52,14 @@ macro_rules! into_future {
 			Box::pin(async move {
 				let (table, data) = match resource? {
 					Resource::Table(table) => (table.into(), Value::Object(Default::default())),
-					Resource::RecordId(record_id) => (
-						Table(record_id.tb.clone()).into(),
-						crate::map! { String::from("id") => record_id.into() }.into(),
-					),
+					Resource::RecordId(record_id) => {
+						let mut table = Table::default();
+						table.0 = record_id.tb.clone();
+						(
+							table.into(),
+							crate::map! { String::from("id") => record_id.into() }.into(),
+						)
+					}
 					Resource::Object(obj) => return Err(Error::InsertOnObject(obj).into()),
 					Resource::Array(arr) => return Err(Error::InsertOnArray(arr).into()),
 					Resource::Edges(edges) => return Err(Error::InsertOnEdges(edges).into()),
@@ -132,8 +136,12 @@ where
 						.into());
 					}
 					false => {
-						content.resource = Ok(Table(record_id.tb.clone()).into());
-						let id = Part::Field(Ident("id".to_owned()));
+						let mut table = Table::default();
+						table.0 = record_id.tb.clone();
+						content.resource = Ok(table.into());
+						let mut ident = Ident::default();
+						ident.0 = "id".to_owned();
+						let id = Part::Field(ident);
 						data.put(&[id], record_id.into());
 						content.content = data;
 					}

--- a/lib/src/api/method/live.rs
+++ b/lib/src/api/method/live.rs
@@ -24,7 +24,6 @@ use crate::sql::Operator;
 use crate::sql::Part;
 use crate::sql::Statement;
 use crate::sql::Table;
-use crate::sql::Thing;
 use crate::sql::Value;
 use crate::Notification;
 use crate::Surreal;
@@ -35,7 +34,6 @@ use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
 use std::mem;
-use std::ops::Bound;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
@@ -60,24 +58,35 @@ macro_rules! into_future {
 				if !router.features.contains(&ExtraFeatures::LiveQueries) {
 					return Err(Error::LiveQueriesNotSupported.into());
 				}
-				let mut stmt = LiveStatement::new(Fields(vec![Field::All], false));
+				let mut fields = Fields::default();
+				fields.0 = vec![Field::All];
+				let mut stmt = LiveStatement::new(fields);
+				let mut table = Table::default();
 				match range {
 					Some(range) => {
 						let range = resource?.with_range(range)?;
-						stmt.what = Table(range.tb.clone()).into();
-						stmt.cond = cond_from_range(range);
+						table.0 = range.tb.clone();
+						stmt.what = table.into();
+						stmt.cond = range.to_cond();
 					}
 					None => match resource? {
 						Resource::Table(table) => {
 							stmt.what = table.into();
 						}
 						Resource::RecordId(record) => {
-							stmt.what = Table(record.tb.clone()).into();
-							stmt.cond = Some(Cond(Value::Expression(Box::new(Expression::new(
-								Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+							table.0 = record.tb.clone();
+							stmt.what = table.into();
+							let mut ident = Ident::default();
+							ident.0 = ID.to_owned();
+							let mut idiom = Idiom::default();
+							idiom.0 = vec![Part::from(ident)];
+							let mut cond = Cond::default();
+							cond.0 = Value::Expression(Box::new(Expression::new(
+								idiom.into(),
 								Operator::Equal,
 								record.into(),
-							)))));
+							)));
+							stmt.cond = Some(cond);
 						}
 						Resource::Object(object) => return Err(Error::LiveOnObject(object).into()),
 						Resource::Array(array) => return Err(Error::LiveOnArray(array).into()),
@@ -121,100 +130,6 @@ where
 	param.other = vec![id];
 	conn.execute_unit(router, param).await?;
 	Ok(rx)
-}
-
-fn cond_from_range(range: crate::sql::Range) -> Option<Cond> {
-	match (range.beg, range.end) {
-		(Bound::Unbounded, Bound::Unbounded) => None,
-		(Bound::Unbounded, Bound::Excluded(id)) => {
-			Some(Cond(Value::Expression(Box::new(Expression::new(
-				Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-				Operator::LessThan,
-				Thing::from((range.tb, id)).into(),
-			)))))
-		}
-		(Bound::Unbounded, Bound::Included(id)) => {
-			Some(Cond(Value::Expression(Box::new(Expression::new(
-				Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-				Operator::LessThanOrEqual,
-				Thing::from((range.tb, id)).into(),
-			)))))
-		}
-		(Bound::Excluded(id), Bound::Unbounded) => {
-			Some(Cond(Value::Expression(Box::new(Expression::new(
-				Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-				Operator::MoreThan,
-				Thing::from((range.tb, id)).into(),
-			)))))
-		}
-		(Bound::Included(id), Bound::Unbounded) => {
-			Some(Cond(Value::Expression(Box::new(Expression::new(
-				Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-				Operator::MoreThanOrEqual,
-				Thing::from((range.tb, id)).into(),
-			)))))
-		}
-		(Bound::Included(lid), Bound::Included(rid)) => {
-			Some(Cond(Value::Expression(Box::new(Expression::new(
-				Value::Expression(Box::new(Expression::new(
-					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-					Operator::MoreThanOrEqual,
-					Thing::from((range.tb.clone(), lid)).into(),
-				))),
-				Operator::And,
-				Value::Expression(Box::new(Expression::new(
-					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-					Operator::LessThanOrEqual,
-					Thing::from((range.tb, rid)).into(),
-				))),
-			)))))
-		}
-		(Bound::Included(lid), Bound::Excluded(rid)) => {
-			Some(Cond(Value::Expression(Box::new(Expression::new(
-				Value::Expression(Box::new(Expression::new(
-					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-					Operator::MoreThanOrEqual,
-					Thing::from((range.tb.clone(), lid)).into(),
-				))),
-				Operator::And,
-				Value::Expression(Box::new(Expression::new(
-					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-					Operator::LessThan,
-					Thing::from((range.tb, rid)).into(),
-				))),
-			)))))
-		}
-		(Bound::Excluded(lid), Bound::Included(rid)) => {
-			Some(Cond(Value::Expression(Box::new(Expression::new(
-				Value::Expression(Box::new(Expression::new(
-					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-					Operator::MoreThan,
-					Thing::from((range.tb.clone(), lid)).into(),
-				))),
-				Operator::And,
-				Value::Expression(Box::new(Expression::new(
-					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-					Operator::LessThanOrEqual,
-					Thing::from((range.tb, rid)).into(),
-				))),
-			)))))
-		}
-		(Bound::Excluded(lid), Bound::Excluded(rid)) => {
-			Some(Cond(Value::Expression(Box::new(Expression::new(
-				Value::Expression(Box::new(Expression::new(
-					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-					Operator::MoreThan,
-					Thing::from((range.tb.clone(), lid)).into(),
-				))),
-				Operator::And,
-				Value::Expression(Box::new(Expression::new(
-					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
-					Operator::LessThan,
-					Thing::from((range.tb, rid)).into(),
-				))),
-			)))))
-		}
-	}
 }
 
 impl<'r, Client> IntoFuture for Select<'r, Client, Value, Live>

--- a/lib/src/api/method/patch.rs
+++ b/lib/src/api/method/patch.rs
@@ -6,7 +6,6 @@ use crate::api::opt::Resource;
 use crate::api::Connection;
 use crate::api::Result;
 use crate::method::OnceLockExt;
-use crate::sql::Array;
 use crate::sql::Id;
 use crate::sql::Value;
 use crate::Surreal;
@@ -61,7 +60,7 @@ macro_rules! into_future {
 				for result in patches {
 					vec.push(result?);
 				}
-				let patches = Value::Array(Array(vec));
+				let patches = vec.into();
 				let mut conn = Client::new(Method::Patch);
 				conn.$method(client.router.extract()?, Param::new(vec![param, patches])).await
 			})

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -14,11 +14,7 @@ use crate::method::Stats;
 use crate::method::WithStats;
 use crate::sql;
 use crate::sql::to_value;
-use crate::sql::Array;
-use crate::sql::Object;
 use crate::sql::Statement;
-use crate::sql::Statements;
-use crate::sql::Strand;
 use crate::sql::Value;
 use crate::Notification;
 use crate::Surreal;
@@ -79,7 +75,8 @@ where
 				statements.extend(query?);
 			}
 			// Build the query and execute it
-			let query = sql::Query(Statements(statements.clone()));
+			let mut query = sql::Query::default();
+			query.0 .0 = statements.clone();
 			let param = Param::query(query, self.bindings?);
 			let mut conn = Client::new(Method::Query);
 			let mut response = conn.execute_query(router, param).await?;
@@ -212,15 +209,15 @@ where
 		if let Ok(current) = &mut self.bindings {
 			match to_value(bindings) {
 				Ok(mut bindings) => {
-					if let Value::Array(Array(array)) = &mut bindings {
-						if let [Value::Strand(Strand(key)), value] = &mut array[..] {
+					if let Value::Array(array) = &mut bindings {
+						if let [Value::Strand(key), value] = &mut array.0[..] {
 							let mut map = BTreeMap::new();
-							map.insert(mem::take(key), mem::take(value));
+							map.insert(mem::take(&mut key.0), mem::take(value));
 							bindings = map.into();
 						}
 					}
 					match &mut bindings {
-						Value::Object(Object(map)) => current.append(map),
+						Value::Object(map) => current.append(&mut map.0),
 						_ => {
 							self.bindings = Err(Error::InvalidBindings(bindings).into());
 						}

--- a/lib/src/api/method/tests/mod.rs
+++ b/lib/src/api/method/tests/mod.rs
@@ -102,12 +102,12 @@ async fn api() {
 		.await
 		.unwrap();
 	let _: QueryResponse = DB
-		.query(BeginStatement)
+		.query(BeginStatement::default())
 		.query("CREATE account:one SET balance = 135605.16")
 		.query("CREATE account:two SET balance = 91031.31")
 		.query("UPDATE account:one SET balance += 300.00")
 		.query("UPDATE account:two SET balance -= 300.00")
-		.query(CommitStatement)
+		.query(CommitStatement::default())
 		.await
 		.unwrap();
 

--- a/lib/src/api/method/tests/server.rs
+++ b/lib/src/api/method/tests/server.rs
@@ -4,7 +4,6 @@ use crate::api::conn::Method;
 use crate::api::conn::Route;
 use crate::api::Response as QueryResponse;
 use crate::sql::to_value;
-use crate::sql::Array;
 use crate::sql::Value;
 use flume::Receiver;
 use futures::StreamExt;
@@ -64,7 +63,7 @@ pub(super) fn mock(route_rx: Receiver<Option<Route>>) {
 				Method::Select | Method::Delete => match &params[..] {
 					[Value::Thing(..)] => Ok(DbResponse::Other(to_value(User::default()).unwrap())),
 					[Value::Table(..) | Value::Array(..) | Value::Range(..)] => {
-						Ok(DbResponse::Other(Value::Array(Array(Vec::new()))))
+						Ok(DbResponse::Other(Value::Array(Default::default())))
 					}
 					_ => unreachable!(),
 				},
@@ -74,13 +73,13 @@ pub(super) fn mock(route_rx: Receiver<Option<Route>>) {
 					}
 					[Value::Table(..) | Value::Array(..) | Value::Range(..)]
 					| [Value::Table(..) | Value::Array(..) | Value::Range(..), _] => {
-						Ok(DbResponse::Other(Value::Array(Array(Vec::new()))))
+						Ok(DbResponse::Other(Value::Array(Default::default())))
 					}
 					_ => unreachable!(),
 				},
 				Method::Insert => match &params[..] {
 					[Value::Table(..), Value::Array(..)] => {
-						Ok(DbResponse::Other(Value::Array(Array(Vec::new()))))
+						Ok(DbResponse::Other(Value::Array(Default::default())))
 					}
 					[Value::Table(..), _] => {
 						Ok(DbResponse::Other(to_value(User::default()).unwrap()))

--- a/lib/src/api/opt/resource.rs
+++ b/lib/src/api/opt/resource.rs
@@ -21,11 +21,7 @@ pub enum Resource {
 impl Resource {
 	pub(crate) fn with_range(self, range: Range<Id>) -> Result<sql::Range> {
 		match self {
-			Resource::Table(Table(table)) => Ok(sql::Range {
-				tb: table,
-				beg: range.start,
-				end: range.end,
-			}),
+			Resource::Table(table) => Ok(sql::Range::new(table.0, range.start, range.end)),
 			Resource::RecordId(record_id) => Err(Error::RangeOnRecordId(record_id).into()),
 			Resource::Object(object) => Err(Error::RangeOnObject(object).into()),
 			Resource::Array(array) => Err(Error::RangeOnArray(array).into()),
@@ -219,21 +215,25 @@ fn blacklist_colon(input: &str) -> Result<()> {
 impl<R> IntoResource<Vec<R>> for &str {
 	fn into_resource(self) -> Result<Resource> {
 		blacklist_colon(self)?;
-		Ok(Resource::Table(Table(self.to_owned())))
+		let mut table = Table::default();
+		table.0 = self.to_owned();
+		Ok(Resource::Table(table))
 	}
 }
 
 impl<R> IntoResource<Vec<R>> for &String {
 	fn into_resource(self) -> Result<Resource> {
 		blacklist_colon(self)?;
-		Ok(Resource::Table(Table(self.to_owned())))
+		IntoResource::<Vec<R>>::into_resource(self.as_str())
 	}
 }
 
 impl<R> IntoResource<Vec<R>> for String {
 	fn into_resource(self) -> Result<Resource> {
 		blacklist_colon(&self)?;
-		Ok(Resource::Table(Table(self)))
+		let mut table = Table::default();
+		table.0 = self;
+		Ok(Resource::Table(table))
 	}
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -199,6 +199,8 @@ impl From<dbs::Action> for Action {
 			dbs::Action::Create => Self::Create,
 			dbs::Action::Update => Self::Update,
 			dbs::Action::Delete => Self::Delete,
+			#[cfg(feature = "sql2")]
+			_ => unreachable!(),
 		}
 	}
 }

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -403,12 +403,12 @@ async fn query_chaining() {
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
 	drop(permit);
 	let response = db
-		.query(BeginStatement)
+		.query(BeginStatement::default())
 		.query("CREATE account:one SET balance = 135605.16")
 		.query("CREATE account:two SET balance = 91031.31")
 		.query("UPDATE account:one SET balance += 300.00")
 		.query("UPDATE account:two SET balance -= 300.00")
-		.query(CommitStatement)
+		.query(CommitStatement::default())
 		.await
 		.unwrap();
 	response.check().unwrap();

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -1473,7 +1473,9 @@ where
 	let part: Vec<Part> = path.iter().map(|p| Part::from(*p)).collect();
 	let res = val.walk(&part);
 	for (i, v) in res {
-		assert_eq!(Idiom(part.clone()), i);
+		let mut idiom = Idiom::default();
+		idiom.0 = part.clone();
+		assert_eq!(idiom, i);
 		check(v);
 	}
 }

--- a/lib/tests/delete.rs
+++ b/lib/tests/delete.rs
@@ -413,16 +413,16 @@ async fn delete_filtered_live_notification() -> Result<(), Error> {
 	let notification = notifications.recv().await.unwrap();
 	assert_eq!(
 		notification,
-		Notification {
-			id: live_id,
-			action: Action::Delete,
-			result: Value::parse(
+		Notification::new(
+			live_id,
+			Action::Delete,
+			Value::parse(
 				"{
 					id: person:test_true,
 					condition: true,
 				}"
 			),
-		}
+		)
 	);
 	Ok(())
 }

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -62,9 +62,10 @@ async fn check_test_is_error(sql: &str, expected_errors: &[&str]) -> Result<(), 
 #[tokio::test]
 async fn error_on_invalid_function() -> Result<(), Error> {
 	let dbs = new_ds().await?;
-	let query = sql::Query(sql::Statements(vec![sql::Statement::Value(sql::Value::Function(
-		Box::new(sql::Function::Normal("this is an invalid function name".to_string(), Vec::new())),
-	))]));
+	let mut query = sql::Query::default();
+	query.0 .0 = vec![sql::Statement::Value(sql::Value::Function(Box::new(
+		sql::Function::Normal("this is an invalid function name".to_string(), Vec::new()),
+	)))];
 	let session = Session::owner().with_ns("test").with_db("test");
 	let mut resp = dbs.process(query, &session, None).await.unwrap();
 	assert_eq!(resp.len(), 1);

--- a/src/net/auth.rs
+++ b/src/net/auth.rs
@@ -134,8 +134,12 @@ async fn check_auth(parts: &mut Parts) -> Result<Session, Error> {
 		parts.extract_with_state(&state).await.unwrap_or(ExtractClientIP(None));
 
 	// Create session
-	#[rustfmt::skip]
-	let mut session = Session { ip, or, id, ns, db, ..Default::default() };
+	let mut session = Session::default();
+	session.ip = ip;
+	session.or = or;
+	session.id = id;
+	session.ns = ns;
+	session.db = db;
 
 	// If Basic authentication data was supplied
 	if let Ok(au) = parts.extract::<TypedHeader<Authorization<Basic>>>().await {

--- a/src/net/ml.rs
+++ b/src/net/ml.rs
@@ -80,19 +80,12 @@ async fn import(
 	// Insert the file data in to the store
 	surrealdb::obs::put(&path, data).await?;
 	// Insert the model in to the database
-	db.process(
-		DefineStatement::Model(DefineModelStatement {
-			hash,
-			name: file.header.name.to_string().into(),
-			version: file.header.version.to_string(),
-			comment: Some(file.header.description.to_string().into()),
-			..Default::default()
-		})
-		.into(),
-		&session,
-		None,
-	)
-	.await?;
+	let mut model = DefineModelStatement::default();
+	model.name = file.header.name.to_string().into();
+	model.version = file.header.version.to_string();
+	model.comment = Some(file.header.description.to_string().into());
+	model.hash = hash;
+	db.process(DefineStatement::Model(model).into(), &session, None).await?;
 	//
 	Ok(output::none())
 }

--- a/src/rpc/format/cbor/convert.rs
+++ b/src/rpc/format/cbor/convert.rs
@@ -257,6 +257,7 @@ impl TryFrom<Value> for Cbor {
 				Number::Decimal(v) => {
 					Ok(Cbor(Data::Tag(TAG_DECIMAL, Box::new(Data::Text(v.to_string())))))
 				}
+				_ => unreachable!(),
 			},
 			Value::Strand(v) => Ok(Cbor(Data::Text(v.0))),
 			Value::Duration(v) => {
@@ -296,6 +297,7 @@ impl TryFrom<Value> for Cbor {
 						Id::Generate(_) => {
 							return Err("Cannot encode an ungenerated Record ID into CBOR")
 						}
+						_ => unreachable!(),
 					},
 				])),
 			))),
@@ -349,5 +351,6 @@ fn encode_geometry(v: Geometry) -> Data {
 
 			Data::Tag(TAG_GEOMETRY_COLLECTION, Box::new(Data::Array(data)))
 		}
+		_ => unreachable!(),
 	}
 }

--- a/src/rpc/format/msgpack/convert.rs
+++ b/src/rpc/format/msgpack/convert.rs
@@ -114,6 +114,7 @@ impl TryFrom<Value> for Pack {
 				Number::Decimal(v) => {
 					Ok(Pack(Data::Ext(TAG_DECIMAL, v.to_string().as_bytes().to_vec())))
 				}
+				_ => unreachable!(),
 			},
 			Value::Strand(v) => Ok(Pack(Data::String(v.0.into()))),
 			Value::Duration(v) => Ok(Pack(Data::Ext(TAG_DURATION, v.to_raw().as_bytes().to_vec()))),


### PR DESCRIPTION
## What is the motivation?

Lack of the said attribute makes it impossible to add new fields or variants in a backwards compatible way.

## What does this change do?

It adds the attribute to all public structs and enums in the core library.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
