### PR TITLE
fix: handle content-type with charset

### DIFF
--- a/src/net/headers/accept.rs
+++ b/src/net/headers/accept.rs
@@ -36,8 +36,10 @@ impl Header for Accept {
 		I: Iterator<Item = &'i HeaderValue>,
 	{
 		let value = values.next().ok_or_else(headers::Error::invalid)?;
+		let parts: Vec<&str> =
+			value.to_str().map_err(|_| headers::Error::invalid())?.split(';').collect();
 
-		match value.to_str().map_err(|_| headers::Error::invalid())? {
+		match parts[0] {
 			"text/plain" => Ok(Accept::TextPlain),
 			"application/json" => Ok(Accept::ApplicationJson),
 			"application/cbor" => Ok(Accept::ApplicationCbor),

--- a/src/net/headers/content_type.rs
+++ b/src/net/headers/content_type.rs
@@ -36,8 +36,10 @@ impl Header for ContentType {
 		I: Iterator<Item = &'i HeaderValue>,
 	{
 		let value = values.next().ok_or_else(headers::Error::invalid)?;
+		let parts: Vec<&str> =
+			value.to_str().map_err(|_| headers::Error::invalid())?.split(';').collect();
 
-		match value.to_str().map_err(|_| headers::Error::invalid())? {
+		match parts[0] {
 			"text/plain" => Ok(ContentType::TextPlain),
 			"application/json" => Ok(ContentType::ApplicationJson),
 			"application/cbor" => Ok(ContentType::ApplicationCbor),


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What does this change do?

Handle `Content-Type` that can contains `charset` in the `/rpc` endpoint

## What is your testing strategy?

Tested via Postman

## Is this related to any issues?

Fixes https://github.com/surrealdb/surrealdb/issues/4106

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
