### PR TITLE
Fix patch workflow permissions

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-tag }}
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Install a TOML parser
         run: |


### PR DESCRIPTION
## What is the motivation?

The patch workflow is currently broken due to changes in Github permission system.

## What does this change do?

It switches to a custom token.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
