### PR TITLE
Delete old change feed timestamps

### DIFF
--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -2927,12 +2927,16 @@ impl Transaction {
 				db,
 				sprint_key(k)
 			);
-			let k = crate::key::database::ts::Ts::decode(k)?;
-			let latest_ts = k.ts;
+			let latest_key = crate::key::database::ts::Ts::decode(k)?;
+			let latest_ts = latest_key.ts;
 			if latest_ts >= ts {
 				return Err(Error::Internal(
 					"ts is less than or equal to the latest ts".to_string(),
 				));
+			}
+			// now delete all expired keys
+			for (k, _) in ts_pairs {
+				self.del(k).await?;
 			}
 		}
 		self.set(ts_key, vs).await?;


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

In #3906 some users are facing a lot of pages related to timestamps associated with change feeds; If there are too many, then they are paged every time there is a poll (every 1s).

## What does this change do?

Remove expired timestamp entries

## What is your testing strategy?

Existing tests, unit-level integration test

## Is this related to any issues?

#3906 

## Does this change need documentation?

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
