### PR TITLE
Fix panic and infinite loop in parser

### DIFF
--- a/core/src/syn/common.rs
+++ b/core/src/syn/common.rs
@@ -88,6 +88,23 @@ impl Location {
 	}
 
 	pub fn range_of_span(source: &str, span: Span) -> Range<Self> {
+		if source.len() == span.offset as usize {
+			// EOF span
+			let (line_idx, column) = LineIterator::new(source)
+				.map(|(l, _)| l.len())
+				.enumerate()
+				.last()
+				.unwrap_or((0, 0));
+
+			return Self {
+				line: line_idx + 1,
+				column: column + 1,
+			}..Self {
+				line: line_idx + 1,
+				column: column + 2,
+			};
+		}
+
 		// Bytes of input before substr.
 		let offset = span.offset as usize;
 		let end = offset + span.len as usize;

--- a/core/src/syn/lexer/mod.rs
+++ b/core/src/syn/lexer/mod.rs
@@ -213,8 +213,8 @@ impl<'a> Lexer<'a> {
 		Token {
 			kind: TokenKind::Eof,
 			span: Span {
-				offset: self.last_offset.saturating_sub(1),
-				len: 1,
+				offset: self.last_offset,
+				len: 0,
 			},
 		}
 	}

--- a/core/src/syn/parser/prime.rs
+++ b/core/src/syn/parser/prime.rs
@@ -344,7 +344,6 @@ impl Parser<'_> {
 		match peek.kind {
 			t!("(") => {
 				self.pop_peek();
-				dbg!("called");
 				self.parse_inner_subquery(ctx, Some(peek.span)).await
 			}
 			t!("IF") => {

--- a/core/src/syn/parser/stmt/mod.rs
+++ b/core/src/syn/parser/stmt/mod.rs
@@ -42,7 +42,10 @@ impl Parser<'_> {
 		loop {
 			match self.peek_kind() {
 				// consume any possible empty statements.
-				t!(";") => continue,
+				t!(";") => {
+					self.pop_peek();
+					continue;
+				}
 				t!("eof") => break,
 				_ => {
 					let stmt = ctx.run(|ctx| self.parse_stmt(ctx)).await?;

--- a/core/src/syn/parser/test/mod.rs
+++ b/core/src/syn/parser/test/mod.rs
@@ -1,4 +1,13 @@
+use crate::{sql, syn::parser::mac::test_parse};
+
 mod limit;
 mod stmt;
 mod streaming;
 mod value;
+
+#[test]
+fn multiple_semicolons() {
+	let res = test_parse!(parse_query, r#";;"#).unwrap();
+	let expected = sql::Query(sql::Statements(vec![]));
+	assert_eq!(res, expected);
+}

--- a/core/src/syn/parser/test/value.rs
+++ b/core/src/syn/parser/test/value.rs
@@ -167,3 +167,8 @@ fn scientific_number() {
 	assert!(matches!(res, Value::Number(Number::Float(_))));
 	assert_eq!(res.to_string(), "0.000097f")
 }
+
+#[test]
+fn empty_string() {
+	test_parse!(parse_value, "").unwrap_err();
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

This PR provides a bugfix for both a panic which can happen during an syntax error at the end of the file and a infinite loop which can happen with multiple semicolons following each other.

## What is your testing strategy?

Added tests to cover the cases where the bugs happened.

## Is this related to any issues?


None

## Does this change need documentation?


- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
