### PR TITLE
Store evaluated live query params

### DIFF
--- a/core/src/kvs/tests/lq.rs
+++ b/core/src/kvs/tests/lq.rs
@@ -1,3 +1,4 @@
+use crate::kvs::lq_structs::{LqIndexKey, LqIndexValue, LqSelector};
 use uuid::Uuid;
 
 #[tokio::test]
@@ -37,4 +38,43 @@ async fn scan_node_lq() {
 	}
 
 	tx.commit().await.unwrap();
+}
+
+#[test_log::test(tokio::test)]
+async fn live_params_are_evaluated() {
+	let node_id = Uuid::parse_str("9cb22db9-1851-4781-8847-d781a3f373ae").unwrap();
+	let clock = Arc::new(SizedClock::Fake(FakeClock::new(Timestamp::default())));
+	let test = init(node_id, clock).await.unwrap();
+
+	let sess = Session::owner().with_ns("test_namespace").with_db("test_database");
+	let params = map! {
+		"expected_table".to_string() => Value::Table(sql::Table("test_table".to_string())),
+	};
+	test.db.execute("LIVE SELECT * FROM $expected_table", &sess, Some(params)).await.unwrap();
+	let mut res = test.db.lq_cf_store.read().await.live_queries_for_selector(&LqSelector {
+		ns: "test_namespace".to_string(),
+		db: "test_database".to_string(),
+		tb: "test_table".to_string(),
+	});
+	assert_eq!(res.len(), 1);
+	// We remove the unknown value
+	res[0].0.lq = Default::default();
+	assert_eq!(
+		res,
+		vec![(
+			LqIndexKey {
+				selector: LqSelector {
+					ns: "test_namespace".to_string(),
+					db: "test_database".to_string(),
+					tb: "test_table".to_string(),
+				},
+				lq: Default::default(),
+			},
+			LqIndexValue {
+				stm: Default::default(),
+				vs: [0; 10],
+				ts: Default::default(),
+			}
+		)]
+	)
 }

--- a/core/src/kvs/tests/mod.rs
+++ b/core/src/kvs/tests/mod.rs
@@ -34,6 +34,7 @@ type ClockType = Arc<SizedClock>;
 #[cfg(feature = "kv-mem")]
 mod mem {
 
+	use crate::fflags::FFLAGS;
 	use crate::kvs::tests::{ClockType, Kvs};
 	use crate::kvs::Datastore;
 	use crate::kvs::LockType;

--- a/core/src/sql/statements/live.rs
+++ b/core/src/sql/statements/live.rs
@@ -109,6 +109,10 @@ impl LiveStatement {
 				let mut run = txn.lock().await;
 				match stm.what.compute(stk, ctx, opt, txn, doc).await? {
 					Value::Table(tb) => {
+						// We modify the table as it can be a $PARAM and the compute evaluates that
+						let mut stm = stm;
+						stm.what = Value::Table(tb.clone());
+
 						let ns = opt.ns().to_string();
 						let db = opt.db().to_string();
 						self.validate_change_feed_valid(&mut run, &ns, &db, &tb).await?;


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Params in a live query get evaluated but the evaluation result is not stored in the ds layer.

## What does this change do?

Modify the live query statement and feed the modified version up.

## What is your testing strategy?

Unit (included), integration (existing), manual.

## Is this related to any issues?

Lq v2

## Does this change need documentation?

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
