### PR TITLE
`INSERT RELATION`

### DIFF
--- a/core/src/dbs/iterator.rs
+++ b/core/src/dbs/iterator.rs
@@ -28,7 +28,7 @@ pub(crate) enum Iterable {
 	Edges(Edges),
 	Defer(Thing),
 	Mergeable(Thing, Value),
-	Relatable(Thing, Thing, Thing),
+	Relatable(Thing, Thing, Thing, Option<Value>),
 	Index(Table, IteratorRef),
 }
 
@@ -41,13 +41,13 @@ pub(crate) struct Processed {
 pub(crate) enum Operable {
 	Value(Value),
 	Mergeable(Value, Value),
-	Relatable(Thing, Value, Thing),
+	Relatable(Thing, Value, Thing, Option<Value>),
 }
 
 pub(crate) enum Workable {
 	Normal,
 	Insert(Value),
-	Relate(Thing, Thing),
+	Relate(Thing, Thing, Option<Value>),
 }
 
 #[derive(Default)]

--- a/core/src/dbs/plan.rs
+++ b/core/src/dbs/plan.rs
@@ -131,7 +131,7 @@ impl ExplainItem {
 					("thing-1", Value::Thing(t1.to_owned())),
 					("thing-2", Value::Thing(t2.to_owned())),
 					("thing-3", Value::Thing(t3.to_owned())),
-					("value", v.to_owned().into()),
+					("value", v.to_owned()),
 				],
 			},
 			Iterable::Index(t, ir) => {

--- a/core/src/dbs/plan.rs
+++ b/core/src/dbs/plan.rs
@@ -117,12 +117,21 @@ impl ExplainItem {
 				name: "Iterate Mergeable".into(),
 				details: vec![("thing", Value::Thing(t.to_owned())), ("value", v.to_owned())],
 			},
-			Iterable::Relatable(t1, t2, t3) => Self {
+			Iterable::Relatable(t1, t2, t3, None) => Self {
 				name: "Iterate Relatable".into(),
 				details: vec![
 					("thing-1", Value::Thing(t1.to_owned())),
 					("thing-2", Value::Thing(t2.to_owned())),
 					("thing-3", Value::Thing(t3.to_owned())),
+				],
+			},
+			Iterable::Relatable(t1, t2, t3, Some(v)) => Self {
+				name: "Iterate Relatable".into(),
+				details: vec![
+					("thing-1", Value::Thing(t1.to_owned())),
+					("thing-2", Value::Thing(t2.to_owned())),
+					("thing-3", Value::Thing(t3.to_owned())),
+					("value", v.to_owned().into()),
 				],
 			},
 			Iterable::Index(t, ir) => {

--- a/core/src/dbs/processor.rs
+++ b/core/src/dbs/processor.rs
@@ -152,8 +152,8 @@ impl<'a> Processor<'a> {
 				Iterable::Mergeable(v, o) => {
 					self.process_mergeable(stk, ctx, opt, stm, v, o).await?
 				}
-				Iterable::Relatable(f, v, w) => {
-					self.process_relatable(stk, ctx, opt, stm, f, v, w).await?
+				Iterable::Relatable(f, v, w, o) => {
+					self.process_relatable(stk, ctx, opt, stm, f, v, w, o).await?
 				}
 			}
 		}
@@ -270,6 +270,7 @@ impl<'a> Processor<'a> {
 		f: Thing,
 		v: Thing,
 		w: Thing,
+		o: Option<Value>,
 	) -> Result<(), Error> {
 		// Check that the table exists
 		ctx.tx_lock().await.check_ns_db_tb(opt.ns(), opt.db(), &v.tb, opt.strict).await?;
@@ -282,7 +283,7 @@ impl<'a> Processor<'a> {
 			None => Value::None,
 		};
 		// Create a new operable value
-		let val = Operable::Relatable(f, x, w);
+		let val = Operable::Relatable(f, x, w, o);
 		// Process the document record
 		let pro = Processed {
 			rid: Some(v),

--- a/core/src/doc/alter.rs
+++ b/core/src/doc/alter.rs
@@ -75,6 +75,9 @@ impl<'a> Document<'a> {
 					if let Workable::Insert(value) = &self.extras {
 						ctx.add_value("input", value);
 					}
+					if let Workable::Relate(_, _, Some(value)) = &self.extras {
+						ctx.add_value("input", value);
+					}
 					// Process ON DUPLICATE KEY clause
 					for x in x.iter() {
 						let v = x.2.compute(stk, &ctx, opt, Some(&self.current)).await?;

--- a/core/src/doc/compute.rs
+++ b/core/src/doc/compute.rs
@@ -29,7 +29,7 @@ impl<'a> Document<'a> {
 			let ins = match pro.val {
 				Operable::Value(v) => (v, Workable::Normal),
 				Operable::Mergeable(v, o) => (v, Workable::Insert(o)),
-				Operable::Relatable(f, v, w) => (v, Workable::Relate(f, w)),
+				Operable::Relatable(f, v, w, o) => (v, Workable::Relate(f, w, o)),
 			};
 			// Setup a new document
 			let mut doc = Document::new(pro.rid.as_ref(), pro.ir.as_ref(), &ins.0, ins.1);
@@ -63,7 +63,7 @@ impl<'a> Document<'a> {
 						val: match doc.extras {
 							Workable::Normal => Operable::Value(val),
 							Workable::Insert(o) => Operable::Mergeable(val, o),
-							Workable::Relate(f, w) => Operable::Relatable(f, val, w),
+							Workable::Relate(f, w, o) => Operable::Relatable(f, val, w, o),
 						},
 					};
 					// Go to top of loop

--- a/core/src/doc/edges.rs
+++ b/core/src/doc/edges.rs
@@ -26,7 +26,7 @@ impl<'a> Document<'a> {
 		// Get the record id
 		let rid = self.id.as_ref().unwrap();
 		// Store the record edges
-		if let Workable::Relate(l, r) = &self.extras {
+		if let Workable::Relate(l, r, _) = &self.extras {
 			// Get temporary edge references
 			let (ref o, ref i) = (Dir::Out, Dir::In);
 			// Store the left pointer edge

--- a/core/src/doc/insert.rs
+++ b/core/src/doc/insert.rs
@@ -55,6 +55,8 @@ impl<'a> Document<'a> {
 		self.relation(ctx, opt, stm).await?;
 		// Merge record data
 		self.merge(stk, ctx, opt, stm).await?;
+		// Store record edges
+		self.edges(ctx, opt, stm).await?;
 		// Merge fields data
 		self.field(stk, ctx, opt, stm).await?;
 		// Reset fields data

--- a/core/src/doc/merge.rs
+++ b/core/src/doc/merge.rs
@@ -25,7 +25,7 @@ impl<'a> Document<'a> {
 		}
 		// This is an INSERT RELATION statement
 		if let Workable::Relate(_, _, Some(v)) = &self.extras {
-			let v = v.compute(stk, ctx, opt, txn, Some(&self.current)).await?;
+			let v = v.compute(stk, ctx, opt, Some(&self.current)).await?;
 			self.current.doc.to_mut().merge(v)?;
 		}
 		// Set default field values

--- a/core/src/doc/merge.rs
+++ b/core/src/doc/merge.rs
@@ -23,6 +23,11 @@ impl<'a> Document<'a> {
 			let v = v.compute(stk, ctx, opt, Some(&self.current)).await?;
 			self.current.doc.to_mut().merge(v)?;
 		}
+		// This is an INSERT RELATION statement
+		if let Workable::Relate(_, _, Some(v)) = &self.extras {
+			let v = v.compute(stk, ctx, opt, txn, Some(&self.current)).await?;
+			self.current.doc.to_mut().merge(v)?;
+		}
 		// Set default field values
 		self.current.doc.to_mut().def(rid);
 		// Carry on

--- a/core/src/doc/process.rs
+++ b/core/src/doc/process.rs
@@ -23,7 +23,7 @@ impl<'a> Document<'a> {
 			let ins = match pro.val {
 				Operable::Value(v) => (v, Workable::Normal),
 				Operable::Mergeable(v, o) => (v, Workable::Insert(o)),
-				Operable::Relatable(f, v, w) => (v, Workable::Relate(f, w)),
+				Operable::Relatable(f, v, w, o) => (v, Workable::Relate(f, w, o)),
 			};
 			// Setup a new document
 			let mut doc = Document::new(pro.rid.as_ref(), pro.ir.as_ref(), &ins.0, ins.1);
@@ -57,7 +57,7 @@ impl<'a> Document<'a> {
 						val: match doc.extras {
 							Workable::Normal => Operable::Value(val),
 							Workable::Insert(o) => Operable::Mergeable(val, o),
-							Workable::Relate(f, w) => Operable::Relatable(f, val, w),
+							Workable::Relate(f, w, o) => Operable::Relatable(f, val, w, o),
 						},
 					};
 					// Go to top of loop

--- a/core/src/doc/relate.rs
+++ b/core/src/doc/relate.rs
@@ -20,6 +20,8 @@ impl<'a> Document<'a> {
 		match self.current.doc.is_some() {
 			// Create new edge
 			false => {
+				// Merge record data
+				self.merge(stk, ctx, opt, txn, stm).await?;
 				// Store record edges
 				self.edges(ctx, opt, stm).await?;
 				// Alter record data
@@ -49,6 +51,8 @@ impl<'a> Document<'a> {
 			}
 			// Update old edge
 			true => {
+				// Merge record data
+				self.merge(stk, ctx, opt, txn, stm).await?;
 				// Check if allowed
 				self.allow(stk, ctx, opt, stm).await?;
 				// Store record edges

--- a/core/src/doc/relate.rs
+++ b/core/src/doc/relate.rs
@@ -20,8 +20,6 @@ impl<'a> Document<'a> {
 		match self.current.doc.is_some() {
 			// Create new edge
 			false => {
-				// Merge record data
-				self.merge(stk, ctx, opt, txn, stm).await?;
 				// Store record edges
 				self.edges(ctx, opt, stm).await?;
 				// Alter record data
@@ -51,8 +49,6 @@ impl<'a> Document<'a> {
 			}
 			// Update old edge
 			true => {
-				// Merge record data
-				self.merge(stk, ctx, opt, txn, stm).await?;
 				// Check if allowed
 				self.allow(stk, ctx, opt, stm).await?;
 				// Store record edges

--- a/core/src/doc/relation.rs
+++ b/core/src/doc/relation.rs
@@ -1,5 +1,5 @@
 use crate::ctx::Context;
-use crate::dbs::{Options, Transaction};
+use crate::dbs::Options;
 use crate::dbs::{Statement, Workable};
 use crate::doc::Document;
 use crate::err::Error;

--- a/core/src/doc/relation.rs
+++ b/core/src/doc/relation.rs
@@ -1,6 +1,6 @@
 use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::dbs::Statement;
+use crate::dbs::{Options, Transaction};
+use crate::dbs::{Statement, Workable};
 use crate::doc::Document;
 use crate::err::Error;
 
@@ -15,7 +15,7 @@ impl<'a> Document<'a> {
 
 		let rid = self.id.as_ref().unwrap();
 		match stm {
-			Statement::Create(_) | Statement::Insert(_) => {
+			Statement::Create(_) => {
 				if !tb.allows_normal() {
 					return Err(Error::TableCheck {
 						thing: rid.to_string(),
@@ -24,6 +24,26 @@ impl<'a> Document<'a> {
 					});
 				}
 			}
+			Statement::Insert(_) => match self.extras {
+				Workable::Relate(_, _, _) => {
+					if !tb.allows_relation() {
+						return Err(Error::TableCheck {
+							thing: rid.to_string(),
+							relation: true,
+							target_type: tb.kind.clone(),
+						});
+					}
+				}
+				_ => {
+					if !tb.allows_normal() {
+						return Err(Error::TableCheck {
+							thing: rid.to_string(),
+							relation: false,
+							target_type: tb.kind.clone(),
+						});
+					}
+				}
+			},
 			Statement::Relate(_) => {
 				if !tb.allows_relation() {
 					return Err(Error::TableCheck {

--- a/core/src/doc/reset.rs
+++ b/core/src/doc/reset.rs
@@ -21,7 +21,7 @@ impl<'a> Document<'a> {
 		// Set default field values
 		self.current.doc.to_mut().def(rid);
 		// This is a RELATE statement, so reset fields
-		if let Workable::Relate(l, r) = &self.extras {
+		if let Workable::Relate(l, r, _) = &self.extras {
 			self.current.doc.to_mut().put(&*EDGE, Value::Bool(true));
 			self.current.doc.to_mut().put(&*IN, l.clone().into());
 			self.current.doc.to_mut().put(&*OUT, r.clone().into());

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -458,6 +458,24 @@ pub enum Error {
 		value: String,
 	},
 
+	/// Can not execute RELATE statement using the specified value
+	#[error("Can not execute RELATE statement where property 'in' is '{value}'")]
+	RelateStatementIn {
+		value: String,
+	},
+
+	/// Can not execute RELATE statement using the specified value
+	#[error("Can not execute RELATE statement where property 'id' is '{value}'")]
+	RelateStatementId {
+		value: String,
+	},
+
+	/// Can not execute RELATE statement using the specified value
+	#[error("Can not execute RELATE statement where property 'out' is '{value}'")]
+	RelateStatementOut {
+		value: String,
+	},
+
 	/// Can not execute DELETE statement using the specified value
 	#[error("Can not execute DELETE statement using value '{value}'")]
 	DeleteStatement {
@@ -467,6 +485,24 @@ pub enum Error {
 	/// Can not execute INSERT statement using the specified value
 	#[error("Can not execute INSERT statement using value '{value}'")]
 	InsertStatement {
+		value: String,
+	},
+
+	/// Can not execute INSERT statement using the specified value
+	#[error("Can not execute INSERT statement where property 'in' is '{value}'")]
+	InsertStatementIn {
+		value: String,
+	},
+
+	/// Can not execute INSERT statement using the specified value
+	#[error("Can not execute INSERT statement where property 'id' is '{value}'")]
+	InsertStatementId {
+		value: String,
+	},
+
+	/// Can not execute INSERT statement using the specified value
+	#[error("Can not execute INSERT statement where property 'out' is '{value}'")]
+	InsertStatementOut {
 		value: String,
 	},
 

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -56,7 +56,7 @@ impl InsertStatement {
 						value: v.to_string(),
 					})
 				}
-			}
+			},
 		};
 
 		match &self.data {
@@ -168,13 +168,16 @@ fn gen_id(v: &Value, into: &Option<Table>) -> Result<Thing, Error> {
 	match into {
 		Some(into) => v.rid().generate(&into, true),
 		None => match v.rid() {
-			Value::Thing(Thing { id: Id::Generate(_), .. }) => Err(Error::InsertStatementId {
+			Value::Thing(Thing {
+				id: Id::Generate(_),
+				..
+			}) => Err(Error::InsertStatementId {
 				value: v.to_string(),
 			}),
 			Value::Thing(v) => Ok(v),
 			_ => Err(Error::InsertStatementId {
 				value: v.to_string(),
-			})
-		}
+			}),
+		},
 	}
 }

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -168,14 +168,16 @@ fn gen_id(v: &Value, into: &Option<Table>) -> Result<Thing, Error> {
 	match into {
 		Some(into) => v.rid().generate(&into, true),
 		None => match v.rid() {
-			Value::Thing(Thing {
-				id: Id::Generate(_),
-				..
-			}) => Err(Error::InsertStatementId {
-				value: v.to_string(),
-			}),
-			Value::Thing(v) => Ok(v),
-			_ => Err(Error::InsertStatementId {
+			Value::Thing(v) => match v {
+				Thing {
+					id: Id::Generate(_),
+					..
+				} => Err(Error::InsertStatementId {
+					value: v.to_string(),
+				}),
+				v => Ok(v),
+			},
+			v => Err(Error::InsertStatementId {
 				value: v.to_string(),
 			}),
 		},

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -46,7 +46,7 @@ impl InsertStatement {
 		let mut i = Iterator::new();
 		// Ensure futures are stored
 		let opt = &opt.new_with_futures(false).with_projections(false);
-		// Parse the expression
+		// Parse the INTO expression
 		let into = match &self.into {
 			None => None,
 			Some(into) => match into.compute(stk, ctx, opt, doc).await? {

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -166,7 +166,7 @@ fn iterable(id: Thing, v: Value, relation: bool) -> Result<Iterable, Error> {
 
 fn gen_id(v: &Value, into: &Option<Table>) -> Result<Thing, Error> {
 	match into {
-		Some(into) => v.rid().generate(&into, true),
+		Some(into) => v.rid().generate(into, true),
 		None => match v.rid() {
 			Value::Thing(v) => match v {
 				Thing {

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -58,7 +58,7 @@ impl InsertStatement {
 				}
 			},
 		};
-
+		// Parse the data expression
 		match &self.data {
 			// Check if this is a traditional statement
 			Data::ValuesExpression(v) => {

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -135,7 +135,7 @@ fn iterable(id: Thing, v: Value, relation: bool) -> Result<Iterable, Error> {
 			let r#in = match v.pick(&*IN) {
 				Value::Thing(v) => v,
 				v => {
-					return Err(Error::RelateStatement {
+					return Err(Error::InsertStatementIn {
 						value: v.to_string(),
 					})
 				}
@@ -143,7 +143,7 @@ fn iterable(id: Thing, v: Value, relation: bool) -> Result<Iterable, Error> {
 			let out = match v.pick(&*OUT) {
 				Value::Thing(v) => v,
 				v => {
-					return Err(Error::RelateStatement {
+					return Err(Error::InsertStatementOut {
 						value: v.to_string(),
 					})
 				}

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -143,7 +143,7 @@ fn iterable(id: Thing, v: Value, relation: bool) -> Result<Iterable, Error> {
 	match relation {
 		false => Ok(Iterable::Mergeable(id, v)),
 		true => {
-			let r#in = match v.pick(&*IN) {
+			let _in = match v.pick(&*IN) {
 				Value::Thing(v) => v,
 				v => {
 					return Err(Error::InsertStatementIn {
@@ -159,7 +159,7 @@ fn iterable(id: Thing, v: Value, relation: bool) -> Result<Iterable, Error> {
 					})
 				}
 			};
-			Ok(Iterable::Relatable(r#in, id, out, Some(v)))
+			Ok(Iterable::Relatable(_in, id, out, Some(v)))
 		}
 	}
 }

--- a/core/src/sql/statements/relate.rs
+++ b/core/src/sql/statements/relate.rs
@@ -135,7 +135,7 @@ impl RelateStatement {
 				let w = w.clone();
 				match &self.kind.compute(stk, ctx, opt, doc).await? {
 					// The relation has a specific record id
-					Value::Thing(id) => i.ingest(Iterable::Relatable(f, id.to_owned(), w)),
+					Value::Thing(id) => i.ingest(Iterable::Relatable(f, id.to_owned(), w, None)),
 					// The relation does not have a specific record id
 					Value::Table(tb) => match &self.data {
 						// There is a data clause so check for a record id
@@ -144,10 +144,10 @@ impl RelateStatement {
 								Some(id) => id.generate(tb, false)?,
 								None => tb.generate(),
 							};
-							i.ingest(Iterable::Relatable(f, id, w))
+							i.ingest(Iterable::Relatable(f, id, w, None))
 						}
 						// There is no data clause so create a record id
-						None => i.ingest(Iterable::Relatable(f, tb.generate(), w)),
+						None => i.ingest(Iterable::Relatable(f, tb.generate(), w, None)),
 					},
 					// The relation can not be any other type
 					v => {

--- a/core/src/sql/statements/relate.rs
+++ b/core/src/sql/statements/relate.rs
@@ -57,13 +57,13 @@ impl RelateStatement {
 							Value::Object(v) => match v.rid() {
 								Some(v) => out.push(v),
 								_ => {
-									return Err(Error::RelateStatement {
+									return Err(Error::RelateStatementOut {
 										value: v.to_string(),
 									})
 								}
 							},
 							v => {
-								return Err(Error::RelateStatement {
+								return Err(Error::RelateStatementOut {
 									value: v.to_string(),
 								})
 							}
@@ -73,13 +73,13 @@ impl RelateStatement {
 				Value::Object(v) => match v.rid() {
 					Some(v) => out.push(v),
 					None => {
-						return Err(Error::RelateStatement {
+						return Err(Error::RelateStatementOut {
 							value: v.to_string(),
 						})
 					}
 				},
 				v => {
-					return Err(Error::RelateStatement {
+					return Err(Error::RelateStatementOut {
 						value: v.to_string(),
 					})
 				}
@@ -99,13 +99,13 @@ impl RelateStatement {
 							Value::Object(v) => match v.rid() {
 								Some(v) => out.push(v),
 								None => {
-									return Err(Error::RelateStatement {
+									return Err(Error::RelateStatementId {
 										value: v.to_string(),
 									})
 								}
 							},
 							v => {
-								return Err(Error::RelateStatement {
+								return Err(Error::RelateStatementId {
 									value: v.to_string(),
 								})
 							}
@@ -115,13 +115,13 @@ impl RelateStatement {
 				Value::Object(v) => match v.rid() {
 					Some(v) => out.push(v),
 					None => {
-						return Err(Error::RelateStatement {
+						return Err(Error::RelateStatementId {
 							value: v.to_string(),
 						})
 					}
 				},
 				v => {
-					return Err(Error::RelateStatement {
+					return Err(Error::RelateStatementId {
 						value: v.to_string(),
 					})
 				}
@@ -151,7 +151,7 @@ impl RelateStatement {
 					},
 					// The relation can not be any other type
 					v => {
-						return Err(Error::RelateStatement {
+						return Err(Error::RelateStatementOut {
 							value: v.to_string(),
 						})
 					}

--- a/core/src/sql/value/serde/ser/statement/insert.rs
+++ b/core/src/sql/value/serde/ser/statement/insert.rs
@@ -60,10 +60,7 @@ impl serde::ser::SerializeStruct for SerializeInsertStatement {
 	{
 		match key {
 			"into" => {
-				self.into = match value.serialize(ser::value::Serializer.wrap())? {
-					Value::None => None,
-					v => Some(v),
-				};
+				self.into = value.serialize(ser::value::opt::Serializer.wrap())?
 			}
 			"data" => {
 				self.data = Some(value.serialize(ser::data::Serializer.wrap())?);

--- a/core/src/sql/value/serde/ser/statement/insert.rs
+++ b/core/src/sql/value/serde/ser/statement/insert.rs
@@ -60,7 +60,10 @@ impl serde::ser::SerializeStruct for SerializeInsertStatement {
 	{
 		match key {
 			"into" => {
-				self.into = Some(value.serialize(ser::value::Serializer.wrap())?);
+				self.into = match value.serialize(ser::value::Serializer.wrap())? {
+					Value::None => None,
+					v => Some(v),
+				};
 			}
 			"data" => {
 				self.data = Some(value.serialize(ser::data::Serializer.wrap())?);

--- a/core/src/sql/value/serde/ser/statement/insert.rs
+++ b/core/src/sql/value/serde/ser/statement/insert.rs
@@ -59,9 +59,7 @@ impl serde::ser::SerializeStruct for SerializeInsertStatement {
 		T: ?Sized + Serialize,
 	{
 		match key {
-			"into" => {
-				self.into = value.serialize(ser::value::opt::Serializer.wrap())?
-			}
+			"into" => self.into = value.serialize(ser::value::opt::Serializer.wrap())?,
 			"data" => {
 				self.data = Some(value.serialize(ser::data::Serializer.wrap())?);
 			}

--- a/core/src/sql/value/serde/ser/statement/insert.rs
+++ b/core/src/sql/value/serde/ser/statement/insert.rs
@@ -92,18 +92,16 @@ impl serde::ser::SerializeStruct for SerializeInsertStatement {
 
 	fn end(self) -> Result<Self::Ok, Error> {
 		match (self.data, self.ignore, self.parallel, self.relation) {
-			(Some(data), Some(ignore), Some(parallel), Some(relation)) => {
-				Ok(InsertStatement {
-					into: self.into,
-					data,
-					ignore,
-					parallel,
-					update: self.update,
-					output: self.output,
-					timeout: self.timeout,
-					relation,
-				})
-			}
+			(Some(data), Some(ignore), Some(parallel), Some(relation)) => Ok(InsertStatement {
+				into: self.into,
+				data,
+				ignore,
+				parallel,
+				update: self.update,
+				output: self.output,
+				timeout: self.timeout,
+				relation,
+			}),
 			_ => Err(Error::custom("`InsertStatement` missing required value(s)")),
 		}
 	}

--- a/core/src/sql/value/serde/ser/statement/insert.rs
+++ b/core/src/sql/value/serde/ser/statement/insert.rs
@@ -47,6 +47,7 @@ pub struct SerializeInsertStatement {
 	output: Option<Output>,
 	timeout: Option<Timeout>,
 	parallel: Option<bool>,
+	relation: Option<bool>,
 }
 
 impl serde::ser::SerializeStruct for SerializeInsertStatement {
@@ -79,6 +80,9 @@ impl serde::ser::SerializeStruct for SerializeInsertStatement {
 			"parallel" => {
 				self.parallel = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
 			}
+			"relation" => {
+				self.relation = Some(value.serialize(ser::primitive::bool::Serializer.wrap())?);
+			}
 			key => {
 				return Err(Error::custom(format!("unexpected field `InsertStatement::{key}`")));
 			}
@@ -87,16 +91,19 @@ impl serde::ser::SerializeStruct for SerializeInsertStatement {
 	}
 
 	fn end(self) -> Result<Self::Ok, Error> {
-		match (self.into, self.data, self.ignore, self.parallel) {
-			(Some(into), Some(data), Some(ignore), Some(parallel)) => Ok(InsertStatement {
-				into,
-				data,
-				ignore,
-				parallel,
-				update: self.update,
-				output: self.output,
-				timeout: self.timeout,
-			}),
+		match (self.into, self.data, self.ignore, self.parallel, self.relation) {
+			(Some(into), Some(data), Some(ignore), Some(parallel), Some(relation)) => {
+				Ok(InsertStatement {
+					into,
+					data,
+					ignore,
+					parallel,
+					update: self.update,
+					output: self.output,
+					timeout: self.timeout,
+					relation,
+				})
+			}
 			_ => Err(Error::custom("`InsertStatement` missing required value(s)")),
 		}
 	}

--- a/core/src/sql/value/serde/ser/statement/insert.rs
+++ b/core/src/sql/value/serde/ser/statement/insert.rs
@@ -91,10 +91,10 @@ impl serde::ser::SerializeStruct for SerializeInsertStatement {
 	}
 
 	fn end(self) -> Result<Self::Ok, Error> {
-		match (self.into, self.data, self.ignore, self.parallel, self.relation) {
-			(Some(into), Some(data), Some(ignore), Some(parallel), Some(relation)) => {
+		match (self.data, self.ignore, self.parallel, self.relation) {
+			(Some(data), Some(ignore), Some(parallel), Some(relation)) => {
 				Ok(InsertStatement {
-					into,
+					into: self.into,
 					data,
 					ignore,
 					parallel,

--- a/core/src/syn/parser/stmt/insert.rs
+++ b/core/src/syn/parser/stmt/insert.rs
@@ -15,17 +15,21 @@ impl Parser<'_> {
 	) -> ParseResult<InsertStatement> {
 		let relation = self.eat(t!("RELATION"));
 		let ignore = self.eat(t!("IGNORE"));
-		expected!(self, t!("INTO"));
-		let next = self.next();
-		// TODO: Explain that more complicated expressions are not allowed here.
-		let into = match next.kind {
-			t!("$param") => {
-				let param = self.token_value(next)?;
-				Value::Param(param)
-			}
-			_ => {
-				let table = self.token_value(next)?;
-				Value::Table(table)
+		let into = match self.eat(t!("INTO")) {
+			false => None,
+			true => {
+				let next = self.next();
+				// TODO: Explain that more complicated expressions are not allowed here.
+				Some(match next.kind {
+					t!("$param") => {
+						let param = self.token_value(next)?;
+						Value::Param(param)
+					}
+					_ => {
+						let table = self.token_value(next)?;
+						Value::Table(table)
+					}
+				})
 			}
 		};
 

--- a/core/src/syn/parser/stmt/insert.rs
+++ b/core/src/syn/parser/stmt/insert.rs
@@ -13,6 +13,7 @@ impl Parser<'_> {
 		&mut self,
 		ctx: &mut Stk,
 	) -> ParseResult<InsertStatement> {
+		let relation = self.eat(t!("RELATION"));
 		let ignore = self.eat(t!("IGNORE"));
 		expected!(self, t!("INTO"));
 		let next = self.next();
@@ -82,6 +83,7 @@ impl Parser<'_> {
 			output,
 			timeout,
 			parallel,
+			relation,
 		})
 	}
 

--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -1571,7 +1571,7 @@ fn parse_insert() {
 	assert_eq!(
 		res,
 		Statement::Insert(InsertStatement {
-			into: Value::Param(Param(Ident("foo".to_owned()))),
+			into: Some(Value::Param(Param(Ident("foo".to_owned())))),
 			data: Data::ValuesExpression(vec![
 				vec![
 					(

--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -1624,6 +1624,7 @@ fn parse_insert() {
 			output: Some(Output::After),
 			timeout: None,
 			parallel: false,
+			relation: false,
 		}),
 	)
 }

--- a/core/src/syn/parser/test/streaming.rs
+++ b/core/src/syn/parser/test/streaming.rs
@@ -522,7 +522,7 @@ fn statements() -> Vec<Statement> {
 			error: Value::Duration(Duration(std::time::Duration::from_secs(1))),
 		}),
 		Statement::Insert(InsertStatement {
-			into: Value::Param(Param(Ident("foo".to_owned()))),
+			into: Some(Value::Param(Param(Ident("foo".to_owned())))),
 			data: Data::ValuesExpression(vec![
 				vec![
 					(

--- a/core/src/syn/parser/test/streaming.rs
+++ b/core/src/syn/parser/test/streaming.rs
@@ -575,6 +575,7 @@ fn statements() -> Vec<Statement> {
 			output: Some(Output::After),
 			timeout: None,
 			parallel: false,
+			relation: false,
 		}),
 		Statement::Kill(KillStatement {
 			id: Value::Uuid(Uuid(uuid::uuid!("e72bee20-f49b-11ec-b939-0242ac120002"))),

--- a/lib/src/api/engine/mod.rs
+++ b/lib/src/api/engine/mod.rs
@@ -99,7 +99,11 @@ fn insert_statement(params: &mut [Value]) -> (bool, InsertStatement) {
 	};
 	let one = !data.is_array();
 	let mut stmt = InsertStatement::default();
-	stmt.into = what;
+	stmt.into = match what {
+		Value::None => None,
+		Value::Null => None,
+		what => Some(what),
+	};
 	stmt.data = Data::SingleExpression(data);
 	stmt.output = Some(Output::After);
 	(one, stmt)


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Ability to do batch creation of relations

## What does this change do?

It adds a `RELATION` keyword to the `INSERT`-statement, allowing you to batch create relations.

Additionally, this PR also make the `INTO` keyword on `INSERT` statements optional, to allow batch inserting relations on arbitrary tables

## What is your testing strategy?

Added tests

## Is this related to any issues?

Fixes #3247

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] surrealdb/docs.surrealdb.com#550

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
