### PR TITLE
Fix decimal decoding

### DIFF
--- a/core/src/rpc/format/cbor/convert.rs
+++ b/core/src/rpc/format/cbor/convert.rs
@@ -1,6 +1,7 @@
 use ciborium::Value as Data;
 use geo::{LineString, Point, Polygon};
 use geo_types::{MultiLineString, MultiPoint, MultiPolygon};
+use rust_decimal::Decimal;
 use std::iter::once;
 use std::ops::Deref;
 

--- a/core/src/rpc/format/cbor/convert.rs
+++ b/core/src/rpc/format/cbor/convert.rs
@@ -13,6 +13,7 @@ use crate::sql::Number;
 use crate::sql::Thing;
 use crate::sql::Uuid;
 use crate::sql::Value;
+use std::str::FromStr;
 
 // Tags from the spec - https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml
 const TAG_SPEC_DATETIME: u64 = 0;

--- a/core/src/rpc/format/cbor/convert.rs
+++ b/core/src/rpc/format/cbor/convert.rs
@@ -119,7 +119,7 @@ impl TryFrom<Cbor> for Value {
 					},
 					// A literal decimal
 					TAG_STRING_DECIMAL => match *v {
-						Data::Text(v) => match Number::try_from(v) {
+						Data::Text(v) => match Decimal::from_str(v.as_str()) {
 							Ok(v) => Ok(v.into()),
 							_ => Err("Expected a valid Decimal value"),
 						},


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Currently, when you send a decimal, it's parsed as a number resulting it to be parsed as a float instead.

## What does this change do?

Parsed decimal tag specifically as decimal values.

## What is your testing strategy?

N/A

## Is this related to any issues?

N/A

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
