### PR TITLE
Disable another flaky MTree test

### DIFF
--- a/core/src/idx/trees/mtree.rs
+++ b/core/src/idx/trees/mtree.rs
@@ -1759,6 +1759,7 @@ mod tests {
 	}
 
 	#[test(tokio::test(flavor = "multi_thread"))]
+	#[ignore]
 	async fn test_mtree_unique_small() -> Result<(), Error> {
 		let mut stack = reblessive::tree::TreeStack::new();
 		stack


### PR DESCRIPTION
## What is the motivation?

#4009 disabled `test_mtree_random_small`. `test_mtree_unique_small` is also flaky [as seen here](https://github.com/surrealdb/surrealdb/actions/runs/9030321944/job/24814357576#step:7:2283).

## What does this change do?

It disables the test.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
