### PR TITLE
Bug: Wrong count when using COUNT with a subquery

### DIFF
--- a/core/src/sql/function.rs
+++ b/core/src/sql/function.rs
@@ -35,6 +35,7 @@ pub enum Function {
 pub(crate) enum OptimisedAggregate {
 	None,
 	Count,
+	CountFunction,
 	MathMax,
 	MathMin,
 	MathSum,
@@ -156,7 +157,13 @@ impl Function {
 	}
 	pub(crate) fn get_optimised_aggregate(&self) -> OptimisedAggregate {
 		match self {
-			Self::Normal(f, _) if f == "count" => OptimisedAggregate::Count,
+			Self::Normal(f, v) if f == "count" => {
+				if v.is_empty() {
+					OptimisedAggregate::Count
+				} else {
+					OptimisedAggregate::CountFunction
+				}
+			}
 			Self::Normal(f, _) if f == "math::max" => OptimisedAggregate::MathMax,
 			Self::Normal(f, _) if f == "math::mean" => OptimisedAggregate::MathMean,
 			Self::Normal(f, _) if f == "math::min" => OptimisedAggregate::MathMin,

--- a/lib/tests/group.rs
+++ b/lib/tests/group.rs
@@ -625,9 +625,9 @@ async fn select_array_group_group_by() -> Result<(), Error> {
 #[tokio::test]
 async fn select_array_count_subquery_group_by() -> Result<(), Error> {
 	let sql = r#"
-		CREATE table CONTENT { bar: "hello"};
+		CREATE table CONTENT { bar: "hello", foo: "Man"};
 		CREATE table CONTENT { bar: "hello", foo: "World"};
-		CREATE table CONTENT { bar: "hello"};
+		CREATE table CONTENT { bar: "world"};
 		SELECT COUNT(foo != none) FROM table GROUP ALL EXPLAIN;
 		SELECT COUNT(foo != none) FROM table GROUP ALL;
 	"#;
@@ -651,7 +651,7 @@ async fn select_array_count_subquery_group_by() -> Result<(), Error> {
 					detail: {
 						idioms: {
 							count: [
-								'count'
+								'count+func'
 							]
 						},
 						type: 'Group'


### PR DESCRIPTION
## What is the motivation?

v1.4.0 introduces this bug: the count aggregation is not anymore filtered but the given predicate.

```sql
select count(outputs != none) from foo group all
```

## What does this change do?

This case is now supported by the optimised aggregation.

## What is your testing strategy?

A test has been added.

## Is this related to any issues?

https://discord.com/channels/902568124350599239/902568124350599242/1227602632261111921

Fixes #3854

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
