### PR TITLE
Fix `surreal upgrade --nightly`

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -111,12 +111,14 @@ pub async fn init(args: UpgradeCommandArguments) -> Result<(), Error> {
 	let new_version = args.version().await?;
 
 	// Parsed version numbers follow semver format (major.minor.patch)
-	let old_version_parsed = parse_version(&old_version)?;
-	let new_version_parsed = parse_version(&new_version)?;
+	if new_version != NIGHTLY && new_version != BETA {
+		let old_version_parsed = parse_version(&old_version)?;
+		let new_version_parsed = parse_version(&new_version)?;
 
-	if old_version_parsed == new_version_parsed {
-		println!("{old_version} is already installed");
-		return Ok(());
+		if old_version_parsed == new_version_parsed {
+			println!("{old_version} is already installed");
+			return Ok(());
+		}
 	}
 
 	let arch = arch();


### PR DESCRIPTION
## What is the motivation?

`surreal upgrade --nightly` is currently broken. It's currently returning something like

```
2024-05-30T17:15:37.925647Z ERROR surreal::cli: Invalid version `nightly`
```

## What does this change do?

It ensures we only compare non-nightly and non-beta versions.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
