### PR TITLE
Prevent subqueries from being executed multiple times

### DIFF
--- a/core/src/sql/data.rs
+++ b/core/src/sql/data.rs
@@ -43,18 +43,21 @@ impl Data {
 		txn: &Transaction,
 	) -> Result<Option<Value>, Error> {
 		match self {
-			Self::MergeExpression(v) => {
-				// This MERGE expression has an 'id' field
-				Ok(v.compute(stk, ctx, opt, txn, None).await?.rid().some())
-			}
-			Self::ReplaceExpression(v) => {
-				// This REPLACE expression has an 'id' field
-				Ok(v.compute(stk, ctx, opt, txn, None).await?.rid().some())
-			}
-			Self::ContentExpression(v) => {
-				// This CONTENT expression has an 'id' field
-				Ok(v.compute(stk, ctx, opt, txn, None).await?.rid().some())
-			}
+			Self::MergeExpression(v) => match v {
+				Value::Param(v) => Ok(v.compute(stk, ctx, opt, txn, None).await?.rid().some()),
+				Value::Object(_) => Ok(v.rid().some()),
+				_ => Ok(None),
+			},
+			Self::ReplaceExpression(v) => match v {
+				Value::Param(v) => Ok(v.compute(stk, ctx, opt, txn, None).await?.rid().some()),
+				Value::Object(_) => Ok(v.rid().some()),
+				_ => Ok(None),
+			},
+			Self::ContentExpression(v) => match v {
+				Value::Param(v) => Ok(v.compute(stk, ctx, opt, txn, None).await?.rid().some()),
+				Value::Object(_) => Ok(v.rid().some()),
+				_ => Ok(None),
+			},
 			Self::SetExpression(v) => match v.iter().find(|f| f.0.is_id()) {
 				Some((_, _, v)) => {
 					// This SET expression has an 'id' field

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -417,7 +417,7 @@ async fn create_with_subquery_execution() -> Result<(), Error> {
 		"[
 			{
 				address: {
-					city: 'Whiterun',
+					city: 'London',
 					id: address:test
 				},
 				id: person:test
@@ -431,13 +431,13 @@ async fn create_with_subquery_execution() -> Result<(), Error> {
 		"[
 			{
 				address: {
-					city: 'Whiterun',
+					city: 'London',
 					id: address:test
 				},
 				id: person:test
 			},
 			{
-				city: 'Whiterun',
+				city: 'London',
 				id: address:test
 			}
 		]",

--- a/lib/tests/create.rs
+++ b/lib/tests/create.rs
@@ -397,6 +397,56 @@ async fn create_with_unique_index_on_two_fields() -> Result<(), Error> {
 	Ok(())
 }
 
+#[tokio::test]
+async fn create_with_subquery_execution() -> Result<(), Error> {
+	let sql = "
+		CREATE person:test CONTENT {
+			address: (CREATE ONLY address CONTENT {
+				id: 'test', city: 'London'
+			})
+		};
+		SELECT * FROM person, address;
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				address: {
+					city: 'Whiterun',
+					id: address:test
+				},
+				id: person:test
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				address: {
+					city: 'Whiterun',
+					id: address:test
+				},
+				id: person:test
+			},
+			{
+				city: 'Whiterun',
+				id: address:test
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
 //
 // Permissions
 //


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Currently subqueries in a `CONTENT`, `REPLACE`, or `MERGE` clause can be executed multiple times, creating multiple records, even though a single record only should be created.

## What does this change do?

Ensures that subqueries are not computed multiple times.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

Closes #4035.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
