### PR TITLE
feat: enable fdb transaction timeout customization

### DIFF
--- a/core/src/kvs/fdb/cnf.rs
+++ b/core/src/kvs/fdb/cnf.rs
@@ -1,0 +1,20 @@
+use foundationdb::options::DatabaseOption;
+use once_cell::sync::Lazy;
+
+pub static FOUNDATIONDB_TRANSACTION_TIMEOUT: Lazy<DatabaseOption::TransactionTimeout> =
+	lazy_env_parse_or_else!("SURREAL_FOUNDATIONDB_TRANSACTION_TIMEOUT", DatabaseOption, |_| {
+		"5000"
+	});
+
+pub static FOUNDATIONDB_TRANSACTION_RETRY_LIMIT: Lazy<DatabaseOption::TransactionRetryLimit> =
+	lazy_env_parse_or_else!("SURREAL_FOUNDATIONDB_TRANSACTION_RETRY_LIMIT", DatabaseOption, |_| {
+		"5"
+	});
+
+pub static FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY: Lazy<
+	DatabaseOption::TransactionMaxRetryDelay,
+> = lazy_env_parse_or_else!(
+	"SURREAL_FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY",
+	DatabaseOption,
+	|_| { "500" }
+);

--- a/core/src/kvs/fdb/cnf.rs
+++ b/core/src/kvs/fdb/cnf.rs
@@ -1,20 +1,10 @@
-use foundationdb::options::DatabaseOption;
 use once_cell::sync::Lazy;
 
-pub static FOUNDATIONDB_TRANSACTION_TIMEOUT: Lazy<DatabaseOption::TransactionTimeout> =
-	lazy_env_parse_or_else!("SURREAL_FOUNDATIONDB_TRANSACTION_TIMEOUT", DatabaseOption, |_| {
-		"5000"
-	});
+pub static FOUNDATIONDB_TRANSACTION_TIMEOUT: Lazy<i32> =
+	lazy_env_parse_or_else!("SURREAL_FOUNDATIONDB_TRANSACTION_TIMEOUT", i32, |_| { 5000 });
 
-pub static FOUNDATIONDB_TRANSACTION_RETRY_LIMIT: Lazy<DatabaseOption::TransactionRetryLimit> =
-	lazy_env_parse_or_else!("SURREAL_FOUNDATIONDB_TRANSACTION_RETRY_LIMIT", DatabaseOption, |_| {
-		"5"
-	});
+pub static FOUNDATIONDB_TRANSACTION_RETRY_LIMIT: Lazy<i32> =
+	lazy_env_parse_or_else!("SURREAL_FOUNDATIONDB_TRANSACTION_RETRY_LIMIT", i32, |_| { 5 });
 
-pub static FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY: Lazy<
-	DatabaseOption::TransactionMaxRetryDelay,
-> = lazy_env_parse_or_else!(
-	"SURREAL_FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY",
-	DatabaseOption,
-	|_| { "500" }
-);
+pub static FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY: Lazy<i32> =
+	lazy_env_parse_or_else!("SURREAL_FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY", i32, |_| { 500 });

--- a/core/src/kvs/fdb/mod.rs
+++ b/core/src/kvs/fdb/mod.rs
@@ -7,7 +7,7 @@ use crate::kvs::Check;
 use crate::kvs::Key;
 use crate::kvs::Val;
 use crate::vs::{u64_to_versionstamp, Versionstamp};
-use foundationdb::options;
+use foundationdb::options::DatabaseOption;
 use futures::TryStreamExt;
 use std::ops::Range;
 use std::sync::Arc;
@@ -93,14 +93,20 @@ impl Datastore {
 		match foundationdb::Database::from_path(path) {
 			Ok(db) => {
 				// Set the transaction timeout
-				db.set_option(*cnf::FOUNDATIONDB_TRANSACTION_TIMEOUT)
-					.map_err(|e| Error::Ds(format!("Unable to set transaction timeout: {e}")))?;
+				db.set_option(DatabaseOption::TransactionTimeout(
+					*cnf::FOUNDATIONDB_TRANSACTION_TIMEOUT,
+				))
+				.map_err(|e| Error::Ds(format!("Unable to set transaction timeout: {e}")))?;
 				// Set the transaction retry liimt
-				db.set_option(*cnf::FOUNDATIONDB_TRANSACTION_RETRY_LIMIT).map_err(|e| {
-					Error::Ds(format!("Unable to set transaction retry limit: {e}"))
-				})?;
+				db.set_option(DatabaseOption::TransactionRetryLimit(
+					*cnf::FOUNDATIONDB_TRANSACTION_RETRY_LIMIT,
+				))
+				.map_err(|e| Error::Ds(format!("Unable to set transaction retry limit: {e}")))?;
 				// Set the transaction max retry delay
-				db.set_option(*cnf::FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY).map_err(|e| {
+				db.set_option(DatabaseOption::TransactionMaxRetryDelay(
+					*cnf::FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY,
+				))
+				.map_err(|e| {
 					Error::Ds(format!("Unable to set transaction max retry delay: {e}"))
 				})?;
 				Ok(Datastore {


### PR DESCRIPTION
## What is the motivation?

Enable customization of fdb transaction timeouts and retries and fallback on default.

## What does this change do?

Add support for `FDB_TRANSACTION_RETRY_LIMIT`, `FDB_TRANSACTION_TIMEOUT` and `FDB_TRANSACTION_MAX_RETRY_DELAY` environment variables.

## What is your testing strategy?

Tested with large tables in fdb that takes more than `5s`.
 
## Is this related to any issues?

This is the [related issue](https://github.com/surrealdb/surrealdb/issues/3345#issue-2084810801)

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
