### PR TITLE
Fixes 3990

### DIFF
--- a/core/src/idx/planner/executor.rs
+++ b/core/src/idx/planner/executor.rs
@@ -332,9 +332,15 @@ impl QueryExecutor {
 		io: IndexOption,
 	) -> Result<Option<ThingIterator>, Error> {
 		Ok(match io.op() {
-			IndexOperator::Equality(value) => Some(ThingIterator::IndexEqual(
-				IndexEqualThingIterator::new(opt.ns(), opt.db(), &ix.what, &ix.name, value),
-			)),
+			IndexOperator::Equality(value) | IndexOperator::Exactness(value) => {
+				Some(ThingIterator::IndexEqual(IndexEqualThingIterator::new(
+					opt.ns(),
+					opt.db(),
+					&ix.what,
+					&ix.name,
+					value,
+				)))
+			}
 			IndexOperator::Union(value) => Some(ThingIterator::IndexUnion(
 				IndexUnionThingIterator::new(opt.ns(), opt.db(), &ix.what, &ix.name, value),
 			)),

--- a/core/src/idx/planner/plan.rs
+++ b/core/src/idx/planner/plan.rs
@@ -175,6 +175,7 @@ pub(super) struct IndexOption {
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub(super) enum IndexOperator {
 	Equality(Value),
+	Exactness(Value),
 	Union(Array),
 	Join(Vec<IndexOption>),
 	RangePart(Operator, Value),
@@ -230,6 +231,10 @@ impl IndexOption {
 		match self.op() {
 			IndexOperator::Equality(v) => {
 				e.insert("operator", Value::from(Operator::Equal.to_string()));
+				e.insert("value", Self::reduce_array(v));
+			}
+			IndexOperator::Exactness(v) => {
+				e.insert("operator", Value::from(Operator::Exact.to_string()));
 				e.insert("value", Self::reduce_array(v));
 			}
 			IndexOperator::Union(a) => {

--- a/core/src/idx/planner/tree.rs
+++ b/core/src/idx/planner/tree.rs
@@ -477,6 +477,7 @@ impl<'a> TreeBuilder<'a> {
 		if let Some(v) = n.is_computed() {
 			match (op, v, p) {
 				(Operator::Equal, v, _) => Some(IndexOperator::Equality(v.clone())),
+				(Operator::Exact, v, _) => Some(IndexOperator::Exactness(v.clone())),
 				(Operator::Contain, v, IdiomPosition::Left) => {
 					Some(IndexOperator::Equality(v.clone()))
 				}


### PR DESCRIPTION
## What is the motivation?

Bug #3990 

## What does this change do?

The query planner recognises the operator exact `==`

## What is your testing strategy?

A test has been added.

## Is this related to any issues?

Fixes #3990

## Does this change need documentation?

- [x] No documentation needed


## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
