### PR TITLE
Replaces option_env by std::env::var

### DIFF
--- a/core/src/cnf/mod.rs
+++ b/core/src/cnf/mod.rs
@@ -17,9 +17,8 @@ pub const MAX_CONCURRENT_TASKS: usize = 64;
 /// During query execution, all potentially-recursive code paths count against this limit. Whereas
 /// parsing assigns equal weight to each recursion, certain expensive code paths are allowed to
 /// count for more than one unit of depth during execution.
-pub static MAX_COMPUTATION_DEPTH: Lazy<u8> = Lazy::new(|| {
-	option_env!("SURREAL_MAX_COMPUTATION_DEPTH").and_then(|s| s.parse::<u8>().ok()).unwrap_or(120)
-});
+pub static MAX_COMPUTATION_DEPTH: Lazy<u8> =
+	lazy_env_parse!("SURREAL_MAX_COMPUTATION_DEPTH", u8, 120);
 
 /// Specifies the names of parameters which can not be specified in a query.
 pub const PROTECTED_PARAM_NAMES: &[&str] = &["auth", "scope", "token", "session"];
@@ -37,8 +36,5 @@ pub const SERVER_NAME: &str = "SurrealDB";
 pub const PROCESSOR_BATCH_SIZE: u32 = 50;
 
 /// Forward all signup/signin query errors to a client trying authenticate to a scope. Do not use in production.
-pub static INSECURE_FORWARD_SCOPE_ERRORS: Lazy<bool> = Lazy::new(|| {
-	option_env!("SURREAL_INSECURE_FORWARD_SCOPE_ERRORS")
-		.and_then(|s| s.parse::<bool>().ok())
-		.unwrap_or(false)
-});
+pub static INSECURE_FORWARD_SCOPE_ERRORS: Lazy<bool> =
+	lazy_env_parse!("SURREAL_INSECURE_FORWARD_SCOPE_ERRORS", bool, false);

--- a/core/src/kvs/rocksdb/cnf.rs
+++ b/core/src/kvs/rocksdb/cnf.rs
@@ -1,55 +1,29 @@
+use crate::{lazy_env_parse, lazy_env_parse_or_else};
 use once_cell::sync::Lazy;
 
-pub static ROCKSDB_THREAD_COUNT: Lazy<i32> = Lazy::new(|| {
-	option_env!("SURREAL_ROCKSDB_THREAD_COUNT")
-		.and_then(|s| s.parse::<i32>().ok())
-		.unwrap_or(num_cpus::get() as i32)
-});
+pub static ROCKSDB_THREAD_COUNT: Lazy<i32> =
+	lazy_env_parse_or_else!("SURREAL_ROCKSDB_THREAD_COUNT", i32, |_| num_cpus::get() as i32);
 
-pub static ROCKSDB_WRITE_BUFFER_SIZE: Lazy<usize> = Lazy::new(|| {
-	option_env!("SURREAL_ROCKSDB_WRITE_BUFFER_SIZE")
-		.and_then(|s| s.parse::<usize>().ok())
-		.unwrap_or(256 * 1024 * 1024)
-});
+pub static ROCKSDB_WRITE_BUFFER_SIZE: Lazy<usize> =
+	lazy_env_parse!("SURREAL_ROCKSDB_WRITE_BUFFER_SIZE", usize, 256 * 1024 * 1024);
 
-pub static ROCKSDB_TARGET_FILE_SIZE_BASE: Lazy<u64> = Lazy::new(|| {
-	option_env!("SURREAL_ROCKSDB_TARGET_FILE_SIZE_BASE")
-		.and_then(|s| s.parse::<u64>().ok())
-		.unwrap_or(512 * 1024 * 1024)
-});
+pub static ROCKSDB_TARGET_FILE_SIZE_BASE: Lazy<u64> =
+	lazy_env_parse!("SURREAL_ROCKSDB_TARGET_FILE_SIZE_BASE", u64, 512 * 1024 * 1024);
 
-pub static ROCKSDB_MAX_WRITE_BUFFER_NUMBER: Lazy<i32> = Lazy::new(|| {
-	option_env!("SURREAL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER")
-		.and_then(|s| s.parse::<i32>().ok())
-		.unwrap_or(32)
-});
+pub static ROCKSDB_MAX_WRITE_BUFFER_NUMBER: Lazy<i32> =
+	lazy_env_parse!("SURREAL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER", i32, 32);
 
-pub static ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE: Lazy<i32> = Lazy::new(|| {
-	option_env!("SURREAL_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE")
-		.and_then(|s| s.parse::<i32>().ok())
-		.unwrap_or(4)
-});
+pub static ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE: Lazy<i32> =
+	lazy_env_parse!("SURREAL_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE", i32, 4);
 
-pub static ROCKSDB_ENABLE_PIPELINED_WRITES: Lazy<bool> = Lazy::new(|| {
-	option_env!("SURREAL_ROCKSDB_ENABLE_PIPELINED_WRITES")
-		.and_then(|s| s.parse::<bool>().ok())
-		.unwrap_or(true)
-});
+pub static ROCKSDB_ENABLE_PIPELINED_WRITES: Lazy<bool> =
+	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_PIPELINED_WRITES", bool, true);
 
-pub static ROCKSDB_ENABLE_BLOB_FILES: Lazy<bool> = Lazy::new(|| {
-	option_env!("SURREAL_ROCKSDB_ENABLE_BLOB_FILES")
-		.and_then(|s| s.parse::<bool>().ok())
-		.unwrap_or(true)
-});
+pub static ROCKSDB_ENABLE_BLOB_FILES: Lazy<bool> =
+	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_BLOB_FILES", bool, true);
 
-pub static ROCKSDB_MIN_BLOB_SIZE: Lazy<u64> = Lazy::new(|| {
-	option_env!("SURREAL_ROCKSDB_MIN_BLOB_SIZE")
-		.and_then(|s| s.parse::<u64>().ok())
-		.unwrap_or(4 * 1024)
-});
+pub static ROCKSDB_MIN_BLOB_SIZE: Lazy<u64> =
+	lazy_env_parse!("SURREAL_ROCKSDB_MIN_BLOB_SIZE", u64, 4 * 1024);
 
-pub static ROCKSDB_KEEP_LOG_FILE_NUM: Lazy<usize> = Lazy::new(|| {
-	option_env!("SURREAL_ROCKSDB_KEEP_LOG_FILE_NUM")
-		.and_then(|s| s.parse::<usize>().ok())
-		.unwrap_or(20)
-});
+pub static ROCKSDB_KEEP_LOG_FILE_NUM: Lazy<usize> =
+	lazy_env_parse!("SURREAL_ROCKSDB_KEEP_LOG_FILE_NUM", usize, 20);

--- a/core/src/kvs/speedb/cnf.rs
+++ b/core/src/kvs/speedb/cnf.rs
@@ -1,55 +1,29 @@
+use crate::{lazy_env_parse, lazy_env_parse_or_else};
 use once_cell::sync::Lazy;
 
-pub static SPEEDB_THREAD_COUNT: Lazy<i32> = Lazy::new(|| {
-	option_env!("SURREAL_SPEEDB_THREAD_COUNT")
-		.and_then(|s| s.parse::<i32>().ok())
-		.unwrap_or(num_cpus::get() as i32)
-});
+pub static SPEEDB_THREAD_COUNT: Lazy<i32> =
+	lazy_env_parse_or_else!("SURREAL_SPEEDB_THREAD_COUNT", i32, |_| num_cpus::get() as i32);
 
-pub static SPEEDB_WRITE_BUFFER_SIZE: Lazy<usize> = Lazy::new(|| {
-	option_env!("SURREAL_SPEEDB_WRITE_BUFFER_SIZE")
-		.and_then(|s| s.parse::<usize>().ok())
-		.unwrap_or(256 * 1024 * 1024)
-});
+pub static SPEEDB_WRITE_BUFFER_SIZE: Lazy<usize> =
+	lazy_env_parse!("SURREAL_SPEEDB_WRITE_BUFFER_SIZE", usize, 256 * 1024 * 1024);
 
-pub static SPEEDB_TARGET_FILE_SIZE_BASE: Lazy<u64> = Lazy::new(|| {
-	option_env!("SURREAL_SPEEDB_TARGET_FILE_SIZE_BASE")
-		.and_then(|s| s.parse::<u64>().ok())
-		.unwrap_or(512 * 1024 * 1024)
-});
+pub static SPEEDB_TARGET_FILE_SIZE_BASE: Lazy<u64> =
+	lazy_env_parse!("SURREAL_SPEEDB_TARGET_FILE_SIZE_BASE", u64, 512 * 1024 * 1024);
 
-pub static SPEEDB_MAX_WRITE_BUFFER_NUMBER: Lazy<i32> = Lazy::new(|| {
-	option_env!("SURREAL_SPEEDB_MAX_WRITE_BUFFER_NUMBER")
-		.and_then(|s| s.parse::<i32>().ok())
-		.unwrap_or(32)
-});
+pub static SPEEDB_MAX_WRITE_BUFFER_NUMBER: Lazy<i32> =
+	lazy_env_parse!("SURREAL_SPEEDB_MAX_WRITE_BUFFER_NUMBER", i32, 32);
 
-pub static SPEEDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE: Lazy<i32> = Lazy::new(|| {
-	option_env!("SURREAL_SPEEDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE")
-		.and_then(|s| s.parse::<i32>().ok())
-		.unwrap_or(4)
-});
+pub static SPEEDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE: Lazy<i32> =
+	lazy_env_parse!("SURREAL_SPEEDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE", i32, 4);
 
-pub static SPEEDB_ENABLE_PIPELINED_WRITES: Lazy<bool> = Lazy::new(|| {
-	option_env!("SURREAL_SPEEDB_ENABLE_PIPELINED_WRITES")
-		.and_then(|s| s.parse::<bool>().ok())
-		.unwrap_or(true)
-});
+pub static SPEEDB_ENABLE_PIPELINED_WRITES: Lazy<bool> =
+	lazy_env_parse!("SURREAL_SPEEDB_ENABLE_PIPELINED_WRITES", bool, true);
 
-pub static SPEEDB_ENABLE_BLOB_FILES: Lazy<bool> = Lazy::new(|| {
-	option_env!("SURREAL_SPEEDB_ENABLE_BLOB_FILES")
-		.and_then(|s| s.parse::<bool>().ok())
-		.unwrap_or(true)
-});
+pub static SPEEDB_ENABLE_BLOB_FILES: Lazy<bool> =
+	lazy_env_parse!("SURREAL_SPEEDB_ENABLE_BLOB_FILES", bool, true);
 
-pub static SPEEDB_MIN_BLOB_SIZE: Lazy<u64> = Lazy::new(|| {
-	option_env!("SURREAL_SPEEDB_MIN_BLOB_SIZE")
-		.and_then(|s| s.parse::<u64>().ok())
-		.unwrap_or(4 * 1024)
-});
+pub static SPEEDB_MIN_BLOB_SIZE: Lazy<u64> =
+	lazy_env_parse!("SURREAL_SPEEDB_MIN_BLOB_SIZE", u64, 4 * 1024);
 
-pub static SPEEDB_KEEP_LOG_FILE_NUM: Lazy<usize> = Lazy::new(|| {
-	option_env!("SURREAL_SPEEDB_KEEP_LOG_FILE_NUM")
-		.and_then(|s| s.parse::<usize>().ok())
-		.unwrap_or(20)
-});
+pub static SPEEDB_KEEP_LOG_FILE_NUM: Lazy<usize> =
+	lazy_env_parse!("SURREAL_SPEEDB_KEEP_LOG_FILE_NUM", usize, 20);

--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -27,3 +27,51 @@ macro_rules! get_cfg {
 		let $i = || { $( if cfg!($i=$s) { return $s; } );+ "unknown"};
 	)
 }
+
+/// A macro that allows lazily parsing a value from the environment variable,
+/// with a fallback default value if the variable is not set or parsing fails.
+///
+/// # Parameters
+///
+/// - `$key`: An expression representing the name of the environment variable.
+/// - `$t`: The type of the value to be parsed.
+/// - `$default`: The default value to fall back to if the environment variable
+///   is not set or parsing fails.
+///
+/// # Return Value
+///
+/// A lazy static variable of type `once_cell::sync::Lazy`, which holds the parsed value
+/// from the environment variable or the default value.
+#[macro_export]
+macro_rules! lazy_env_parse {
+	($key:expr, $t:ty, $default:expr) => {
+		once_cell::sync::Lazy::new(|| {
+			std::env::var($key)
+				.and_then(|s| Ok(s.parse::<$t>().unwrap_or($default)))
+				.unwrap_or($default)
+		})
+	};
+}
+
+/// Lazily parses an environment variable into a specified type. If the environment variable is not set or the parsing fails,
+/// it returns a default value.
+///
+/// # Parameters
+///
+/// - `$key`: A string literal representing the name of the environment variable.
+/// - `$t`: The type to parse the environment variable into.
+/// - `$default`: A fallback function or constant value to be returned if the environment variable is not set or the parsing fails.
+///
+/// # Returns
+///
+/// A `Lazy` static variable that stores the parsed value or the default value.
+#[macro_export]
+macro_rules! lazy_env_parse_or_else {
+	($key:expr, $t:ty, $default:expr) => {
+		once_cell::sync::Lazy::new(|| {
+			std::env::var($key)
+				.and_then(|s| Ok(s.parse::<$t>().unwrap_or_else($default)))
+				.unwrap_or_else($default)
+		})
+	};
+}

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::Lazy;
 use std::time::Duration;
+use surrealdb::{lazy_env_parse, lazy_env_parse_or_else};
 
 pub const LOGO: &str = "
  .d8888b.                                             888 8888888b.  888888b.
@@ -31,45 +32,31 @@ pub const APP_ENDPOINT: &str = "https://surrealdb.com/app";
 pub const WEBSOCKET_PING_FREQUENCY: Duration = Duration::from_secs(5);
 
 /// What is the maximum WebSocket frame size (defaults to 16 MiB)
-pub static WEBSOCKET_MAX_FRAME_SIZE: Lazy<usize> = Lazy::new(|| {
-	option_env!("SURREAL_WEBSOCKET_MAX_FRAME_SIZE")
-		.and_then(|s| s.parse::<usize>().ok())
-		.unwrap_or(16 << 20)
-});
+pub static WEBSOCKET_MAX_FRAME_SIZE: Lazy<usize> =
+	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_FRAME_SIZE", usize, 16 << 20);
 
 /// What is the maximum WebSocket message size (defaults to 128 MiB)
-pub static WEBSOCKET_MAX_MESSAGE_SIZE: Lazy<usize> = Lazy::new(|| {
-	option_env!("SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE")
-		.and_then(|s| s.parse::<usize>().ok())
-		.unwrap_or(128 << 20)
-});
+pub static WEBSOCKET_MAX_MESSAGE_SIZE: Lazy<usize> =
+	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE", usize, 128 << 20);
 
 /// How many concurrent tasks can be handled on each WebSocket (defaults to 24)
-pub static WEBSOCKET_MAX_CONCURRENT_REQUESTS: Lazy<usize> = Lazy::new(|| {
-	option_env!("SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS")
-		.and_then(|s| s.parse::<usize>().ok())
-		.unwrap_or(24)
-});
+pub static WEBSOCKET_MAX_CONCURRENT_REQUESTS: Lazy<usize> =
+	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS", usize, 24);
 
 /// What is the runtime thread memory stack size (defaults to 10MiB)
-pub static RUNTIME_STACK_SIZE: Lazy<usize> = Lazy::new(|| {
-	// Stack frames are generally larger in debug mode.
-	let default = if cfg!(debug_assertions) {
-		20 * 1024 * 1024 // 20MiB in debug mode
-	} else {
-		10 * 1024 * 1024 // 10MiB in release mode
-	};
-	option_env!("SURREAL_RUNTIME_STACK_SIZE")
-		.and_then(|s| s.parse::<usize>().ok())
-		.unwrap_or(default)
-});
+pub static RUNTIME_STACK_SIZE: Lazy<usize> =
+	lazy_env_parse_or_else!("SURREAL_RUNTIME_STACK_SIZE", usize, |_| {
+		// Stack frames are generally larger in debug mode.
+		if cfg!(debug_assertions) {
+			20 * 1024 * 1024 // 20MiB in debug mode
+		} else {
+			10 * 1024 * 1024 // 10MiB in release mode
+		}
+	});
 
 /// How many threads which can be started for blocking operations (defaults to 512)
-pub static RUNTIME_MAX_BLOCKING_THREADS: Lazy<usize> = Lazy::new(|| {
-	option_env!("SURREAL_RUNTIME_MAX_BLOCKING_THREADS")
-		.and_then(|s| s.parse::<usize>().ok())
-		.unwrap_or(512)
-});
+pub static RUNTIME_MAX_BLOCKING_THREADS: Lazy<usize> =
+	lazy_env_parse!("SURREAL_RUNTIME_MAX_BLOCKING_THREADS", usize, 512);
 
 /// The version identifier of this build
 pub static PKG_VERSION: Lazy<String> = Lazy::new(|| match option_env!("SURREAL_BUILD_METADATA") {


### PR DESCRIPTION
## What is the motivation?

Some environment variables are evaluated at compile time rather than at runtime.

## What does this change do?

Backports #3777 to beta.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
