### PR TITLE
[backport] Rely on `kty` when `alg` is not in JWK

### DIFF
--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -28,7 +28,7 @@ async fn config(
 		#[cfg(feature = "jwks")]
 		// The key identifier header must be present
 		if let Some(kid) = _token_header.kid {
-			jwks::config(_kvs, &kid, &de_code).await
+			jwks::config(_kvs, &kid, &de_code, _token_header.alg).await
 		} else {
 			Err(Error::MissingTokenHeader("kid".to_string()))
 		}


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Backport #3891

## What does this change do?

Backport #3891

## What is your testing strategy?

Ensure all tests still pass

## Is this related to any issues?

N/A

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
