### PR TITLE
bugfix: Enforce `TYPE RELATION`

### DIFF
--- a/core/src/syn/v1/stmt/define/table.rs
+++ b/core/src/syn/v1/stmt/define/table.rs
@@ -29,7 +29,7 @@ pub fn table(i: &str) -> IResult<&str, DefineTableStatement> {
 	let (i, name) = cut(ident)(i)?;
 	let (i, opts) = many0(table_opts)(i)?;
 	let (i, _) = expected(
-		"TYPE, RELATION, DROP, SCHEMALESS, SCHEMAFUL(L), VIEW, CHANGEFEED, PERMISSIONS, or COMMENT",
+		"TYPE, DROP, SCHEMALESS, SCHEMAFUL(L), VIEW, CHANGEFEED, PERMISSIONS, or COMMENT",
 		ending::query,
 	)(i)?;
 	// Create the base statement
@@ -129,7 +129,6 @@ fn table_opts(i: &str) -> IResult<&str, DefineTableOption> {
 		table_permissions,
 		table_changefeed,
 		table_type,
-		table_relation,
 	))(i)
 }
 

--- a/core/src/syn/v2/parser/stmt/define.rs
+++ b/core/src/syn/v2/parser/stmt/define.rs
@@ -354,10 +354,6 @@ impl Parser<'_> {
 					self.pop_peek();
 					res.drop = true;
 				}
-				t!("RELATION") => {
-					self.pop_peek();
-					res.kind = TableType::Relation(self.parse_relation_schema()?);
-				}
 				t!("TYPE") => {
 					self.pop_peek();
 					match self.peek_kind() {

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -2648,7 +2648,7 @@ async fn redefining_existing_user_with_if_not_exists_should_error() -> Result<()
 #[cfg(feature = "sql2")]
 async fn define_table_relation() -> Result<(), Error> {
 	let sql = "
-		DEFINE TABLE likes RELATION;
+		DEFINE TABLE likes TYPE RELATION;
 		CREATE person:raphael, person:tobie;
 		RELATE person:raphael->likes->person:tobie;
 		CREATE likes:1;

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -789,7 +789,7 @@ async fn field_definition_edge_permissions() -> Result<(), Error> {
 		DEFINE TABLE user SCHEMAFULL;
 		DEFINE TABLE business SCHEMAFULL;
 		DEFINE FIELD owner ON TABLE business TYPE record<user>;
-		DEFINE TABLE contact RELATION SCHEMAFULL PERMISSIONS FOR create WHERE in.owner.id = $auth.id;
+		DEFINE TABLE contact TYPE RELATION SCHEMAFULL PERMISSIONS FOR create WHERE in.owner.id = $auth.id;
 		INSERT INTO user (id, name) VALUES (user:one, 'John'), (user:two, 'Lucy');
 		INSERT INTO business (id, owner) VALUES (business:one, user:one), (business:two, user:two);
 	";


### PR DESCRIPTION
## What is the motivation?

As an artefact from development DEFINE TABLE foo RELATION was parsed when it should be rejected and require DEFINE TABLE foo TYPE RELATION

## What does this change do?

Backports #3732 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
