### PR TITLE
Redact secrets from access statements in `INFO`

### DIFF
--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -1463,6 +1463,19 @@ impl Transaction {
 		})
 	}
 
+	/// Retrieve all namespace access method definitions in redacted form.
+	pub async fn all_ns_accesses_redacted(
+		&mut self,
+		ns: &str,
+	) -> Result<Arc<[DefineAccessStatement]>, Error> {
+		let accesses: Arc<[DefineAccessStatement]> = self.all_ns_accesses(ns).await?;
+		let mut redacted = vec![];
+		for statement in accesses.as_ref() {
+			redacted.push(statement.redacted());
+		}
+		Ok(Arc::from(redacted))
+	}
+
 	/// Retrieve all database definitions for a specific namespace.
 	pub async fn all_db(&mut self, ns: &str) -> Result<Arc<[DefineDatabaseStatement]>, Error> {
 		let key = crate::key::namespace::db::prefix(ns);
@@ -1526,6 +1539,20 @@ impl Transaction {
 			self.cache.set(key, Entry::Das(Arc::clone(&val)));
 			val
 		})
+	}
+
+	/// Retrieve all database access method definitions in redacted form.
+	pub async fn all_db_accesses_redacted(
+		&mut self,
+		ns: &str,
+		db: &str,
+	) -> Result<Arc<[DefineAccessStatement]>, Error> {
+		let accesses: Arc<[DefineAccessStatement]> = self.all_db_accesses(ns, db).await?;
+		let mut redacted = vec![];
+		for statement in accesses.as_ref() {
+			redacted.push(statement.redacted());
+		}
+		Ok(Arc::from(redacted))
 	}
 
 	/// Retrieve all analyzer definitions for a specific database.

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -1468,11 +1468,8 @@ impl Transaction {
 		&mut self,
 		ns: &str,
 	) -> Result<Arc<[DefineAccessStatement]>, Error> {
-		let accesses: Arc<[DefineAccessStatement]> = self.all_ns_accesses(ns).await?;
-		let mut redacted = vec![];
-		for statement in accesses.as_ref() {
-			redacted.push(statement.redacted());
-		}
+		let accesses = self.all_ns_accesses(ns).await?;
+		let redacted: Vec<_> = accesses.iter().map(|statement| statement.redacted()).collect();
 		Ok(Arc::from(redacted))
 	}
 
@@ -1547,11 +1544,8 @@ impl Transaction {
 		ns: &str,
 		db: &str,
 	) -> Result<Arc<[DefineAccessStatement]>, Error> {
-		let accesses: Arc<[DefineAccessStatement]> = self.all_db_accesses(ns, db).await?;
-		let mut redacted = vec![];
-		for statement in accesses.as_ref() {
-			redacted.push(statement.redacted());
-		}
+		let accesses = self.all_db_accesses(ns, db).await?;
+		let redacted: Vec<_> = accesses.iter().map(|statement| statement.redacted()).collect();
 		Ok(Arc::from(redacted))
 	}
 

--- a/core/src/sql/access_type.rs
+++ b/core/src/sql/access_type.rs
@@ -80,7 +80,7 @@ impl JwtAccess {
 			}
 			None => None,
 		};
-		return jwt;
+		jwt
 	}
 }
 

--- a/core/src/sql/access_type.rs
+++ b/core/src/sql/access_type.rs
@@ -59,6 +59,31 @@ impl Default for JwtAccess {
 	}
 }
 
+impl JwtAccess {
+	pub(crate) fn redacted(&self) -> JwtAccess {
+		let mut jwt = self.clone();
+		jwt.verify = match jwt.verify {
+			JwtAccessVerify::Key(mut key) => {
+				// If algorithm is symmetric, the verification key is a secret
+				if key.alg.is_symmetric() {
+					key.key = "[REDACTED]".to_string();
+				}
+				JwtAccessVerify::Key(key)
+			}
+			// No secrets in JWK
+			JwtAccessVerify::Jwks(jwks) => JwtAccessVerify::Jwks(jwks),
+		};
+		jwt.issue = match jwt.issue {
+			Some(mut issue) => {
+				issue.key = "[REDACTED]".to_string();
+				Some(issue)
+			}
+			None => None,
+		};
+		return jwt;
+	}
+}
+
 #[revisioned(revision = 1)]
 #[derive(Debug, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/core/src/sql/algorithm.rs
+++ b/core/src/sql/algorithm.rs
@@ -25,7 +25,7 @@ pub enum Algorithm {
 }
 
 impl Algorithm {
-	// Does the algorithm us the same key for signing and verification?
+	// Does the algorithm use the same key for signing and verification?
 	pub(crate) fn is_symmetric(self) -> bool {
 		matches!(self, Algorithm::Hs256 | Algorithm::Hs384 | Algorithm::Hs512)
 	}

--- a/core/src/sql/statements/define/access.rs
+++ b/core/src/sql/statements/define/access.rs
@@ -3,7 +3,6 @@ use crate::dbs::{Options, Transaction};
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
-use crate::sql::access_type::{JwtAccessVerify, JwtAccessVerifyKey};
 use crate::sql::statements::info::InfoStructure;
 use crate::sql::{AccessType, Base, Ident, Object, Strand, Value};
 use derive::Store;
@@ -46,7 +45,7 @@ impl DefineAccessStatement {
 				AccessType::Record(ac)
 			}
 		};
-		return das;
+		das
 	}
 }
 

--- a/core/src/sql/statements/info.rs
+++ b/core/src/sql/statements/info.rs
@@ -116,7 +116,7 @@ impl InfoStatement {
 				res.insert("users".to_owned(), tmp.into());
 				// Process the accesses
 				let mut tmp = Object::default();
-				for v in run.all_ns_accesses(opt.ns()).await?.iter() {
+				for v in run.all_ns_accesses_redacted(opt.ns()).await?.iter() {
 					tmp.insert(v.name.to_string(), v.to_string().into());
 				}
 				res.insert("accesses".to_owned(), tmp.into());
@@ -156,7 +156,7 @@ impl InfoStatement {
 				res.insert("params".to_owned(), tmp.into());
 				// Process the accesses
 				let mut tmp = Object::default();
-				for v in run.all_db_accesses(opt.ns(), opt.db()).await?.iter() {
+				for v in run.all_db_accesses_redacted(opt.ns(), opt.db()).await?.iter() {
 					tmp.insert(v.name.to_string(), v.to_string().into());
 				}
 				res.insert("accesses".to_owned(), tmp.into());
@@ -260,7 +260,7 @@ impl InfoStatement {
 				// Process the accesses
 				res.insert(
 					"accesses".to_owned(),
-					process_arr(run.all_ns_accesses(opt.ns()).await?),
+					process_arr(run.all_ns_accesses_redacted(opt.ns()).await?),
 				);
 				// Ok all good
 				Value::from(res).ok()
@@ -300,7 +300,7 @@ impl InfoStatement {
 				// Process the accesses
 				res.insert(
 					"accesses".to_owned(),
-					process_arr(run.all_db_accesses(opt.ns(), opt.db()).await?),
+					process_arr(run.all_db_accesses_redacted(opt.ns(), opt.db()).await?),
 				);
 				// Process the tables
 				res.insert("tables".to_owned(), process_arr(run.all_tb(opt.ns(), opt.db()).await?));

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -1675,7 +1675,7 @@ async fn permissions_checks_define_access_ns() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ accesses: { access: \"DEFINE ACCESS access ON NAMESPACE TYPE JWT ALGORITHM HS512 KEY 'secret' WITH ISSUER KEY 'secret' DURATION 1h\" }, databases: {  }, users: {  } }"],
+        vec!["{ accesses: { access: \"DEFINE ACCESS access ON NAMESPACE TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION 1h\" }, databases: {  }, users: {  } }"],
 		vec!["{ accesses: {  }, databases: {  }, users: {  } }"]
     ];
 
@@ -1717,7 +1717,7 @@ async fn permissions_checks_define_access_db() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ accesses: { access: \"DEFINE ACCESS access ON DATABASE TYPE JWT ALGORITHM HS512 KEY 'secret' WITH ISSUER KEY 'secret' DURATION 1h\" }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"],
+        vec!["{ accesses: { access: \"DEFINE ACCESS access ON DATABASE TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION 1h\" }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"],
 		vec!["{ accesses: {  }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"]
     ];
 
@@ -1885,7 +1885,7 @@ async fn permissions_checks_define_access_record() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ accesses: { account: \"DEFINE ACCESS account ON DATABASE TYPE RECORD DURATION 1h WITH JWT ALGORITHM HS512 KEY 'secret' WITH ISSUER KEY 'secret' DURATION 1h\" }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"],
+        vec!["{ accesses: { account: \"DEFINE ACCESS account ON DATABASE TYPE RECORD DURATION 1h WITH JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION 1h\" }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"],
 		vec!["{ accesses: {  }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"]
     ];
 

--- a/lib/tests/info.rs
+++ b/lib/tests/info.rs
@@ -485,3 +485,51 @@ async fn permissions_checks_info_user_db() {
 	let res = iam_check_cases(test_cases.iter(), &scenario, check_results).await;
 	assert!(res.is_ok(), "{}", res.unwrap_err());
 }
+
+#[tokio::test]
+async fn access_info_redacted() {
+	let sql = r#"
+        DEFINE ACCESS access ON NS TYPE JWT ALGORITHM HS512 KEY 'secret';
+        INFO FOR NS
+    "#;
+	let dbs = new_ds().await.unwrap();
+	let ses = Session::owner().with_ns("ns");
+
+	let mut res = dbs.execute(sql, &ses, None).await.unwrap();
+	assert_eq!(res.len(), 2);
+
+	let out = res.pop().unwrap().output();
+	assert!(out.is_ok(), "Unexpected error: {:?}", out);
+
+	let out_expected =
+		r#"{ accesses: { access: "DEFINE ACCESS access ON NAMESPACE TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION 1h" }, databases: {  }, users: {  } }"#.to_string();
+	let out_str = out.unwrap().to_string();
+	assert_eq!(
+		out_str, out_expected,
+		"Output '{out_str}' doesn't match expected output '{out_expected}'",
+	);
+}
+
+#[tokio::test]
+async fn access_info_redacted_structure() {
+	let sql = r#"
+        DEFINE ACCESS access ON NS TYPE JWT ALGORITHM HS512 KEY 'secret';
+        INFO FOR NS STRUCTURE
+    "#;
+	let dbs = new_ds().await.unwrap();
+	let ses = Session::owner().with_ns("ns");
+
+	let mut res = dbs.execute(sql, &ses, None).await.unwrap();
+	assert_eq!(res.len(), 2);
+
+	let out = res.pop().unwrap().output();
+	assert!(out.is_ok(), "Unexpected error: {:?}", out);
+
+	let out_expected =
+		r#"{ accesses: [{ base: 'NAMESPACE', kind: { jwt: { alg: 'HS512', issuer: "{ alg: 'HS512', duration: 1h, key: '[REDACTED]' }", key: '[REDACTED]' }, kind: 'JWT' }, name: 'access' }], databases: [], users: [] }"#.to_string();
+	let out_str = out.unwrap().to_string();
+	assert_eq!(
+		out_str, out_expected,
+		"Output '{out_str}' doesn't match expected output '{out_expected}'",
+	);
+}

--- a/lib/tests/info.rs
+++ b/lib/tests/info.rs
@@ -534,6 +534,29 @@ async fn access_info_redacted() {
 			"Output '{out_str}' doesn't match expected output '{out_expected}'",
 		);
 	}
+	// Record
+	{
+		let sql = r#"
+			DEFINE ACCESS access ON NS TYPE RECORD WITH JWT ALGORITHM HS512 KEY 'secret' WITH ISSUER KEY 'secret';
+			INFO FOR NS
+		"#;
+		let dbs = new_ds().await.unwrap();
+		let ses = Session::owner().with_ns("ns");
+
+		let mut res = dbs.execute(sql, &ses, None).await.unwrap();
+		assert_eq!(res.len(), 2);
+
+		let out = res.pop().unwrap().output();
+		assert!(out.is_ok(), "Unexpected error: {:?}", out);
+
+		let out_expected =
+			r#"{ accesses: { access: "DEFINE ACCESS access ON NAMESPACE TYPE RECORD DURATION 1h WITH JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION 1h" }, databases: {  }, users: {  } }"#.to_string();
+		let out_str = out.unwrap().to_string();
+		assert_eq!(
+			out_str, out_expected,
+			"Output '{out_str}' doesn't match expected output '{out_expected}'",
+		);
+	}
 }
 
 #[tokio::test]
@@ -578,6 +601,29 @@ async fn access_info_redacted_structure() {
 
 		let out_expected =
 			r#"{ accesses: [{ base: 'NAMESPACE', kind: { jwt: { alg: 'PS512', issuer: "{ alg: 'PS512', duration: 1h, key: '[REDACTED]' }", key: 'public' }, kind: 'JWT' }, name: 'access' }], databases: [], users: [] }"#.to_string();
+		let out_str = out.unwrap().to_string();
+		assert_eq!(
+			out_str, out_expected,
+			"Output '{out_str}' doesn't match expected output '{out_expected}'",
+		);
+	}
+	// Record
+	{
+		let sql = r#"
+			DEFINE ACCESS access ON NS TYPE RECORD WITH JWT ALGORITHM HS512 KEY 'secret';
+			INFO FOR NS STRUCTURE
+		"#;
+		let dbs = new_ds().await.unwrap();
+		let ses = Session::owner().with_ns("ns");
+
+		let mut res = dbs.execute(sql, &ses, None).await.unwrap();
+		assert_eq!(res.len(), 2);
+
+		let out = res.pop().unwrap().output();
+		assert!(out.is_ok(), "Unexpected error: {:?}", out);
+
+		let out_expected =
+			r#"{ accesses: [{ base: 'NAMESPACE', kind: { duration: 1h, jwt: { alg: 'HS512', issuer: "{ alg: 'HS512', duration: 1h, key: '[REDACTED]' }", key: '[REDACTED]' }, kind: 'RECORD' }, name: 'access' }], databases: [], users: [] }"#.to_string();
 		let out_str = out.unwrap().to_string();
 		assert_eq!(
 			out_str, out_expected,

--- a/lib/tests/info.rs
+++ b/lib/tests/info.rs
@@ -488,48 +488,100 @@ async fn permissions_checks_info_user_db() {
 
 #[tokio::test]
 async fn access_info_redacted() {
-	let sql = r#"
-        DEFINE ACCESS access ON NS TYPE JWT ALGORITHM HS512 KEY 'secret';
-        INFO FOR NS
-    "#;
-	let dbs = new_ds().await.unwrap();
-	let ses = Session::owner().with_ns("ns");
+	// Symmetric
+	{
+		let sql = r#"
+			DEFINE ACCESS access ON NS TYPE JWT ALGORITHM HS512 KEY 'secret' WITH ISSUER KEY 'secret';
+			INFO FOR NS
+		"#;
+		let dbs = new_ds().await.unwrap();
+		let ses = Session::owner().with_ns("ns");
 
-	let mut res = dbs.execute(sql, &ses, None).await.unwrap();
-	assert_eq!(res.len(), 2);
+		let mut res = dbs.execute(sql, &ses, None).await.unwrap();
+		assert_eq!(res.len(), 2);
 
-	let out = res.pop().unwrap().output();
-	assert!(out.is_ok(), "Unexpected error: {:?}", out);
+		let out = res.pop().unwrap().output();
+		assert!(out.is_ok(), "Unexpected error: {:?}", out);
 
-	let out_expected =
-		r#"{ accesses: { access: "DEFINE ACCESS access ON NAMESPACE TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION 1h" }, databases: {  }, users: {  } }"#.to_string();
-	let out_str = out.unwrap().to_string();
-	assert_eq!(
-		out_str, out_expected,
-		"Output '{out_str}' doesn't match expected output '{out_expected}'",
-	);
+		let out_expected =
+			r#"{ accesses: { access: "DEFINE ACCESS access ON NAMESPACE TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION 1h" }, databases: {  }, users: {  } }"#.to_string();
+		let out_str = out.unwrap().to_string();
+		assert_eq!(
+			out_str, out_expected,
+			"Output '{out_str}' doesn't match expected output '{out_expected}'",
+		);
+	}
+	// Asymmetric
+	{
+		let sql = r#"
+			DEFINE ACCESS access ON NS TYPE JWT ALGORITHM PS512 KEY 'public' WITH ISSUER KEY 'private';
+			INFO FOR NS
+		"#;
+		let dbs = new_ds().await.unwrap();
+		let ses = Session::owner().with_ns("ns");
+
+		let mut res = dbs.execute(sql, &ses, None).await.unwrap();
+		assert_eq!(res.len(), 2);
+
+		let out = res.pop().unwrap().output();
+		assert!(out.is_ok(), "Unexpected error: {:?}", out);
+
+		let out_expected =
+			r#"{ accesses: { access: "DEFINE ACCESS access ON NAMESPACE TYPE JWT ALGORITHM PS512 KEY 'public' WITH ISSUER KEY '[REDACTED]' DURATION 1h" }, databases: {  }, users: {  } }"#.to_string();
+		let out_str = out.unwrap().to_string();
+		assert_eq!(
+			out_str, out_expected,
+			"Output '{out_str}' doesn't match expected output '{out_expected}'",
+		);
+	}
 }
 
 #[tokio::test]
 async fn access_info_redacted_structure() {
-	let sql = r#"
-        DEFINE ACCESS access ON NS TYPE JWT ALGORITHM HS512 KEY 'secret';
-        INFO FOR NS STRUCTURE
-    "#;
-	let dbs = new_ds().await.unwrap();
-	let ses = Session::owner().with_ns("ns");
+	// Symmetric
+	{
+		let sql = r#"
+			DEFINE ACCESS access ON NS TYPE JWT ALGORITHM HS512 KEY 'secret';
+			INFO FOR NS STRUCTURE
+		"#;
+		let dbs = new_ds().await.unwrap();
+		let ses = Session::owner().with_ns("ns");
 
-	let mut res = dbs.execute(sql, &ses, None).await.unwrap();
-	assert_eq!(res.len(), 2);
+		let mut res = dbs.execute(sql, &ses, None).await.unwrap();
+		assert_eq!(res.len(), 2);
 
-	let out = res.pop().unwrap().output();
-	assert!(out.is_ok(), "Unexpected error: {:?}", out);
+		let out = res.pop().unwrap().output();
+		assert!(out.is_ok(), "Unexpected error: {:?}", out);
 
-	let out_expected =
-		r#"{ accesses: [{ base: 'NAMESPACE', kind: { jwt: { alg: 'HS512', issuer: "{ alg: 'HS512', duration: 1h, key: '[REDACTED]' }", key: '[REDACTED]' }, kind: 'JWT' }, name: 'access' }], databases: [], users: [] }"#.to_string();
-	let out_str = out.unwrap().to_string();
-	assert_eq!(
-		out_str, out_expected,
-		"Output '{out_str}' doesn't match expected output '{out_expected}'",
-	);
+		let out_expected =
+			r#"{ accesses: [{ base: 'NAMESPACE', kind: { jwt: { alg: 'HS512', issuer: "{ alg: 'HS512', duration: 1h, key: '[REDACTED]' }", key: '[REDACTED]' }, kind: 'JWT' }, name: 'access' }], databases: [], users: [] }"#.to_string();
+		let out_str = out.unwrap().to_string();
+		assert_eq!(
+			out_str, out_expected,
+			"Output '{out_str}' doesn't match expected output '{out_expected}'",
+		);
+	}
+	// Asymmetric
+	{
+		let sql = r#"
+			DEFINE ACCESS access ON NS TYPE JWT ALGORITHM PS512 KEY 'public' WITH ISSUER KEY 'private';
+			INFO FOR NS STRUCTURE
+		"#;
+		let dbs = new_ds().await.unwrap();
+		let ses = Session::owner().with_ns("ns");
+
+		let mut res = dbs.execute(sql, &ses, None).await.unwrap();
+		assert_eq!(res.len(), 2);
+
+		let out = res.pop().unwrap().output();
+		assert!(out.is_ok(), "Unexpected error: {:?}", out);
+
+		let out_expected =
+			r#"{ accesses: [{ base: 'NAMESPACE', kind: { jwt: { alg: 'PS512', issuer: "{ alg: 'PS512', duration: 1h, key: '[REDACTED]' }", key: 'public' }, kind: 'JWT' }, name: 'access' }], databases: [], users: [] }"#.to_string();
+		let out_str = out.unwrap().to_string();
+		assert_eq!(
+			out_str, out_expected,
+			"Output '{out_str}' doesn't match expected output '{out_expected}'",
+		);
+	}
 }

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -662,7 +662,7 @@ async fn permissions_checks_remove_ns_access() {
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
 		vec!["{ accesses: {  }, databases: {  }, users: {  } }"],
-        vec!["{ accesses: { access: \"DEFINE ACCESS access ON NAMESPACE TYPE JWT ALGORITHM HS512 KEY 'secret' WITH ISSUER KEY 'secret' DURATION 1h\" }, databases: {  }, users: {  } }"],
+        vec!["{ accesses: { access: \"DEFINE ACCESS access ON NAMESPACE TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION 1h\" }, databases: {  }, users: {  } }"],
     ];
 
 	let test_cases = [
@@ -704,7 +704,7 @@ async fn permissions_checks_remove_db_access() {
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
 		vec!["{ accesses: {  }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"],
-        vec!["{ accesses: { access: \"DEFINE ACCESS access ON DATABASE TYPE JWT ALGORITHM HS512 KEY 'secret' WITH ISSUER KEY 'secret' DURATION 1h\" }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"],
+        vec!["{ accesses: { access: \"DEFINE ACCESS access ON DATABASE TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION 1h\" }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"],
     ];
 
 	let test_cases = [


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To increase security by redacting secrets when displaying the `DEFINE ACCESS` statement via the `INFO` statement. We want to mitigate the risk of a datastore user (e.g. one with only read access) to be able to escalate privileges by accessing a secret that can be used to issue tokens than can grant access with higher privileges. We also want to mitigate the risk of accidentally exposing secrets when sharing the output of `INFO` statements for debugging purposes and similar risks. Users in control of the SurrealDB server will still be able to export secrets.

## What does this change do?

This change introduces a `redacted` method to the `access` define statement, which returns a copy of the define statement structure with any secret values replaced by `[REDACTED]`. This includes symmetric and private keys which can be used to sign tokens, but not public keys which can only be used to verify them. The redacted copy returned by this method is used instead of the original structure in the `*_redacted` variants of the transaction methods.

In the case of the `INFO` statement, the `*_redacted` variants of the transaction methods will be called instead of the original. In the case of export operations, the original variant of the transaction method will be called so that the secrets are correctly included in the export data, not only to ensure that exports can be reliably imported but also to eliminate the risk of users inadvertently trusting all tokens signed with `[REDACTED]` after a re-import.

## What is your testing strategy?

I have added some tests to verify that any relevant secrets are properly redacted.

## Is this related to any issues?

No.

## Does this change need documentation?

This could use some documentation on the `INFO` statement documentation.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
