### PR TITLE
[Bug fix] Iterator not found on unique indexes with ==

### DIFF
--- a/core/src/dbs/processor.rs
+++ b/core/src/dbs/processor.rs
@@ -578,7 +578,7 @@ impl<'a> Processor<'a> {
 				return Ok(());
 			} else {
 				return Err(Error::QueryNotExecutedDetail {
-					message: "No Iterator has been found.".to_string(),
+					message: "No iterator has been found.".to_string(),
 				});
 			}
 		}

--- a/core/src/idx/planner/executor.rs
+++ b/core/src/idx/planner/executor.rs
@@ -450,9 +450,16 @@ impl QueryExecutor {
 		io: IndexOption,
 	) -> Result<Option<ThingIterator>, Error> {
 		Ok(match io.op() {
-			IndexOperator::Equality(value) => Some(ThingIterator::UniqueEqual(
-				UniqueEqualThingIterator::new(irf, opt.ns(), opt.db(), &ix.what, &ix.name, value),
-			)),
+			IndexOperator::Equality(value) | IndexOperator::Exactness(value) => {
+				Some(ThingIterator::UniqueEqual(UniqueEqualThingIterator::new(
+					irf,
+					opt.ns(),
+					opt.db(),
+					&ix.what,
+					&ix.name,
+					value,
+				)))
+			}
 			IndexOperator::Union(value) => {
 				Some(ThingIterator::UniqueUnion(UniqueUnionThingIterator::new(irf, opt, ix, value)))
 			}

--- a/lib/tests/matches.rs
+++ b/lib/tests/matches.rs
@@ -1,6 +1,7 @@
 mod parse;
 use parse::Parse;
 mod helpers;
+use crate::helpers::skip_ok;
 use helpers::new_ds;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
@@ -20,9 +21,8 @@ async fn select_where_matches_using_index() -> Result<(), Error> {
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
 	//
-	let _ = res.remove(0).result?;
-	let _ = res.remove(0).result?;
-	let _ = res.remove(0).result?;
+	skip_ok(res, 3)?;
+	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
@@ -74,10 +74,8 @@ async fn select_where_matches_without_using_index_iterator() -> Result<(), Error
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 6);
 	//
-	let _ = res.remove(0).result?;
-	let _ = res.remove(0).result?;
-	let _ = res.remove(0).result?;
-	let _ = res.remove(0).result?;
+	skip_ok(res, 4)?;
+	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
@@ -135,9 +133,7 @@ async fn select_where_matches_using_index_and_arrays(parallel: bool) -> Result<(
 	let res = &mut dbs.execute(&sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
 	//
-	let _ = res.remove(0).result?;
-	let _ = res.remove(0).result?;
-	let _ = res.remove(0).result?;
+	skip_ok(res, 3)?;
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
@@ -208,9 +204,7 @@ async fn select_where_matches_partial_highlight() -> Result<(), Error> {
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 9);
 	//
-	for _ in 0..3 {
-		let _ = res.remove(0).result?;
-	}
+	skip_ok(res, 3)?;
 	//
 	for i in 0..2 {
 		let tmp = res.remove(0).result?;
@@ -295,9 +289,7 @@ async fn select_where_matches_partial_highlight_ngram() -> Result<(), Error> {
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 10);
 	//
-	for _ in 0..3 {
-		let _ = res.remove(0).result?;
-	}
+	skip_ok(res, 3)?;
 	//
 	for i in 0..3 {
 		let tmp = res.remove(0).result?;
@@ -383,9 +375,7 @@ async fn select_where_matches_using_index_and_objects(parallel: bool) -> Result<
 	let res = &mut dbs.execute(&sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
 	//
-	let _ = res.remove(0).result?;
-	let _ = res.remove(0).result?;
-	let _ = res.remove(0).result?;
+	skip_ok(res, 3)?;
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
@@ -453,9 +443,8 @@ async fn select_where_matches_using_index_offsets() -> Result<(), Error> {
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
 	//
-	for _ in 0..4 {
-		let _ = res.remove(0).result?;
-	}
+	skip_ok(res, 4)?;
+	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
@@ -491,9 +480,8 @@ async fn select_where_matches_using_index_and_score() -> Result<(), Error> {
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 7);
 	//
-	for _ in 0..6 {
-		let _ = res.remove(0).result?;
-	}
+	skip_ok(res, 6)?;
+	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
@@ -529,10 +517,8 @@ async fn select_where_matches_without_using_index_and_score() -> Result<(), Erro
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 9);
 	//
-	for _ in 0..7 {
-		let _ = res.remove(0).result?;
-	}
-
+	skip_ok(res, 7)?;
+	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
@@ -579,10 +565,8 @@ async fn select_where_matches_without_complex_query() -> Result<(), Error> {
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 10);
 	//
-	for _ in 0..6 {
-		let _ = res.remove(0).result?;
-	}
-
+	skip_ok(res, 6)?;
+	//
 	let tmp = res.remove(0).result?;
 	let val_docs = Value::parse(
 		"[
@@ -651,5 +635,71 @@ async fn select_where_matches_without_complex_query() -> Result<(), Error> {
 
 	let tmp = res.remove(0).result?;
 	assert_eq!(format!("{:#}", tmp), format!("{:#}", val_docs));
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_where_matches_mixing_indexes() -> Result<(), Error> {
+	let sql = r"
+		DEFINE ANALYZER edgeNgram TOKENIZERS class FILTERS lowercase,ascii,edgeNgram(1,10);
+		DEFINE INDEX idxPersonName ON TABLE person COLUMNS name SEARCH ANALYZER edgeNgram BM25;
+		DEFINE INDEX idxSecurityNumber ON TABLE person COLUMNS securityNumber UNIQUE;
+		CREATE person:1 content {name: 'Tobie', securityNumber: '123456'};
+		SELECT * FROM person WHERE name @@ 'Tobie' || securityNumber == '123456' EXPLAIN;
+		SELECT * FROM person WHERE name @@ 'Tobie' || securityNumber == '123456';
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 6);
+	//
+	skip_ok(res, 4)?;
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+				{
+					detail: {
+						plan: {
+							index: 'idxPersonName',
+							operator: '@@',
+							value: 'Tobie'
+						},
+						table: 'person'
+					},
+					operation: 'Iterate Index'
+				},
+				{
+					detail: {
+						plan: {
+							index: 'idxSecurityNumber',
+							operator: '==',
+							value: '123456'
+						},
+						table: 'person'
+					},
+					operation: 'Iterate Index'
+				},
+				{
+					detail: {
+						type: 'Memory'
+					},
+					operation: 'Collector'
+				}
+			]",
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+				{
+					id: person:1,
+					name: 'Tobie',
+					securityNumber: '123456'
+				}
+			]",
+	);
+	assert_eq!(format!("{:#}", tmp), format!("{:#}", val));
 	Ok(())
 }

--- a/lib/tests/matches.rs
+++ b/lib/tests/matches.rs
@@ -645,15 +645,16 @@ async fn select_where_matches_mixing_indexes() -> Result<(), Error> {
 		DEFINE INDEX idxPersonName ON TABLE person COLUMNS name SEARCH ANALYZER edgeNgram BM25;
 		DEFINE INDEX idxSecurityNumber ON TABLE person COLUMNS securityNumber UNIQUE;
 		CREATE person:1 content {name: 'Tobie', securityNumber: '123456'};
+		CREATE person:2 content {name: 'Jaime', securityNumber: 'ABCDEF'};
 		SELECT * FROM person WHERE name @@ 'Tobie' || securityNumber == '123456' EXPLAIN;
 		SELECT * FROM person WHERE name @@ 'Tobie' || securityNumber == '123456';
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 6);
+	assert_eq!(res.len(), 7);
 	//
-	skip_ok(res, 4)?;
+	skip_ok(res, 5)?;
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(


### PR DESCRIPTION
## What is the motivation?

Bug related there: #4085.

The operator `==` does not trigger the unique index.

## What does this change do?

The query planner recognizes the operator and allows the unique iterator to be created.

## What is your testing strategy?

A test has been written.

## Is this related to any issues?

Fixes #4085

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
