### PR TITLE
Add `type::is::nil` function

### DIFF
--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -335,6 +335,7 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"type::is::geometry" => r#type::is::geometry,
 		"type::is::int" => r#type::is::int,
 		"type::is::line" => r#type::is::line,
+		"type::is::nil" => r#type::is::nil,
 		"type::is::none" => r#type::is::none,
 		"type::is::null" => r#type::is::null,
 		"type::is::multiline" => r#type::is::multiline,

--- a/core/src/fnc/script/modules/surrealdb/functions/type/is.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/type/is.rs
@@ -18,6 +18,7 @@ impl_module_def!(
 	"geometry" => run,
 	"int" => run,
 	"line" => run,
+	"nil" => run,
 	"none" => run,
 	"null" => run,
 	"multiline" => run,

--- a/core/src/fnc/type.rs
+++ b/core/src/fnc/type.rs
@@ -271,6 +271,11 @@ pub mod is {
 		Ok(matches!(arg, Value::Geometry(Geometry::Line(_))).into())
 	}
 
+	pub fn nil((arg,): (Value,)) -> Result<Value, Error> {
+		let result = arg.is_none() || arg.is_null();
+		Ok(result.into())
+	}
+
 	pub fn none((arg,): (Value,)) -> Result<Value, Error> {
 		Ok(arg.is_none().into())
 	}

--- a/core/src/syn/parser/builtin.rs
+++ b/core/src/syn/parser/builtin.rs
@@ -326,6 +326,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("type::is::geometry") => PathKind::Function,
 		UniCase::ascii("type::is::int") => PathKind::Function,
 		UniCase::ascii("type::is::line") => PathKind::Function,
+		UniCase::ascii("type::is::nil") => PathKind::Function,
 		UniCase::ascii("type::is::null") => PathKind::Function,
 		UniCase::ascii("type::is::none") => PathKind::Function,
 		UniCase::ascii("type::is::multiline") => PathKind::Function,

--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -377,6 +377,7 @@
 "type::is::geometry("
 "type::is::int("
 "type::is::line("
+"type::is::nil("
 "type::is::none("
 "type::is::null("
 "type::is::multiline("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -375,6 +375,7 @@
 "type::is::geometry("
 "type::is::int("
 "type::is::line("
+"type::is::nil("
 "type::is::none("
 "type::is::null("
 "type::is::multiline("

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -5223,6 +5223,33 @@ async fn function_type_is_line() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn function_type_is_nil() -> Result<(), Error> {
+	let sql = r#"
+		RETURN type::is::nil(none);
+		RETURN type::is::nil(null);
+		RETURN type::is::nil("123");
+	"#;
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 3);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from(true);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from(true);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::from(false);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_type_is_none() -> Result<(), Error> {
 	let sql = r#"
 		RETURN type::is::none(none);


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Add a simple way to check for nullable (not truthy) values.
Note: can be useful for building an ORM.

## What does this change do?

Before:

```sql
WHERE (value != NONE AND value != null);
```

After:

```sql
WHERE !type::is::nil(value);
```

## What is your testing strategy?

Unit tests

## Is this related to any issues?

N/A

## Does this change need documentation?

- [x] https://github.com/surrealdb/docs.surrealdb.com/pull/525

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
