### PR TITLE
Add `Range::new` to core1

### DIFF
--- a/core/src/sql/range.rs
+++ b/core/src/sql/range.rs
@@ -42,6 +42,15 @@ impl TryFrom<&str> for Range {
 }
 
 impl Range {
+	/// Construct a new range
+	pub fn new(tb: String, beg: Bound<Id>, end: Bound<Id>) -> Self {
+		Self {
+			tb,
+			beg,
+			end,
+		}
+	}
+
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,


### PR DESCRIPTION
## What is the motivation?

To fix the 1.x branch when building without the sql2 feature enabled.

## What does this change do?

It imports `Range::new` from 1.x.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
