### PR TITLE
TreeCache is currently inefficient on writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,6 +2499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5926,6 +5935,7 @@ dependencies = [
  "fuzzy-matcher",
  "geo 0.27.0",
  "geo-types",
+ "hashlink",
  "hex",
  "indxdb",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,15 +2499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
-dependencies = [
- "hashbrown 0.14.3",
-]
-
-[[package]]
 name = "headers"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5935,7 +5926,6 @@ dependencies = [
  "fuzzy-matcher",
  "geo 0.27.0",
  "geo-types",
- "hashlink",
  "hex",
  "indxdb",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick_cache"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347e1a588d1de074eeb3c00eadff93db4db65aeb62aee852b1efd0949fe65b6c"
+dependencies = [
+ "ahash 0.8.11",
+ "equivalent",
+ "hashbrown 0.14.3",
+ "parking_lot",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5902,6 +5914,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "criterion",
+ "dashmap",
  "deunicode",
  "dmp",
  "echodb",
@@ -5929,7 +5942,7 @@ dependencies = [
  "phf",
  "pin-project-lite",
  "pprof",
- "quick_cache",
+ "quick_cache 0.5.1",
  "radix_trie",
  "rand 0.8.5",
  "reblessive",
@@ -6051,7 +6064,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "lru",
  "parking_lot",
- "quick_cache",
+ "quick_cache 0.4.2",
  "sha2",
  "tokio",
  "vart",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -86,7 +86,6 @@ futures = "0.3.29"
 fuzzy-matcher = "0.3.7"
 geo = { version = "0.27.0", features = ["use-serde"] }
 geo-types = { version = "0.7.12", features = ["arbitrary"] }
-hashlink = "0.9.0"
 hex = { version = "0.4.3" }
 indxdb = { version = "0.4.0", optional = true }
 ipnet = "2.9.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -71,6 +71,7 @@ ciborium = "0.2.1"
 cedar-policy = "2.4.2"
 channel = { version = "1.9.0", package = "async-channel" }
 chrono = { version = "0.4.31", features = ["serde"] }
+dashmap = "5.5.3"
 derive = { version = "0.12.0", package = "surrealdb-derive" }
 deunicode = "1.4.1"
 dmp = "0.2.0"
@@ -111,7 +112,7 @@ once_cell = "1.18.0"
 pbkdf2 = { version = "0.12.2", features = ["simple"] }
 phf = { version = "0.11.2", features = ["macros", "unicase"] }
 pin-project-lite = "0.2.13"
-quick_cache = "0.4.0"
+quick_cache = "0.5.1"
 radix_trie = { version = "0.2.1", features = ["serde"] }
 rand = "0.8.5"
 reblessive = { version = "0.3.3", features = ["tree"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -86,6 +86,7 @@ futures = "0.3.29"
 fuzzy-matcher = "0.3.7"
 geo = { version = "0.27.0", features = ["use-serde"] }
 geo-types = { version = "0.7.12", features = ["arbitrary"] }
+hashlink = "0.9.0"
 hex = { version = "0.4.3" }
 indxdb = { version = "0.4.0", optional = true }
 ipnet = "2.9.0"

--- a/core/src/doc/index.rs
+++ b/core/src/doc/index.rs
@@ -365,9 +365,7 @@ impl<'a> IndexOperation<'a> {
 		p: &SearchParams,
 	) -> Result<(), Error> {
 		let ikb = IndexKeyBase::new(self.opt, self.ix);
-
 		let ixs = ctx.get_index_stores();
-
 		let mut ft =
 			FtIndex::new(ixs, self.opt, txn, &p.az, ikb, p, TransactionType::Write).await?;
 
@@ -376,7 +374,7 @@ impl<'a> IndexOperation<'a> {
 		} else {
 			ft.remove_document(txn, self.rid).await?;
 		}
-		ft.finish(&ixs, txn).await
+		ft.finish(txn).await
 	}
 
 	async fn index_mtree(

--- a/core/src/doc/index.rs
+++ b/core/src/doc/index.rs
@@ -366,23 +366,17 @@ impl<'a> IndexOperation<'a> {
 	) -> Result<(), Error> {
 		let ikb = IndexKeyBase::new(self.opt, self.ix);
 
-		let mut ft = FtIndex::new(
-			ctx.get_index_stores(),
-			self.opt,
-			txn,
-			&p.az,
-			ikb,
-			p,
-			TransactionType::Write,
-		)
-		.await?;
+		let ixs = ctx.get_index_stores();
+
+		let mut ft =
+			FtIndex::new(ixs, self.opt, txn, &p.az, ikb, p, TransactionType::Write).await?;
 
 		if let Some(n) = self.n.take() {
 			ft.index_document(stk, ctx, self.opt, txn, self.rid, n).await?;
 		} else {
 			ft.remove_document(txn, self.rid).await?;
 		}
-		ft.finish(txn).await
+		ft.finish(&ixs, txn).await
 	}
 
 	async fn index_mtree(

--- a/core/src/doc/index.rs
+++ b/core/src/doc/index.rs
@@ -365,9 +365,16 @@ impl<'a> IndexOperation<'a> {
 		p: &SearchParams,
 	) -> Result<(), Error> {
 		let ikb = IndexKeyBase::new(self.opt, self.ix);
-		let ixs = ctx.get_index_stores();
-		let mut ft =
-			FtIndex::new(ixs, self.opt, txn, &p.az, ikb, p, TransactionType::Write).await?;
+		let mut ft = FtIndex::new(
+			ctx.get_index_stores(),
+			self.opt,
+			txn,
+			&p.az,
+			ikb,
+			p,
+			TransactionType::Write,
+		)
+		.await?;
 
 		if let Some(n) = self.n.take() {
 			ft.index_document(stk, ctx, self.opt, txn, self.rid, n).await?;

--- a/core/src/doc/index.rs
+++ b/core/src/doc/index.rs
@@ -365,6 +365,7 @@ impl<'a> IndexOperation<'a> {
 		p: &SearchParams,
 	) -> Result<(), Error> {
 		let ikb = IndexKeyBase::new(self.opt, self.ix);
+
 		let mut ft = FtIndex::new(
 			ctx.get_index_stores(),
 			self.opt,
@@ -398,11 +399,11 @@ impl<'a> IndexOperation<'a> {
 				.await?;
 		// Delete the old index data
 		if let Some(o) = self.o.take() {
-			mt.remove_document(stk, &mut tx, self.rid, o).await?;
+			mt.remove_document(stk, &mut tx, self.rid, &o).await?;
 		}
 		// Create the new index data
 		if let Some(n) = self.n.take() {
-			mt.index_document(stk, &mut tx, self.rid, n).await?;
+			mt.index_document(stk, &mut tx, self.rid, &n).await?;
 		}
 		mt.finish(&mut tx).await
 	}

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1,6 +1,6 @@
 use crate::iam::Error as IamError;
 use crate::idx::ft::MatchRef;
-use crate::idx::trees::vector::SharedVector;
+use crate::idx::trees::vector::HashedSharedVector;
 use crate::key::error::KeyCategory;
 use crate::sql::idiom::Idiom;
 use crate::sql::index::Distance;
@@ -239,8 +239,8 @@ pub enum Error {
 	/// The size of the vector is incorrect
 	#[error("Unable to compute distance.The calculated result is not a valid number: {dist}. Vectors: {left:?} - {right:?}")]
 	InvalidVectorDistance {
-		left: SharedVector,
-		right: SharedVector,
+		left: HashedSharedVector,
+		right: HashedSharedVector,
 		dist: f64,
 	},
 

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1,6 +1,6 @@
 use crate::iam::Error as IamError;
 use crate::idx::ft::MatchRef;
-use crate::idx::trees::vector::HashedSharedVector;
+use crate::idx::trees::vector::SharedVector;
 use crate::key::error::KeyCategory;
 use crate::sql::idiom::Idiom;
 use crate::sql::index::Distance;
@@ -239,8 +239,8 @@ pub enum Error {
 	/// The size of the vector is incorrect
 	#[error("Unable to compute distance.The calculated result is not a valid number: {dist}. Vectors: {left:?} - {right:?}")]
 	InvalidVectorDistance {
-		left: HashedSharedVector,
-		right: HashedSharedVector,
+		left: SharedVector,
+		right: SharedVector,
 		dist: f64,
 	},
 

--- a/core/src/fnc/util/math/deviation.rs
+++ b/core/src/fnc/util/math/deviation.rs
@@ -1,5 +1,6 @@
 use crate::fnc::util::math::mean::Mean;
 use crate::fnc::util::math::variance::variance;
+use crate::fnc::util::math::ToFloat;
 use crate::sql::number::Number;
 
 pub trait Deviation {
@@ -13,6 +14,11 @@ impl Deviation for Vec<Number> {
 	}
 }
 
-pub(super) fn deviation(v: &[Number], mean: f64, sample: bool) -> f64 {
+// This function is exposed to optimise the pearson distance calculation.
+// As the mean of the vector is already calculated, we pass it as a parameter rather than recalculating it.
+pub(crate) fn deviation<T>(v: &[T], mean: f64, sample: bool) -> f64
+where
+	T: ToFloat,
+{
 	variance(v, mean, sample).sqrt()
 }

--- a/core/src/fnc/util/math/mean.rs
+++ b/core/src/fnc/util/math/mean.rs
@@ -1,10 +1,20 @@
-use crate::sql::number::Number;
+use crate::fnc::util::math::ToFloat;
+use crate::sql::Number;
 
 pub trait Mean {
 	fn mean(&self) -> f64;
 }
 
 impl Mean for Vec<Number> {
+	fn mean(&self) -> f64 {
+		self.as_slice().mean()
+	}
+}
+
+impl<T> Mean for &[T]
+where
+	T: ToFloat,
+{
 	fn mean(&self) -> f64 {
 		let len = self.len() as f64;
 		let sum = self.iter().map(|n| n.to_float()).sum::<f64>();

--- a/core/src/fnc/util/math/variance.rs
+++ b/core/src/fnc/util/math/variance.rs
@@ -1,4 +1,5 @@
 use super::mean::Mean;
+use crate::fnc::util::math::ToFloat;
 use crate::sql::number::Number;
 
 pub trait Variance {
@@ -13,7 +14,12 @@ impl Variance for Vec<Number> {
 	}
 }
 
-pub(super) fn variance(v: &[Number], mean: f64, sample: bool) -> f64 {
+// This function is exposed to optimise the pearson distance calculation.
+// As the mean of the vector is already calculated, we pass it as a parameter rather than recalculating it.
+pub(super) fn variance<T>(v: &[T], mean: f64, sample: bool) -> f64
+where
+	T: ToFloat,
+{
 	match v.len() {
 		0 => f64::NAN,
 		1 => 0.0,

--- a/core/src/idx/ft/doclength.rs
+++ b/core/src/idx/ft/doclength.rs
@@ -9,6 +9,7 @@ use crate::kvs::{Key, Transaction, TransactionType};
 pub(super) type DocLength = u64;
 
 pub(super) struct DocLengths {
+	ixs: IndexStores,
 	state_key: Key,
 	btree: BTree<TrieKeys>,
 	store: BTreeStore<TrieKeys>,
@@ -38,6 +39,7 @@ impl DocLengths {
 			)
 			.await;
 		Ok(Self {
+			ixs: ixs.clone(),
 			state_key,
 			btree: BTree::new(state),
 			store,
@@ -83,10 +85,10 @@ impl DocLengths {
 	}
 
 	pub(super) async fn finish(&mut self, tx: &mut Transaction) -> Result<(), Error> {
-		if self.store.finish(tx).await? {
+		if let Some(new_cache) = self.store.finish(tx).await? {
 			let state = self.btree.inc_generation();
 			tx.set(self.state_key.clone(), state.try_to_val()?).await?;
-			self.store.completed(self.btree.generation());
+			self.ixs.advance_cache_btree_trie(new_cache);
 		}
 		Ok(())
 	}

--- a/core/src/idx/ft/doclength.rs
+++ b/core/src/idx/ft/doclength.rs
@@ -86,6 +86,7 @@ impl DocLengths {
 		if self.store.finish(tx).await? {
 			let state = self.btree.inc_generation();
 			tx.set(self.state_key.clone(), state.try_to_val()?).await?;
+			self.store.completed(self.btree.generation());
 		}
 		Ok(())
 	}

--- a/core/src/idx/ft/mod.rs
+++ b/core/src/idx/ft/mod.rs
@@ -467,9 +467,9 @@ impl FtIndex {
 		})
 	}
 
-	pub(crate) async fn finish(&self, ixs: &IndexStores, tx: &Transaction) -> Result<(), Error> {
+	pub(crate) async fn finish(&self, tx: &Transaction) -> Result<(), Error> {
 		let mut run = tx.lock().await;
-		self.doc_ids.write().await.finish(ixs, &mut run).await?;
+		self.doc_ids.write().await.finish(&mut run).await?;
 		self.doc_lengths.write().await.finish(&mut run).await?;
 		self.postings.write().await.finish(&mut run).await?;
 		self.terms.write().await.finish(&mut run).await?;

--- a/core/src/idx/ft/mod.rs
+++ b/core/src/idx/ft/mod.rs
@@ -467,9 +467,9 @@ impl FtIndex {
 		})
 	}
 
-	pub(crate) async fn finish(&self, tx: &Transaction) -> Result<(), Error> {
+	pub(crate) async fn finish(&self, ixs: &IndexStores, tx: &Transaction) -> Result<(), Error> {
 		let mut run = tx.lock().await;
-		self.doc_ids.write().await.finish(&mut run).await?;
+		self.doc_ids.write().await.finish(ixs, &mut run).await?;
 		self.doc_lengths.write().await.finish(&mut run).await?;
 		self.postings.write().await.finish(&mut run).await?;
 		self.terms.write().await.finish(&mut run).await?;

--- a/core/src/idx/ft/postings.rs
+++ b/core/src/idx/ft/postings.rs
@@ -86,6 +86,7 @@ impl Postings {
 		if self.store.finish(tx).await? {
 			let state = self.btree.inc_generation();
 			tx.set(self.state_key.clone(), state.try_to_val()?).await?;
+			self.store.completed(state.generation());
 		}
 		Ok(())
 	}

--- a/core/src/idx/ft/postings.rs
+++ b/core/src/idx/ft/postings.rs
@@ -10,6 +10,7 @@ use crate::kvs::{Key, Transaction, TransactionType};
 pub(super) type TermFrequency = u64;
 
 pub(super) struct Postings {
+	ixs: IndexStores,
 	state_key: Key,
 	index_key_base: IndexKeyBase,
 	btree: BTree<TrieKeys>,
@@ -40,6 +41,7 @@ impl Postings {
 			)
 			.await;
 		Ok(Self {
+			ixs: ixs.clone(),
 			state_key,
 			index_key_base,
 			btree: BTree::new(state),
@@ -83,10 +85,10 @@ impl Postings {
 	}
 
 	pub(super) async fn finish(&mut self, tx: &mut Transaction) -> Result<(), Error> {
-		if self.store.finish(tx).await? {
+		if let Some(new_cache) = self.store.finish(tx).await? {
 			let state = self.btree.inc_generation();
 			tx.set(self.state_key.clone(), state.try_to_val()?).await?;
-			self.store.completed(state.generation());
+			self.ixs.advance_cache_btree_trie(new_cache);
 		}
 		Ok(())
 	}

--- a/core/src/idx/ft/terms.rs
+++ b/core/src/idx/ft/terms.rs
@@ -122,12 +122,14 @@ impl Terms {
 	pub(super) async fn finish(&mut self, tx: &mut Transaction) -> Result<(), Error> {
 		if self.store.finish(tx).await? {
 			let btree = self.btree.inc_generation().clone();
+			let new_gen = btree.generation();
 			let state = State {
 				btree,
 				available_ids: self.available_ids.take(),
 				next_term_id: self.next_term_id,
 			};
 			tx.set(self.state_key.clone(), state.try_to_val()?).await?;
+			self.store.completed(new_gen);
 		}
 		Ok(())
 	}

--- a/core/src/idx/ft/terms.rs
+++ b/core/src/idx/ft/terms.rs
@@ -12,6 +12,7 @@ pub(crate) type TermId = u64;
 pub(crate) type TermLen = u32;
 
 pub(in crate::idx) struct Terms {
+	ixs: IndexStores,
 	state_key: Key,
 	index_key_base: IndexKeyBase,
 	btree: BTree<FstKeys>,
@@ -44,6 +45,7 @@ impl Terms {
 			)
 			.await;
 		Ok(Self {
+			ixs: ixs.clone(),
 			state_key,
 			index_key_base,
 			btree: BTree::new(state.btree),
@@ -120,16 +122,15 @@ impl Terms {
 	}
 
 	pub(super) async fn finish(&mut self, tx: &mut Transaction) -> Result<(), Error> {
-		if self.store.finish(tx).await? {
+		if let Some(new_cache) = self.store.finish(tx).await? {
 			let btree = self.btree.inc_generation().clone();
-			let new_gen = btree.generation();
 			let state = State {
 				btree,
 				available_ids: self.available_ids.take(),
 				next_term_id: self.next_term_id,
 			};
 			tx.set(self.state_key.clone(), state.try_to_val()?).await?;
-			self.store.completed(new_gen);
+			self.ixs.advance_store_btree_fst(new_cache);
 		}
 		Ok(())
 	}

--- a/core/src/idx/planner/executor.rs
+++ b/core/src/idx/planner/executor.rs
@@ -137,7 +137,7 @@ impl InnerQueryExecutor {
 						if let IndexOperator::Knn(a, k) = io.op() {
 							let mut tx = txn.lock().await;
 							let entry = if let Some(mt) = mt_map.get(&ix_ref) {
-								MtEntry::new(&mut tx, mt, a.clone(), *k).await?
+								MtEntry::new(&mut tx, mt, a, *k).await?
 							} else {
 								let ikb = IndexKeyBase::new(opt, idx_def);
 								let mt = MTreeIndex::new(
@@ -148,7 +148,7 @@ impl InnerQueryExecutor {
 									TransactionType::Read,
 								)
 								.await?;
-								let entry = MtEntry::new(&mut tx, &mt, a.clone(), *k).await?;
+								let entry = MtEntry::new(&mut tx, &mt, a, *k).await?;
 								mt_map.insert(ix_ref, mt);
 								entry
 							};
@@ -397,8 +397,11 @@ impl QueryExecutor {
 
 	fn new_mtree_index_knn_iterator(&self, it_ref: IteratorRef) -> Option<ThingIterator> {
 		if let Some(IteratorEntry::Single(exp, ..)) = self.0.it_entries.get(it_ref as usize) {
-			if let Some(mte) = self.0.mt_entries.get(exp.as_ref()) {
-				let it = DocIdsIterator::new(mte.doc_ids.clone(), mte.res.clone());
+			if let Some(mte) = self.0.mt_entries.get(exp) {
+				let it = DocIdsIterator::new(
+					mte.doc_ids.clone(),
+					mte.res.iter().map(|(d, _)| *d).collect(),
+				);
 				return Some(ThingIterator::Knn(it));
 			}
 		}
@@ -640,14 +643,14 @@ impl FtEntry {
 #[derive(Clone)]
 pub(super) struct MtEntry {
 	doc_ids: Arc<RwLock<DocIds>>,
-	res: VecDeque<DocId>,
+	res: VecDeque<(DocId, f64)>,
 }
 
 impl MtEntry {
 	async fn new(
 		tx: &mut kvs::Transaction,
 		mt: &MTreeIndex,
-		a: Array,
+		a: &Array,
 		k: u32,
 	) -> Result<Self, Error> {
 		let res = mt.knn_search(tx, a, k as usize).await?;

--- a/core/src/idx/trees/knn.rs
+++ b/core/src/idx/trees/knn.rs
@@ -1,0 +1,752 @@
+use crate::idx::docids::DocId;
+use crate::idx::trees::store::NodeId;
+use roaring::RoaringTreemap;
+use std::cmp::{Ordering, Reverse};
+use std::collections::btree_map::Entry;
+#[cfg(debug_assertions)]
+use std::collections::HashMap;
+use std::collections::{BTreeMap, VecDeque};
+
+#[derive(Debug, Clone, Copy, Ord, Eq, PartialEq, PartialOrd)]
+pub(super) struct PriorityNode(Reverse<FloatKey>, NodeId);
+impl PriorityNode {
+	pub(super) fn new(d: f64, id: NodeId) -> Self {
+		Self(Reverse(FloatKey::new(d)), id)
+	}
+
+	pub(super) fn id(&self) -> NodeId {
+		self.1
+	}
+}
+
+/// Treats f64 as a sortable data type.
+/// It provides an implementation so it can be used as a key in a BTreeMap or BTreeSet.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct FloatKey(f64);
+
+impl FloatKey {
+	pub(super) fn new(f: f64) -> Self {
+		FloatKey(f)
+	}
+}
+impl From<FloatKey> for f64 {
+	fn from(v: FloatKey) -> Self {
+		v.0
+	}
+}
+
+impl Eq for FloatKey {}
+
+impl PartialEq<Self> for FloatKey {
+	fn eq(&self, other: &Self) -> bool {
+		self.0.total_cmp(&other.0) == Ordering::Equal
+	}
+}
+
+impl PartialOrd<Self> for FloatKey {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl Ord for FloatKey {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.0.total_cmp(&other.0)
+	}
+}
+
+/// Ids64 is a collection able to store u64 identifiers in an optimised way.
+/// The enumerations are optimised in a way that, depending on the number of identifiers,
+/// the most memory efficient variant is used.
+/// When identifiers are added or removed, the method returned the most appropriate
+/// variant (if required).
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum Ids64 {
+	#[allow(dead_code)] // Will be used with HNSW
+	Empty,
+	One(u64),
+	Vec2([u64; 2]),
+	Vec3([u64; 3]),
+	Vec4([u64; 4]),
+	Vec5([u64; 5]),
+	Vec6([u64; 6]),
+	Vec7([u64; 7]),
+	Vec8([u64; 8]),
+	Bits(RoaringTreemap),
+}
+
+impl Ids64 {
+	fn len(&self) -> u64 {
+		match self {
+			Self::Empty => 0,
+			Self::One(_) => 1,
+			Self::Vec2(_) => 2,
+			Self::Vec3(_) => 3,
+			Self::Vec4(_) => 4,
+			Self::Vec5(_) => 5,
+			Self::Vec6(_) => 6,
+			Self::Vec7(_) => 7,
+			Self::Vec8(_) => 8,
+			Self::Bits(b) => b.len(),
+		}
+	}
+
+	fn append_to(&self, to: &mut RoaringTreemap) {
+		match &self {
+			Self::Empty => {}
+			Self::One(d) => {
+				to.insert(*d);
+			}
+			Self::Vec2(a) => {
+				for d in a {
+					to.insert(*d);
+				}
+			}
+			Self::Vec3(a) => {
+				for d in a {
+					to.insert(*d);
+				}
+			}
+			Self::Vec4(a) => {
+				for d in a {
+					to.insert(*d);
+				}
+			}
+			Self::Vec5(a) => {
+				for d in a {
+					to.insert(*d);
+				}
+			}
+			Self::Vec6(a) => {
+				for d in a {
+					to.insert(*d);
+				}
+			}
+			Self::Vec7(a) => {
+				for d in a {
+					to.insert(*d);
+				}
+			}
+			Self::Vec8(a) => {
+				for d in a {
+					to.insert(*d);
+				}
+			}
+			Self::Bits(b) => {
+				for d in b {
+					to.insert(d);
+				}
+			}
+		}
+	}
+
+	fn remove_to(&self, to: &mut RoaringTreemap) {
+		match &self {
+			Self::Empty => {}
+			Self::One(d) => {
+				to.remove(*d);
+			}
+			Self::Vec2(a) => {
+				for &d in a {
+					to.remove(d);
+				}
+			}
+			Self::Vec3(a) => {
+				for &d in a {
+					to.remove(d);
+				}
+			}
+			Self::Vec4(a) => {
+				for &d in a {
+					to.remove(d);
+				}
+			}
+			Self::Vec5(a) => {
+				for &d in a {
+					to.remove(d);
+				}
+			}
+			Self::Vec6(a) => {
+				for &d in a {
+					to.remove(d);
+				}
+			}
+			Self::Vec7(a) => {
+				for &d in a {
+					to.remove(d);
+				}
+			}
+			Self::Vec8(a) => {
+				for &d in a {
+					to.remove(d);
+				}
+			}
+			Self::Bits(b) => {
+				for d in b {
+					to.remove(d);
+				}
+			}
+		}
+	}
+
+	fn append_iter_ref<'a, I>(&mut self, docs: I) -> Option<Self>
+	where
+		I: Iterator<Item = &'a DocId>,
+	{
+		let mut new_doc: Option<Self> = None;
+		for &doc in docs {
+			if let Some(ref mut nd) = new_doc {
+				let nd = nd.insert(doc);
+				if nd.is_some() {
+					new_doc = nd;
+				};
+			} else {
+				new_doc = self.insert(doc);
+			}
+		}
+		new_doc
+	}
+
+	fn append_iter<I>(&mut self, docs: I) -> Option<Self>
+	where
+		I: Iterator<Item = DocId>,
+	{
+		let mut new_doc: Option<Self> = None;
+		for doc in docs {
+			if let Some(mut nd) = new_doc {
+				new_doc = nd.insert(doc);
+			} else {
+				new_doc = self.insert(doc);
+			}
+		}
+		new_doc
+	}
+	fn append_from(&mut self, from: &Ids64) -> Option<Self> {
+		match from {
+			Self::Empty => None,
+			Self::One(d) => self.insert(*d),
+			Self::Vec2(a) => self.append_iter_ref(a.iter()),
+			Self::Vec3(a) => self.append_iter_ref(a.iter()),
+			Self::Vec4(a) => self.append_iter_ref(a.iter()),
+			Self::Vec5(a) => self.append_iter_ref(a.iter()),
+			Self::Vec6(a) => self.append_iter_ref(a.iter()),
+			Self::Vec7(a) => self.append_iter_ref(a.iter()),
+			Self::Vec8(a) => self.append_iter_ref(a.iter()),
+			Self::Bits(a) => self.append_iter(a.iter()),
+		}
+	}
+
+	fn iter(&self) -> Box<dyn Iterator<Item = DocId> + '_> {
+		match &self {
+			Self::Empty => Box::new(EmptyIterator {}),
+			Self::One(d) => Box::new(OneDocIterator(Some(*d))),
+			Self::Vec2(a) => Box::new(SliceDocIterator(a.iter())),
+			Self::Vec3(a) => Box::new(SliceDocIterator(a.iter())),
+			Self::Vec4(a) => Box::new(SliceDocIterator(a.iter())),
+			Self::Vec5(a) => Box::new(SliceDocIterator(a.iter())),
+			Self::Vec6(a) => Box::new(SliceDocIterator(a.iter())),
+			Self::Vec7(a) => Box::new(SliceDocIterator(a.iter())),
+			Self::Vec8(a) => Box::new(SliceDocIterator(a.iter())),
+			Self::Bits(a) => Box::new(a.iter()),
+		}
+	}
+
+	fn contains(&self, d: DocId) -> bool {
+		match self {
+			Self::Empty => false,
+			Self::One(o) => *o == d,
+			Self::Vec2(a) => a.contains(&d),
+			Self::Vec3(a) => a.contains(&d),
+			Self::Vec4(a) => a.contains(&d),
+			Self::Vec5(a) => a.contains(&d),
+			Self::Vec6(a) => a.contains(&d),
+			Self::Vec7(a) => a.contains(&d),
+			Self::Vec8(a) => a.contains(&d),
+			Self::Bits(b) => b.contains(d),
+		}
+	}
+
+	pub(super) fn insert(&mut self, d: DocId) -> Option<Self> {
+		if !self.contains(d) {
+			match self {
+				Self::Empty => Some(Self::One(d)),
+				Self::One(o) => Some(Self::Vec2([*o, d])),
+				Self::Vec2(a) => Some(Self::Vec3([a[0], a[1], d])),
+				Self::Vec3(a) => Some(Self::Vec4([a[0], a[1], a[2], d])),
+				Self::Vec4(a) => Some(Self::Vec5([a[0], a[1], a[2], a[3], d])),
+				Self::Vec5(a) => Some(Self::Vec6([a[0], a[1], a[2], a[3], a[4], d])),
+				Self::Vec6(a) => Some(Self::Vec7([a[0], a[1], a[2], a[3], a[4], a[5], d])),
+				Self::Vec7(a) => Some(Self::Vec8([a[0], a[1], a[2], a[3], a[4], a[5], a[6], d])),
+				Self::Vec8(a) => Some(Self::Bits(RoaringTreemap::from([
+					a[0], a[1], a[2], a[3], a[4], a[5], a[6], a[7], d,
+				]))),
+				Self::Bits(b) => {
+					b.insert(d);
+					None
+				}
+			}
+		} else {
+			None
+		}
+	}
+
+	#[allow(dead_code)] // Will be used with HNSW
+	pub(super) fn remove(&mut self, d: DocId) -> Option<Self> {
+		match self {
+			Self::Empty => None,
+			Self::One(i) => {
+				if d == *i {
+					Some(Self::Empty)
+				} else {
+					None
+				}
+			}
+			Self::Vec2(a) => a.iter().find(|&&i| i != d).map(|&i| Self::One(i)),
+			Self::Vec3(a) => {
+				let v: Vec<DocId> = a.iter().filter(|&&i| i != d).cloned().collect();
+				if v.len() == 2 {
+					Some(Self::Vec2([v[0], v[1]]))
+				} else {
+					None
+				}
+			}
+			Self::Vec4(a) => {
+				let v: Vec<DocId> = a.iter().filter(|&&i| i != d).cloned().collect();
+				if v.len() == 3 {
+					Some(Self::Vec3([v[0], v[1], v[2]]))
+				} else {
+					None
+				}
+			}
+			Self::Vec5(a) => {
+				let v: Vec<DocId> = a.iter().filter(|&&i| i != d).cloned().collect();
+				if v.len() == 4 {
+					Some(Self::Vec4([v[0], v[1], v[2], v[3]]))
+				} else {
+					None
+				}
+			}
+			Self::Vec6(a) => {
+				let v: Vec<DocId> = a.iter().filter(|&&i| i != d).cloned().collect();
+				if v.len() == 5 {
+					Some(Self::Vec5([v[0], v[1], v[2], v[3], v[4]]))
+				} else {
+					None
+				}
+			}
+			Self::Vec7(a) => {
+				let v: Vec<DocId> = a.iter().filter(|&&i| i != d).cloned().collect();
+				if v.len() == 6 {
+					Some(Self::Vec6([v[0], v[1], v[2], v[3], v[4], v[5]]))
+				} else {
+					None
+				}
+			}
+			Self::Vec8(a) => {
+				let v: Vec<DocId> = a.iter().filter(|&&i| i != d).cloned().collect();
+				if v.len() == 7 {
+					Some(Self::Vec7([v[0], v[1], v[2], v[3], v[4], v[5], v[6]]))
+				} else {
+					None
+				}
+			}
+			Self::Bits(b) => {
+				if !b.remove(d) || b.len() != 8 {
+					None
+				} else {
+					let v: Vec<DocId> = b.iter().collect();
+					Some(Self::Vec8([v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7]]))
+				}
+			}
+		}
+	}
+}
+
+struct EmptyIterator;
+
+impl Iterator for EmptyIterator {
+	type Item = DocId;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		None
+	}
+}
+
+struct OneDocIterator(Option<DocId>);
+
+impl Iterator for OneDocIterator {
+	type Item = DocId;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		self.0.take()
+	}
+}
+
+struct SliceDocIterator<'a, I>(I)
+where
+	I: Iterator<Item = &'a DocId>;
+
+impl<'a, I> Iterator for SliceDocIterator<'a, I>
+where
+	I: Iterator<Item = &'a DocId>,
+{
+	type Item = DocId;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		self.0.next().cloned()
+	}
+}
+
+#[non_exhaustive]
+pub(super) struct KnnResultBuilder {
+	knn: u64,
+	docs: RoaringTreemap,
+	priority_list: BTreeMap<FloatKey, Ids64>,
+}
+
+impl KnnResultBuilder {
+	pub(super) fn new(knn: usize) -> Self {
+		Self {
+			knn: knn as u64,
+			docs: RoaringTreemap::default(),
+			priority_list: BTreeMap::default(),
+		}
+	}
+	pub(super) fn check_add(&self, dist: f64) -> bool {
+		if self.docs.len() < self.knn {
+			true
+		} else if let Some(pr) = self.priority_list.keys().last() {
+			dist <= pr.0
+		} else {
+			true
+		}
+	}
+
+	pub(super) fn add(&mut self, dist: f64, docs: &Ids64) {
+		let pr = FloatKey(dist);
+		docs.append_to(&mut self.docs);
+		match self.priority_list.entry(pr) {
+			Entry::Vacant(e) => {
+				e.insert(docs.clone());
+			}
+			Entry::Occupied(mut e) => {
+				let d = e.get_mut();
+				if let Some(n) = d.append_from(docs) {
+					e.insert(n);
+				}
+			}
+		}
+
+		// Do possible eviction
+		let docs_len = self.docs.len();
+		if docs_len > self.knn {
+			if let Some((_, d)) = self.priority_list.last_key_value() {
+				if docs_len - d.len() >= self.knn {
+					if let Some((_, evicted_docs)) = self.priority_list.pop_last() {
+						evicted_docs.remove_to(&mut self.docs);
+					}
+				}
+			}
+		}
+	}
+
+	pub(super) fn build(
+		self,
+		#[cfg(debug_assertions)] visited_nodes: HashMap<NodeId, usize>,
+	) -> KnnResult {
+		let mut sorted_docs = VecDeque::with_capacity(self.knn as usize);
+		let mut left = self.knn;
+		for (pr, docs) in self.priority_list {
+			let dl = docs.len();
+			if dl > left {
+				for doc_id in docs.iter().take(left as usize) {
+					sorted_docs.push_back((doc_id, pr.0));
+				}
+				break;
+			}
+			for doc_id in docs.iter() {
+				sorted_docs.push_back((doc_id, pr.0));
+			}
+			left -= dl;
+			// We don't expect anymore result, we can leave
+			if left == 0 {
+				break;
+			}
+		}
+		trace!("sorted_docs: {:?}", sorted_docs);
+		KnnResult {
+			docs: sorted_docs,
+			#[cfg(debug_assertions)]
+			visited_nodes,
+		}
+	}
+}
+
+pub struct KnnResult {
+	pub(in crate::idx::trees) docs: VecDeque<(DocId, f64)>,
+	#[cfg(debug_assertions)]
+	#[allow(dead_code)]
+	pub(in crate::idx::trees) visited_nodes: HashMap<NodeId, usize>,
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+	use crate::idx::docids::DocId;
+	use crate::idx::trees::knn::{FloatKey, Ids64, KnnResultBuilder};
+	use crate::idx::trees::vector::{HashedSharedVector, Vector};
+	use crate::sql::index::{Distance, VectorType};
+	use crate::sql::Number;
+	use rand::prelude::SmallRng;
+	use rand::{Rng, SeedableRng};
+	use roaring::RoaringTreemap;
+	use rust_decimal::prelude::Zero;
+	use std::cmp::Reverse;
+	#[cfg(debug_assertions)]
+	use std::collections::HashMap;
+	use std::collections::{BTreeSet, BinaryHeap, VecDeque};
+	use test_log::test;
+
+	pub(crate) fn get_seed_rnd() -> SmallRng {
+		let seed: u64 = std::env::var("TEST_SEED")
+			.unwrap_or_else(|_| rand::random::<u64>().to_string())
+			.parse()
+			.expect("Failed to parse seed");
+		info!("Seed: {}", seed);
+		// Create a seeded RNG
+		SmallRng::seed_from_u64(seed)
+	}
+
+	#[derive(Debug)]
+	pub(in crate::idx::trees) enum TestCollection {
+		Unique(Vec<(DocId, HashedSharedVector)>),
+		NonUnique(Vec<(DocId, HashedSharedVector)>),
+	}
+
+	impl TestCollection {
+		pub(in crate::idx::trees) fn to_vec_ref(&self) -> &Vec<(DocId, HashedSharedVector)> {
+			match self {
+				TestCollection::Unique(c) | TestCollection::NonUnique(c) => c,
+			}
+		}
+
+		pub(in crate::idx::trees) fn len(&self) -> usize {
+			self.to_vec_ref().len()
+		}
+	}
+
+	pub(in crate::idx::trees) fn new_vec(
+		mut n: i64,
+		t: VectorType,
+		dim: usize,
+	) -> HashedSharedVector {
+		let mut vec = Vector::new(t, dim);
+		vec.add(&Number::Int(n));
+		for _ in 1..dim {
+			n += 1;
+			vec.add(&Number::Int(n));
+		}
+		vec.into()
+	}
+
+	pub(in crate::idx::trees) fn new_random_vec(
+		rng: &mut SmallRng,
+		t: VectorType,
+		dim: usize,
+		gen: &RandomItemGenerator,
+	) -> HashedSharedVector {
+		let mut vec = Vector::new(t, dim);
+		for _ in 0..dim {
+			vec.add(&gen.generate(rng));
+		}
+		if vec.is_null() {
+			// Some similarities (cosine) is undefined for null vector.
+			new_random_vec(rng, t, dim, gen)
+		} else {
+			vec.into()
+		}
+	}
+
+	impl Vector {
+		pub(super) fn is_null(&self) -> bool {
+			match self {
+				Self::F64(a) => !a.iter().any(|a| !a.is_zero()),
+				Self::F32(a) => !a.iter().any(|a| !a.is_zero()),
+				Self::I64(a) => !a.iter().any(|a| !a.is_zero()),
+				Self::I32(a) => !a.iter().any(|a| !a.is_zero()),
+				Self::I16(a) => !a.iter().any(|a| !a.is_zero()),
+			}
+		}
+	}
+
+	impl TestCollection {
+		pub(in crate::idx::trees) fn new(
+			unique: bool,
+			collection_size: usize,
+			vt: VectorType,
+			dimension: usize,
+			distance: &Distance,
+		) -> Self {
+			let mut rng = get_seed_rnd();
+			let gen = RandomItemGenerator::new(&distance, dimension);
+			if unique {
+				TestCollection::new_unique(collection_size, vt, dimension, &gen, &mut rng)
+			} else {
+				TestCollection::new_random(collection_size, vt, dimension, &gen, &mut rng)
+			}
+		}
+
+		fn add(&mut self, doc: DocId, pt: HashedSharedVector) {
+			match self {
+				TestCollection::Unique(vec) => vec,
+				TestCollection::NonUnique(vec) => vec,
+			}
+			.push((doc, pt));
+		}
+
+		fn new_unique(
+			collection_size: usize,
+			vector_type: VectorType,
+			dimension: usize,
+			gen: &RandomItemGenerator,
+			rng: &mut SmallRng,
+		) -> Self {
+			let mut vector_set = BTreeSet::new();
+			let mut attempts = collection_size * 2;
+			while vector_set.len() < collection_size {
+				vector_set.insert(new_random_vec(rng, vector_type, dimension, gen));
+				attempts -= 1;
+				if attempts == 0 {
+					panic!("Fail generating a unique random collection {vector_type} {dimension}");
+				}
+			}
+			let mut coll = TestCollection::Unique(Vec::with_capacity(vector_set.len()));
+			for (i, v) in vector_set.into_iter().enumerate() {
+				coll.add(i as DocId, v.into());
+			}
+			coll
+		}
+
+		fn new_random(
+			collection_size: usize,
+			vector_type: VectorType,
+			dimension: usize,
+			gen: &RandomItemGenerator,
+			rng: &mut SmallRng,
+		) -> Self {
+			let mut coll = TestCollection::NonUnique(Vec::with_capacity(collection_size));
+			// Prepare data set
+			for doc_id in 0..collection_size {
+				coll.add(doc_id as DocId, new_random_vec(rng, vector_type, dimension, gen).into());
+			}
+			coll
+		}
+
+		pub(in crate::idx::trees) fn is_unique(&self) -> bool {
+			matches!(self, TestCollection::Unique(_))
+		}
+	}
+
+	pub(in crate::idx::trees) enum RandomItemGenerator {
+		Int(i64, i64),
+		Float(f64, f64),
+	}
+
+	impl RandomItemGenerator {
+		pub(in crate::idx::trees) fn new(dist: &Distance, dim: usize) -> Self {
+			match dist {
+				Distance::Jaccard => Self::Int(0, (dim / 2) as i64),
+				Distance::Hamming => Self::Int(0, 2),
+				_ => Self::Float(-20.0, 20.0),
+			}
+		}
+		fn generate(&self, rng: &mut SmallRng) -> Number {
+			match self {
+				RandomItemGenerator::Int(from, to) => Number::Int(rng.gen_range(*from..*to)),
+				RandomItemGenerator::Float(from, to) => Number::Float(rng.gen_range(*from..=*to)),
+			}
+		}
+	}
+
+	#[test]
+	fn knn_result_builder_test() {
+		let mut b = KnnResultBuilder::new(7);
+		b.add(0.0, &Ids64::One(5));
+		b.add(0.2, &Ids64::Vec3([0, 1, 2]));
+		b.add(0.2, &Ids64::One(3));
+		b.add(0.2, &Ids64::Vec2([6, 8]));
+		let res = b.build(
+			#[cfg(debug_assertions)]
+			HashMap::new(),
+		);
+		assert_eq!(
+			res.docs,
+			VecDeque::from([(5, 0.0), (0, 0.2), (1, 0.2), (2, 0.2), (3, 0.2), (6, 0.2), (8, 0.2)])
+		);
+	}
+
+	#[test]
+	fn test_ids() {
+		let mut ids = Ids64::Empty;
+		let mut ids = ids.insert(10).expect("Ids64::One");
+		assert_eq!(ids, Ids64::One(10));
+		let mut ids = ids.insert(20).expect("Ids64::Vec2");
+		assert_eq!(ids, Ids64::Vec2([10, 20]));
+		let mut ids = ids.insert(30).expect("Ids64::Vec3");
+		assert_eq!(ids, Ids64::Vec3([10, 20, 30]));
+		let mut ids = ids.insert(40).expect("Ids64::Vec4");
+		assert_eq!(ids, Ids64::Vec4([10, 20, 30, 40]));
+		let mut ids = ids.insert(50).expect("Ids64::Vec5");
+		assert_eq!(ids, Ids64::Vec5([10, 20, 30, 40, 50]));
+		let mut ids = ids.insert(60).expect("Ids64::Vec6");
+		assert_eq!(ids, Ids64::Vec6([10, 20, 30, 40, 50, 60]));
+		let mut ids = ids.insert(70).expect("Ids64::Vec7");
+		assert_eq!(ids, Ids64::Vec7([10, 20, 30, 40, 50, 60, 70]));
+		let mut ids = ids.insert(80).expect("Ids64::Vec8");
+		assert_eq!(ids, Ids64::Vec8([10, 20, 30, 40, 50, 60, 70, 80]));
+		let mut ids = ids.insert(90).expect("Ids64::Bits");
+		assert_eq!(ids, Ids64::Bits(RoaringTreemap::from([10, 20, 30, 40, 50, 60, 70, 80, 90])));
+		assert_eq!(ids.insert(100), None);
+		assert_eq!(
+			ids,
+			Ids64::Bits(RoaringTreemap::from([10, 20, 30, 40, 50, 60, 70, 80, 90, 100]))
+		);
+		assert_eq!(ids.remove(10), None);
+		assert_eq!(ids, Ids64::Bits(RoaringTreemap::from([20, 30, 40, 50, 60, 70, 80, 90, 100])));
+		let mut ids = ids.remove(20).expect("Ids64::Vec8");
+		assert_eq!(ids, Ids64::Vec8([30, 40, 50, 60, 70, 80, 90, 100]));
+		let mut ids = ids.remove(30).expect("Ids64::Vec7");
+		assert_eq!(ids, Ids64::Vec7([40, 50, 60, 70, 80, 90, 100]));
+		let mut ids = ids.remove(40).expect("Ids64::Vec6");
+		assert_eq!(ids, Ids64::Vec6([50, 60, 70, 80, 90, 100]));
+		let mut ids = ids.remove(50).expect("Ids64::Vec5");
+		assert_eq!(ids, Ids64::Vec5([60, 70, 80, 90, 100]));
+		let mut ids = ids.remove(60).expect("Ids64::Vec4");
+		assert_eq!(ids, Ids64::Vec4([70, 80, 90, 100]));
+		let mut ids = ids.remove(70).expect("Ids64::Vec3");
+		assert_eq!(ids, Ids64::Vec3([80, 90, 100]));
+		let mut ids = ids.remove(80).expect("Ids64::Vec2");
+		assert_eq!(ids, Ids64::Vec2([90, 100]));
+		let mut ids = ids.remove(90).expect("Ids64::One");
+		assert_eq!(ids, Ids64::One(100));
+		let ids = ids.remove(100).expect("Ids64::Empty");
+		assert_eq!(ids, Ids64::Empty);
+	}
+
+	#[test]
+	fn test_priority_node() {
+		let (n1, n2, n3) =
+			((FloatKey::new(1.0), 1), (FloatKey::new(2.0), 2), (FloatKey::new(3.0), 3));
+		let mut q = BinaryHeap::from([n3, n1, n2]);
+
+		assert_eq!(q.pop(), Some(n3));
+		assert_eq!(q.pop(), Some(n2));
+		assert_eq!(q.pop(), Some(n1));
+
+		let (n1, n2, n3) = (Reverse(n1), Reverse(n2), Reverse(n3));
+		let mut q = BinaryHeap::from([n3, n1, n2]);
+
+		assert_eq!(q.pop(), Some(n1));
+		assert_eq!(q.pop(), Some(n2));
+		assert_eq!(q.pop(), Some(n3));
+	}
+}

--- a/core/src/idx/trees/knn.rs
+++ b/core/src/idx/trees/knn.rs
@@ -534,20 +534,6 @@ pub(super) mod tests {
 		}
 	}
 
-	pub(in crate::idx::trees) fn new_vec(
-		mut n: i64,
-		t: VectorType,
-		dim: usize,
-	) -> HashedSharedVector {
-		let mut vec = Vector::new(t, dim);
-		vec.add(&Number::Int(n));
-		for _ in 1..dim {
-			n += 1;
-			vec.add(&Number::Int(n));
-		}
-		vec.into()
-	}
-
 	pub(in crate::idx::trees) fn new_random_vec(
 		rng: &mut SmallRng,
 		t: VectorType,

--- a/core/src/idx/trees/knn.rs
+++ b/core/src/idx/trees/knn.rs
@@ -493,7 +493,7 @@ pub struct KnnResult {
 pub(super) mod tests {
 	use crate::idx::docids::DocId;
 	use crate::idx::trees::knn::{FloatKey, Ids64, KnnResultBuilder};
-	use crate::idx::trees::vector::{HashedSharedVector, Vector};
+	use crate::idx::trees::vector::{SharedVector, Vector};
 	use crate::sql::index::{Distance, VectorType};
 	use crate::sql::Number;
 	use rand::prelude::SmallRng;
@@ -518,12 +518,12 @@ pub(super) mod tests {
 
 	#[derive(Debug)]
 	pub(in crate::idx::trees) enum TestCollection {
-		Unique(Vec<(DocId, HashedSharedVector)>),
-		NonUnique(Vec<(DocId, HashedSharedVector)>),
+		Unique(Vec<(DocId, SharedVector)>),
+		NonUnique(Vec<(DocId, SharedVector)>),
 	}
 
 	impl TestCollection {
-		pub(in crate::idx::trees) fn to_vec_ref(&self) -> &Vec<(DocId, HashedSharedVector)> {
+		pub(in crate::idx::trees) fn to_vec_ref(&self) -> &Vec<(DocId, SharedVector)> {
 			match self {
 				TestCollection::Unique(c) | TestCollection::NonUnique(c) => c,
 			}
@@ -539,7 +539,7 @@ pub(super) mod tests {
 		t: VectorType,
 		dim: usize,
 		gen: &RandomItemGenerator,
-	) -> HashedSharedVector {
+	) -> SharedVector {
 		let mut vec = Vector::new(t, dim);
 		for _ in 0..dim {
 			vec.add(&gen.generate(rng));
@@ -581,7 +581,7 @@ pub(super) mod tests {
 			}
 		}
 
-		fn add(&mut self, doc: DocId, pt: HashedSharedVector) {
+		fn add(&mut self, doc: DocId, pt: SharedVector) {
 			match self {
 				TestCollection::Unique(vec) => vec,
 				TestCollection::NonUnique(vec) => vec,

--- a/core/src/idx/trees/mod.rs
+++ b/core/src/idx/trees/mod.rs
@@ -1,5 +1,6 @@
 pub mod bkeys;
 pub mod btree;
+pub mod knn;
 pub mod mtree;
 pub mod store;
 pub mod vector;

--- a/core/src/idx/trees/mtree.rs
+++ b/core/src/idx/trees/mtree.rs
@@ -1472,7 +1472,7 @@ mod tests {
 		commit: bool,
 	) -> Result<(), Error> {
 		if let Some(new_cache) = st.finish(&mut tx).await? {
-			assert!(new_cache.len().await > 0, "new_cache.len() = {}", new_cache.len().await);
+			assert!(new_cache.len() > 0, "new_cache.len() = {}", new_cache.len());
 			t.state.generation += 1;
 			ds.index_store().advance_store_mtree(new_cache);
 		}
@@ -1761,7 +1761,7 @@ mod tests {
 			.await
 	}
 
-	#[test(tokio::test)]
+	#[test(tokio::test(flavor = "multi_thread"))]
 	async fn test_mtree_unique_small() -> Result<(), Error> {
 		let mut stack = reblessive::tree::TreeStack::new();
 		stack
@@ -1785,7 +1785,7 @@ mod tests {
 			.await
 	}
 
-	#[test(tokio::test)]
+	#[test(tokio::test(flavor = "multi_thread"))]
 	async fn test_mtree_unique_normal() -> Result<(), Error> {
 		let mut stack = reblessive::tree::TreeStack::new();
 		stack
@@ -1809,7 +1809,7 @@ mod tests {
 			.await
 	}
 
-	#[test(tokio::test)]
+	#[test(tokio::test(flavor = "multi_thread"))]
 	async fn test_mtree_unique_normal_full_cache() -> Result<(), Error> {
 		let mut stack = reblessive::tree::TreeStack::new();
 		stack
@@ -1833,7 +1833,7 @@ mod tests {
 			.await
 	}
 
-	#[test(tokio::test)]
+	#[test(tokio::test(flavor = "multi_thread"))]
 	async fn test_mtree_unique_normal_small_cache() -> Result<(), Error> {
 		let mut stack = reblessive::tree::TreeStack::new();
 		stack
@@ -1891,7 +1891,7 @@ mod tests {
 			.await
 	}
 
-	#[test(tokio::test)]
+	#[test(tokio::test(flavor = "multi_thread"))]
 	async fn test_mtree_random_small() -> Result<(), Error> {
 		let mut stack = reblessive::tree::TreeStack::new();
 		stack
@@ -1915,7 +1915,7 @@ mod tests {
 			.await
 	}
 
-	#[test(tokio::test)]
+	#[test(tokio::test(flavor = "multi_thread"))]
 	async fn test_mtree_random_normal() -> Result<(), Error> {
 		let mut stack = reblessive::tree::TreeStack::new();
 		stack

--- a/core/src/idx/trees/mtree.rs
+++ b/core/src/idx/trees/mtree.rs
@@ -1,26 +1,24 @@
-use std::cmp::{Ordering, Reverse};
-use std::collections::btree_map::Entry;
-#[cfg(debug_assertions)]
-use std::collections::HashMap;
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, VecDeque};
-use std::fmt::{Debug, Display, Formatter};
-use std::io::Cursor;
-use std::sync::Arc;
-
 use reblessive::tree::Stk;
 use revision::revisioned;
 use roaring::RoaringTreemap;
 use serde::{Deserialize, Serialize};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::collections::{BinaryHeap, HashSet, VecDeque};
+use std::fmt::{Debug, Display, Formatter};
+use std::io::Cursor;
+use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::err::Error;
 
 use crate::idx::docids::{DocId, DocIds};
 use crate::idx::trees::btree::BStatistics;
+use crate::idx::trees::knn::{Ids64, KnnResult, KnnResultBuilder, PriorityNode};
 use crate::idx::trees::store::{
 	IndexStores, NodeId, StoredNode, TreeNode, TreeNodeProvider, TreeStore,
 };
-use crate::idx::trees::vector::{SharedVector, Vector};
+use crate::idx::trees::vector::{HashedSharedVector, Vector};
 use crate::idx::{IndexKeyBase, VersionedSerdeState};
 use crate::kvs::{Key, Transaction, TransactionType, Val};
 use crate::sql::index::{Distance, MTreeParams, VectorType};
@@ -77,7 +75,7 @@ impl MTreeIndex {
 		stk: &mut Stk,
 		tx: &mut Transaction,
 		rid: &Thing,
-		content: Vec<Value>,
+		content: &Vec<Value>,
 	) -> Result<(), Error> {
 		// Resolve the doc_id
 		let resolved = self.doc_ids.write().await.resolve_doc_id(tx, rid.into()).await?;
@@ -86,8 +84,10 @@ impl MTreeIndex {
 		let mut mtree = self.mtree.write().await;
 		for v in content {
 			// Extract the vector
-			let vector = self.extract_vector(v)?.into();
-			mtree.insert(stk, tx, &mut self.store, vector, doc_id).await?;
+			let vector = Vector::try_from_value(self.vector_type, self.dim, v)?;
+			vector.check_dimension(self.dim)?;
+			// Insert the vector in the index
+			mtree.insert(stk, tx, &mut self.store, vector.into(), doc_id).await?;
 		}
 		Ok(())
 	}
@@ -95,63 +95,18 @@ impl MTreeIndex {
 	pub(crate) async fn knn_search(
 		&self,
 		tx: &mut Transaction,
-		a: Array,
+		a: &Array,
 		k: usize,
-	) -> Result<VecDeque<DocId>, Error> {
+	) -> Result<VecDeque<(DocId, f64)>, Error> {
 		// Extract the vector
-		let vector = self.check_vector_array(a)?;
-		// Lock the store
-		let res = self.mtree.read().await.knn_search(tx, &self.store, &vector, k).await?;
+		let vector = Vector::try_from_array(self.vector_type, a)?;
+		vector.check_dimension(self.dim)?;
+		let vector: HashedSharedVector = vector.into();
+		// Lock the index
+		let mtree = self.mtree.read().await;
+		// Do the search
+		let res = mtree.knn_search(tx, &self.store, &vector, k).await?;
 		Ok(res.docs)
-	}
-
-	fn check_vector_array(&self, a: Array) -> Result<SharedVector, Error> {
-		if a.0.len() != self.dim {
-			return Err(Error::InvalidVectorDimension {
-				current: a.0.len(),
-				expected: self.dim,
-			});
-		}
-		let mut vec = Vector::new(self.vector_type, a.len());
-		for v in a.0 {
-			if let Value::Number(n) = v {
-				vec.add(n);
-			} else {
-				return Err(Error::InvalidVectorType {
-					current: v.clone().to_string(),
-					expected: "Number",
-				});
-			}
-		}
-		Ok(vec.into())
-	}
-
-	fn extract_vector(&self, v: Value) -> Result<Vector, Error> {
-		let mut vec = Vector::new(self.vector_type, self.dim);
-		Self::check_vector_value(v, &mut vec)?;
-		if vec.len() != self.dim {
-			return Err(Error::InvalidVectorDimension {
-				current: vec.len(),
-				expected: self.dim,
-			});
-		}
-		Ok(vec)
-	}
-
-	fn check_vector_value(value: Value, vec: &mut Vector) -> Result<(), Error> {
-		match value {
-			Value::Array(a) => {
-				for v in a {
-					Self::check_vector_value(v, vec)?;
-				}
-				Ok(())
-			}
-			Value::Number(n) => {
-				vec.add(n);
-				Ok(())
-			}
-			_ => Err(Error::InvalidVectorValue(value.clone().to_raw_string())),
-		}
 	}
 
 	pub(crate) async fn remove_document(
@@ -159,14 +114,17 @@ impl MTreeIndex {
 		stk: &mut Stk,
 		tx: &mut Transaction,
 		rid: &Thing,
-		content: Vec<Value>,
+		content: &Vec<Value>,
 	) -> Result<(), Error> {
 		if let Some(doc_id) = self.doc_ids.write().await.remove_doc(tx, rid.into()).await? {
+			// Lock the index
 			let mut mtree = self.mtree.write().await;
 			for v in content {
 				// Extract the vector
-				let vector = self.extract_vector(v)?.into();
-				mtree.delete(stk, tx, &mut self.store, vector, doc_id).await?;
+				let vector = Vector::try_from_value(self.vector_type, self.dim, v)?;
+				vector.check_dimension(self.dim)?;
+				// Remove the vector
+				mtree.delete(stk, tx, &mut self.store, vector.into(), doc_id).await?;
 			}
 		}
 		Ok(())
@@ -194,104 +152,6 @@ impl MTreeIndex {
 	}
 }
 
-struct KnnResultBuilder {
-	knn: u64,
-	docs: RoaringTreemap,
-	priority_list: BTreeMap<PriorityResult, RoaringTreemap>,
-}
-
-impl KnnResultBuilder {
-	fn new(knn: usize) -> Self {
-		Self {
-			knn: knn as u64,
-			docs: RoaringTreemap::default(),
-			priority_list: BTreeMap::default(),
-		}
-	}
-	fn check_add(&self, dist: f64) -> bool {
-		if self.docs.len() < self.knn {
-			true
-		} else if let Some(pr) = self.priority_list.keys().last() {
-			dist <= pr.0
-		} else {
-			true
-		}
-	}
-
-	fn add(&mut self, dist: f64, docs: &RoaringTreemap) {
-		let pr = PriorityResult(dist);
-		match self.priority_list.entry(pr) {
-			Entry::Vacant(e) => {
-				for doc in docs {
-					self.docs.insert(doc);
-				}
-				e.insert(docs.clone());
-			}
-			Entry::Occupied(mut e) => {
-				let d = e.get_mut();
-				for doc in docs {
-					d.insert(doc);
-					self.docs.insert(doc);
-				}
-			}
-		}
-
-		#[cfg(debug_assertions)]
-		debug!("KnnResult add - dist: {} - docs: {:?} - total: {}", dist, docs, self.docs.len());
-		debug!("{:?}", self.priority_list);
-
-		// Do possible eviction
-		let docs_len = self.docs.len();
-		if docs_len > self.knn {
-			if let Some((_, d)) = self.priority_list.last_key_value() {
-				if docs_len - d.len() >= self.knn {
-					if let Some((_, evicted_docs)) = self.priority_list.pop_last() {
-						self.docs -= evicted_docs;
-					}
-				}
-			}
-		}
-	}
-
-	fn build(self, #[cfg(debug_assertions)] visited_nodes: HashMap<NodeId, usize>) -> KnnResult {
-		let mut sorted_docs = VecDeque::with_capacity(self.knn as usize);
-		#[cfg(debug_assertions)]
-		debug!("self.priority_list: {:?} - self.docs: {:?}", self.priority_list, self.docs);
-		let mut left = self.knn;
-		for (_, docs) in self.priority_list {
-			let dl = docs.len();
-			if dl > left {
-				for doc_id in docs.iter().take(left as usize) {
-					sorted_docs.push_back(doc_id);
-				}
-				break;
-			}
-			for doc_id in docs {
-				sorted_docs.push_back(doc_id);
-			}
-			left -= dl;
-			// We don't expect anymore result, we can leave
-			if left == 0 {
-				break;
-			}
-		}
-		debug!("sorted_docs: {:?}", sorted_docs);
-		KnnResult {
-			docs: sorted_docs,
-			#[cfg(debug_assertions)]
-			visited_nodes,
-		}
-	}
-}
-
-#[non_exhaustive]
-pub struct KnnResult {
-	docs: VecDeque<DocId>,
-	#[cfg(debug_assertions)]
-	#[allow(dead_code)]
-	visited_nodes: HashMap<NodeId, usize>,
-}
-
 // https://en.wikipedia.org/wiki/M-tree
 // https://arxiv.org/pdf/1004.4216.pdf
 #[non_exhaustive]
@@ -315,7 +175,7 @@ impl MTree {
 		&self,
 		tx: &mut Transaction,
 		store: &MTreeStore,
-		v: &SharedVector,
+		v: &HashedSharedVector,
 		k: usize,
 	) -> Result<KnnResult, Error> {
 		#[cfg(debug_assertions)]
@@ -323,16 +183,17 @@ impl MTree {
 		let mut queue = BinaryHeap::new();
 		let mut res = KnnResultBuilder::new(k);
 		if let Some(root_id) = self.state.root {
-			queue.push(Reverse(PriorityNode(0.0, root_id)));
+			queue.push(PriorityNode::new(0.0, root_id));
 		}
 		#[cfg(debug_assertions)]
 		let mut visited_nodes = HashMap::new();
-		while let Some(current) = queue.pop() {
-			let node = store.get_node(tx, current.0 .1).await?;
+		while let Some(e) = queue.pop() {
+			let id = e.id();
+			let node = store.get_node(tx, id).await?;
 			#[cfg(debug_assertions)]
 			{
-				debug!("Visit node id: {} - dist: {}", current.0 .1, current.0 .1);
-				if visited_nodes.insert(current.0 .1, node.n.len()).is_some() {
+				debug!("Visit node id: {}", id);
+				if visited_nodes.insert(id, node.n.len()).is_some() {
 					return Err(Error::Unreachable("MTree::knn_search"));
 				}
 			}
@@ -345,7 +206,7 @@ impl MTree {
 						if res.check_add(d) {
 							#[cfg(debug_assertions)]
 							debug!("Add: {d} - obj: {o:?} - docs: {:?}", p.docs);
-							res.add(d, &p.docs);
+							res.add(d, &Ids64::Bits(p.docs.clone()));
 						}
 					}
 				}
@@ -357,7 +218,7 @@ impl MTree {
 						let min_dist = (d - p.radius).max(0.0);
 						if res.check_add(min_dist) {
 							debug!("Queue add - dist: {} - node: {}", min_dist, p.node);
-							queue.push(Reverse(PriorityNode(min_dist, p.node)));
+							queue.push(PriorityNode::new(min_dist, p.node));
 						}
 					}
 				}
@@ -373,7 +234,7 @@ impl MTree {
 enum InsertionResult {
 	DocAdded,
 	CoveringRadius(f64),
-	PromotedEntries(SharedVector, RoutingProperties, SharedVector, RoutingProperties),
+	PromotedEntries(HashedSharedVector, RoutingProperties, HashedSharedVector, RoutingProperties),
 }
 
 enum DeletionResult {
@@ -396,7 +257,7 @@ impl MTree {
 		stk: &mut Stk,
 		tx: &mut Transaction,
 		store: &mut MTreeStore,
-		obj: SharedVector,
+		obj: HashedSharedVector,
 		id: DocId,
 	) -> Result<(), Error> {
 		#[cfg(debug_assertions)]
@@ -422,7 +283,7 @@ impl MTree {
 	async fn create_new_leaf_root(
 		&mut self,
 		store: &mut MTreeStore,
-		obj: SharedVector,
+		obj: HashedSharedVector,
 		id: DocId,
 	) -> Result<(), Error> {
 		let new_root_id = self.new_node_id();
@@ -438,9 +299,9 @@ impl MTree {
 	async fn create_new_internal_root(
 		&mut self,
 		store: &mut MTreeStore,
-		o1: SharedVector,
+		o1: HashedSharedVector,
 		p1: RoutingProperties,
-		o2: SharedVector,
+		o2: HashedSharedVector,
 		p2: RoutingProperties,
 	) -> Result<(), Error> {
 		let new_root_id = self.new_node_id();
@@ -468,7 +329,7 @@ impl MTree {
 		&mut self,
 		tx: &mut Transaction,
 		store: &mut MTreeStore,
-		object: &SharedVector,
+		object: &HashedSharedVector,
 		id: DocId,
 	) -> Result<bool, Error> {
 		let mut queue = BinaryHeap::new();
@@ -507,8 +368,8 @@ impl MTree {
 		tx: &mut Transaction,
 		store: &mut MTreeStore,
 		node: MStoredNode,
-		parent_center: &Option<SharedVector>,
-		object: SharedVector,
+		parent_center: &Option<HashedSharedVector>,
+		object: HashedSharedVector,
 		doc: DocId,
 	) -> Result<InsertionResult, Error> {
 		#[cfg(debug_assertions)]
@@ -545,8 +406,8 @@ impl MTree {
 		node_id: NodeId,
 		node_key: Key,
 		mut node: InternalNode,
-		parent_center: &Option<SharedVector>,
-		object: SharedVector,
+		parent_center: &Option<HashedSharedVector>,
+		object: HashedSharedVector,
 		doc_id: DocId,
 	) -> Result<InsertionResult, Error> {
 		// Choose `best` subtree entry ObestSubstree from N;
@@ -572,7 +433,7 @@ impl MTree {
 				// Remove ObestSubtree from N;
 				node.remove(&best_entry_obj);
 				// if (N U P will fit into N)
-				let mut nup: BTreeSet<SharedVector> = BTreeSet::from_iter(node.keys().cloned());
+				let mut nup: HashSet<HashedSharedVector> = HashSet::from_iter(node.keys().cloned());
 				nup.insert(o1.clone());
 				nup.insert(o2.clone());
 				if nup.len() <= self.state.capacity as usize {
@@ -633,8 +494,8 @@ impl MTree {
 	fn find_closest(
 		&self,
 		node: &InternalNode,
-		object: &SharedVector,
-	) -> Result<(SharedVector, RoutingProperties), Error> {
+		object: &HashedSharedVector,
+	) -> Result<(HashedSharedVector, RoutingProperties), Error> {
 		let mut closest = None;
 		let mut dist = f64::MAX;
 		for (o, p) in node {
@@ -660,8 +521,8 @@ impl MTree {
 		node_id: NodeId,
 		node_key: Key,
 		mut node: LeafNode,
-		parent_center: &Option<SharedVector>,
-		object: SharedVector,
+		parent_center: &Option<HashedSharedVector>,
+		object: HashedSharedVector,
 		doc_id: DocId,
 	) -> Result<InsertionResult, Error> {
 		match node.entry(object) {
@@ -712,7 +573,7 @@ impl MTree {
 		node_id: NodeId,
 		node_key: Key,
 		mut node: N,
-	) -> Result<(SharedVector, RoutingProperties, SharedVector, RoutingProperties), Error>
+	) -> Result<(HashedSharedVector, RoutingProperties, HashedSharedVector, RoutingProperties), Error>
 	where
 		N: NodeVectors + Debug,
 	{
@@ -728,7 +589,7 @@ impl MTree {
 			d1.total_cmp(&d2)
 		});
 		let a1_size = a2.len() / 2;
-		let a1: Vec<SharedVector> = a2.drain(0..a1_size).collect();
+		let a1: Vec<HashedSharedVector> = a2.drain(0..a1_size).collect();
 
 		let (node1, r1, o1) = node.extract_node(&distances, p1, a1)?;
 		let (node2, r2, o2) = node.extract_node(&distances, p2, a2)?;
@@ -764,12 +625,12 @@ impl MTree {
 	// Compute the distance cache, and return the most distant objects
 	fn compute_distances_and_promoted_objects(
 		&self,
-		objects: &[SharedVector],
-	) -> Result<(DistanceCache, SharedVector, SharedVector), Error> {
+		objects: &[HashedSharedVector],
+	) -> Result<(DistanceCache, HashedSharedVector, HashedSharedVector), Error> {
 		let mut promo = None;
 		let mut max_dist = 0f64;
 		let n = objects.len();
-		let mut dist_cache = BTreeMap::new();
+		let mut dist_cache = HashMap::new();
 		for (i, o1) in objects.iter().enumerate() {
 			for o2 in objects.iter().take(n).skip(i + 1) {
 				let distance = self.calculate_distance(o1, o2)?;
@@ -815,7 +676,7 @@ impl MTree {
 	fn compute_leaf_max_distance(
 		&self,
 		node: &LeafNode,
-		parent: &Option<SharedVector>,
+		parent: &Option<HashedSharedVector>,
 	) -> Result<f64, Error> {
 		Ok(if let Some(p) = parent {
 			let mut max_dist = 0f64;
@@ -828,17 +689,15 @@ impl MTree {
 		})
 	}
 
-	fn calculate_distance(&self, v1: &SharedVector, v2: &SharedVector) -> Result<f64, Error> {
+	fn calculate_distance(
+		&self,
+		v1: &HashedSharedVector,
+		v2: &HashedSharedVector,
+	) -> Result<f64, Error> {
 		if v1.eq(v2) {
 			return Ok(0.0);
 		}
-		let dist = match &self.distance {
-			Distance::Euclidean => v1.euclidean_distance(v2)?,
-			Distance::Cosine => v1.cosine_distance(v2),
-			Distance::Manhattan => v1.manhattan_distance(v2)?,
-			Distance::Minkowski(order) => v1.minkowski_distance(v2, order)?,
-			_ => return Err(Error::UnsupportedDistance(self.distance.clone())),
-		};
+		let dist = self.distance.calculate(v1, v2);
 		if dist.is_finite() {
 			Ok(dist)
 		} else {
@@ -855,7 +714,7 @@ impl MTree {
 		stk: &mut Stk,
 		tx: &mut Transaction,
 		store: &mut MTreeStore,
-		object: SharedVector,
+		object: HashedSharedVector,
 		doc_id: DocId,
 	) -> Result<bool, Error> {
 		let mut deleted = false;
@@ -902,8 +761,8 @@ impl MTree {
 		tx: &mut Transaction,
 		store: &mut MTreeStore,
 		node: MStoredNode,
-		parent_center: &Option<SharedVector>,
-		object: SharedVector,
+		parent_center: &Option<HashedSharedVector>,
+		object: HashedSharedVector,
 		id: DocId,
 		deleted: &mut bool,
 	) -> Result<DeletionResult, Error> {
@@ -953,8 +812,8 @@ impl MTree {
 		node_id: NodeId,
 		node_key: Key,
 		mut n_node: InternalNode,
-		parent_center: &Option<SharedVector>,
-		od: SharedVector,
+		parent_center: &Option<HashedSharedVector>,
+		od: HashedSharedVector,
 		id: DocId,
 		deleted: &mut bool,
 	) -> Result<DeletionResult, Error> {
@@ -1081,9 +940,9 @@ impl MTree {
 		&mut self,
 		tx: &mut Transaction,
 		store: &mut MTreeStore,
-		parent_center: &Option<SharedVector>,
+		parent_center: &Option<HashedSharedVector>,
 		n_node: &mut InternalNode,
-		on_obj: SharedVector,
+		on_obj: HashedSharedVector,
 		p: MStoredNode,
 		p_updated: bool,
 	) -> Result<bool, Error> {
@@ -1136,9 +995,9 @@ impl MTree {
 		&mut self,
 		store: &mut MTreeStore,
 		n_node: &mut InternalNode,
-		on_obj: SharedVector,
+		on_obj: HashedSharedVector,
 		p: MStoredNode,
-		onn_obj: SharedVector,
+		onn_obj: HashedSharedVector,
 		mut onn_entry: RoutingProperties,
 		mut onn_child: MStoredNode,
 	) -> Result<(), Error> {
@@ -1200,10 +1059,10 @@ impl MTree {
 	async fn delete_underflown_redistribute(
 		&mut self,
 		store: &mut MTreeStore,
-		parent_center: &Option<SharedVector>,
+		parent_center: &Option<HashedSharedVector>,
 		n_node: &mut InternalNode,
-		on_obj: SharedVector,
-		onn_obj: SharedVector,
+		on_obj: HashedSharedVector,
+		onn_obj: HashedSharedVector,
 		mut p: MStoredNode,
 		onn_child: MStoredNode,
 	) -> Result<(), Error> {
@@ -1240,8 +1099,8 @@ impl MTree {
 		node_id: NodeId,
 		node_key: Key,
 		mut leaf_node: LeafNode,
-		parent_center: &Option<SharedVector>,
-		od: SharedVector,
+		parent_center: &Option<HashedSharedVector>,
+		od: HashedSharedVector,
 		id: DocId,
 		deleted: &mut bool,
 	) -> Result<DeletionResult, Error> {
@@ -1287,78 +1146,14 @@ impl MTree {
 	}
 }
 
-struct DistanceCache(BTreeMap<(SharedVector, SharedVector), f64>);
-
-struct PriorityNode(f64, NodeId);
-
-impl PartialEq<Self> for PriorityNode {
-	fn eq(&self, other: &Self) -> bool {
-		self.0 == other.0 && self.1 == other.1
-	}
-}
-
-impl Eq for PriorityNode {}
-
-impl PartialOrd<Self> for PriorityNode {
-	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		Some(self.cmp(other))
-	}
-}
-
-impl Ord for PriorityNode {
-	fn cmp(&self, other: &Self) -> Ordering {
-		let cmp = cmp_f64(&self.0, &other.0);
-		if cmp != Ordering::Equal {
-			return cmp;
-		}
-		self.1.cmp(&other.1)
-	}
-}
-
-#[derive(Debug)]
-struct PriorityResult(f64);
-
-impl Eq for PriorityResult {}
-
-impl PartialEq<Self> for PriorityResult {
-	fn eq(&self, other: &Self) -> bool {
-		self.0 == other.0
-	}
-}
-
-impl PartialOrd<Self> for PriorityResult {
-	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		Some(self.cmp(other))
-	}
-}
-
-impl Ord for PriorityResult {
-	fn cmp(&self, other: &Self) -> Ordering {
-		cmp_f64(&self.0, &other.0)
-	}
-}
-
-fn cmp_f64(f1: &f64, f2: &f64) -> Ordering {
-	if let Some(cmp) = f1.partial_cmp(f2) {
-		return cmp;
-	}
-	if f1.is_nan() {
-		if f2.is_nan() {
-			Ordering::Equal
-		} else {
-			Ordering::Less
-		}
-	} else {
-		Ordering::Greater
-	}
-}
+struct DistanceCache(HashMap<(HashedSharedVector, HashedSharedVector), f64>);
 
 pub(in crate::idx) type MTreeStore = TreeStore<MTreeNode>;
 type MStoredNode = StoredNode<MTreeNode>;
 
-type InternalMap = BTreeMap<SharedVector, RoutingProperties>;
+type InternalMap = HashMap<HashedSharedVector, RoutingProperties>;
 
-type LeafMap = BTreeMap<SharedVector, ObjectProperties>;
+type LeafMap = HashMap<HashedSharedVector, ObjectProperties>;
 
 #[derive(Debug, Clone)]
 /// A node in this tree structure holds entries.
@@ -1445,14 +1240,14 @@ trait NodeVectors: Sized {
 	#[allow(dead_code)]
 	fn len(&self) -> usize;
 
-	fn get_objects(&self) -> Vec<SharedVector>;
+	fn get_objects(&self) -> Vec<HashedSharedVector>;
 
 	fn extract_node(
 		&mut self,
 		distances: &DistanceCache,
-		p: SharedVector,
-		a: Vec<SharedVector>,
-	) -> Result<(Self, f64, SharedVector), Error>;
+		p: HashedSharedVector,
+		a: Vec<HashedSharedVector>,
+	) -> Result<(Self, f64, HashedSharedVector), Error>;
 
 	fn into_mtree_node(self) -> MTreeNode;
 }
@@ -1462,16 +1257,16 @@ impl NodeVectors for LeafNode {
 		self.len()
 	}
 
-	fn get_objects(&self) -> Vec<SharedVector> {
+	fn get_objects(&self) -> Vec<HashedSharedVector> {
 		self.keys().cloned().collect()
 	}
 
 	fn extract_node(
 		&mut self,
 		distances: &DistanceCache,
-		p: SharedVector,
-		a: Vec<SharedVector>,
-	) -> Result<(Self, f64, SharedVector), Error> {
+		p: HashedSharedVector,
+		a: Vec<HashedSharedVector>,
+	) -> Result<(Self, f64, HashedSharedVector), Error> {
 		let mut n = LeafNode::new();
 		let mut r = 0f64;
 		for o in a {
@@ -1497,16 +1292,16 @@ impl NodeVectors for InternalNode {
 		self.len()
 	}
 
-	fn get_objects(&self) -> Vec<SharedVector> {
+	fn get_objects(&self) -> Vec<HashedSharedVector> {
 		self.keys().cloned().collect()
 	}
 
 	fn extract_node(
 		&mut self,
 		distances: &DistanceCache,
-		p: SharedVector,
-		a: Vec<SharedVector>,
-	) -> Result<(Self, f64, SharedVector), Error> {
+		p: HashedSharedVector,
+		a: Vec<HashedSharedVector>,
+	) -> Result<(Self, f64, HashedSharedVector), Error> {
 		let mut n = InternalNode::new();
 		let mut max_r = 0f64;
 		for o in a {
@@ -1538,13 +1333,11 @@ impl TreeNode for MTreeNode {
 		let node_type: u8 = bincode::deserialize_from(&mut c)?;
 		match node_type {
 			1u8 => {
-				let objects: BTreeMap<SharedVector, ObjectProperties> =
-					bincode::deserialize_from(c)?;
+				let objects: LeafNode = bincode::deserialize_from(c)?;
 				Ok(MTreeNode::Leaf(objects))
 			}
 			2u8 => {
-				let entries: BTreeMap<SharedVector, RoutingProperties> =
-					bincode::deserialize_from(c)?;
+				let entries: InternalNode = bincode::deserialize_from(c)?;
 				Ok(MTreeNode::Internal(entries))
 			}
 			_ => Err(Error::CorruptedIndex("MTreeNode::try_from_val")),
@@ -1641,25 +1434,23 @@ impl VersionedSerdeState for MState {}
 
 #[cfg(test)]
 mod tests {
-	use rand::prelude::StdRng;
-	use rand::{Rng, SeedableRng};
 	use reblessive::tree::Stk;
-	use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+	use std::collections::{HashMap, HashSet, VecDeque};
 
 	use crate::err::Error;
 	use test_log::test;
 
 	use crate::idx::docids::DocId;
+	use crate::idx::trees::knn::tests::{new_vec, TestCollection};
 	use crate::idx::trees::mtree::{
-		InternalMap, MState, MTree, MTreeNode, MTreeStore, ObjectProperties,
+		InternalMap, LeafMap, LeafNode, MState, MTree, MTreeNode, MTreeStore, ObjectProperties,
 	};
 	use crate::idx::trees::store::{NodeId, TreeNodeProvider, TreeStore};
-	use crate::idx::trees::vector::{SharedVector, Vector};
+	use crate::idx::trees::vector::HashedSharedVector;
 	use crate::kvs::LockType::*;
 	use crate::kvs::Transaction;
 	use crate::kvs::{Datastore, TransactionType};
 	use crate::sql::index::{Distance, VectorType};
-	use crate::sql::Number;
 
 	async fn new_operation(
 		ds: &Datastore,
@@ -1683,7 +1474,7 @@ mod tests {
 		commit: bool,
 	) -> Result<(), Error> {
 		if let Some(new_cache) = st.finish(&mut tx).await? {
-			assert!(new_cache.len() > 0, "new_cache.len() = {}", new_cache.len());
+			assert!(new_cache.len().await > 0, "new_cache.len() = {}", new_cache.len().await);
 			t.state.generation += 1;
 			ds.index_store().advance_store_mtree(new_cache);
 		}
@@ -1695,394 +1486,16 @@ mod tests {
 		}
 	}
 
-	fn new_vec(mut n: i64, t: VectorType, dim: usize) -> SharedVector {
-		let mut vec = Vector::new(t, dim);
-		vec.add(Number::Int(n));
-		for _ in 1..dim {
-			n += 1;
-			vec.add(Number::Int(n));
-		}
-		vec.into()
-	}
-
-	fn new_random_vec(rng: &mut StdRng, t: VectorType, dim: usize) -> SharedVector {
-		let mut vec = Vector::new(t, dim);
-		for _ in 0..dim {
-			vec.add(Number::Float(rng.gen_range(-5.0..5.0)));
-		}
-		vec.into()
-	}
-
-	#[test(tokio::test)]
-	async fn test_mtree_insertions() -> Result<(), Error> {
-		const CACHE_SIZE: usize = 20;
-
-		let mut stack = reblessive::tree::TreeStack::new();
-
-		let mut t = MTree::new(MState::new(3), Distance::Euclidean);
-		let ds = Datastore::new("memory").await?;
-
-		let vec1 = new_vec(1, VectorType::F64, 1);
-		// First the index is empty
-		{
-			let (st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec1, 10).await?;
-			check_knn(&res.docs, vec![]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 0);
-		}
-		// Insert single element
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Write, CACHE_SIZE).await;
-			stack.enter(|stk| t.insert(stk, &mut tx, &mut st, vec1.clone(), 1)).finish().await?;
-			assert_eq!(t.state.root, Some(0));
-			check_leaf_write(&mut tx, &mut st, 0, |m| {
-				assert_eq!(m.len(), 1);
-				check_leaf_vec(m, &vec1, 0.0, &[1]);
-			})
-			.await;
-			finish_operation(&ds, &mut t, tx, st, true).await?;
-		}
-		// Check KNN
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec1, 10).await?;
-			check_knn(&res.docs, vec![1]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 1);
-			check_tree_properties(&mut tx, &mut st, &t).await?.check(1, 1, Some(1), Some(1), 1, 1);
-		}
-
-		// insert second element
-		let vec2 = new_vec(2, VectorType::F64, 1);
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Write, CACHE_SIZE).await;
-			stack.enter(|stk| t.insert(stk, &mut tx, &mut st, vec2.clone(), 2)).finish().await?;
-			finish_operation(&ds, &mut t, tx, st, true).await?;
-		}
-		// vec1 knn
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec1, 10).await?;
-			check_knn(&res.docs, vec![1, 2]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 1);
-			assert_eq!(t.state.root, Some(0));
-			check_leaf_read(&mut tx, &mut st, 0, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec1, 0.0, &[1]);
-				check_leaf_vec(m, &vec2, 0.0, &[2]);
-			})
-			.await;
-			check_tree_properties(&mut tx, &mut st, &t).await?.check(1, 1, Some(2), Some(2), 2, 2);
-		}
-		// vec2 knn
-		{
-			let (st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec2, 10).await?;
-			check_knn(&res.docs, vec![2, 1]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 1);
-		}
-
-		// insert new doc to existing vector
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Write, CACHE_SIZE).await;
-			stack.enter(|stk| t.insert(stk, &mut tx, &mut st, vec2.clone(), 3)).finish().await?;
-			finish_operation(&ds, &mut t, tx, st, true).await?;
-		}
-		// vec2 knn
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec2, 10).await?;
-			check_knn(&res.docs, vec![2, 3, 1]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 1);
-			assert_eq!(t.state.root, Some(0));
-			check_leaf_read(&mut tx, &mut st, 0, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec1, 0.0, &[1]);
-				check_leaf_vec(m, &vec2, 0.0, &[2, 3]);
-			})
-			.await;
-			check_tree_properties(&mut tx, &mut st, &t).await?.check(1, 1, Some(2), Some(2), 2, 3);
-		}
-
-		// insert third vector
-		let vec3 = new_vec(3, VectorType::F64, 1);
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Write, CACHE_SIZE).await;
-			stack.enter(|stk| t.insert(stk, &mut tx, &mut st, vec3.clone(), 3)).finish().await?;
-			finish_operation(&ds, &mut t, tx, st, true).await?;
-		}
-		// vec3 knn
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec3, 10).await?;
-			check_knn(&res.docs, vec![3, 2, 3, 1]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 1);
-			assert_eq!(t.state.root, Some(0));
-			check_leaf_read(&mut tx, &mut st, 0, |m| {
-				assert_eq!(m.len(), 3);
-				check_leaf_vec(m, &vec1, 0.0, &[1]);
-				check_leaf_vec(m, &vec2, 0.0, &[2, 3]);
-				check_leaf_vec(m, &vec3, 0.0, &[3]);
-			})
-			.await;
-			check_tree_properties(&mut tx, &mut st, &t).await?.check(1, 1, Some(3), Some(3), 3, 4);
-		}
-
-		// Check split leaf node
-		let vec4 = new_vec(4, VectorType::F64, 1);
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Write, CACHE_SIZE).await;
-			stack.enter(|stk| t.insert(stk, &mut tx, &mut st, vec4.clone(), 4)).finish().await?;
-			finish_operation(&ds, &mut t, tx, st, true).await?;
-		}
-		// vec4 knn
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec4, 10).await?;
-			check_knn(&res.docs, vec![4, 3, 2, 3, 1]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 3);
-			assert_eq!(t.state.root, Some(2));
-			check_internal(&mut tx, &mut st, 2, |m| {
-				assert_eq!(m.len(), 2);
-				check_routing_vec(m, &vec1, 0.0, 0, 1.0);
-				check_routing_vec(m, &vec4, 0.0, 1, 1.0);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 0, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec1, 0.0, &[1]);
-				check_leaf_vec(m, &vec2, 1.0, &[2, 3]);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 1, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec3, 1.0, &[3]);
-				check_leaf_vec(m, &vec4, 0.0, &[4]);
-			})
-			.await;
-			check_tree_properties(&mut tx, &mut st, &t).await?.check(3, 2, Some(2), Some(2), 4, 5);
-		}
-
-		// Insert vec extending the radius of the last node, calling compute_leaf_radius
-		let vec6 = new_vec(6, VectorType::F64, 1);
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Write, CACHE_SIZE).await;
-			stack.enter(|stk| t.insert(stk, &mut tx, &mut st, vec6.clone(), 6)).finish().await?;
-			finish_operation(&ds, &mut t, tx, st, true).await?;
-		}
-		// vec6 knn
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec6, 10).await?;
-			check_knn(&res.docs, vec![6, 4, 3, 2, 3, 1]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 3);
-			assert_eq!(t.state.root, Some(2));
-			check_internal(&mut tx, &mut st, 2, |m| {
-				assert_eq!(m.len(), 2);
-				check_routing_vec(m, &vec1, 0.0, 0, 1.0);
-				check_routing_vec(m, &vec4, 0.0, 1, 2.0);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 0, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec1, 0.0, &[1]);
-				check_leaf_vec(m, &vec2, 1.0, &[2, 3]);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 1, |m| {
-				assert_eq!(m.len(), 3);
-				check_leaf_vec(m, &vec3, 1.0, &[3]);
-				check_leaf_vec(m, &vec4, 0.0, &[4]);
-				check_leaf_vec(m, &vec6, 2.0, &[6]);
-			})
-			.await;
-			check_tree_properties(&mut tx, &mut st, &t).await?.check(3, 2, Some(2), Some(3), 5, 6);
-		}
-
-		// Insert check split internal node
-
-		// Insert vec8
-		let vec8 = new_vec(8, VectorType::F64, 1);
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Write, CACHE_SIZE).await;
-			stack.enter(|stk| t.insert(stk, &mut tx, &mut st, vec8.clone(), 8)).finish().await?;
-			finish_operation(&ds, &mut t, tx, st, true).await?;
-		}
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			check_tree_properties(&mut tx, &mut st, &t).await?.check(4, 2, Some(2), Some(2), 6, 7);
-			assert_eq!(t.state.root, Some(2));
-			// Check Root node (level 1)
-			check_internal(&mut tx, &mut st, 2, |m| {
-				assert_eq!(m.len(), 3);
-				check_routing_vec(m, &vec1, 0.0, 0, 1.0);
-				check_routing_vec(m, &vec3, 0.0, 1, 1.0);
-				check_routing_vec(m, &vec8, 0.0, 3, 2.0);
-			})
-			.await;
-			// Check level 2
-			check_leaf_read(&mut tx, &mut st, 0, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec1, 0.0, &[1]);
-				check_leaf_vec(m, &vec2, 1.0, &[2, 3]);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 1, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec3, 0.0, &[3]);
-				check_leaf_vec(m, &vec4, 1.0, &[4]);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 3, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec6, 2.0, &[6]);
-				check_leaf_vec(m, &vec8, 0.0, &[8]);
-			})
-			.await;
-		}
-
-		let vec9 = new_vec(9, VectorType::F64, 1);
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Write, CACHE_SIZE).await;
-			stack.enter(|stk| t.insert(stk, &mut tx, &mut st, vec9.clone(), 9)).finish().await?;
-			finish_operation(&ds, &mut t, tx, st, true).await?;
-		}
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			check_tree_properties(&mut tx, &mut st, &t).await?.check(4, 2, Some(2), Some(3), 7, 8);
-			assert_eq!(t.state.root, Some(2));
-			// Check Root node (level 1)
-			check_internal(&mut tx, &mut st, 2, |m| {
-				assert_eq!(m.len(), 3);
-				check_routing_vec(m, &vec1, 0.0, 0, 1.0);
-				check_routing_vec(m, &vec3, 0.0, 1, 1.0);
-				check_routing_vec(m, &vec8, 0.0, 3, 2.0);
-			})
-			.await;
-			// Check level 2
-			check_leaf_read(&mut tx, &mut st, 0, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec1, 0.0, &[1]);
-				check_leaf_vec(m, &vec2, 1.0, &[2, 3]);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 1, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec3, 0.0, &[3]);
-				check_leaf_vec(m, &vec4, 1.0, &[4]);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 3, |m| {
-				assert_eq!(m.len(), 3);
-				check_leaf_vec(m, &vec6, 2.0, &[6]);
-				check_leaf_vec(m, &vec8, 0.0, &[8]);
-				check_leaf_vec(m, &vec9, 1.0, &[9]);
-			})
-			.await;
-		}
-
-		let vec10 = new_vec(10, VectorType::F64, 1);
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Write, CACHE_SIZE).await;
-			stack.enter(|stk| t.insert(stk, &mut tx, &mut st, vec10.clone(), 10)).finish().await?;
-			finish_operation(&ds, &mut t, tx, st, true).await?;
-		}
-		{
-			let (mut st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			check_tree_properties(&mut tx, &mut st, &t).await?.check(7, 3, Some(2), Some(2), 8, 9);
-			assert_eq!(t.state.root, Some(6));
-			// Check Root node (level 1)
-			check_internal(&mut tx, &mut st, 6, |m| {
-				assert_eq!(m.len(), 2);
-				check_routing_vec(m, &vec1, 0.0, 2, 3.0);
-				check_routing_vec(m, &vec10, 0.0, 5, 6.0);
-			})
-			.await;
-			// Check level 2
-			check_internal(&mut tx, &mut st, 2, |m| {
-				assert_eq!(m.len(), 2);
-				check_routing_vec(m, &vec1, 0.0, 0, 1.0);
-				check_routing_vec(m, &vec3, 2.0, 1, 1.0);
-			})
-			.await;
-			check_internal(&mut tx, &mut st, 5, |m| {
-				assert_eq!(m.len(), 2);
-				check_routing_vec(m, &vec6, 4.0, 3, 2.0);
-				check_routing_vec(m, &vec10, 0.0, 4, 1.0);
-			})
-			.await;
-			// Check level 3
-			check_leaf_read(&mut tx, &mut st, 0, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec1, 0.0, &[1]);
-				check_leaf_vec(m, &vec2, 1.0, &[2, 3]);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 1, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec3, 0.0, &[3]);
-				check_leaf_vec(m, &vec4, 1.0, &[4]);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 3, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec6, 0.0, &[6]);
-				check_leaf_vec(m, &vec8, 2.0, &[8]);
-			})
-			.await;
-			check_leaf_read(&mut tx, &mut st, 4, |m| {
-				assert_eq!(m.len(), 2);
-				check_leaf_vec(m, &vec9, 1.0, &[9]);
-				check_leaf_vec(m, &vec10, 0.0, &[10]);
-			})
-			.await;
-		}
-
-		// vec8 knn
-		{
-			let (st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec8, 20).await?;
-			check_knn(&res.docs, vec![8, 9, 6, 10, 4, 3, 2, 3, 1]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 7);
-		}
-		// vec4 knn(2)
-		{
-			let (st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec4, 2).await?;
-			check_knn(&res.docs, vec![4, 3]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 6);
-		}
-
-		// vec10 knn(2)
-		{
-			let (st, mut tx) = new_operation(&ds, &t, TransactionType::Read, CACHE_SIZE).await;
-			let res = t.knn_search(&mut tx, &st, &vec10, 2).await?;
-			check_knn(&res.docs, vec![10, 9]);
-			#[cfg(debug_assertions)]
-			assert_eq!(res.visited_nodes.len(), 5);
-		}
-		Ok(())
-	}
-
 	async fn insert_collection_one_by_one(
 		stk: &mut Stk,
 		ds: &Datastore,
 		t: &mut MTree,
 		collection: &TestCollection,
 		cache_size: usize,
-	) -> Result<HashMap<DocId, SharedVector>, Error> {
-		let mut map = HashMap::with_capacity(collection.as_ref().len());
+	) -> Result<HashMap<DocId, HashedSharedVector>, Error> {
+		let mut map = HashMap::with_capacity(collection.len());
 		let mut c = 0;
-		for (doc_id, obj) in collection.as_ref() {
+		for (doc_id, obj) in collection.to_vec_ref() {
 			{
 				let (mut st, mut tx) =
 					new_operation(ds, t, TransactionType::Write, cache_size).await;
@@ -2107,11 +1520,11 @@ mod tests {
 		t: &mut MTree,
 		collection: &TestCollection,
 		cache_size: usize,
-	) -> Result<HashMap<DocId, SharedVector>, Error> {
-		let mut map = HashMap::with_capacity(collection.as_ref().len());
+	) -> Result<HashMap<DocId, HashedSharedVector>, Error> {
+		let mut map = HashMap::with_capacity(collection.len());
 		{
 			let (mut st, mut tx) = new_operation(ds, t, TransactionType::Write, cache_size).await;
-			for (doc_id, obj) in collection.as_ref() {
+			for (doc_id, obj) in collection.to_vec_ref() {
 				t.insert(stk, &mut tx, &mut st, obj.clone(), *doc_id).await?;
 				map.insert(*doc_id, obj.clone());
 			}
@@ -2132,7 +1545,7 @@ mod tests {
 		cache_size: usize,
 	) -> Result<(), Error> {
 		let mut all_deleted = true;
-		for (doc_id, obj) in collection.as_ref() {
+		for (doc_id, obj) in collection.to_vec_ref() {
 			let deleted = {
 				debug!("### Remove {} {:?}", doc_id, obj);
 				let (mut st, mut tx) =
@@ -2145,7 +1558,12 @@ mod tests {
 			if deleted {
 				let (st, mut tx) = new_operation(ds, t, TransactionType::Read, cache_size).await;
 				let res = t.knn_search(&mut tx, &st, obj, 1).await?;
-				assert!(!res.docs.contains(doc_id), "Found: {} {:?}", doc_id, obj);
+				assert!(
+					!res.docs.iter().any(|(id, _)| id == doc_id),
+					"Found: {} {:?}",
+					doc_id,
+					obj
+				);
 			} else {
 				// In v1.2.x deletion is experimental. Will be fixed in 1.3
 				warn!("Delete failed: {} {:?}", doc_id, obj);
@@ -2171,13 +1589,14 @@ mod tests {
 		cache_size: usize,
 	) -> Result<(), Error> {
 		let (mut st, mut tx) = new_operation(ds, t, TransactionType::Read, cache_size).await;
-		let max_knn = 20.max(collection.as_ref().len());
-		for (doc_id, obj) in collection.as_ref() {
+		let max_knn = 20.max(collection.len());
+		for (doc_id, obj) in collection.to_vec_ref() {
 			for knn in 1..max_knn {
 				let res = t.knn_search(&mut tx, &st, obj, knn).await?;
+				let docs: Vec<DocId> = res.docs.iter().map(|(d, _)| *d).collect();
 				if collection.is_unique() {
 					assert!(
-						res.docs.contains(doc_id),
+						docs.contains(doc_id),
 						"Search: {:?} - Knn: {} - Wrong Doc - Expected: {} - Got: {:?}",
 						obj,
 						knn,
@@ -2185,8 +1604,9 @@ mod tests {
 						res.docs
 					);
 				}
-				let expected_len = collection.as_ref().len().min(knn);
+				let expected_len = collection.len().min(knn);
 				if expected_len != res.docs.len() {
+					#[cfg(debug_assertions)]
 					debug!("{:?}", res.visited_nodes);
 					check_tree_properties(&mut tx, &mut st, t).await?;
 				}
@@ -2196,7 +1616,7 @@ mod tests {
 					"Wrong knn count - Expected: {} - Got: {} - Collection: {}",
 					expected_len,
 					res.docs.len(),
-					collection.as_ref().len(),
+					collection.len(),
 				)
 			}
 		}
@@ -2206,7 +1626,7 @@ mod tests {
 	async fn check_full_knn(
 		ds: &Datastore,
 		t: &mut MTree,
-		map: &HashMap<DocId, SharedVector>,
+		map: &HashMap<DocId, HashedSharedVector>,
 		cache_size: usize,
 	) -> Result<(), Error> {
 		let (st, mut tx) = new_operation(ds, t, TransactionType::Read, cache_size).await;
@@ -2222,9 +1642,8 @@ mod tests {
 			);
 			// We check that the results are sorted by ascending distance
 			let mut dist = 0.0;
-			for doc in res.docs {
+			for (doc, d) in res.docs {
 				let o = map.get(&doc).unwrap();
-				let d = t.calculate_distance(obj, o)?;
 				debug!("doc: {doc} - d: {d} - {obj:?} - {o:?}");
 				assert!(d >= dist, "d: {d} - dist: {dist}");
 				dist = d;
@@ -2253,13 +1672,13 @@ mod tests {
 					"test_mtree_collection - Distance: {:?} - Capacity: {} - Collection: {} - Vector type: {}",
 					distance,
 					capacity,
-					collection.as_ref().len(),
+					collection.len(),
 					vector_type,
 				);
 				let ds = Datastore::new("memory").await?;
 				let mut t = MTree::new(MState::new(*capacity), distance.clone());
 
-				let map = if collection.as_ref().len() < 1000 {
+				let map = if collection.len() < 1000 {
 					insert_collection_one_by_one(stk, &ds, &mut t, &collection, cache_size).await?
 				} else {
 					insert_collection_batch(stk, &ds, &mut t, &collection, cache_size).await?
@@ -2276,53 +1695,6 @@ mod tests {
 			}
 		}
 		Ok(())
-	}
-
-	enum TestCollection {
-		Unique(Vec<(DocId, SharedVector)>),
-		NonUnique(Vec<(DocId, SharedVector)>),
-	}
-
-	impl AsRef<Vec<(DocId, SharedVector)>> for TestCollection {
-		fn as_ref(&self) -> &Vec<(DocId, SharedVector)> {
-			match self {
-				TestCollection::Unique(c) | TestCollection::NonUnique(c) => c,
-			}
-		}
-	}
-
-	impl TestCollection {
-		fn new_unique(
-			collection_size: usize,
-			vector_type: VectorType,
-			dimension: usize,
-		) -> TestCollection {
-			let mut collection = vec![];
-			for doc_id in 0..collection_size as DocId {
-				collection.push((doc_id, new_vec((doc_id + 1) as i64, vector_type, dimension)));
-			}
-			TestCollection::Unique(collection)
-		}
-
-		fn new_random(
-			collection_size: usize,
-			vector_type: VectorType,
-			dimension: usize,
-		) -> TestCollection {
-			let mut rng = get_seed_rnd();
-			let mut collection = vec![];
-
-			// Prepare data set
-			for doc_id in 0..collection_size {
-				collection
-					.push((doc_id as DocId, new_random_vec(&mut rng, vector_type, dimension)));
-			}
-			TestCollection::NonUnique(collection)
-		}
-
-		fn is_unique(&self) -> bool {
-			matches!(self, TestCollection::Unique(_))
-		}
 	}
 
 	#[test(tokio::test)]
@@ -2343,7 +1715,7 @@ mod tests {
 							stk,
 							&[3, 40],
 							vt,
-							TestCollection::new_unique(i, vt, 2),
+							TestCollection::new(true, i, vt, 2, &Distance::Euclidean),
 							true,
 							true,
 							true,
@@ -2376,7 +1748,7 @@ mod tests {
 							stk,
 							&[3, 40],
 							vt,
-							TestCollection::new_unique(i, vt, 2),
+							TestCollection::new(true, i, vt, 2, &Distance::Euclidean),
 							true,
 							true,
 							true,
@@ -2401,7 +1773,7 @@ mod tests {
 						stk,
 						&[10, 20],
 						vt,
-						TestCollection::new_unique(150, vt, 3),
+						TestCollection::new(true, 150, vt, 3, &Distance::Euclidean),
 						true,
 						true,
 						false,
@@ -2425,7 +1797,7 @@ mod tests {
 						stk,
 						&[40],
 						vt,
-						TestCollection::new_unique(1000, vt, 10),
+						TestCollection::new(true, 1000, vt, 10, &Distance::Euclidean),
 						false,
 						true,
 						false,
@@ -2449,7 +1821,7 @@ mod tests {
 						stk,
 						&[40],
 						vt,
-						TestCollection::new_unique(1000, vt, 10),
+						TestCollection::new(true, 1000, vt, 10, &Distance::Euclidean),
 						false,
 						true,
 						false,
@@ -2473,7 +1845,7 @@ mod tests {
 						stk,
 						&[40],
 						vt,
-						TestCollection::new_unique(1000, vt, 10),
+						TestCollection::new(true, 1000, vt, 10, &Distance::Euclidean),
 						false,
 						true,
 						false,
@@ -2506,7 +1878,7 @@ mod tests {
 							stk,
 							&[3, 40],
 							vt,
-							TestCollection::new_random(i, vt, 1),
+							TestCollection::new(false, i, vt, 1, &Distance::Euclidean),
 							true,
 							true,
 							true,
@@ -2531,7 +1903,7 @@ mod tests {
 						stk,
 						&[10, 20],
 						vt,
-						TestCollection::new_random(150, vt, 3),
+						TestCollection::new(false, 150, vt, 3, &Distance::Euclidean),
 						true,
 						true,
 						false,
@@ -2555,7 +1927,7 @@ mod tests {
 						stk,
 						&[40],
 						vt,
-						TestCollection::new_random(1000, vt, 10),
+						TestCollection::new(false, 1000, vt, 10, &Distance::Euclidean),
 						false,
 						true,
 						false,
@@ -2570,8 +1942,8 @@ mod tests {
 	}
 
 	fn check_leaf_vec(
-		m: &BTreeMap<SharedVector, ObjectProperties>,
-		obj: &Vector,
+		m: &HashMap<HashedSharedVector, ObjectProperties>,
+		obj: &HashedSharedVector,
 		parent_dist: f64,
 		docs: &[DocId],
 	) {
@@ -2585,14 +1957,14 @@ mod tests {
 
 	fn check_routing_vec(
 		m: &InternalMap,
-		center: &Vector,
+		center: &HashedSharedVector,
 		parent_dist: f64,
 		node_id: NodeId,
 		radius: f64,
 	) {
 		let p = m.get(center).unwrap();
 		assert_eq!(parent_dist, p.parent_dist);
-		assert_eq!(node_id, p.node);
+		assert_eq!(node_id, p.node, "{:?}", m);
 		assert_eq!(radius, p.radius);
 	}
 
@@ -2627,7 +1999,7 @@ mod tests {
 		node_id: NodeId,
 		check_func: F,
 	) where
-		F: FnOnce(&BTreeMap<SharedVector, ObjectProperties>),
+		F: FnOnce(&LeafNode),
 	{
 		check_node_read(tx, st, node_id, |n| {
 			if let MTreeNode::Leaf(m) = n {
@@ -2645,7 +2017,7 @@ mod tests {
 		node_id: NodeId,
 		check_func: F,
 	) where
-		F: FnOnce(&BTreeMap<SharedVector, ObjectProperties>),
+		F: FnOnce(&LeafMap),
 	{
 		check_node_write(tx, st, node_id, |n| {
 			if let MTreeNode::Leaf(m) = n {
@@ -2675,9 +2047,9 @@ mod tests {
 		.await
 	}
 
-	fn check_knn(res: &VecDeque<DocId>, expected: Vec<DocId>) {
-		let expected: VecDeque<DocId> = expected.into_iter().collect();
-		assert_eq!(res, &expected);
+	fn check_knn(res: &VecDeque<(DocId, f64)>, expected: Vec<DocId>) {
+		let res: Vec<DocId> = res.into_iter().map(|(doc, _)| *doc).collect();
+		assert_eq!(res, expected);
 	}
 
 	#[derive(Default, Debug)]
@@ -2726,11 +2098,11 @@ mod tests {
 		debug!("CheckTreeProperties");
 		let mut node_ids = HashSet::new();
 		let mut checks = CheckedProperties::default();
-		let mut nodes: VecDeque<(NodeId, f64, Option<SharedVector>, usize)> = VecDeque::new();
+		let mut nodes: VecDeque<(NodeId, f64, Option<HashedSharedVector>, usize)> = VecDeque::new();
 		if let Some(root_id) = t.state.root {
 			nodes.push_back((root_id, 0.0, None, 1));
 		}
-		let mut leaf_objects = BTreeSet::new();
+		let mut leaf_objects = HashSet::new();
 		while let Some((node_id, radius, center, depth)) = nodes.pop_front() {
 			assert!(node_ids.insert(node_id), "Node already exist: {}", node_id);
 			checks.node_count += 1;
@@ -2807,15 +2179,5 @@ mod tests {
 		} else {
 			*max = Some(val);
 		}
-	}
-
-	fn get_seed_rnd() -> StdRng {
-		let seed: u64 = std::env::var("TEST_SEED")
-			.unwrap_or_else(|_| rand::random::<u64>().to_string())
-			.parse()
-			.expect("Failed to parse seed");
-		debug!("Seed: {}", seed);
-		// Create a seeded RNG
-		StdRng::seed_from_u64(seed)
 	}
 }

--- a/core/src/idx/trees/store/cache.rs
+++ b/core/src/idx/trees/store/cache.rs
@@ -417,3 +417,67 @@ where
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use crate::idx::trees::store::cache::TreeLru;
+
+	#[test]
+	fn test_minimal_tree_lru() {
+		let mut lru = TreeLru::new(1);
+		assert_eq!(lru.len(), 0);
+		//
+		lru.insert(1, 'a');
+		assert_eq!(lru.len(), 1);
+		assert_eq!(lru.get(&1), Some('a'));
+		//
+		lru.insert(2, 'b');
+		assert_eq!(lru.len(), 1);
+		assert_eq!(lru.get(&1), None);
+		assert_eq!(lru.get(&2), Some('b'));
+		//
+		lru.insert(2, 'c');
+		assert_eq!(lru.len(), 1);
+		assert_eq!(lru.get(&2), Some('c'));
+		//
+		lru.remove(&1);
+		assert_eq!(lru.len(), 1);
+		assert_eq!(lru.get(&2), Some('c'));
+		//
+		lru.remove(&2);
+		assert_eq!(lru.len(), 0);
+		assert_eq!(lru.get(&1), None);
+		assert_eq!(lru.get(&2), None);
+	}
+
+	#[test]
+	fn test_tree_lru() {
+		let mut lru = TreeLru::new(4);
+		//
+		lru.insert(1, 'a');
+		lru.insert(2, 'b');
+		lru.insert(3, 'c');
+		lru.insert(4, 'd');
+		assert_eq!(lru.len(), 4);
+		assert_eq!(lru.get(&1), Some('a'));
+		assert_eq!(lru.get(&2), Some('b'));
+		assert_eq!(lru.get(&3), Some('c'));
+		assert_eq!(lru.get(&4), Some('d'));
+		//
+		lru.insert(5, 'e');
+		assert_eq!(lru.len(), 4);
+		assert_eq!(lru.get(&1), None);
+		assert_eq!(lru.get(&2), Some('b'));
+		assert_eq!(lru.get(&3), Some('c'));
+		assert_eq!(lru.get(&4), Some('d'));
+		assert_eq!(lru.get(&5), Some('e'));
+		//
+		let mut lru = lru.duplicate(|k| *k != 3);
+		assert_eq!(lru.len(), 3);
+		assert_eq!(lru.get(&1), None);
+		assert_eq!(lru.get(&2), Some('b'));
+		assert_eq!(lru.get(&3), None);
+		assert_eq!(lru.get(&4), Some('d'));
+		assert_eq!(lru.get(&5), Some('e'));
+	}
+}

--- a/core/src/idx/trees/store/cache.rs
+++ b/core/src/idx/trees/store/cache.rs
@@ -3,13 +3,12 @@ use crate::idx::trees::store::{NodeId, StoreGeneration, StoredNode, TreeNode, Tr
 use crate::kvs::{Key, Transaction};
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
-use hashlink::linked_hash_map::RawEntryMut;
-use hashlink::LinkedHashMap;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
+use std::hash::Hash;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::Mutex;
 
 pub(super) struct TreeCaches<N>(Arc<DashMap<Key, Arc<TreeCache<N>>>>)
 where
@@ -126,7 +125,7 @@ where
 	#[cfg(test)]
 	pub(in crate::idx) async fn len(&self) -> usize {
 		match self {
-			Self::Lru(_, _, c) => c.cache.read().await.len(),
+			Self::Lru(_, _, c) => c.lru.lock().await.len(),
 			Self::Full(_, _, c) => c.cache.len(),
 		}
 	}
@@ -193,8 +192,7 @@ where
 	N: TreeNode + Debug + Clone + Display,
 {
 	keys: TreeNodeProvider,
-	cache: RwLock<LinkedHashMap<NodeId, Arc<StoredNode<N>>>>,
-	size: usize,
+	lru: Mutex<TreeLru<NodeId, Arc<StoredNode<N>>>>,
 }
 
 impl<N> TreeLruCache<N>
@@ -202,11 +200,10 @@ where
 	N: TreeNode + Debug + Clone,
 {
 	fn new(keys: TreeNodeProvider, size: usize) -> Self {
-		let cache = RwLock::new(LinkedHashMap::with_capacity(size));
+		let lru = Mutex::new(TreeLru::new(size));
 		Self {
 			keys,
-			cache,
-			size,
+			lru,
 		}
 	}
 
@@ -215,23 +212,20 @@ where
 		tx: &mut Transaction,
 		node_id: NodeId,
 	) -> Result<Arc<StoredNode<N>>, Error> {
-		if let Some(n) = self.cache.read().await.get(&node_id).cloned() {
+		let mut lru = self.lru.lock().await;
+		if let Some(n) = lru.get(&node_id) {
 			return Ok(n);
 		}
-		match self.cache.write().await.raw_entry_mut().from_key(&node_id) {
-			RawEntryMut::Occupied(e) => Ok(e.get().clone()),
-			RawEntryMut::Vacant(e) => {
-				let n = Arc::new(self.keys.load::<N>(tx, node_id).await?);
-				e.insert(node_id, n.clone());
-				Ok(n)
-			}
-		}
+		let n = Arc::new(self.keys.load::<N>(tx, node_id).await?);
+		lru.insert(node_id, n.clone());
+		Ok(n)
 	}
+
 	async fn set_node(&self, node: StoredNode<N>) {
-		self.cache.write().await.insert(node.id, node.into());
+		self.lru.lock().await.insert(node.id, node.into());
 	}
 	async fn remove_node(&self, node_id: &NodeId) {
-		self.cache.write().await.remove(node_id);
+		self.lru.lock().await.remove(node_id);
 	}
 
 	async fn next_generation(
@@ -239,21 +233,14 @@ where
 		updated: &HashSet<NodeId>,
 		removed: &HashMap<NodeId, Key>,
 	) -> Self {
-		let mut map = LinkedHashMap::with_capacity(self.size);
-		self.cache
-			.read()
+		let lru = self
+			.lru
+			.lock()
 			.await
-			.iter()
-			.filter(|(id, _)| !removed.contains_key(id))
-			.filter(|(id, _)| !updated.contains(id))
-			.for_each(|(id, n)| {
-				map.insert(*id, n.clone());
-			});
-
+			.duplicate(|id| !removed.contains_key(id) || !updated.contains(id));
 		Self {
 			keys: self.keys.clone(),
-			cache: RwLock::new(map),
-			size: self.size,
+			lru: Mutex::new(lru),
 		}
 	}
 }
@@ -311,5 +298,122 @@ where
 				new_cache.cache.insert(r.id, r.value().clone());
 			});
 		new_cache
+	}
+}
+
+struct TreeLru<K, V>
+where
+	K: Clone + PartialEq + Eq + Hash,
+	V: Clone,
+{
+	map: HashMap<K, usize>,
+	vec: Vec<Option<(K, V)>>,
+	capacity: usize,
+}
+
+impl<K, V> TreeLru<K, V>
+where
+	K: Clone + PartialEq + Eq + Hash,
+	V: Clone,
+{
+	fn new(capacity: usize) -> Self {
+		Self {
+			map: HashMap::with_capacity(capacity),
+			vec: Vec::with_capacity(capacity),
+			capacity,
+		}
+	}
+
+	fn get(&mut self, key: &K) -> Option<V> {
+		if let Some(pos) = self.map.get(key).copied() {
+			let val = self.vec[pos].clone();
+			if pos > 0 {
+				self.promote(key.clone(), pos);
+			}
+			val.map(|(_, v)| v.clone())
+		} else {
+			None
+		}
+	}
+
+	fn promote(&mut self, key: K, pos: usize) {
+		let new_pos = pos - 1;
+		let flip_key = self.vec[new_pos].as_ref().map(|(k, _)| k).cloned();
+		self.vec.swap(pos, new_pos);
+		self.map.insert(key, new_pos);
+		if let Some(flip_key) = flip_key {
+			self.map.insert(flip_key, pos);
+		} else {
+			if pos == self.vec.len() - 1 {
+				self.vec.remove(pos);
+			}
+		}
+	}
+
+	fn insert(&mut self, key: K, val: V) {
+		if let Some(pos) = self.map.get(&key).copied() {
+			// If the entry is already there, just update it
+			self.vec[pos] = Some((key, val));
+		} else {
+			// If we reached the capacity
+			if self.map.len() >= self.capacity {
+				// Find the last entry...
+				while !self.vec.is_empty() {
+					if let Some(remove) = self.vec.pop() {
+						if let Some((k, _v)) = remove {
+							// ... and remove it
+							self.map.remove(&k);
+							break;
+						}
+					}
+				}
+			}
+			// Now we can insert the new entry
+			let pos = self.vec.len();
+			self.vec.push(Some((key.clone(), val)));
+			// If it is the head
+			if pos == 0 {
+				// ...we just insert it
+				self.map.insert(key, pos);
+			} else {
+				// or we promote it
+				self.promote(key, pos);
+			}
+		}
+	}
+
+	fn remove(&mut self, key: &K) {
+		if let Some(pos) = self.map.remove(key) {
+			if pos == self.vec.len() - 1 {
+				// If it is the last element, we can just remove it from the vec
+				self.vec.pop();
+			} else {
+				// Otherwise we set a placeholder
+				self.vec[pos] = None;
+			}
+		}
+	}
+
+	#[cfg(test)]
+	fn len(&self) -> usize {
+		self.map.len()
+	}
+
+	fn duplicate<F>(&self, filter: F) -> Self
+	where
+		F: Fn(&K) -> bool,
+	{
+		let mut map = HashMap::with_capacity(self.capacity);
+		let mut vec = Vec::with_capacity(self.capacity);
+		self.map.iter().filter(|&(k, _pos)| filter(k)).for_each(|(k, pos)| {
+			let new_pos = vec.len();
+			map.insert(k.clone(), new_pos);
+			vec.push(self.vec[*pos].clone());
+		});
+		Self {
+			map,
+			vec,
+			capacity: self.capacity,
+		}
 	}
 }

--- a/core/src/idx/trees/store/cache.rs
+++ b/core/src/idx/trees/store/cache.rs
@@ -1,4 +1,5 @@
 use crate::err::Error;
+use crate::idx::trees::store::lru::{CacheKey, ConcurrentLru};
 use crate::idx::trees::store::{NodeId, StoreGeneration, StoredNode, TreeNode, TreeNodeProvider};
 use crate::kvs::{Key, Transaction};
 use dashmap::mapref::entry::Entry;
@@ -6,9 +7,7 @@ use dashmap::DashMap;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
-use std::hash::Hash;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 
 pub(super) struct TreeCaches<N>(Arc<DashMap<Key, Arc<TreeCache<N>>>>)
 where
@@ -123,9 +122,9 @@ where
 	}
 
 	#[cfg(test)]
-	pub(in crate::idx) async fn len(&self) -> usize {
+	pub(in crate::idx) fn len(&self) -> usize {
 		match self {
-			Self::Lru(_, _, c) => c.lru.lock().await.len(),
+			Self::Lru(_, _, c) => c.lru.len(),
 			Self::Full(_, _, c) => c.cache.len(),
 		}
 	}
@@ -192,7 +191,7 @@ where
 	N: TreeNode + Debug + Clone + Display,
 {
 	keys: TreeNodeProvider,
-	lru: Mutex<TreeLru<NodeId, Arc<StoredNode<N>>>>,
+	lru: ConcurrentLru<Arc<StoredNode<N>>>,
 }
 
 impl<N> TreeLruCache<N>
@@ -200,7 +199,7 @@ where
 	N: TreeNode + Debug + Clone,
 {
 	fn new(keys: TreeNodeProvider, size: usize) -> Self {
-		let lru = Mutex::new(TreeLru::new(size));
+		let lru = ConcurrentLru::new(size);
 		Self {
 			keys,
 			lru,
@@ -212,20 +211,19 @@ where
 		tx: &mut Transaction,
 		node_id: NodeId,
 	) -> Result<Arc<StoredNode<N>>, Error> {
-		let mut lru = self.lru.lock().await;
-		if let Some(n) = lru.get(&node_id) {
+		if let Some(n) = self.lru.get(node_id).await {
 			return Ok(n);
 		}
 		let n = Arc::new(self.keys.load::<N>(tx, node_id).await?);
-		lru.insert(node_id, n.clone());
+		self.lru.insert(node_id as CacheKey, n.clone()).await;
 		Ok(n)
 	}
 
 	async fn set_node(&self, node: StoredNode<N>) {
-		self.lru.lock().await.insert(node.id, node.into());
+		self.lru.insert(node.id as CacheKey, node.into()).await;
 	}
 	async fn remove_node(&self, node_id: &NodeId) {
-		self.lru.lock().await.remove(node_id);
+		self.lru.remove(*node_id as CacheKey).await;
 	}
 
 	async fn next_generation(
@@ -233,14 +231,9 @@ where
 		updated: &HashSet<NodeId>,
 		removed: &HashMap<NodeId, Key>,
 	) -> Self {
-		let lru = self
-			.lru
-			.lock()
-			.await
-			.duplicate(|id| !removed.contains_key(id) || !updated.contains(id));
 		Self {
 			keys: self.keys.clone(),
-			lru: Mutex::new(lru),
+			lru: self.lru.duplicate(|id| !removed.contains_key(id) || !updated.contains(id)).await,
 		}
 	}
 }
@@ -298,186 +291,5 @@ where
 				new_cache.cache.insert(r.id, r.value().clone());
 			});
 		new_cache
-	}
-}
-
-struct TreeLru<K, V>
-where
-	K: Clone + PartialEq + Eq + Hash,
-	V: Clone,
-{
-	map: HashMap<K, usize>,
-	vec: Vec<Option<(K, V)>>,
-	capacity: usize,
-}
-
-impl<K, V> TreeLru<K, V>
-where
-	K: Clone + PartialEq + Eq + Hash,
-	V: Clone,
-{
-	fn new(capacity: usize) -> Self {
-		Self {
-			map: HashMap::with_capacity(capacity),
-			vec: Vec::with_capacity(capacity),
-			capacity,
-		}
-	}
-
-	fn get(&mut self, key: &K) -> Option<V> {
-		if let Some(pos) = self.map.get(key).copied() {
-			let val = self.vec[pos].clone();
-			if pos > 0 {
-				self.promote(key.clone(), pos);
-			}
-			val.map(|(_, v)| v.clone())
-		} else {
-			None
-		}
-	}
-
-	fn promote(&mut self, key: K, pos: usize) {
-		let new_pos = pos - 1;
-		let flip_key = self.vec[new_pos].as_ref().map(|(k, _)| k).cloned();
-		self.vec.swap(pos, new_pos);
-		self.map.insert(key, new_pos);
-		if let Some(flip_key) = flip_key {
-			self.map.insert(flip_key, pos);
-		} else {
-			if pos == self.vec.len() - 1 {
-				self.vec.remove(pos);
-			}
-		}
-	}
-
-	fn insert(&mut self, key: K, val: V) {
-		if let Some(pos) = self.map.get(&key).copied() {
-			// If the entry is already there, just update it
-			self.vec[pos] = Some((key, val));
-		} else {
-			// If we reached the capacity
-			if self.map.len() >= self.capacity {
-				// Find the last entry...
-				while !self.vec.is_empty() {
-					if let Some(remove) = self.vec.pop() {
-						if let Some((k, _v)) = remove {
-							// ... and remove it
-							self.map.remove(&k);
-							break;
-						}
-					}
-				}
-			}
-			// Now we can insert the new entry
-			let pos = self.vec.len();
-			self.vec.push(Some((key.clone(), val)));
-			// If it is the head
-			if pos == 0 {
-				// ...we just insert it
-				self.map.insert(key, pos);
-			} else {
-				// or we promote it
-				self.promote(key, pos);
-			}
-		}
-	}
-
-	fn remove(&mut self, key: &K) {
-		if let Some(pos) = self.map.remove(key) {
-			if pos == self.vec.len() - 1 {
-				// If it is the last element, we can just remove it from the vec
-				self.vec.pop();
-			} else {
-				// Otherwise we set a placeholder
-				self.vec[pos] = None;
-			}
-		}
-	}
-
-	#[cfg(test)]
-	fn len(&self) -> usize {
-		self.map.len()
-	}
-
-	fn duplicate<F>(&self, filter: F) -> Self
-	where
-		F: Fn(&K) -> bool,
-	{
-		let mut map = HashMap::with_capacity(self.capacity);
-		let mut vec = Vec::with_capacity(self.capacity);
-		self.map.iter().filter(|&(k, _pos)| filter(k)).for_each(|(k, pos)| {
-			let new_pos = vec.len();
-			map.insert(k.clone(), new_pos);
-			vec.push(self.vec[*pos].clone());
-		});
-		Self {
-			map,
-			vec,
-			capacity: self.capacity,
-		}
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use crate::idx::trees::store::cache::TreeLru;
-
-	#[test]
-	fn test_minimal_tree_lru() {
-		let mut lru = TreeLru::new(1);
-		assert_eq!(lru.len(), 0);
-		//
-		lru.insert(1, 'a');
-		assert_eq!(lru.len(), 1);
-		assert_eq!(lru.get(&1), Some('a'));
-		//
-		lru.insert(2, 'b');
-		assert_eq!(lru.len(), 1);
-		assert_eq!(lru.get(&1), None);
-		assert_eq!(lru.get(&2), Some('b'));
-		//
-		lru.insert(2, 'c');
-		assert_eq!(lru.len(), 1);
-		assert_eq!(lru.get(&2), Some('c'));
-		//
-		lru.remove(&1);
-		assert_eq!(lru.len(), 1);
-		assert_eq!(lru.get(&2), Some('c'));
-		//
-		lru.remove(&2);
-		assert_eq!(lru.len(), 0);
-		assert_eq!(lru.get(&1), None);
-		assert_eq!(lru.get(&2), None);
-	}
-
-	#[test]
-	fn test_tree_lru() {
-		let mut lru = TreeLru::new(4);
-		//
-		lru.insert(1, 'a');
-		lru.insert(2, 'b');
-		lru.insert(3, 'c');
-		lru.insert(4, 'd');
-		assert_eq!(lru.len(), 4);
-		assert_eq!(lru.get(&1), Some('a'));
-		assert_eq!(lru.get(&2), Some('b'));
-		assert_eq!(lru.get(&3), Some('c'));
-		assert_eq!(lru.get(&4), Some('d'));
-		//
-		lru.insert(5, 'e');
-		assert_eq!(lru.len(), 4);
-		assert_eq!(lru.get(&1), None);
-		assert_eq!(lru.get(&2), Some('b'));
-		assert_eq!(lru.get(&3), Some('c'));
-		assert_eq!(lru.get(&4), Some('d'));
-		assert_eq!(lru.get(&5), Some('e'));
-		//
-		let mut lru = lru.duplicate(|k| *k != 3);
-		assert_eq!(lru.len(), 3);
-		assert_eq!(lru.get(&1), None);
-		assert_eq!(lru.get(&2), Some('b'));
-		assert_eq!(lru.get(&3), None);
-		assert_eq!(lru.get(&4), Some('d'));
-		assert_eq!(lru.get(&5), Some('e'));
 	}
 }

--- a/core/src/idx/trees/store/cache.rs
+++ b/core/src/idx/trees/store/cache.rs
@@ -1,15 +1,16 @@
 use crate::err::Error;
 use crate::idx::trees::store::{NodeId, StoreGeneration, StoredNode, TreeNode, TreeNodeProvider};
 use crate::kvs::{Key, Transaction};
-use quick_cache::sync::Cache;
-use quick_cache::GuardResult;
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+use quick_cache::sync::{Cache, GuardResult};
+use quick_cache::{DefaultHashBuilder, Lifecycle, UnitWeighter};
 use std::cmp::Ordering;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
-use tokio::sync::RwLock;
-pub(super) struct TreeCaches<N>(Arc<RwLock<HashMap<Key, Arc<TreeCache<N>>>>>)
+
+pub(super) struct TreeCaches<N>(Arc<DashMap<Key, Arc<TreeCache<N>>>>)
 where
 	N: TreeNode + Debug + Clone + Display;
 
@@ -26,8 +27,8 @@ where
 		#[cfg(debug_assertions)]
 		debug!("get_cache {generation}");
 		// We take the key from the node 0 as the key identifier for the cache
-		let key = keys.get_key(0);
-		match self.0.write().await.entry(key) {
+		let cache_key = keys.get_key(0);
+		match self.0.entry(cache_key.clone()) {
 			Entry::Occupied(mut e) => {
 				let c = e.get_mut();
 				// The cache and the store are matching, we can send a clone of the cache.
@@ -35,13 +36,18 @@ where
 					Ordering::Less => {
 						// The store generation is older than the current cache,
 						// we return an empty cache, but we don't hold it
-						Arc::new(TreeCache::new(generation, keys.clone(), cache_size))
+						Arc::new(TreeCache::new(generation, cache_key, keys.clone(), cache_size))
 					}
 					Ordering::Equal => c.clone(),
 					Ordering::Greater => {
 						// The store generation is more recent than the cache,
 						// we create a new one and hold it
-						let c = Arc::new(TreeCache::new(generation, keys.clone(), cache_size));
+						let c = Arc::new(TreeCache::new(
+							generation,
+							cache_key,
+							keys.clone(),
+							cache_size,
+						));
 						e.insert(c.clone());
 						c
 					}
@@ -49,16 +55,15 @@ where
 			}
 			Entry::Vacant(e) => {
 				// There is no cache for index, we create one and hold it
-				let c = Arc::new(TreeCache::new(generation, keys.clone(), cache_size));
+				let c = Arc::new(TreeCache::new(generation, cache_key, keys.clone(), cache_size));
 				e.insert(c.clone());
 				c
 			}
 		}
 	}
 
-	pub(super) async fn new_cache(&self, keys: &TreeNodeProvider, new_cache: TreeCache<N>) {
-		let key = keys.get_key(0);
-		match self.0.write().await.entry(key) {
+	pub(super) fn new_cache(&self, new_cache: TreeCache<N>) {
+		match self.0.entry(new_cache.cache_key().clone()) {
 			Entry::Occupied(mut e) => {
 				let old_cache = e.get();
 				// We only store the cache if it is a newer generation
@@ -72,13 +77,13 @@ where
 		}
 	}
 
-	pub(super) async fn remove_caches(&self, keys: &TreeNodeProvider) {
+	pub(super) fn remove_caches(&self, keys: &TreeNodeProvider) {
 		let key = keys.get_key(0);
-		self.0.write().await.remove(&key);
+		self.0.remove(&key);
 	}
 
-	pub(crate) async fn is_empty(&self) -> bool {
-		self.0.read().await.is_empty()
+	pub(crate) fn is_empty(&self) -> bool {
+		self.0.is_empty()
 	}
 }
 
@@ -87,7 +92,7 @@ where
 	N: TreeNode + Debug + Clone + Display,
 {
 	fn default() -> Self {
-		Self(Arc::new(RwLock::new(HashMap::new())))
+		Self(Arc::new(DashMap::new()))
 	}
 }
 
@@ -96,19 +101,32 @@ pub enum TreeCache<N>
 where
 	N: TreeNode + Debug + Clone + Display,
 {
-	Lru(StoreGeneration, TreeLruCache<N>),
-	Full(StoreGeneration, TreeFullCache<N>),
+	Lru(Key, StoreGeneration, TreeLruCache<N>),
+	Full(Key, StoreGeneration, TreeFullCache<N>),
 }
 
 impl<N> TreeCache<N>
 where
 	N: TreeNode + Debug + Clone + Display,
 {
-	pub fn new(generation: StoreGeneration, keys: TreeNodeProvider, cache_size: usize) -> Self {
+	pub fn new(
+		generation: StoreGeneration,
+		cache_key: Key,
+		keys: TreeNodeProvider,
+		cache_size: usize,
+	) -> Self {
 		if cache_size == 0 {
-			Self::Full(generation, TreeFullCache::new(keys))
+			Self::Full(cache_key, generation, TreeFullCache::new(keys))
 		} else {
-			Self::Lru(generation, TreeLruCache::new(keys, cache_size))
+			Self::Lru(cache_key, generation, TreeLruCache::new(keys, cache_size))
+		}
+	}
+
+	#[cfg(test)]
+	pub(in crate::idx) fn len(&self) -> usize {
+		match self {
+			Self::Lru(_, _, c) => c.cache.len(),
+			Self::Full(_, _, c) => c.cache.len(),
 		}
 	}
 
@@ -118,57 +136,80 @@ where
 		node_id: NodeId,
 	) -> Result<Arc<StoredNode<N>>, Error> {
 		match self {
-			Self::Lru(_, c) => c.get_node(tx, node_id).await,
-			Self::Full(_, c) => c.get_node(tx, node_id).await,
+			Self::Lru(_, _, c) => c.get_node(tx, node_id).await,
+			Self::Full(_, _, c) => c.get_node(tx, node_id).await,
 		}
 	}
 
-	pub(super) async fn set_node(&self, node: StoredNode<N>) {
+	pub(super) fn set_node(&self, node: StoredNode<N>) {
 		match self {
-			Self::Lru(_, c) => c.set_node(node),
-			Self::Full(_, c) => c.set_node(node).await,
+			Self::Lru(_, _, c) => c.set_node(node),
+			Self::Full(_, _, c) => c.set_node(node),
 		}
 	}
 
-	pub(super) async fn remove_node(&self, node_id: NodeId) {
+	pub(super) fn remove_node(&self, node_id: &NodeId) {
 		match self {
-			Self::Lru(_, c) => c.remove_node(node_id),
-			Self::Full(_, c) => c.remove_node(node_id).await,
+			Self::Lru(_, _, c) => c.remove_node(node_id),
+			Self::Full(_, _, c) => c.remove_node(node_id),
+		}
+	}
+
+	pub(super) fn cache_key(&self) -> &Key {
+		match self {
+			Self::Lru(k, _, _) => k,
+			Self::Full(k, _, _) => k,
 		}
 	}
 
 	fn generation(&self) -> StoreGeneration {
 		match self {
-			Self::Lru(gen, _) | TreeCache::Full(gen, _) => *gen,
+			Self::Lru(_, gen, _) | TreeCache::Full(_, gen, _) => *gen,
 		}
 	}
 
-	pub(super) fn new_generation(&self, new_gen: StoreGeneration) -> TreeCache<N> {
+	/// Creates a copy of the cache, with a generation number incremented by one.
+	/// The new cache does not contain the NodeID contained in `updated` and `removed`.
+	pub(super) fn next_generation(
+		&self,
+		updated: &HashSet<NodeId>,
+		removed: &HashMap<NodeId, Key>,
+	) -> Self {
 		match self {
-			Self::Lru(_, c) => Self::Lru(new_gen, c.clone()),
-			Self::Full(_, c) => Self::Full(new_gen, c.clone()),
+			Self::Lru(k, g, c) => Self::Lru(k.clone(), *g + 1, c.next_generation(updated, removed)),
+			Self::Full(k, g, c) => {
+				Self::Full(k.clone(), *g + 1, c.next_generation(updated, removed))
+			}
 		}
 	}
 }
 
 #[non_exhaustive]
-#[derive(Clone)]
 pub struct TreeLruCache<N>
 where
 	N: TreeNode + Debug + Clone + Display,
 {
 	keys: TreeNodeProvider,
-	cache: Cache<NodeId, Arc<StoredNode<N>>>,
+	tracker: NodeIdsTracker<N>,
+	cache: Cache<NodeId, Arc<StoredNode<N>>, UnitWeighter, DefaultHashBuilder, NodeIdsTracker<N>>,
+	size: usize,
 }
 
 impl<N> TreeLruCache<N>
 where
 	N: TreeNode + Debug + Clone,
 {
-	fn new(keys: TreeNodeProvider, cache_size: usize) -> Self {
+	fn new(keys: TreeNodeProvider, size: usize) -> Self {
+		let tracker = NodeIdsTracker(Default::default());
+		// Quick-cache requires a minimum size of 2, otherwise the capacity will be 0.
+		let size = size.max(2);
+		let cache =
+			Cache::with(size, size as u64, Default::default(), Default::default(), tracker.clone());
 		Self {
 			keys,
-			cache: Cache::new(cache_size),
+			tracker,
+			cache,
+			size,
 		}
 	}
 
@@ -189,11 +230,57 @@ where
 	}
 
 	fn set_node(&self, node: StoredNode<N>) {
-		self.cache.insert(node.id, Arc::new(node));
+		let node = Arc::new(node);
+		self.cache.insert(node.id, node.clone());
+		self.tracker.insert(node);
 	}
 
-	fn remove_node(&self, node_id: NodeId) {
-		self.cache.remove(&node_id);
+	fn remove_node(&self, node_id: &NodeId) {
+		self.cache.remove(node_id);
+		self.tracker.remove(node_id);
+	}
+
+	fn next_generation(&self, updated: &HashSet<NodeId>, removed: &HashMap<NodeId, Key>) -> Self {
+		let new_cache = Self::new(self.keys.clone(), self.size);
+		self.tracker
+			.0
+			.iter()
+			.filter(|r| !removed.contains_key(r.key()))
+			.filter(|r| !updated.contains(r.key()))
+			.for_each(|r| {
+				new_cache.cache.insert(r.id, r.value().clone());
+			});
+		new_cache
+	}
+}
+
+#[derive(Debug, Clone)]
+struct NodeIdsTracker<N>(Arc<DashMap<NodeId, Arc<StoredNode<N>>>>)
+where
+	N: TreeNode + Debug + Clone + Display;
+
+impl<N> NodeIdsTracker<N>
+where
+	N: TreeNode + Debug + Clone + Display,
+{
+	fn insert(&self, node: Arc<StoredNode<N>>) {
+		self.0.insert(node.id, node);
+	}
+
+	fn remove(&self, node_id: &NodeId) {
+		self.0.remove(node_id);
+	}
+}
+impl<N> Lifecycle<NodeId, Arc<StoredNode<N>>> for NodeIdsTracker<N>
+where
+	N: TreeNode + Debug + Clone + Display,
+{
+	type RequestState = ();
+
+	fn begin_request(&self) -> Self::RequestState {}
+
+	fn on_evict(&self, _state: &mut Self::RequestState, key: NodeId, _val: Arc<StoredNode<N>>) {
+		self.remove(&key);
 	}
 }
 
@@ -204,7 +291,7 @@ where
 	N: TreeNode + Debug + Clone,
 {
 	keys: TreeNodeProvider,
-	cache: RwLock<HashMap<NodeId, Arc<StoredNode<N>>>>,
+	cache: DashMap<NodeId, Arc<StoredNode<N>>>,
 }
 
 impl<N> TreeFullCache<N>
@@ -214,7 +301,7 @@ where
 	pub fn new(keys: TreeNodeProvider) -> Self {
 		Self {
 			keys,
-			cache: RwLock::new(HashMap::new()),
+			cache: DashMap::new(),
 		}
 	}
 
@@ -223,11 +310,7 @@ where
 		tx: &mut Transaction,
 		node_id: NodeId,
 	) -> Result<Arc<StoredNode<N>>, Error> {
-		// Let's first try with the read lock
-		if let Some(n) = self.cache.read().await.get(&node_id).cloned() {
-			return Ok(n);
-		}
-		match self.cache.write().await.entry(node_id) {
+		match self.cache.entry(node_id) {
 			Entry::Occupied(e) => Ok(e.get().clone()),
 			Entry::Vacant(e) => {
 				let n = Arc::new(self.keys.load::<N>(tx, node_id).await?);
@@ -237,11 +320,23 @@ where
 		}
 	}
 
-	pub(super) async fn set_node(&self, node: StoredNode<N>) {
-		self.cache.write().await.insert(node.id, Arc::new(node));
+	pub(super) fn set_node(&self, node: StoredNode<N>) {
+		self.cache.insert(node.id, Arc::new(node));
 	}
 
-	pub(super) async fn remove_node(&self, node_id: NodeId) {
-		self.cache.write().await.remove(&node_id);
+	pub(super) fn remove_node(&self, node_id: &NodeId) {
+		self.cache.remove(node_id);
+	}
+
+	fn next_generation(&self, updated: &HashSet<NodeId>, removed: &HashMap<NodeId, Key>) -> Self {
+		let new_cache = Self::new(self.keys.clone());
+		self.cache
+			.iter()
+			.filter(|r| !removed.contains_key(r.key()))
+			.filter(|r| !updated.contains(r.key()))
+			.for_each(|r| {
+				new_cache.cache.insert(r.id, r.value().clone());
+			});
+		new_cache
 	}
 }

--- a/core/src/idx/trees/store/cache.rs
+++ b/core/src/idx/trees/store/cache.rs
@@ -3,12 +3,13 @@ use crate::idx::trees::store::{NodeId, StoreGeneration, StoredNode, TreeNode, Tr
 use crate::kvs::{Key, Transaction};
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
-use quick_cache::sync::{Cache, GuardResult};
-use quick_cache::{DefaultHashBuilder, Lifecycle, UnitWeighter};
+use hashlink::linked_hash_map::RawEntryMut;
+use hashlink::LinkedHashMap;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 pub(super) struct TreeCaches<N>(Arc<DashMap<Key, Arc<TreeCache<N>>>>)
 where
@@ -123,9 +124,9 @@ where
 	}
 
 	#[cfg(test)]
-	pub(in crate::idx) fn len(&self) -> usize {
+	pub(in crate::idx) async fn len(&self) -> usize {
 		match self {
-			Self::Lru(_, _, c) => c.cache.len(),
+			Self::Lru(_, _, c) => c.cache.read().await.len(),
 			Self::Full(_, _, c) => c.cache.len(),
 		}
 	}
@@ -141,16 +142,16 @@ where
 		}
 	}
 
-	pub(super) fn set_node(&self, node: StoredNode<N>) {
+	pub(super) async fn set_node(&self, node: StoredNode<N>) {
 		match self {
-			Self::Lru(_, _, c) => c.set_node(node),
+			Self::Lru(_, _, c) => c.set_node(node).await,
 			Self::Full(_, _, c) => c.set_node(node),
 		}
 	}
 
-	pub(super) fn remove_node(&self, node_id: &NodeId) {
+	pub(super) async fn remove_node(&self, node_id: &NodeId) {
 		match self {
-			Self::Lru(_, _, c) => c.remove_node(node_id),
+			Self::Lru(_, _, c) => c.remove_node(node_id).await,
 			Self::Full(_, _, c) => c.remove_node(node_id),
 		}
 	}
@@ -170,13 +171,15 @@ where
 
 	/// Creates a copy of the cache, with a generation number incremented by one.
 	/// The new cache does not contain the NodeID contained in `updated` and `removed`.
-	pub(super) fn next_generation(
+	pub(super) async fn next_generation(
 		&self,
 		updated: &HashSet<NodeId>,
 		removed: &HashMap<NodeId, Key>,
 	) -> Self {
 		match self {
-			Self::Lru(k, g, c) => Self::Lru(k.clone(), *g + 1, c.next_generation(updated, removed)),
+			Self::Lru(k, g, c) => {
+				Self::Lru(k.clone(), *g + 1, c.next_generation(updated, removed).await)
+			}
 			Self::Full(k, g, c) => {
 				Self::Full(k.clone(), *g + 1, c.next_generation(updated, removed))
 			}
@@ -190,8 +193,7 @@ where
 	N: TreeNode + Debug + Clone + Display,
 {
 	keys: TreeNodeProvider,
-	tracker: NodeIdsTracker<N>,
-	cache: Cache<NodeId, Arc<StoredNode<N>>, UnitWeighter, DefaultHashBuilder, NodeIdsTracker<N>>,
+	cache: RwLock<LinkedHashMap<NodeId, Arc<StoredNode<N>>>>,
 	size: usize,
 }
 
@@ -200,14 +202,9 @@ where
 	N: TreeNode + Debug + Clone,
 {
 	fn new(keys: TreeNodeProvider, size: usize) -> Self {
-		let tracker = NodeIdsTracker(Default::default());
-		// Quick-cache requires a minimum size of 2, otherwise the capacity will be 0.
-		let size = size.max(2);
-		let cache =
-			Cache::with(size, size as u64, Default::default(), Default::default(), tracker.clone());
+		let cache = RwLock::new(LinkedHashMap::with_capacity(size));
 		Self {
 			keys,
-			tracker,
 			cache,
 			size,
 		}
@@ -218,74 +215,50 @@ where
 		tx: &mut Transaction,
 		node_id: NodeId,
 	) -> Result<Arc<StoredNode<N>>, Error> {
-		match self.cache.get_value_or_guard(&node_id, None) {
-			GuardResult::Value(v) => Ok(v),
-			GuardResult::Guard(g) => {
+		if let Some(n) = self.cache.read().await.get(&node_id).cloned() {
+			return Ok(n);
+		}
+		match self.cache.write().await.raw_entry_mut().from_key(&node_id) {
+			RawEntryMut::Occupied(e) => Ok(e.get().clone()),
+			RawEntryMut::Vacant(e) => {
 				let n = Arc::new(self.keys.load::<N>(tx, node_id).await?);
-				g.insert(n.clone()).ok();
+				e.insert(node_id, n.clone());
 				Ok(n)
 			}
-			GuardResult::Timeout => Err(Error::Unreachable("TreeCache::get_node")),
 		}
 	}
-
-	fn set_node(&self, node: StoredNode<N>) {
-		let node = Arc::new(node);
-		self.cache.insert(node.id, node.clone());
-		self.tracker.insert(node);
+	async fn set_node(&self, node: StoredNode<N>) {
+		self.cache.write().await.insert(node.id, node.into());
+	}
+	async fn remove_node(&self, node_id: &NodeId) {
+		self.cache.write().await.remove(node_id);
 	}
 
-	fn remove_node(&self, node_id: &NodeId) {
-		self.cache.remove(node_id);
-		self.tracker.remove(node_id);
-	}
-
-	fn next_generation(&self, updated: &HashSet<NodeId>, removed: &HashMap<NodeId, Key>) -> Self {
-		let new_cache = Self::new(self.keys.clone(), self.size);
-		self.tracker
-			.0
+	async fn next_generation(
+		&self,
+		updated: &HashSet<NodeId>,
+		removed: &HashMap<NodeId, Key>,
+	) -> Self {
+		let mut map = LinkedHashMap::with_capacity(self.size);
+		self.cache
+			.read()
+			.await
 			.iter()
-			.filter(|r| !removed.contains_key(r.key()))
-			.filter(|r| !updated.contains(r.key()))
-			.for_each(|r| {
-				new_cache.cache.insert(r.id, r.value().clone());
+			.filter(|(id, _)| !removed.contains_key(id))
+			.filter(|(id, _)| !updated.contains(id))
+			.for_each(|(id, n)| {
+				map.insert(*id, n.clone());
 			});
-		new_cache
-	}
-}
 
-#[derive(Debug, Clone)]
-struct NodeIdsTracker<N>(Arc<DashMap<NodeId, Arc<StoredNode<N>>>>)
-where
-	N: TreeNode + Debug + Clone + Display;
-
-impl<N> NodeIdsTracker<N>
-where
-	N: TreeNode + Debug + Clone + Display,
-{
-	fn insert(&self, node: Arc<StoredNode<N>>) {
-		self.0.insert(node.id, node);
-	}
-
-	fn remove(&self, node_id: &NodeId) {
-		self.0.remove(node_id);
-	}
-}
-impl<N> Lifecycle<NodeId, Arc<StoredNode<N>>> for NodeIdsTracker<N>
-where
-	N: TreeNode + Debug + Clone + Display,
-{
-	type RequestState = ();
-
-	fn begin_request(&self) -> Self::RequestState {}
-
-	fn on_evict(&self, _state: &mut Self::RequestState, key: NodeId, _val: Arc<StoredNode<N>>) {
-		self.remove(&key);
+		Self {
+			keys: self.keys.clone(),
+			cache: RwLock::new(map),
+			size: self.size,
+		}
 	}
 }
 
 #[non_exhaustive]
-#[derive(Clone)]
 pub struct TreeFullCache<N>
 where
 	N: TreeNode + Debug + Clone,
@@ -321,7 +294,7 @@ where
 	}
 
 	pub(super) fn set_node(&self, node: StoredNode<N>) {
-		self.cache.insert(node.id, Arc::new(node));
+		self.cache.insert(node.id, node.into());
 	}
 
 	pub(super) fn remove_node(&self, node_id: &NodeId) {

--- a/core/src/idx/trees/store/lru.rs
+++ b/core/src/idx/trees/store/lru.rs
@@ -1,0 +1,312 @@
+use futures::future::join_all;
+use std::collections::HashMap;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use tokio::sync::Mutex;
+
+pub(super) type CacheKey = u64;
+
+pub(super) struct ConcurrentLru<V>
+where
+	V: Clone,
+{
+	/// Each shard is a LRU cache
+	shards: Vec<Mutex<LruShard<V>>>,
+	/// Keep track of sizes for each shard
+	lengths: Vec<AtomicUsize>,
+	/// If lengths == capacity, then full is true
+	full: AtomicBool,
+	/// The number of shards
+	shards_count: usize,
+	/// The maximum capacity
+	capacity: usize,
+}
+
+impl<V> ConcurrentLru<V>
+where
+	V: Clone,
+{
+	pub(super) fn new(capacity: usize) -> Self {
+		let shards_count = num_cpus::get().min(capacity);
+		let mut shards = Vec::with_capacity(shards_count);
+		let mut lengths = Vec::with_capacity(shards_count);
+		for _ in 0..shards_count {
+			shards.push(Mutex::new(LruShard::new()));
+			lengths.push(AtomicUsize::new(0));
+		}
+		Self {
+			shards_count,
+			shards,
+			lengths,
+			full: AtomicBool::new(false),
+			capacity,
+		}
+	}
+	pub(super) async fn get<K: Into<CacheKey>>(&self, key: K) -> Option<V> {
+		let key = key.into();
+		// Locate the shard
+		let n = key as usize % self.shards_count;
+		// Get and promote the key
+		self.shards[n].lock().await.get_and_promote(key)
+	}
+
+	pub(super) async fn insert<K: Into<CacheKey>>(&self, key: K, val: V) {
+		let key = key.into();
+		// Locate the shard
+		let shard = key as usize % self.shards_count;
+		// Insert the key/object in the shard and get the new length
+		let new_length = self.shards[shard].lock().await.insert(key, val, self.full.load(Relaxed));
+		// Update lengths
+		self.check_length(new_length, shard);
+	}
+
+	pub(super) async fn remove<K: Into<CacheKey>>(&self, key: K) {
+		let key = key.into();
+		// Locate the shard
+		let shard = key as usize % self.shards_count;
+		// Remove the key
+		let new_length = self.shards[shard].lock().await.remove(key);
+		// Update lengths
+		self.check_length(new_length, shard);
+	}
+
+	fn check_length(&self, new_length: usize, shard: usize) {
+		// Set the length for this shard
+		self.lengths[shard].store(new_length, Relaxed);
+		// Compute the total length
+		let total_length: usize = self.lengths.iter().map(|l| l.load(Relaxed)).sum();
+		// Check if the cache is full
+		self.full.store(total_length == self.capacity, Relaxed);
+	}
+
+	#[cfg(test)]
+	pub(super) fn len(&self) -> usize {
+		self.lengths.iter().map(|l| l.load(Relaxed)).sum()
+	}
+
+	pub(super) async fn duplicate<F>(&self, filter: F) -> Self
+	where
+		F: Fn(&CacheKey) -> bool + Copy,
+	{
+		// We cant the shards to be copied concurrently.
+		// So we create one future per shard.
+		let futures: Vec<_> = self
+			.shards
+			.iter()
+			.map(|s| async {
+				let shard = s.lock().await.duplicate(filter);
+				(shard.map.len(), Mutex::new(shard))
+			})
+			.collect();
+		let mut shards = Vec::with_capacity(self.shards_count);
+		let mut lengths = Vec::with_capacity(self.shards_count);
+		let mut total_lengths = 0;
+		for (length, shard) in join_all(futures).await {
+			shards.push(shard);
+			total_lengths += length;
+			lengths.push(length.into());
+		}
+		Self {
+			shards,
+			lengths,
+			full: AtomicBool::new(total_lengths >= self.capacity),
+			shards_count: self.shards_count,
+			capacity: self.capacity,
+		}
+	}
+}
+
+struct LruShard<T>
+where
+	T: Clone,
+{
+	map: HashMap<CacheKey, usize>,
+	vec: Vec<Option<(CacheKey, T)>>,
+}
+
+impl<T> LruShard<T>
+where
+	T: Clone,
+{
+	fn new() -> Self {
+		Self {
+			map: HashMap::new(),
+			vec: Vec::new(),
+		}
+	}
+
+	fn get_and_promote(&mut self, key: CacheKey) -> Option<T> {
+		if let Some(pos) = self.map.get(&key).copied() {
+			let val = self.vec[pos].clone();
+			if pos > 0 {
+				self.promote(key, pos);
+			}
+			val.map(|(_, v)| v.clone())
+		} else {
+			None
+		}
+	}
+
+	// The promotion implements a very low-cost strategy.
+	// Promotion is done by flipping the entry with the entry just before.
+	// Each time an entry is hit, its weight increase.
+	fn promote(&mut self, key: CacheKey, pos: usize) {
+		// Promotion is flipping the current entry with the entry before
+		let new_pos = pos - 1;
+		let flip_key = self.vec[new_pos].as_ref().map(|(k, _)| k).cloned();
+		self.vec.swap(pos, new_pos);
+		self.map.insert(key, new_pos);
+		if let Some(flip_key) = flip_key {
+			self.map.insert(flip_key, pos);
+		} else if pos == self.vec.len() - 1 {
+			self.vec.remove(pos);
+		}
+	}
+
+	fn insert(&mut self, key: CacheKey, val: T, replace: bool) -> usize {
+		if let Some(pos) = self.map.get(&key).copied() {
+			// If the entry is already there, just update it
+			self.vec[pos] = Some((key, val));
+		} else {
+			// If we reached the capacity
+			if replace {
+				// Find the last entry...
+				while !self.vec.is_empty() {
+					if let Some(Some((k, _v))) = self.vec.pop() {
+						// ... and remove it
+						self.map.remove(&k);
+						break;
+					}
+				}
+			}
+			// Now we can insert the new entry
+			let pos = self.vec.len();
+			self.vec.push(Some((key, val)));
+			// If it is the head
+			if pos == 0 {
+				// ...we just insert it
+				self.map.insert(key, pos);
+			} else {
+				// or we promote it
+				self.promote(key, pos);
+			}
+		}
+		self.map.len()
+	}
+
+	fn remove(&mut self, key: CacheKey) -> usize {
+		if let Some(pos) = self.map.remove(&key) {
+			if pos == self.vec.len() - 1 {
+				// If it is the last element, we can just remove it from the vec
+				self.vec.pop();
+			} else {
+				// Otherwise we set a placeholder
+				self.vec[pos] = None;
+			}
+		}
+		self.map.len()
+	}
+
+	/// Make a copy of this cache containing every entry for which the specified filter returns true.
+	fn duplicate<F>(&self, filter: F) -> Self
+	where
+		F: Fn(&CacheKey) -> bool,
+	{
+		let mut map = HashMap::with_capacity(self.map.len());
+		let mut vec = Vec::with_capacity(self.vec.len());
+		self.map.iter().filter(|&(k, _pos)| filter(k)).for_each(|(k, pos)| {
+			let new_pos = vec.len();
+			map.insert(*k, new_pos);
+			vec.push(self.vec[*pos].clone());
+		});
+		Self {
+			map,
+			vec,
+		}
+	}
+}
+#[cfg(test)]
+mod tests {
+	use super::ConcurrentLru;
+	use futures::future::join_all;
+	use test_log::test;
+
+	#[test(tokio::test)]
+	async fn test_minimal_tree_lru() {
+		let lru = ConcurrentLru::new(1);
+		assert_eq!(lru.len(), 0);
+		//
+		lru.insert(1u64, 'a').await;
+		assert_eq!(lru.len(), 1);
+		assert_eq!(lru.get(1u64).await, Some('a'));
+		//
+		lru.insert(2u64, 'b').await;
+		assert_eq!(lru.len(), 1);
+		assert_eq!(lru.get(1u64).await, None);
+		assert_eq!(lru.get(2u64).await, Some('b'));
+		//
+		lru.insert(2u64, 'c').await;
+		assert_eq!(lru.len(), 1);
+		assert_eq!(lru.get(2u64).await, Some('c'));
+		//
+		lru.remove(1u64).await;
+		assert_eq!(lru.len(), 1);
+		assert_eq!(lru.get(2u64).await, Some('c'));
+		//
+		lru.remove(2u64).await;
+		assert_eq!(lru.len(), 0);
+		assert_eq!(lru.get(1u64).await, None);
+		assert_eq!(lru.get(2u64).await, None);
+	}
+
+	#[test(tokio::test)]
+	async fn test_tree_lru() {
+		let lru = ConcurrentLru::new(4);
+		//
+		lru.insert(1u64, 'a').await;
+		lru.insert(2u64, 'b').await;
+		lru.insert(3u64, 'c').await;
+		lru.insert(4u64, 'd').await;
+		assert_eq!(lru.len(), 4);
+		assert_eq!(lru.get(1u64).await, Some('a'));
+		assert_eq!(lru.get(2u64).await, Some('b'));
+		assert_eq!(lru.get(3u64).await, Some('c'));
+		assert_eq!(lru.get(4u64).await, Some('d'));
+		//
+		lru.insert(5u64, 'e').await;
+		assert_eq!(lru.len(), 4);
+		assert_eq!(lru.get(1u64).await, None);
+		assert_eq!(lru.get(2u64).await, Some('b'));
+		assert_eq!(lru.get(3u64).await, Some('c'));
+		assert_eq!(lru.get(4u64).await, Some('d'));
+		assert_eq!(lru.get(5u64).await, Some('e'));
+		//
+		let lru = lru.duplicate(|k| *k != 3).await;
+		assert_eq!(lru.len(), 3);
+		assert_eq!(lru.get(1u64).await, None);
+		assert_eq!(lru.get(2u64).await, Some('b'));
+		assert_eq!(lru.get(3u64).await, None);
+		assert_eq!(lru.get(4u64).await, Some('d'));
+		assert_eq!(lru.get(5u64).await, Some('e'));
+	}
+
+	#[test(tokio::test(flavor = "multi_thread"))]
+	async fn concurrent_lru_test() {
+		let num_threads = 4;
+		let lru = ConcurrentLru::new(100);
+
+		let futures: Vec<_> = (0..num_threads)
+			.map(|_| async {
+				lru.insert(10u64, 'a').await;
+				lru.get(10u64).await;
+				lru.insert(20u64, 'b').await;
+				lru.remove(10u64).await;
+			})
+			.collect();
+
+		join_all(futures).await;
+
+		assert!(lru.get(10u64).await.is_none());
+		assert!(lru.get(20u64).await.is_some());
+	}
+}

--- a/core/src/idx/trees/store/mod.rs
+++ b/core/src/idx/trees/store/mod.rs
@@ -137,11 +137,12 @@ impl TreeNodeProvider {
 		}
 	}
 
-	async fn save<N>(&self, tx: &mut Transaction, node: &StoredNode<N>) -> Result<(), Error>
+	async fn save<N>(&self, tx: &mut Transaction, node: &mut StoredNode<N>) -> Result<(), Error>
 	where
 		N: TreeNode + Clone + Display,
 	{
 		let val = node.n.try_into_val()?;
+		node.size = val.len() as u32;
 		tx.set(node.key.clone(), val).await?;
 		Ok(())
 	}

--- a/core/src/idx/trees/store/mod.rs
+++ b/core/src/idx/trees/store/mod.rs
@@ -16,6 +16,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 
 pub type NodeId = u64;
+pub type StoreGeneration = u64;
 
 #[non_exhaustive]
 pub enum TreeStore<N>
@@ -32,7 +33,11 @@ impl<N> TreeStore<N>
 where
 	N: TreeNode + Debug + Display + Clone,
 {
-	pub async fn new(keys: TreeNodeProvider, cache: TreeCache<N>, tt: TransactionType) -> Self {
+	pub async fn new(
+		keys: TreeNodeProvider,
+		cache: Arc<TreeCache<N>>,
+		tt: TransactionType,
+	) -> Self {
 		match tt {
 			TransactionType::Read => Self::Read(TreeRead::new(cache)),
 			TransactionType::Write => Self::Write(TreeWrite::new(keys, cache)),
@@ -45,7 +50,7 @@ where
 		node_id: NodeId,
 	) -> Result<StoredNode<N>, Error> {
 		match self {
-			TreeStore::Write(w) => w.get_node_mut(tx, node_id).await,
+			Self::Write(w) => w.get_node_mut(tx, node_id).await,
 			_ => Err(Error::Unreachable("TreeStore::get_node_mut")),
 		}
 	}
@@ -56,7 +61,7 @@ where
 		node_id: NodeId,
 	) -> Result<Arc<StoredNode<N>>, Error> {
 		match self {
-			TreeStore::Read(r) => r.get_node(tx, node_id).await,
+			Self::Read(r) => r.get_node(tx, node_id).await,
 			_ => Err(Error::Unreachable("TreeStore::get_node")),
 		}
 	}
@@ -67,14 +72,14 @@ where
 		updated: bool,
 	) -> Result<(), Error> {
 		match self {
-			TreeStore::Write(w) => w.set_node(node, updated),
+			Self::Write(w) => w.set_node(node, updated),
 			_ => Err(Error::Unreachable("TreeStore::set_node")),
 		}
 	}
 
 	pub(in crate::idx) fn new_node(&mut self, id: NodeId, node: N) -> Result<StoredNode<N>, Error> {
 		match self {
-			TreeStore::Write(w) => Ok(w.new_node(id, node)),
+			Self::Write(w) => Ok(w.new_node(id, node)),
 			_ => Err(Error::Unreachable("TreeStore::new_node")),
 		}
 	}
@@ -85,15 +90,25 @@ where
 		node_key: Key,
 	) -> Result<(), Error> {
 		match self {
-			TreeStore::Write(w) => w.remove_node(node_id, node_key),
+			Self::Write(w) => w.remove_node(node_id, node_key),
 			_ => Err(Error::Unreachable("TreeStore::remove_node")),
 		}
 	}
 
-	pub async fn finish(&mut self, tx: &mut Transaction) -> Result<bool, Error> {
+	pub(super) fn cache(&self) -> Option<&TreeCache<N>> {
 		match self {
-			TreeStore::Write(w) => w.finish(tx).await,
-			_ => Ok(false),
+			Self::Write(w) => Some(w.cache()),
+			_ => None,
+		}
+	}
+	pub async fn finish(
+		&mut self,
+		tx: &mut Transaction,
+		new_generation: StoreGeneration,
+	) -> Result<Option<TreeCache<N>>, Error> {
+		match self {
+			Self::Write(w) => w.finish(tx, new_generation).await,
+			_ => Ok(None),
 		}
 	}
 }
@@ -135,12 +150,12 @@ impl TreeNodeProvider {
 		}
 	}
 
-	async fn save<N>(&self, tx: &mut Transaction, mut node: StoredNode<N>) -> Result<(), Error>
+	async fn save<N>(&self, tx: &mut Transaction, node: &StoredNode<N>) -> Result<(), Error>
 	where
 		N: TreeNode + Clone + Display,
 	{
 		let val = node.n.try_into_val()?;
-		tx.set(node.key, val).await?;
+		tx.set(node.key.clone(), val).await?;
 		Ok(())
 	}
 }
@@ -180,10 +195,11 @@ where
 }
 
 pub trait TreeNode: Debug + Clone + Display {
+	fn prepare_save(&mut self) {}
 	fn try_from_val(val: Val) -> Result<Self, Error>
 	where
 		Self: Sized;
-	fn try_into_val(&mut self) -> Result<Val, Error>;
+	fn try_into_val(&self) -> Result<Val, Error>;
 }
 
 #[derive(Clone)]
@@ -209,7 +225,7 @@ impl IndexStores {
 	pub(in crate::idx) async fn get_store_btree_fst(
 		&self,
 		keys: TreeNodeProvider,
-		generation: u64,
+		generation: StoreGeneration,
 		tt: TransactionType,
 		cache_size: usize,
 	) -> BTreeStore<FstKeys> {
@@ -217,10 +233,20 @@ impl IndexStores {
 		TreeStore::new(keys, cache, tt).await
 	}
 
+	pub(in crate::idx) async fn advance_store_btree_fst(
+		&self,
+		new_gen: StoreGeneration,
+		store: &BTreeStore<FstKeys>,
+	) {
+		if let Some(cache) = store.cache() {
+			self.0.btree_fst_caches.advance_cache(new_gen, cache).await;
+		}
+	}
+
 	pub(in crate::idx) async fn get_store_btree_trie(
 		&self,
 		keys: TreeNodeProvider,
-		generation: u64,
+		generation: StoreGeneration,
 		tt: TransactionType,
 		cache_size: usize,
 	) -> BTreeStore<TrieKeys> {
@@ -228,15 +254,33 @@ impl IndexStores {
 		TreeStore::new(keys, cache, tt).await
 	}
 
+	pub(in crate::idx) async fn advance_cache_btree_trie(
+		&self,
+		keys: &TreeNodeProvider,
+		new_cache: TreeCache<BTreeNode<TrieKeys>>,
+	) {
+		self.0.btree_trie_caches.new_cache(keys, new_cache).await;
+	}
+
 	pub(in crate::idx) async fn get_store_mtree(
 		&self,
 		keys: TreeNodeProvider,
-		generation: u64,
+		generation: StoreGeneration,
 		tt: TransactionType,
 		cache_size: usize,
 	) -> MTreeStore {
 		let cache = self.0.mtree_caches.get_cache(generation, &keys, cache_size).await;
 		TreeStore::new(keys, cache, tt).await
+	}
+
+	pub(in crate::idx) async fn advance_store_mtree(
+		&self,
+		new_gen: StoreGeneration,
+		store: &MTreeStore,
+	) {
+		if let Some(cache) = store.cache() {
+			self.0.mtree_caches.advance_cache(new_gen, cache).await;
+		}
 	}
 
 	pub(crate) async fn index_removed(
@@ -280,26 +324,26 @@ impl IndexStores {
 		let ikb = IndexKeyBase::new(opt, ix);
 		match ix.index {
 			Index::Search(_) => {
-				self.remove_search_cache(ikb).await;
+				self.remove_search_caches(ikb).await;
 			}
 			Index::MTree(_) => {
-				self.remove_mtree_cache(ikb).await;
+				self.remove_mtree_caches(ikb).await;
 			}
 			_ => {}
 		}
 		Ok(())
 	}
 
-	async fn remove_search_cache(&self, ikb: IndexKeyBase) {
-		self.0.btree_trie_caches.remove_cache(&TreeNodeProvider::DocIds(ikb.clone())).await;
-		self.0.btree_trie_caches.remove_cache(&TreeNodeProvider::DocLengths(ikb.clone())).await;
-		self.0.btree_trie_caches.remove_cache(&TreeNodeProvider::Postings(ikb.clone())).await;
-		self.0.btree_fst_caches.remove_cache(&TreeNodeProvider::Terms(ikb)).await;
+	async fn remove_search_caches(&self, ikb: IndexKeyBase) {
+		self.0.btree_trie_caches.remove_caches(&TreeNodeProvider::DocIds(ikb.clone())).await;
+		self.0.btree_trie_caches.remove_caches(&TreeNodeProvider::DocLengths(ikb.clone())).await;
+		self.0.btree_trie_caches.remove_caches(&TreeNodeProvider::Postings(ikb.clone())).await;
+		self.0.btree_fst_caches.remove_caches(&TreeNodeProvider::Terms(ikb)).await;
 	}
 
-	async fn remove_mtree_cache(&self, ikb: IndexKeyBase) {
-		self.0.btree_trie_caches.remove_cache(&TreeNodeProvider::DocIds(ikb.clone())).await;
-		self.0.mtree_caches.remove_cache(&TreeNodeProvider::Vector(ikb.clone())).await;
+	async fn remove_mtree_caches(&self, ikb: IndexKeyBase) {
+		self.0.btree_trie_caches.remove_caches(&TreeNodeProvider::DocIds(ikb.clone())).await;
+		self.0.mtree_caches.remove_caches(&TreeNodeProvider::Vector(ikb.clone())).await;
 	}
 
 	pub async fn is_empty(&self) -> bool {

--- a/core/src/idx/trees/store/mod.rs
+++ b/core/src/idx/trees/store/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+mod lru;
 pub(crate) mod tree;
 
 use crate::dbs::Options;

--- a/core/src/idx/trees/store/tree.rs
+++ b/core/src/idx/trees/store/tree.rs
@@ -109,7 +109,7 @@ where
 			return Ok(None);
 		}
 		// Create a new cache hydrated with non-updated and non-removed previous cache entries.
-		let new_cache = self.cache.next_generation(&self.updated, &self.removed);
+		let new_cache = self.cache.next_generation(&self.updated, &self.removed).await;
 
 		let updated = mem::take(&mut self.updated);
 		for node_id in updated {
@@ -117,7 +117,7 @@ where
 				node.n.prepare_save();
 				self.np.save(tx, &node).await?;
 				// Update the cache with updated entries.
-				new_cache.set_node(node);
+				new_cache.set_node(node).await;
 			} else {
 				return Err(Error::Unreachable("TreeTransactionWrite::finish(2)"));
 			}
@@ -125,7 +125,7 @@ where
 		let removed = mem::take(&mut self.removed);
 		for (node_id, node_key) in removed {
 			tx.del(node_key).await?;
-			new_cache.remove_node(&node_id);
+			new_cache.remove_node(&node_id).await;
 		}
 
 		Ok(Some(new_cache))

--- a/core/src/idx/trees/store/tree.rs
+++ b/core/src/idx/trees/store/tree.rs
@@ -1,9 +1,10 @@
 use crate::err::Error;
 use crate::idx::trees::store::cache::TreeCache;
-use crate::idx::trees::store::{NodeId, StoreGeneration, StoredNode, TreeNode, TreeNodeProvider};
+use crate::idx::trees::store::{NodeId, StoredNode, TreeNode, TreeNodeProvider};
 use crate::kvs::{Key, Transaction};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
+use std::mem;
 use std::sync::Arc;
 
 #[non_exhaustive]
@@ -13,6 +14,7 @@ where
 {
 	np: TreeNodeProvider,
 	cache: Arc<TreeCache<N>>,
+	cached: HashSet<NodeId>,
 	nodes: HashMap<NodeId, StoredNode<N>>,
 	updated: HashSet<NodeId>,
 	removed: HashMap<NodeId, Key>,
@@ -24,20 +26,17 @@ impl<N> TreeWrite<N>
 where
 	N: TreeNode + Clone + Debug + Display,
 {
-	pub(super) fn new(keys: TreeNodeProvider, cache: Arc<TreeCache<N>>) -> Self {
+	pub(super) fn new(np: TreeNodeProvider, cache: Arc<TreeCache<N>>) -> Self {
 		Self {
-			np: keys,
+			np,
 			cache,
+			cached: HashSet::new(),
 			nodes: HashMap::new(),
 			updated: HashSet::new(),
 			removed: HashMap::new(),
 			#[cfg(debug_assertions)]
 			out: HashSet::new(),
 		}
-	}
-
-	pub(super) fn cache(&self) -> &TreeCache<N> {
-		&self.cache
 	}
 
 	pub(super) async fn get_node_mut(
@@ -47,33 +46,26 @@ where
 	) -> Result<StoredNode<N>, Error> {
 		#[cfg(debug_assertions)]
 		{
-			debug!("GET: {}", node_id);
 			self.out.insert(node_id);
 			if self.removed.contains_key(&node_id) {
 				return Err(Error::Unreachable("TreeTransactionWrite::get_node_mut"));
 			}
 		}
 		if let Some(n) = self.nodes.remove(&node_id) {
-			#[cfg(debug_assertions)]
-			debug!("GET (NODES): {}", n.n);
 			return Ok(n);
 		}
 		let r = self.cache.get_node(tx, node_id).await?;
-		#[cfg(debug_assertions)]
-		debug!("GET (CACHE): {}", r.n);
+		self.cached.insert(node_id);
 		Ok(StoredNode::new(r.n.clone(), r.id, r.key.clone(), r.size))
 	}
 
 	pub(super) fn set_node(&mut self, node: StoredNode<N>, updated: bool) -> Result<(), Error> {
 		#[cfg(debug_assertions)]
-		{
-			if updated {
-				debug!("SET {updated}: {node}");
-			}
-			self.out.remove(&node.id);
-		}
+		self.out.remove(&node.id);
+
 		if updated {
 			self.updated.insert(node.id);
+			self.cached.remove(&node.id);
 		}
 		if self.removed.contains_key(&node.id) {
 			return Err(Error::Unreachable("TreeTransactionWrite::set_node(2)"));
@@ -84,23 +76,21 @@ where
 
 	pub(super) fn new_node(&mut self, id: NodeId, node: N) -> StoredNode<N> {
 		#[cfg(debug_assertions)]
-		{
-			debug!("NEW: {}", id);
-			self.out.insert(id);
-		}
+		self.out.insert(id);
+
 		StoredNode::new(node, id, self.np.get_key(id), 0)
 	}
 
 	pub(super) fn remove_node(&mut self, node_id: NodeId, node_key: Key) -> Result<(), Error> {
 		#[cfg(debug_assertions)]
 		{
-			debug!("REMOVE: {}", node_id);
 			if self.nodes.contains_key(&node_id) {
 				return Err(Error::Unreachable("TreeTransactionWrite::remove_node"));
 			}
 			self.out.remove(&node_id);
 		}
 		self.updated.remove(&node_id);
+		self.cached.remove(&node_id);
 		self.removed.insert(node_id, node_key);
 		Ok(())
 	}
@@ -108,41 +98,36 @@ where
 	pub(super) async fn finish(
 		&mut self,
 		tx: &mut Transaction,
-		new_generation: StoreGeneration,
 	) -> Result<Option<TreeCache<N>>, Error> {
 		#[cfg(debug_assertions)]
 		{
-			debug!("finish");
 			if !self.out.is_empty() {
-				debug!("OUT: {:?}", self.out);
 				return Err(Error::Unreachable("TreeTransactionWrite::finish(1)"));
 			}
 		}
 		if self.updated.is_empty() && self.removed.is_empty() {
 			return Ok(None);
 		}
-		let new_cache = self.cache.new_generation(new_generation);
-		for node_id in &self.updated {
-			if let Some(mut node) = self.nodes.remove(node_id) {
-				#[cfg(debug_assertions)]
-				debug!("finish: tx.save {node_id}");
+		// Create a new cache hydrated with non-updated and non-removed previous cache entries.
+		let new_cache = self.cache.next_generation(&self.updated, &self.removed);
+
+		let updated = mem::take(&mut self.updated);
+		for node_id in updated {
+			if let Some(mut node) = self.nodes.remove(&node_id) {
 				node.n.prepare_save();
 				self.np.save(tx, &node).await?;
-				new_cache.set_node(node).await;
+				// Update the cache with updated entries.
+				new_cache.set_node(node);
 			} else {
 				return Err(Error::Unreachable("TreeTransactionWrite::finish(2)"));
 			}
 		}
-		self.updated.clear();
-		let node_ids: Vec<NodeId> = self.removed.keys().copied().collect();
-		for node_id in node_ids {
-			if let Some(node_key) = self.removed.remove(&node_id) {
-				#[cfg(debug_assertions)]
-				debug!("finish: tx.del {node_id}");
-				tx.del(node_key).await?;
-				new_cache.remove_node(node_id).await;
-			}
+		let removed = mem::take(&mut self.removed);
+		for (node_id, node_key) in removed {
+			tx.del(node_key).await?;
+			new_cache.remove_node(&node_id);
 		}
+
 		Ok(Some(new_cache))
 	}
 }

--- a/core/src/idx/trees/store/tree.rs
+++ b/core/src/idx/trees/store/tree.rs
@@ -115,7 +115,7 @@ where
 		for node_id in updated {
 			if let Some(mut node) = self.nodes.remove(&node_id) {
 				node.n.prepare_save();
-				self.np.save(tx, &node).await?;
+				self.np.save(tx, &mut node).await?;
 				// Update the cache with updated entries.
 				new_cache.set_node(node).await;
 			} else {

--- a/core/src/idx/trees/vector.rs
+++ b/core/src/idx/trees/vector.rs
@@ -1,11 +1,16 @@
 use crate::err::Error;
+use crate::fnc::util::math::deviation::deviation;
+use crate::fnc::util::math::mean::Mean;
 use crate::fnc::util::math::ToFloat;
-use crate::sql::index::VectorType;
-use crate::sql::Number;
+use crate::sql::index::{Distance, VectorType};
+use crate::sql::{Array, Number, Value};
 use revision::revisioned;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Borrow;
 use std::cmp::Ordering;
-use std::ops::Mul;
+use std::collections::HashSet;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::ops::{Mul, Sub};
 use std::sync::Arc;
 
 /// In the context of a Symmetric MTree index, the term object refers to a vector, representing the indexed item.
@@ -24,7 +29,96 @@ pub enum Vector {
 /// So the requirement is multiple ownership but not thread safety.
 /// However, because we are running in an async context, and because we are using cache structures that use the Arc as a key,
 /// the cached objects has to be Sent, which then requires the use of Arc (rather than just Rc).
-pub(crate) type SharedVector = Arc<Vector>;
+/// As computing the hash for a large vector is costly, this structures also caches the hashcode to avoid recomputing it.
+#[derive(Debug, Clone)]
+pub struct HashedSharedVector(Arc<Vector>, u64);
+impl From<Vector> for HashedSharedVector {
+	fn from(v: Vector) -> Self {
+		let mut h = DefaultHasher::new();
+		v.hash(&mut h);
+		Self(v.into(), h.finish())
+	}
+}
+
+impl Borrow<Vector> for &HashedSharedVector {
+	fn borrow(&self) -> &Vector {
+		self.0.as_ref()
+	}
+}
+
+impl Hash for HashedSharedVector {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		state.write_u64(self.1);
+	}
+}
+
+impl PartialEq for HashedSharedVector {
+	fn eq(&self, other: &Self) -> bool {
+		self.1 == other.1 && self.0 == other.0
+	}
+}
+impl Eq for HashedSharedVector {}
+
+impl PartialOrd for HashedSharedVector {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl Ord for HashedSharedVector {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.0.as_ref().cmp(other.0.as_ref())
+	}
+}
+
+impl Serialize for HashedSharedVector {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		// We only serialize the vector part, not the u64
+		self.0.serialize(serializer)
+	}
+}
+
+impl<'de> Deserialize<'de> for HashedSharedVector {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		// We deserialize into a vector and construct the struct
+		// assuming some default or dummy value for the u64, e.g., 0
+		let v = Vector::deserialize(deserializer)?;
+		Ok(v.into())
+	}
+}
+
+impl Hash for Vector {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		match self {
+			Vector::F64(v) => {
+				let h = v.iter().fold(0, |acc, &x| acc ^ x.to_bits());
+				state.write_u64(h);
+			}
+			Vector::F32(v) => {
+				let h = v.iter().fold(0, |acc, &x| acc ^ x.to_bits());
+				state.write_u32(h);
+			}
+			Vector::I64(v) => {
+				let h = v.iter().fold(0, |acc, &x| acc ^ x);
+				state.write_i64(h);
+			}
+			Vector::I32(v) => {
+				let h = v.iter().fold(0, |acc, &x| acc ^ x);
+				state.write_i32(h);
+			}
+			Vector::I16(v) => {
+				let h = v.iter().fold(0, |acc, &x| acc ^ x);
+				state.write_i16(h);
+			}
+		}
+	}
+}
 
 impl PartialEq for Vector {
 	fn eq(&self, other: &Self) -> bool {
@@ -70,41 +164,78 @@ impl Ord for Vector {
 }
 
 impl Vector {
-	pub(super) fn new(t: VectorType, l: usize) -> Self {
+	pub(super) fn new(t: VectorType, d: usize) -> Self {
 		match t {
-			VectorType::F64 => Self::F64(Vec::with_capacity(l)),
-			VectorType::F32 => Self::F32(Vec::with_capacity(l)),
-			VectorType::I64 => Self::I64(Vec::with_capacity(l)),
-			VectorType::I32 => Self::I32(Vec::with_capacity(l)),
-			VectorType::I16 => Self::I16(Vec::with_capacity(l)),
+			VectorType::F64 => Self::F64(Vec::with_capacity(d)),
+			VectorType::F32 => Self::F32(Vec::with_capacity(d)),
+			VectorType::I64 => Self::I64(Vec::with_capacity(d)),
+			VectorType::I32 => Self::I32(Vec::with_capacity(d)),
+			VectorType::I16 => Self::I16(Vec::with_capacity(d)),
 		}
 	}
 
-	pub(super) fn add(&mut self, n: Number) {
+	pub(super) fn try_from_value(t: VectorType, d: usize, v: &Value) -> Result<Self, Error> {
+		let mut vec = Vector::new(t, d);
+		vec.check_vector_value(v)?;
+		Ok(vec)
+	}
+
+	fn check_vector_value(&mut self, value: &Value) -> Result<(), Error> {
+		match value {
+			Value::Array(a) => {
+				for v in a.0.iter() {
+					self.check_vector_value(v)?;
+				}
+				Ok(())
+			}
+			Value::Number(n) => {
+				self.add(n);
+				Ok(())
+			}
+			_ => Err(Error::InvalidVectorValue(value.clone().to_raw_string())),
+		}
+	}
+
+	pub fn try_from_array(t: VectorType, a: &Array) -> Result<Self, Error> {
+		let mut vec = Vector::new(t, a.len());
+		for v in &a.0 {
+			if let Value::Number(n) = v {
+				vec.add(n);
+			} else {
+				return Err(Error::InvalidVectorType {
+					current: v.clone().to_string(),
+					expected: "Number",
+				});
+			}
+		}
+		Ok(vec)
+	}
+
+	pub(super) fn add(&mut self, n: &Number) {
 		match self {
-			Vector::F64(v) => v.push(n.to_float()),
-			Vector::F32(v) => v.push(n.to_float() as f32),
-			Vector::I64(v) => v.push(n.to_int()),
-			Vector::I32(v) => v.push(n.to_int() as i32),
-			Vector::I16(v) => v.push(n.to_int() as i16),
+			Self::F64(v) => v.push(n.to_float()),
+			Self::F32(v) => v.push(n.to_float() as f32),
+			Self::I64(v) => v.push(n.to_int()),
+			Self::I32(v) => v.push(n.to_int() as i32),
+			Self::I16(v) => v.push(n.to_int() as i16),
 		};
 	}
 
 	pub(super) fn len(&self) -> usize {
 		match self {
-			Vector::F64(v) => v.len(),
-			Vector::F32(v) => v.len(),
-			Vector::I64(v) => v.len(),
-			Vector::I32(v) => v.len(),
-			Vector::I16(v) => v.len(),
+			Self::F64(v) => v.len(),
+			Self::F32(v) => v.len(),
+			Self::I64(v) => v.len(),
+			Self::I32(v) => v.len(),
+			Self::I16(v) => v.len(),
 		}
 	}
 
-	fn check_same_dimension(fnc: &str, a: &Vector, b: &Vector) -> Result<(), Error> {
-		if a.len() != b.len() {
-			Err(Error::InvalidArguments {
-				name: String::from(fnc),
-				message: String::from("The two vectors must be of the same dimension."),
+	pub(super) fn check_expected_dimension(current: usize, expected: usize) -> Result<(), Error> {
+		if current != expected {
+			Err(Error::InvalidVectorDimension {
+				current,
+				expected,
 			})
 		} else {
 			Ok(())
@@ -170,82 +301,287 @@ impl Vector {
 		}
 	}
 
-	pub(super) fn euclidean_distance(&self, other: &Self) -> Result<f64, Error> {
-		Self::check_same_dimension("vector::distance::euclidean", self, other)?;
+	pub(super) fn check_dimension(&self, expected_dim: usize) -> Result<(), Error> {
+		Self::check_expected_dimension(self.len(), expected_dim)
+	}
+
+	fn chebyshev<T>(a: &[T], b: &[T]) -> f64
+	where
+		T: ToFloat,
+	{
+		a.iter()
+			.zip(b.iter())
+			.map(|(a, b)| (a.to_float() - b.to_float()).abs())
+			.fold(f64::MIN, f64::max)
+	}
+
+	pub(crate) fn chebyshev_distance(&self, other: &Self) -> f64 {
 		match (self, other) {
-			(Vector::F64(a), Vector::F64(b)) => {
-				Ok(a.iter().zip(b.iter()).map(|(a, b)| (a - b).powi(2)).sum::<f64>().sqrt())
-			}
-			(Vector::F32(a), Vector::F32(b)) => Ok(a
-				.iter()
-				.zip(b.iter())
-				.map(|(a, b)| (*a as f64 - *b as f64).powi(2))
-				.sum::<f64>()
-				.sqrt()),
-			(Vector::I64(a), Vector::I64(b)) => {
-				Ok((a.iter().zip(b.iter()).map(|(a, b)| (a - b).pow(2)).sum::<i64>() as f64).sqrt())
-			}
-			(Vector::I32(a), Vector::I32(b)) => {
-				Ok((a.iter().zip(b.iter()).map(|(a, b)| (a - b).pow(2)).sum::<i32>() as f64).sqrt())
-			}
-			(Vector::I16(a), Vector::I16(b)) => {
-				Ok((a.iter().zip(b.iter()).map(|(a, b)| (a - b).pow(2)).sum::<i16>() as f64).sqrt())
-			}
-			_ => Err(Error::Unreachable("Vector::euclidean_distance")),
+			(Self::F64(a), Self::F64(b)) => Self::chebyshev(a, b),
+			(Self::F32(a), Self::F32(b)) => Self::chebyshev(a, b),
+			(Self::I64(a), Self::I64(b)) => Self::chebyshev(a, b),
+			(Self::I32(a), Self::I32(b)) => Self::chebyshev(a, b),
+			(Self::I16(a), Self::I16(b)) => Self::chebyshev(a, b),
+			_ => f64::NAN,
 		}
 	}
 
-	pub(super) fn manhattan_distance(&self, other: &Self) -> Result<f64, Error> {
-		Self::check_same_dimension("vector::distance::manhattan", self, other)?;
+	fn euclidean<T>(a: &[T], b: &[T]) -> f64
+	where
+		T: ToFloat,
+	{
+		a.iter()
+			.zip(b.iter())
+			.map(|(a, b)| (a.to_float() - b.to_float()).powi(2))
+			.sum::<f64>()
+			.sqrt()
+	}
+
+	pub(crate) fn euclidean_distance(&self, other: &Self) -> f64 {
 		match (self, other) {
-			(Vector::F64(a), Vector::F64(b)) => {
-				Ok(a.iter().zip(b.iter()).map(|(a, b)| (a - b).abs()).sum())
-			}
-			(Vector::F32(a), Vector::F32(b)) => {
-				Ok(a.iter().zip(b.iter()).map(|(a, b)| (*a as f64 - *b as f64).abs()).sum::<f64>())
-			}
-			(Vector::I64(a), Vector::I64(b)) => {
-				Ok(a.iter().zip(b.iter()).map(|(a, b)| (a - b).abs()).sum::<i64>() as f64)
-			}
-			(Vector::I32(a), Vector::I32(b)) => {
-				Ok(a.iter().zip(b.iter()).map(|(a, b)| (a - b).abs()).sum::<i32>() as f64)
-			}
-			(Vector::I16(a), Vector::I16(b)) => {
-				Ok(a.iter().zip(b.iter()).map(|(a, b)| (a - b).abs()).sum::<i16>() as f64)
-			}
-			_ => Err(Error::Unreachable("Vector::manhattan_distance")),
+			(Self::F64(a), Self::F64(b)) => Self::euclidean(a, b),
+			(Self::F32(a), Self::F32(b)) => Self::euclidean(a, b),
+			(Self::I64(a), Self::I64(b)) => Self::euclidean(a, b),
+			(Self::I32(a), Self::I32(b)) => Self::euclidean(a, b),
+			(Self::I16(a), Self::I16(b)) => Self::euclidean(a, b),
+			_ => f64::INFINITY,
 		}
 	}
-	pub(super) fn minkowski_distance(&self, other: &Self, order: &Number) -> Result<f64, Error> {
-		Self::check_same_dimension("vector::distance::minkowski", self, other)?;
-		let dist = match (self, other) {
-			(Vector::F64(a), Vector::F64(b)) => a
-				.iter()
-				.zip(b.iter())
-				.map(|(a, b)| (a - b).abs().powf(order.to_float()))
-				.sum::<f64>(),
-			(Vector::F32(a), Vector::F32(b)) => a
-				.iter()
-				.zip(b.iter())
-				.map(|(a, b)| (a - b).abs().powf(order.to_float() as f32))
-				.sum::<f32>() as f64,
-			(Vector::I64(a), Vector::I64(b)) => a
-				.iter()
-				.zip(b.iter())
-				.map(|(a, b)| (a - b).abs().pow(order.to_int() as u32))
-				.sum::<i64>() as f64,
-			(Vector::I32(a), Vector::I32(b)) => a
-				.iter()
-				.zip(b.iter())
-				.map(|(a, b)| (a - b).abs().pow(order.to_int() as u32))
-				.sum::<i32>() as f64,
-			(Vector::I16(a), Vector::I16(b)) => a
-				.iter()
-				.zip(b.iter())
-				.map(|(a, b)| (a - b).abs().pow(order.to_int() as u32))
-				.sum::<i16>() as f64,
-			_ => return Err(Error::Unreachable("Vector::minkowski_distance")),
-		};
-		Ok(dist.powf(1.0 / order.to_float()))
+	fn hamming<T>(a: &[T], b: &[T]) -> f64
+	where
+		T: PartialEq,
+	{
+		a.iter().zip(b.iter()).filter(|&(a, b)| a != b).count() as f64
+	}
+
+	pub(crate) fn hamming_distance(&self, other: &Self) -> f64 {
+		match (self, other) {
+			(Self::F64(a), Self::F64(b)) => Self::hamming(a, b),
+			(Self::F32(a), Self::F32(b)) => Self::hamming(a, b),
+			(Self::I64(a), Self::I64(b)) => Self::hamming(a, b),
+			(Self::I32(a), Self::I32(b)) => Self::hamming(a, b),
+			(Self::I16(a), Self::I16(b)) => Self::hamming(a, b),
+			_ => f64::NAN,
+		}
+	}
+
+	fn jaccard_f64(a: &[f64], b: &[f64]) -> f64 {
+		let mut union: HashSet<u64> = HashSet::from_iter(a.iter().map(|f| f.to_bits()));
+		let intersection_size = b.iter().filter(|n| !union.insert(n.to_bits())).count() as f64;
+		intersection_size / union.len() as f64
+	}
+
+	fn jaccard_f32(a: &[f32], b: &[f32]) -> f64 {
+		let mut union: HashSet<u32> = HashSet::from_iter(a.iter().map(|f| f.to_bits()));
+		let intersection_size = b.iter().filter(|n| !union.insert(n.to_bits())).count() as f64;
+		intersection_size / union.len() as f64
+	}
+
+	fn jaccard_integers<T>(a: &[T], b: &[T]) -> f64
+	where
+		T: Eq + Hash,
+	{
+		let mut union: HashSet<&T> = HashSet::from_iter(a.iter());
+		let intersection_size = b.iter().filter(|n| !union.insert(n)).count() as f64;
+		intersection_size / union.len() as f64
+	}
+
+	pub(crate) fn jaccard_similarity(&self, other: &Self) -> f64 {
+		match (self, other) {
+			(Self::F64(a), Self::F64(b)) => Self::jaccard_f64(a, b),
+			(Self::F32(a), Self::F32(b)) => Self::jaccard_f32(a, b),
+			(Self::I64(a), Self::I64(b)) => Self::jaccard_integers(a, b),
+			(Self::I32(a), Self::I32(b)) => Self::jaccard_integers(a, b),
+			(Self::I16(a), Self::I16(b)) => Self::jaccard_integers(a, b),
+			_ => f64::NAN,
+		}
+	}
+
+	fn manhattan<T>(a: &[T], b: &[T]) -> f64
+	where
+		T: Sub<Output = T> + ToFloat + Copy,
+	{
+		a.iter().zip(b.iter()).map(|(&a, &b)| ((a - b).to_float()).abs()).sum()
+	}
+
+	pub(crate) fn manhattan_distance(&self, other: &Self) -> f64 {
+		match (self, other) {
+			(Self::F64(a), Self::F64(b)) => Self::manhattan(a, b),
+			(Self::F32(a), Self::F32(b)) => Self::manhattan(a, b),
+			(Self::I64(a), Self::I64(b)) => Self::manhattan(a, b),
+			(Self::I32(a), Self::I32(b)) => Self::manhattan(a, b),
+			(Self::I16(a), Self::I16(b)) => Self::manhattan(a, b),
+			_ => f64::NAN,
+		}
+	}
+
+	fn minkowski<T>(a: &[T], b: &[T], order: f64) -> f64
+	where
+		T: ToFloat,
+	{
+		let dist: f64 = a
+			.iter()
+			.zip(b.iter())
+			.map(|(a, b)| (a.to_float() - b.to_float()).abs().powf(order))
+			.sum();
+		dist.powf(1.0 / order)
+	}
+
+	pub(crate) fn minkowski_distance(&self, other: &Self, order: f64) -> f64 {
+		match (self, other) {
+			(Self::F64(a), Self::F64(b)) => Self::minkowski(a, b, order),
+			(Self::F32(a), Self::F32(b)) => Self::minkowski(a, b, order),
+			(Self::I64(a), Self::I64(b)) => Self::minkowski(a, b, order),
+			(Self::I32(a), Self::I32(b)) => Self::minkowski(a, b, order),
+			(Self::I16(a), Self::I16(b)) => Self::minkowski(a, b, order),
+			_ => f64::NAN,
+		}
+	}
+
+	fn pearson<T>(a: &[T], b: &[T]) -> f64
+	where
+		T: ToFloat,
+	{
+		let m1 = a.mean();
+		let m2 = b.mean();
+		let covar: f64 =
+			a.iter().zip(b.iter()).map(|(x, y)| (x.to_float() - m1) * (y.to_float() - m2)).sum();
+		let covar = covar / a.len() as f64;
+		let std_dev1 = deviation(a, m1, false);
+		let std_dev2 = deviation(b, m2, false);
+		covar / (std_dev1 * std_dev2)
+	}
+
+	fn pearson_similarity(&self, other: &Self) -> f64 {
+		match (self, other) {
+			(Self::F64(a), Self::F64(b)) => Self::pearson(a, b),
+			(Self::F32(a), Self::F32(b)) => Self::pearson(a, b),
+			(Self::I64(a), Self::I64(b)) => Self::pearson(a, b),
+			(Self::I32(a), Self::I32(b)) => Self::pearson(a, b),
+			(Self::I16(a), Self::I16(b)) => Self::pearson(a, b),
+			_ => f64::NAN,
+		}
+	}
+}
+impl Distance {
+	pub(super) fn calculate<V>(&self, a: V, b: V) -> f64
+	where
+		V: Borrow<Vector>,
+	{
+		match self {
+			Distance::Chebyshev => a.borrow().chebyshev_distance(b.borrow()),
+			Distance::Cosine => a.borrow().cosine_distance(b.borrow()),
+			Distance::Euclidean => a.borrow().euclidean_distance(b.borrow()),
+			Distance::Hamming => a.borrow().hamming_distance(b.borrow()),
+			Distance::Jaccard => a.borrow().jaccard_similarity(b.borrow()),
+			Distance::Manhattan => a.borrow().manhattan_distance(b.borrow()),
+			Distance::Minkowski(order) => {
+				a.borrow().minkowski_distance(b.borrow(), order.to_float())
+			}
+			Distance::Pearson => a.borrow().pearson_similarity(b.borrow()),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::idx::trees::knn::tests::{get_seed_rnd, new_random_vec, RandomItemGenerator};
+	use crate::idx::trees::vector::Vector;
+	use crate::sql::index::{Distance, VectorType};
+	use crate::sql::Array;
+
+	fn test_distance(dist: Distance, a1: &[f64], a2: &[f64], res: f64) {
+		// Convert the arrays to Vec<Number>
+		let mut v1 = vec![];
+		a1.iter().for_each(|&n| v1.push(n.into()));
+		let mut v2 = vec![];
+		a2.iter().for_each(|&n| v2.push(n.into()));
+
+		// Check the generic distance implementation
+		assert_eq!(dist.compute(&v1, &v2).unwrap(), res.into());
+
+		// Check the "Vector" optimised implementations
+		for t in [VectorType::F64] {
+			let v1 = Vector::try_from_array(t, &Array::from(v1.clone())).unwrap();
+			let v2 = Vector::try_from_array(t, &Array::from(v2.clone())).unwrap();
+			assert_eq!(dist.calculate(&v1, &v2), res);
+		}
+	}
+
+	fn test_distance_collection(dist: Distance, size: usize, dim: usize) {
+		let mut rng = get_seed_rnd();
+		for vt in
+			[VectorType::F64, VectorType::F32, VectorType::I64, VectorType::I32, VectorType::I16]
+		{
+			let gen = RandomItemGenerator::new(&dist, dim);
+			let mut num_zero = 0;
+			for i in 0..size {
+				let v1 = new_random_vec(&mut rng, vt, dim, &gen);
+				let v2 = new_random_vec(&mut rng, vt, dim, &gen);
+				let d = dist.calculate(&v1, &v2);
+				assert!(
+					d.is_finite() && !d.is_nan(),
+					"i: {i} - vt: {vt} - v1: {v1:?} - v2: {v2:?}"
+				);
+				assert_ne!(d, f64::NAN, "i: {i} - vt: {vt} - v1: {v1:?} - v2: {v2:?}");
+				assert_ne!(d, f64::INFINITY, "i: {i} - vt: {vt} - v1: {v1:?} - v2: {v2:?}");
+				if d == 0.0 {
+					num_zero += 1;
+				}
+			}
+			let zero_rate = num_zero as f64 / size as f64;
+			assert!(zero_rate < 0.1, "vt: {vt} - zero_rate: {zero_rate}");
+		}
+	}
+
+	#[test]
+	fn test_distance_chebyshev() {
+		test_distance_collection(Distance::Chebyshev, 2000, 1536);
+		test_distance(Distance::Chebyshev, &[1.0, 2.0, 3.0], &[2.0, 3.0, 4.0], 1.0);
+	}
+
+	#[test]
+	fn test_distance_cosine() {
+		test_distance_collection(Distance::Cosine, 2000, 1536);
+		test_distance(Distance::Cosine, &[1.0, 2.0, 3.0], &[2.0, 3.0, 4.0], 0.007416666029069652);
+	}
+
+	#[test]
+	fn test_distance_euclidean() {
+		test_distance_collection(Distance::Euclidean, 2000, 1536);
+		test_distance(Distance::Euclidean, &[1.0, 2.0, 3.0], &[2.0, 3.0, 4.0], 1.7320508075688772);
+	}
+
+	#[test]
+	fn test_distance_hamming() {
+		test_distance_collection(Distance::Hamming, 2000, 1536);
+		test_distance(Distance::Hamming, &[1.0, 2.0, 3.0], &[2.0, 3.0, 4.0], 3.0);
+	}
+
+	#[test]
+	fn test_distance_jaccard() {
+		test_distance_collection(Distance::Jaccard, 1000, 768);
+		test_distance(Distance::Jaccard, &[1.0, 2.0, 3.0], &[2.0, 3.0, 4.0], 0.5);
+	}
+	#[test]
+	fn test_distance_manhattan() {
+		test_distance_collection(Distance::Manhattan, 2000, 1536);
+		test_distance(Distance::Manhattan, &[1.0, 2.0, 3.0], &[2.0, 3.0, 4.0], 3.0);
+	}
+	#[test]
+	fn test_distance_minkowski() {
+		test_distance_collection(Distance::Minkowski(3.into()), 2000, 1536);
+		test_distance(
+			Distance::Minkowski(3.into()),
+			&[1.0, 2.0, 3.0],
+			&[2.0, 3.0, 4.0],
+			1.4422495703074083,
+		);
+	}
+
+	#[test]
+	fn test_distance_pearson() {
+		test_distance_collection(Distance::Pearson, 2000, 1536);
+		test_distance(Distance::Pearson, &[1.0, 2.0, 3.0], &[2.0, 3.0, 4.0], 1.0);
 	}
 }

--- a/core/src/idx/trees/vector.rs
+++ b/core/src/idx/trees/vector.rs
@@ -31,8 +31,8 @@ pub enum Vector {
 /// the cached objects has to be Sent, which then requires the use of Arc (rather than just Rc).
 /// As computing the hash for a large vector is costly, this structures also caches the hashcode to avoid recomputing it.
 #[derive(Debug, Clone)]
-pub struct HashedSharedVector(Arc<Vector>, u64);
-impl From<Vector> for HashedSharedVector {
+pub struct SharedVector(Arc<Vector>, u64);
+impl From<Vector> for SharedVector {
 	fn from(v: Vector) -> Self {
 		let mut h = DefaultHasher::new();
 		v.hash(&mut h);
@@ -40,38 +40,38 @@ impl From<Vector> for HashedSharedVector {
 	}
 }
 
-impl Borrow<Vector> for &HashedSharedVector {
+impl Borrow<Vector> for &SharedVector {
 	fn borrow(&self) -> &Vector {
 		self.0.as_ref()
 	}
 }
 
-impl Hash for HashedSharedVector {
+impl Hash for SharedVector {
 	fn hash<H: Hasher>(&self, state: &mut H) {
 		state.write_u64(self.1);
 	}
 }
 
-impl PartialEq for HashedSharedVector {
+impl PartialEq for SharedVector {
 	fn eq(&self, other: &Self) -> bool {
 		self.1 == other.1 && self.0 == other.0
 	}
 }
-impl Eq for HashedSharedVector {}
+impl Eq for SharedVector {}
 
-impl PartialOrd for HashedSharedVector {
+impl PartialOrd for SharedVector {
 	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
 		Some(self.cmp(other))
 	}
 }
 
-impl Ord for HashedSharedVector {
+impl Ord for SharedVector {
 	fn cmp(&self, other: &Self) -> Ordering {
 		self.0.as_ref().cmp(other.0.as_ref())
 	}
 }
 
-impl Serialize for HashedSharedVector {
+impl Serialize for SharedVector {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: Serializer,
@@ -81,7 +81,7 @@ impl Serialize for HashedSharedVector {
 	}
 }
 
-impl<'de> Deserialize<'de> for HashedSharedVector {
+impl<'de> Deserialize<'de> for SharedVector {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: Deserializer<'de>,

--- a/core/src/sql/index.rs
+++ b/core/src/sql/index.rs
@@ -1,6 +1,6 @@
 use crate::err::Error;
 use crate::fnc::util::math::vector::{
-	ChebyshevDistance, CosineSimilarity, EuclideanDistance, HammingDistance, JaccardSimilarity,
+	ChebyshevDistance, CosineDistance, EuclideanDistance, HammingDistance, JaccardSimilarity,
 	ManhattanDistance, MinkowskiDistance, PearsonSimilarity,
 };
 use crate::sql::ident::Ident;
@@ -118,7 +118,7 @@ pub enum Distance {
 impl Distance {
 	pub(crate) fn compute(&self, v1: &Vec<Number>, v2: &Vec<Number>) -> Result<Number, Error> {
 		match self {
-			Self::Cosine => v1.cosine_similarity(v2),
+			Self::Cosine => v1.cosine_distance(v2),
 			Self::Chebyshev => v1.chebyshev_distance(v2),
 			Self::Euclidean => v1.euclidean_distance(v2),
 			Self::Hamming => v1.hamming_distance(v2),

--- a/core/src/sql/number.rs
+++ b/core/src/sql/number.rs
@@ -1,5 +1,6 @@
 use super::value::{TryAdd, TryDiv, TryMul, TryNeg, TryPow, TryRem, TrySub};
 use crate::err::Error;
+use crate::fnc::util::math::ToFloat;
 use crate::sql::strand::Strand;
 use revision::revisioned;
 use rust_decimal::prelude::*;
@@ -733,5 +734,11 @@ impl Sort for Vec<Number> {
 	fn sorted(&mut self) -> Sorted<&Vec<Number>> {
 		self.sort();
 		Sorted(self)
+	}
+}
+
+impl ToFloat for Number {
+	fn to_float(&self) -> f64 {
+		self.to_float()
 	}
 }

--- a/core/src/sql/regex.rs
+++ b/core/src/sql/regex.rs
@@ -1,6 +1,5 @@
 use once_cell::sync::Lazy;
-use quick_cache::sync::Cache;
-use quick_cache::GuardResult;
+use quick_cache::sync::{Cache, GuardResult};
 use revision::revisioned;
 use serde::{
 	de::{self, Visitor},

--- a/core/src/syn/lexer/keywords.rs
+++ b/core/src/syn/lexer/keywords.rs
@@ -1,3 +1,4 @@
+use crate::syn::token::VectorTypeKind;
 use crate::{
 	sql::change_feed_include::ChangeFeedInclude,
 	sql::{language::Language, Algorithm},
@@ -341,6 +342,13 @@ pub(crate) static KEYWORDS: phf::Map<UniCase<&'static str>, TokenKind> = phf_map
 	UniCase::ascii("MANHATTAN") => TokenKind::Distance(DistanceKind::Manhattan),
 	UniCase::ascii("MINKOWSKI") => TokenKind::Distance(DistanceKind::Minkowski),
 	UniCase::ascii("PEARSON") => TokenKind::Distance(DistanceKind::Pearson),
+
+	// VectorTypes
+	UniCase::ascii("F64") => TokenKind::VectorType(VectorTypeKind::F64),
+	UniCase::ascii("F32") => TokenKind::VectorType(VectorTypeKind::F32),
+	UniCase::ascii("I64") => TokenKind::VectorType(VectorTypeKind::I64),
+	UniCase::ascii("I32") => TokenKind::VectorType(VectorTypeKind::I32),
+	UniCase::ascii("I16") => TokenKind::VectorType(VectorTypeKind::I16),
 
 	// Change Feed keywords
 	UniCase::ascii("ORIGINAL") => TokenKind::ChangeFeedInclude(ChangeFeedInclude::Original),

--- a/core/src/syn/parser/basic.rs
+++ b/core/src/syn/parser/basic.rs
@@ -21,7 +21,8 @@ impl TokenValue for Ident {
 			TokenKind::Keyword(_)
 			| TokenKind::Language(_)
 			| TokenKind::Algorithm(_)
-			| TokenKind::Distance(_) => {
+			| TokenKind::Distance(_)
+			| TokenKind::VectorType(_) => {
 				let str = parser.lexer.reader.span(token.span);
 				// Lexer should ensure that the token is valid utf-8
 				let str = std::str::from_utf8(str).unwrap().to_owned();

--- a/core/src/syn/parser/object.rs
+++ b/core/src/syn/parser/object.rs
@@ -653,7 +653,8 @@ impl Parser<'_> {
 			TokenKind::Keyword(_)
 			| TokenKind::Language(_)
 			| TokenKind::Algorithm(_)
-			| TokenKind::Distance(_) => {
+			| TokenKind::Distance(_)
+			| TokenKind::VectorType(_) => {
 				self.pop_peek();
 				let str = self.lexer.reader.span(token.span);
 				// Lexer should ensure that the token is valid utf-8

--- a/core/src/syn/parser/stmt/define.rs
+++ b/core/src/syn/parser/stmt/define.rs
@@ -639,31 +639,41 @@ impl Parser<'_> {
 					self.pop_peek();
 					expected!(self, t!("DIMENSION"));
 					let dimension = self.next_token_value()?;
-					let distance = self.try_parse_distance()?.unwrap_or(Distance::Euclidean);
-					let capacity = self
-						.eat(t!("CAPACITY"))
-						.then(|| self.next_token_value())
-						.transpose()?
-						.unwrap_or(40);
-
-					let doc_ids_order = self
-						.eat(t!("DOC_IDS_ORDER"))
-						.then(|| self.next_token_value())
-						.transpose()?
-						.unwrap_or(100);
-
-					let doc_ids_cache = self
-						.eat(t!("DOC_IDS_CACHE"))
-						.then(|| self.next_token_value())
-						.transpose()?
-						.unwrap_or(100);
-
-					let mtree_cache = self
-						.eat(t!("MTREE_CACHE"))
-						.then(|| self.next_token_value())
-						.transpose()?
-						.unwrap_or(100);
-
+					let mut distance = Distance::Euclidean;
+					let mut vector_type = VectorType::F64;
+					let mut capacity = 40;
+					let mut doc_ids_cache = 100;
+					let mut doc_ids_order = 100;
+					let mut mtree_cache = 100;
+					loop {
+						match self.peek_kind() {
+							t!("DISTANCE") => {
+								self.pop_peek();
+								distance = self.parse_distance()?
+							}
+							t!("TYPE") => {
+								self.pop_peek();
+								vector_type = self.parse_vector_type()?
+							}
+							t!("CAPACITY") => {
+								self.pop_peek();
+								capacity = self.next_token_value()?
+							}
+							t!("DOC_IDS_CACHE") => {
+								self.pop_peek();
+								doc_ids_cache = self.next_token_value()?
+							}
+							t!("DOC_IDS_ORDER") => {
+								self.pop_peek();
+								doc_ids_order = self.next_token_value()?
+							}
+							t!("MTREE_CACHE") => {
+								self.pop_peek();
+								mtree_cache = self.next_token_value()?
+							}
+							_ => break,
+						}
+					}
 					res.index = Index::MTree(crate::sql::index::MTreeParams {
 						dimension,
 						_distance: Default::default(),
@@ -672,7 +682,7 @@ impl Parser<'_> {
 						doc_ids_order,
 						doc_ids_cache,
 						mtree_cache,
-						vector_type: VectorType::F64,
+						vector_type,
 					})
 				}
 				t!("COMMENT") => {

--- a/core/src/syn/parser/stmt/parts.rs
+++ b/core/src/syn/parser/stmt/parts.rs
@@ -2,6 +2,8 @@
 
 use reblessive::Stk;
 
+use crate::sql::index::VectorType;
+use crate::syn::token::VectorTypeKind;
 use crate::{
 	sql::{
 		change_feed_include::ChangeFeedInclude, changefeed::ChangeFeed, index::Distance, Base,
@@ -407,6 +409,19 @@ impl Parser<'_> {
 		}
 
 		self.parse_distance().map(Some)
+	}
+
+	pub fn parse_vector_type(&mut self) -> ParseResult<VectorType> {
+		match self.next().kind {
+			TokenKind::VectorType(x) => Ok(match x {
+				VectorTypeKind::F64 => VectorType::F64,
+				VectorTypeKind::F32 => VectorType::F32,
+				VectorTypeKind::I64 => VectorType::I64,
+				VectorTypeKind::I32 => VectorType::I32,
+				VectorTypeKind::I16 => VectorType::I16,
+			}),
+			x => unexpected!(self, x, "a vector type"),
+		}
 	}
 
 	pub fn parse_custom_function_name(&mut self) -> ParseResult<Ident> {

--- a/core/src/syn/token/mod.rs
+++ b/core/src/syn/token/mod.rs
@@ -223,6 +223,28 @@ impl DistanceKind {
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
 #[non_exhaustive]
+pub enum VectorTypeKind {
+	F64,
+	F32,
+	I64,
+	I32,
+	I16,
+}
+
+impl VectorTypeKind {
+	pub fn as_str(&self) -> &'static str {
+		match self {
+			Self::F64 => "F64",
+			Self::F32 => "F32",
+			Self::I64 => "I64",
+			Self::I32 => "I32",
+			Self::I16 => "I16",
+		}
+	}
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[non_exhaustive]
 pub enum NumberKind {
 	// A plain integer number.
 	Integer,
@@ -250,6 +272,7 @@ pub enum TokenKind {
 	ChangeFeedInclude(ChangeFeedInclude),
 	Language(Language),
 	Distance(DistanceKind),
+	VectorType(VectorTypeKind),
 	Operator(Operator),
 	OpenDelim(Delim),
 	CloseDelim(Delim),
@@ -366,6 +389,7 @@ impl TokenKind {
 			TokenKind::Algorithm(x) => Self::algorithm_as_str(x),
 			TokenKind::Language(x) => x.as_str(),
 			TokenKind::Distance(x) => x.as_str(),
+			TokenKind::VectorType(x) => x.as_str(),
 			TokenKind::OpenDelim(Delim::Paren) => "(",
 			TokenKind::OpenDelim(Delim::Brace) => "{",
 			TokenKind::OpenDelim(Delim::Bracket) => "[",

--- a/lib/benches/index_btree.rs
+++ b/lib/benches/index_btree.rs
@@ -66,8 +66,9 @@ where
 	let ds = Datastore::new("memory").await.unwrap();
 	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
 	let mut t = BTree::<BK>::new(BState::new(100));
-	let c = TreeCache::new(0, TreeNodeProvider::Debug, cache_size);
-	let mut s = TreeStore::new(TreeNodeProvider::Debug, c, Write).await;
+	let np = TreeNodeProvider::Debug;
+	let c = TreeCache::new(0, np.get_key(0), np.clone(), cache_size);
+	let mut s = TreeStore::new(np, c.into(), Write).await;
 	for i in 0..samples_size {
 		let (key, payload) = sample_provider(i);
 		// Insert the sample

--- a/lib/benches/index_btree.rs
+++ b/lib/benches/index_btree.rs
@@ -19,7 +19,7 @@ fn bench_index_btree(c: &mut Criterion) {
 	let (samples_len, samples) = setup();
 
 	let mut group = c.benchmark_group("index_btree");
-	group.throughput(Throughput::Elements(1));
+	group.throughput(Throughput::Elements(samples_len as u64));
 	group.sample_size(10);
 	group.measurement_time(Duration::from_secs(30));
 

--- a/lib/benches/index_mtree.rs
+++ b/lib/benches/index_mtree.rs
@@ -7,8 +7,7 @@ use reblessive::TreeStack;
 use std::time::Duration;
 use surrealdb::idx::docids::DocId;
 use surrealdb::idx::trees::mtree::{MState, MTree};
-use surrealdb::idx::trees::store::cache::TreeCache;
-use surrealdb::idx::trees::store::{TreeNodeProvider, TreeStore};
+use surrealdb::idx::trees::store::TreeNodeProvider;
 use surrealdb::idx::trees::vector::Vector;
 use surrealdb::kvs::Datastore;
 use surrealdb::kvs::LockType::Optimistic;
@@ -127,8 +126,8 @@ async fn insert_objects(
 	let mut rng = thread_rng();
 	let mut t = mtree();
 	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	let c = TreeCache::new(0, TreeNodeProvider::Debug, cache_size);
-	let mut s = TreeStore::new(TreeNodeProvider::Debug, c.clone(), Write).await;
+	let ixs = ds.index_store();
+	let mut s = ixs.get_store_mtree(TreeNodeProvider::Debug, 0, Write, cache_size).await;
 	let mut stack = TreeStack::new();
 	stack.enter(|stk| async {
 		for i in 0..samples_size {
@@ -137,7 +136,9 @@ async fn insert_objects(
 			t.insert(stk, &mut tx, &mut s, object, i as DocId).await.unwrap();
 		}
 	});
-	s.finish(&mut tx).await.unwrap();
+	if let Some(new_cache) = s.finish(&mut tx).await.unwrap() {
+		ixs.advance_store_mtree(new_cache);
+	}
 	tx.commit().await.unwrap();
 }
 
@@ -151,8 +152,8 @@ async fn knn_lookup_objects(
 	let mut rng = thread_rng();
 	let t = mtree();
 	let mut tx = ds.transaction(Read, Optimistic).await.unwrap();
-	let c = TreeCache::new(0, TreeNodeProvider::Debug, cache_size);
-	let s = TreeStore::new(TreeNodeProvider::Debug, c, Read).await;
+	let ixs = ds.index_store();
+	let s = ixs.get_store_mtree(TreeNodeProvider::Debug, 0, Read, cache_size).await;
 	for _ in 0..samples_size {
 		let object = random_object(&mut rng, vector_size).into();
 		// Insert the sample

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -125,7 +125,7 @@ async fn remove_statement_index() -> Result<(), Error> {
 	}
 
 	// Every index store cache has been removed
-	assert!(dbs.index_store().is_empty().await);
+	assert!(dbs.index_store().is_empty());
 	Ok(())
 }
 

--- a/lib/tests/vector.rs
+++ b/lib/tests/vector.rs
@@ -12,7 +12,7 @@ async fn select_where_mtree_knn() -> Result<(), Error> {
 		CREATE pts:1 SET point = [1,2,3,4];
 		CREATE pts:2 SET point = [4,5,6,7];
 		CREATE pts:3 SET point = [8,9,10,11];
-		DEFINE INDEX mt_pts ON pts FIELDS point MTREE DIMENSION 4;
+		DEFINE INDEX mt_pts ON pts FIELDS point MTREE DIMENSION 4 TYPE F32;
 		LET $pt = [2,3,4,5];
 		SELECT id, vector::distance::euclidean(point, $pt) AS dist FROM pts WHERE point <|2|> $pt;
 		SELECT id FROM pts WHERE point <|2|> $pt EXPLAIN;
@@ -71,7 +71,7 @@ async fn delete_update_mtree_index() -> Result<(), Error> {
 		CREATE pts:1 SET point = [1,2,3,4];
 		CREATE pts:2 SET point = [4,5,6,7];
 		CREATE pts:3 SET point = [2,3,4,5];
-		DEFINE INDEX mt_pts ON pts FIELDS point MTREE DIMENSION 4;
+		DEFINE INDEX mt_pts ON pts FIELDS point MTREE DIMENSION 4 TYPE I32;
 		CREATE pts:4 SET point = [8,9,10,11];
 		DELETE pts:2;
 		UPDATE pts:3 SET point = [12,13,14,15];

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -6,6 +6,12 @@ who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
 criteria = "safe-to-deploy"
 version = "0.9.0"
 
+[[audits.hashlink]]
+who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
+criteria = "safe-to-deploy"
+version = "0.9.0"
+notes = "Unsafe code from handling its internal linked list. It currently passes tests under miri and sanitizers."
+
 [[audits.quick_cache]]
 who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,17 +1,6 @@
 
 # cargo-vet audits file
 
-[[audits.hashlink]]
-who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
-criteria = "safe-to-deploy"
-version = "0.9.0"
-
-[[audits.hashlink]]
-who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
-criteria = "safe-to-deploy"
-version = "0.9.0"
-notes = "Unsafe code from handling its internal linked list. It currently passes tests under miri and sanitizers."
-
 [[audits.quick_cache]]
 who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,11 @@
 
 # cargo-vet audits file
 
+[[audits.hashlink]]
+who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
+criteria = "safe-to-deploy"
+version = "0.9.0"
+
 [[audits.quick_cache]]
 who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,11 @@
 
 # cargo-vet audits file
 
+[[audits.quick_cache]]
+who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
+criteria = "safe-to-deploy"
+version = "0.5.1"
+
 [[audits.rustls]]
 who = "Tobie Morgan Hitchcock <tobie@surrealdb.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -244,10 +244,6 @@ version = "0.3.71"
 criteria = "safe-to-deploy"
 
 [[exemptions.base64]]
-version = "0.21.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.base64]]
 version = "0.22.0"
 criteria = "safe-to-deploy"
 
@@ -423,10 +419,6 @@ criteria = "safe-to-deploy"
 version = "0.18.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.core-foundation]]
-version = "0.9.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.cpp_demangle]]
 version = "0.4.3"
 criteria = "safe-to-deploy"
@@ -593,10 +585,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.fail]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.fastrand]]
-version = "2.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.figment]]
@@ -979,10 +967,6 @@ criteria = "safe-to-deploy"
 version = "0.4.11"
 criteria = "safe-to-deploy"
 
-[[exemptions.log]]
-version = "0.4.21"
-criteria = "safe-to-deploy"
-
 [[exemptions.loom]]
 version = "0.5.6"
 criteria = "safe-to-deploy"
@@ -1039,10 +1023,6 @@ criteria = "safe-to-deploy"
 version = "0.2.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.miniz_oxide]]
-version = "0.7.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.mio]]
 version = "0.8.11"
 criteria = "safe-to-deploy"
@@ -1089,10 +1069,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.num-complex]]
 version = "0.4.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.num-conv]]
-version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.num-format]]
@@ -1233,10 +1209,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.pin-project-internal]]
 version = "1.1.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.pin-project-lite]]
-version = "0.2.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.pkcs1]]
@@ -1623,10 +1595,6 @@ criteria = "safe-to-deploy"
 version = "2.10.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.semver]]
-version = "1.0.22"
-criteria = "safe-to-deploy"
-
 [[exemptions.send_wrapper]]
 version = "0.6.0"
 criteria = "safe-to-deploy"
@@ -1843,18 +1811,6 @@ criteria = "safe-to-run"
 version = "0.2.15"
 criteria = "safe-to-run"
 
-[[exemptions.thiserror]]
-version = "1.0.58"
-criteria = "safe-to-deploy"
-
-[[exemptions.thiserror-impl]]
-version = "1.0.58"
-criteria = "safe-to-deploy"
-
-[[exemptions.thread_local]]
-version = "1.1.8"
-criteria = "safe-to-deploy"
-
 [[exemptions.time]]
 version = "0.3.34"
 criteria = "safe-to-deploy"
@@ -2064,14 +2020,6 @@ version = "0.4.42"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
-version = "0.2.92"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.92"
-criteria = "safe-to-deploy"
-
-[[exemptions.wasm-bindgen-shared]]
 version = "0.2.92"
 criteria = "safe-to-deploy"
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -3,11 +3,11 @@
 
 [[unpublished.surrealdb]]
 version = "1.5.0"
-audited_as = "1.3.1"
+audited_as = "1.4.2"
 
 [[unpublished.surrealdb-core]]
 version = "2.0.0-1.5.0"
-audited_as = "1.3.1"
+audited_as = "2.0.0-1.4.2"
 
 [[publisher.addr]]
 version = "0.15.6"
@@ -37,6 +37,13 @@ user-id = 3788
 user-login = "emilio"
 user-name = "Emilio Cobos Álvarez"
 
+[[publisher.core-foundation]]
+version = "0.9.3"
+when = "2022-02-07"
+user-id = 5946
+user-login = "jrmuizel"
+user-name = "Jeff Muizelaar"
+
 [[publisher.core-foundation-sys]]
 version = "0.8.4"
 when = "2023-04-03"
@@ -54,13 +61,6 @@ user-name = "Nick Fitzgerald"
 [[publisher.dmp]]
 version = "0.2.0"
 when = "2023-05-19"
-user-id = 145457
-user-login = "tobiemh"
-user-name = "Tobie Morgan Hitchcock"
-
-[[publisher.echodb]]
-version = "0.4.0"
-when = "2023-03-26"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -101,22 +101,8 @@ user-login = "rushmorem"
 user-name = "Rushmore Mushambi"
 
 [[publisher.revision]]
-version = "0.5.0"
-when = "2023-08-29"
-user-id = 145457
-user-login = "tobiemh"
-user-name = "Tobie Morgan Hitchcock"
-
-[[publisher.revision]]
 version = "0.7.0"
 when = "2024-04-17"
-user-id = 145457
-user-login = "tobiemh"
-user-name = "Tobie Morgan Hitchcock"
-
-[[publisher.revision-derive]]
-version = "0.5.0"
-when = "2023-08-29"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -136,15 +122,15 @@ user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb]]
-version = "1.3.1"
-when = "2024-03-15"
+version = "1.4.2"
+when = "2024-04-19"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb-core]]
-version = "1.3.1"
-when = "2024-03-15"
+version = "2.0.0-1.4.2"
+when = "2024-04-19"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -162,20 +148,6 @@ when = "2023-08-29"
 user-id = 3987
 user-login = "rushmorem"
 user-name = "Rushmore Mushambi"
-
-[[publisher.surrealkv]]
-version = "0.1.3"
-when = "2024-02-22"
-user-id = 145457
-user-login = "tobiemh"
-user-name = "Tobie Morgan Hitchcock"
-
-[[publisher.surrealkv]]
-version = "0.1.4"
-when = "2024-04-10"
-user-id = 145457
-user-login = "tobiemh"
-user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealkv]]
 version = "0.1.5"
@@ -220,20 +192,6 @@ user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
 [[publisher.vart]]
-version = "0.1.1"
-when = "2024-02-10"
-user-id = 145457
-user-login = "tobiemh"
-user-name = "Tobie Morgan Hitchcock"
-
-[[publisher.vart]]
-version = "0.2.0"
-when = "2024-04-04"
-user-id = 145457
-user-login = "tobiemh"
-user-name = "Tobie Morgan Hitchcock"
-
-[[publisher.vart]]
 version = "0.2.1"
 when = "2024-04-24"
 user-id = 145457
@@ -275,6 +233,12 @@ criteria = "safe-to-deploy"
 version = "0.1.6"
 notes = "Contains no unsafe code, no IO, no build.rs."
 
+[[audits.bytecode-alliance.audits.base64]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.21.0"
+notes = "This crate has no dependencies, no build.rs, and contains no unsafe code."
+
 [[audits.bytecode-alliance.audits.block-buffer]]
 who = "Benjamin Bouvier <public@benj.me>"
 criteria = "safe-to-deploy"
@@ -311,6 +275,15 @@ who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
 delta = "0.3.0 -> 0.3.1"
 notes = "Just a dependency version bump and a bug fix for redox"
+
+[[audits.bytecode-alliance.audits.fastrand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0 -> 2.0.1"
+notes = """
+This update had a few doc updates but no otherwise-substantial source code
+updates.
+"""
 
 [[audits.bytecode-alliance.audits.fd-lock]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -391,6 +364,20 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.1.0"
 
+[[audits.bytecode-alliance.audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+notes = """
+This crate is a Rust implementation of zlib compression/decompression and has
+been used by default by the Rust standard library for quite some time. It's also
+a default dependency of the popular `backtrace` crate for decompressing debug
+information. This crate forbids unsafe code and does not otherwise access system
+resources. It's originally a port of the `miniz.c` library as well, and given
+its own longevity should be relatively hardened against some of the more common
+compression-related issues.
+"""
+
 [[audits.bytecode-alliance.audits.native-tls]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -452,6 +439,12 @@ criteria = "safe-to-deploy"
 version = "0.1.21"
 notes = "I am the author of this crate."
 
+[[audits.bytecode-alliance.audits.semver]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.0.17"
+notes = "plenty of unsafe pointer and vec tricks, but in well-structured and commented code that appears to be correct"
+
 [[audits.bytecode-alliance.audits.sharded-slab]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -462,6 +455,12 @@ notes = "I always really enjoy reading eliza's code, she left perfect comments a
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "1.4.1"
+
+[[audits.bytecode-alliance.audits.thread_local]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.1.4"
+notes = "uses unsafe to implement thread local storage of objects"
 
 [[audits.bytecode-alliance.audits.tinyvec]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -578,6 +577,18 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 version = "1.0.1"
 notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.thiserror]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.40"
+notes = "Wrapper over implementation crate, found no unsafe or ambient capabilities used"
+
+[[audits.embark-studios.audits.thiserror-impl]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.40"
+notes = "Found no unsafe or ambient capabilities used"
 
 [[audits.embark-studios.audits.utf8parse]]
 who = "Johan Andersson <opensource@embark-studios.com>"
@@ -786,6 +797,20 @@ criteria = "safe-to-deploy"
 delta = "0.1.0 -> 0.1.1"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.pin-project-lite]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+version = "0.2.9"
+notes = "Reviewed on https://fxrev.dev/824504"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.pin-project-lite]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.9 -> 0.2.13"
+notes = "Audited at https://fxrev.dev/946396"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.predicates-core]]
 who = "Max Lee <endlesspring@google.com>"
 criteria = "safe-to-run"
@@ -927,6 +952,21 @@ criteria = "safe-to-deploy"
 version = "0.9.4"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.isrg.audits.base64]]
+who = "Tim Geoghegan <timg@letsencrypt.org>"
+criteria = "safe-to-deploy"
+delta = "0.21.0 -> 0.21.1"
+
+[[audits.isrg.audits.base64]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.21.1 -> 0.21.2"
+
+[[audits.isrg.audits.base64]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.21.2 -> 0.21.3"
+
 [[audits.isrg.audits.block-buffer]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
@@ -1012,10 +1052,25 @@ who = "Ameer Ghani <inahga@divviup.org>"
 criteria = "safe-to-deploy"
 version = "1.12.1"
 
+[[audits.isrg.audits.thiserror]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.40 -> 1.0.43"
+
+[[audits.isrg.audits.thiserror-impl]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.40 -> 1.0.43"
+
 [[audits.isrg.audits.untrusted]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.7.1"
+
+[[audits.isrg.audits.wasm-bindgen-shared]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.2.83"
 
 [[audits.mozilla.wildcard-audits.cexpr]]
 who = "Emilio Cobos Álvarez <emilio@crisal.io>"
@@ -1024,6 +1079,16 @@ user-id = 3788 # Emilio Cobos Álvarez (emilio)
 start = "2021-06-21"
 end = "2024-04-21"
 notes = "No unsafe code, rather straight-forward parser."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.wildcard-audits.core-foundation]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 5946 # Jeff Muizelaar (jrmuizel)
+start = "2019-03-29"
+end = "2023-05-04"
+renew = false
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.wildcard-audits.core-foundation-sys]]
@@ -1142,6 +1207,13 @@ criteria = "safe-to-deploy"
 delta = "0.10.2 -> 0.10.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.core-foundation]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.3 -> 0.9.4"
+notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.crossbeam-channel]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -1176,6 +1248,12 @@ aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supp
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.1 -> 0.3.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.9.0 -> 2.0.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.fd-lock]]
@@ -1254,6 +1332,26 @@ criteria = "safe-to-deploy"
 version = "1.4.0"
 notes = "I have read over the macros, and audited the unsafe code."
 aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+version = "0.4.17"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.17 -> 0.4.18"
+notes = "One dependency removed, others updated (which we don't rely on), some APIs (which we don't use) changed."
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Kagami Sascha Rosylight <krosylight@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.18 -> 0.4.20"
+notes = "Only cfg attribute and internal macro changes and module refactorings"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-bigint]]
 who = "Josh Stone <jistone@redhat.com>"
@@ -1465,6 +1563,24 @@ criteria = "safe-to-deploy"
 delta = "2.4.1 -> 2.5.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.zcash.audits.base64]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.21.3 -> 0.21.4"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.base64]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.21.4 -> 0.21.5"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.base64]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.21.5 -> 0.21.7"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
 [[audits.zcash.audits.block-buffer]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -1476,6 +1592,12 @@ aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/suppl
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "0.3.3 -> 0.3.8"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.fastrand]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "2.0.1 -> 2.0.2"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.futures-channel]]
@@ -1509,6 +1631,30 @@ who = "Daira Hopwood <daira@jacaranda.org>"
 criteria = "safe-to-deploy"
 version = "0.1.3"
 notes = "Reviewed in full."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.log]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.20 -> 0.4.21"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.miniz_oxide]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.1 -> 0.7.2"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.num-conv]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.pin-project-lite]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.13 -> 0.2.14"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.quote]]
@@ -1550,6 +1696,30 @@ be set correctly by `cargo`.
 """
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
+[[audits.zcash.audits.semver]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.17 -> 1.0.18"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.semver]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.18 -> 1.0.19"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.semver]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.19 -> 1.0.20"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.semver]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.20 -> 1.0.22"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
 [[audits.zcash.audits.sharded-slab]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -1571,6 +1741,93 @@ aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/suppl
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "2.1.0 -> 2.2.0"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.43 -> 1.0.48"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.48 -> 1.0.51"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.51 -> 1.0.52"
+notes = "Reruns the build script if the `RUSTC_BOOTSTRAP` env variable changes."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.52 -> 1.0.56"
+notes = """
+Build script changes are to refactor the existing probe into a separate file
+(which removes a filesystem write), and adjust how it gets rerun in response to
+changes in the build environment.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.56 -> 1.0.58"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.43 -> 1.0.48"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.48 -> 1.0.51"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.51 -> 1.0.52"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.52 -> 1.0.56"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.56 -> 1.0.58"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thread_local]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "1.1.4 -> 1.1.7"
+notes = """
+New `unsafe` usage:
+- An extra `deallocate_bucket`, to replace a `Mutex::lock` with a `compare_exchange`.
+- Setting and getting a `#[thread_local] static mut Option<Thread>` on nightly.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thread_local]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "1.1.7 -> 1.1.8"
+notes = """
+Adds `unsafe` code that makes an assumption that `ptr::null_mut::<Entry<T>>()` is a valid representation
+of an `AtomicPtr<Entry<T>>`, but this is likely a correct assumption.
+"""
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.time-core]]
@@ -1613,4 +1870,35 @@ notes = """
 Migrates to `try-lock 0.2.4` to replace some unsafe APIs that were not marked
 `unsafe` (but that were being used safely).
 """
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.wasm-bindgen-macro-support]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+version = "0.2.92"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.wasm-bindgen-shared]]
+who = "Jack Grigg <jack@z.cash>"
+criteria = "safe-to-deploy"
+delta = "0.2.83 -> 0.2.84"
+notes = "Bumps the schema version to add `linked_modules`."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.wasm-bindgen-shared]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.84 -> 0.2.87"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.wasm-bindgen-shared]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.87 -> 0.2.89"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.wasm-bindgen-shared]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.89 -> 0.2.92"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -177,6 +177,13 @@ user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
+[[publisher.surrealkv]]
+version = "0.1.5"
+when = "2024-04-24"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
 [[publisher.surrealml-core]]
 version = "0.1.2"
 when = "2024-04-02"
@@ -222,6 +229,13 @@ user-name = "Tobie Morgan Hitchcock"
 [[publisher.vart]]
 version = "0.2.0"
 when = "2024-04-04"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.vart]]
+version = "0.2.1"
+when = "2024-04-24"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"


### PR DESCRIPTION
## What is the motivation?

Currently, the Tree cache (cache for BTree and MTree based indexes) is flushed with every new version of the index.
The cache is only effective on reads.

## What does this change do?

- Each time a new version of the index is created (due to writes), the cache is now recycled.
- HashMap replaces BTreeMap in the MTree index. Hashes are now precomputed for Vectors.
- A concurrent lightweight Lru optimised for the Tree structure has been implemented.
- The parameter TYPE setting the vector type is now properly accepted.
- MTree index parameters can be given in any order.

## What is your testing strategy?

Tests already testing the cache.

Ingestion & MTree indexing speed increased by a factor of 2.8.

Checked on ANN Benchmark (100,000 vectors, dimension 100, Euclidean): 1059 seconds down to 372 seconds.

## Is this related to any issues?

Fixes: #3945 
<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
