### PR TITLE
Implement missing modulo operator in new parser

### DIFF
--- a/core/src/syn/lexer/byte.rs
+++ b/core/src/syn/lexer/byte.rs
@@ -281,6 +281,7 @@ impl<'a> Lexer<'a> {
 				}
 				_ => t!("/"),
 			},
+			b'%' => t!("%"),
 			b'*' => match self.reader.peek() {
 				Some(b'*') => {
 					self.reader.next();

--- a/core/src/syn/parser/expression.rs
+++ b/core/src/syn/parser/expression.rs
@@ -113,7 +113,7 @@ impl Parser<'_> {
 			| t!("<|") => Some((9, 10)),
 
 			t!("+") | t!("-") => Some((11, 12)),
-			t!("*") | t!("×") | t!("/") | t!("÷") => Some((13, 14)),
+			t!("*") | t!("×") | t!("/") | t!("÷") | t!("%") => Some((13, 14)),
 			t!("**") => Some((15, 16)),
 			t!("?:") | t!("??") => Some((17, 18)),
 			_ => None,
@@ -271,6 +271,7 @@ impl Parser<'_> {
 			t!("-") => Operator::Sub,
 			t!("*") | t!("×") => Operator::Mul,
 			t!("/") | t!("÷") => Operator::Div,
+			t!("%") => Operator::Rem,
 			t!("∋") | t!("CONTAINS") => Operator::Contain,
 			t!("∌") | t!("CONTAINSNOT") => Operator::NotContain,
 			t!("∈") | t!("INSIDE") => Operator::Inside,

--- a/core/src/syn/token/mac.rs
+++ b/core/src/syn/token/mac.rs
@@ -160,6 +160,9 @@ macro_rules! t {
 	("+") => {
 		$crate::syn::token::TokenKind::Operator($crate::syn::token::Operator::Add)
 	};
+	("%") => {
+		$crate::syn::token::TokenKind::Operator($crate::syn::token::Operator::Modulo)
+	};
 	("-") => {
 		$crate::syn::token::TokenKind::Operator($crate::syn::token::Operator::Subtract)
 	};

--- a/core/src/syn/token/mod.rs
+++ b/core/src/syn/token/mod.rs
@@ -78,6 +78,8 @@ pub enum Operator {
 	Divide,
 	/// `×` or `∙`
 	Mult,
+	/// `%`
+	Modulo,
 	/// `||`
 	Or,
 	/// `&&`
@@ -156,6 +158,7 @@ impl Operator {
 			Operator::Or => "||",
 			Operator::And => "&&",
 			Operator::Mult => "×",
+			Operator::Modulo => "%",
 			Operator::LessEqual => "<=",
 			Operator::GreaterEqual => ">=",
 			Operator::Star => "*",

--- a/lib/tests/expression.rs
+++ b/lib/tests/expression.rs
@@ -1,0 +1,9 @@
+mod helpers;
+use helpers::Test;
+use surrealdb::err::Error;
+
+#[tokio::test]
+async fn modulo() -> Result<(), Error> {
+	Test::new("8 % 3").await?.expect_val("2")?;
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The modulo operator was never implemented in the new parser

## What does this change do?

Implements the operator into the parser.

## What is your testing strategy?

Added a test for the module expression.

## Is this related to any issues?

If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
