### PR TITLE
Require authentication by default

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -14,7 +14,6 @@ DEV_FEATURES={ value = "storage-mem,scripting,http,ml,jwks", condition = { env_n
 SURREAL_LOG={ value = "trace", condition = { env_not_set = ["SURREAL_LOG"] } }
 SURREAL_USER={ value = "root", condition = { env_not_set = ["SURREAL_USER"] } }
 SURREAL_PASS={ value = "root", condition = { env_not_set = ["SURREAL_PASS"] } }
-SURREAL_AUTH={ value = "true", condition = { env_not_set = ["SURREAL_AUTH"] } }
 SURREAL_PATH={ value = "memory", condition = { env_not_set = ["SURREAL_PATH"] } }
 SURREAL_NAMESPACE={ value = "test", condition = { env_not_set = ["SURREAL_NAMESPACE"] } }
 SURREAL_DATABASE={ value = "test", condition = { env_not_set = ["SURREAL_DATABASE"] } }

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -122,7 +122,6 @@ Here is an example of `.env` file.
 
 ```dotenv
 SURREAL_LOG=trace
-SURREAL_AUTH=true
 SURREAL_USER=root
 SURREAL_PASS=root
 SURREAL_CAPS_ALLOW_ALL=true

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -30,10 +30,10 @@ pub struct StartCommandDbsOptions {
 	#[arg(env = "SURREAL_TRANSACTION_TIMEOUT", long)]
 	#[arg(value_parser = super::cli::validator::duration)]
 	transaction_timeout: Option<Duration>,
-	#[arg(help = "Whether to enable authentication", help_heading = "Authentication")]
-	#[arg(env = "SURREAL_AUTH", long = "auth")]
+	#[arg(help = "Whether to allow unauthenticated access", help_heading = "Authentication")]
+	#[arg(env = "SURREAL_UNAUTHENTICATED", long = "unauthenticated")]
 	#[arg(default_value_t = false)]
-	auth_enabled: bool,
+	unauthenticated: bool,
 	// TODO(gguillemas): Remove this argument once the legacy authentication is deprecated in v2.0.0
 	#[arg(
 		help = "Whether to enable explicit authentication level selection",
@@ -229,7 +229,7 @@ pub async fn init(
 		strict_mode,
 		query_timeout,
 		transaction_timeout,
-		auth_enabled,
+		unauthenticated,
 		// TODO(gguillemas): Remove this field once the legacy authentication is deprecated in v2.0.0
 		auth_level_enabled,
 		caps,
@@ -255,10 +255,8 @@ pub async fn init(
 	if let Some(v) = transaction_timeout {
 		debug!("Maximum transaction processing timeout is {v:?}");
 	}
-	// Log whether authentication is enabled
-	if auth_enabled {
-		info!("✅🔒 Authentication is enabled 🔒✅");
-	} else {
+	// Log whether authentication is disabled
+	if unauthenticated {
 		warn!("❌🔒 IMPORTANT: Authentication is disabled. This is not recommended for production use. 🔒❌");
 	}
 	// Log whether authentication levels are enabled
@@ -278,7 +276,7 @@ pub async fn init(
 		.with_strict_mode(strict_mode)
 		.with_query_timeout(query_timeout)
 		.with_transaction_timeout(transaction_timeout)
-		.with_auth_enabled(auth_enabled)
+		.with_auth_enabled(!unauthenticated)
 		.with_auth_level_enabled(auth_level_enabled)
 		.with_capabilities(caps);
 	#[cfg(any(

--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -19,7 +19,7 @@ impl DockerContainer {
 		let mut args =
 			Arguments::new(["run", "-p", &format!("127.0.0.1:8000:{DOCKER_EXPOSED_PORT}"), "-d"]);
 		args.add([docker_image]);
-		args.add(["start", "--auth", "--user", user, "--pass", pass]);
+		args.add(["start", "--user", user, "--pass", pass]);
 		args.add([format!("file:{file_path}")]);
 		let id = Self::docker(args);
 		Self {

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -220,8 +220,8 @@ pub async fn start_server(
 		extra_args.push_str(format!(" --web-crt {crt_path} --web-key {key_path}").as_str());
 	}
 
-	if auth {
-		extra_args.push_str(" --auth");
+	if !auth {
+		extra_args.push_str(" --unauthenticated");
 	}
 
 	if enable_auth_level {


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To prevent SurrealDB users from accidentally allowing unauthenticated access to their server. This is specially relevant for users running SurrealDB in cloud instances with publicly addressable network interfaces.

## What does this change do?

Replaces the `--auth` flag with `--unauthenticated`, which defaults to `false`. If no flag is provided, the server will run with authentication and a message will no longer be printed announcing it to the user. If the `--unauthenticated` flag is provided, the server will run without requiring authentication and a warning will be printed.

## What is your testing strategy?

Ensure that existing tests pass.

## Is this related to any issues?

No.

## Does this change need documentation?

Yes, this needs an update on the [CLI documentation page](https://surrealdb.com/docs/surrealdb/cli/start).

- https://github.com/surrealdb/docs.surrealdb.com/pull/549

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
