### PR TITLE
[backport] Add `INFO STRUCTURE`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4739,7 +4739,25 @@ dependencies = [
  "chrono",
  "geo 0.26.0",
  "regex",
- "revision-derive",
+ "revision-derive 0.5.0",
+ "roaring",
+ "rust_decimal",
+ "serde",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "revision"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588784c1d9453cfd2ce1b7aff06c903513677cf0e63779a0a3085ee8a44f5b17"
+dependencies = [
+ "bincode",
+ "chrono",
+ "geo 0.26.0",
+ "regex",
+ "revision-derive 0.7.0",
  "roaring",
  "rust_decimal",
  "serde",
@@ -4752,6 +4770,19 @@ name = "revision-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf996fc5f61f1dbec35799b5c00c6dda12e8862e8cb782ed24e10d0292e60ed3"
+dependencies = [
+ "darling",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "revision-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ff0b6794d4e0aab5e4486870941caefe9f258e63cad2f21b49a6302377c85"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -5841,7 +5872,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "reqwest",
- "revision",
+ "revision 0.7.0",
  "rmp-serde",
  "rmpv",
  "rustyline",
@@ -5894,7 +5925,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest",
- "revision",
+ "revision 0.7.0",
  "ring 0.17.8",
  "rust_decimal",
  "rustls 0.21.10",
@@ -5972,7 +6003,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.3",
  "reqwest",
- "revision",
+ "revision 0.5.0",
  "ring 0.17.8",
  "roaring",
  "rocksdb",
@@ -6058,7 +6089,7 @@ dependencies = [
  "regex",
  "regex-syntax 0.8.3",
  "reqwest",
- "revision",
+ "revision 0.7.0",
  "ring 0.17.8",
  "roaring",
  "rocksdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,13 @@ parser2 = ["surrealdb/parser2"]
 performance-profiler = ["dep:pprof"]
 
 [workspace]
-members = ["core", "lib", "lib/examples/actix", "lib/examples/axum", "lib/examples/rocket"]
+members = [
+    "core",
+    "lib",
+    "lib/examples/actix",
+    "lib/examples/axum",
+    "lib/examples/rocket",
+]
 
 [profile.release]
 lto = true
@@ -46,10 +52,10 @@ base64 = "0.21.5"
 bytes = "1.5.0"
 ciborium = "0.2.1"
 clap = { version = "4.4.11", features = [
-	"env",
-	"derive",
-	"wrap_help",
-	"unicode",
+    "env",
+    "derive",
+    "wrap_help",
+    "unicode",
 ] }
 futures = "0.3.29"
 futures-util = "0.3.29"
@@ -64,15 +70,22 @@ opentelemetry = { version = "0.19", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.12.0", features = ["metrics"] }
 pin-project-lite = "0.2.13"
 pprof = { version = "0.13.0", features = [
-	"flamegraph",
-	"prost-codec",
+    "flamegraph",
+    "prost-codec",
 ], optional = true }
 rand = "0.8.5"
 reqwest = { version = "0.11.22", default-features = false, features = [
-	"blocking",
-	"gzip",
+    "blocking",
+    "gzip",
 ] }
-revision = "0.5.0"
+revision = { version = "0.7.0", features = [
+    "chrono",
+    "geo",
+    "roaring",
+    "regex",
+    "rust_decimal",
+    "uuid",
+] }
 rmpv = "1.0.1"
 rustyline = { version = "12.0.0", features = ["derive"] }
 semver = "1.0.20"
@@ -91,17 +104,17 @@ tokio = { version = "1.34.0", features = ["macros", "signal"] }
 tokio-util = { version = "0.7.10", features = ["io"] }
 tower = "0.4.13"
 tower-http = { version = "0.4.4", features = [
-	"trace",
-	"sensitive-headers",
-	"auth",
-	"request-id",
-	"util",
-	"catch-panic",
-	"cors",
-	"set-header",
-	"limit",
-	"add-extension",
-	"compression-full",
+    "trace",
+    "sensitive-headers",
+    "auth",
+    "request-id",
+    "util",
+    "catch-panic",
+    "cors",
+    "set-header",
+    "limit",
+    "add-extension",
+    "compression-full",
 ] }
 tracing = "0.1"
 tracing-opentelemetry = "0.19.0"
@@ -125,10 +138,10 @@ jemallocator = "0.5.4"
 assert_fs = "1.0.13"
 env_logger = "0.10.1"
 opentelemetry-proto = { version = "0.2.0", features = [
-	"gen-tonic",
-	"traces",
-	"metrics",
-	"logs",
+    "gen-tonic",
+    "traces",
+    "metrics",
+    "logs",
 ] }
 rcgen = "0.11.3"
 serial_test = "2.0.0"
@@ -152,16 +165,16 @@ depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
-	[
-		"target/release/surreal",
-		"usr/share/surrealdb/surreal",
-		"755",
-	],
-	[
-		"pkg/deb/README",
-		"usr/share/surrealdb/README",
-		"644",
-	],
+    [
+        "target/release/surreal",
+        "usr/share/surrealdb/surreal",
+        "755",
+    ],
+    [
+        "pkg/deb/README",
+        "usr/share/surrealdb/README",
+        "644",
+    ],
 ]
 extended-description = "A scalable, distributed, collaborative, document-graph database, for the realtime web."
 license-file = ["LICENSE", "4"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -122,7 +122,7 @@ reqwest = { version = "0.11.22", default-features = false, features = [
     "stream",
     "multipart",
 ], optional = true }
-revision = "0.5.0"
+revision = { version = "0.7.0", features = ["chrono", "geo", "roaring", "regex", "rust_decimal", "uuid"] }
 roaring = { version = "0.10.2", features = ["serde"] }
 rocksdb = { version = "0.21.0", features = ["lz4", "snappy"], optional = true }
 rust_decimal = { version = "1.33.1", features = ["maths", "serde-str"] }
@@ -166,8 +166,11 @@ wiremock = "0.5.22"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pharos = "0.5.3"
-ring = { version = "0.17.7", features = ["wasm32_unknown_unknown_js"] } # Make ring-based dependencies work on Wasm
-tokio = { version = "1.34.0", default-features = false, features = ["rt", "sync"] }
+ring = { version = "0.17.7", features = ["wasm32_unknown_unknown_js"] }
+tokio = { version = "1.34.0", default-features = false, features = [
+    "rt",
+    "sync",
+] }
 uuid = { version = "1.6.1", features = ["serde", "js", "v4", "v7"] }
 wasm-bindgen-futures = "0.4.39"
 wasmtimer = { version = "0.2.0", default-features = false, features = [

--- a/core/src/cf/mutations.rs
+++ b/core/src/cf/mutations.rs
@@ -13,8 +13,8 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self, Display, Formatter};
 
 // Mutation is a single mutation to a table.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[non_exhaustive]
 pub enum TableMutation {
 	// Although the Value is supposed to contain a field "id" of Thing,
@@ -42,8 +42,8 @@ impl From<DefineTableStatement> for Value {
 	}
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[non_exhaustive]
 pub struct TableMutations(pub String, pub Vec<TableMutation>);
 
@@ -53,8 +53,8 @@ impl TableMutations {
 	}
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[non_exhaustive]
 pub struct DatabaseMutation(pub Vec<TableMutations>);
 
@@ -71,8 +71,8 @@ impl Default for DatabaseMutation {
 }
 
 // Change is a set of mutations made to a table at the specific timestamp.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[non_exhaustive]
 pub struct ChangeSet(pub [u8; 10], pub DatabaseMutation);
 

--- a/core/src/dbs/node.rs
+++ b/core/src/dbs/node.rs
@@ -8,8 +8,8 @@ use std::ops::{Add, Sub};
 
 // NOTE: This is not a statement, but as per layering, keeping it here till we
 // have a better structure.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, PartialOrd, Hash, Store)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, PartialOrd, Hash, Store)]
 #[non_exhaustive]
 pub struct ClusterMembership {
 	pub name: String,
@@ -20,10 +20,10 @@ pub struct ClusterMembership {
 // This struct is meant to represent a timestamp that can be used to partially order
 // events in a cluster. It should be derived from a timestamp oracle, such as the
 // one available in TiKV via the client `TimestampExt` implementation.
+#[revisioned(revision = 1)]
 #[derive(
 	Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize, Ord, PartialOrd, Hash, Store, Default,
 )]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Timestamp {
 	pub value: u64,
@@ -39,8 +39,8 @@ impl From<u64> for Timestamp {
 
 // This struct is to be used only when storing keys as the macro currently
 // conflicts when you have Store and Key derive macros.
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, PartialOrd, Hash, Key)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize, PartialOrd, Hash, Key)]
 #[non_exhaustive]
 pub struct KeyTimestamp {
 	pub value: u64,

--- a/core/src/dbs/notification.rs
+++ b/core/src/dbs/notification.rs
@@ -3,9 +3,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display};
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Action {
 	Create,
@@ -23,8 +23,8 @@ impl Display for Action {
 	}
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[non_exhaustive]
 pub struct Notification {
 	/// The id of the LIVE query to which this notification belongs

--- a/core/src/dbs/response.rs
+++ b/core/src/dbs/response.rs
@@ -42,9 +42,9 @@ impl Response {
 	}
 }
 
+#[revisioned(revision = 1)]
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
-#[revisioned(revision = 1)]
 #[doc(hidden)]
 #[non_exhaustive]
 pub enum Status {
@@ -73,8 +73,8 @@ impl Serialize for Response {
 	}
 }
 
-#[derive(Debug, Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Debug, Serialize, Deserialize)]
 #[doc(hidden)]
 #[non_exhaustive]
 pub struct QueryMethodResponse {

--- a/core/src/iam/auth.rs
+++ b/core/src/iam/auth.rs
@@ -5,9 +5,9 @@ use serde::{Deserialize, Serialize};
 use super::{is_allowed, Action, Actor, Error, Level, Resource, Role};
 
 /// Specifies the current authentication for the datastore execution context.
+#[revisioned(revision = 1)]
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Auth {
 	actor: Actor,

--- a/core/src/iam/entities/resources/actor.rs
+++ b/core/src/iam/entities/resources/actor.rs
@@ -13,9 +13,9 @@ use crate::sql::statements::{DefineTokenStatement, DefineUserStatement};
 //
 // User
 //
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Actor {
 	res: Resource,

--- a/core/src/iam/entities/resources/level.rs
+++ b/core/src/iam/entities/resources/level.rs
@@ -7,9 +7,9 @@ use std::{
 use cedar_policy::{Entity, EntityTypeName, EntityUid, RestrictedExpression};
 use serde::{Deserialize, Serialize};
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Deserialize, Serialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Level {
 	#[default]

--- a/core/src/iam/entities/resources/resource.rs
+++ b/core/src/iam/entities/resources/resource.rs
@@ -9,9 +9,9 @@ use super::Level;
 use cedar_policy::{Entity, EntityId, EntityTypeName, EntityUid, RestrictedExpression};
 use serde::{Deserialize, Serialize};
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum ResourceKind {
 	#[default]
@@ -79,9 +79,9 @@ impl ResourceKind {
 	}
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Resource(String, ResourceKind, Level);
 

--- a/core/src/iam/entities/roles.rs
+++ b/core/src/iam/entities/roles.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 // In the future, we will allow for custom roles. For now, provide predefined roles.
+#[revisioned(revision = 1)]
 #[derive(Hash, Clone, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Role {
 	#[default]

--- a/core/src/idx/docids.rs
+++ b/core/src/idx/docids.rs
@@ -149,8 +149,8 @@ impl DocIds {
 	}
 }
 
-#[derive(Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Serialize, Deserialize)]
 struct State {
 	btree: BState,
 	available_ids: Option<RoaringTreemap>,
@@ -175,8 +175,8 @@ impl VersionedSerdeState for State {
 	}
 }
 
-#[derive(Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Serialize, Deserialize)]
 struct State1 {
 	btree: BState1,
 	available_ids: Option<RoaringTreemap>,
@@ -195,8 +195,8 @@ impl From<State1> for State {
 
 impl VersionedSerdeState for State1 {}
 
-#[derive(Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Serialize, Deserialize)]
 struct State1skip {
 	btree: BState1skip,
 	available_ids: Option<RoaringTreemap>,

--- a/core/src/idx/ft/mod.rs
+++ b/core/src/idx/ft/mod.rs
@@ -86,8 +86,8 @@ impl From<FtStatistics> for Value {
 	}
 }
 
-#[derive(Default, Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Default, Serialize, Deserialize)]
 struct State {
 	total_docs_lengths: u128,
 	doc_count: u64,

--- a/core/src/idx/ft/terms.rs
+++ b/core/src/idx/ft/terms.rs
@@ -132,16 +132,16 @@ impl Terms {
 	}
 }
 
-#[derive(Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Serialize, Deserialize)]
 struct State {
 	btree: BState,
 	available_ids: Option<RoaringTreemap>,
 	next_term_id: TermId,
 }
 
-#[derive(Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Serialize, Deserialize)]
 struct State1 {
 	btree: BState1,
 	available_ids: Option<RoaringTreemap>,
@@ -150,8 +150,8 @@ struct State1 {
 
 impl VersionedSerdeState for State1 {}
 
-#[derive(Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Serialize, Deserialize)]
 struct State1skip {
 	btree: BState1skip,
 	available_ids: Option<RoaringTreemap>,

--- a/core/src/idx/trees/btree.rs
+++ b/core/src/idx/trees/btree.rs
@@ -28,8 +28,8 @@ where
 	bk: PhantomData<BK>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct BState {
 	minimum_degree: u32,
@@ -57,16 +57,16 @@ impl VersionedSerdeState for BState {
 	}
 }
 
-#[derive(Clone, Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Serialize, Deserialize)]
 pub(in crate::idx) struct BState1 {
 	minimum_degree: u32,
 	root: Option<NodeId>,
 	next_node_id: NodeId,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Serialize, Deserialize)]
 pub(in crate::idx) struct BState1skip {
 	minimum_degree: u32,
 	root: Option<NodeId>,

--- a/core/src/idx/trees/mtree.rs
+++ b/core/src/idx/trees/mtree.rs
@@ -1550,8 +1550,8 @@ impl From<MtStatistics> for Value {
 	}
 }
 
-#[derive(Clone, Serialize, Deserialize)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct MState {
 	capacity: u16,

--- a/core/src/idx/trees/vector.rs
+++ b/core/src/idx/trees/vector.rs
@@ -9,8 +9,8 @@ use std::ops::Mul;
 use std::sync::Arc;
 
 /// In the context of a Symmetric MTree index, the term object refers to a vector, representing the indexed item.
-#[derive(Debug, Clone, Serialize, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Vector {
 	F64(Vec<f64>),

--- a/core/src/rpc/response.rs
+++ b/core/src/rpc/response.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 /// The data returned by the database
 // The variants here should be in exactly the same order as `crate::engine::remote::ws::Data`
 // In future, they will possibly be merged to avoid having to keep them in sync.
-#[derive(Debug, Serialize)]
 #[revisioned(revision = 1)]
+#[derive(Debug, Serialize)]
 #[non_exhaustive]
 pub enum Data {
 	/// Generally methods return a `sql::Value`

--- a/core/src/sql/algorithm.rs
+++ b/core/src/sql/algorithm.rs
@@ -4,9 +4,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Algorithm {
 	EdDSA,

--- a/core/src/sql/algorithm.rs
+++ b/core/src/sql/algorithm.rs
@@ -1,3 +1,5 @@
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::Value;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -47,5 +49,10 @@ impl fmt::Display for Algorithm {
 			Self::Rs512 => "RS512",
 			Self::Jwks => "JWKS", // Not an algorithm.
 		})
+	}
+}
+impl InfoStructure for Algorithm {
+	fn structure(self) -> Value {
+		self.to_string().into()
 	}
 }

--- a/core/src/sql/array.rs
+++ b/core/src/sql/array.rs
@@ -16,9 +16,9 @@ use std::ops::DerefMut;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Array";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Array")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Array(pub Vec<Value>);

--- a/core/src/sql/base.rs
+++ b/core/src/sql/base.rs
@@ -4,9 +4,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Base {
 	Root,

--- a/core/src/sql/base.rs
+++ b/core/src/sql/base.rs
@@ -1,4 +1,5 @@
-use crate::sql::Ident;
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{Ident, Value};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -28,5 +29,10 @@ impl fmt::Display for Base {
 			Self::Sc(sc) => write!(f, "SCOPE {sc}"),
 			Self::Root => f.write_str("ROOT"),
 		}
+	}
+}
+impl InfoStructure for Base {
+	fn structure(self) -> Value {
+		self.to_string().into()
 	}
 }

--- a/core/src/sql/block.rs
+++ b/core/src/sql/block.rs
@@ -18,9 +18,9 @@ use std::ops::Deref;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Block";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Block")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Block(pub Vec<Entry>);
@@ -172,8 +172,9 @@ impl InfoStructure for Block {
 		self.to_string().into()
 	}
 }
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Entry {

--- a/core/src/sql/block.rs
+++ b/core/src/sql/block.rs
@@ -3,6 +3,7 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::sql::fmt::{is_pretty, pretty_indent, Fmt, Pretty};
+use crate::sql::statements::info::InfoStructure;
 use crate::sql::statements::{
 	BreakStatement, ContinueStatement, CreateStatement, DefineStatement, DeleteStatement,
 	ForeachStatement, IfelseStatement, InsertStatement, OutputStatement, RelateStatement,
@@ -166,6 +167,11 @@ impl Display for Block {
 	}
 }
 
+impl InfoStructure for Block {
+	fn structure(self) -> Value {
+		self.to_string().into()
+	}
+}
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/core/src/sql/bytes.rs
+++ b/core/src/sql/bytes.rs
@@ -7,8 +7,8 @@ use serde::{
 use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Bytes(pub(crate) Vec<u8>);

--- a/core/src/sql/cast.rs
+++ b/core/src/sql/cast.rs
@@ -11,9 +11,9 @@ use std::fmt;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Cast";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Cast")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Cast(pub Kind, pub Value);

--- a/core/src/sql/change_feed_include.rs
+++ b/core/src/sql/change_feed_include.rs
@@ -2,9 +2,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 /// ChangeFeedInclude statements are an appendix
 #[non_exhaustive]
 pub enum ChangeFeedInclude {

--- a/core/src/sql/changefeed.rs
+++ b/core/src/sql/changefeed.rs
@@ -7,8 +7,8 @@ use std::fmt::{self, Display, Formatter};
 use std::str;
 use std::time;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[non_exhaustive]
 pub struct ChangeFeed {
 	pub expiry: time::Duration,

--- a/core/src/sql/changefeed.rs
+++ b/core/src/sql/changefeed.rs
@@ -1,4 +1,6 @@
 use crate::sql::duration::Duration;
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::Value;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
@@ -29,5 +31,10 @@ impl Default for ChangeFeed {
 			expiry: time::Duration::from_secs(0),
 			store_original: false,
 		}
+	}
+}
+impl InfoStructure for ChangeFeed {
+	fn structure(self) -> Value {
+		self.to_string().into()
 	}
 }

--- a/core/src/sql/cond.rs
+++ b/core/src/sql/cond.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::Deref;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Cond(pub Value);

--- a/core/src/sql/cond.rs
+++ b/core/src/sql/cond.rs
@@ -1,3 +1,4 @@
+use crate::sql::statements::info::InfoStructure;
 use crate::sql::value::Value;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -20,5 +21,10 @@ impl Deref for Cond {
 impl fmt::Display for Cond {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "WHERE {}", self.0)
+	}
+}
+impl InfoStructure for Cond {
+	fn structure(self) -> Value {
+		self.0.structure()
 	}
 }

--- a/core/src/sql/constant.rs
+++ b/core/src/sql/constant.rs
@@ -13,9 +13,9 @@ use std::fmt;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Constant";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Constant")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Constant {

--- a/core/src/sql/data.rs
+++ b/core/src/sql/data.rs
@@ -9,8 +9,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Data {

--- a/core/src/sql/datetime.rs
+++ b/core/src/sql/datetime.rs
@@ -14,9 +14,9 @@ use super::escape::quote_str;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Datetime";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Datetime")]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Datetime(pub DateTime<Utc>);
 

--- a/core/src/sql/dir.rs
+++ b/core/src/sql/dir.rs
@@ -2,8 +2,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Dir {

--- a/core/src/sql/duration.rs
+++ b/core/src/sql/duration.rs
@@ -20,9 +20,9 @@ pub(crate) static NANOSECONDS_PER_MICROSECOND: u32 = 1000;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Duration";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Duration")]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Duration(pub time::Duration);
 

--- a/core/src/sql/edges.rs
+++ b/core/src/sql/edges.rs
@@ -7,10 +7,10 @@ use std::fmt;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Edges";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Edges")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Edges {
 	pub dir: Dir,

--- a/core/src/sql/explain.rs
+++ b/core/src/sql/explain.rs
@@ -2,8 +2,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Explain(pub bool);

--- a/core/src/sql/expression.rs
+++ b/core/src/sql/expression.rs
@@ -13,9 +13,9 @@ use std::str;
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Expression";
 
 /// Binary expressions.
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Expression")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Expression {

--- a/core/src/sql/fetch.rs
+++ b/core/src/sql/fetch.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Fetchs(pub Vec<Fetch>);
@@ -39,8 +39,9 @@ impl InfoStructure for Fetchs {
 		Value::Array(self.0.into_iter().map(|f| f.0.structure()).collect())
 	}
 }
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Fetch(pub Idiom);

--- a/core/src/sql/fetch.rs
+++ b/core/src/sql/fetch.rs
@@ -1,5 +1,7 @@
 use crate::sql::fmt::Fmt;
 use crate::sql::idiom::Idiom;
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::Value;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
@@ -32,6 +34,11 @@ impl fmt::Display for Fetchs {
 	}
 }
 
+impl InfoStructure for Fetchs {
+	fn structure(self) -> Value {
+		Value::Array(self.0.into_iter().map(|f| f.0.structure()).collect())
+	}
+}
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/core/src/sql/field.rs
+++ b/core/src/sql/field.rs
@@ -11,8 +11,8 @@ use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter, Write};
 use std::ops::Deref;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Fields(pub Vec<Field>, pub bool);
@@ -242,8 +242,8 @@ impl Fields {
 	}
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Field {

--- a/core/src/sql/field.rs
+++ b/core/src/sql/field.rs
@@ -2,6 +2,7 @@ use crate::ctx::Context;
 use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
+use crate::sql::statements::info::InfoStructure;
 use crate::sql::{fmt::Fmt, Idiom, Part, Value};
 use crate::syn;
 use revision::revisioned;
@@ -65,6 +66,11 @@ impl Display for Fields {
 	}
 }
 
+impl InfoStructure for Fields {
+	fn structure(self) -> Value {
+		self.to_string().into()
+	}
+}
 impl Fields {
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(

--- a/core/src/sql/filter.rs
+++ b/core/src/sql/filter.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Display;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Filter {
 	Ascii,

--- a/core/src/sql/function.rs
+++ b/core/src/sql/function.rs
@@ -20,9 +20,9 @@ use super::Kind;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Function";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Function")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Function {

--- a/core/src/sql/future.rs
+++ b/core/src/sql/future.rs
@@ -10,9 +10,9 @@ use std::fmt;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Future";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Future")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Future(pub Block);

--- a/core/src/sql/geometry.rs
+++ b/core/src/sql/geometry.rs
@@ -15,10 +15,10 @@ use std::{fmt, hash};
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Geometry";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename = "$surrealdb::private::sql::Geometry")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Geometry {
 	Point(Point<f64>),

--- a/core/src/sql/graph.rs
+++ b/core/src/sql/graph.rs
@@ -12,8 +12,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter, Write};
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Graph {

--- a/core/src/sql/group.rs
+++ b/core/src/sql/group.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Groups(pub Vec<Group>);
@@ -36,8 +36,8 @@ impl Display for Groups {
 	}
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Group(pub Idiom);

--- a/core/src/sql/id.rs
+++ b/core/src/sql/id.rs
@@ -11,8 +11,8 @@ use std::collections::BTreeMap;
 use std::fmt::{self, Display, Formatter};
 use ulid::Ulid;
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Gen {
@@ -21,8 +21,8 @@ pub enum Gen {
 	Uuid,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Id {

--- a/core/src/sql/ident.rs
+++ b/core/src/sql/ident.rs
@@ -6,8 +6,8 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 use std::str;
 
-#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Ident(#[serde(with = "no_nul_bytes")] pub String);

--- a/core/src/sql/ident.rs
+++ b/core/src/sql/ident.rs
@@ -1,4 +1,5 @@
-use crate::sql::{escape::escape_ident, strand::no_nul_bytes};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{escape::escape_ident, strand::no_nul_bytes, Value};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
@@ -56,5 +57,11 @@ impl Ident {
 impl Display for Ident {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&escape_ident(&self.0), f)
+	}
+}
+
+impl InfoStructure for Ident {
+	fn structure(self) -> Value {
+		self.0.into()
 	}
 }

--- a/core/src/sql/idiom.rs
+++ b/core/src/sql/idiom.rs
@@ -18,8 +18,8 @@ use std::str;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Idiom";
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Idioms(pub Vec<Idiom>);
@@ -45,9 +45,9 @@ impl Display for Idioms {
 	}
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Idiom")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Idiom(pub Vec<Part>);

--- a/core/src/sql/idiom.rs
+++ b/core/src/sql/idiom.rs
@@ -2,6 +2,7 @@ use crate::ctx::Context;
 use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
+use crate::sql::statements::info::InfoStructure;
 use crate::sql::{
 	fmt::{fmt_separated_by, Fmt},
 	part::Next,
@@ -197,5 +198,17 @@ impl Display for Idiom {
 			),
 			f,
 		)
+	}
+}
+
+impl InfoStructure for Idioms {
+	fn structure(self) -> Value {
+		self.to_string().into()
+	}
+}
+
+impl InfoStructure for Idiom {
+	fn structure(self) -> Value {
+		self.to_string().into()
 	}
 }

--- a/core/src/sql/index.rs
+++ b/core/src/sql/index.rs
@@ -12,9 +12,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Index {
 	/// (Basic) non unique
@@ -28,9 +28,9 @@ pub enum Index {
 	MTree(MTreeParams),
 }
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct SearchParams {
 	pub az: Ident,
@@ -50,9 +50,9 @@ pub struct SearchParams {
 	pub terms_cache: u32,
 }
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct MTreeParams {
 	pub dimension: u16,
@@ -86,9 +86,9 @@ impl MTreeParams {
 	}
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Distance1 {
 	#[default]
@@ -99,9 +99,9 @@ pub enum Distance1 {
 	Minkowski(Number),
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Distance {
 	Chebyshev,
@@ -145,9 +145,9 @@ impl Display for Distance {
 	}
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum VectorType {
 	#[default]

--- a/core/src/sql/index.rs
+++ b/core/src/sql/index.rs
@@ -5,7 +5,8 @@ use crate::fnc::util::math::vector::{
 };
 use crate::sql::ident::Ident;
 use crate::sql::scoring::Scoring;
-use crate::sql::Number;
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{Number, Value};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -202,5 +203,11 @@ impl Display for Index {
 				)
 			}
 		}
+	}
+}
+
+impl InfoStructure for Index {
+	fn structure(self) -> Value {
+		self.to_string().into()
 	}
 }

--- a/core/src/sql/kind.rs
+++ b/core/src/sql/kind.rs
@@ -4,9 +4,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Kind {
 	Any,

--- a/core/src/sql/kind.rs
+++ b/core/src/sql/kind.rs
@@ -1,4 +1,5 @@
-use crate::sql::{fmt::Fmt, Table};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{fmt::Fmt, Table, Value};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
@@ -128,5 +129,11 @@ impl Display for Kind {
 			},
 			Kind::Either(k) => write!(f, "{}", Fmt::verbar_separated(k)),
 		}
+	}
+}
+
+impl InfoStructure for Kind {
+	fn structure(self) -> Value {
+		self.to_string().into()
 	}
 }

--- a/core/src/sql/language.rs
+++ b/core/src/sql/language.rs
@@ -3,9 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Display;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Language {
 	Arabic,

--- a/core/src/sql/limit.rs
+++ b/core/src/sql/limit.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Limit(pub Value);

--- a/core/src/sql/mock.rs
+++ b/core/src/sql/mock.rs
@@ -44,9 +44,9 @@ impl Iterator for IntoIter {
 	}
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Mock")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Mock {

--- a/core/src/sql/model.rs
+++ b/core/src/sql/model.rs
@@ -26,9 +26,9 @@ use std::collections::HashMap;
 #[cfg(any(feature = "ml", feature = "ml2"))]
 const ARGUMENTS: &str = "The model expects 1 argument. The argument can be either a number, an object, or an array of numbers.";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Model {
 	pub name: String,

--- a/core/src/sql/number.rs
+++ b/core/src/sql/number.rs
@@ -13,9 +13,9 @@ use std::ops::{self, Add, Div, Mul, Neg, Rem, Sub};
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Number";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename = "$surrealdb::private::sql::Number")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Number {

--- a/core/src/sql/object.rs
+++ b/core/src/sql/object.rs
@@ -18,9 +18,9 @@ use std::ops::DerefMut;
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Object";
 
 /// Invariant: Keys never contain NUL bytes.
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Object")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Object(#[serde(with = "no_nul_bytes_in_keys")] pub BTreeMap<String, Value>);

--- a/core/src/sql/operation.rs
+++ b/core/src/sql/operation.rs
@@ -3,10 +3,10 @@ use crate::sql::value::Value;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(tag = "op")]
 #[serde(rename_all = "lowercase")]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Operation {
 	Add {

--- a/core/src/sql/operator.rs
+++ b/core/src/sql/operator.rs
@@ -6,8 +6,8 @@ use std::fmt;
 use std::fmt::Write;
 
 /// Binary operators.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Operator {

--- a/core/src/sql/order.rs
+++ b/core/src/sql/order.rs
@@ -7,8 +7,8 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::ops::Deref;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Orders(pub Vec<Order>);
@@ -61,8 +61,8 @@ impl fmt::Display for Orders {
 	}
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Order {

--- a/core/src/sql/output.rs
+++ b/core/src/sql/output.rs
@@ -3,8 +3,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Output {

--- a/core/src/sql/param.rs
+++ b/core/src/sql/param.rs
@@ -12,10 +12,10 @@ use std::{fmt, ops::Deref, str};
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Param";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Param")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Param(pub Ident);
 

--- a/core/src/sql/part.rs
+++ b/core/src/sql/part.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Part {

--- a/core/src/sql/permission.rs
+++ b/core/src/sql/permission.rs
@@ -9,9 +9,9 @@ use std::fmt::Write;
 use std::fmt::{self, Display, Formatter};
 use std::str;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Permissions {
 	pub select: Permission,
@@ -132,9 +132,9 @@ impl PermissionKind {
 	}
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Permission {
 	None,

--- a/core/src/sql/permission.rs
+++ b/core/src/sql/permission.rs
@@ -1,7 +1,8 @@
 use crate::sql::fmt::is_pretty;
 use crate::sql::fmt::pretty_indent;
 use crate::sql::fmt::pretty_sequence_item;
-use crate::sql::Value;
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{Object, Value};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::Write;
@@ -164,5 +165,34 @@ impl Display for Permission {
 			Self::Full => f.write_str("FULL"),
 			Self::Specific(ref v) => write!(f, "WHERE {v}"),
 		}
+	}
+}
+
+impl InfoStructure for Permission {
+	fn structure(self) -> Value {
+		match self {
+			Permission::None => Value::Bool(false),
+			Permission::Full => Value::Bool(true),
+			Permission::Specific(v) => Value::Strand(v.to_string().into()),
+		}
+	}
+}
+
+impl InfoStructure for Permissions {
+	fn structure(self) -> Value {
+		let Self {
+			select,
+			create,
+			update,
+			delete,
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("select".to_string(), select.structure());
+		acc.insert("create".to_string(), create.structure());
+		acc.insert("update".to_string(), update.structure());
+		acc.insert("delete".to_string(), delete.structure());
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/query.rs
+++ b/core/src/sql/query.rs
@@ -11,8 +11,8 @@ use std::str;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Query";
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Query")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]

--- a/core/src/sql/range.rs
+++ b/core/src/sql/range.rs
@@ -21,10 +21,10 @@ use std::str::FromStr;
 const ID: &str = "id";
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Range";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Range")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Range {
 	#[serde(with = "no_nul_bytes")]

--- a/core/src/sql/regex.rs
+++ b/core/src/sql/regex.rs
@@ -15,8 +15,8 @@ use std::{env, str};
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Regex";
 
-#[derive(Clone)]
 #[revisioned(revision = 1)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct Regex(pub regex::Regex);
 

--- a/core/src/sql/scoring.rs
+++ b/core/src/sql/scoring.rs
@@ -3,9 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Scoring {
 	Bm {

--- a/core/src/sql/script.rs
+++ b/core/src/sql/script.rs
@@ -5,8 +5,8 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 use std::str;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Script(#[serde(with = "no_nul_bytes")] pub String);

--- a/core/src/sql/split.rs
+++ b/core/src/sql/split.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Splits(pub Vec<Split>);
@@ -32,8 +32,8 @@ impl fmt::Display for Splits {
 	}
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Split(pub Idiom);

--- a/core/src/sql/start.rs
+++ b/core/src/sql/start.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Start(pub Value);

--- a/core/src/sql/statement.rs
+++ b/core/src/sql/statement.rs
@@ -22,9 +22,9 @@ use std::{
 	time::Duration,
 };
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Statements(pub Vec<Statement>);
 
@@ -52,9 +52,9 @@ impl Display for Statements {
 	}
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Statement {
 	Value(Value),

--- a/core/src/sql/statements/analyze.rs
+++ b/core/src/sql/statements/analyze.rs
@@ -18,8 +18,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum AnalyzeStatement {

--- a/core/src/sql/statements/begin.rs
+++ b/core/src/sql/statements/begin.rs
@@ -3,8 +3,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct BeginStatement;

--- a/core/src/sql/statements/break.rs
+++ b/core/src/sql/statements/break.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct BreakStatement;

--- a/core/src/sql/statements/cancel.rs
+++ b/core/src/sql/statements/cancel.rs
@@ -3,8 +3,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct CancelStatement;

--- a/core/src/sql/statements/commit.rs
+++ b/core/src/sql/statements/commit.rs
@@ -3,9 +3,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct CommitStatement;
 

--- a/core/src/sql/statements/continue.rs
+++ b/core/src/sql/statements/continue.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct ContinueStatement;

--- a/core/src/sql/statements/create.rs
+++ b/core/src/sql/statements/create.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct CreateStatement {

--- a/core/src/sql/statements/define/analyzer.rs
+++ b/core/src/sql/statements/define/analyzer.rs
@@ -10,9 +10,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
+#[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 3)]
 #[non_exhaustive]
 pub struct DefineAnalyzerStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/define/analyzer.rs
+++ b/core/src/sql/statements/define/analyzer.rs
@@ -3,7 +3,8 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
-use crate::sql::{filter::Filter, tokenizer::Tokenizer, Base, Ident, Strand, Value};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{filter::Filter, tokenizer::Tokenizer, Base, Ident, Object, Strand, Value};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -87,5 +88,45 @@ impl Display for DefineAnalyzerStatement {
 			write!(f, " COMMENT {v}")?
 		}
 		Ok(())
+	}
+}
+
+impl InfoStructure for DefineAnalyzerStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			function,
+			tokenizers,
+			filters,
+			comment,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		if let Some(function) = function {
+			acc.insert("function".to_string(), function.structure());
+		}
+
+		if let Some(tokenizers) = tokenizers {
+			acc.insert(
+				"tokenizers".to_string(),
+				Value::Array(tokenizers.into_iter().map(|t| t.to_string().into()).collect()),
+			);
+		}
+
+		if let Some(filters) = filters {
+			acc.insert(
+				"filters".to_string(),
+				Value::Array(filters.into_iter().map(|f| f.to_string().into()).collect()),
+			);
+		}
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/database.rs
+++ b/core/src/sql/statements/define/database.rs
@@ -10,9 +10,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DefineDatabaseStatement {
 	pub id: Option<u32>,

--- a/core/src/sql/statements/define/database.rs
+++ b/core/src/sql/statements/define/database.rs
@@ -3,7 +3,8 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
-use crate::sql::{changefeed::ChangeFeed, Base, Ident, Strand, Value};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{changefeed::ChangeFeed, Base, Ident, Object, Strand, Value};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -85,5 +86,24 @@ impl Display for DefineDatabaseStatement {
 			write!(f, " {v}")?;
 		}
 		Ok(())
+	}
+}
+
+impl InfoStructure for DefineDatabaseStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			comment,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/event.rs
+++ b/core/src/sql/statements/define/event.rs
@@ -10,9 +10,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DefineEventStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/define/event.rs
+++ b/core/src/sql/statements/define/event.rs
@@ -3,7 +3,8 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
-use crate::sql::{Base, Ident, Strand, Value, Values};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{Base, Ident, Object, Strand, Value, Values};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -78,5 +79,36 @@ impl Display for DefineEventStatement {
 			write!(f, " COMMENT {v}")?
 		}
 		Ok(())
+	}
+}
+
+impl InfoStructure for DefineEventStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			what,
+			when,
+			then,
+			comment,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		acc.insert("what".to_string(), what.structure());
+
+		acc.insert("when".to_string(), when.structure());
+
+		acc.insert(
+			"then".to_string(),
+			Value::Array(then.0.iter().map(|v| v.to_string().into()).collect()),
+		);
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/field.rs
+++ b/core/src/sql/statements/define/field.rs
@@ -15,9 +15,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Write};
 
+#[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 3)]
 #[non_exhaustive]
 pub struct DefineFieldStatement {
 	pub name: Idiom,

--- a/core/src/sql/statements/define/field.rs
+++ b/core/src/sql/statements/define/field.rs
@@ -3,11 +3,12 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
+use crate::sql::statements::info::InfoStructure;
 use crate::sql::statements::DefineTableStatement;
-use crate::sql::Part;
 use crate::sql::{
 	fmt::is_pretty, fmt::pretty_indent, Base, Ident, Idiom, Kind, Permissions, Strand, Value,
 };
+use crate::sql::{Object, Part};
 use crate::sql::{Relation, TableType};
 use derive::Store;
 use revision::revisioned;
@@ -202,5 +203,56 @@ impl Display for DefineFieldStatement {
 		};
 		write!(f, "{}", self.permissions)?;
 		Ok(())
+	}
+}
+
+impl InfoStructure for DefineFieldStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			what,
+			flex,
+			kind,
+			readonly,
+			value,
+			assert,
+			default,
+			permissions,
+			comment,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		acc.insert("what".to_string(), what.structure());
+
+		acc.insert("flex".to_string(), flex.into());
+
+		if let Some(kind) = kind {
+			acc.insert("kind".to_string(), kind.structure());
+		}
+
+		acc.insert("readonly".to_string(), readonly.into());
+
+		if let Some(value) = value {
+			acc.insert("value".to_string(), value.structure());
+		}
+
+		if let Some(assert) = assert {
+			acc.insert("assert".to_string(), assert.structure());
+		}
+
+		if let Some(default) = default {
+			acc.insert("default".to_string(), default.structure());
+		}
+
+		acc.insert("permissions".to_string(), permissions.structure());
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/function.rs
+++ b/core/src/sql/statements/define/function.rs
@@ -13,9 +13,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Write};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DefineFunctionStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/define/index.rs
+++ b/core/src/sql/statements/define/index.rs
@@ -13,9 +13,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 use std::sync::Arc;
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DefineIndexStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/define/index.rs
+++ b/core/src/sql/statements/define/index.rs
@@ -3,7 +3,10 @@ use crate::dbs::{Force, Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
-use crate::sql::{statements::UpdateStatement, Base, Ident, Idioms, Index, Strand, Value, Values};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{
+	statements::UpdateStatement, Base, Ident, Idioms, Index, Object, Strand, Value, Values,
+};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -96,5 +99,33 @@ impl Display for DefineIndexStatement {
 			write!(f, " COMMENT {v}")?
 		}
 		Ok(())
+	}
+}
+
+impl InfoStructure for DefineIndexStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			what,
+			cols,
+			index,
+			comment,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		acc.insert("what".to_string(), what.structure());
+
+		acc.insert("cols".to_string(), cols.structure());
+
+		acc.insert("index".to_string(), index.structure());
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/mod.rs
+++ b/core/src/sql/statements/define/mod.rs
@@ -37,9 +37,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum DefineStatement {
 	Namespace(DefineNamespaceStatement),

--- a/core/src/sql/statements/define/model.rs
+++ b/core/src/sql/statements/define/model.rs
@@ -13,9 +13,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Write};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DefineModelStatement {
 	pub hash: String,

--- a/core/src/sql/statements/define/model.rs
+++ b/core/src/sql/statements/define/model.rs
@@ -3,9 +3,10 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
+use crate::sql::statements::info::InfoStructure;
 use crate::sql::{
 	fmt::{is_pretty, pretty_indent},
-	Base, Ident, Permission, Strand, Value,
+	Base, Ident, Object, Permission, Strand, Value,
 };
 use derive::Store;
 use revision::revisioned;
@@ -87,5 +88,30 @@ impl DefineModelStatement {
 		// TODO
 		// Ok all good
 		Ok(Value::None)
+	}
+}
+
+impl InfoStructure for DefineModelStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			version,
+			comment,
+			permissions,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		acc.insert("version".to_string(), version.into());
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		acc.insert("permissions".to_string(), permissions.structure());
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/namespace.rs
+++ b/core/src/sql/statements/define/namespace.rs
@@ -10,9 +10,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DefineNamespaceStatement {
 	pub id: Option<u32>,

--- a/core/src/sql/statements/define/namespace.rs
+++ b/core/src/sql/statements/define/namespace.rs
@@ -3,7 +3,8 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
-use crate::sql::{Base, Ident, Strand, Value};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{Base, Ident, Object, Strand, Value};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -78,5 +79,24 @@ impl Display for DefineNamespaceStatement {
 			write!(f, " COMMENT {v}")?
 		}
 		Ok(())
+	}
+}
+
+impl InfoStructure for DefineNamespaceStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			comment,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/param.rs
+++ b/core/src/sql/statements/define/param.rs
@@ -11,9 +11,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Write};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DefineParamStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/define/param.rs
+++ b/core/src/sql/statements/define/param.rs
@@ -4,7 +4,8 @@ use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
 use crate::sql::fmt::{is_pretty, pretty_indent};
-use crate::sql::{Base, Ident, Permission, Strand, Value};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{Base, Ident, Object, Permission, Strand, Value};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -82,5 +83,30 @@ impl Display for DefineParamStatement {
 		};
 		write!(f, "PERMISSIONS {}", self.permissions)?;
 		Ok(())
+	}
+}
+
+impl InfoStructure for DefineParamStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			value,
+			comment,
+			permissions,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		acc.insert("value".to_string(), value.structure());
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		acc.insert("permissions".to_string(), permissions.structure());
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/scope.rs
+++ b/core/src/sql/statements/define/scope.rs
@@ -12,9 +12,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DefineScopeStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/define/scope.rs
+++ b/core/src/sql/statements/define/scope.rs
@@ -3,7 +3,8 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
-use crate::sql::{Base, Duration, Ident, Strand, Value};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{Base, Duration, Ident, Object, Strand, Value};
 use derive::Store;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
@@ -91,5 +92,34 @@ impl Display for DefineScopeStatement {
 			write!(f, " COMMENT {v}")?
 		}
 		Ok(())
+	}
+}
+
+impl InfoStructure for DefineScopeStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			signup,
+			signin,
+			comment,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		if let Some(signup) = signup {
+			acc.insert("signup".to_string(), signup.structure());
+		}
+
+		if let Some(signin) = signin {
+			acc.insert("signin".to_string(), signin.structure());
+		}
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/table.rs
+++ b/core/src/sql/statements/define/table.rs
@@ -20,9 +20,9 @@ use std::fmt::{self, Display, Write};
 
 use super::DefineFieldStatement;
 
+#[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 3)]
 #[non_exhaustive]
 pub struct DefineTableStatement {
 	pub id: Option<u32>,

--- a/core/src/sql/statements/define/table.rs
+++ b/core/src/sql/statements/define/table.rs
@@ -7,10 +7,11 @@ use crate::sql::{
 	changefeed::ChangeFeed,
 	fmt::{is_pretty, pretty_indent},
 	statements::UpdateStatement,
-	Base, Ident, Permissions, Strand, Value, Values, View,
+	Base, Ident, Object, Permissions, Strand, Value, Values, View,
 };
 use std::sync::Arc;
 
+use crate::sql::statements::info::InfoStructure;
 use crate::sql::{Idiom, Kind, Part, Table, TableType};
 use derive::Store;
 use revision::revisioned;
@@ -209,5 +210,45 @@ impl Display for DefineTableStatement {
 		};
 		write!(f, "{}", self.permissions)?;
 		Ok(())
+	}
+}
+
+impl InfoStructure for DefineTableStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			drop,
+			full,
+			view,
+			permissions,
+			changefeed,
+			comment,
+			kind,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		acc.insert("drop".to_string(), drop.into());
+		acc.insert("full".to_string(), full.into());
+
+		if let Some(view) = view {
+			acc.insert("view".to_string(), view.structure());
+		}
+
+		acc.insert("permissions".to_string(), permissions.structure());
+
+		if let Some(changefeed) = changefeed {
+			acc.insert("changefeed".to_string(), changefeed.structure());
+		}
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		acc.insert("kind".to_string(), kind.structure());
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/token.rs
+++ b/core/src/sql/statements/define/token.rs
@@ -10,9 +10,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DefineTokenStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/define/token.rs
+++ b/core/src/sql/statements/define/token.rs
@@ -3,7 +3,8 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
-use crate::sql::{escape::quote_str, Algorithm, Base, Ident, Strand, Value};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{escape::quote_str, Algorithm, Base, Ident, Object, Strand, Value};
 use derive::Store;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -141,5 +142,33 @@ impl Display for DefineTokenStatement {
 			write!(f, " COMMENT {v}")?
 		}
 		Ok(())
+	}
+}
+
+impl InfoStructure for DefineTokenStatement {
+	fn structure(self) -> Value {
+		let Self {
+			name,
+			base,
+			kind,
+			code,
+			comment,
+			..
+		} = self;
+		let mut acc = Object::default();
+
+		acc.insert("name".to_string(), name.structure());
+
+		acc.insert("base".to_string(), base.structure());
+
+		acc.insert("kind".to_string(), kind.structure());
+
+		acc.insert("code".to_string(), code.into());
+
+		if let Some(comment) = comment {
+			acc.insert("comment".to_string(), comment.into());
+		}
+
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/define/user.rs
+++ b/core/src/sql/statements/define/user.rs
@@ -15,9 +15,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DefineUserStatement {
 	pub name: Ident,
@@ -206,7 +206,7 @@ impl InfoStructure for DefineUserStatement {
 		let Self {
 			name,
 			base,
-			code,
+			hash,
 			roles,
 			comment,
 			..
@@ -217,7 +217,7 @@ impl InfoStructure for DefineUserStatement {
 
 		acc.insert("base".to_string(), base.structure());
 
-		acc.insert("code".to_string(), code.into());
+		acc.insert("passhash".to_string(), hash.into());
 
 		acc.insert(
 			"roles".to_string(),

--- a/core/src/sql/statements/delete.rs
+++ b/core/src/sql/statements/delete.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct DeleteStatement {
 	#[revision(start = 2)]

--- a/core/src/sql/statements/foreach.rs
+++ b/core/src/sql/statements/foreach.rs
@@ -9,9 +9,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct ForeachStatement {
 	pub param: Param,

--- a/core/src/sql/statements/ifelse.rs
+++ b/core/src/sql/statements/ifelse.rs
@@ -9,8 +9,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Write};
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct IfelseStatement {

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct InsertStatement {
 	pub into: Value,

--- a/core/src/sql/statements/kill.rs
+++ b/core/src/sql/statements/kill.rs
@@ -13,9 +13,9 @@ use crate::kvs::lq_structs::{KillEntry, TrackedResult};
 use crate::sql::Uuid;
 use crate::sql::Value;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct KillStatement {
 	// Uuid of Live Query

--- a/core/src/sql/statements/live.rs
+++ b/core/src/sql/statements/live.rs
@@ -13,9 +13,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct LiveStatement {
 	pub id: Uuid,

--- a/core/src/sql/statements/live.rs
+++ b/core/src/sql/statements/live.rs
@@ -5,7 +5,8 @@ use crate::err::{Error, LiveQueryCause};
 use crate::fflags::FFLAGS;
 use crate::iam::Auth;
 use crate::kvs::lq_structs::{LqEntry, TrackedResult};
-use crate::sql::{Cond, Fetchs, Fields, Table, Uuid, Value};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{Cond, Fetchs, Fields, Object, Table, Uuid, Value};
 use derive::Store;
 use futures::lock::MutexGuard;
 use revision::revisioned;
@@ -189,5 +190,32 @@ impl fmt::Display for LiveStatement {
 			write!(f, " {v}")?
 		}
 		Ok(())
+	}
+}
+
+impl InfoStructure for LiveStatement {
+	fn structure(self) -> Value {
+		let Self {
+			expr,
+			what,
+			cond,
+			fetch,
+			..
+		} = self;
+
+		let mut acc = Object::default();
+
+		acc.insert("expr".to_string(), expr.structure());
+
+		acc.insert("what".to_string(), what.structure());
+
+		if let Some(cond) = cond {
+			acc.insert("cond".to_string(), cond.structure());
+		}
+
+		if let Some(fetch) = fetch {
+			acc.insert("fetch".to_string(), fetch.structure());
+		}
+		Value::Object(acc)
 	}
 }

--- a/core/src/sql/statements/option.rs
+++ b/core/src/sql/statements/option.rs
@@ -4,9 +4,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct OptionStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/output.rs
+++ b/core/src/sql/statements/output.rs
@@ -9,8 +9,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct OutputStatement {

--- a/core/src/sql/statements/relate.rs
+++ b/core/src/sql/statements/relate.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct RelateStatement {
 	#[revision(start = 2)]

--- a/core/src/sql/statements/remove/analyzer.rs
+++ b/core/src/sql/statements/remove/analyzer.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct RemoveAnalyzerStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/remove/database.rs
+++ b/core/src/sql/statements/remove/database.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct RemoveDatabaseStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/remove/event.rs
+++ b/core/src/sql/statements/remove/event.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct RemoveEventStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/remove/field.rs
+++ b/core/src/sql/statements/remove/field.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct RemoveFieldStatement {

--- a/core/src/sql/statements/remove/function.rs
+++ b/core/src/sql/statements/remove/function.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct RemoveFunctionStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/remove/index.rs
+++ b/core/src/sql/statements/remove/index.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct RemoveIndexStatement {

--- a/core/src/sql/statements/remove/mod.rs
+++ b/core/src/sql/statements/remove/mod.rs
@@ -36,8 +36,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum RemoveStatement {

--- a/core/src/sql/statements/remove/model.rs
+++ b/core/src/sql/statements/remove/model.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct RemoveModelStatement {

--- a/core/src/sql/statements/remove/namespace.rs
+++ b/core/src/sql/statements/remove/namespace.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct RemoveNamespaceStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/remove/param.rs
+++ b/core/src/sql/statements/remove/param.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct RemoveParamStatement {

--- a/core/src/sql/statements/remove/scope.rs
+++ b/core/src/sql/statements/remove/scope.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct RemoveScopeStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/remove/table.rs
+++ b/core/src/sql/statements/remove/table.rs
@@ -9,8 +9,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct RemoveTableStatement {

--- a/core/src/sql/statements/remove/token.rs
+++ b/core/src/sql/statements/remove/token.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 2)]
 #[non_exhaustive]
 pub struct RemoveTokenStatement {
 	pub name: Ident,

--- a/core/src/sql/statements/remove/user.rs
+++ b/core/src/sql/statements/remove/user.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct RemoveUserStatement {

--- a/core/src/sql/statements/select.rs
+++ b/core/src/sql/statements/select.rs
@@ -12,8 +12,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct SelectStatement {

--- a/core/src/sql/statements/set.rs
+++ b/core/src/sql/statements/set.rs
@@ -9,8 +9,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct SetStatement {

--- a/core/src/sql/statements/show.rs
+++ b/core/src/sql/statements/show.rs
@@ -10,9 +10,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum ShowSince {
 	Timestamp(Datetime),
@@ -34,9 +34,9 @@ impl ShowSince {
 
 // ShowStatement is used to show changes in a table or database via
 // the SHOW CHANGES statement.
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct ShowStatement {
 	pub table: Option<Table>,

--- a/core/src/sql/statements/sleep.rs
+++ b/core/src/sql/statements/sleep.rs
@@ -9,8 +9,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[non_exhaustive]
 pub struct SleepStatement {
 	pub(crate) duration: Duration,

--- a/core/src/sql/statements/throw.rs
+++ b/core/src/sql/statements/throw.rs
@@ -8,9 +8,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct ThrowStatement {
 	pub error: Value,

--- a/core/src/sql/statements/update.rs
+++ b/core/src/sql/statements/update.rs
@@ -8,8 +8,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[revisioned(revision = 2)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct UpdateStatement {

--- a/core/src/sql/statements/use.rs
+++ b/core/src/sql/statements/use.rs
@@ -5,9 +5,9 @@ use std::fmt;
 
 use crate::sql::escape::escape_ident;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct UseStatement {
 	pub ns: Option<String>,

--- a/core/src/sql/strand.rs
+++ b/core/src/sql/strand.rs
@@ -9,9 +9,9 @@ use std::str;
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Strand";
 
 /// A string that doesn't contain NUL bytes.
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Strand")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Strand(#[serde(with = "no_nul_bytes")] pub String);

--- a/core/src/sql/subquery.rs
+++ b/core/src/sql/subquery.rs
@@ -14,10 +14,10 @@ use std::fmt::{self, Display, Formatter};
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Subquery";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Subquery")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Subquery {
 	Value(Value),

--- a/core/src/sql/table.rs
+++ b/core/src/sql/table.rs
@@ -7,9 +7,9 @@ use std::str;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Table";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Tables(pub Vec<Table>);
 
@@ -32,10 +32,10 @@ impl Display for Tables {
 	}
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Table")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct Table(#[serde(with = "no_nul_bytes")] pub String);
 

--- a/core/src/sql/table_type.rs
+++ b/core/src/sql/table_type.rs
@@ -8,8 +8,9 @@ use std::fmt::Display;
 use super::{Kind, Object, Table, Value};
 
 /// The type of records stored by a table
-#[derive(Debug, Default, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
 #[revisioned(revision = 1)]
+#[derive(Debug, Default, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum TableType {
 	#[default]
@@ -79,8 +80,9 @@ fn get_tables_from_kind(tables: &[Table]) -> Vec<&str> {
 	tables.iter().map(|t| t.0.as_str()).collect::<Vec<_>>()
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
 #[revisioned(revision = 1)]
+#[derive(Debug, Default, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Relation {
 	pub from: Option<Kind>,

--- a/core/src/sql/table_type.rs
+++ b/core/src/sql/table_type.rs
@@ -1,9 +1,11 @@
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::Array;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Display;
 
-use super::{Kind, Table};
+use super::{Kind, Object, Table, Value};
 
 /// The type of records stored by a table
 #[derive(Debug, Default, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
@@ -25,10 +27,10 @@ impl Display for TableType {
 			TableType::Relation(rel) => {
 				f.write_str(" RELATION")?;
 				if let Some(Kind::Record(kind)) = &rel.from {
-					write!(f, " IN {}", get_tables_from_kind(kind))?;
+					write!(f, " IN {}", get_tables_from_kind(kind).join(" | "))?;
 				}
 				if let Some(Kind::Record(kind)) = &rel.to {
-					write!(f, " OUT {}", get_tables_from_kind(kind))?;
+					write!(f, " OUT {}", get_tables_from_kind(kind).join(" | "))?;
 				}
 			}
 			TableType::Any => {
@@ -39,8 +41,42 @@ impl Display for TableType {
 	}
 }
 
-fn get_tables_from_kind(tables: &[Table]) -> String {
-	tables.iter().map(|t| t.0.as_str()).collect::<Vec<_>>().join(" | ")
+impl InfoStructure for TableType {
+	fn structure(self) -> Value {
+		let mut acc = Object::default();
+
+		match &self {
+			TableType::Any => {
+				acc.insert("kind".to_string(), "ANY".into());
+			}
+			TableType::Normal => {
+				acc.insert("kind".to_string(), "NORMAL".into());
+			}
+			TableType::Relation(rel) => {
+				acc.insert("kind".to_string(), "RELATION".into());
+
+				if let Some(Kind::Record(tables)) = &rel.from {
+					acc.insert(
+						"in".to_string(),
+						Value::Array(Array::from(get_tables_from_kind(tables))),
+					);
+				}
+
+				if let Some(Kind::Record(tables)) = &rel.to {
+					acc.insert(
+						"out".to_string(),
+						Value::Array(Array::from(get_tables_from_kind(tables))),
+					);
+				}
+			}
+		};
+
+		Value::Object(acc)
+	}
+}
+
+fn get_tables_from_kind(tables: &[Table]) -> Vec<&str> {
+	tables.iter().map(|t| t.0.as_str()).collect::<Vec<_>>()
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]

--- a/core/src/sql/thing.rs
+++ b/core/src/sql/thing.rs
@@ -12,9 +12,9 @@ use std::str::FromStr;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Thing";
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Thing")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Thing {

--- a/core/src/sql/timeout.rs
+++ b/core/src/sql/timeout.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::Deref;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Timeout(pub Duration);

--- a/core/src/sql/tokenizer.rs
+++ b/core/src/sql/tokenizer.rs
@@ -3,9 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Display;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Tokenizer {
 	Blank,

--- a/core/src/sql/uuid.rs
+++ b/core/src/sql/uuid.rs
@@ -8,11 +8,11 @@ use std::str::FromStr;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Uuid";
 
+#[revisioned(revision = 1)]
 #[derive(
 	Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Hash,
 )]
 #[serde(rename = "$surrealdb::private::sql::Uuid")]
-#[revisioned(revision = 1)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Uuid(pub uuid::Uuid);

--- a/core/src/sql/value/serde/ser/statement/info.rs
+++ b/core/src/sql/value/serde/ser/statement/info.rs
@@ -7,6 +7,7 @@ use ser::Serializer as _;
 use serde::ser::Error as _;
 use serde::ser::Impossible;
 use serde::ser::Serialize;
+use std::fmt::{Display, Formatter};
 
 pub(super) struct Serializer;
 
@@ -25,21 +26,6 @@ impl ser::Serializer for Serializer {
 	const EXPECTED: &'static str = "an enum `InfoStatement`";
 
 	#[inline]
-	fn serialize_unit_variant(
-		self,
-		name: &'static str,
-		_variant_index: u32,
-		variant: &'static str,
-	) -> Result<Self::Ok, Error> {
-		match variant {
-			"Root" => Ok(InfoStatement::Root),
-			"Ns" => Ok(InfoStatement::Ns),
-			"Db" => Ok(InfoStatement::Db),
-			variant => Err(Error::custom(format!("unexpected unit variant `{name}::{variant}`"))),
-		}
-	}
-
-	#[inline]
 	fn serialize_newtype_variant<T>(
 		self,
 		name: &'static str,
@@ -51,8 +37,15 @@ impl ser::Serializer for Serializer {
 		T: ?Sized + Serialize,
 	{
 		match variant {
-			"Sc" => Ok(InfoStatement::Sc(Ident(value.serialize(ser::string::Serializer.wrap())?))),
-			"Tb" => Ok(InfoStatement::Tb(Ident(value.serialize(ser::string::Serializer.wrap())?))),
+			"Root" => {
+				Ok(InfoStatement::Root(value.serialize(ser::primitive::bool::Serializer.wrap())?))
+			}
+			"Ns" => {
+				Ok(InfoStatement::Ns(value.serialize(ser::primitive::bool::Serializer.wrap())?))
+			}
+			"Db" => {
+				Ok(InfoStatement::Db(value.serialize(ser::primitive::bool::Serializer.wrap())?))
+			}
 			variant => {
 				Err(Error::custom(format!("unexpected newtype variant `{name}::{variant}`")))
 			}
@@ -68,16 +61,51 @@ impl ser::Serializer for Serializer {
 		_len: usize,
 	) -> Result<Self::SerializeTupleVariant, Self::Error> {
 		match variant {
-			"User" => Ok(SerializeInfoStatement::default()),
+			"Sc" => Ok(SerializeInfoStatement::with(Which::Sc)),
+			"Tb" => Ok(SerializeInfoStatement::with(Which::Tb)),
+			"User" => Ok(SerializeInfoStatement::with(Which::User)),
 			variant => Err(Error::custom(format!("unexpected tuple variant `{name}::{variant}`"))),
 		}
 	}
 }
 
-#[derive(Default)]
+#[derive(Clone, Copy)]
+enum Which {
+	Sc,
+	Tb,
+	User,
+}
+
+impl Display for Which {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Which::Sc => {
+				write!(f, "Sc")
+			}
+			Which::Tb => {
+				write!(f, "Tb")
+			}
+			Which::User => {
+				write!(f, "User")
+			}
+		}
+	}
+}
+
 pub(super) struct SerializeInfoStatement {
 	index: usize,
-	tuple: (Option<Ident>, Option<Base>),
+	which: Which,
+	tuple: (Option<Ident>, Option<Base>, bool),
+}
+
+impl SerializeInfoStatement {
+	fn with(which: Which) -> Self {
+		Self {
+			index: 0,
+			which,
+			tuple: (None, None, false),
+		}
+	}
 }
 
 impl serde::ser::SerializeTupleVariant for SerializeInfoStatement {
@@ -88,16 +116,24 @@ impl serde::ser::SerializeTupleVariant for SerializeInfoStatement {
 	where
 		T: Serialize + ?Sized,
 	{
-		match self.index {
-			0 => {
+		use Which::*;
+		match (self.which, self.index) {
+			(_, 0) => {
 				self.tuple.0 = Some(Ident(value.serialize(ser::string::Serializer.wrap())?));
 			}
-			1 => {
+			(Sc, 1) | (Tb, 1) => {
+				self.tuple.2 = value.serialize(ser::primitive::bool::Serializer.wrap())?;
+			}
+			(User, 1) => {
 				self.tuple.1 = value.serialize(ser::base::opt::Serializer.wrap())?;
 			}
-			index => {
+			(User, 2) => {
+				self.tuple.2 = value.serialize(ser::primitive::bool::Serializer.wrap())?;
+			}
+			(_, index) => {
 				return Err(Error::custom(format!(
-					"unexpected `InfoStatement::User` index `{index}`"
+					"unexpected `InfoStatement::{}` index `{index}`",
+					self.which
 				)));
 			}
 		}
@@ -106,9 +142,14 @@ impl serde::ser::SerializeTupleVariant for SerializeInfoStatement {
 	}
 
 	fn end(self) -> Result<Self::Ok, Self::Error> {
-		match self.tuple.0 {
-			Some(ident) => Ok(InfoStatement::User(ident, self.tuple.1)),
-			None => Err(Error::custom("`InfoStatement::User` missing required value(s)")),
+		use Which::*;
+		match (self.which, self.tuple.0) {
+			(Sc, Some(ident)) => Ok(InfoStatement::Sc(ident, self.tuple.2)),
+			(Sc, None) => Err(Error::custom("`InfoStatement::Sc` missing required value(s)")),
+			(Tb, Some(ident)) => Ok(InfoStatement::Tb(ident, self.tuple.2)),
+			(Tb, None) => Err(Error::custom("`InfoStatement::Tb` missing required value(s)")),
+			(User, Some(ident)) => Ok(InfoStatement::User(ident, self.tuple.1, self.tuple.2)),
+			(User, None) => Err(Error::custom("`InfoStatement::User` missing required value(s)")),
 		}
 	}
 }
@@ -119,42 +160,42 @@ mod tests {
 
 	#[test]
 	fn root() {
-		let stmt = InfoStatement::Root;
+		let stmt = InfoStatement::Root(Default::default());
 		let serialized = stmt.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(stmt, serialized);
 	}
 
 	#[test]
 	fn ns() {
-		let stmt = InfoStatement::Ns;
+		let stmt = InfoStatement::Ns(Default::default());
 		let serialized = stmt.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(stmt, serialized);
 	}
 
 	#[test]
 	fn db() {
-		let stmt = InfoStatement::Db;
+		let stmt = InfoStatement::Db(Default::default());
 		let serialized = stmt.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(stmt, serialized);
 	}
 
 	#[test]
 	fn sc() {
-		let stmt = InfoStatement::Sc(Default::default());
+		let stmt = InfoStatement::Sc(Default::default(), Default::default());
 		let serialized = stmt.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(stmt, serialized);
 	}
 
 	#[test]
 	fn tb() {
-		let stmt = InfoStatement::Tb(Default::default());
+		let stmt = InfoStatement::Tb(Default::default(), Default::default());
 		let serialized = stmt.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(stmt, serialized);
 	}
 
 	#[test]
 	fn user() {
-		let stmt = InfoStatement::User(Default::default(), Default::default());
+		let stmt = InfoStatement::User(Default::default(), Default::default(), Default::default());
 		let serialized = stmt.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(stmt, serialized);
 	}

--- a/core/src/sql/value/serde/ser/statement/mod.rs
+++ b/core/src/sql/value/serde/ser/statement/mod.rs
@@ -161,7 +161,7 @@ mod tests {
 
 	#[test]
 	fn info() {
-		let statement = Statement::Info(InfoStatement::Ns);
+		let statement = Statement::Info(InfoStatement::Ns(Default::default()));
 		let serialized = statement.serialize(Serializer.wrap()).unwrap();
 		assert_eq!(statement, serialized);
 	}

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -31,8 +31,8 @@ use std::ops::Deref;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Value";
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Values(pub Vec<Value>);
@@ -58,10 +58,10 @@ impl Display for Values {
 	}
 }
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Value")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub enum Value {
 	// These value types are simple values which

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -5,6 +5,7 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::fnc::util::string::fuzzy::Fuzzy;
+use crate::sql::statements::info::InfoStructure;
 use crate::sql::{
 	array::Uniq,
 	fmt::{Fmt, Pretty},
@@ -2602,6 +2603,12 @@ impl fmt::Display for Value {
 			Value::Thing(v) => write!(f, "{v}"),
 			Value::Uuid(v) => write!(f, "{v}"),
 		}
+	}
+}
+
+impl InfoStructure for Value {
+	fn structure(self) -> Value {
+		self.to_string().into()
 	}
 }
 

--- a/core/src/sql/version.rs
+++ b/core/src/sql/version.rs
@@ -3,8 +3,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Version(pub Datetime);

--- a/core/src/sql/view.rs
+++ b/core/src/sql/view.rs
@@ -4,9 +4,9 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+#[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[revisioned(revision = 1)]
 #[non_exhaustive]
 pub struct View {
 	pub expr: Fields,

--- a/core/src/sql/view.rs
+++ b/core/src/sql/view.rs
@@ -1,4 +1,5 @@
-use crate::sql::{cond::Cond, field::Fields, group::Groups, table::Tables};
+use crate::sql::statements::info::InfoStructure;
+use crate::sql::{cond::Cond, field::Fields, group::Groups, table::Tables, Value};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -24,5 +25,10 @@ impl fmt::Display for View {
 			write!(f, " {v}")?
 		}
 		Ok(())
+	}
+}
+impl InfoStructure for View {
+	fn structure(self) -> Value {
+		self.to_string().into()
 	}
 }

--- a/core/src/sql/with.rs
+++ b/core/src/sql/with.rs
@@ -2,8 +2,8 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result};
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum With {

--- a/core/src/syn/v1/stmt/info.rs
+++ b/core/src/syn/v1/stmt/info.rs
@@ -14,39 +14,45 @@ pub fn info(i: &str) -> IResult<&str, InfoStatement> {
 	let (i, _) = shouldbespace(i)?;
 	let (i, _) = tag_no_case("FOR")(i)?;
 	let (i, _) = cut(shouldbespace)(i)?;
-	expected(
+	let (i, stm) = expected(
 		"ROOT, NAMESPACE, DATABASE, SCOPE, TABLE or USER",
 		cut(alt((root, ns, db, sc, tb, user))),
-	)(i)
+	)(i)?;
+
+	let (i, structure) = opt(tag_no_case("STRUCTURE"))(i)?;
+	Ok((i, match structure {
+		Some(_) => stm.structurize(),
+		None => stm,
+	}))
 }
 
 fn root(i: &str) -> IResult<&str, InfoStatement> {
 	let (i, _) = alt((tag_no_case("ROOT"), tag_no_case("KV")))(i)?;
-	Ok((i, InfoStatement::Root))
+	Ok((i, InfoStatement::Root(false)))
 }
 
 fn ns(i: &str) -> IResult<&str, InfoStatement> {
 	let (i, _) = alt((tag_no_case("NAMESPACE"), tag_no_case("NS")))(i)?;
-	Ok((i, InfoStatement::Ns))
+	Ok((i, InfoStatement::Ns(false)))
 }
 
 fn db(i: &str) -> IResult<&str, InfoStatement> {
 	let (i, _) = alt((tag_no_case("DATABASE"), tag_no_case("DB")))(i)?;
-	Ok((i, InfoStatement::Db))
+	Ok((i, InfoStatement::Db(false)))
 }
 
 fn sc(i: &str) -> IResult<&str, InfoStatement> {
 	let (i, _) = alt((tag_no_case("SCOPE"), tag_no_case("SC")))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, scope) = cut(ident)(i)?;
-	Ok((i, InfoStatement::Sc(scope)))
+	Ok((i, InfoStatement::Sc(scope, false)))
 }
 
 fn tb(i: &str) -> IResult<&str, InfoStatement> {
 	let (i, _) = alt((tag_no_case("TABLE"), tag_no_case("TB")))(i)?;
 	let (i, _) = shouldbespace(i)?;
 	let (i, table) = cut(ident)(i)?;
-	Ok((i, InfoStatement::Tb(table)))
+	Ok((i, InfoStatement::Tb(table, false)))
 }
 
 fn user(i: &str) -> IResult<&str, InfoStatement> {
@@ -65,7 +71,7 @@ fn user(i: &str) -> IResult<&str, InfoStatement> {
 			})(i)
 		})(i)?;
 
-		Ok((i, InfoStatement::User(user, base)))
+		Ok((i, InfoStatement::User(user, base, false)))
 	})(i)
 }
 
@@ -80,7 +86,7 @@ mod tests {
 		let sql = "INFO FOR ROOT";
 		let res = info(sql);
 		let out = res.unwrap().1;
-		assert_eq!(out, InfoStatement::Root);
+		assert_eq!(out, InfoStatement::Root(false));
 		assert_eq!("INFO FOR ROOT", format!("{}", out));
 	}
 
@@ -89,7 +95,7 @@ mod tests {
 		let sql = "INFO FOR NAMESPACE";
 		let res = info(sql);
 		let out = res.unwrap().1;
-		assert_eq!(out, InfoStatement::Ns);
+		assert_eq!(out, InfoStatement::Ns(false));
 		assert_eq!("INFO FOR NAMESPACE", format!("{}", out));
 	}
 
@@ -98,7 +104,7 @@ mod tests {
 		let sql = "INFO FOR DATABASE";
 		let res = info(sql);
 		let out = res.unwrap().1;
-		assert_eq!(out, InfoStatement::Db);
+		assert_eq!(out, InfoStatement::Db(false));
 		assert_eq!("INFO FOR DATABASE", format!("{}", out));
 	}
 
@@ -107,7 +113,7 @@ mod tests {
 		let sql = "INFO FOR SCOPE test";
 		let res = info(sql);
 		let out = res.unwrap().1;
-		assert_eq!(out, InfoStatement::Sc(Ident::from("test")));
+		assert_eq!(out, InfoStatement::Sc(Ident::from("test"), false));
 		assert_eq!("INFO FOR SCOPE test", format!("{}", out));
 	}
 
@@ -116,7 +122,7 @@ mod tests {
 		let sql = "INFO FOR TABLE test";
 		let res = info(sql);
 		let out = res.unwrap().1;
-		assert_eq!(out, InfoStatement::Tb(Ident::from("test")));
+		assert_eq!(out, InfoStatement::Tb(Ident::from("test"), false));
 		assert_eq!("INFO FOR TABLE test", format!("{}", out));
 	}
 
@@ -125,25 +131,34 @@ mod tests {
 		let sql = "INFO FOR USER test ON ROOT";
 		let res = info(sql);
 		let out = res.unwrap().1;
-		assert_eq!(out, InfoStatement::User(Ident::from("test"), Some(Base::Root)));
+		assert_eq!(out, InfoStatement::User(Ident::from("test"), Some(Base::Root), false));
 		assert_eq!("INFO FOR USER test ON ROOT", format!("{}", out));
 
 		let sql = "INFO FOR USER test ON NS";
 		let res = info(sql);
 		let out = res.unwrap().1;
-		assert_eq!(out, InfoStatement::User(Ident::from("test"), Some(Base::Ns)));
+		assert_eq!(out, InfoStatement::User(Ident::from("test"), Some(Base::Ns), false));
 		assert_eq!("INFO FOR USER test ON NAMESPACE", format!("{}", out));
 
 		let sql = "INFO FOR USER test ON DB";
 		let res = info(sql);
 		let out = res.unwrap().1;
-		assert_eq!(out, InfoStatement::User(Ident::from("test"), Some(Base::Db)));
+		assert_eq!(out, InfoStatement::User(Ident::from("test"), Some(Base::Db), false));
 		assert_eq!("INFO FOR USER test ON DATABASE", format!("{}", out));
 
 		let sql = "INFO FOR USER test";
 		let res = info(sql);
 		let out = res.unwrap().1;
-		assert_eq!(out, InfoStatement::User(Ident::from("test"), None));
+		assert_eq!(out, InfoStatement::User(Ident::from("test"), None, false));
 		assert_eq!("INFO FOR USER test", format!("{}", out));
+	}
+
+	#[test]
+	fn info_query_root_structure() {
+		let sql = "INFO FOR ROOT STRUCTURE";
+		let res = info(sql);
+		let out = res.unwrap().1;
+		assert_eq!(out, InfoStatement::Root(true));
+		assert_eq!("INFO FOR ROOT", format!("{}", out));
 	}
 }

--- a/core/src/syn/v2/lexer/keywords.rs
+++ b/core/src/syn/v2/lexer/keywords.rs
@@ -185,6 +185,7 @@ pub(crate) static KEYWORDS: phf::Map<UniCase<&'static str>, TokenKind> = phf_map
 	UniCase::ascii("SNOWBALL") => TokenKind::Keyword(Keyword::Snowball),
 	UniCase::ascii("SPLIT") => TokenKind::Keyword(Keyword::Split),
 	UniCase::ascii("START") => TokenKind::Keyword(Keyword::Start),
+	UniCase::ascii("STRUCTURE") => TokenKind::Keyword(Keyword::Structure),
 	UniCase::ascii("TABLE") => TokenKind::Keyword(Keyword::Table),
 	UniCase::ascii("TB") => TokenKind::Keyword(Keyword::Table),
 	UniCase::ascii("TERMS_CACHE") => TokenKind::Keyword(Keyword::TermsCache),

--- a/core/src/syn/v2/parser/stmt/mod.rs
+++ b/core/src/syn/v2/parser/stmt/mod.rs
@@ -425,7 +425,7 @@ impl Parser<'_> {
 	/// Expects `INFO` to already be consumed.
 	pub(crate) fn parse_info_stmt(&mut self) -> ParseResult<InfoStatement> {
 		expected!(self, t!("FOR"));
-		let stmt = match self.next().kind {
+		let mut stmt = match self.next().kind {
 			t!("ROOT") => InfoStatement::Root,
 			t!("NAMESPACE") => InfoStatement::Ns,
 			t!("DATABASE") => InfoStatement::Db,
@@ -443,6 +443,18 @@ impl Parser<'_> {
 				InfoStatement::User(ident, base)
 			}
 			x => unexpected!(self, x, "an info target"),
+		};
+
+		if self.peek_kind() == t!("STRUCTURE") {
+			stmt = match stmt.structurize() {
+				Ok(s) => {
+					self.pop_peek();
+					s
+				}
+				Err(_) => {
+					unexpected!(self, t!("STRUCTURE"), "not STRUCTURE")
+				}
+			}
 		};
 		Ok(stmt)
 	}

--- a/core/src/syn/v2/parser/test/stmt.rs
+++ b/core/src/syn/v2/parser/test/stmt.rs
@@ -647,28 +647,31 @@ fn parse_if_block() {
 #[test]
 fn parse_info() {
 	let res = test_parse!(parse_stmt, "INFO FOR ROOT").unwrap();
-	assert_eq!(res, Statement::Info(InfoStatement::Root));
+	assert_eq!(res, Statement::Info(InfoStatement::Root(false)));
 
 	let res = test_parse!(parse_stmt, "INFO FOR KV").unwrap();
-	assert_eq!(res, Statement::Info(InfoStatement::Root));
+	assert_eq!(res, Statement::Info(InfoStatement::Root(false)));
 
 	let res = test_parse!(parse_stmt, "INFO FOR NAMESPACE").unwrap();
-	assert_eq!(res, Statement::Info(InfoStatement::Ns));
+	assert_eq!(res, Statement::Info(InfoStatement::Ns(false)));
 
 	let res = test_parse!(parse_stmt, "INFO FOR NS").unwrap();
-	assert_eq!(res, Statement::Info(InfoStatement::Ns));
+	assert_eq!(res, Statement::Info(InfoStatement::Ns(false)));
 
 	let res = test_parse!(parse_stmt, "INFO FOR SCOPE scope").unwrap();
-	assert_eq!(res, Statement::Info(InfoStatement::Sc(Ident("scope".to_owned()))));
+	assert_eq!(res, Statement::Info(InfoStatement::Sc(Ident("scope".to_owned()), false)));
 
 	let res = test_parse!(parse_stmt, "INFO FOR TABLE table").unwrap();
-	assert_eq!(res, Statement::Info(InfoStatement::Tb(Ident("table".to_owned()))));
+	assert_eq!(res, Statement::Info(InfoStatement::Tb(Ident("table".to_owned()), false)));
 
 	let res = test_parse!(parse_stmt, "INFO FOR USER user").unwrap();
-	assert_eq!(res, Statement::Info(InfoStatement::User(Ident("user".to_owned()), None)));
+	assert_eq!(res, Statement::Info(InfoStatement::User(Ident("user".to_owned()), None, false)));
 
 	let res = test_parse!(parse_stmt, "INFO FOR USER user ON namespace").unwrap();
-	assert_eq!(res, Statement::Info(InfoStatement::User(Ident("user".to_owned()), Some(Base::Ns))));
+	assert_eq!(
+		res,
+		Statement::Info(InfoStatement::User(Ident("user".to_owned()), Some(Base::Ns), false))
+	);
 }
 
 #[test]

--- a/core/src/syn/v2/parser/test/streaming.rs
+++ b/core/src/syn/v2/parser/test/streaming.rs
@@ -433,10 +433,10 @@ fn statements() -> Vec<Statement> {
 				vec![Part::Field(Ident("baq".to_owned()))],
 			)))])))),
 		}),
-		Statement::Info(InfoStatement::Root),
-		Statement::Info(InfoStatement::Ns),
-		Statement::Info(InfoStatement::Sc(Ident("scope".to_owned()))),
-		Statement::Info(InfoStatement::User(Ident("user".to_owned()), Some(Base::Ns))),
+		Statement::Info(InfoStatement::Root(false)),
+		Statement::Info(InfoStatement::Ns(false)),
+		Statement::Info(InfoStatement::Sc(Ident("scope".to_owned()), false)),
+		Statement::Info(InfoStatement::User(Ident("user".to_owned()), Some(Base::Ns), false)),
 		Statement::Select(SelectStatement {
 			expr: Fields(
 				vec![

--- a/core/src/syn/v2/token/keyword.rs
+++ b/core/src/syn/v2/token/keyword.rs
@@ -144,6 +144,7 @@ keyword! {
 	Snowball => "SNOWBALL",
 	Split => "SPLIT",
 	Start => "START",
+	Structure => "STRUCTURE",
 	Table => "TABLE",
 	TermsCache => "TERMS_CACHE",
 	TermsOrder => "TERMS_ORDER",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -92,7 +92,14 @@ reqwest = { version = "0.11.22", default-features = false, features = [
     "stream",
     "multipart",
 ], optional = true }
-revision = "0.5.0"
+revision = { version = "0.7.0", features = [
+    "chrono",
+    "geo",
+    "roaring",
+    "regex",
+    "rust_decimal",
+    "uuid",
+] }
 rust_decimal = { version = "1.33.1", features = ["maths", "serde-str"] }
 rustls = { version = "0.21.10", optional = true }
 semver = { version = "1.0.20", features = ["serde"] }
@@ -124,8 +131,11 @@ wiremock = "0.5.22"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pharos = "0.5.3"
-ring = { version = "0.17.7", features = ["wasm32_unknown_unknown_js"] } # Make ring-based dependencies work on Wasm
-tokio = { version = "1.34.0", default-features = false, features = ["rt", "sync"] }
+ring = { version = "0.17.7", features = ["wasm32_unknown_unknown_js"] }
+tokio = { version = "1.34.0", default-features = false, features = [
+    "rt",
+    "sync",
+] }
 uuid = { version = "1.6.1", features = ["serde", "js", "v4", "v7"] }
 wasm-bindgen-futures = "0.4.39"
 wasmtimer = { version = "0.2.0", default-features = false, features = [

--- a/lib/src/api/engine/remote/ws/mod.rs
+++ b/lib/src/api/engine/remote/ws/mod.rs
@@ -84,15 +84,15 @@ impl Surreal<Client> {
 	}
 }
 
-#[derive(Clone, Debug, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Deserialize)]
 pub(crate) struct Failure {
 	pub(crate) code: i64,
 	pub(crate) message: String,
 }
 
-#[derive(Debug, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Debug, Deserialize)]
 pub(crate) enum Data {
 	Other(Value),
 	Query(Vec<QueryMethodResponse>),
@@ -151,8 +151,8 @@ impl DbResponse {
 	}
 }
 
-#[derive(Debug, Deserialize)]
 #[revisioned(revision = 1)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct Response {
 	id: Option<Value>,
 	pub(crate) result: ServerResult,

--- a/src/rpc/failure.rs
+++ b/src/rpc/failure.rs
@@ -12,8 +12,8 @@ pub struct Failure {
 	pub(crate) message: Cow<'static, str>,
 }
 
-#[derive(Clone, Debug, Serialize)]
 #[revisioned(revision = 1)]
+#[derive(Clone, Debug, Serialize)]
 struct Inner {
 	code: i64,
 	message: String,

--- a/src/rpc/response.rs
+++ b/src/rpc/response.rs
@@ -12,8 +12,8 @@ use surrealdb::rpc::Data;
 use surrealdb::sql::Value;
 use tracing::Span;
 
-#[derive(Debug, Serialize)]
 #[revisioned(revision = 1)]
+#[derive(Debug, Serialize)]
 pub struct Response {
 	id: Option<Value>,
 	result: Result<Data, Failure>,


### PR DESCRIPTION
Co-authored-by: Micha de Vries <micha@devrie.sh>

Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Backport #3876
Backport #3886

## What does this change do?

Backport #3876
Backport #3886
Adds `STRUCTURE` keyword to syn1

## What is your testing strategy?

Ensure all tests still pass. Added a test for new syntax in syn1

## Is this related to any issues?

N/A

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
