### PR TITLE
Fixes #3950

### DIFF
--- a/core/src/syn/lexer/uuid.rs
+++ b/core/src/syn/lexer/uuid.rs
@@ -15,7 +15,7 @@ pub enum Error {
 	InvalidRange,
 	#[error("expected uuid-strand to end")]
 	ExpectedStrandEnd,
-	#[error("missing a uuid seperator")]
+	#[error("missing a uuid separator")]
 	MissingSeperator,
 }
 


### PR DESCRIPTION
## What is the motivation?

The query planner does not evaluate non boolean expressions. Therefore it can't trigger an execution plan that would include an index.

## What does this change do?

...

## What is your testing strategy?

A test has been written.

## Is this related to any issues?

Fixes #3950

## Does this change need documentation?

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
