### PR TITLE
Hide surrealdb-core datastructures in the public rust library.

### DIFF
--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -1,6 +1,5 @@
 use crate::ctx::canceller::Canceller;
 use crate::ctx::reason::Reason;
-use crate::dbs::capabilities::FuncTarget;
 #[cfg(feature = "http")]
 use crate::dbs::capabilities::NetTarget;
 use crate::dbs::{Capabilities, Notification, Transaction};
@@ -25,7 +24,6 @@ use std::fmt::{self, Debug};
 	feature = "kv-speedb"
 ))]
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;

--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -387,12 +387,7 @@ impl<'a> Context<'a> {
 
 	/// Check if a function is allowed
 	pub fn check_allowed_function(&self, target: &str) -> Result<(), Error> {
-		let func_target = FuncTarget::from_str(target).map_err(|_| Error::InvalidFunction {
-			name: target.to_string(),
-			message: "Invalid function name".to_string(),
-		})?;
-
-		if !self.capabilities.allows_function(&func_target) {
+		if !self.capabilities.allows_function_name(target) {
 			return Err(Error::FunctionNotAllowed(target.to_string()));
 		}
 		Ok(())

--- a/core/src/dbs/capabilities.rs
+++ b/core/src/dbs/capabilities.rs
@@ -62,6 +62,10 @@ impl std::str::FromStr for FuncTarget {
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		let s = s.trim();
 
+		if s.is_empty() {
+			return Err(ParseFuncTargetError::InvalidName);
+		}
+
 		if s.bytes().any(|x| !(x.is_ascii_alphabetic() || x == b':')) {
 			return Err(ParseFuncTargetError::InvalidName);
 		}
@@ -305,6 +309,14 @@ mod tests {
 	use test_log::test;
 
 	use super::*;
+
+	#[test]
+	fn test_invalid_func_target() {
+		FuncTarget::from_str("te::*st").unwrap_err();
+		FuncTarget::from_str("\0::st").unwrap_err();
+		FuncTarget::from_str("").unwrap_err();
+		FuncTarget::from_str("❤️").unwrap_err();
+	}
 
 	#[test]
 	fn test_func_target() {

--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -183,11 +183,14 @@ pub async fn db_access(
 										_ => Err(Error::NoRecordFound),
 									}
 								}
-								Err(e) => match e {
-									Error::Thrown(_) => Err(e),
-									e if *INSECURE_FORWARD_RECORD_ACCESS_ERRORS => Err(e),
-									_ => Err(Error::AccessRecordSigninQueryFailed),
-								},
+								Err(e) => {
+									dbg!(&e);
+									match e {
+										Error::Thrown(_) => Err(e),
+										e if *INSECURE_FORWARD_RECORD_ACCESS_ERRORS => Err(e),
+										_ => Err(Error::AccessRecordSigninQueryFailed),
+									}
+								}
 							}
 						}
 						_ => Err(Error::AccessRecordNoSignin),

--- a/core/src/iam/signup.rs
+++ b/core/src/iam/signup.rs
@@ -122,11 +122,14 @@ pub async fn db_access(
 										_ => Err(Error::NoRecordFound),
 									}
 								}
-								Err(e) => match e {
-									Error::Thrown(_) => Err(e),
-									e if *INSECURE_FORWARD_RECORD_ACCESS_ERRORS => Err(e),
-									_ => Err(Error::AccessRecordSignupQueryFailed),
-								},
+								Err(e) => {
+									dbg!(&e);
+									match e {
+										Error::Thrown(_) => Err(e),
+										e if *INSECURE_FORWARD_RECORD_ACCESS_ERRORS => Err(e),
+										_ => Err(Error::AccessRecordSignupQueryFailed),
+									}
+								}
 							}
 						}
 						_ => Err(Error::AccessRecordNoSignup),

--- a/lib/src/api/engine/local/native.rs
+++ b/lib/src/api/engine/local/native.rs
@@ -149,7 +149,7 @@ pub(crate) fn router(
 		#[cfg(any(
 			feature = "kv-mem",
 			feature = "kv-surrealkv",
-			feature = "kv-file",
+			
 			feature = "kv-rocksdb",
 			feature = "kv-fdb",
 			feature = "kv-tikv",

--- a/lib/src/api/mod.rs
+++ b/lib/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod err;
 pub mod headers;
 pub mod method;
 pub mod opt;
+pub mod value;
 
 mod conn;
 

--- a/lib/src/api/opt/capabilities.rs
+++ b/lib/src/api/opt/capabilities.rs
@@ -1,5 +1,11 @@
 //! The capabilities that can be enabled for a database instance
 
+use std::collections::HashSet;
+
+use surrealdb_core::dbs::capabilities::{
+	Capabilities, FuncTarget, NetTarget, ParseFuncTargetError, ParseNetTargetError, Targets,
+};
+
 /// Capabilities are used to limit what a user can do to the system.
 ///
 /// Capabilities are split into 4 categories:
@@ -32,13 +38,12 @@
 /// # use surrealdb::engine::local::File;
 /// # #[tokio::main]
 /// # async fn main() -> surrealdb::Result<()> {
-/// let capabilities = Capabilities::all();
+/// let capabilities = CapabilitiesBuilder::all();
 /// let config = Config::default().capabilities(capabilities);
 /// let db = Surreal::new::<File>(("temp.db", config)).await?;
 /// # Ok(())
 /// # }
 /// ```
-///
 /// Create a new instance, and allow certain functions
 #[cfg_attr(feature = "kv-rocksdb", doc = "```no_run")]
 #[cfg_attr(not(feature = "kv-rocksdb"), doc = "```ignore")]
@@ -51,18 +56,285 @@
 /// # use surrealdb::Surreal;
 /// # #[tokio::main]
 /// # async fn main() -> surrealdb::Result<()> {
-/// let capabilities = Capabilities::default()
-///     .with_functions(Targets::<FuncTarget>::All)
-///     .without_functions(Targets::<FuncTarget>::Some(
-///         [FuncTarget::from_str("http::*").unwrap()].into(),
-///     ));
+/// let capabilities = CapabilitiesBuilder::default()
+///     .without_functions("http::*");
 /// let config = Config::default().capabilities(capabilities);
 /// let db = Surreal::new::<File>(("temp.db", config)).await?;
 /// # Ok(())
 /// # }
 /// ```
-pub use crate::dbs::Capabilities;
 
-pub use crate::dbs::capabilities::FuncTarget;
-pub use crate::dbs::capabilities::NetTarget;
-pub use crate::dbs::capabilities::Targets;
+pub struct CapabilitiesBuilder {
+	cap: Capabilities,
+	allow_funcs: Targets<FuncTarget>,
+	deny_funcs: Targets<FuncTarget>,
+	allow_net: Targets<NetTarget>,
+	deny_net: Targets<NetTarget>,
+}
+
+impl CapabilitiesBuilder {
+	pub fn new() -> Self {
+		CapabilitiesBuilder {
+			cap: Capabilities::default(),
+			allow_funcs: Targets::All,
+			deny_funcs: Targets::None,
+			allow_net: Targets::None,
+			deny_net: Targets::None,
+		}
+	}
+
+	pub fn all() -> Self {
+		CapabilitiesBuilder {
+			cap: Capabilities::all(),
+			allow_funcs: Targets::All,
+			deny_funcs: Targets::None,
+			allow_net: Targets::All,
+			deny_net: Targets::None,
+		}
+	}
+
+	pub fn none() -> Self {
+		CapabilitiesBuilder {
+			cap: Capabilities::default(),
+			allow_funcs: Targets::None,
+			deny_funcs: Targets::None,
+			allow_net: Targets::None,
+			deny_net: Targets::None,
+		}
+	}
+
+	pub fn with_scripting(self, enabled: bool) -> Self {
+		Self {
+			cap: self.cap.with_scripting(enabled),
+			..self
+		}
+	}
+
+	pub fn with_quest_access(self, enabled: bool) -> Self {
+		Self {
+			cap: self.cap.with_guest_access(enabled),
+			..self
+		}
+	}
+
+	pub fn with_live_query_notifications(self, enabled: bool) -> Self {
+		Self {
+			cap: self.cap.with_live_query_notifications(enabled),
+			..self
+		}
+	}
+	pub fn allow_all_functions(&mut self) -> &mut Self {
+		self.allow_funcs = Targets::All;
+		self
+	}
+
+	pub fn with_allow_all_functions(mut self) -> Self {
+		self.allow_all_functions();
+		self
+	}
+
+	pub fn deny_all_functions(&mut self) -> &mut Self {
+		self.deny_funcs = Targets::All;
+		self
+	}
+
+	pub fn with_deny_all_function(mut self) -> Self {
+		self.deny_all_functions();
+		self
+	}
+
+	pub fn allow_none_functions(&mut self) -> &mut Self {
+		self.allow_funcs = Targets::None;
+		self
+	}
+
+	pub fn with_allow_none_functions(mut self) -> Self {
+		self.allow_none_functions();
+		self
+	}
+
+	pub fn deny_none_functions(&mut self) -> &mut Self {
+		self.deny_funcs = Targets::None;
+		self
+	}
+
+	pub fn with_deny_none_function(mut self) -> Self {
+		self.deny_none_functions();
+		self
+	}
+
+	pub fn allow_function<S: AsRef<str>>(
+		&mut self,
+		func: S,
+	) -> Result<&mut Self, ParseFuncTargetError> {
+		self.allow_function_str(func.as_ref())
+	}
+
+	pub fn with_allow_function<S: AsRef<str>>(
+		mut self,
+		func: S,
+	) -> Result<Self, ParseFuncTargetError> {
+		self.allow_function(func)?;
+		Ok(self)
+	}
+
+	fn allow_function_str(&mut self, s: &str) -> Result<&mut Self, ParseFuncTargetError> {
+		let target: FuncTarget = s.parse()?;
+		match self.allow_funcs {
+			Targets::None | Targets::All => {
+				let mut set = HashSet::new();
+				set.insert(target);
+				self.allow_funcs = Targets::Some(set);
+			}
+			Targets::Some(ref mut x) => {
+				x.insert(target);
+			}
+			_ => unreachable!(),
+		}
+		Ok(self)
+	}
+
+	fn deny_function_str(&mut self, s: &str) -> Result<&mut Self, ParseFuncTargetError> {
+		let target: FuncTarget = s.parse()?;
+		match self.deny_funcs {
+			Targets::None | Targets::All => {
+				let mut set = HashSet::new();
+				set.insert(target);
+				self.deny_funcs = Targets::Some(set);
+			}
+			Targets::Some(ref mut x) => {
+				x.insert(target);
+			}
+			_ => unreachable!(),
+		}
+		Ok(self)
+	}
+
+	pub fn deny_function<S: AsRef<str>>(
+		&mut self,
+		func: S,
+	) -> Result<&mut Self, ParseFuncTargetError> {
+		self.deny_function_str(func.as_ref())
+	}
+
+	pub fn with_deny_function<S: AsRef<str>>(
+		mut self,
+		func: S,
+	) -> Result<Self, ParseFuncTargetError> {
+		self.deny_function(func)?;
+		Ok(self)
+	}
+
+	pub fn allow_all_net_targets(&mut self) -> &mut Self {
+		self.allow_net = Targets::All;
+		self
+	}
+
+	pub fn with_allow_all_net_targets(mut self) -> Self {
+		self.allow_all_net_targets();
+		self
+	}
+
+	pub fn deny_all_net_targets(&mut self) -> &mut Self {
+		self.deny_net = Targets::All;
+		self
+	}
+
+	pub fn with_deny_all_net_target(mut self) -> Self {
+		self.deny_all_net_targets();
+		self
+	}
+
+	pub fn allow_none_net_targets(&mut self) -> &mut Self {
+		self.allow_net = Targets::None;
+		self
+	}
+
+	pub fn with_allow_none_net_targets(mut self) -> Self {
+		self.allow_none_net_targets();
+		self
+	}
+
+	pub fn deny_none_net_targets(&mut self) -> &mut Self {
+		self.deny_net = Targets::None;
+		self
+	}
+
+	pub fn with_deny_none_net_target(mut self) -> Self {
+		self.deny_none_net_targets();
+		self
+	}
+
+	pub fn allow_net_target<S: AsRef<str>>(
+		&mut self,
+		func: S,
+	) -> Result<&mut Self, ParseNetTargetError> {
+		self.allow_net_target_str(func.as_ref())
+	}
+
+	pub fn with_allow_net_target<S: AsRef<str>>(
+		mut self,
+		func: S,
+	) -> Result<Self, ParseNetTargetError> {
+		self.allow_net_target(func)?;
+		Ok(self)
+	}
+
+	fn allow_net_target_str(&mut self, s: &str) -> Result<&mut Self, ParseNetTargetError> {
+		let target = s.parse()?;
+		match self.allow_net {
+			Targets::None | Targets::All => {
+				let mut set = HashSet::new();
+				set.insert(target);
+				self.allow_net = Targets::Some(set);
+			}
+			Targets::Some(ref mut x) => {
+				x.insert(target);
+			}
+			_ => unreachable!(),
+		}
+		Ok(self)
+	}
+
+	fn deny_net_target_str(&mut self, s: &str) -> Result<&mut Self, ParseNetTargetError> {
+		let target = s.parse()?;
+		match self.deny_net {
+			Targets::None | Targets::All => {
+				let mut set = HashSet::new();
+				set.insert(target);
+				self.deny_net = Targets::Some(set);
+			}
+			Targets::Some(ref mut x) => {
+				x.insert(target);
+			}
+			_ => unreachable!(),
+		}
+		Ok(self)
+	}
+
+	pub fn deny_net_target<S: AsRef<str>>(
+		&mut self,
+		func: S,
+	) -> Result<&mut Self, ParseNetTargetError> {
+		self.deny_net_target_str(func.as_ref())
+	}
+
+	pub fn with_deny_net_target<S: AsRef<str>>(
+		mut self,
+		func: S,
+	) -> Result<Self, ParseNetTargetError> {
+		self.deny_net_target(func)?;
+		Ok(self)
+	}
+
+	pub(crate) fn build(self) -> Capabilities {
+		let cap = self
+			.cap
+			.with_functions(self.allow_funcs)
+			.without_functions(self.deny_funcs)
+			.with_network_targets(self.allow_net)
+			.without_network_targets(self.deny_net);
+
+		cap
+	}
+}

--- a/lib/src/api/opt/config.rs
+++ b/lib/src/api/opt/config.rs
@@ -2,7 +2,7 @@ use crate::{dbs::Capabilities, iam::Level};
 #[cfg(any(
 	feature = "kv-mem",
 	feature = "kv-surrealkv",
-	feature = "kv-file",
+	
 	feature = "kv-rocksdb",
 	feature = "kv-fdb",
 	feature = "kv-tikv",
@@ -32,7 +32,7 @@ pub struct Config {
 	#[cfg(any(
 		feature = "kv-mem",
 		feature = "kv-surrealkv",
-		feature = "kv-file",
+		
 		feature = "kv-rocksdb",
 		feature = "kv-fdb",
 		feature = "kv-tikv",
@@ -130,7 +130,7 @@ impl Config {
 	#[cfg(any(
 		feature = "kv-mem",
 		feature = "kv-surrealkv",
-		feature = "kv-file",
+		
 		feature = "kv-rocksdb",
 		feature = "kv-fdb",
 		feature = "kv-tikv",

--- a/lib/src/api/opt/config.rs
+++ b/lib/src/api/opt/config.rs
@@ -11,6 +11,8 @@ use crate::{dbs::Capabilities, iam::Level};
 use std::path::PathBuf;
 use std::time::Duration;
 
+use super::capabilities::CapabilitiesBuilder;
+
 /// Configuration for server connection, including: strictness, notifications, query_timeout, transaction_timeout
 #[derive(Debug, Clone, Default)]
 pub struct Config {
@@ -120,8 +122,8 @@ impl Config {
 	}
 
 	/// Set the capabilities for the database
-	pub fn capabilities(mut self, capabilities: Capabilities) -> Self {
-		self.capabilities = capabilities;
+	pub fn capabilities(mut self, capabilities: CapabilitiesBuilder) -> Self {
+		self.capabilities = capabilities.build();
 		self
 	}
 

--- a/lib/src/api/value.rs
+++ b/lib/src/api/value.rs
@@ -1,0 +1,101 @@
+use std::{
+	borrow::Borrow,
+	collections::{btree_map::IterMut, BTreeMap},
+};
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use time::Duration;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub struct Bytes(Vec<u8>);
+
+#[derive(Debug)]
+pub struct Datetime(DateTime<Utc>);
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum RecordIdKey {
+	String(String),
+	Integer(i64),
+	Object(Object),
+	Array(Array),
+}
+
+#[derive(Debug)]
+pub struct RecordId {
+	table: String,
+	key: RecordIdKey,
+}
+
+#[derive(Debug)]
+pub enum Number {
+	Float(f64),
+	Number(i64),
+	Decimal(Decimal),
+}
+
+#[derive(Debug)]
+pub struct ObjectIterMut<'a>(IterMut<'a, String, Value>);
+
+impl<'a> Iterator for ObjectIterMut<'a> {
+	type Item = (&'a String, &'a mut Value);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		self.0.next()
+	}
+
+	fn size_hint(&self) -> (usize, Option<usize>) {
+		self.0.size_hint()
+	}
+}
+
+impl<'a> std::iter::FusedIterator for ObjectIterMut<'a> {}
+
+impl<'a> ExactSizeIterator for ObjectIterMut<'a> {
+	fn len(&self) -> usize {
+		<IterMut<'a, String, Value> as ExactSizeIterator>::len(&self.0)
+	}
+}
+
+#[derive(Debug)]
+pub struct Object(BTreeMap<String, Value>);
+
+impl Object {
+	pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&Value>
+	where
+		String: Borrow<Q>,
+	{
+		self.0.get(key)
+	}
+
+	pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut Value>
+	where
+		String: Borrow<Q>,
+	{
+		self.0.get_mut(key)
+	}
+
+	pub fn iter_mut(&mut self) -> ObjectIterMut<'_> {
+		ObjectIterMut(self.0.iter_mut())
+	}
+}
+
+#[derive(Debug)]
+pub struct Array(Vec<Value>);
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum Value {
+	Null,
+	Bool(bool),
+	Number(Number),
+	Object(Object),
+	Array(Array),
+	Uuid(Uuid),
+	Datetime(Datetime),
+	Duration(Duration),
+	Bytes(Bytes),
+	RecordId(RecordId),
+}

--- a/lib/src/api/value.rs
+++ b/lib/src/api/value.rs
@@ -1,6 +1,7 @@
 use std::{
 	borrow::Borrow,
 	collections::{btree_map::IterMut, BTreeMap},
+	fmt,
 };
 
 use chrono::{DateTime, Utc};
@@ -8,31 +9,31 @@ use rust_decimal::Decimal;
 use time::Duration;
 use uuid::Uuid;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Bytes(Vec<u8>);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Datetime(DateTime<Utc>);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum RecordIdKey {
 	String(String),
 	Integer(i64),
 	Object(Object),
-	Array(Array),
+	Array(Vec<Value>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RecordId {
 	table: String,
 	key: RecordIdKey,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Number {
 	Float(f64),
-	Number(i64),
+	Integer(i64),
 	Decimal(Decimal),
 }
 
@@ -59,13 +60,22 @@ impl<'a> ExactSizeIterator for ObjectIterMut<'a> {
 	}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default, Clone)]
 pub struct Object(BTreeMap<String, Value>);
 
 impl Object {
+	pub fn new() -> Self {
+		Object(BTreeMap::new())
+	}
+
+	pub fn clear(&mut self) {
+		self.0.clear()
+	}
+
 	pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&Value>
 	where
 		String: Borrow<Q>,
+		Q: Ord,
 	{
 		self.0.get(key)
 	}
@@ -73,29 +83,163 @@ impl Object {
 	pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut Value>
 	where
 		String: Borrow<Q>,
+		Q: Ord,
 	{
 		self.0.get_mut(key)
+	}
+
+	pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+	where
+		String: Borrow<Q>,
+		Q: Ord,
+	{
+		self.0.contains_key(key)
+	}
+
+	pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<Value>
+	where
+		String: Borrow<Q>,
+		Q: Ord,
+	{
+		self.0.remove(key)
+	}
+
+	pub fn remove_entry<Q: ?Sized>(&mut self, key: &Q) -> Option<(String, Value)>
+	where
+		String: Borrow<Q>,
+		Q: Ord,
+	{
+		self.0.remove_entry(key)
 	}
 
 	pub fn iter_mut(&mut self) -> ObjectIterMut<'_> {
 		ObjectIterMut(self.0.iter_mut())
 	}
+
+	pub fn len(&self) -> usize {
+		self.0.len()
+	}
 }
 
-#[derive(Debug)]
-pub struct Array(Vec<Value>);
-
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Value {
 	Null,
 	Bool(bool),
 	Number(Number),
 	Object(Object),
-	Array(Array),
+	Array(Vec<Value>),
 	Uuid(Uuid),
 	Datetime(Datetime),
 	Duration(Duration),
 	Bytes(Bytes),
 	RecordId(RecordId),
+}
+
+impl Value {
+	pub fn int(v: i64) -> Self {
+		Value::Number(Number::Integer(v))
+	}
+
+	pub fn float(v: f64) -> Self {
+		Value::Number(Number::Float(v))
+	}
+
+	pub fn decimal(v: Decimal) -> Self {
+		Value::Number(Number::Decimal(v))
+	}
+}
+
+macro_rules! impl_convert(
+	($(($variant:ident($ty:ty), $as:ident,$as_mut:ident, $into:ident)),*$(,)?) => {
+		impl Value{
+
+			$(
+			#[doc = concat!("Get a reference to the internal ",stringify!($ty)," if the value is of that type")]
+			pub fn $as(&self) -> Option<&$ty>{
+				if let Value::$variant(ref x) = self{
+					Some(x)
+				}else{
+					None
+				}
+			}
+
+			#[doc = concat!("Get a reference to the internal ",stringify!($ty)," if the value is of that type")]
+			pub fn $as_mut(&mut self) -> Option<&mut $ty>{
+				if let Value::$variant(ref mut x) = self{
+					Some(x)
+				}else{
+					None
+				}
+			}
+
+			#[doc = concat!("Convert the value to ",stringify!($ty)," if the value is of that type")]
+			pub fn $into(self) -> Option<$ty>{
+				if let Value::$variant(x) = self{
+					Some(x)
+				}else{
+					None
+				}
+			}
+			)*
+		}
+
+		$(
+		impl From<$ty> for Value {
+			fn from(v: $ty) -> Self{
+				Value::$variant(v)
+			}
+		}
+
+		impl TryFrom<Value> for $ty {
+			type Error = ConversionError;
+
+			fn try_from(v: Value) -> Result<Self, Self::Error>{
+				v.$into().ok_or(ConversionError{
+					from: Kind::$variant,
+					expected: stringify!($ty),
+				})
+			}
+		}
+		)*
+	};
+);
+
+impl_convert!(
+	(Bool(bool), as_bool, as_bool_mut, into_bool),
+	(Number(Number), as_number, as_number_mut, into_number),
+	(Uuid(Uuid), as_uuid, as_uuid_mut, into_uuid),
+	(Datetime(Datetime), as_datetime, as_datetime_mut, into_dateime),
+	(Duration(Duration), as_duration, as_duration_mut, into_duration),
+	(Bytes(Bytes), as_bytes, as_bytes_mut, into_bytes),
+	(RecordId(RecordId), as_record_id, as_record_id_mut, into_record_id),
+);
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum Kind {
+	Null,
+	Bool,
+	Number,
+	Object,
+	Array,
+	Uuid,
+	Datetime,
+	Duration,
+	Bytes,
+	RecordId,
+}
+
+pub struct ConversionError {
+	from: Kind,
+	expected: &'static str,
+}
+
+impl fmt::Display for ConversionError {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		writeln!(
+			f,
+			"failed to convert into `{}` from value with type `{:?}`",
+			self.expected, self.from
+		)
+	}
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -137,7 +137,7 @@ pub use api::Response;
 pub use api::Result;
 #[doc(inline)]
 pub use api::Surreal;
-#[doc(inline)]
+#[doc(hidden)]
 pub use surrealdb_core::*;
 
 use uuid::Uuid;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -138,6 +138,7 @@ pub use api::Result;
 #[doc(inline)]
 pub use api::Surreal;
 #[doc(hidden)]
+#[deprecated]
 pub use surrealdb_core::*;
 
 use uuid::Uuid;

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -100,7 +100,7 @@ pub(crate) fn func_targets(value: &str) -> Result<Targets<FuncTarget>, String> {
 	let mut result = HashSet::new();
 
 	for target in value.split(',').filter(|s| !s.is_empty()) {
-		result.insert(FuncTarget::from_str(target)?);
+		result.insert(FuncTarget::from_str(target).map_err(|e| e.to_string())?);
 	}
 
 	Ok(Targets::Some(result))


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The current version of the library exposes a lot data structures which are used heavily within surrealdb.
Exposing all these structures forces stability on these structures which we might want to change when implementing new features or fixing bugs.
This stability makes has already caused us quite a lot of problems and has forced us to maintain two versions of the database.

## What does this change do?

Hides any structure that is used within surrealdb-core, and re-implements a similar API with a lib-only version of the structs.

## What is your testing strategy?

Write your test plan here. Please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] surrealdb/docs.surrealdb.com#todo

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
