### PR TITLE
Constructing an empty Thing should error

### DIFF
--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1001,11 +1001,11 @@ pub enum Error {
 	#[error("This record access method does not allow signin")]
 	AccessRecordNoSignin,
 
-	#[error("Cannot construct a Record ID with table: {0}")]
-	InvalidThingTb(String),
-
-	#[error("Cannot construct a Record ID with id: {0}")]
-	InvalidThingId(String),
+	/// Found a table name for the record but this is not a valid table
+	#[error("Found {value} for the Record ID but this is not a valid table name")]
+	TbInvalid {
+		value: String,
+	},
 }
 
 impl From<Error> for String {

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1000,6 +1000,12 @@ pub enum Error {
 
 	#[error("This record access method does not allow signin")]
 	AccessRecordNoSignin,
+
+	#[error("Cannot construct a Record ID with table: {0}")]
+	InvalidThingTb(String),
+
+	#[error("Cannot construct a Record ID with id: {0}")]
+	InvalidThingId(String),
 }
 
 impl From<Error> for String {

--- a/core/src/fnc/type.rs
+++ b/core/src/fnc/type.rs
@@ -98,12 +98,12 @@ pub fn thing((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 	match (arg1, arg2) {
 		// Empty table name
 		(Value::Strand(arg1), _) if arg1.is_empty() => Err(Error::TbInvalid {
-			value: arg1.to_string(),
+			value: arg1.as_string(),
 		}),
 
 		// Empty ID part
 		(_, Some(Value::Strand(arg2))) if arg2.is_empty() => Err(Error::IdInvalid {
-			value: arg2.to_string(),
+			value: arg2.as_string(),
 		}),
 
 		// Handle second argument

--- a/core/src/fnc/type.rs
+++ b/core/src/fnc/type.rs
@@ -97,12 +97,14 @@ pub fn table((val,): (Value,)) -> Result<Value, Error> {
 pub fn thing((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 	match (arg1, arg2) {
 		// Empty table name
-		(Value::Strand(arg1), _) if arg1.is_empty() => Err(Error::InvalidThingTb(arg1.to_string())),
+		(Value::Strand(arg1), _) if arg1.is_empty() => Err(Error::TbInvalid {
+			value: arg1.to_string(),
+		}),
 
 		// Empty ID part
-		(_, Some(Value::Strand(arg2))) if arg2.is_empty() => {
-			Err(Error::InvalidThingId(arg2.to_string()))
-		}
+		(_, Some(Value::Strand(arg2))) if arg2.is_empty() => Err(Error::IdInvalid {
+			value: arg2.to_string(),
+		}),
 
 		// Handle second argument
 		(arg1, Some(arg2)) => Ok(Value::Thing(Thing {
@@ -338,13 +340,17 @@ mod tests {
 	#[test]
 	fn no_empty_thing() {
 		let value = super::thing(("".into(), None));
-		let _expected = Error::InvalidThingTb("".into());
+		let _expected = Error::TbInvalid {
+			value: "".into(),
+		};
 		if !matches!(value, Err(_expected)) {
 			panic!("An empty thing tb part should result in an error");
 		}
 
 		let value = super::thing(("table".into(), Some("".into())));
-		let _expected = Error::InvalidThingId("".into());
+		let _expected = Error::IdInvalid {
+			value: "".into(),
+		};
 		if !matches!(value, Err(_expected)) {
 			panic!("An empty thing id part should result in an error");
 		}


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

It's currently possible to construct a thing with an empty table name or empty id part with the `type::thing()` method. See #4109

## What does this change do?

It ensures that the `type::thing()` method throws an error if you pass an empty table name or empty id part.

## What is your testing strategy?

Added a test

## Is this related to any issues?

Fixes #4109

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
