### PR TITLE
Fix `$value` being `NONE` for `DELETE` events

### DIFF
--- a/core/src/doc/event.rs
+++ b/core/src/doc/event.rs
@@ -34,21 +34,23 @@ impl<'a> Document<'a> {
 			} else {
 				Value::from("UPDATE")
 			};
+			// Depending on type of event, how do we populate the document
+			let doc = match stm.is_delete() {
+				true => &self.initial,
+				false => &self.current,
+			};
 			// Configure the context
 			let mut ctx = Context::new(ctx);
 			ctx.add_value("event", met);
-			ctx.add_value("value", match stm.is_delete() {
-				true => self.initial.doc.deref(),
-				false => self.current.doc.deref(),
-			});
+			ctx.add_value("value", doc.doc.deref());
 			ctx.add_value("after", self.current.doc.deref());
 			ctx.add_value("before", self.initial.doc.deref());
 			// Process conditional clause
-			let val = ev.when.compute(&ctx, opt, txn, Some(&self.current)).await?;
+			let val = ev.when.compute(&ctx, opt, txn, Some(&doc)).await?;
 			// Execute event if value is truthy
 			if val.is_truthy() {
 				for v in ev.then.iter() {
-					v.compute(&ctx, opt, txn, Some(&self.current)).await?;
+					v.compute(&ctx, opt, txn, Some(&doc)).await?;
 				}
 			}
 		}

--- a/core/src/doc/event.rs
+++ b/core/src/doc/event.rs
@@ -37,7 +37,10 @@ impl<'a> Document<'a> {
 			// Configure the context
 			let mut ctx = Context::new(ctx);
 			ctx.add_value("event", met);
-			ctx.add_value("value", self.current.doc.deref());
+			ctx.add_value("value", match stm.is_delete() {
+				true => self.initial.doc.deref(),
+				false => self.current.doc.deref(),
+			});
 			ctx.add_value("after", self.current.doc.deref());
 			ctx.add_value("before", self.initial.doc.deref());
 			// Process conditional clause


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The `$value` variable and document are currently `NONE` for `DELETE` events, as they always points to the "current" document (doc after create/update/delete). This makes it inconvenient to write events, as you need to introduce logic like `$after ?? $before` in a lot of places. The document and the `$value` variable pointing to the current document for create+update, and initial document for delete events makes this more ergonomic.

**Point of discussion**
Do we want to backport this to 1.x?

## What does this change do?

This PR makes it so that `$value` and the document point to the current document for create and update events, and the initial document for delete events.

## What is your testing strategy?

Write your test plan here. Please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
