### PR TITLE
Ensure the beta workflow runs against `1.x`

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -43,7 +43,7 @@ jobs:
           if git branch -r | grep -w 'releases/beta'; then
             echo "branch=releases/beta" >> $GITHUB_OUTPUT
           else
-            echo "branch=main" >> $GITHUB_OUTPUT
+            echo "branch=1.x" >> $GITHUB_OUTPUT
           fi
 
   release:
@@ -59,7 +59,7 @@ jobs:
     secrets: inherit
 
   bump-version:
-    name: Bump main version
+    name: Bump 1.x version
     if: ${{ inputs.publish }}
     needs: [checks, release]
     runs-on: ubuntu-latest
@@ -101,9 +101,9 @@ jobs:
         run: |
           set -x
 
-          # Checkout the main branch
-          git fetch origin main
-          git checkout main
+          # Checkout the 1.x branch
+          git fetch origin 1.x
+          git checkout 1.x
 
           # Switch to version bump branch
           git checkout -b version-bump/v${{ steps.bump.outputs.version }}
@@ -138,7 +138,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
           set -x
-          url=$(gh pr create --base main --title "Bump version to v${{ steps.bump.outputs.version }}" --body "Update main version")
+          url=$(gh pr create --base 1.x --title "Bump version to v${{ steps.bump.outputs.version }}" --body "Update 1.x version")
           echo "url=${url}" >> $GITHUB_OUTPUT
 
       - name: Merge the PR


### PR DESCRIPTION
## What is the motivation?

This workflow is now outdated after the 1.x branch off.

## What does this change do?

Point beta to `1.x`.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
