### PR TITLE
Serialisation size checks for large vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5887,6 +5887,7 @@ dependencies = [
  "async-channel 1.9.0",
  "bincode",
  "chrono",
+ "ciborium",
  "criterion",
  "dmp",
  "env_logger 0.10.2",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -113,6 +113,7 @@ url = "2.5.0"
 reblessive = { version = "0.3.5", features = ["tree"] }
 
 [dev-dependencies]
+ciborium = "0.2.1"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 env_logger = "0.10.1"
 flate2 = "1.0.28"

--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -597,6 +597,7 @@ mod tests {
 	use super::serialize;
 	use flate2::write::GzEncoder;
 	use flate2::Compression;
+	use rand::{thread_rng, Rng};
 	use std::io::Write;
 	use std::time::SystemTime;
 	use surrealdb_core::rpc::format::cbor::Cbor;
@@ -616,10 +617,16 @@ mod tests {
 			encoder.finish().unwrap()
 		};
 
-		// Native vector
-		let mut vector = Vec::new();
-		for i in 0..1_900_000 {
-			vector.push(i);
+		// Generate a random vector
+		let vector_size = if cfg!(debug_assertions) {
+			2_000_000 // Debug is slow
+		} else {
+			2_000_000 // Release is fast
+		};
+		let mut vector: Vec<i32> = Vec::new();
+		let mut rng = thread_rng();
+		for _ in 0..vector_size {
+			vector.push(rng.gen());
 		}
 
 		// Bincode Vec<i32>
@@ -668,7 +675,7 @@ mod tests {
 		let (compression_duration, payload) = timed(&|| compress(&payload));
 		let duration = duration + compression_duration;
 		info!(
-			"Compressed Versioned vec<Value> - Size: {} - Duration: {duration:?} - Factor: {}",
+			"Compressed Versioned Vec<Value> - Size: {} - Duration: {duration:?} - Factor: {}",
 			payload.len(),
 			payload.len() as f32 / ref_compressed
 		);
@@ -690,7 +697,7 @@ mod tests {
 		let (compression_duration, payload) = timed(&|| compress(&payload));
 		let duration = duration + compression_duration;
 		info!(
-			"Compressed CBor vec<Value> - Size: {} - Duration: {duration:?} - Factor: {}",
+			"Compressed CBor Vec<Value> - Size: {} - Duration: {duration:?} - Factor: {}",
 			payload.len(),
 			payload.len() as f32 / ref_compressed
 		);

--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -634,23 +634,40 @@ mod tests {
 		let ref_payload;
 		let ref_compressed;
 		//
-		const BINCODE: &str = "Bincode Vec<i32>";
-		const COMPRESSED_BINCODE: &str = "Compressed Bincode Vec<i32>";
+		const BINCODE_REF: &str = "Bincode Vec<i32>";
+		const COMPRESSED_BINCODE_REF: &str = "Compressed Bincode Vec<i32>";
 		{
 			// Bincode Vec<i32>
 			let (duration, payload) = timed(&|| bincode::serialize(&vector).unwrap());
 			ref_payload = payload.len() as f32;
-			results.push((payload.len(), BINCODE, duration, 1.0));
+			results.push((payload.len(), BINCODE_REF, duration, 1.0));
 
 			// Compressed bincode
 			let (compression_duration, payload) = timed(&|| compress(&payload));
 			let duration = duration + compression_duration;
 			ref_compressed = payload.len() as f32;
-			results.push((payload.len(), COMPRESSED_BINCODE, duration, 1.0));
+			results.push((payload.len(), COMPRESSED_BINCODE_REF, duration, 1.0));
 		}
 		// Build the Value
 		let vector = Value::Array(Array::from(vector));
 		//
+		const BINCODE: &str = "Bincode Vec<Value>";
+		const COMPRESSED_BINCODE: &str = "Compressed Bincode Vec<Value>";
+		{
+			// Bincode Vec<i32>
+			let (duration, payload) = timed(&|| bincode::serialize(&vector).unwrap());
+			results.push((payload.len(), BINCODE, duration, payload.len() as f32 / ref_payload));
+
+			// Compressed bincode
+			let (compression_duration, payload) = timed(&|| compress(&payload));
+			let duration = duration + compression_duration;
+			results.push((
+				payload.len(),
+				COMPRESSED_BINCODE,
+				duration,
+				payload.len() as f32 / ref_compressed,
+			));
+		}
 		const UNVERSIONED: &str = "Unversioned Vec<Value>";
 		const COMPRESSED_UNVERSIONED: &str = "Compressed Unversioned Vec<Value>";
 		{
@@ -724,14 +741,16 @@ mod tests {
 		assert_eq!(
 			results,
 			vec![
-				BINCODE,
-				COMPRESSED_BINCODE,
+				BINCODE_REF,
+				COMPRESSED_BINCODE_REF,
 				COMPRESSED_CBOR,
 				COMPRESSED_UNVERSIONED,
 				CBOR,
 				COMPRESSED_VERSIONED,
+				COMPRESSED_BINCODE,
 				UNVERSIONED,
-				VERSIONED
+				VERSIONED,
+				BINCODE
 			]
 		)
 	}


### PR DESCRIPTION
## What is the motivation?

We want to monitor the serialisation cost for large vectors.

## What does this change do?

It implements a test checking that the hierarchy between the possible serialisation is preserved.
It compares the size of different serialized strategy to  reference, a `Vec<i32>` serialised with bincode with the best options.

## What is your testing strategy?

A test has been written. Here are the results run in local with -r.

```bash
export RUST_LOG=info
cargo test -r  --package surrealdb --lib api::engine::remote::ws::native::tests::large_vector_serialisation_bench --show-output

Bincode Vec<i32> - Size: 8000008 - Duration: 1.789ms - Factor: 1
Compressed Bincode Vec<i32> - Size: 8001291 - Duration: 158.476ms - Factor: 1
Compressed CBor Vec<Value> - Size: 9101972 - Duration: 303.749ms - Factor: 1.1375629
Compressed Bincode Vec<Value> - Size: 9981821 - Duration: 1.018289s - Factor: 1.2475263
Compressed Unversioned Vec<Value> - Size: 9981821 - Duration: 1.020073s - Factor: 1.2475263
CBor Vec<Value> - Size: 9999868 - Duration: 64.983ms - Factor: 1.2499822
Compressed Versioned Vec<Value> - Size: 10067182 - Duration: 1.06691s - Factor: 1.2581947
Bincode Vec<Value> - Size: 13999946 - Duration: 14.331ms - Factor: 1.7499915
Unversioned Vec<Value> - Size: 13999946 - Duration: 20.017ms - Factor: 1.7499915
Versioned Vec<Value> - Size: 17999948 - Duration: 16.327ms - Factor: 2.2499912
```

## Is this related to any issues?

This study, without solving it, is related to #4007 

## Does this change need documentation?

- [x] No documentation needed


## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
