### PR TITLE
Fix Wasm builds on 1.x

### DIFF
--- a/lib/src/api/engine/local/wasm.rs
+++ b/lib/src/api/engine/local/wasm.rs
@@ -5,6 +5,7 @@ use crate::api::conn::Param;
 use crate::api::conn::Route;
 use crate::api::conn::Router;
 use crate::api::engine::local::Db;
+#[cfg(feature = "sql2")]
 use crate::api::engine::local::DEFAULT_TICK_INTERVAL;
 use crate::api::opt::Endpoint;
 use crate::api::ExtraFeatures;
@@ -17,6 +18,7 @@ use crate::iam::Level;
 use crate::kvs::Datastore;
 use crate::opt::auth::Root;
 use crate::opt::WaitFor;
+#[cfg(feature = "sql2")]
 use crate::options::EngineOptions;
 use flume::Receiver;
 use flume::Sender;
@@ -147,9 +149,17 @@ pub(crate) fn router(
 		let mut live_queries = HashMap::new();
 		let mut session = Session::default().with_rt(true);
 
+		#[cfg(feature = "sql2")]
 		let mut opt = EngineOptions::default();
-		opt.tick_interval = address.config.tick_interval.unwrap_or(DEFAULT_TICK_INTERVAL);
-		let (_tasks, task_chans) = start_tasks(&opt, kvs.clone());
+		#[cfg(feature = "sql2")]
+		{
+			opt.tick_interval = address.config.tick_interval.unwrap_or(DEFAULT_TICK_INTERVAL);
+		}
+		let (_tasks, task_chans) = start_tasks(
+			#[cfg(feature = "sql2")]
+			&opt,
+			kvs.clone(),
+		);
 
 		let mut notifications = kvs.notifications();
 		let notification_stream = poll_fn(move |cx| match &mut notifications {


### PR DESCRIPTION
## What is the motivation?

Wasm builds on 1.x are broken when not using `sql2`.

## What does this change do?

It fixes the build.

## What is your testing strategy?

Ran

```
cargo check --package surrealdb --features protocol-ws,protocol-http,kv-mem,kv-indxdb,http --target wasm32-unknown-unknown
```

## Is this related to any issues?

Fixes #3750.

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
