### PR TITLE
Indexes should be populated on import

### DIFF
--- a/core/src/doc/index.rs
+++ b/core/src/doc/index.rs
@@ -23,10 +23,6 @@ impl<'a> Document<'a> {
 		txn: &Transaction,
 		_stm: &Statement<'_>,
 	) -> Result<(), Error> {
-		// Check import
-		if opt.import {
-			return Ok(());
-		}
 		// Was this force targeted at a specific index?
 		let targeted_force = matches!(opt.force, Force::Index(_));
 		// Collect indexes or skip


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

As noticed in #4031, indexes are not being populated on import anymore. This was caused by a regression here: https://github.com/surrealdb/surrealdb/pull/3632/files#diff-ec313aa751dde595da0727780ee2e3d60be8355ad4633decfdd068a1bea182f2L175-L218

Previously, when using `OPTION IMPORT`, indexing would not be disabled. In an oversight, the `index()` implementation on `Document` would return early when importing.

## What does this change do?

It removes the clause causing the `index()` method on `Document` to return early, leaving indexes to be populated again when importing data.

## What is your testing strategy?

Not sure how to best write a test for this, suggestions are welcome.

## Is this related to any issues?

Fixes #4031 

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
