### PR TITLE
Stabilise and use `parser2` for parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,46 +344,6 @@ jobs:
           path: target/llvm-cov/html/
           retention-days: 5
 
-  test-parser:
-    name: Test workspace with experimental parser
-    runs-on: ["self-hosted", "arm64", "builder"]
-    steps:
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get -y update
-
-      - name: Free up some disk space
-        run: |
-          (set -x; df -h)
-          # Free up some disk space by removing unused files
-          (set -x; sudo rm -rf /imagegeneration || true)
-          (set -x; sudo rm -rf /opt/az || true)
-          (set -x; sudo rm -rf /opt/hostedtoolcache || true)
-          (set -x; sudo rm -rf /opt/google || true)
-          (set -x; sudo rm -rf /opt/pipx || true)
-          (set -x; df -h)
-
-      - name: Install cargo-make
-        run: cargo install --debug --locked cargo-make
-
-      - name: Test workspace for experimental_parser
-        env:
-          RUSTFLAGS: "--cfg surrealdb_unstable"
-        run: cargo make test-experimental-parser
-
   ws-engine:
     name: WebSocket engine
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ http = ["surrealdb/http"]
 http-compression = []
 ml = ["surrealdb/ml"]
 jwks = ["surrealdb/jwks"]
-parser2 = ["surrealdb/parser2"]
 performance-profiler = ["dep:pprof"]
 
 [workspace]

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -60,20 +60,6 @@ args = [
     "--skip", "database_upgrade"
 ]
 
-
-[tasks.test-experimental-parser]
-category = "CI - INTEGRATION TESTS"
-command = "cargo"
-env = { RUST_BACKTRACE = 1, RUSTFLAGS = "--cfg surrealdb_unstable", RUSTDOCFLAGS = "--cfg surrealdb_unstable" }
-args = [
-    "test", "--locked", "--no-default-features", "--features", "storage-mem,scripting,http,parser2", "--workspace", "--",
-    "--skip", "api_integration",
-    "--skip", "cli_integration",
-    "--skip", "http_integration",
-    "--skip", "ws_integration",
-    "--skip", "database_upgrade"
-]
-
 [tasks.test-workspace-coverage-complete]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"

--- a/cackle.toml
+++ b/cackle.toml
@@ -611,10 +611,6 @@ from.build.allow_apis = [
 allow_unsafe = true
 
 [pkg.wasm-bindgen-shared]
-build.allow_apis = [
-    "fs",
-    "process",
-]
 build.allow_build_instructions = [
     "cargo:rustc-env=SCHEMA_FILE_HASH=*",
 ]
@@ -719,9 +715,6 @@ allow_unsafe = true
 
 [pkg.wasm-bindgen-backend]
 allow_unsafe = true
-allow_apis = [
-    "fs",
-]
 
 [pkg.alloc-stdlib]
 allow_unsafe = true
@@ -1313,3 +1306,6 @@ allow_proc_macro = true
 allow_apis = [
     "fs",
 ]
+
+[pkg.phf_macros]
+allow_proc_macro = true

--- a/core/src/syn/v2/mod.rs
+++ b/core/src/syn/v2/mod.rs
@@ -59,7 +59,7 @@ pub fn value(input: &str) -> Result<Value, Error> {
 /// Parses a SurrealQL [`Value`].
 #[instrument(level = "debug", name = "parser", skip_all, fields(length = input.len()))]
 pub fn value_legacy_strand(input: &str) -> Result<Value, Error> {
-	debug!("parsing value, input = {input}");
+	debug!("parsing value with legacy strings, input = {input}");
 	let mut parser = Parser::new(input.as_bytes());
 	let mut stack = Stack::new();
 	parser.allow_legacy_strand(true);
@@ -86,7 +86,7 @@ pub fn json(input: &str) -> Result<Value, Error> {
 /// Parses JSON into an inert SurrealQL [`Value`]
 #[instrument(level = "debug", name = "parser", skip_all, fields(length = input.len()))]
 pub fn json_legacy_strand(input: &str) -> Result<Value, Error> {
-	debug!("parsing json, input = {input}");
+	debug!("parsing json with legacy strings, input = {input}");
 	let mut parser = Parser::new(input.as_bytes());
 	let mut stack = Stack::new();
 	parser.allow_legacy_strand(true);

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -49,7 +49,7 @@ rustls = [
 ml = ["surrealdb-core/ml"]
 jwks = ["surrealdb-core/jwks"]
 arbitrary = ["surrealdb-core/arbitrary"]
-parser2 = ["surrealdb-core/experimental-parser"]
+
 # Private features
 kv-fdb = ["tokio/time"]
 
@@ -91,7 +91,7 @@ rustls = { version = "0.21.10", optional = true }
 semver = { version = "1.0.20", features = ["serde"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
-surrealdb-core = { version = "=2.0.0-1.5.0", default-features = false, path = "../core" }
+surrealdb-core = { version = "=2.0.0-1.5.0", default-features = false, features = ["experimental-parser"], path = "../core" }
 thiserror = "1.0.50"
 tokio-util = { version = "0.7.10", optional = true, features = ["compat"] }
 tracing = "0.1.40"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -113,11 +113,6 @@
 #[cfg(all(target_arch = "wasm32", feature = "ml"))]
 compile_error!("The `ml` feature is not supported on the `wasm32` architecture.");
 
-#[cfg(all(not(surrealdb_unstable), feature = "parser2"))]
-compile_error!(
-	"`parser2` is currently unstable. You need to enable the `surrealdb_unstable` flag to use it."
-);
-
 #[macro_use]
 extern crate tracing;
 

--- a/lib/tests/api/live.rs
+++ b/lib/tests/api/live.rs
@@ -15,7 +15,7 @@ async fn live_select_table() {
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
 
 	{
-		let table = Ulid::new().to_string();
+		let table = format!("table_{}", Ulid::new());
 
 		// Start listening
 		let mut users = db.select(&table).live().await.unwrap();
@@ -48,7 +48,7 @@ async fn live_select_table() {
 	}
 
 	{
-		let table = Ulid::new().to_string();
+		let table = format!("table_{}", Ulid::new());
 
 		// Start listening
 		let mut users = db.select(Resource::from(&table)).live().await.unwrap();
@@ -133,7 +133,7 @@ async fn live_select_record_ranges() {
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
 
 	{
-		let table = Ulid::new().to_string();
+		let table = format!("table_{}", Ulid::new());
 
 		// Start listening
 		let mut users = db.select(&table).range("jane".."john").live().await.unwrap();
@@ -167,7 +167,7 @@ async fn live_select_record_ranges() {
 	}
 
 	{
-		let table = Ulid::new().to_string();
+		let table = format!("table_{}", Ulid::new());
 
 		// Start listening
 		let mut users =
@@ -194,7 +194,7 @@ async fn live_select_query() {
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
 
 	{
-		let table = Ulid::new().to_string();
+		let table = format!("table_{}", Ulid::new());
 
 		// Start listening
 		let mut users = db
@@ -234,7 +234,7 @@ async fn live_select_query() {
 	}
 
 	{
-		let table = Ulid::new().to_string();
+		let table = format!("table_{}", Ulid::new());
 
 		// Start listening
 		let mut users = db
@@ -256,7 +256,7 @@ async fn live_select_query() {
 	}
 
 	{
-		let table = Ulid::new().to_string();
+		let table = format!("table_{}", Ulid::new());
 
 		// Start listening
 		let mut users = db
@@ -295,7 +295,7 @@ async fn live_select_query() {
 	}
 
 	{
-		let table = Ulid::new().to_string();
+		let table = format!("table_{}", Ulid::new());
 
 		// Start listening
 		let mut users = db

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -345,20 +345,9 @@ async fn define_statement_event() -> Result<(), Error> {
 	assert!(tmp.is_ok());
 	//
 	let tmp = res.remove(0).result?;
-	#[cfg(feature = "parser2")]
 	let val = Value::parse(
 		"{
 			events: { test: 'DEFINE EVENT test ON user WHEN true THEN (CREATE activity SET user = $this, `value` = $after.email, action = $event)' },
-			fields: {},
-			tables: {},
-			indexes: {},
-			lives: {},
-		}",
-	);
-	#[cfg(not(feature = "parser2"))]
-	let val = Value::parse(
-		"{
-			events: { test: 'DEFINE EVENT test ON user WHEN true THEN (CREATE activity SET user = $this, value = $after.email, action = $event)' },
 			fields: {},
 			tables: {},
 			indexes: {},
@@ -414,20 +403,9 @@ async fn define_statement_event_when_event() -> Result<(), Error> {
 	assert!(tmp.is_ok());
 	//
 	let tmp = res.remove(0).result?;
-	#[cfg(feature = "parser2")]
 	let val = Value::parse(
 		r#"{
 			events: { test: "DEFINE EVENT test ON user WHEN $event = 'CREATE' THEN (CREATE activity SET user = $this, `value` = $after.email, action = $event)" },
-			fields: {},
-			tables: {},
-			indexes: {},
-			lives: {},
-		}"#,
-	);
-	#[cfg(not(feature = "parser2"))]
-	let val = Value::parse(
-		r#"{
-			events: { test: "DEFINE EVENT test ON user WHEN $event = 'CREATE' THEN (CREATE activity SET user = $this, value = $after.email, action = $event)" },
 			fields: {},
 			tables: {},
 			indexes: {},
@@ -483,20 +461,9 @@ async fn define_statement_event_when_logic() -> Result<(), Error> {
 	assert!(tmp.is_ok());
 	//
 	let tmp = res.remove(0).result?;
-	#[cfg(feature = "parser2")]
 	let val = Value::parse(
 		"{
 			events: { test: 'DEFINE EVENT test ON user WHEN $before.email != $after.email THEN (CREATE activity SET user = $this, `value` = $after.email, action = $event)' },
-			fields: {},
-			tables: {},
-			indexes: {},
-			lives: {},
-		}",
-	);
-	#[cfg(not(feature = "parser2"))]
-	let val = Value::parse(
-		"{
-			events: { test: 'DEFINE EVENT test ON user WHEN $before.email != $after.email THEN (CREATE activity SET user = $this, value = $after.email, action = $event)' },
 			fields: {},
 			tables: {},
 			indexes: {},

--- a/src/rpc/format/json.rs
+++ b/src/rpc/format/json.rs
@@ -11,7 +11,7 @@ use surrealdb::sql;
 pub fn req_ws(msg: Message) -> Result<Request, RpcError> {
 	match msg {
 		Message::Text(val) => {
-			surrealdb::sql::value(&val).map_err(|_| RpcError::ParseError)?.try_into()
+			surrealdb::syn::value_legacy_strand(&val).map_err(|_| RpcError::ParseError)?.try_into()
 		}
 		_ => Err(RpcError::InvalidRequest),
 	}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1219,10 +1219,6 @@ criteria = "safe-to-deploy"
 version = "0.11.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.phf_macros]]
-version = "0.11.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.phf_shared]]
 version = "0.10.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1219,6 +1219,10 @@ criteria = "safe-to-deploy"
 version = "0.11.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.phf_macros]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.phf_shared]]
 version = "0.10.0"
 criteria = "safe-to-deploy"

--- a/tests/common/socket.rs
+++ b/tests/common/socket.rs
@@ -117,7 +117,7 @@ impl Socket {
 				// First of all we convert the JSON type to a string.
 				let json = message.to_string();
 				// Then we parse the JSON in to SurrealQL.
-				let surrealql = surrealdb::sql::value(&json)?;
+				let surrealql = surrealdb::syn::value_legacy_strand(&json)?;
 				// Then we convert the SurrealQL in to CBOR.
 				let cbor = try_from_impls::Cbor::try_from(surrealql)?;
 				// Then serialize the CBOR as binary data.
@@ -136,7 +136,7 @@ impl Socket {
 				// First of all we convert the JSON type to a string.
 				let json = message.to_string();
 				// Then we parse the JSON in to SurrealQL.
-				let surrealql = surrealdb::sql::value(&json)?;
+				let surrealql = surrealdb::syn::value_legacy_strand(&json)?;
 				// Then we convert the SurrealQL in to MessagePack.
 				let pack = try_from_impls::Pack::try_from(surrealql)?;
 				// Then serialize the MessagePack as binary data.

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -790,7 +790,7 @@ async fn kill() -> Result<(), Box<dyn std::error::Error>> {
 	let res = res["result"].as_object().unwrap();
 	assert_eq!(res["id"], "tester:two", "result: {:?}", res);
 	// Send QUERY command
-	let res = socket.send_request("query", json!([format!("KILL '{live2}'")])).await?;
+	let res = socket.send_request("query", json!([format!("KILL u'{live2}'")])).await?;
 	assert!(res.is_object(), "result: {:?}", res);
 	assert!(res["result"].is_array(), "result: {:?}", res);
 	let res = res["result"].as_array().unwrap();


### PR DESCRIPTION
## What is the motivation?

v2 is going to use `parser2`.

## What does this change do?

It switches the codebase to use `parser2` and stabilises it. It doesn't drop the old parser itself. That will be done in a followup PR.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] surrealdb/docs.surrealdb.com#455

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
