### PR TITLE
Fix `FFLAGS` import and warnings in tests

### DIFF
--- a/core/src/kvs/lq_cf.rs
+++ b/core/src/kvs/lq_cf.rs
@@ -292,21 +292,18 @@ mod test {
 		tracker.register_live_query(&lq1, DEFAULT_WATERMARK).unwrap();
 
 		// Check watermark is "default"
-		let selector = {
-			let wms = tracker.get_watermarks();
-			assert_eq!(wms.len(), 1);
-			let (selector, watermark) = wms.iter().next().unwrap();
-			assert_eq!(
-				selector,
-				&LqSelector {
-					ns: NS.to_string(),
-					db: DB.to_string(),
-					tb: TB.to_string(),
-				}
-			);
-			assert_eq!(watermark, &DEFAULT_WATERMARK);
-			selector.clone()
-		};
+		let wms = tracker.get_watermarks();
+		assert_eq!(wms.len(), 1);
+		let (selector, watermark) = wms.iter().next().unwrap();
+		assert_eq!(
+			selector,
+			&LqSelector {
+				ns: NS.to_string(),
+				db: DB.to_string(),
+				tb: TB.to_string(),
+			}
+		);
+		assert_eq!(watermark, &DEFAULT_WATERMARK);
 
 		// Progress the watermark
 		let progressed_watermark = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];

--- a/core/src/kvs/lq_v2_doc.rs
+++ b/core/src/kvs/lq_v2_doc.rs
@@ -189,7 +189,6 @@ mod test_check_lqs_and_send_notifications {
 		ns: String,
 		db: String,
 		tb: String,
-		rid: Value,
 	}
 
 	async fn setup_test_suite_init() -> TestSuite {
@@ -222,7 +221,6 @@ mod test_check_lqs_and_send_notifications {
 			ns: ns.to_string(),
 			db: db.to_string(),
 			tb: tb.to_string(),
-			rid: Value::Thing(Thing::from(("user", "test"))),
 		}
 	}
 

--- a/core/src/kvs/tests/lq.rs
+++ b/core/src/kvs/tests/lq.rs
@@ -1,3 +1,4 @@
+use crate::fflags::FFLAGS;
 use crate::kvs::lq_structs::{LqIndexKey, LqIndexValue, LqSelector};
 use uuid::Uuid;
 

--- a/core/src/kvs/tests/mod.rs
+++ b/core/src/kvs/tests/mod.rs
@@ -34,7 +34,6 @@ type ClockType = Arc<SizedClock>;
 #[cfg(feature = "kv-mem")]
 mod mem {
 
-	use crate::fflags::FFLAGS;
 	use crate::kvs::tests::{ClockType, Kvs};
 	use crate::kvs::Datastore;
 	use crate::kvs::LockType;

--- a/core/src/kvs/tests/timestamp_to_versionstamp.rs
+++ b/core/src/kvs/tests/timestamp_to_versionstamp.rs
@@ -1,5 +1,3 @@
-use crate::key;
-
 // Timestamp to versionstamp tests
 // This translation mechanism is currently used by the garbage collector to determine which change feed entries to delete.
 //

--- a/lib/tests/api/live.rs
+++ b/lib/tests/api/live.rs
@@ -402,7 +402,7 @@ async fn receive_all_pending_notifications<
 	S: Stream<Item = Result<Notification<I>, Error>> + Unpin,
 	I,
 >(
-	mut stream: Arc<RwLock<S>>,
+	stream: Arc<RwLock<S>>,
 	timeout: Duration,
 ) -> Vec<Notification<I>> {
 	let (send, mut recv) = channel::<Notification<I>>(MAX_NOTIFICATIONS);

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -3,6 +3,7 @@ use surrealdb::sql::value;
 use surrealdb::sql::Thing;
 use surrealdb::sql::Value;
 
+#[allow(dead_code)]
 pub trait Parse<T> {
 	fn parse(val: &str) -> T;
 }


### PR DESCRIPTION
## What is the motivation?

The `FFLAGS` import sometimes causes a build failure when running tests.

## What does this change do?

It fixes the import and also fixes some warnings when running `make test`.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
