### PR TITLE
Restructure the Query struct in the rust library

### DIFF
--- a/lib/src/api/engine/any/mod.rs
+++ b/lib/src/api/engine/any/mod.rs
@@ -240,7 +240,6 @@ impl Surreal<Any> {
 			engine: PhantomData,
 			address: address.into_endpoint(),
 			capacity: 0,
-			client: PhantomData,
 			waiter: self.waiter.clone(),
 			response_type: PhantomData,
 		}
@@ -297,7 +296,6 @@ pub fn connect(address: impl IntoEndpoint) -> Connect<Any, Surreal<Any>> {
 		engine: PhantomData,
 		address: address.into_endpoint(),
 		capacity: 0,
-		client: PhantomData,
 		waiter: Arc::new(watch::channel(None)),
 		response_type: PhantomData,
 	}

--- a/lib/src/api/engine/any/native.rs
+++ b/lib/src/api/engine/any/native.rs
@@ -231,15 +231,14 @@ impl Connection for Any {
 				EndpointKind::Unsupported(v) => return Err(Error::Scheme(v).into()),
 			}
 
-			Ok(Surreal {
-				router: Arc::new(OnceLock::with_value(Router {
+			Ok(Surreal::new_from_router_waiter(
+				Arc::new(OnceLock::with_value(Router {
 					features,
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
-				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
-				engine: PhantomData,
-			})
+				Arc::new(watch::channel(Some(WaitFor::Connection))),
+			))
 		})
 	}
 

--- a/lib/src/api/engine/any/native.rs
+++ b/lib/src/api/engine/any/native.rs
@@ -27,7 +27,6 @@ use flume::Receiver;
 use reqwest::ClientBuilder;
 use std::collections::HashSet;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;

--- a/lib/src/api/engine/any/wasm.rs
+++ b/lib/src/api/engine/any/wasm.rs
@@ -184,15 +184,14 @@ impl Connection for Any {
 				EndpointKind::Unsupported(v) => return Err(Error::Scheme(v).into()),
 			}
 
-			Ok(Surreal {
-				router: Arc::new(OnceLock::with_value(Router {
+			Ok(Surreal::new_from_router_waiter(
+				Arc::new(OnceLock::with_value(Router {
 					features,
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
-				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
-				engine: PhantomData,
-			})
+				Arc::new(watch::channel(Some(WaitFor::Connection))),
+			))
 		})
 	}
 

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -389,7 +389,6 @@ impl Surreal<Db> {
 			engine: PhantomData,
 			address: address.into_endpoint(),
 			capacity: 0,
-			client: PhantomData,
 			waiter: self.waiter.clone(),
 			response_type: PhantomData,
 		}

--- a/lib/src/api/engine/local/native.rs
+++ b/lib/src/api/engine/local/native.rs
@@ -27,7 +27,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
@@ -64,15 +63,14 @@ impl Connection for Db {
 			features.insert(ExtraFeatures::Backup);
 			features.insert(ExtraFeatures::LiveQueries);
 
-			Ok(Surreal {
-				router: Arc::new(OnceLock::with_value(Router {
+			Ok(Surreal::new_from_router_waiter(
+				Arc::new(OnceLock::with_value(Router {
 					features,
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
-				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
-				engine: PhantomData,
-			})
+				Arc::new(watch::channel(Some(WaitFor::Connection))),
+			))
 		})
 	}
 

--- a/lib/src/api/engine/local/wasm.rs
+++ b/lib/src/api/engine/local/wasm.rs
@@ -65,15 +65,14 @@ impl Connection for Db {
 			let mut features = HashSet::new();
 			features.insert(ExtraFeatures::LiveQueries);
 
-			Ok(Surreal {
-				router: Arc::new(OnceLock::with_value(Router {
+			Ok(Surreal::new_from_router_waiter(
+				Arc::new(OnceLock::with_value(Router {
 					features,
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
-				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
-				engine: PhantomData,
-			})
+				Arc::new(watch::channel(Some(WaitFor::Connection))),
+			))
 		})
 	}
 

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -102,7 +102,6 @@ impl Surreal<Client> {
 			engine: PhantomData,
 			address: address.into_endpoint(),
 			capacity: 0,
-			client: PhantomData,
 			waiter: self.waiter.clone(),
 			response_type: PhantomData,
 		}

--- a/lib/src/api/engine/remote/http/native.rs
+++ b/lib/src/api/engine/remote/http/native.rs
@@ -20,7 +20,6 @@ use reqwest::header::HeaderMap;
 use reqwest::ClientBuilder;
 use std::collections::HashSet;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
@@ -73,15 +72,14 @@ impl Connection for Client {
 			let mut features = HashSet::new();
 			features.insert(ExtraFeatures::Backup);
 
-			Ok(Surreal {
-				router: Arc::new(OnceLock::with_value(Router {
+			Ok(Surreal::new_from_router_waiter(
+				Arc::new(OnceLock::with_value(Router {
 					features,
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
-				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
-				engine: PhantomData,
-			})
+				Arc::new(watch::channel(Some(WaitFor::Connection))),
+			))
 		})
 	}
 

--- a/lib/src/api/engine/remote/http/wasm.rs
+++ b/lib/src/api/engine/remote/http/wasm.rs
@@ -52,15 +52,14 @@ impl Connection for Client {
 
 			conn_rx.into_recv_async().await??;
 
-			Ok(Surreal {
-				router: Arc::new(OnceLock::with_value(Router {
+			Ok(Surreal::new_from_router_waiter(
+				Arc::new(OnceLock::with_value(Router {
 					features: HashSet::new(),
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
-				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
-				engine: PhantomData,
-			})
+				Arc::new(watch::channel(Some(WaitFor::Connection))),
+			))
 		})
 	}
 

--- a/lib/src/api/engine/remote/ws/mod.rs
+++ b/lib/src/api/engine/remote/ws/mod.rs
@@ -77,7 +77,6 @@ impl Surreal<Client> {
 			engine: PhantomData,
 			address: address.into_endpoint(),
 			capacity: 0,
-			client: PhantomData,
 			waiter: self.waiter.clone(),
 			response_type: PhantomData,
 		}

--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -35,7 +35,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::mem;
 use std::pin::Pin;
 use std::sync::atomic::AtomicI64;

--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -150,15 +150,14 @@ impl Connection for Client {
 			let mut features = HashSet::new();
 			features.insert(ExtraFeatures::LiveQueries);
 
-			Ok(Surreal {
-				router: Arc::new(OnceLock::with_value(Router {
+			Ok(Surreal::new_from_router_waiter(
+				Arc::new(OnceLock::with_value(Router {
 					features,
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
-				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
-				engine: PhantomData,
-			})
+				Arc::new(watch::channel(Some(WaitFor::Connection))),
+			))
 		})
 	}
 

--- a/lib/src/api/engine/remote/ws/wasm.rs
+++ b/lib/src/api/engine/remote/ws/wasm.rs
@@ -90,15 +90,14 @@ impl Connection for Client {
 			let mut features = HashSet::new();
 			features.insert(ExtraFeatures::LiveQueries);
 
-			Ok(Surreal {
-				router: Arc::new(OnceLock::with_value(Router {
+			Ok(Surreal::new_from_router_waiter(
+				Arc::new(OnceLock::with_value(Router {
 					features,
 					sender: route_tx,
 					last_id: AtomicI64::new(0),
 				})),
-				waiter: Arc::new(watch::channel(Some(WaitFor::Connection))),
-				engine: PhantomData,
-			})
+				Arc::new(watch::channel(Some(WaitFor::Connection))),
+			))
 		})
 	}
 

--- a/lib/src/api/method/live.rs
+++ b/lib/src/api/method/live.rs
@@ -101,17 +101,11 @@ macro_rules! into_future {
 				);
 				let id: Value = query.await?.take(0)?;
 				let rx = register::<Client>(router, id.clone()).await?;
-				Ok(Stream {
+				Ok(Stream::new(
+					Surreal::new_from_router_waiter(client.router.clone(), client.waiter.clone()),
 					id,
-					rx: Some(rx),
-					client: Surreal {
-						router: client.router.clone(),
-						waiter: client.waiter.clone(),
-						engine: PhantomData,
-					},
-					response_type: PhantomData,
-					engine: PhantomData,
-				})
+					Some(rx),
+				))
 			})
 		}
 	};

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -264,7 +264,6 @@ where
 			engine: PhantomData,
 			address: address.into_endpoint(),
 			capacity: 0,
-			client: PhantomData,
 			waiter: Arc::new(watch::channel(None)),
 			response_type: PhantomData,
 		}

--- a/lib/src/api/method/mod.rs
+++ b/lib/src/api/method/mod.rs
@@ -86,6 +86,8 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 
+use self::query::ValidQuery;
+
 /// Query statistics
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
@@ -662,11 +664,15 @@ where
 	/// # }
 	/// ```
 	pub fn query(&self, query: impl opt::IntoQuery) -> Query<C> {
-		Query {
+		let inner = query.into_query().map(|x| ValidQuery {
 			client: Cow::Borrowed(self),
-			query: vec![query.into_query()],
-			bindings: Ok(Default::default()),
+			query: x,
+			bindings: Default::default(),
 			register_live_queries: true,
+		});
+
+		Query {
+			inner,
 		}
 	}
 

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -174,7 +174,10 @@ where
 
 				let res = live::register::<Client>(router, id.clone()).await.map(|rx| {
 					Stream::new(
-						Surreal::new_surreal(client.router.clone(), client.waiter.clone()),
+						Surreal::new_from_router_waiter(
+							client.router.clone(),
+							client.waiter.clone(),
+						),
 						id.clone(),
 						Some(rx),
 					)
@@ -183,7 +186,8 @@ where
 				response.live_queries.insert(idx, res);
 			}
 
-			response.client = Surreal::new_surreal(client.router.clone(), client.waiter.clone());
+			response.client =
+				Surreal::new_from_router_waiter(client.router.clone(), client.waiter.clone());
 			Ok(response)
 		})
 	}

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -29,7 +29,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::future::Future;
 use std::future::IntoFuture;
-use std::marker::PhantomData;
 use std::mem;
 use std::pin::Pin;
 use std::task::Context;
@@ -39,21 +38,70 @@ use std::task::Poll;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Query<'r, C: Connection> {
-	pub(super) client: Cow<'r, Surreal<C>>,
-	pub(super) query: Vec<Result<Vec<Statement>>>,
-	pub(super) bindings: Result<BTreeMap<String, Value>>,
-	pub(crate) register_live_queries: bool,
+	pub(crate) inner: Result<ValidQuery<'r, C>>,
 }
 
-impl<C> Query<'_, C>
+#[derive(Debug)]
+pub(crate) struct ValidQuery<'r, C: Connection> {
+	pub client: Cow<'r, Surreal<C>>,
+	pub query: Vec<Statement>,
+	pub bindings: BTreeMap<String, Value>,
+	pub register_live_queries: bool,
+}
+
+impl<'r, C> Query<'r, C>
 where
 	C: Connection,
 {
+	pub(crate) fn new(
+		client: Cow<'r, Surreal<C>>,
+		query: Vec<Statement>,
+		bindings: BTreeMap<String, Value>,
+		register_live_queries: bool,
+	) -> Self {
+		Query {
+			inner: Ok(ValidQuery {
+				client,
+				query,
+				bindings,
+				register_live_queries,
+			}),
+		}
+	}
+
+	pub(crate) fn map_valid<F>(self, f: F) -> Self
+	where
+		F: FnOnce(ValidQuery<'r, C>) -> Result<ValidQuery<'r, C>>,
+	{
+		match self.inner {
+			Ok(x) => Query {
+				inner: f(x),
+			},
+			x => Query {
+				inner: x,
+			},
+		}
+	}
+
 	/// Converts to an owned type which can easily be moved to a different thread
 	pub fn into_owned(self) -> Query<'static, C> {
+		let inner = match self.inner {
+			Ok(ValidQuery {
+				client,
+				query,
+				bindings,
+				register_live_queries,
+			}) => Ok(ValidQuery::<'static, C> {
+				client: Cow::Owned(client.into_owned()),
+				query,
+				bindings,
+				register_live_queries,
+			}),
+			Err(e) => Err(e),
+		};
+
 		Query {
-			client: Cow::Owned(self.client.into_owned()),
-			..self
+			inner,
 		}
 	}
 }
@@ -66,69 +114,76 @@ where
 	type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
 	fn into_future(self) -> Self::IntoFuture {
+		let ValidQuery {
+			client,
+			query,
+			bindings,
+			register_live_queries,
+		} = match self.inner {
+			Ok(x) => x,
+			Err(error) => return Box::pin(async move { return Err(error) }),
+		};
+
+		let query_statements = query;
+
 		Box::pin(async move {
 			// Extract the router from the client
-			let router = self.client.router.extract()?;
-			// Combine all query statements supplied
-			let mut statements = Vec::with_capacity(self.query.len());
-			for query in self.query {
-				statements.extend(query?);
+			let router = client.router.extract()?;
+
+			// Collect the indexes of the live queries which should be registerd.
+			let query_indicies = if register_live_queries {
+				query_statements
+					.iter()
+					// BEGIN, COMMIT, and CANCEL don't return a result.
+					.filter(|x| {
+						matches!(
+							x,
+							Statement::Begin(_) | Statement::Commit(_) | Statement::Cancel(_)
+						)
+					})
+					.enumerate()
+					.filter(|(_, x)| matches!(x, Statement::Live(_)))
+					.map(|(i, _)| i)
+					.collect()
+			} else {
+				Vec::new()
+			};
+
+			// If there are live queries and it is not supported, return an error.
+			if !query_indicies.is_empty() && !router.features.contains(&ExtraFeatures::LiveQueries)
+			{
+				return Err(Error::LiveQueriesNotSupported.into());
 			}
-			// Build the query and execute it
+
 			let mut query = sql::Query::default();
-			query.0 .0.clone_from(&statements);
-			let param = Param::query(query, self.bindings?);
+			query.0 .0 = query_statements;
+
+			let param = Param::query(query, bindings);
 			let mut conn = Client::new(Method::Query);
 			let mut response = conn.execute_query(router, param).await?;
-			// Register live queries if necessary
-			if self.register_live_queries {
-				let mut live_queries = IndexMap::new();
-				let mut checked = false;
-				// Adjusting offsets as a workaround to https://github.com/surrealdb/surrealdb/issues/3318
-				let mut offset = 0;
-				for (index, stmt) in statements.into_iter().enumerate() {
-					if let Statement::Live(stmt) = stmt {
-						if !checked && !router.features.contains(&ExtraFeatures::LiveQueries) {
-							return Err(Error::LiveQueriesNotSupported.into());
-						}
-						checked = true;
-						let index = index - offset;
-						if let Some((_, result)) = response.results.get(&index) {
-							let result =
-								match result {
-									Ok(id) => live::register::<Client>(router, id.clone())
-										.await
-										.map(|rx| Stream {
-											id: stmt.id.into(),
-											rx: Some(rx),
-											client: Surreal {
-												router: self.client.router.clone(),
-												waiter: self.client.waiter.clone(),
-												engine: PhantomData,
-											},
-											response_type: PhantomData,
-											engine: PhantomData,
-										}),
-									// This is a live query. We are using this as a workaround to avoid
-									// creating another public error variant for this internal error.
-									Err(..) => Err(Error::NotLiveQuery(index).into()),
-								};
-							live_queries.insert(index, result);
-						}
-					} else if matches!(
-						stmt,
-						Statement::Begin(..) | Statement::Commit(..) | Statement::Cancel(..)
-					) {
-						offset += 1;
-					}
-				}
-				response.live_queries = live_queries;
+
+			for idx in query_indicies {
+				let Some((_, result)) = response.results.get(&idx) else {
+					continue;
+				};
+
+				// This is a live query. We are using this as a workaround to avoid
+				// creating another public error variant for this internal error.
+				let id =
+					result.as_ref().map_err(|_| crate::Error::from(Error::NotLiveQuery(idx)))?;
+
+				let res = live::register::<Client>(router, id.clone()).await.map(|rx| {
+					Stream::new(
+						Surreal::new_surreal(client.router.clone(), client.waiter.clone()),
+						id.clone(),
+						Some(rx),
+					)
+				});
+
+				response.live_queries.insert(idx, res);
 			}
-			response.client = Surreal {
-				router: self.client.router.clone(),
-				waiter: self.client.waiter.clone(),
-				engine: PhantomData,
-			};
+
+			response.client = Surreal::new_surreal(client.router.clone(), client.waiter.clone());
 			Ok(response)
 		})
 	}
@@ -154,9 +209,12 @@ where
 	C: Connection,
 {
 	/// Chains a query onto an existing query
-	pub fn query(mut self, query: impl opt::IntoQuery) -> Self {
-		self.query.push(query.into_query());
-		self
+	pub fn query(self, query: impl opt::IntoQuery) -> Self {
+		self.map_valid(move |mut valid| {
+			let new_query = query.into_query()?;
+			valid.query.extend(new_query);
+			Ok(valid)
+		})
 	}
 
 	/// Return query statistics along with its results
@@ -205,30 +263,25 @@ where
 	/// # Ok(())
 	/// # }
 	/// ```
-	pub fn bind(mut self, bindings: impl Serialize) -> Self {
-		if let Ok(current) = &mut self.bindings {
-			match to_value(bindings) {
-				Ok(mut bindings) => {
-					if let Value::Array(array) = &mut bindings {
-						if let [Value::Strand(key), value] = &mut array.0[..] {
-							let mut map = BTreeMap::new();
-							map.insert(mem::take(&mut key.0), mem::take(value));
-							bindings = map.into();
-						}
-					}
-					match &mut bindings {
-						Value::Object(map) => current.append(&mut map.0),
-						_ => {
-							self.bindings = Err(Error::InvalidBindings(bindings).into());
-						}
-					}
-				}
-				Err(error) => {
-					self.bindings = Err(error.into());
+	pub fn bind(self, bindings: impl Serialize) -> Self {
+		self.map_valid(move |mut valid| {
+			let mut bindings = to_value(bindings)?;
+			if let Value::Array(array) = &mut bindings {
+				if let [Value::Strand(key), value] = &mut array.0[..] {
+					let mut map = BTreeMap::new();
+					map.insert(mem::take(&mut key.0), mem::take(value));
+					bindings = map.into();
 				}
 			}
-		}
-		self
+			match &mut bindings {
+				Value::Object(map) => valid.bindings.append(&mut map.0),
+				_ => {
+					return Err(Error::InvalidBindings(bindings).into());
+				}
+			}
+
+			Ok(valid)
+		})
 	}
 }
 

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -136,7 +136,7 @@ where
 					.iter()
 					// BEGIN, COMMIT, and CANCEL don't return a result.
 					.filter(|x| {
-						matches!(
+						!matches!(
 							x,
 							Statement::Begin(_) | Statement::Commit(_) | Statement::Cancel(_)
 						)
@@ -183,6 +183,7 @@ where
 					Err(_) => Err(crate::Error::from(Error::NotLiveQuery(idx))),
 				};
 
+				dbg!(&response);
 				response.live_queries.insert(idx, res);
 			}
 

--- a/lib/src/api/method/tests/protocol.rs
+++ b/lib/src/api/method/tests/protocol.rs
@@ -79,11 +79,10 @@ impl Connection for Client {
 				last_id: AtomicI64::new(0),
 			};
 			server::mock(route_rx);
-			Ok(Surreal {
-				router: Arc::new(OnceLock::with_value(router)),
-				waiter: Arc::new(watch::channel(None)),
-				engine: PhantomData,
-			})
+			Ok(Surreal::new_from_router_waiter(
+				Arc::new(OnceLock::with_value(router)),
+				Arc::new(watch::channel(None)),
+			))
 		})
 	}
 

--- a/lib/src/api/method/tests/protocol.rs
+++ b/lib/src/api/method/tests/protocol.rs
@@ -49,7 +49,6 @@ impl Surreal<Client> {
 			engine: PhantomData,
 			address: address.into_endpoint(),
 			capacity: 0,
-			client: PhantomData,
 			waiter: self.waiter.clone(),
 			response_type: PhantomData,
 		}

--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -177,6 +177,14 @@ impl<C> Surreal<C>
 where
 	C: Connection,
 {
+	pub(crate) fn new_surreal(router: Arc<OnceLock<Router>>, waiter: Arc<Waiter>) -> Self {
+		Surreal {
+			router,
+			waiter,
+			engine: PhantomData,
+		}
+	}
+
 	async fn check_server_version(&self, version: &Version) -> Result<()> {
 		let (versions, build_meta) = SUPPORTED_VERSIONS;
 		// invalid version requirements should be caught during development

--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -51,7 +51,6 @@ pub struct Connect<C: Connection, Response> {
 	engine: PhantomData<C>,
 	address: Result<Endpoint>,
 	capacity: usize,
-	client: PhantomData<C>,
 	waiter: Arc<Waiter>,
 	response_type: PhantomData<Response>,
 }

--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -177,7 +177,10 @@ impl<C> Surreal<C>
 where
 	C: Connection,
 {
-	pub(crate) fn new_surreal(router: Arc<OnceLock<Router>>, waiter: Arc<Waiter>) -> Self {
+	pub(crate) fn new_from_router_waiter(
+		router: Arc<OnceLock<Router>>,
+		waiter: Arc<Waiter>,
+	) -> Self {
 		Surreal {
 			router,
 			waiter,


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Simplifies the handling of errors in the Query struct a bit.

## What does this change do?

The Query struct collects any errors that happens during it's creation and returns the first when awaited as a future. 
This PR restructures this struct so that only a single error has to be stored and after an error happened all future operations on the query are a no-op. 

This simplifies the code a bit and does less allocations.

## What is your testing strategy?

API should remain the same, existing tests should continue to function

## Is this related to any issues?

None

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
