### PR TITLE
IN operator should be recognised by the query planner

### DIFF
--- a/core/src/idx/planner/tree.rs
+++ b/core/src/idx/planner/tree.rs
@@ -441,6 +441,9 @@ impl<'a> TreeBuilder<'a> {
 				(Operator::Contain, v, IdiomPosition::Left) => {
 					Some(IndexOperator::Equality(v.clone()))
 				}
+				(Operator::Inside, v, IdiomPosition::Right) => {
+					Some(IndexOperator::Equality(v.clone()))
+				}
 				(
 					Operator::ContainAny | Operator::ContainAll | Operator::Inside,
 					Value::Array(a),

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -2278,3 +2278,156 @@ async fn select_with_record_id_link_full_text_no_record_index() -> Result<(), Er
 	//
 	Ok(())
 }
+
+#[tokio::test]
+async fn select_with_record_id_index() -> Result<(), Error> {
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	//
+	let sql = "
+		CREATE t:1 SET links = [a:2, a:1];
+		CREATE t:2 SET links = [a:3, a:4];
+		SELECT * FROM t WHERE links CONTAINS a:2;
+		SELECT * FROM t WHERE links CONTAINS a:2 EXPLAIN;
+		SELECT * FROM t WHERE links CONTAINSANY [a:2];
+		SELECT * FROM t WHERE links CONTAINSANY [a:2] EXPLAIN;
+		SELECT * FROM t WHERE a:2 IN links;
+		SELECT * FROM t WHERE a:2 IN links EXPLAIN;
+		DEFINE INDEX idx ON t FIELDS links;
+		SELECT * FROM t WHERE links CONTAINS a:2;
+		SELECT * FROM t WHERE links CONTAINS a:2 EXPLAIN;
+		SELECT * FROM t WHERE links CONTAINSANY [a:2];
+		SELECT * FROM t WHERE links CONTAINSANY [a:2] EXPLAIN;
+		SELECT * FROM t WHERE a:2 IN links;
+		SELECT * FROM t WHERE a:2 IN links EXPLAIN;
+	";
+	let mut res = dbs.execute(&sql, &ses, None).await?;
+
+	let expected = Value::parse(
+		r#"[
+			{
+				id: t:1,
+				links: [ a:2, a:1 ]
+			}
+		]"#,
+	);
+	//
+	assert_eq!(res.len(), 15);
+	skip_ok(&mut res, 2)?;
+	//
+	for t in ["CONTAINS", "CONTAINSANY", "IN"] {
+		let tmp = res.remove(0).result?;
+		assert_eq!(format!("{:#}", tmp), format!("{:#}", expected), "{t}");
+		//
+		let tmp = res.remove(0).result?;
+		let val = Value::parse(
+			r#"[
+				{
+					detail: {
+						table: 't'
+					},
+					operation: 'Iterate Table'
+				},
+				{
+					detail: {
+						reason: 'NO INDEX FOUND'
+					},
+					operation: 'Fallback'
+				},
+				{
+					detail: {
+						type: 'Memory'
+					},
+					operation: 'Collector'
+				}
+			]"#,
+		);
+		assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	}
+	//
+	skip_ok(&mut res, 1)?;
+	// CONTAINS
+	let tmp = res.remove(0).result?;
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", expected));
+	// CONTAINS EXPLAIN
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+				{
+					detail: {
+						plan: {
+							index: 'idx',
+							operator: '=',
+							value: a:2
+						},
+						table: 't'
+					},
+					operation: 'Iterate Index'
+				},
+				{
+					detail: {
+						type: 'Memory'
+					},
+					operation: 'Collector'
+				}
+			]"#,
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	// CONTAINSANY
+	let tmp = res.remove(0).result?;
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", expected));
+	// CONTAINSANY EXPLAIN
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+				{
+					detail: {
+						plan: {
+							index: 'idx',
+							operator: '=',
+							value: a:2
+						},
+						table: 't'
+					},
+					operation: 'Iterate Index'
+				},
+				{
+					detail: {
+						type: 'Memory'
+					},
+					operation: 'Collector'
+				}
+			]"#,
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	// IN
+	let tmp = res.remove(0).result?;
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", expected));
+	// IN EXPLAIN
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		r#"[
+				{
+					detail: {
+						plan: {
+							index: 'idx',
+							operator: 'union',
+							value: [
+								a:2
+							]
+						},
+						table: 't'
+					},
+					operation: 'Iterate Index'
+				},
+				{
+					detail: {
+						type: 'Memory'
+					},
+					operation: 'Collector'
+				}
+			]"#,
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	Ok(())
+}

--- a/lib/tests/planner.rs
+++ b/lib/tests/planner.rs
@@ -2384,8 +2384,10 @@ async fn select_with_record_id_index() -> Result<(), Error> {
 					detail: {
 						plan: {
 							index: 'idx',
-							operator: '=',
-							value: a:2
+							operator: 'union',
+							value: [
+								a:2
+							]
 						},
 						table: 't'
 					},
@@ -2411,10 +2413,8 @@ async fn select_with_record_id_index() -> Result<(), Error> {
 					detail: {
 						plan: {
 							index: 'idx',
-							operator: 'union',
-							value: [
-								a:2
-							]
+							operator: '=',
+							value: a:2
 						},
 						table: 't'
 					},


### PR DESCRIPTION
## What is the motivation?

The query planner did not recognized a possible indexed operation when the operator is IN and the idiom is on the right poisition. Eg: 

```sql
CREATE t:1 SET links = [a:2, a:1];
CREATE t:2 SET links = [a:3, a:4];
DEFINE INDEX idx ON t FIELDS links;
SELECT * FROM t WHERE a:2 IN links;
SELECT * FROM t WHERE a:2 IN links EXPLAIN;
```

## What does this change do?

Add this case.

## What is your testing strategy?

A test has been created.

## Is this related to any issues?

No

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
