### PR TITLE
[Bug fix] Index creation schemafull checks

### DIFF
--- a/lib/tests/helpers.rs
+++ b/lib/tests/helpers.rs
@@ -197,8 +197,11 @@ pub fn with_enough_stack(
 
 #[allow(dead_code)]
 pub fn skip_ok(res: &mut Vec<Response>, skip: usize) -> Result<(), Error> {
-	for _ in 0..skip {
-		let _ = res.remove(0).result?;
+	for i in 0..skip {
+		let r = res.remove(0).result;
+		let _ = r.is_err_and(|e| {
+			panic!("Statement #{i} fails with: {e}");
+		});
 	}
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

On a schemafull table, it is possible to create an index on a field that does not exist.

## What does this change do?

1. If the table is schemafull, the index creation checks that the field exists.
2. If the database runs with the strict option, it checks that the table exists.

## What is your testing strategy?

A test has been written.

## Is this related to any issues?

Fixes #2926 

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)