### PR TITLE
Add FuzzyEq trait

### DIFF
--- a/core/src/dbs/fuzzy_eq.rs
+++ b/core/src/dbs/fuzzy_eq.rs
@@ -1,0 +1,10 @@
+/// FuzzyEq trait is used to compare objects while ignoring values that are non-deterministic.
+/// Non detereministic values include:
+/// - Timestamps
+/// - UUIDs
+#[doc(hidden)]
+pub trait FuzzyEq<Rhs: ?Sized = Self> {
+	/// Use this when comparing objects that you do not want to compare properties that are
+	/// non-deterministic
+	fn fuzzy_eq(&self, other: &Rhs) -> bool;
+}

--- a/core/src/dbs/mod.rs
+++ b/core/src/dbs/mod.rs
@@ -35,5 +35,7 @@ pub(crate) use self::statement::*;
 pub(crate) use self::transaction::*;
 pub(crate) use self::variables::*;
 
+#[doc(hidden)]
+pub mod fuzzy_eq;
 #[cfg(test)]
 pub(crate) mod test;

--- a/core/src/dbs/notification.rs
+++ b/core/src/dbs/notification.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use crate::dbs::fuzzy_eq::FuzzyEq;
 use crate::sql::{Object, Uuid, Value};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -55,5 +57,12 @@ impl Notification {
 			action,
 			result,
 		}
+	}
+}
+
+#[cfg(test)]
+impl FuzzyEq for Notification {
+	fn fuzzy_eq(&self, other: &Self) -> bool {
+		self.action == other.action && self.result == other.result
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Introduce the FuzzyEq trait which is equivalent to Eq but ignores non-deterministic fields such as UUIDs, timestamps

## What does this change do?

Introduce FuzzyEq trait which is used in other tests.

## What is your testing strategy?

Other tests utilise this code for convenience

## Is this related to any issues?

N/A

## Does this change need documentation?

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
