### PR TITLE
Fuzz experimental parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,8 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check fuzzers
+        env:
+          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: cargo build --manifest-path lib/fuzz/Cargo.toml
 
       - name: Check OSS-Fuzz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,6 @@ jobs:
         with:
           oss-fuzz-project-name: surrealdb
           language: rust
-        # Temporarily allow this step to fail
-        continue-on-error: true
 
   check-wasm:
     name: Check Wasm

--- a/lib/fuzz/Cargo.lock
+++ b/lib/fuzz/Cargo.lock
@@ -1714,12 +1714,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared 0.11.2",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "unicase",
+]
+
+[[package]]
 name = "phf_shared"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+ "unicase",
 ]
 
 [[package]]
@@ -2574,7 +2618,7 @@ dependencies = [
  "new_debug_unreachable",
  "once_cell",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.10.0",
  "precomputed-hash",
 ]
 
@@ -2659,6 +2703,7 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "pharos",
+ "phf",
  "pin-project-lite",
  "quick_cache",
  "radix_trie",
@@ -2686,6 +2731,7 @@ dependencies = [
  "tracing",
  "trice",
  "ulid",
+ "unicase",
  "url",
  "uuid",
  "wasm-bindgen-futures",
@@ -2964,6 +3010,15 @@ checksum = "7e37c4b6cbcc59a8dcd09a6429fbc7890286bcbb79215cea7b38a3c4c0921d93"
 dependencies = [
  "rand",
  "serde",
+]
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/lib/fuzz/Cargo.toml
+++ b/lib/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ tokio = "1.33.0"
 
 [dependencies.surrealdb]
 path = ".."
-features = ["kv-mem", "arbitrary"]
+features = ["kv-mem", "arbitrary", "parser2"]
 default-features = false
 
 # Prevent this from interfering with workspaces

--- a/lib/fuzz/README.md
+++ b/lib/fuzz/README.md
@@ -3,7 +3,7 @@ Surrealdb maintains a set of fuzz testing harnesses that are managed by
 [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz).
 
 To build and run the fuzzer we will need to;
-- Install a specific version of the nightly compiler
+- Install the nightly compiler
 - Install cargo fuzz
 - Build a fuzz friendly version of surrealdb with our harnesses
 
@@ -14,23 +14,13 @@ version of rustc we can't instrument our fuzz-harnesses with coverage feedback.
 Because of this we need to use some of the more bleeding edge features 
 available in the nightly release. 
 
-Unfortunately for us the nightly release is a little unstable and there
-was a [bug](https://github.com/rust-lang/rust/issues/110475) in the 
-latest version of the nightly compiler that prevents use from compiling
-some of surrealdb's dependencies. To workaround this issue we've carefully
-picked a version of the nightly compiler that works with both cargo-fuzz
-and our dependencies. This version is `nightly-2023-04-21`. To install
-this version we simply need to run;
-
-`rustup install nightly-2023-04-21`
-
 ## Installing cargo-fuzz
 Full details on the different install options are available, in the
 [cargo-fuzz book](https://rust-fuzz.github.io/book/cargo-fuzz/setup.html).
 but for the sake of brevity you can just install the basics with the
 command below.
 
-`cargo +nightly-2023-04-21 install cargo-fuzz`
+`cargo +nightly install cargo-fuzz`
 
 ## Building the fuzzers
 Now that we've install cargo-fuzz we can go ahead and build our fuzzers.
@@ -38,20 +28,20 @@ Now that we've install cargo-fuzz we can go ahead and build our fuzzers.
 cd lib  
 # -O: Optimised build
 # --debug-assertions: Catch common bugs, e.g. integer overflow.
-cargo +nightly-2023-04-21 fuzz build -O --debug-assertions
+cargo +nightly fuzz build -O --debug-assertions
 ````
 
 ## Running the fuzzer
 Now that the fuzzer has successfully built we can actually run them. To
 list the available fuzz harnesses we can use the command.
 ```
-cargo +nightly-2023-04-21 fuzz list
+cargo +nightly fuzz list
 ```
 
 Once we know what fuzzer (in this case fuzz_executor) we want to run we 
 can it using the command;
 ```
-cargo +nightly-2023-04-21 fuzz run -O --debug-assertions fuzz_executor
+cargo +nightly fuzz run -O --debug-assertions fuzz_executor
 ```
 
 The previous command will run the fuzzer in libfuzzer's default mode,
@@ -62,7 +52,7 @@ up we can make use of all cores, and use a dictionary file. e.g.
 #        use nproc to match the number of processors on our local
 #        machine.
 # -dict: Make use the fuzzer specific dictionary file.
-cargo +nightly-2023-04-21 fuzz run -O --debug-assertions \
+cargo +nightly fuzz run -O --debug-assertions \
   fuzz_executor -- -fork=$(nproc) \
   -dict=fuzz/fuzz_targets/fuzz_executor.dict
 ```


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To start fuzzing the new parser to identify any issues with it before it becomes the default. The old parser has been fuzzed in OSS-Fuzz for a year and no new issues have been identified for months. Since no significant changes are planned on the old parser, it makes sense to start fuzzing the new one in OSS-Fuzz instead. Fuzzing the old parser is still possible in branch `1.x`.

## What does this change do?

Enables the `parser2` feature in the fuzzing build so that the new experimental parser is used. Enforces that the fuzzer check passes and updates the README file with current information. The fuzzer check will fail until https://github.com/google/oss-fuzz/pull/11777 is merged. After the new parser is the default in `main`, the `parser2` feature can be dropped from `Cargo.toml`.

## What is your testing strategy?

Tested the build locally on the https://github.com/google/oss-fuzz/pull/11777 branch. Ensure that the fuzzer check passes in CI.

## Is this related to any issues?

No.

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
