### PR TITLE
`.generate()` should not format table name

### DIFF
--- a/core/src/sql/value/generate.rs
+++ b/core/src/sql/value/generate.rs
@@ -9,44 +9,44 @@ impl Value {
 		match self {
 			// There is a floating point number for the id field
 			Value::Number(id) if id.is_float() => Ok(Thing {
-				tb: tb.to_string(),
+				tb: tb.0.to_string(),
 				id: id.as_int().into(),
 			}),
 			// There is an integer number for the id field
 			Value::Number(id) if id.is_int() => Ok(Thing {
-				tb: tb.to_string(),
+				tb: tb.0.to_string(),
 				id: id.as_int().into(),
 			}),
 			// There is a string for the id field
 			Value::Strand(id) if !id.is_empty() => Ok(Thing {
-				tb: tb.to_string(),
+				tb: tb.0.to_string(),
 				id: id.into(),
 			}),
 			// There is an object for the id field
 			Value::Object(id) => Ok(Thing {
-				tb: tb.to_string(),
+				tb: tb.0.to_string(),
 				id: id.into(),
 			}),
 			// There is an array for the id field
 			Value::Array(id) => Ok(Thing {
-				tb: tb.to_string(),
+				tb: tb.0.to_string(),
 				id: id.into(),
 			}),
 			// There is a UUID for the id field
 			Value::Uuid(id) => Ok(Thing {
-				tb: tb.to_string(),
+				tb: tb.0.to_string(),
 				id: id.into(),
 			}),
 			// There is no record id field
 			Value::None => Ok(Thing {
-				tb: tb.to_string(),
+				tb: tb.0.to_string(),
 				id: Id::rand(),
 			}),
 			// There is a record id defined
 			Value::Thing(id) => match retable {
 				// Let's re-table this record id
 				true => Ok(Thing {
-					tb: tb.to_string(),
+					tb: tb.0.to_string(),
 					id: id.id,
 				}),
 				// Let's use the specified record id
@@ -55,7 +55,7 @@ impl Value {
 					true => Ok(id),
 					// The record id is from another table
 					false => Ok(Thing {
-						tb: tb.to_string(),
+						tb: tb.0.to_string(),
 						id: id.id,
 					}),
 				},

--- a/lib/tests/insert.rs
+++ b/lib/tests/insert.rs
@@ -11,7 +11,7 @@ use surrealdb::sql::Value;
 #[tokio::test]
 async fn insert_statement_object_single() -> Result<(), Error> {
 	let sql = "
-		INSERT INTO test {
+		INSERT INTO `test-table` {
 			id: 'tester',
 			test: true,
 			something: 'other',
@@ -23,7 +23,7 @@ async fn insert_statement_object_single() -> Result<(), Error> {
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::parse("[{ id: test:tester, test: true, something: 'other' }]");
+	let val = Value::parse("[{ id: `test-table`:tester, test: true, something: 'other' }]");
 	assert_eq!(tmp, val);
 	//
 	Ok(())


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

See https://github.com/surrealdb/surrealdb/issues/4101 and #4077

## What does this change do?

It ensures that the `.generate()` function does not format the table name, but rather takes the raw value.

## What is your testing strategy?

Updated an existing test to ensure this works correctly.

## Is this related to any issues?

Fixes #4101 
Fixes #4077 

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
