### PR TITLE
Handle both number and string for rpc request method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5762,6 +5762,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5954,6 +5973,8 @@ dependencies = [
  "snap",
  "speedb",
  "storekey",
+ "strum",
+ "strum_macros",
  "surrealdb-derive",
  "surrealdb-jsonwebtoken",
  "surrealdb-tikv-client",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -153,6 +153,8 @@ criterion = { version = "0.5.1", features = ["async_tokio"] }
 env_logger = "0.10.1"
 pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
 serial_test = "2.0.0"
+strum = "0.26.2"
+strum_macros = "0.26.2"
 temp-dir = "0.1.11"
 test-log = { version = "0.2.13", features = ["trace"] }
 time = { version = "0.3.30", features = ["serde"] }

--- a/core/src/rpc/method.rs
+++ b/core/src/rpc/method.rs
@@ -1,4 +1,10 @@
+#[cfg(test)]
+use strum::IntoEnumIterator;
+#[cfg(test)]
+use strum_macros::EnumIter;
+
 #[non_exhaustive]
+#[cfg_attr(test, derive(Debug, Copy, Clone, PartialEq, EnumIter))]
 pub enum Method {
 	Unknown,
 	Ping,
@@ -140,5 +146,22 @@ impl Method {
 				| Method::Query | Method::Relate
 				| Method::Run | Method::Unknown
 		)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn all_variants_from_u8() {
+		for method in Method::iter() {
+			assert_eq!(method.clone(), Method::from(method as u8));
+		}
+	}
+
+	#[test]
+	fn unknown_from_out_of_range_u8() {
+		assert_eq!(Method::Unknown, Method::from(182));
 	}
 }

--- a/core/src/rpc/method.rs
+++ b/core/src/rpc/method.rs
@@ -88,6 +88,36 @@ impl Method {
 	}
 }
 
+impl From<u8> for Method {
+	fn from(n: u8) -> Self {
+		match n {
+			1 => Self::Ping,
+			2 => Self::Info,
+			3 => Self::Use,
+			4 => Self::Signup,
+			5 => Self::Signin,
+			6 => Self::Invalidate,
+			7 => Self::Authenticate,
+			8 => Self::Kill,
+			9 => Self::Live,
+			10 => Self::Set,
+			11 => Self::Unset,
+			12 => Self::Select,
+			13 => Self::Insert,
+			14 => Self::Create,
+			15 => Self::Update,
+			16 => Self::Merge,
+			17 => Self::Patch,
+			18 => Self::Delete,
+			19 => Self::Version,
+			20 => Self::Query,
+			21 => Self::Relate,
+			22 => Self::Run,
+			_ => Self::Unknown,
+		}
+	}
+}
+
 impl Method {
 	pub fn is_valid(&self) -> bool {
 		!matches!(self, Self::Unknown)

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -35,7 +35,7 @@ pub trait RpcContext {
 		async { unreachable!() }
 	}
 
-	async fn execute(&mut self, method: Method, params: Array) -> Result<Data, RpcError> {
+	async fn execute(&mut self, method: &Method, params: Array) -> Result<Data, RpcError> {
 		match method {
 			Method::Ping => Ok(Value::None.into()),
 			Method::Info => self.info().await.map(Into::into).map_err(Into::into),
@@ -65,7 +65,7 @@ pub trait RpcContext {
 		}
 	}
 
-	async fn execute_immut(&self, method: Method, params: Array) -> Result<Data, RpcError> {
+	async fn execute_immut(&self, method: &Method, params: Array) -> Result<Data, RpcError> {
 		match method {
 			Method::Ping => Ok(Value::None.into()),
 			Method::Info => self.info().await.map(Into::into).map_err(Into::into),

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -23,7 +23,6 @@ use http_body::Body as HttpBody;
 use surrealdb::dbs::Session;
 use surrealdb::rpc::format::Format;
 use surrealdb::rpc::format::PROTOCOLS;
-use surrealdb::rpc::method::Method;
 use tower_http::request_id::RequestId;
 use uuid::Uuid;
 
@@ -116,7 +115,7 @@ async fn post_handler(
 
 	match fmt.req_http(body) {
 		Ok(req) => {
-			let res = rpc_ctx.execute(Method::parse(req.method), req.params).await;
+			let res = rpc_ctx.execute(&req.method, req.params).await;
 			fmt.res_http(res.into_response(None)).map_err(Error::from)
 		}
 		Err(err) => Err(Error::from(err)),

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -747,6 +747,54 @@ mod http_integration {
 	}
 
 	#[test(tokio::test)]
+	async fn rpc_endpoint_with_method_as_string() -> Result<(), Box<dyn std::error::Error>> {
+		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let url = &format!("http://{addr}/rpc");
+
+		// Prepare HTTP client
+		let mut headers = reqwest::header::HeaderMap::new();
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
+		headers.insert(header::ACCEPT, "application/json".parse()?);
+		let client = reqwest::Client::builder()
+			.connect_timeout(Duration::from_millis(10))
+			.default_headers(headers)
+			.build()?;
+
+		let res = client.post(url).json(&json!({"method": "ping"})).send().await?;
+		assert!(res.status().is_success());
+
+		let result = res.text().await?;
+		assert_eq!(result, "{\"result\":null}");
+
+		Ok(())
+	}
+
+	#[test(tokio::test)]
+	async fn rpc_endpoint_with_method_as_number() -> Result<(), Box<dyn std::error::Error>> {
+		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let url = &format!("http://{addr}/rpc");
+
+		// Prepare HTTP client
+		let mut headers = reqwest::header::HeaderMap::new();
+		headers.insert("NS", Ulid::new().to_string().parse()?);
+		headers.insert("DB", Ulid::new().to_string().parse()?);
+		headers.insert(header::ACCEPT, "application/json".parse()?);
+		let client = reqwest::Client::builder()
+			.connect_timeout(Duration::from_millis(10))
+			.default_headers(headers)
+			.build()?;
+
+		let res = client.post(url).json(&json!({"method": 1})).send().await?;
+		assert!(res.status().is_success());
+
+		let result = res.text().await?;
+		assert_eq!(result, "{\"result\":null}");
+
+		Ok(())
+	}
+
+	#[test(tokio::test)]
 	async fn signin_endpoint() -> Result<(), Box<dyn std::error::Error>> {
 		let (addr, _server) = common::start_server_with_auth_level().await.unwrap();
 		let url = &format!("http://{addr}/signin");


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

When consuming the `/rpc` endpoint, we have to pass the method name as a `string`. There is a small optimization to be done by only sending a small number.

## What does this change do?

Handle both `string` and `u8` for `Method` type.

## What is your testing strategy?

N/A

## Is this related to any issues?

N/A

## Does this change need documentation?

- [x] https://github.com/surrealdb/docs.surrealdb.com/pull/518

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
