### PR TITLE
Bugfix: Fix problems with `if` in identifiers after remove and define statements

### DIFF
--- a/core/src/syn/v1/stmt/define/analyzer.rs
+++ b/core/src/syn/v1/stmt/define/analyzer.rs
@@ -15,7 +15,10 @@ pub fn analyzer(i: &str) -> IResult<&str, DefineAnalyzerStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		cut(tag_no_case("EXISTS")),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;

--- a/core/src/syn/v1/stmt/define/database.rs
+++ b/core/src/syn/v1/stmt/define/database.rs
@@ -15,7 +15,10 @@ pub fn database(i: &str) -> IResult<&str, DefineDatabaseStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		cut(tag_no_case("EXISTS")),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;

--- a/core/src/syn/v1/stmt/define/event.rs
+++ b/core/src/syn/v1/stmt/define/event.rs
@@ -21,7 +21,10 @@ pub fn event(i: &str) -> IResult<&str, DefineEventStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		cut(tag_no_case("EXISTS")),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, (name, what, opts)) = cut(|i| {

--- a/core/src/syn/v1/stmt/define/field.rs
+++ b/core/src/syn/v1/stmt/define/field.rs
@@ -23,7 +23,10 @@ pub fn field(i: &str) -> IResult<&str, DefineFieldStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		cut(tag_no_case("EXISTS")),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, (name, what, opts)) = cut(|i| {

--- a/core/src/syn/v1/stmt/define/function.rs
+++ b/core/src/syn/v1/stmt/define/function.rs
@@ -24,7 +24,10 @@ pub fn function(i: &str) -> IResult<&str, DefineFunctionStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		tag_no_case("EXISTS"),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, _) = tag("fn::")(i)?;

--- a/core/src/syn/v1/stmt/define/index.rs
+++ b/core/src/syn/v1/stmt/define/index.rs
@@ -25,7 +25,10 @@ pub fn index(i: &str) -> IResult<&str, DefineIndexStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		cut(tag_no_case("EXISTS")),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, (name, what, opts)) = cut(|i| {

--- a/core/src/syn/v1/stmt/define/namespace.rs
+++ b/core/src/syn/v1/stmt/define/namespace.rs
@@ -14,7 +14,10 @@ pub fn namespace(i: &str) -> IResult<&str, DefineNamespaceStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		tag_no_case("EXISTS"),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;

--- a/core/src/syn/v1/stmt/define/param.rs
+++ b/core/src/syn/v1/stmt/define/param.rs
@@ -22,7 +22,10 @@ pub fn param(i: &str) -> IResult<&str, DefineParamStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		cut(tag_no_case("EXISTS")),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, _) = cut(char('$'))(i)?;

--- a/core/src/syn/v1/stmt/define/scope.rs
+++ b/core/src/syn/v1/stmt/define/scope.rs
@@ -15,7 +15,10 @@ pub fn scope(i: &str) -> IResult<&str, DefineScopeStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		cut(tag_no_case("EXISTS")),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;

--- a/core/src/syn/v1/stmt/define/table.rs
+++ b/core/src/syn/v1/stmt/define/table.rs
@@ -23,7 +23,10 @@ pub fn table(i: &str) -> IResult<&str, DefineTableStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		cut(tag_no_case("EXISTS")),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;

--- a/core/src/syn/v1/stmt/define/token.rs
+++ b/core/src/syn/v1/stmt/define/token.rs
@@ -21,7 +21,10 @@ pub fn token(i: &str) -> IResult<&str, DefineTokenStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		cut(tag_no_case("EXISTS")),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, (name, base, opts)) = cut(|i| {

--- a/core/src/syn/v1/stmt/define/user.rs
+++ b/core/src/syn/v1/stmt/define/user.rs
@@ -25,7 +25,10 @@ pub fn user(i: &str) -> IResult<&str, DefineUserStatement> {
 	let (i, if_not_exists) = opt(tuple((
 		shouldbespace,
 		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("NOT"), shouldbespace, tag_no_case("EXISTS")))),
+		shouldbespace,
+		tag_no_case("NOT"),
+		shouldbespace,
+		cut(tag_no_case("EXISTS")),
 	)))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, (name, base, opts)) = cut(|i| {
@@ -118,4 +121,12 @@ fn user_roles(i: &str) -> IResult<&str, DefineUserOption> {
 	})(i)?;
 
 	Ok((i, DefineUserOption::Roles(roles)))
+}
+
+#[cfg(test)]
+mod test {
+	fn test_define_user_exists() {
+		let (_, q) = super::user("USER IF ON NS").unwrap();
+		assert!(format("{}", q).starts_with("DEFINE USER IF ON NS"));
+	}
 }

--- a/core/src/syn/v1/stmt/define/user.rs
+++ b/core/src/syn/v1/stmt/define/user.rs
@@ -127,6 +127,6 @@ fn user_roles(i: &str) -> IResult<&str, DefineUserOption> {
 mod test {
 	fn test_define_user_exists() {
 		let (_, q) = super::user("USER IF ON NS").unwrap();
-		assert!(format("{}", q).starts_with("DEFINE USER IF ON NS"));
+		assert!(format!("{}", q).starts_with("DEFINE USER IF ON NS"));
 	}
 }

--- a/core/src/syn/v1/stmt/define/user.rs
+++ b/core/src/syn/v1/stmt/define/user.rs
@@ -128,6 +128,10 @@ mod test {
 	#[test]
 	fn test_define_user_exists() {
 		let (_, q) = super::user("USER IF ON NS").unwrap();
-		assert!(format!("{}", q).starts_with("DEFINE USER IF ON NS"));
+		assert!(
+			format!("{}", q).starts_with("DEFINE USER IF ON NAMESPACE"),
+			"got {}, expected it to start with 'DEFINE USER IF ON NAMESPACE'",
+			q
+		);
 	}
 }

--- a/core/src/syn/v1/stmt/define/user.rs
+++ b/core/src/syn/v1/stmt/define/user.rs
@@ -125,6 +125,7 @@ fn user_roles(i: &str) -> IResult<&str, DefineUserOption> {
 
 #[cfg(test)]
 mod test {
+	#[test]
 	fn test_define_user_exists() {
 		let (_, q) = super::user("USER IF ON NS").unwrap();
 		assert!(format!("{}", q).starts_with("DEFINE USER IF ON NS"));

--- a/core/src/syn/v1/stmt/remove.rs
+++ b/core/src/syn/v1/stmt/remove.rs
@@ -290,13 +290,6 @@ mod tests {
 		assert_eq!("REMOVE ANALYZER IF EXISTS test", format!("{}", out))
 	}
 
-	#[test]
-	fn remove_analyzer_if() {
-		let sql = "REMOVE ANALYZER IF test";
-		let res = remove(sql);
-		assert!(res.is_err());
-	}
-
 	/// REMOVE DATABASE tests
 
 	#[test]
@@ -313,13 +306,6 @@ mod tests {
 		let res = remove(sql);
 		let out = res.unwrap().1;
 		assert_eq!("REMOVE DATABASE IF EXISTS test", format!("{}", out))
-	}
-
-	#[test]
-	fn remove_database_if() {
-		let sql = "REMOVE DATABASE IF test";
-		let res = remove(sql);
-		assert!(res.is_err());
 	}
 
 	/// REMOVE EVENT tests
@@ -340,13 +326,6 @@ mod tests {
 		assert_eq!("REMOVE EVENT IF EXISTS test ON test", format!("{}", out))
 	}
 
-	#[test]
-	fn remove_event_if() {
-		let sql = "REMOVE EVENT IF test ON test";
-		let res = remove(sql);
-		assert!(res.is_err());
-	}
-
 	/// REMOVE FIELD tests
 
 	#[test]
@@ -365,13 +344,6 @@ mod tests {
 		assert_eq!("REMOVE FIELD IF EXISTS test ON test", format!("{}", out))
 	}
 
-	#[test]
-	fn remove_field_if() {
-		let sql = "REMOVE FIELD IF test ON test";
-		let res = remove(sql);
-		assert!(res.is_err());
-	}
-
 	/// REMOVE FUNCTION tests
 
 	#[test]
@@ -388,13 +360,6 @@ mod tests {
 		let res = remove(sql);
 		let out = res.unwrap().1;
 		assert_eq!("REMOVE FUNCTION IF EXISTS fn::test", format!("{}", out))
-	}
-
-	#[test]
-	fn remove_function_if() {
-		let sql = "REMOVE FUNCTION IF fn::test";
-		let res = remove(sql);
-		assert!(res.is_err());
 	}
 
 	#[test]
@@ -423,13 +388,6 @@ mod tests {
 		assert_eq!("REMOVE INDEX IF EXISTS test ON test", format!("{}", out))
 	}
 
-	#[test]
-	fn remove_index_if() {
-		let sql = "REMOVE INDEX IF test ON test";
-		let res = remove(sql);
-		assert!(res.is_err());
-	}
-
 	/// REMOVE NAMESPACE tests
 
 	#[test]
@@ -447,14 +405,6 @@ mod tests {
 		let out = res.unwrap().1;
 		assert_eq!("REMOVE NAMESPACE IF EXISTS test", format!("{}", out))
 	}
-
-	#[test]
-	fn remove_namespace_if() {
-		let sql = "REMOVE NAMESPACE IF test";
-		let res = remove(sql);
-		assert!(res.is_err());
-	}
-
 	/// REMOVE PARAM tests
 
 	#[test]
@@ -472,14 +422,6 @@ mod tests {
 		let out = res.unwrap().1;
 		assert_eq!("REMOVE PARAM IF EXISTS $test", format!("{}", out))
 	}
-
-	#[test]
-	fn remove_param_if() {
-		let sql = "REMOVE PARAM IF $test";
-		let res = remove(sql);
-		assert!(res.is_err());
-	}
-
 	/// REMOVE SCOPE tests
 
 	#[test]
@@ -496,13 +438,6 @@ mod tests {
 		let res = remove(sql);
 		let out = res.unwrap().1;
 		assert_eq!("REMOVE SCOPE IF EXISTS test", format!("{}", out))
-	}
-
-	#[test]
-	fn remove_scope_if() {
-		let sql = "REMOVE SCOPE IF test";
-		let res = remove(sql);
-		assert!(res.is_err());
 	}
 
 	/// REMOVE TABLE tests
@@ -523,13 +458,6 @@ mod tests {
 		assert_eq!("REMOVE TABLE IF EXISTS test", format!("{}", out))
 	}
 
-	#[test]
-	fn remove_table_if() {
-		let sql = "REMOVE TABLE IF test";
-		let res = remove(sql);
-		assert!(res.is_err());
-	}
-
 	/// REMOVE TOKEN tests
 
 	#[test]
@@ -546,13 +474,6 @@ mod tests {
 		let res = remove(sql);
 		let out = res.unwrap().1;
 		assert_eq!("REMOVE TOKEN IF EXISTS test ON NAMESPACE", format!("{}", out))
-	}
-
-	#[test]
-	fn remove_token_if() {
-		let sql = "REMOVE TOKEN IF test ON NAMESPACE";
-		let res = remove(sql);
-		assert!(res.is_err());
 	}
 
 	/// REMOVE USER tests

--- a/core/src/syn/v1/stmt/remove.rs
+++ b/core/src/syn/v1/stmt/remove.rs
@@ -488,10 +488,10 @@ mod tests {
 
 	#[test]
 	fn remove_user_if_ident() {
-		let sql = "REMOVE USER IF";
+		let sql = "REMOVE USER IF ON ROOT";
 		let res = remove(sql);
 		let out = res.unwrap().1;
-		assert_eq!("REMOVE USER IF", format!("{}", out))
+		assert_eq!("REMOVE USER IF ON ROOT", format!("{}", out))
 	}
 
 	#[test]

--- a/core/src/syn/v1/stmt/remove.rs
+++ b/core/src/syn/v1/stmt/remove.rs
@@ -566,6 +566,14 @@ mod tests {
 	}
 
 	#[test]
+	fn remove_user_if_ident() {
+		let sql = "REMOVE USER IF";
+		let res = remove(sql);
+		let out = res.unwrap().1;
+		assert_eq!("REMOVE USER IF", format!("{}", out))
+	}
+
+	#[test]
 	fn remove_user_if_exists() {
 		let sql = "REMOVE USER IF EXISTS test ON ROOT";
 		let res = remove(sql);

--- a/core/src/syn/v1/stmt/remove.rs
+++ b/core/src/syn/v1/stmt/remove.rs
@@ -41,11 +41,8 @@ pub fn remove(i: &str) -> IResult<&str, RemoveStatement> {
 
 pub fn analyzer(i: &str) -> IResult<&str, RemoveAnalyzerStatement> {
 	let (i, _) = tag_no_case("ANALYZER")(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;
 	Ok((
@@ -59,11 +56,8 @@ pub fn analyzer(i: &str) -> IResult<&str, RemoveAnalyzerStatement> {
 
 pub fn database(i: &str) -> IResult<&str, RemoveDatabaseStatement> {
 	let (i, _) = alt((tag_no_case("DB"), tag_no_case("DATABASE")))(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;
 	Ok((
@@ -77,11 +71,8 @@ pub fn database(i: &str) -> IResult<&str, RemoveDatabaseStatement> {
 
 pub fn event(i: &str) -> IResult<&str, RemoveEventStatement> {
 	let (i, _) = tag_no_case("EVENT")(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;
 	let (i, _) = shouldbespace(i)?;
@@ -101,11 +92,8 @@ pub fn event(i: &str) -> IResult<&str, RemoveEventStatement> {
 
 pub fn field(i: &str) -> IResult<&str, RemoveFieldStatement> {
 	let (i, _) = tag_no_case("FIELD")(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(idiom::local)(i)?;
 	let (i, _) = shouldbespace(i)?;
@@ -125,11 +113,8 @@ pub fn field(i: &str) -> IResult<&str, RemoveFieldStatement> {
 
 pub fn function(i: &str) -> IResult<&str, RemoveFunctionStatement> {
 	let (i, _) = tag_no_case("FUNCTION")(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, _) = tag("fn::")(i)?;
 	let (i, name) = ident_path(i)?;
@@ -151,11 +136,8 @@ pub fn function(i: &str) -> IResult<&str, RemoveFunctionStatement> {
 
 pub fn index(i: &str) -> IResult<&str, RemoveIndexStatement> {
 	let (i, _) = tag_no_case("INDEX")(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;
 	let (i, _) = shouldbespace(i)?;
@@ -175,11 +157,8 @@ pub fn index(i: &str) -> IResult<&str, RemoveIndexStatement> {
 
 pub fn namespace(i: &str) -> IResult<&str, RemoveNamespaceStatement> {
 	let (i, _) = alt((tag_no_case("NS"), tag_no_case("NAMESPACE")))(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;
 	Ok((
@@ -193,11 +172,8 @@ pub fn namespace(i: &str) -> IResult<&str, RemoveNamespaceStatement> {
 
 pub fn param(i: &str) -> IResult<&str, RemoveParamStatement> {
 	let (i, _) = tag_no_case("PARAM")(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, _) = cut(char('$'))(i)?;
 	let (i, name) = cut(ident)(i)?;
@@ -212,11 +188,8 @@ pub fn param(i: &str) -> IResult<&str, RemoveParamStatement> {
 
 pub fn scope(i: &str) -> IResult<&str, RemoveScopeStatement> {
 	let (i, _) = tag_no_case("SCOPE")(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;
 	Ok((
@@ -230,11 +203,8 @@ pub fn scope(i: &str) -> IResult<&str, RemoveScopeStatement> {
 
 pub fn table(i: &str) -> IResult<&str, RemoveTableStatement> {
 	let (i, _) = tag_no_case("TABLE")(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;
 	Ok((
@@ -248,11 +218,8 @@ pub fn table(i: &str) -> IResult<&str, RemoveTableStatement> {
 
 pub fn token(i: &str) -> IResult<&str, RemoveTokenStatement> {
 	let (i, _) = tag_no_case("TOKEN")(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;
 	let (i, _) = shouldbespace(i)?;
@@ -271,11 +238,8 @@ pub fn token(i: &str) -> IResult<&str, RemoveTokenStatement> {
 
 pub fn user(i: &str) -> IResult<&str, RemoveUserStatement> {
 	let (i, _) = tag_no_case("USER")(i)?;
-	let (i, if_exists) = opt(tuple((
-		shouldbespace,
-		tag_no_case("IF"),
-		cut(tuple((shouldbespace, tag_no_case("EXISTS")))),
-	)))(i)?;
+	let (i, if_exists) =
+		opt(tuple((shouldbespace, tag_no_case("IF"), shouldbespace, tag_no_case("EXISTS"))))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, name) = cut(ident)(i)?;
 	let (i, _) = shouldbespace(i)?;


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

There is a bug in the old parser where `if` in an identifier after remove would cause a parsing error because the parser committed too early.

This PR is currently blocked, needing the backport of #3805.

## What does this change do?

Hold off parsing `if` as part of the `if exists` clause until we can be sure that the statement is part of the clause.

## What is your testing strategy?

Added a test for catching this bug.

## Is this related to any issues?

Fixes #3780.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?


<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
