### PR TITLE
Add a defer async macro for testing

### DIFF
--- a/core/src/kvs/tests/raw.rs
+++ b/core/src/kvs/tests/raw.rs
@@ -258,41 +258,56 @@ async fn scan_paged() {
 	assert!(tx.put(Unknown, "test5", "5").await.is_ok());
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
-	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
-	let val =
-		tx.scan_paged(ScanPage::from("test1".into().."test9".into()), u32::MAX).await.unwrap();
-	let val = val.values;
-	assert_eq!(val.len(), 5);
-	assert_eq!(val[0].0, b"test1");
-	assert_eq!(val[0].1, b"1");
-	assert_eq!(val[1].0, b"test2");
-	assert_eq!(val[1].1, b"2");
-	assert_eq!(val[2].0, b"test3");
-	assert_eq!(val[2].1, b"3");
-	assert_eq!(val[3].0, b"test4");
-	assert_eq!(val[3].1, b"4");
-	assert_eq!(val[4].0, b"test5");
-	assert_eq!(val[4].1, b"5");
-	tx.cancel().await.unwrap();
+	let tx = ds.transaction(Read, Optimistic).await.unwrap();
+
+	async_defer!(let tx = (tx) defer {
+		tx.cancel().await.unwrap();
+	} after {
+		let val =
+			tx.scan_paged(ScanPage::from("test1".into().."test9".into()), u32::MAX).await.unwrap();
+		let val = val.values;
+		assert_eq!(val.len(), 5);
+		assert_eq!(val[0].0, b"test1");
+		assert_eq!(val[0].1, b"1");
+		assert_eq!(val[1].0, b"test2");
+		assert_eq!(val[1].1, b"2");
+		assert_eq!(val[2].0, b"test3");
+		assert_eq!(val[2].1, b"3");
+		assert_eq!(val[3].0, b"test4");
+		assert_eq!(val[3].1, b"4");
+		assert_eq!(val[4].0, b"test5");
+		assert_eq!(val[4].1, b"5");
+	})
+	.await;
+
 	// Create a readonly transaction
-	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
-	let val =
-		tx.scan_paged(ScanPage::from("test2".into().."test4".into()), u32::MAX).await.unwrap();
-	let val = val.values;
-	assert_eq!(val.len(), 2);
-	assert_eq!(val[0].0, b"test2");
-	assert_eq!(val[0].1, b"2");
-	assert_eq!(val[1].0, b"test3");
-	assert_eq!(val[1].1, b"3");
-	tx.cancel().await.unwrap();
+	let tx = ds.transaction(Read, Optimistic).await.unwrap();
+	async_defer!(let tx = (tx) defer {
+		tx.cancel().await.unwrap();
+	} after {
+		let val =
+			tx.scan_paged(ScanPage::from("test2".into().."test4".into()), u32::MAX).await.unwrap();
+		let val = val.values;
+		assert_eq!(val.len(), 2);
+		assert_eq!(val[0].0, b"test2");
+		assert_eq!(val[0].1, b"2");
+		assert_eq!(val[1].0, b"test3");
+		assert_eq!(val[1].1, b"3");
+	})
+	.await;
 	// Create a readonly transaction
-	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
-	let val = tx.scan_paged(ScanPage::from("test1".into().."test9".into()), 2).await.unwrap();
-	let val = val.values;
-	assert_eq!(val.len(), 2);
-	assert_eq!(val[0].0, b"test1");
-	assert_eq!(val[0].1, b"1");
-	assert_eq!(val[1].0, b"test2");
-	assert_eq!(val[1].1, b"2");
-	tx.cancel().await.unwrap();
+	let tx = ds.transaction(Read, Optimistic).await.unwrap();
+	async_defer!(let tx = (tx) defer {
+		tx.cancel().await.unwrap();
+	} after {
+		let val =
+			tx.scan_paged(ScanPage::from("test2".into().."test4".into()), u32::MAX).await.unwrap();
+		let val = val.values;
+		assert_eq!(val.len(), 2);
+		assert_eq!(val[0].0, b"test2");
+		assert_eq!(val[0].1, b"2");
+		assert_eq!(val[1].0, b"test3");
+		assert_eq!(val[1].1, b"3");
+	})
+	.await;
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Add a macro for running code after an async scope has completed.

## What does this change do?

Adds the `async_defer` macro.
A confience macro for running some async code at the end of a scope. Usage is like the following:
```rust
    // Capture the value of transaction into the binding tx, for use within the async scopes.
    async_defer!(let tx = (transaction) defer {
        // Run some code if the captured variable was not yet consumed.
        tx.cancel().await;
    } after {
        // This might quit early, and then the defer scope runs.
        tx.get_some_value().await?;
        // If this panics, the defer scope will still run.
        tx.set_some_other_value(42).await.unwrap();
        // We take the captured value here, so if this runs the defer scope will no longer run.
        tx.take().commit().await;
        Ok::<(),()>(())
    }).await
```

## What is your testing strategy?

This is not code for the database itself but for implementing tests.

## Is this related to any issues?

N/A

## Does this change need documentation?

N/A

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
