### PR TITLE
Disable database upgrade tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,3 +695,28 @@ jobs:
           df -h
           ps auxf
           cat /tmp/surrealdb.log || true
+
+  db-upgrade:
+    name: Database Upgrade from previous versions
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install cargo-make
+        run: cargo install --debug --locked cargo-make
+
+      - name: Test upgrade
+        run: cargo make ci-database-upgrade
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,5 +718,6 @@ jobs:
         run: cargo install --debug --locked cargo-make
 
       - name: Test upgrade
+        # Allow breaking changes until v2 stabilises
+        continue-on-error: true
         run: cargo make ci-database-upgrade
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,28 +695,3 @@ jobs:
           df -h
           ps auxf
           cat /tmp/surrealdb.log || true
-
-  db-upgrade:
-    name: Database Upgrade from previous versions
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install cargo-make
-        run: cargo install --debug --locked cargo-make
-
-      - name: Test upgrade
-        run: cargo make ci-database-upgrade
-


### PR DESCRIPTION
## What is the motivation?

`main` is now tracking v2 which is a new major version. Breaking changes are allowed here and will be necessary before we stabilise.

## What does this change do?

It allows the CI to continue when the `db-upgrade` job fails.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
