### PR TITLE
Fix scheduled nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,16 +2,11 @@
 
 name: Nightly release
 
-run-name: "Nightly release '${{ inputs.git-ref }}' (publish: ${{ inputs.publish || github.event_name == 'schedule' }})"
+run-name: "Nightly release (publish: ${{ inputs.publish || github.event_name == 'schedule' }})"
 
 on:
   workflow_dispatch:
     inputs:
-      git-ref:
-        required: true
-        type: string
-        description: "The github ref of this nightly version (i.e. main, 1234567)"
-        default: 1.x
       publish:
         required: false
         type: boolean
@@ -34,6 +29,6 @@ jobs:
     with:
       environment: nightly
       extra-features: storage-surrealkv
-      git-ref: ${{ inputs.git-ref }}
+      git-ref: 1.x
       publish: ${{ inputs.publish || github.event_name == 'schedule' }}
     secrets: inherit


### PR DESCRIPTION
## What is the motivation?

Scheduled nightly builds are currently broken. This is because the `git-ref` input is not being properly filled for scheduled builds even though it has a default value.

## What does this change do?

It drops the input and makes sure nightly always builds against `1.x`.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
