### PR TITLE
Drop dependency on `storekey::encode::Error` in the serialiser

### DIFF
--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -936,6 +936,10 @@ pub enum Error {
 	/// An error related to live query occurred
 	#[error("Failed to process Live Query: {0}")]
 	LiveQueryError(LiveQueryCause),
+
+	/// The supplied type could not be serialiazed into `sql::Value`
+	#[error("Serialization error: {0}")]
+	Serialization(String),
 }
 
 impl From<Error> for String {

--- a/core/src/sql/value/serde/ser/value/mod.rs
+++ b/core/src/sql/value/serde/ser/value/mod.rs
@@ -35,7 +35,6 @@ use serde::ser::Serialize;
 use serde::ser::SerializeMap as _;
 use serde::ser::SerializeSeq as _;
 use std::fmt::Display;
-use storekey::encode::Error as EncodeError;
 use vec::SerializeValueVec;
 
 /// Convert a `T` into `surrealdb::sql::Value` which is an enum that can represent any valid SQL data.
@@ -51,7 +50,7 @@ impl serde::ser::Error for Error {
 	where
 		T: Display,
 	{
-		Self::Encode(EncodeError::Message(msg.to_string()))
+		Self::Serialization(msg.to_string())
 	}
 }
 


### PR DESCRIPTION
## What is the motivation?

To reduce dependencies.

## What does this change do?

It replaces the use of `surrealdb::error::Db::Encode` in the serialiser with a new variant to drop the reliance on that error.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
