### PR TITLE
Strip namespace prefix from custom claims

### DIFF
--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -136,11 +136,14 @@ impl From<Claims> for Value {
 						continue;
 					}
 				};
-				out.insert(
-					// Strip namespace prefix to store only cannonical claim names
-					claim.strip_prefix("https://surrealdb.com/").unwrap_or(&claim).to_owned(),
-					claim_value,
-				);
+				// Strip namespace prefix to store only canonical claim names
+				if let Some(canonical_claim) = claim.strip_prefix("https://surrealdb.com/") {
+					// TODO(gguillemas): Kept for backward compatibility. Remove in 2.0.0.
+					out.insert(claim.to_owned(), claim_value.clone());
+					out.insert(canonical_claim.to_owned(), claim_value);
+				} else {
+					out.insert(claim.to_owned(), claim_value);
+				}
 			}
 		}
 		// Return value

--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -140,7 +140,7 @@ impl From<Claims> for Value {
 				if let Some(canonical_claim) = claim.strip_prefix("https://surrealdb.com/") {
 					// TODO(gguillemas): Kept for backward compatibility. Remove in 2.0.0.
 					out.insert(claim.to_owned(), claim_value.clone());
-					// Avoid replacing a private claim
+					// Avoid replacing a public claim with a private one
 					if !out.contains_key(canonical_claim) {
 						out.insert(canonical_claim.to_owned(), claim_value);
 					}

--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -136,7 +136,11 @@ impl From<Claims> for Value {
 						continue;
 					}
 				};
-				out.insert(claim, claim_value);
+				out.insert(
+					// Strip namespace prefix to store only cannonical claim names
+					claim.strip_prefix("https://surrealdb.com/").unwrap_or(&claim).to_owned(),
+					claim_value,
+				);
 			}
 		}
 		// Return value

--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -140,7 +140,10 @@ impl From<Claims> for Value {
 				if let Some(canonical_claim) = claim.strip_prefix("https://surrealdb.com/") {
 					// TODO(gguillemas): Kept for backward compatibility. Remove in 2.0.0.
 					out.insert(claim.to_owned(), claim_value.clone());
-					out.insert(canonical_claim.to_owned(), claim_value);
+					// Avoid replacing a private claim
+					if !out.contains_key(canonical_claim) {
+						out.insert(canonical_claim.to_owned(), claim_value);
+					}
 				} else {
 					out.insert(claim.to_owned(), claim_value);
 				}

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -1416,6 +1416,7 @@ mod tests {
 					"iat": {now},
 					"nbf": {now},
 					"exp": {later},
+					"https://surrealdb.com/iss": "surrealdb-other-test",
 					"https://surrealdb.com/tk": "token",
 					"https://surrealdb.com/ns": "test",
 					"https://surrealdb.com/db": "test",
@@ -1453,6 +1454,9 @@ mod tests {
 				Some(Value::Object(tk)) => tk,
 				_ => panic!("Session token is not an object"),
 			};
+			// Private claims should not be overwritten
+			let iss = tk.get("iss").unwrap();
+			assert_eq!(*iss, Value::Strand("surrealdb-test".into()));
 			// First level custom claims are extracted without the namespace prefix
 			let string_claim = tk.get("string_claim").unwrap();
 			assert_eq!(*string_claim, Value::Strand("test".into()));
@@ -1465,6 +1469,8 @@ mod tests {
 
 			// TODO(gguillemas): Kept for backward compatibility. Remove in 2.0.0.
 			// Check that the claims are still accessible by their original names
+			let iss = tk.get("https://surrealdb.com/iss").unwrap();
+			assert_eq!(*iss, Value::Strand("surrealdb-other-test".into()));
 			let string_claim = tk.get("https://surrealdb.com/string_claim").unwrap();
 			assert_eq!(*string_claim, Value::Strand("test".into()));
 			let object_claim = tk.get("https://surrealdb.com/object_claim").unwrap();

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -1462,6 +1462,16 @@ mod tests {
 			test_object
 				.insert("https://surrealdb.com/test".to_string(), Value::Strand("test".into()));
 			assert_eq!(*object_claim, Value::Object(test_object.into()));
+
+			// TODO(gguillemas): Kept for backward compatibility. Remove in 2.0.0.
+			// Check that the claims are still accessible by their original names
+			let string_claim = tk.get("https://surrealdb.com/string_claim").unwrap();
+			assert_eq!(*string_claim, Value::Strand("test".into()));
+			let object_claim = tk.get("https://surrealdb.com/object_claim").unwrap();
+			let mut test_object: HashMap<String, Value> = HashMap::new();
+			test_object
+				.insert("https://surrealdb.com/test".to_string(), Value::Strand("test".into()));
+			assert_eq!(*object_claim, Value::Object(test_object.into()));
 		}
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To behave similarly with custom JWT claims as with default JWT claims expected by SurrealDB. With default claims, names are aliased to support namespace prefixes. With custom claims, namespace prefixes will be stripped so that the canonical claim names can be directly accessible using the token parameter.

## What does this change do?

Strips namespace prefixes from custom claims before adding it to the token object unless the claim already exists to prevent overwriting a public claim with a private one. Keeps the original claims accessible through the `$token` parameter in order to preserve backward compatibility in `1.X`. This will not be the case in `2.X`.

## What is your testing strategy?

Add a test to ensure that namespaced custom claims are correctly extracted.

## Is this related to any issues?

- May resolve #4058.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
