### PR TITLE
Disable flaky part of Mtree tests

### DIFF
--- a/core/src/cf/mutations.rs
+++ b/core/src/cf/mutations.rs
@@ -190,8 +190,6 @@ impl Default for WriteMutationSet {
 
 #[cfg(test)]
 mod tests {
-	use crate::sql::Strand;
-
 	#[test]
 	fn serialization() {
 		use super::*;

--- a/core/src/cf/writer.rs
+++ b/core/src/cf/writer.rs
@@ -141,7 +141,7 @@ mod tests {
 	use crate::sql::value::Value;
 	use crate::vs;
 
-	const dont_store_previous: bool = false;
+	const DONT_STORE_PREVIOUS: bool = false;
 
 	#[tokio::test]
 	async fn test_changefeed_read_write() {
@@ -200,7 +200,7 @@ mod tests {
 			id: Id::String("A".to_string()),
 		};
 		let value_a: super::Value = "a".into();
-		let mut previous = Cow::from(Value::None);
+		let previous = Cow::from(Value::None);
 		tx1.record_change(
 			ns,
 			db,
@@ -208,7 +208,7 @@ mod tests {
 			&thing_a,
 			previous.clone(),
 			Cow::Borrowed(&value_a),
-			dont_store_previous,
+			DONT_STORE_PREVIOUS,
 		);
 		tx1.complete_changes(true).await.unwrap();
 		tx1.commit().await.unwrap();
@@ -226,7 +226,7 @@ mod tests {
 			&thing_c,
 			previous.clone(),
 			Cow::Borrowed(&value_c),
-			dont_store_previous,
+			DONT_STORE_PREVIOUS,
 		);
 		tx2.complete_changes(true).await.unwrap();
 		tx2.commit().await.unwrap();
@@ -245,7 +245,7 @@ mod tests {
 			&thing_b,
 			previous.clone(),
 			Cow::Borrowed(&value_b),
-			dont_store_previous,
+			DONT_STORE_PREVIOUS,
 		);
 		let thing_c2 = Thing {
 			tb: tb.to_owned(),
@@ -259,7 +259,7 @@ mod tests {
 			&thing_c2,
 			previous.clone(),
 			Cow::Borrowed(&value_c2),
-			dont_store_previous,
+			DONT_STORE_PREVIOUS,
 		);
 		tx3.complete_changes(true).await.unwrap();
 		tx3.commit().await.unwrap();

--- a/core/src/idx/trees/mtree.rs
+++ b/core/src/idx/trees/mtree.rs
@@ -2332,7 +2332,7 @@ mod tests {
 				TestCollection::new_unique(150, vt, 3),
 				true,
 				true,
-				true,
+				false,
 				0,
 			)
 			.await?;
@@ -2423,7 +2423,7 @@ mod tests {
 				TestCollection::new_random(150, vt, 3),
 				true,
 				true,
-				true,
+				false,
 				0,
 			)
 			.await?;
@@ -2440,7 +2440,7 @@ mod tests {
 				TestCollection::new_random(1000, vt, 10),
 				false,
 				true,
-				true,
+				false,
 				0,
 			)
 			.await?;


### PR DESCRIPTION
## What is the motivation?

Some tests related to MTree are flaky.

## What does this change do?

Backports #3733 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
