### PR TITLE
Fixes math:min in foreign table

### DIFF
--- a/core/src/dbs/group.rs
+++ b/core/src/dbs/group.rs
@@ -380,7 +380,7 @@ impl Aggregator {
 			collections.push("math::min".into());
 		}
 		if self.math_sum.is_some() {
-			collections.push("math::sun".into());
+			collections.push("math::sum".into());
 		}
 		if self.time_max.is_some() {
 			collections.push("time::max".into());

--- a/core/src/fnc/operate.rs
+++ b/core/src/fnc/operate.rs
@@ -105,19 +105,19 @@ pub fn any_like(a: &Value, b: &Value) -> Result<Value, Error> {
 }
 
 pub fn less_than(a: &Value, b: &Value) -> Result<Value, Error> {
-	Ok(a.lt(b).into())
+	Ok((a.is_none_or_null() || b.is_none_or_null() || a.lt(b)).into())
 }
 
 pub fn less_than_or_equal(a: &Value, b: &Value) -> Result<Value, Error> {
-	Ok(a.le(b).into())
+	Ok((a.is_none_or_null() || b.is_none_or_null() || a.le(b)).into())
 }
 
 pub fn more_than(a: &Value, b: &Value) -> Result<Value, Error> {
-	Ok(a.gt(b).into())
+	Ok((a.is_none_or_null() || b.is_none_or_null() || a.gt(b)).into())
 }
 
 pub fn more_than_or_equal(a: &Value, b: &Value) -> Result<Value, Error> {
-	Ok(a.ge(b).into())
+	Ok((a.is_none_or_null() || b.is_none_or_null() || a.ge(b)).into())
 }
 
 pub fn contain(a: &Value, b: &Value) -> Result<Value, Error> {

--- a/lib/tests/group.rs
+++ b/lib/tests/group.rs
@@ -415,10 +415,10 @@ async fn select_multi_aggregate() -> Result<(), Error> {
 								'math::mean'
 							],
 							one: [
-								'math::sun'
+								'math::sum'
 							],
 							two: [
-								'math::sun'
+								'math::sum'
 							]
 						},
 						type: 'Group'
@@ -567,10 +567,10 @@ async fn select_multi_aggregate_composed() -> Result<(), Error> {
 								'first'
 							],
 							one: [
-								'math::sun'
+								'math::sum'
 							],
 							two: [
-								'math::sun'
+								'math::sum'
 							]
 						},
 						type: 'Group'

--- a/lib/tests/table.rs
+++ b/lib/tests/table.rs
@@ -15,7 +15,9 @@ async fn define_foreign_table() -> Result<(), Error> {
 				count(),
 				age,
 				math::sum(age) AS total,
-				math::mean(score) AS average
+				math::mean(score) AS average,
+				math::max(score) AS max,
+				math::min(score) AS min
 			FROM person
 			GROUP BY age
 		;
@@ -43,7 +45,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 		"{
 			events: {},
 			fields: {},
-			tables: { person_by_age: 'DEFINE TABLE person_by_age TYPE ANY SCHEMALESS AS SELECT count(), age, math::sum(age) AS total, math::mean(score) AS average FROM person GROUP BY age PERMISSIONS NONE' },
+			tables: { person_by_age: 'DEFINE TABLE person_by_age TYPE ANY SCHEMALESS AS SELECT count(), age, math::sum(age) AS total, math::mean(score) AS average, math::max(score) AS max, math::min(score) AS min FROM person GROUP BY age PERMISSIONS NONE' },
 			indexes: {},
 			lives: {},
 		}",
@@ -62,6 +64,8 @@ async fn define_foreign_table() -> Result<(), Error> {
 				average: 70,
 				count: 1,
 				id: person_by_age:[39],
+				max: 70,
+				min: 70,
 				total: 39
 			}
 		]",
@@ -80,6 +84,8 @@ async fn define_foreign_table() -> Result<(), Error> {
 				average: 75,
 				count: 2,
 				id: person_by_age:[39],
+				max: 80,
+				min: 70,
 				total: 78
 			}
 		]",
@@ -98,6 +104,8 @@ async fn define_foreign_table() -> Result<(), Error> {
 				average: 80,
 				count: 2,
 				id: person_by_age:[39],
+				max: 90,
+				min: 70,
 				total: 78
 			}
 		]",


### PR DESCRIPTION
## What is the motivation?

- `Math::min` does not work on foreign tables.
- Typo in function `math:sum`: was `math::sun`

Math::min failed because of this:

```
None < 70 = true
None > 70 = false
None <= 70 = true
None >= 70 = false
```

Therefore, the update command for min returns always `None`:

```sql
UPDATE person_by_age:[39] SET count += 1, age = 39, total += 39, 
    average = (((average ?? 0) * (__.`6927a3a7218a3195858411433ec20a21`.c ?? 0)) + 90) / ((__.`6927a3a7218a3195858411433ec20a21`.c ?? 0) + 1),
     __.`6927a3a7218a3195858411433ec20a21`.c += 1,
    max = IF max < 90 THEN 90 ELSE max END,
    min = IF min > 90 THEN 90 ELSE min END

[{ age: 39, average: 80, count: 2, id: person_by_age:[39], max: 90, min: 70, total: 78 }]
```

## What does this change do?

Fixes above.

Now: 

```
None < 70 = true
None > 70 = true
None <= 70 = true
None >= 70 = true
```


## What is your testing strategy?

A test has been updated including `math::min`

## Is this related to any issues?

Fixes #3974

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
