### PR TITLE
Make temporary table active only if the temporary directory is set

### DIFF
--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -12,15 +12,6 @@ use crate::sql::value::Value;
 use channel::Sender;
 use std::borrow::Cow;
 use std::collections::HashMap;
-#[cfg(any(
-	feature = "kv-surrealkv",
-	feature = "kv-file",
-	feature = "kv-rocksdb",
-	feature = "kv-fdb",
-	feature = "kv-tikv",
-	feature = "kv-speedb"
-))]
-use std::env;
 use std::fmt::{self, Debug};
 #[cfg(any(
 	feature = "kv-surrealkv",
@@ -30,7 +21,7 @@ use std::fmt::{self, Debug};
 	feature = "kv-tikv",
 	feature = "kv-speedb"
 ))]
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -91,7 +82,7 @@ pub struct Context<'a> {
 		feature = "kv-speedb"
 	))]
 	// The temporary directory
-	temporary_directory: Arc<PathBuf>,
+	temporary_directory: Option<Arc<PathBuf>>,
 }
 
 impl<'a> Default for Context<'a> {
@@ -133,7 +124,7 @@ impl<'a> Context<'a> {
 			feature = "kv-tikv",
 			feature = "kv-speedb"
 		))]
-		temporary_directory: Arc<PathBuf>,
+		temporary_directory: Option<Arc<PathBuf>>,
 	) -> Result<Context<'a>, Error> {
 		let mut ctx = Self {
 			values: HashMap::default(),
@@ -200,7 +191,7 @@ impl<'a> Context<'a> {
 				feature = "kv-tikv",
 				feature = "kv-speedb"
 			))]
-			temporary_directory: Arc::new(env::temp_dir()),
+			temporary_directory: None,
 		}
 	}
 
@@ -371,8 +362,8 @@ impl<'a> Context<'a> {
 		feature = "kv-tikv",
 		feature = "kv-speedb"
 	))]
-	/// Return the location of the temporary directory
-	pub fn temporary_directory(&self) -> &Path {
+	/// Return the location of the temporary directory if any
+	pub fn temporary_directory(&self) -> Option<&Arc<PathBuf>> {
 		self.temporary_directory.as_ref()
 	}
 

--- a/core/src/dbs/result.rs
+++ b/core/src/dbs/result.rs
@@ -57,7 +57,9 @@ impl Results {
 			feature = "kv-speedb"
 		))]
 		if !ctx.is_memory() {
-			return Ok(Self::File(Box::new(FileCollector::new(ctx.temporary_directory())?)));
+			if let Some(temp_dir) = ctx.temporary_directory() {
+				return Ok(Self::File(Box::new(FileCollector::new(temp_dir)?)));
+			}
 		}
 		Ok(Self::Memory(Default::default()))
 	}

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -1,13 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet};
-#[cfg(any(
-	feature = "kv-surrealkv",
-	feature = "kv-file",
-	feature = "kv-rocksdb",
-	feature = "kv-fdb",
-	feature = "kv-tikv",
-	feature = "kv-speedb"
-))]
-use std::env;
 use std::fmt;
 #[cfg(any(
 	feature = "kv-surrealkv",
@@ -110,7 +101,7 @@ pub struct Datastore {
 		feature = "kv-speedb"
 	))]
 	// The temporary directory
-	temporary_directory: Arc<PathBuf>,
+	temporary_directory: Option<Arc<PathBuf>>,
 	pub(crate) lq_cf_store: Arc<RwLock<LiveQueryTracker>>,
 }
 
@@ -392,7 +383,7 @@ impl Datastore {
 				feature = "kv-tikv",
 				feature = "kv-speedb"
 			))]
-			temporary_directory: Arc::new(env::temp_dir()),
+			temporary_directory: None,
 			lq_cf_store: Arc::new(RwLock::new(LiveQueryTracker::new())),
 		})
 	}
@@ -454,8 +445,8 @@ impl Datastore {
 		feature = "kv-tikv",
 		feature = "kv-speedb"
 	))]
-	pub fn with_temporary_directory(mut self, path: Option<PathBuf>) -> Self {
-		self.temporary_directory = Arc::new(path.unwrap_or_else(env::temp_dir));
+	pub fn with_temporary_directory(mut self, path: PathBuf) -> Self {
+		self.temporary_directory = Some(Arc::new(path));
 		self
 	}
 

--- a/lib/src/api/engine/local/native.rs
+++ b/lib/src/api/engine/local/native.rs
@@ -145,6 +145,7 @@ pub(crate) fn router(
 			.with_query_timeout(address.config.query_timeout)
 			.with_transaction_timeout(address.config.transaction_timeout)
 			.with_capabilities(address.config.capabilities);
+
 		#[cfg(any(
 			feature = "kv-surrealkv",
 			feature = "kv-file",
@@ -153,7 +154,10 @@ pub(crate) fn router(
 			feature = "kv-tikv",
 			feature = "kv-speedb"
 		))]
-		let kvs = kvs.with_temporary_directory(address.config.temporary_directory);
+		let kvs = match address.config.temporary_directory {
+			Some(tmp_dir) => kvs.with_temporary_directory(tmp_dir),
+			_ => kvs,
+		};
 
 		let kvs = Arc::new(kvs);
 		let mut vars = BTreeMap::new();

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -281,6 +281,7 @@ pub async fn init(
 		.with_auth_enabled(auth_enabled)
 		.with_auth_level_enabled(auth_level_enabled)
 		.with_capabilities(caps);
+
 	#[cfg(any(
 		feature = "storage-surrealkv",
 		feature = "storage-rocksdb",
@@ -288,7 +289,11 @@ pub async fn init(
 		feature = "storage-tikv",
 		feature = "storage-speedb"
 	))]
-	let mut dbs = dbs.with_temporary_directory(temporary_directory);
+	let mut dbs = match temporary_directory {
+		Some(tmp_dir) => dbs.with_temporary_directory(tmp_dir),
+		_ => dbs,
+	};
+
 	if let Some(engine_options) = opt.engine {
 		dbs = dbs.with_engine_options(engine_options);
 	}


### PR DESCRIPTION
## What is the motivation?

The temporary table is always active, even if no temporary directory has been set up (using the system's default temporary directory).

## What does this change do?

The temporary table is enabled only if a temporary directory is explicitly set.

## What is your testing strategy?

No test changes

## Is this related to any issues?

#3749 

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

- [x] No documentation needed

## What's next (upcoming PR)?

In the statement, an optional argument should be mandatory to enable the temporary table.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
