### PR TITLE
[Bug fix] Redefining HNSW index error

### DIFF
--- a/core/src/idx/trees/hnsw/heuristic.rs
+++ b/core/src/idx/trees/hnsw/heuristic.rs
@@ -113,12 +113,17 @@ impl Heuristic {
 		let mut ex = c.to_set();
 		let mut ext = Vec::with_capacity(m_max.min(c.len()));
 		for (_, e_id) in c.to_vec().into_iter() {
-			for &e_adj in layer.get_edges(&e_id).unwrap_or_else(|| unreachable!()).iter() {
-				if e_adj != q_id && ex.insert(e_adj) {
-					if let Some(d) = elements.get_distance(q_pt, &e_adj) {
-						ext.push((d, e_adj));
+			if let Some(e_conn) = layer.get_edges(&e_id) {
+				for &e_adj in e_conn.iter() {
+					if e_adj != q_id && ex.insert(e_adj) {
+						if let Some(d) = elements.get_distance(q_pt, &e_adj) {
+							ext.push((d, e_adj));
+						}
 					}
 				}
+			} else {
+				#[cfg(debug_assertions)]
+				unreachable!()
 			}
 		}
 		for (e_dist, e_id) in ext {

--- a/core/src/idx/trees/hnsw/layer.rs
+++ b/core/src/idx/trees/hnsw/layer.rs
@@ -235,17 +235,20 @@ where
 		let neighbors = self.graph.add_node_and_bidirectional_edges(q_id, neighbors);
 
 		for e_id in neighbors {
-			let e_conn =
-				self.graph.get_edges(&e_id).unwrap_or_else(|| unreachable!("Element: {}", e_id));
-			if e_conn.len() > self.m_max {
-				if let Some(e_pt) = elements.get_vector(&e_id) {
-					let e_c = self.build_priority_list(elements, e_id, e_conn);
-					let mut e_new_conn = self.graph.new_edges();
-					heuristic.select(elements, self, e_id, e_pt, e_c, &mut e_new_conn);
-					#[cfg(debug_assertions)]
-					assert!(!e_new_conn.contains(&e_id));
-					self.graph.set_node(e_id, e_new_conn);
+			if let Some(e_conn) = self.graph.get_edges(&e_id) {
+				if e_conn.len() > self.m_max {
+					if let Some(e_pt) = elements.get_vector(&e_id) {
+						let e_c = self.build_priority_list(elements, e_id, e_conn);
+						let mut e_new_conn = self.graph.new_edges();
+						heuristic.select(elements, self, e_id, e_pt, e_c, &mut e_new_conn);
+						#[cfg(debug_assertions)]
+						assert!(!e_new_conn.contains(&e_id));
+						self.graph.set_node(e_id, e_new_conn);
+					}
 				}
+			} else {
+				#[cfg(debug_assertions)]
+				unreachable!("Element: {}", e_id);
 			}
 		}
 		eps


### PR DESCRIPTION
## What is the motivation?

- Redefining an HNSW index crashes the server: 

## What does this change do?

The `index store cache` is now properly cleared when an index is redefined.

Activate the "unreachable!" only in debug. In `release`, it will return zero results.

## What is your testing strategy?

A test has been written

## Is this related to any issues?

https://discord.com/channels/902568124350599239/1018618253695795261/1244697068262395964

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
