### PR TITLE
feat: check valid func target on start command

### DIFF
--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -5,7 +5,7 @@ use std::{
 	time::Duration,
 };
 
-use surrealdb::dbs::capabilities::{FuncTarget, NetTarget, Targets};
+use surrealdb::dbs::capabilities::{FuncTarget, NetTarget, Target, Targets};
 
 pub(crate) mod parser;
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What does this change do?

Enforce validation on targets used in the `start`, e.g. for `--allow-funcs` params.

## What is your testing strategy?

![image](https://github.com/surrealdb/surrealdb/assets/6053067/1bd3c2ab-6333-4abf-a9a1-5c1cfec63a8d)

## Is this related to any issues?

Closes https://github.com/surrealdb/surrealdb/issues/3965

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
