### PR TITLE
Bugfix: check if update version is already installed

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -110,7 +110,11 @@ pub async fn init(args: UpgradeCommandArguments) -> Result<(), Error> {
 	let old_version = PKG_VERSION.deref().clone();
 	let new_version = args.version().await?;
 
-	if old_version == new_version {
+	// Parsed version numbers follow semver format (major.minor.patch)
+	let old_version_parsed = parse_version(&old_version)?;
+	let new_version_parsed = parse_version(&new_version)?;
+
+	if old_version_parsed == new_version_parsed {
 		println!("{old_version} is already installed");
 		return Ok(());
 	}


### PR DESCRIPTION
## What is the motivation?

Fixes the check for the installed version versus the version that's being upgraded to, to avoid the unnecessary waste of resources of upgrading to the same version.

## What does this change do?

Backports #3756 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
