### PR TITLE
Allow defining a maximum session duration on `DEFINE USER`

### DIFF
--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -235,8 +235,7 @@ pub async fn db_user(
 			session.tk = Some(val.into());
 			session.ns = Some(ns.to_owned());
 			session.db = Some(db.to_owned());
-			// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
-			session.exp = None;
+			session.exp = expiration(u.session)?;
 			session.au = Arc::new((&u, Level::Database(ns.to_owned(), db.to_owned())).into());
 			// Check the authentication token
 			match enc {
@@ -279,8 +278,7 @@ pub async fn ns_user(
 			// Set the authentication on the session
 			session.tk = Some(val.into());
 			session.ns = Some(ns.to_owned());
-			// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
-			session.exp = None;
+			session.exp = expiration(u.session)?;
 			session.au = Arc::new((&u, Level::Namespace(ns.to_owned())).into());
 			// Check the authentication token
 			match enc {
@@ -321,8 +319,7 @@ pub async fn root_user(
 			let enc = encode(&HEADER, &val, &key);
 			// Set the authentication on the session
 			session.tk = Some(val.into());
-			// TODO(gguillemas): Enforce expiration once session lifetime can be customized.
-			session.exp = None;
+			session.exp = expiration(u.session)?;
 			session.au = Arc::new((&u, Level::Root).into());
 			// Check the authentication token
 			match enc {

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -59,6 +59,9 @@ const LQ_CHANNEL_SIZE: usize = 100;
 // The batch size used for non-paged operations (i.e. if there are more results, they are ignored)
 const NON_PAGED_BATCH_SIZE: u32 = 100_000;
 
+// The role assigned to the initial user created when starting the server with credentials for the first time
+const INITIAL_USER_ROLE: &str = "owner";
+
 /// The underlying datastore instance which stores the dataset.
 #[allow(dead_code)]
 #[non_exhaustive]
@@ -482,8 +485,9 @@ impl Datastore {
 			Ok(v) if v.is_empty() => {
 				// Display information in the logs
 				info!("Credentials were provided, and no root users were found. The root user '{}' will be created", username);
-				// Create and save a new root users
-				let stm = DefineUserStatement::from((Base::Root, username, password, "owner"));
+				// Create and save a new root user
+				let stm =
+					DefineUserStatement::from((Base::Root, username, password, INITIAL_USER_ROLE));
 				let ctx = Context::default().set_transaction(txn.clone());
 				let opt = Options::new().with_auth(Arc::new(Auth::for_root(Role::Owner)));
 				let _ = stm.compute(&ctx, &opt, None).await?;

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -483,7 +483,7 @@ impl Datastore {
 				// Display information in the logs
 				info!("Credentials were provided, and no root users were found. The root user '{}' will be created", username);
 				// Create and save a new root users
-				let stm = DefineUserStatement::from((Base::Root, username, password));
+				let stm = DefineUserStatement::from((Base::Root, username, password, "owner"));
 				let ctx = Context::default().set_transaction(txn.clone());
 				let opt = Options::new().with_auth(Arc::new(Auth::for_root(Role::Owner)));
 				let _ = stm.compute(&ctx, &opt, None).await?;

--- a/core/src/sql/statements/define/user.rs
+++ b/core/src/sql/statements/define/user.rs
@@ -4,7 +4,7 @@ use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::{Action, ResourceKind};
 use crate::sql::statements::info::InfoStructure;
-use crate::sql::{escape::quote_str, fmt::Fmt, Base, Ident, Object, Strand, Value};
+use crate::sql::{escape::quote_str, fmt::Fmt, Base, Duration, Ident, Object, Strand, Value};
 use argon2::{
 	password_hash::{PasswordHasher, SaltString},
 	Argon2,
@@ -25,6 +25,8 @@ pub struct DefineUserStatement {
 	pub hash: String,
 	pub code: String,
 	pub roles: Vec<Ident>,
+	#[revision(start = 2)]
+	pub session: Option<Duration>,
 	pub comment: Option<Strand>,
 	#[revision(start = 2)]
 	pub if_not_exists: bool,
@@ -45,6 +47,7 @@ impl From<(Base, &str, &str)> for DefineUserStatement {
 				.map(char::from)
 				.collect::<String>(),
 			roles: vec!["owner".into()],
+			session: None,
 			comment: None,
 			if_not_exists: false,
 		}
@@ -52,11 +55,17 @@ impl From<(Base, &str, &str)> for DefineUserStatement {
 }
 
 impl DefineUserStatement {
-	pub(crate) fn from_parsed_values(name: Ident, base: Base, roles: Vec<Ident>) -> Self {
+	pub(crate) fn from_parsed_values(
+		name: Ident,
+		base: Base,
+		roles: Vec<Ident>,
+		session: Option<Duration>,
+	) -> Self {
 		DefineUserStatement {
 			name,
 			base,
-			roles, // New users get the viewer role by default
+			roles,   // New users get the viewer role by default
+			session, // Sessions for system users do not expire by default
 			code: rand::thread_rng()
 				.sample_iter(&Alphanumeric)
 				.take(128)
@@ -75,6 +84,10 @@ impl DefineUserStatement {
 
 	pub(crate) fn set_passhash(&mut self, passhash: String) {
 		self.hash = passhash;
+	}
+
+	pub(crate) fn set_session(&mut self, session: Option<Duration>) {
+		self.session = session;
 	}
 
 	/// Process this type returning a computed simple Value
@@ -191,8 +204,11 @@ impl Display for DefineUserStatement {
 			quote_str(&self.hash),
 			Fmt::comma_separated(
 				&self.roles.iter().map(|r| r.to_string().to_uppercase()).collect::<Vec<String>>()
-			)
+			),
 		)?;
+		if let Some(ref v) = self.session {
+			write!(f, " SESSION {v}")?
+		}
 		if let Some(ref v) = self.comment {
 			write!(f, " COMMENT {v}")?
 		}
@@ -207,6 +223,7 @@ impl InfoStructure for DefineUserStatement {
 			base,
 			hash,
 			roles,
+			session,
 			comment,
 			..
 		} = self;
@@ -222,6 +239,10 @@ impl InfoStructure for DefineUserStatement {
 			"roles".to_string(),
 			Value::Array(roles.into_iter().map(|r| r.structure()).collect()),
 		);
+
+		if let Some(session) = session {
+			acc.insert("session".to_string(), session.into());
+		}
 
 		if let Some(comment) = comment {
 			acc.insert("comment".to_string(), comment.into());

--- a/core/src/sql/statements/define/user.rs
+++ b/core/src/sql/statements/define/user.rs
@@ -32,8 +32,8 @@ pub struct DefineUserStatement {
 	pub if_not_exists: bool,
 }
 
-impl From<(Base, &str, &str)> for DefineUserStatement {
-	fn from((base, user, pass): (Base, &str, &str)) -> Self {
+impl From<(Base, &str, &str, &str)> for DefineUserStatement {
+	fn from((base, user, pass, role): (Base, &str, &str, &str)) -> Self {
 		DefineUserStatement {
 			base,
 			name: user.into(),
@@ -46,7 +46,7 @@ impl From<(Base, &str, &str)> for DefineUserStatement {
 				.take(128)
 				.map(char::from)
 				.collect::<String>(),
-			roles: vec!["owner".into()],
+			roles: vec![role.into()],
 			session: None,
 			comment: None,
 			if_not_exists: false,

--- a/core/src/sql/statements/define/user.rs
+++ b/core/src/sql/statements/define/user.rs
@@ -15,7 +15,7 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
-#[revisioned(revision = 2)]
+#[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
@@ -25,7 +25,7 @@ pub struct DefineUserStatement {
 	pub hash: String,
 	pub code: String,
 	pub roles: Vec<Ident>,
-	#[revision(start = 2)]
+	#[revision(start = 3)]
 	pub session: Option<Duration>,
 	pub comment: Option<Strand>,
 	#[revision(start = 2)]

--- a/core/src/sql/value/serde/ser/statement/define/user.rs
+++ b/core/src/sql/value/serde/ser/statement/define/user.rs
@@ -2,6 +2,7 @@ use crate::err::Error;
 use crate::sql::statements::DefineUserStatement;
 use crate::sql::value::serde::ser;
 use crate::sql::Base;
+use crate::sql::Duration;
 use crate::sql::Ident;
 use crate::sql::Strand;
 use ser::Serializer as _;
@@ -44,6 +45,7 @@ pub struct SerializeDefineUserStatement {
 	hash: String,
 	code: String,
 	roles: Vec<Ident>,
+	session: Option<Duration>,
 	comment: Option<Strand>,
 	if_not_exists: bool,
 }
@@ -72,6 +74,10 @@ impl serde::ser::SerializeStruct for SerializeDefineUserStatement {
 			"roles" => {
 				self.roles = value.serialize(ser::ident::vec::Serializer.wrap())?;
 			}
+			"session" => {
+				self.session =
+					value.serialize(ser::duration::opt::Serializer.wrap())?.map(Into::into);
+			}
 			"comment" => {
 				self.comment = value.serialize(ser::strand::opt::Serializer.wrap())?;
 			}
@@ -94,6 +100,7 @@ impl serde::ser::SerializeStruct for SerializeDefineUserStatement {
 			hash: self.hash,
 			code: self.code,
 			roles: self.roles,
+			session: self.session,
 			comment: self.comment,
 			if_not_exists: self.if_not_exists,
 		})

--- a/core/src/syn/parser/stmt/define.rs
+++ b/core/src/syn/parser/stmt/define.rs
@@ -182,6 +182,7 @@ impl Parser<'_> {
 			name,
 			base,
 			vec!["Viewer".into()], // New users get the viewer role by default
+			None,                  // Sessions for system users do not expire by default
 		);
 
 		if if_not_exists {
@@ -208,6 +209,10 @@ impl Parser<'_> {
 					while self.eat(t!(",")) {
 						res.roles.push(self.next_token_value()?);
 					}
+				}
+				t!("SESSION") => {
+					self.pop_peek();
+					res.set_session(Some(self.next_token_value()?));
 				}
 				_ => break,
 			}

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -1782,13 +1782,13 @@ async fn permissions_checks_define_access_db() {
 async fn permissions_checks_define_user_root() {
 	let scenario = HashMap::from([
 		("prepare", ""),
-		("test", "DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER"),
+		("test", "DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER SESSION 1d"),
 		("check", "INFO FOR ROOT"),
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ namespaces: {  }, users: { user: \"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER\" } }"],
+        vec!["{ namespaces: {  }, users: { user: \"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER SESSION 1d\" } }"],
 		vec!["{ namespaces: {  }, users: {  } }"]
     ];
 
@@ -1824,13 +1824,13 @@ async fn permissions_checks_define_user_root() {
 async fn permissions_checks_define_user_ns() {
 	let scenario = HashMap::from([
 		("prepare", ""),
-		("test", "DEFINE USER user ON NS PASSHASH 'secret' ROLES VIEWER"),
+		("test", "DEFINE USER user ON NS PASSHASH 'secret' ROLES VIEWER SESSION 1d"),
 		("check", "INFO FOR NS"),
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ accesses: {  }, databases: {  }, users: { user: \"DEFINE USER user ON NAMESPACE PASSHASH 'secret' ROLES VIEWER\" } }"],
+        vec!["{ accesses: {  }, databases: {  }, users: { user: \"DEFINE USER user ON NAMESPACE PASSHASH 'secret' ROLES VIEWER SESSION 1d\" } }"],
 		vec!["{ accesses: {  }, databases: {  }, users: {  } }"]
     ];
 
@@ -1866,13 +1866,13 @@ async fn permissions_checks_define_user_ns() {
 async fn permissions_checks_define_user_db() {
 	let scenario = HashMap::from([
 		("prepare", ""),
-		("test", "DEFINE USER user ON DB PASSHASH 'secret' ROLES VIEWER"),
+		("test", "DEFINE USER user ON DB PASSHASH 'secret' ROLES VIEWER SESSION 1d"),
 		("check", "INFO FOR DB"),
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ accesses: {  }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: { user: \"DEFINE USER user ON DATABASE PASSHASH 'secret' ROLES VIEWER\" } }"],
+        vec!["{ accesses: {  }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: { user: \"DEFINE USER user ON DATABASE PASSHASH 'secret' ROLES VIEWER SESSION 1d\" } }"],
 		vec!["{ accesses: {  }, analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"]
     ];
 
@@ -2601,8 +2601,8 @@ async fn redefining_existing_table_with_if_not_exists_should_error() -> Result<(
 #[tokio::test]
 async fn redefining_existing_user_should_not_error() -> Result<(), Error> {
 	let sql = "
-		DEFINE USER example ON ROOT PASSWORD \"example\" ROLES OWNER;
-		DEFINE USER example ON ROOT PASSWORD \"example\" ROLES OWNER;
+		DEFINE USER example ON ROOT PASSWORD \"example\" ROLES OWNER SESSION 1d;
+		DEFINE USER example ON ROOT PASSWORD \"example\" ROLES OWNER SESSION 1d;
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
@@ -2621,8 +2621,8 @@ async fn redefining_existing_user_should_not_error() -> Result<(), Error> {
 #[tokio::test]
 async fn redefining_existing_user_with_if_not_exists_should_error() -> Result<(), Error> {
 	let sql = "
-		DEFINE USER IF NOT EXISTS example ON ROOT PASSWORD \"example\" ROLES OWNER;
-		DEFINE USER IF NOT EXISTS example ON ROOT PASSWORD \"example\" ROLES OWNER;
+		DEFINE USER IF NOT EXISTS example ON ROOT PASSWORD \"example\" ROLES OWNER SESSION 1d;
+		DEFINE USER IF NOT EXISTS example ON ROOT PASSWORD \"example\" ROLES OWNER SESSION 1d;
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");

--- a/lib/tests/info.rs
+++ b/lib/tests/info.rs
@@ -363,15 +363,15 @@ async fn permissions_checks_info_table() {
 #[tokio::test]
 async fn permissions_checks_info_user_root() {
 	let scenario = HashMap::from([
-		("prepare", "DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER"),
+		("prepare", "DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER SESSION 1d"),
 		("test", "INFO FOR USER user ON ROOT"),
 		("check", "INFO FOR USER user ON ROOT"),
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-		vec!["\"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER\""],
-		vec!["\"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER\""],
+		vec!["\"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER SESSION 1d\""],
+		vec!["\"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER SESSION 1d\""],
 	];
 
 	let test_cases = [
@@ -405,15 +405,15 @@ async fn permissions_checks_info_user_root() {
 #[tokio::test]
 async fn permissions_checks_info_user_ns() {
 	let scenario = HashMap::from([
-		("prepare", "DEFINE USER user ON NS PASSHASH 'secret' ROLES VIEWER"),
+		("prepare", "DEFINE USER user ON NS PASSHASH 'secret' ROLES VIEWER SESSION 1d"),
 		("test", "INFO FOR USER user ON NS"),
 		("check", "INFO FOR USER user ON NS"),
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-		vec!["\"DEFINE USER user ON NAMESPACE PASSHASH 'secret' ROLES VIEWER\""],
-		vec!["\"DEFINE USER user ON NAMESPACE PASSHASH 'secret' ROLES VIEWER\""],
+		vec!["\"DEFINE USER user ON NAMESPACE PASSHASH 'secret' ROLES VIEWER SESSION 1d\""],
+		vec!["\"DEFINE USER user ON NAMESPACE PASSHASH 'secret' ROLES VIEWER SESSION 1d\""],
 	];
 
 	let test_cases = [
@@ -447,15 +447,15 @@ async fn permissions_checks_info_user_ns() {
 #[tokio::test]
 async fn permissions_checks_info_user_db() {
 	let scenario = HashMap::from([
-		("prepare", "DEFINE USER user ON DB PASSHASH 'secret' ROLES VIEWER"),
+		("prepare", "DEFINE USER user ON DB PASSHASH 'secret' ROLES VIEWER SESSION 1d"),
 		("test", "INFO FOR USER user ON DB"),
 		("check", "INFO FOR USER user ON DB"),
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-		vec!["\"DEFINE USER user ON DATABASE PASSHASH 'secret' ROLES VIEWER\""],
-		vec!["\"DEFINE USER user ON DATABASE PASSHASH 'secret' ROLES VIEWER\""],
+		vec!["\"DEFINE USER user ON DATABASE PASSHASH 'secret' ROLES VIEWER SESSION 1d\""],
+		vec!["\"DEFINE USER user ON DATABASE PASSHASH 'secret' ROLES VIEWER SESSION 1d\""],
 	];
 
 	let test_cases = [


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To allow SurrealDB administrators to set a specific session expiration (or none) for system users, so that all sessions will be able to expire regardless of the access method (e.g. basic authentication or token) or type of user that they belong to. 

## What does this change do?

Introduces the `SESSION` clause to the `DEFINE USER` statement, which defaults to `None`. If included when defining a user, sessions for that user will expire after the specified duration when authenticating with a password or passhash.

The token returned after successful authentication will still expire after an hour, the SurrealDB default when issuing tokens, and sessions created with that token will inherit the expiration from the token. This is to consistently ensure that sessions cannot be authenticated for longer than the lifetime of the token that was used to establish them.

Makes a small change to improve clarity around the default role when the original root user is created.

## What is your testing strategy?

I have updated the tests to ensure that the `SESSION` clause works as intended, as well as to ensure that the actual session expiration matches the value of the clause when performing basic authentication.

## Is this related to any issues?

No.

## Does this change need documentation?

Yes, this requires updating the `DEFINE USER` documentation as well as the "[Sessions](https://surrealdb.com/docs/surrealdb/security/authentication#sessions)" section under "Authentication".

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
