### PR TITLE
Bind to loopback address by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ To listen to code changes as you develop, use the following command:
 cargo watch -x 'run --no-default-features --features storage-mem,http,scripting -- start --log trace --user root --pass root memory'
 ```
 
-SurrealDB runs by default on port 8000. To change the default port, use the following command:
+By default, SurrealDB runs locally on port 8000. To change the default listening address or port, use the following command:
 
 ```bash
 cargo run --no-default-features --features storage-mem,http,scripting -- start --log trace --user root --pass root --bind 0.0.0.0:9000 memory

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -92,9 +92,9 @@ pub struct StartCommandArguments {
 	#[arg(env = "SURREAL_CLIENT_IP", long)]
 	#[arg(default_value = "socket", value_enum)]
 	client_ip: ClientIp,
-	#[arg(help = "The hostname or ip address to listen for connections on")]
+	#[arg(help = "The hostname or IP address to listen for connections on")]
 	#[arg(env = "SURREAL_BIND", short = 'b', long = "bind")]
-	#[arg(default_value = "0.0.0.0:8000")]
+	#[arg(default_value = "127.0.0.1:8000")]
 	listen_addresses: Vec<SocketAddr>,
 
 	//


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To prevent SurrealDB users from accidentally exposing the service to an untrusted network. This is specially relevant for users running SurrealDB in cloud instances with publicly addressable network interfaces.

## What does this change do?

Changes the default value for the `--bind` flag of the `start` subcommand from `0.0.0.0:8000` to `127.0.0.1:8000`.

## What is your testing strategy?

Ensure that existing tests work.

## Is this related to any issues?

- Closes #3368.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

Yes, this needs an update on the [CLI documentation page](https://surrealdb.com/docs/surrealdb/cli/start).

- https://github.com/surrealdb/docs.surrealdb.com/pull/548

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
