### PR TITLE
Batched export

### DIFF
--- a/core/src/cnf/mod.rs
+++ b/core/src/cnf/mod.rs
@@ -53,4 +53,5 @@ pub static INSECURE_FORWARD_RECORD_ACCESS_ERRORS: Lazy<bool> =
 pub static EXTERNAL_SORTING_BUFFER_LIMIT: Lazy<usize> =
 	lazy_env_parse!("SURREAL_EXTERNAL_SORTING_BUFFER_LIMIT", usize, 50_000);
 
+/// The number of records that should be fetched and grouped together in an INSERT statement when exporting.
 pub static EXPORT_BATCH_SIZE: Lazy<u32> = lazy_env_parse!("SURREAL_EXPORT_BATCH_SIZE", u32, 1000);

--- a/core/src/cnf/mod.rs
+++ b/core/src/cnf/mod.rs
@@ -52,3 +52,5 @@ pub static INSECURE_FORWARD_RECORD_ACCESS_ERRORS: Lazy<bool> =
 /// If the environment variable is not present or cannot be parsed, a default value of 50,000 is used.
 pub static EXTERNAL_SORTING_BUFFER_LIMIT: Lazy<usize> =
 	lazy_env_parse!("SURREAL_EXTERNAL_SORTING_BUFFER_LIMIT", usize, 50_000);
+
+pub static EXPORT_BATCH_SIZE: Lazy<u32> = lazy_env_parse!("SURREAL_EXPORT_BATCH_SIZE", u32, 1000);

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -2584,19 +2584,20 @@ impl Transaction {
 
 						// Add batches of INSERT statements
 						// No need to chunk here, the scan it limited to 1000
-						for records in normal.into_iter() {
-							let values = records.join(", ");
+						{
+							let values = normal.join(", ");
 							let sql = format!("INSERT [ {values} ];");
 							chn.send(bytes!(sql)).await?;
 						}
 
 						// Add batches of INSERT RELATION statements
 						// No need to chunk here, the scan it limited to 1000
-						for records in relation.into_iter() {
-							let values = records.join(", ");
+						{
+							let values = relation.join(", ");
 							let sql = format!("INSERT RELATION [ {values} ];");
 							chn.send(bytes!(sql)).await?;
 						}
+
 						continue;
 					}
 					chn.send(bytes!("")).await?;

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -2583,14 +2583,14 @@ impl Transaction {
 						}
 
 						// Add batches of INSERT statements
-						for records in normal.chunks(1000).into_iter() {
+						for records in normal.chunks(1000) {
 							let values = records.join(", ");
 							let sql = format!("INSERT [ {values} ];");
 							chn.send(bytes!(sql)).await?;
 						}
 
 						// Add batches of INSERT RELATION statements
-						for records in relation.chunks(1000).into_iter() {
+						for records in relation.chunks(1000) {
 							let values = records.join(", ");
 							let sql = format!("INSERT RELATION [ {values} ];");
 							chn.send(bytes!(sql)).await?;

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -2583,14 +2583,16 @@ impl Transaction {
 						}
 
 						// Add batches of INSERT statements
-						for records in normal.chunks(1000) {
+						// No need to chunk here, the scan it limited to 1000
+						for records in normal.into_iter() {
 							let values = records.join(", ");
 							let sql = format!("INSERT [ {values} ];");
 							chn.send(bytes!(sql)).await?;
 						}
 
 						// Add batches of INSERT RELATION statements
-						for records in relation.chunks(1000) {
+						// No need to chunk here, the scan it limited to 1000
+						for records in relation.into_iter() {
 							let values = records.join(", ");
 							let sql = format!("INSERT RELATION [ {values} ];");
 							chn.send(bytes!(sql)).await?;

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -2584,17 +2584,15 @@ impl Transaction {
 
 						// Add batches of INSERT statements
 						for records in normal.chunks(1000).into_iter() {
-							let tb_name = &tb.name;
 							let values = records.join(", ");
-							let sql = format!("INSERT INTO {tb_name} [ {values} ]");
+							let sql = format!("INSERT [ {values} ]");
 							chn.send(bytes!(sql)).await?;
 						}
 
 						// Add batches of INSERT RELATION statements
 						for records in relation.chunks(1000).into_iter() {
-							let tb_name = &tb.name;
 							let values = records.join(", ");
-							let sql = format!("INSERT RELATION INTO {tb_name} [ {values} ]");
+							let sql = format!("INSERT RELATION [ {values} ]");
 							chn.send(bytes!(sql)).await?;
 						}
 						continue;

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -2585,14 +2585,14 @@ impl Transaction {
 						// Add batches of INSERT statements
 						for records in normal.chunks(1000).into_iter() {
 							let values = records.join(", ");
-							let sql = format!("INSERT [ {values} ]");
+							let sql = format!("INSERT [ {values} ];");
 							chn.send(bytes!(sql)).await?;
 						}
 
 						// Add batches of INSERT RELATION statements
 						for records in relation.chunks(1000).into_iter() {
 							let values = records.join(", ");
-							let sql = format!("INSERT RELATION [ {values} ]");
+							let sql = format!("INSERT RELATION [ {values} ];");
 							chn.send(bytes!(sql)).await?;
 						}
 						continue;

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -101,7 +101,7 @@ mod cli_integration {
 			let args = format!("export --conn http://{addr} {creds} --ns {ns} --db {db} -");
 			let output = common::run(&args).output().expect("failed to run stdout export: {args}");
 			assert!(output.contains("DEFINE TABLE thing TYPE ANY SCHEMALESS PERMISSIONS NONE;"));
-			assert!(output.contains("UPDATE thing:one CONTENT { id: thing:one };"));
+			assert!(output.contains("INSERT [ { id: thing:one } ];"));
 		}
 
 		info!("* Export to file");


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To optimize exporting and importing data in SurrealDB, we can make use of the `INSERT` statement to batch insert data, a thousand records at a time.

## What does this change do?

This PR changes the export behaviour to create batches of a thousand records at a time, via the `INSERT` statement, also utilising the new `INSERT RELATION` statement to achieve the same behaviour for relations.

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

Not that I know of

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
