### PR TITLE
Fix benchmarks

### DIFF
--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -45,8 +45,8 @@ use crate::sql::paths::OUT;
 use crate::sql::thing::Thing;
 use crate::sql::Strand;
 use crate::sql::Value;
+use crate::vs::Oracle;
 use crate::vs::Versionstamp;
-use crate::vs::{conv, Oracle};
 
 use super::kv::Add;
 use super::kv::Convert;
@@ -2907,7 +2907,7 @@ impl Transaction {
 		trace!(
 			"Setting timestamp {} for versionstamp {:?} in ns: {}, db: {}",
 			ts,
-			conv::versionstamp_to_u64(&vs),
+			crate::vs::conv::versionstamp_to_u64(&vs),
 			ns,
 			db
 		);

--- a/lib/benches/sdb_benches/lib/routines/create.rs
+++ b/lib/benches/sdb_benches/lib/routines/create.rs
@@ -13,7 +13,7 @@ impl Create {
 	pub fn new(runtime: &'static Runtime) -> Self {
 		Self {
 			runtime,
-			table_name: format!("table_{}", Id::rand()),
+			table_name: format!("table_{}", Id::rand().to_raw()),
 		}
 	}
 }

--- a/lib/benches/sdb_benches/lib/routines/read.rs
+++ b/lib/benches/sdb_benches/lib/routines/read.rs
@@ -13,7 +13,7 @@ impl Read {
 	pub fn new(runtime: &'static Runtime) -> Self {
 		Self {
 			runtime,
-			table_name: format!("table_{}", Id::rand()),
+			table_name: format!("table_{}", Id::rand().to_raw()),
 		}
 	}
 }

--- a/lib/benches/sdb_benches/sdk/routines/create.rs
+++ b/lib/benches/sdb_benches/sdk/routines/create.rs
@@ -12,7 +12,7 @@ impl Create {
 	pub fn new(runtime: &'static Runtime) -> Self {
 		Self {
 			runtime,
-			table_name: format!("table_{}", Id::rand()),
+			table_name: format!("table_{}", Id::rand().to_raw()),
 		}
 	}
 }

--- a/lib/benches/sdb_benches/sdk/routines/read.rs
+++ b/lib/benches/sdb_benches/sdk/routines/read.rs
@@ -12,7 +12,7 @@ impl Read {
 	pub fn new(runtime: &'static Runtime) -> Self {
 		Self {
 			runtime,
-			table_name: format!("table_{}", Id::rand()),
+			table_name: format!("table_{}", Id::rand().to_raw()),
 		}
 	}
 }


### PR DESCRIPTION
## What is the motivation?

Benchmarks are currently broken.

## What does this change do?

This is due to table names being now generated as something like `table_⟨27evotb48g7tex91aduj⟩`, resulting in statements like

```sql
DEFINE TABLE table_⟨27evotb48g7tex91aduj⟩
```

which the parser doesn't like. This PR makes sure the table name is generated as `table_27evotb48g7tex91aduj`.

## What is your testing strategy?

Ran ` cargo make ci-bench` locally till completion.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
