### PR TITLE
4065: Use url crate port_or_known_default to allow parsing default ports

### DIFF
--- a/core/src/fnc/parse.rs
+++ b/core/src/fnc/parse.rs
@@ -118,4 +118,33 @@ pub mod url {
 			Err(_) => Ok(Value::None),
 		}
 	}
+
+	#[cfg(test)]
+	mod tests {
+		use crate::sql::value::Value;
+
+		#[test]
+		fn port_default_port_specified() {
+			let value = super::port(("http://www.google.com:80".to_string(),)).unwrap();
+			assert_eq!(value, 80.into());
+		}
+
+		#[test]
+		fn port_nondefault_port_specified() {
+			let value = super::port(("http://www.google.com:8080".to_string(),)).unwrap();
+			assert_eq!(value, 8080.into());
+		}
+
+		#[test]
+		fn port_no_port_specified() {
+			let value = super::port(("http://www.google.com".to_string(),)).unwrap();
+			assert_eq!(value, 80.into());
+		}
+
+		#[test]
+		fn port_no_scheme_no_port_specified() {
+			let value = super::port(("www.google.com".to_string(),)).unwrap();
+			assert_eq!(value, Value::None);
+		}
+	}
 }

--- a/core/src/fnc/parse.rs
+++ b/core/src/fnc/parse.rs
@@ -92,7 +92,7 @@ pub mod url {
 	pub fn port((string,): (String,)) -> Result<Value, Error> {
 		// Parse the URL
 		match Url::parse(&string) {
-			Ok(v) => match v.port() {
+			Ok(v) => match v.port_or_known_default() {
 				Some(v) => Ok(v.into()),
 				None => Ok(Value::None),
 			},


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Allow parsing urls where the url specifies the scheme and its default port. We are currently using a function from a crate that returns `None` when the default port is specified with a scheme in a url (e.g. `http://www.google.com:80`) and we would like to use their function that _actually_ returns the port number instead of `None`.

## What does this change do?

Allow parsing urls where the url specifies the scheme and its default port.

## What is your testing strategy?

Ran the new code against these tests that I've since deleted. (I don't think there's a need to add maintenance load by testing the url crate, but I tested the new behaviour and did some basic regression with my tests below.)

```rust
#[cfg(test)]
mod tests {
    use crate::sql::value::Value;

    #[test]
    fn port_default_port_specified() {
        let value = super::port(("http://www.google.com:80".to_string(),)).unwrap();
        assert_eq!(value, 80.into());
    }

    #[test]
    fn port_nondefault_port_specified() {
        let value = super::port(("http://www.google.com:8080".to_string(),)).unwrap();
        assert_eq!(value, 8080.into());
    }

    #[test]
    fn port_no_port_specified() {
        let value = super::port(("http://www.google.com".to_string(),)).unwrap();
        assert_eq!(value, 80.into());
    }

    #[test]
    fn port_no_scheme_no_port_specified() {
        let value = super::port(("www.google.com".to_string(),)).unwrap();
        assert_eq!(value, Value::None);
    }
}
```

These tests all passed.
<img width="687" alt="image" src="https://github.com/surrealdb/surrealdb/assets/141739703/fd7e84e7-80dc-4dee-91f8-e2ea4fcffd93">


## Is this related to any issues?

Closes #4065 

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
