### PR TITLE
Add `Range::to_cond` to core1

### DIFF
--- a/core/src/sql/range.rs
+++ b/core/src/sql/range.rs
@@ -2,6 +2,13 @@ use crate::ctx::Context;
 use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
+use crate::sql::Cond;
+use crate::sql::Expression;
+use crate::sql::Ident;
+use crate::sql::Idiom;
+use crate::sql::Operator;
+use crate::sql::Part;
+use crate::sql::Thing;
 use crate::sql::{strand::no_nul_bytes, Id, Value};
 use crate::syn;
 use revision::revisioned;
@@ -11,6 +18,7 @@ use std::fmt;
 use std::ops::Bound;
 use std::str::FromStr;
 
+const ID: &str = "id";
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Range";
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
@@ -48,6 +56,101 @@ impl Range {
 			tb,
 			beg,
 			end,
+		}
+	}
+
+	/// Convert `Range` to `Cond`
+	pub fn to_cond(self) -> Option<Cond> {
+		match (self.beg, self.end) {
+			(Bound::Unbounded, Bound::Unbounded) => None,
+			(Bound::Unbounded, Bound::Excluded(id)) => {
+				Some(Cond(Value::Expression(Box::new(Expression::new(
+					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+					Operator::LessThan,
+					Thing::from((self.tb, id)).into(),
+				)))))
+			}
+			(Bound::Unbounded, Bound::Included(id)) => {
+				Some(Cond(Value::Expression(Box::new(Expression::new(
+					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+					Operator::LessThanOrEqual,
+					Thing::from((self.tb, id)).into(),
+				)))))
+			}
+			(Bound::Excluded(id), Bound::Unbounded) => {
+				Some(Cond(Value::Expression(Box::new(Expression::new(
+					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+					Operator::MoreThan,
+					Thing::from((self.tb, id)).into(),
+				)))))
+			}
+			(Bound::Included(id), Bound::Unbounded) => {
+				Some(Cond(Value::Expression(Box::new(Expression::new(
+					Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+					Operator::MoreThanOrEqual,
+					Thing::from((self.tb, id)).into(),
+				)))))
+			}
+			(Bound::Included(lid), Bound::Included(rid)) => {
+				Some(Cond(Value::Expression(Box::new(Expression::new(
+					Value::Expression(Box::new(Expression::new(
+						Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+						Operator::MoreThanOrEqual,
+						Thing::from((self.tb.clone(), lid)).into(),
+					))),
+					Operator::And,
+					Value::Expression(Box::new(Expression::new(
+						Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+						Operator::LessThanOrEqual,
+						Thing::from((self.tb, rid)).into(),
+					))),
+				)))))
+			}
+			(Bound::Included(lid), Bound::Excluded(rid)) => {
+				Some(Cond(Value::Expression(Box::new(Expression::new(
+					Value::Expression(Box::new(Expression::new(
+						Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+						Operator::MoreThanOrEqual,
+						Thing::from((self.tb.clone(), lid)).into(),
+					))),
+					Operator::And,
+					Value::Expression(Box::new(Expression::new(
+						Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+						Operator::LessThan,
+						Thing::from((self.tb, rid)).into(),
+					))),
+				)))))
+			}
+			(Bound::Excluded(lid), Bound::Included(rid)) => {
+				Some(Cond(Value::Expression(Box::new(Expression::new(
+					Value::Expression(Box::new(Expression::new(
+						Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+						Operator::MoreThan,
+						Thing::from((self.tb.clone(), lid)).into(),
+					))),
+					Operator::And,
+					Value::Expression(Box::new(Expression::new(
+						Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+						Operator::LessThanOrEqual,
+						Thing::from((self.tb, rid)).into(),
+					))),
+				)))))
+			}
+			(Bound::Excluded(lid), Bound::Excluded(rid)) => {
+				Some(Cond(Value::Expression(Box::new(Expression::new(
+					Value::Expression(Box::new(Expression::new(
+						Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+						Operator::MoreThan,
+						Thing::from((self.tb.clone(), lid)).into(),
+					))),
+					Operator::And,
+					Value::Expression(Box::new(Expression::new(
+						Idiom(vec![Part::from(Ident(ID.to_owned()))]).into(),
+						Operator::LessThan,
+						Thing::from((self.tb, rid)).into(),
+					))),
+				)))))
+			}
 		}
 	}
 


### PR DESCRIPTION
## What is the motivation?

To fix the 1.x branch when building without the sql2 feature enabled.

## What does this change do?

It imports Range::to_cond from 1.x.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
