### PR TITLE
Add Droppy Boy

### DIFF
--- a/core/src/kvs/droppy_boy.rs
+++ b/core/src/kvs/droppy_boy.rs
@@ -1,0 +1,104 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use std::thread;
+use std::time::Duration;
+
+/// Blocking future handling that should be avoided.
+/// It is required for this code because otherwise you need to detect if you are (or are not) in tokio,
+/// get the tokio runtime (needs to passed down), and then _NOT_ create a blocking future - because
+/// that is still async... trust me this is the best way to synchronously handle async code without
+/// knowing the runtime and without creating more async code
+fn block_on_special<F: Future>(mut future: F) -> F::Output {
+	// Create a RawWakerVTable that does nothing (since we don't need to wake anything for this example)
+	static VTABLE: RawWakerVTable =
+		RawWakerVTable::new(|_| RawWaker::new(std::ptr::null(), &VTABLE), |_| {}, |_| {}, |_| {});
+
+	// Create a RawWaker from the VTable.
+	let raw_waker = RawWaker::new(std::ptr::null(), &VTABLE);
+	// Convert the RawWaker to a Waker.
+	let waker = unsafe { Waker::from_raw(raw_waker) };
+	// Create a Context from the Waker.
+	let mut context = Context::from_waker(&waker);
+
+	// Pin the future to the stack.
+	let mut future = unsafe { Pin::new_unchecked(&mut future) };
+
+	loop {
+		// Poll the future.
+		match future.as_mut().poll(&mut context) {
+			Poll::Ready(output) => return output, // If the future is ready, return the output.
+			Poll::Pending => {
+				// If the future is not ready, sleep for a small amount of time and try again.
+				// This is a very crude way to wait and should not be used in production code.
+				thread::sleep(Duration::from_millis(10));
+			}
+		}
+	}
+}
+
+/// This must always be declared in a named way:
+/// `let foo = DroppyBoy::new(async { ... });` or `let _foo = DroppyBoy::new(async { ... });`
+/// If you assign in an unnamed way, it will be dropped immediately irresepective of optimisation
+/// level.
+pub struct DroppyBoy<F>
+where
+	F: Future + Send + 'static,
+{
+	f: Option<F>,
+}
+
+impl<F: Future + Send + 'static> DroppyBoy<F> {
+	pub fn new(future: F) -> Self {
+		Self {
+			f: Some(future),
+		}
+	}
+}
+
+impl<F: Future + Send + 'static> Drop for DroppyBoy<F>
+where
+	F: Future + Send + 'static,
+{
+	fn drop(&mut self) {
+		let dummy_future: Option<F> = None;
+		let f = std::mem::replace(&mut self.f, dummy_future);
+		let f: F = match f {
+			Some(f) => f,
+			None => panic!("DroppyBoy future has an existing clone"),
+		};
+		block_on_special(f);
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use crate::kvs::droppy_boy::DroppyBoy;
+	use std::sync::atomic::AtomicBool;
+	use std::sync::Arc;
+	use std::time::Duration;
+	use tokio::sync::mpsc::channel;
+
+	#[test]
+	fn can_drop_sync_without_async_runtime() {
+		let counter = Arc::new(AtomicBool::new(false));
+		let counter_clone = counter.clone();
+		{
+			let _ = DroppyBoy::new(async move {
+				counter_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+			});
+		}
+		assert!(counter.load(std::sync::atomic::Ordering::Relaxed));
+	}
+
+	#[tokio::test]
+	async fn can_drop_async_under_tokio() {
+		let (sender, mut receiver) = channel(1);
+		{
+			let _ = DroppyBoy::new(async move {
+				sender.send(()).await.unwrap();
+			});
+		}
+		tokio::time::timeout(Duration::from_secs(1), receiver.recv()).await.unwrap().unwrap();
+	}
+}

--- a/core/src/kvs/mod.rs
+++ b/core/src/kvs/mod.rs
@@ -25,8 +25,9 @@ mod surrealkv;
 mod tikv;
 mod tx;
 
+#[cfg(test)]
+mod droppy_boy;
 pub(crate) mod lq_structs;
-
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Often in tests we want to close transactions conveniently. In languages like Golang you can use the `defer` to execute once scope is dropped. We need to add this struct to execute async functions during drop, in a synchronous way, without the runtime.

## What does this change do?

Add test-only struct to help with safe closing of transactions - this simplifies testing logic such as in case of unwrap, early termination, branching etc.

## What is your testing strategy?

I have other code that uses this.

## Is this related to any issues?

Testing

## Does this change need documentation?

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
