### PR TITLE
Add `array::shuffle` function

### DIFF
--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -12,6 +12,8 @@ use crate::sql::array::Union;
 use crate::sql::array::Uniq;
 use crate::sql::value::Value;
 
+use rand::prelude::SliceRandom;
+
 pub fn add((mut array, value): (Array, Value)) -> Result<Value, Error> {
 	match value {
 		Value::Array(value) => {
@@ -328,6 +330,12 @@ pub fn remove((mut array, mut index): (Array, i64)) -> Result<Value, Error> {
 
 pub fn reverse((mut array,): (Array,)) -> Result<Value, Error> {
 	array.reverse();
+	Ok(array.into())
+}
+
+pub fn shuffle((mut array,): (Array,)) -> Result<Value, Error> {
+	let mut rng = rand::thread_rng();
+	array.0.shuffle(&mut rng);
 	Ok(array.into())
 }
 

--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -125,6 +125,7 @@ pub fn synchronous(ctx: &Context<'_>, name: &str, args: Vec<Value>) -> Result<Va
 		"array::push" => array::push,
 		"array::remove" => array::remove,
 		"array::reverse" => array::reverse,
+		"array::shuffle" => array::shuffle,
 		"array::slice" => array::slice,
 		"array::sort" => array::sort,
 		"array::transpose" => array::transpose,

--- a/core/src/fnc/script/modules/surrealdb/functions/array.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/array.rs
@@ -45,6 +45,7 @@ impl_module_def!(
 	"prepend" => run,
 	"remove" => run,
 	"reverse" => run,
+	"shuffle" => run,
 	"slice" => run,
 	"sort" => (sort::Package),
 	"transpose" => run,

--- a/core/src/syn/parser/builtin.rs
+++ b/core/src/syn/parser/builtin.rs
@@ -115,6 +115,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("array::push") => PathKind::Function,
 		UniCase::ascii("array::remove") => PathKind::Function,
 		UniCase::ascii("array::reverse") => PathKind::Function,
+		UniCase::ascii("array::shuffle") => PathKind::Function,
 		UniCase::ascii("array::slice") => PathKind::Function,
 		UniCase::ascii("array::sort") => PathKind::Function,
 		UniCase::ascii("array::transpose") => PathKind::Function,

--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -184,6 +184,7 @@
 "array::push("
 "array::remove("
 "array::reverse("
+"array::shuffle("
 "array::slice("
 "array::sort("
 "array::sort::asc("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -184,6 +184,7 @@
 "array::push("
 "array::remove("
 "array::reverse("
+"array::shuffle("
 "array::slice("
 "array::sort("
 "array::sort::asc("


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Ability to create a random array from an existing one in a record.

## What does this change do?

Add `array::shuffle` function

## What is your testing strategy?

Unit tests

## Is this related to any issues?

N/A

## Does this change need documentation?

- [x] https://github.com/surrealdb/docs.surrealdb.com/pull/526

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
