### PR TITLE
Fix exponent numbers causing record ids to fail

### DIFF
--- a/core/src/syn/parser/thing.rs
+++ b/core/src/syn/parser/thing.rs
@@ -278,7 +278,7 @@ impl Parser<'_> {
 				}
 			}
 			TokenKind::Number(NumberKind::Exponent) if self.flexible_record_id => {
-				let mut text = self.lexer.string.take().unwrap();
+				let text = self.lexer.string.take().unwrap();
 				if text.bytes().any(|x| !x.is_ascii_alphanumeric()) {
 					unexpected!(self, token.kind, "a identifier");
 				}

--- a/core/src/syn/parser/thing.rs
+++ b/core/src/syn/parser/thing.rs
@@ -565,5 +565,6 @@ mod tests {
 		assert_ident_parses_correctly("1ns");
 		assert_ident_parses_correctly("1ns1");
 		assert_ident_parses_correctly("1ns1h");
+		assert_ident_parses_correctly("000e8bla");
 	}
 }

--- a/core/src/syn/parser/thing.rs
+++ b/core/src/syn/parser/thing.rs
@@ -277,10 +277,25 @@ impl Parser<'_> {
 					Ok(Id::String(text))
 				}
 			}
-			TokenKind::Number(NumberKind::Decimal | NumberKind::DecimalExponent)
-				if self.flexible_record_id =>
-			{
+			TokenKind::Number(NumberKind::Exponent) if self.flexible_record_id => {
 				let mut text = self.lexer.string.take().unwrap();
+				if text.bytes().any(|x| !x.is_ascii_alphanumeric()) {
+					unexpected!(self, token.kind, "a identifier");
+				}
+				Ok(Id::String(text))
+			}
+			TokenKind::Number(NumberKind::Decimal) if self.flexible_record_id => {
+				let mut text = self.lexer.string.take().unwrap();
+				text.push('d');
+				text.push('e');
+				text.push('c');
+				Ok(Id::String(text))
+			}
+			TokenKind::Number(NumberKind::DecimalExponent) if self.flexible_record_id => {
+				let mut text = self.lexer.string.take().unwrap();
+				if text.bytes().any(|x| !x.is_ascii_alphanumeric()) {
+					unexpected!(self, token.kind, "a identifier");
+				}
 				text.push('d');
 				text.push('e');
 				text.push('c');
@@ -565,6 +580,7 @@ mod tests {
 		assert_ident_parses_correctly("1ns");
 		assert_ident_parses_correctly("1ns1");
 		assert_ident_parses_correctly("1ns1h");
+		assert_ident_parses_correctly("000e8");
 		assert_ident_parses_correctly("000e8bla");
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

In some conditions record id's fail to properly parse when flexible record id's are enabled.

## What does this change do?

Fixes this problem

## What is your testing strategy?

Changed a test to test for the issue.

## Is this related to any issues?

Fixes #4044

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?


<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
