### PR TITLE
Stabilise `sql2` and `jwks`

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -120,14 +120,6 @@ compile_error!(
 	"`ml2` is currently unstable. You need to enable the `surrealdb_unstable` flag to use it."
 );
 
-#[cfg(all(not(surrealdb_unstable), feature = "jwks"))]
-compile_error!("`jwks` depends on a currently unstable feature, `sql2`. You need to enable the `surrealdb_unstable` flag to use it.");
-
-#[cfg(all(not(surrealdb_unstable), feature = "sql2"))]
-compile_error!(
-	"`sql2` is currently unstable. You need to enable the `surrealdb_unstable` flag to use it."
-);
-
 #[cfg(all(not(surrealdb_unstable), feature = "kv-surrealkv"))]
 compile_error!(
 	"`kv-surrealkv` is currently unstable. You need to enable the `surrealdb_unstable` flag to use it."


### PR DESCRIPTION
## What is the motivation?

With #3781 now merged, these features can be stabilised.

## What does this change do?

It removes the requirement for `surrealdb_unstable` when building these features.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

It's a followup to #3781.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
