### PR TITLE
Update time dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6359,9 +6359,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -6380,9 +6380,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1820,7 +1820,7 @@ version = "0.2.15"
 criteria = "safe-to-run"
 
 [[exemptions.time]]
-version = "0.3.34"
+version = "0.3.36"
 criteria = "safe-to-deploy"
 
 [[exemptions.time-macros]]


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The currently used version of the `time` crate causes a compile error on the newest version of rust.

## What does this change do?

Updates the time dependency to the newest version.

## What is your testing strategy?

N/A

## Is this related to any issues?

N/A

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?


- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
