### PR TITLE
Remove `github.ref_name` from the nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@
 
 name: Nightly release
 
-run-name: "Nightly release '${{ inputs.git-ref || github.ref_name }}' (publish: ${{ inputs.publish || github.event_name == 'schedule' }})"
+run-name: "Nightly release '${{ inputs.git-ref }}' (publish: ${{ inputs.publish || github.event_name == 'schedule' }})"
 
 on:
   workflow_dispatch:
@@ -34,6 +34,6 @@ jobs:
     with:
       environment: nightly
       extra-features: storage-surrealkv
-      git-ref: ${{ inputs.git-ref || github.ref_name }}
+      git-ref: ${{ inputs.git-ref }}
       publish: ${{ inputs.publish || github.event_name == 'schedule' }}
     secrets: inherit


### PR DESCRIPTION
## What is the motivation?

It's causing the scheduled nightly workflow to run against `main` instead of `1.x`.

## What does this change do?

It removes it to ensure only `git-ref` is used. 

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
