### PR TITLE
Add more array functions

### DIFF
--- a/core/src/cnf/mod.rs
+++ b/core/src/cnf/mod.rs
@@ -60,9 +60,9 @@ pub static EXPERIMENTAL_BEARER_ACCESS: Lazy<bool> =
 #[cfg(test)]
 pub static EXPERIMENTAL_BEARER_ACCESS: Lazy<bool> = Lazy::new(|| true);
 
-/// Forward all signup/signin/authenticate query errors to a client performing authentication. Do not use in production.
-pub static ARRAY_ALLOCATION_LIMIT: Lazy<usize> = once_cell::sync::Lazy::new(|| {
-	let n = std::env::var("SURREAL_ARRAY_ALLOCATION_LIMIT")
+/// Used to limit allocation for builtin functions
+pub static FNC_ALLOCATION_LIMIT: Lazy<usize> = once_cell::sync::Lazy::new(|| {
+	let n = std::env::var("SURREAL_FNC_ALLOCATION_LIMIT")
 		.map(|s| s.parse::<u32>().unwrap_or(20))
 		.unwrap_or(20);
 	2usize.pow(n)

--- a/core/src/cnf/mod.rs
+++ b/core/src/cnf/mod.rs
@@ -63,7 +63,7 @@ pub static EXPERIMENTAL_BEARER_ACCESS: Lazy<bool> = Lazy::new(|| true);
 /// Forward all signup/signin/authenticate query errors to a client performing authentication. Do not use in production.
 pub static ARRAY_ALLOCATION_LIMIT: Lazy<usize> = once_cell::sync::Lazy::new(|| {
 	let n = std::env::var("SURREAL_ARRAY_ALLOCATION_LIMIT")
-		.and_then(|s| Ok(s.parse::<u32>().unwrap_or(20)))
+		.map(|s| s.parse::<u32>().unwrap_or(20))
 		.unwrap_or(20);
-	2usize.pow(n) as usize
+	2usize.pow(n)
 });

--- a/core/src/cnf/mod.rs
+++ b/core/src/cnf/mod.rs
@@ -59,3 +59,11 @@ pub static EXPERIMENTAL_BEARER_ACCESS: Lazy<bool> =
 // Run tests with bearer access enabled as it introduces new functionality that needs to be tested.
 #[cfg(test)]
 pub static EXPERIMENTAL_BEARER_ACCESS: Lazy<bool> = Lazy::new(|| true);
+
+/// Forward all signup/signin/authenticate query errors to a client performing authentication. Do not use in production.
+pub static ARRAY_ALLOCATION_LIMIT: Lazy<usize> = once_cell::sync::Lazy::new(|| {
+	let n = std::env::var("SURREAL_ARRAY_ALLOCATION_LIMIT")
+		.and_then(|s| Ok(s.parse::<u32>().unwrap_or(20)))
+		.unwrap_or(20);
+	2usize.pow(n) as usize
+});

--- a/core/src/cnf/mod.rs
+++ b/core/src/cnf/mod.rs
@@ -61,8 +61,8 @@ pub static EXPERIMENTAL_BEARER_ACCESS: Lazy<bool> =
 pub static EXPERIMENTAL_BEARER_ACCESS: Lazy<bool> = Lazy::new(|| true);
 
 /// Used to limit allocation for builtin functions
-pub static FNC_ALLOCATION_LIMIT: Lazy<usize> = once_cell::sync::Lazy::new(|| {
-	let n = std::env::var("SURREAL_FNC_ALLOCATION_LIMIT")
+pub static FUNCTION_ALLOCATION_LIMIT: Lazy<usize> = once_cell::sync::Lazy::new(|| {
+	let n = std::env::var("SURREAL_FUNCTION_ALLOCATION_LIMIT")
 		.map(|s| s.parse::<u32>().unwrap_or(20))
 		.unwrap_or(20);
 	2usize.pow(n)

--- a/core/src/fnc/args.rs
+++ b/core/src/fnc/args.rs
@@ -1,6 +1,8 @@
 use crate::err::Error;
 use crate::sql::value::Value;
-use crate::sql::{Array, Bytes, Datetime, Duration, Kind, Number, Object, Regex, Strand, Thing};
+use crate::sql::{
+	Array, Bytes, Closure, Datetime, Duration, Kind, Number, Object, Regex, Strand, Thing,
+};
 use std::vec::IntoIter;
 
 /// Implemented by types that are commonly used, in a certain way, as arguments.
@@ -11,6 +13,12 @@ pub trait FromArg: Sized {
 impl FromArg for Value {
 	fn from_arg(arg: Value) -> Result<Self, Error> {
 		Ok(arg)
+	}
+}
+
+impl FromArg for Closure {
+	fn from_arg(arg: Value) -> Result<Self, Error> {
+		arg.coerce_to_function()
 	}
 }
 

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -1,3 +1,4 @@
+use crate::cnf::ARRAY_ALLOCATION_LIMIT;
 use crate::err::Error;
 use crate::sql::array::Array;
 use crate::sql::array::Clump;
@@ -18,11 +19,10 @@ use std::mem::size_of_val;
 
 /// Returns an error if an array of this length is too much to allocate.
 fn limit(name: &str, n: usize) -> Result<(), Error> {
-	const LIMIT: usize = 2usize.pow(20);
-	if n > LIMIT {
+	if n > *ARRAY_ALLOCATION_LIMIT {
 		Err(Error::InvalidArguments {
 			name: name.to_owned(),
-			message: format!("Output must not exceed {LIMIT} bytes."),
+			message: format!("Output must not exceed {} bytes.", *ARRAY_ALLOCATION_LIMIT),
 		})
 	} else {
 		Ok(())

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -1,4 +1,4 @@
-use crate::cnf::ARRAY_ALLOCATION_LIMIT;
+use crate::cnf::FNC_ALLOCATION_LIMIT;
 use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::doc::CursorDoc;
@@ -25,10 +25,10 @@ use std::mem::size_of_val;
 
 /// Returns an error if an array of this length is too much to allocate.
 fn limit(name: &str, n: usize) -> Result<(), Error> {
-	if n > *ARRAY_ALLOCATION_LIMIT {
+	if n > *FNC_ALLOCATION_LIMIT {
 		Err(Error::InvalidArguments {
 			name: name.to_owned(),
-			message: format!("Output must not exceed {} bytes.", *ARRAY_ALLOCATION_LIMIT),
+			message: format!("Output must not exceed {} bytes.", *FNC_ALLOCATION_LIMIT),
 		})
 	} else {
 		Ok(())

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -135,20 +135,22 @@ pub fn distinct((array,): (Array,)) -> Result<Value, Error> {
 	Ok(array.uniq().into())
 }
 
-pub fn fill((mut array, value, start, end): (Array, Value, Option<isize>, Option<isize>)) -> Result<Value, Error> {
+pub fn fill(
+	(mut array, value, start, end): (Array, Value, Option<isize>, Option<isize>),
+) -> Result<Value, Error> {
 	let min = 0;
 	let max = array.len();
 	let negative_max = -(max as isize);
 
 	let start = match start {
 		Some(start) if negative_max <= start && start < 0 => (start + max as isize) as usize,
-  		Some(start) if start < negative_max => 0,
+		Some(start) if start < negative_max => 0,
 		Some(start) => start as usize,
 		None => min,
 	};
 	let end = match end {
 		Some(end) if negative_max <= end && end < 0 => (end + max as isize) as usize,
-  		Some(end) if end < negative_max => 0,
+		Some(end) if end < negative_max => 0,
 		Some(end) => end as usize,
 		None => max,
 	};
@@ -164,7 +166,7 @@ pub fn fill((mut array, value, start, end): (Array, Value, Option<isize>, Option
 			}
 		}
 	}
-	
+
 	Ok(array.into())
 }
 
@@ -352,10 +354,12 @@ pub fn range((start, count): (i64, i64)) -> Result<Value, Error> {
 	if count < 0 {
 		return Err(Error::InvalidArguments {
 			name: String::from("array::range"),
-			message: String::from(format!("Argument 1 was the wrong type. Expected a positive number but found {count}")),
+			message: format!(
+				"Argument 1 was the wrong type. Expected a positive number but found {count}"
+			),
 		});
 	}
-	
+
 	if let Some(end) = start.checked_add(count - 1) {
 		Ok(Array((start..=end).map(Value::from).collect::<Vec<_>>()).into())
 	} else {
@@ -385,7 +389,9 @@ pub fn repeat((value, count): (Value, i64)) -> Result<Value, Error> {
 	if count < 0 {
 		return Err(Error::InvalidArguments {
 			name: String::from("array::repeat"),
-			message: String::from(format!("Argument 2 was the wrong type. Expected a positive number but found {count}")),
+			message: format!(
+				"Argument 2 was the wrong type. Expected a positive number but found {count}"
+			),
 		});
 	}
 
@@ -462,7 +468,9 @@ pub fn swap((mut array, from, to): (Array, isize, isize)) -> Result<Value, Error
 	let from = match from {
 		from if from < negative_max || from >= max as isize => Err(Error::InvalidArguments {
 			name: String::from("array::swap"),
-			message: String::from(format!("Argument 1 is out of range. Expected a number between {negative_max} and {max}")),
+			message: format!(
+				"Argument 1 is out of range. Expected a number between {negative_max} and {max}"
+			),
 		}),
 		from if negative_max <= from && from < min => Ok((from + max as isize) as usize),
 		from => Ok(from as usize),
@@ -471,7 +479,9 @@ pub fn swap((mut array, from, to): (Array, isize, isize)) -> Result<Value, Error
 	let to = match to {
 		to if to < negative_max || to >= max as isize => Err(Error::InvalidArguments {
 			name: String::from("array::swap"),
-			message: String::from(format!("Argument 2 is out of range. Expected a number between {negative_max} and {max}")),
+			message: format!(
+				"Argument 2 is out of range. Expected a number between {negative_max} and {max}"
+			),
 		}),
 		to if negative_max <= to && to < min => Ok((to + max as isize) as usize),
 		to => Ok(to as usize),

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -158,11 +158,17 @@ pub fn fill(
 	if start == min && end >= max {
 		array.fill(value);
 	} else {
-		let range = start..end;
-
-		if let Some(subslice) = array.get_mut(range) {
-			for elem in subslice {
-				*elem = value.clone();
+		if end > start {
+			let end_minus_one = end - 1;
+		
+			for i in start..end_minus_one { 
+				if let Some(elem) = array.get_mut(i) { 
+					*elem = value.clone(); 
+				}
+			}
+			
+			if let Some(last_elem) = array.get_mut(end_minus_one) { 
+				*last_elem = value;
 			}
 		}
 	}

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -135,6 +135,39 @@ pub fn distinct((array,): (Array,)) -> Result<Value, Error> {
 	Ok(array.uniq().into())
 }
 
+pub fn fill((mut array, value, start, end): (Array, Value, Option<isize>, Option<isize>)) -> Result<Value, Error> {
+	let min = 0;
+	let max = array.len();
+	let negative_max = -(max as isize);
+
+	let start = match start {
+		Some(start) if negative_max <= start && start < 0 => (start + max as isize) as usize,
+  		Some(start) if start < negative_max => 0,
+		Some(start) => start as usize,
+		None => 0,
+	};
+	let end = match end {
+		Some(end) if negative_max <= end && end < 0 => (end + max as isize) as usize,
+  		Some(end) if end < negative_max => 0,
+		Some(end) => end as usize,
+		None => max,
+	};
+
+	if start == min && end >= max {
+		array.fill(value);
+	} else {
+		let range = start..end;
+
+		if let Some(subslice) = array.get_mut(range) {
+			for elem in subslice {
+				*elem = value.clone();
+			}
+		}
+	}
+	
+	Ok(array.into())
+}
+
 pub fn filter_index((array, value): (Array, Value)) -> Result<Value, Error> {
 	Ok(array
 		.iter()

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -160,14 +160,14 @@ pub fn fill(
 	} else {
 		if end > start {
 			let end_minus_one = end - 1;
-		
-			for i in start..end_minus_one { 
-				if let Some(elem) = array.get_mut(i) { 
-					*elem = value.clone(); 
+
+			for i in start..end_minus_one {
+				if let Some(elem) = array.get_mut(i) {
+					*elem = value.clone();
 				}
 			}
-			
-			if let Some(last_elem) = array.get_mut(end_minus_one) { 
+
+			if let Some(last_elem) = array.get_mut(end_minus_one) {
 				*last_elem = value;
 			}
 		}
@@ -240,6 +240,10 @@ pub fn insert((mut array, value, index): (Array, Value, Option<i64>)) -> Result<
 
 pub fn intersect((array, other): (Array, Array)) -> Result<Value, Error> {
 	Ok(array.intersect(other).into())
+}
+
+pub fn is_empty((array,): (Array,)) -> Result<Value, Error> {
+	Ok(array.is_empty().into())
 }
 
 pub fn join((arr, sep): (Array, String)) -> Result<Value, Error> {

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -315,6 +315,24 @@ pub fn push((mut array, value): (Array, Value)) -> Result<Value, Error> {
 	Ok(array.into())
 }
 
+pub fn range((start, count): (i64, i64)) -> Result<Value, Error> {
+	if count < 0 {
+		return Err(Error::InvalidArguments {
+			name: String::from("array::range"),
+			message: String::from(format!("Argument 1 was the wrong type. Expected a positive number but found {count}")),
+		});
+	}
+	
+	if let Some(end) = start.checked_add(count - 1) {
+		Ok(Array((start..=end).map(Value::from).collect::<Vec<_>>()).into())
+	} else {
+		Err(Error::InvalidArguments {
+			name: String::from("array::range"),
+			message: String::from("The range overflowed the maximum value for an integer"),
+		})
+	}
+}
+
 pub fn remove((mut array, mut index): (Array, i64)) -> Result<Value, Error> {
 	// Negative index means start from the back
 	if index < 0 {

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -157,19 +157,17 @@ pub fn fill(
 
 	if start == min && end >= max {
 		array.fill(value);
-	} else {
-		if end > start {
-			let end_minus_one = end - 1;
+	} else if end > start {
+		let end_minus_one = end - 1;
 
-			for i in start..end_minus_one {
-				if let Some(elem) = array.get_mut(i) {
-					*elem = value.clone();
-				}
+		for i in start..end_minus_one {
+			if let Some(elem) = array.get_mut(i) {
+				*elem = value.clone();
 			}
+		}
 
-			if let Some(last_elem) = array.get_mut(end_minus_one) {
-				*last_elem = value;
-			}
+		if let Some(last_elem) = array.get_mut(end_minus_one) {
+			*last_elem = value;
 		}
 	}
 

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -348,6 +348,17 @@ pub fn remove((mut array, mut index): (Array, i64)) -> Result<Value, Error> {
 	Ok(array.into())
 }
 
+pub fn repeat((value, count): (Value, i64)) -> Result<Value, Error> {
+	if count < 0 {
+		return Err(Error::InvalidArguments {
+			name: String::from("array::repeat"),
+			message: String::from(format!("Argument 2 was the wrong type. Expected a positive number but found {count}")),
+		});
+	}
+
+	Ok(Array(std::iter::repeat(value).take(count as usize).collect()).into())
+}
+
 pub fn reverse((mut array,): (Array,)) -> Result<Value, Error> {
 	array.reverse();
 	Ok(array.into())

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -1,4 +1,4 @@
-use crate::cnf::FNC_ALLOCATION_LIMIT;
+use crate::cnf::FUNCTION_ALLOCATION_LIMIT;
 use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::doc::CursorDoc;
@@ -25,10 +25,10 @@ use std::mem::size_of_val;
 
 /// Returns an error if an array of this length is too much to allocate.
 fn limit(name: &str, n: usize) -> Result<(), Error> {
-	if n > *FNC_ALLOCATION_LIMIT {
+	if n > *FUNCTION_ALLOCATION_LIMIT {
 		Err(Error::InvalidArguments {
 			name: name.to_owned(),
-			message: format!("Output must not exceed {} bytes.", *FNC_ALLOCATION_LIMIT),
+			message: format!("Output must not exceed {} bytes.", *FUNCTION_ALLOCATION_LIMIT),
 		})
 	} else {
 		Ok(())

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -144,7 +144,7 @@ pub fn fill((mut array, value, start, end): (Array, Value, Option<isize>, Option
 		Some(start) if negative_max <= start && start < 0 => (start + max as isize) as usize,
   		Some(start) if start < negative_max => 0,
 		Some(start) => start as usize,
-		None => 0,
+		None => min,
 	};
 	let end = match end {
 		Some(end) if negative_max <= end && end < 0 => (end + max as isize) as usize,
@@ -399,7 +399,7 @@ pub fn reverse((mut array,): (Array,)) -> Result<Value, Error> {
 
 pub fn shuffle((mut array,): (Array,)) -> Result<Value, Error> {
 	let mut rng = rand::thread_rng();
-	array.0.shuffle(&mut rng);
+	array.shuffle(&mut rng);
 	Ok(array.into())
 }
 
@@ -452,6 +452,33 @@ pub fn sort((mut array, order): (Array, Option<Value>)) -> Result<Value, Error> 
 			Ok(array.into())
 		}
 	}
+}
+
+pub fn swap((mut array, from, to): (Array, isize, isize)) -> Result<Value, Error> {
+	let min = 0;
+	let max = array.len();
+	let negative_max = -(max as isize);
+
+	let from = match from {
+		from if from < negative_max || from >= max as isize => Err(Error::InvalidArguments {
+			name: String::from("array::swap"),
+			message: String::from(format!("Argument 1 is out of range. Expected a number between {negative_max} and {max}")),
+		}),
+		from if negative_max <= from && from < min => Ok((from + max as isize) as usize),
+		from => Ok(from as usize),
+	}?;
+
+	let to = match to {
+		to if to < negative_max || to >= max as isize => Err(Error::InvalidArguments {
+			name: String::from("array::swap"),
+			message: String::from(format!("Argument 2 is out of range. Expected a number between {negative_max} and {max}")),
+		}),
+		to if negative_max <= to && to < min => Ok((to + max as isize) as usize),
+		to => Ok(to as usize),
+	}?;
+
+	array.swap(from, to);
+	Ok(array.into())
 }
 
 pub fn transpose((array,): (Array,)) -> Result<Value, Error> {

--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -789,6 +789,8 @@ mod tests {
 
 	#[tokio::test]
 	async fn implementations_are_present() {
+		let excluded_from_scripting = &["array::map"];
+
 		// Accumulate and display all problems at once to avoid a test -> fix -> test -> fix cycle.
 		let mut problems = Vec::new();
 
@@ -838,6 +840,10 @@ mod tests {
 			#[cfg(all(feature = "scripting", feature = "kv-mem"))]
 			{
 				use crate::sql::Value;
+
+				if excluded_from_scripting.contains(&name) {
+					continue;
+				}
 
 				let name = name.replace("::", ".");
 				let sql =

--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -131,6 +131,7 @@ pub fn synchronous(
 		"array::push" => array::push,
 		"array::range" => array::range,
 		"array::remove" => array::remove,
+		"array::repeat" => array::repeat,
 		"array::reverse" => array::reverse,
 		"array::shuffle" => array::shuffle,
 		"array::slice" => array::slice,

--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -443,6 +443,7 @@ pub fn idiom(
 				"concat" => array::concat,
 				"difference" => array::difference,
 				"distinct" => array::distinct,
+				"fill" => array::fill,
 				"filter_index" => array::filter_index,
 				"find_index" => array::find_index,
 				"first" => array::first,
@@ -450,6 +451,7 @@ pub fn idiom(
 				"group" => array::group,
 				"insert" => array::insert,
 				"intersect" => array::intersect,
+				"is_empty" => array::is_empty,
 				"join" => array::join,
 				"last" => array::last,
 				"len" => array::len,
@@ -467,6 +469,7 @@ pub fn idiom(
 				"shuffle" => array::shuffle,
 				"slice" => array::slice,
 				"sort" => array::sort,
+				"swap" => array::swap,
 				"transpose" => array::transpose,
 				"union" => array::union,
 				"sort_asc" => array::sort::asc,
@@ -689,6 +692,8 @@ pub fn idiom(
 				"to_record" => r#type::record,
 				"to_string" => r#type::string,
 				"to_uuid" => r#type::uuid,
+				//
+				"repeat" => array::repeat,
 			)
 		}
 		v => v,

--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -110,6 +110,7 @@ pub fn synchronous(
 		"array::concat" => array::concat,
 		"array::difference" => array::difference,
 		"array::distinct" => array::distinct,
+		"array::fill" => array::fill,
 		"array::filter_index" => array::filter_index,
 		"array::find_index" => array::find_index,
 		"array::first" => array::first,

--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -129,6 +129,7 @@ pub fn synchronous(
 		"array::pop" => array::pop,
 		"array::prepend" => array::prepend,
 		"array::push" => array::push,
+		"array::range" => array::range,
 		"array::remove" => array::remove,
 		"array::reverse" => array::reverse,
 		"array::shuffle" => array::shuffle,

--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -789,6 +789,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn implementations_are_present() {
+		#[cfg(all(feature = "scripting", feature = "kv-mem"))]
 		let excluded_from_scripting = &["array::map"];
 
 		// Accumulate and display all problems at once to avoid a test -> fix -> test -> fix cycle.
@@ -798,7 +799,7 @@ mod tests {
 		let fnc_mod = include_str!("mod.rs");
 
 		// Patch out idiom methods
-		let re = Regex::new(r"(?ms)pub fn idiom\(.*}\n+///").unwrap();
+		let re = Regex::new(r"(?ms)pub async fn idiom\(.*}\n+///").unwrap();
 		let fnc_no_idiom = re.replace(fnc_mod, "");
 
 		for line in fnc_no_idiom.lines() {

--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -118,6 +118,7 @@ pub fn synchronous(
 		"array::group" => array::group,
 		"array::insert" => array::insert,
 		"array::intersect" => array::intersect,
+		"array::is_empty" => array::is_empty,
 		"array::join" => array::join,
 		"array::last" => array::last,
 		"array::len" => array::len,

--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -137,6 +137,7 @@ pub fn synchronous(
 		"array::shuffle" => array::shuffle,
 		"array::slice" => array::slice,
 		"array::sort" => array::sort,
+		"array::swap" => array::swap,
 		"array::transpose" => array::transpose,
 		"array::union" => array::union,
 		"array::sort::asc" => array::sort::asc,

--- a/core/src/fnc/script/modules/surrealdb/functions/array.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/array.rs
@@ -45,6 +45,7 @@ impl_module_def!(
 	"prepend" => run,
 	"range" => run,
 	"remove" => run,
+	"repeat" => run,
 	"reverse" => run,
 	"shuffle" => run,
 	"slice" => run,

--- a/core/src/fnc/script/modules/surrealdb/functions/array.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/array.rs
@@ -23,6 +23,7 @@ impl_module_def!(
 	"concat" => run,
 	"difference" => run,
 	"distinct" => run,
+	"fill" => run,
 	"filter_index" => run,
 	"find_index" => run,
 	"first" => run,

--- a/core/src/fnc/script/modules/surrealdb/functions/array.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/array.rs
@@ -51,6 +51,7 @@ impl_module_def!(
 	"shuffle" => run,
 	"slice" => run,
 	"sort" => (sort::Package),
+	"swap" => run,
 	"transpose" => run,
 	"union" => run,
 	"windows" => run

--- a/core/src/fnc/script/modules/surrealdb/functions/array.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/array.rs
@@ -43,6 +43,7 @@ impl_module_def!(
 	"pop" => run,
 	"push" => run,
 	"prepend" => run,
+	"range" => run,
 	"remove" => run,
 	"reverse" => run,
 	"shuffle" => run,

--- a/core/src/fnc/script/modules/surrealdb/functions/array.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/array.rs
@@ -31,6 +31,7 @@ impl_module_def!(
 	"group" => run,
 	"insert" => run,
 	"intersect" => run,
+	"is_empty" => run,
 	"join" => run,
 	"knn" => run,
 	"last" => run,

--- a/core/src/fnc/script/modules/surrealdb/functions/mod.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/mod.rs
@@ -72,10 +72,9 @@ fn run(js_ctx: js::Ctx<'_>, name: &str, args: Vec<Value>) -> Result<Value> {
 async fn fut(js_ctx: js::Ctx<'_>, name: &str, args: Vec<Value>) -> Result<Value> {
 	let this = js_ctx.globals().get::<_, OwnedBorrow<QueryContext>>(QUERY_DATA_PROP_NAME)?;
 	// Process the called function
-	let res = Stk::enter_run(|stk| {
-		fnc::asynchronous(stk, this.context, Some(this.opt), this.doc, name, args)
-	})
-	.await;
+	let res =
+		Stk::enter_run(|stk| fnc::asynchronous(stk, this.context, this.opt, this.doc, name, args))
+			.await;
 	// Convert any response error
 	res.map_err(|err| {
 		js::Exception::from_message(js_ctx, &err.to_string())

--- a/core/src/fnc/string.rs
+++ b/core/src/fnc/string.rs
@@ -1,4 +1,4 @@
-use crate::cnf::FNC_ALLOCATION_LIMIT;
+use crate::cnf::FUNCTION_ALLOCATION_LIMIT;
 use crate::err::Error;
 use crate::fnc::util::string;
 use crate::sql::value::Value;
@@ -6,10 +6,10 @@ use crate::sql::Regex;
 
 /// Returns `true` if a string of this length is too much to allocate.
 fn limit(name: &str, n: usize) -> Result<(), Error> {
-	if n > *FNC_ALLOCATION_LIMIT {
+	if n > *FUNCTION_ALLOCATION_LIMIT {
 		Err(Error::InvalidArguments {
 			name: name.to_owned(),
-			message: format!("Output must not exceed {} bytes.", *FNC_ALLOCATION_LIMIT),
+			message: format!("Output must not exceed {} bytes.", *FUNCTION_ALLOCATION_LIMIT),
 		})
 	} else {
 		Ok(())

--- a/core/src/fnc/string.rs
+++ b/core/src/fnc/string.rs
@@ -1,3 +1,4 @@
+use crate::cnf::FNC_ALLOCATION_LIMIT;
 use crate::err::Error;
 use crate::fnc::util::string;
 use crate::sql::value::Value;
@@ -5,11 +6,10 @@ use crate::sql::Regex;
 
 /// Returns `true` if a string of this length is too much to allocate.
 fn limit(name: &str, n: usize) -> Result<(), Error> {
-	const LIMIT: usize = 2usize.pow(20);
-	if n > LIMIT {
+	if n > *FNC_ALLOCATION_LIMIT {
 		Err(Error::InvalidArguments {
 			name: name.to_owned(),
-			message: format!("Output must not exceed {LIMIT} bytes."),
+			message: format!("Output must not exceed {} bytes.", *FNC_ALLOCATION_LIMIT),
 		})
 	} else {
 		Ok(())

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -60,7 +60,11 @@ impl Value {
 						stk.run(|stk| obj.get(stk, ctx, opt, doc, path)).await
 					}
 					Part::Method(name, args) => {
-						let v = idiom(ctx, doc, v.clone().into(), name, args.clone())?;
+						let v = stk
+							.run(|stk| {
+								idiom(stk, ctx, opt, doc, v.clone().into(), name, args.clone())
+							})
+							.await?;
 						stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
 					}
 					// Otherwise return none
@@ -141,7 +145,11 @@ impl Value {
 						stk.run(|stk| obj.get(stk, ctx, opt, doc, path.next())).await
 					}
 					Part::Method(name, args) => {
-						let res = idiom(ctx, doc, v.clone().into(), name, args.clone());
+						let res = stk
+							.run(|stk| {
+								idiom(stk, ctx, opt, doc, v.clone().into(), name, args.clone())
+							})
+							.await;
 						let res = match &res {
 							Ok(_) => res,
 							Err(Error::InvalidFunction {
@@ -214,7 +222,11 @@ impl Value {
 						_ => Ok(Value::None),
 					},
 					Part::Method(name, args) => {
-						let v = idiom(ctx, doc, v.clone().into(), name, args.clone())?;
+						let v = stk
+							.run(|stk| {
+								idiom(stk, ctx, opt, doc, v.clone().into(), name, args.clone())
+							})
+							.await?;
 						stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
 					}
 					_ => stk
@@ -302,7 +314,19 @@ impl Value {
 								}
 							}
 							Part::Method(name, args) => {
-								let v = idiom(ctx, doc, v.clone().into(), name, args.clone())?;
+								let v = stk
+									.run(|stk| {
+										idiom(
+											stk,
+											ctx,
+											opt,
+											doc,
+											v.clone().into(),
+											name,
+											args.clone(),
+										)
+									})
+									.await?;
 								stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
 							}
 							// This is a remote field expression
@@ -325,7 +349,9 @@ impl Value {
 							stk.run(|stk| v.get(stk, ctx, opt, None, path.next())).await
 						}
 						Part::Method(name, args) => {
-							let v = idiom(ctx, doc, v.clone(), name, args.clone())?;
+							let v = stk
+								.run(|stk| idiom(stk, ctx, opt, doc, v.clone(), name, args.clone()))
+								.await?;
 							stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
 						}
 						// Only continue processing the path from the point that it contains a method

--- a/core/src/syn/parser/builtin.rs
+++ b/core/src/syn/parser/builtin.rs
@@ -105,6 +105,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("array::group") => PathKind::Function,
 		UniCase::ascii("array::insert") => PathKind::Function,
 		UniCase::ascii("array::intersect") => PathKind::Function,
+		UniCase::ascii("array::is_empty") => PathKind::Function,
 		UniCase::ascii("array::join") => PathKind::Function,
 		UniCase::ascii("array::last") => PathKind::Function,
 		UniCase::ascii("array::len") => PathKind::Function,

--- a/core/src/syn/parser/builtin.rs
+++ b/core/src/syn/parser/builtin.rs
@@ -117,6 +117,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("array::prepend") => PathKind::Function,
 		UniCase::ascii("array::push") => PathKind::Function,
 		UniCase::ascii("array::remove") => PathKind::Function,
+		UniCase::ascii("array::range") => PathKind::Function,
 		UniCase::ascii("array::reverse") => PathKind::Function,
 		UniCase::ascii("array::shuffle") => PathKind::Function,
 		UniCase::ascii("array::slice") => PathKind::Function,

--- a/core/src/syn/parser/builtin.rs
+++ b/core/src/syn/parser/builtin.rs
@@ -113,6 +113,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("array::logical_or") => PathKind::Function,
 		UniCase::ascii("array::logical_xor") => PathKind::Function,
 		UniCase::ascii("array::matches") => PathKind::Function,
+		UniCase::ascii("array::map") => PathKind::Function,
 		UniCase::ascii("array::max") => PathKind::Function,
 		UniCase::ascii("array::min") => PathKind::Function,
 		UniCase::ascii("array::pop") => PathKind::Function,

--- a/core/src/syn/parser/builtin.rs
+++ b/core/src/syn/parser/builtin.rs
@@ -124,6 +124,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("array::shuffle") => PathKind::Function,
 		UniCase::ascii("array::slice") => PathKind::Function,
 		UniCase::ascii("array::sort") => PathKind::Function,
+		UniCase::ascii("array::swap") => PathKind::Function,
 		UniCase::ascii("array::transpose") => PathKind::Function,
 		UniCase::ascii("array::union") => PathKind::Function,
 		UniCase::ascii("array::sort::asc") => PathKind::Function,

--- a/core/src/syn/parser/builtin.rs
+++ b/core/src/syn/parser/builtin.rs
@@ -97,6 +97,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("array::concat") => PathKind::Function,
 		UniCase::ascii("array::difference") => PathKind::Function,
 		UniCase::ascii("array::distinct") => PathKind::Function,
+		UniCase::ascii("array::fill") => PathKind::Function,
 		UniCase::ascii("array::filter_index") => PathKind::Function,
 		UniCase::ascii("array::find_index") => PathKind::Function,
 		UniCase::ascii("array::first") => PathKind::Function,

--- a/core/src/syn/parser/builtin.rs
+++ b/core/src/syn/parser/builtin.rs
@@ -117,6 +117,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("array::prepend") => PathKind::Function,
 		UniCase::ascii("array::push") => PathKind::Function,
 		UniCase::ascii("array::remove") => PathKind::Function,
+		UniCase::ascii("array::repeat") => PathKind::Function,
 		UniCase::ascii("array::range") => PathKind::Function,
 		UniCase::ascii("array::reverse") => PathKind::Function,
 		UniCase::ascii("array::shuffle") => PathKind::Function,

--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -185,6 +185,7 @@
 "array::pop("
 "array::prepend("
 "array::push("
+"array::range("
 "array::remove("
 "array::reverse("
 "array::shuffle("

--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -166,6 +166,7 @@
 "array::concat("
 "array::difference("
 "array::distinct("
+"array::fill("
 "array::filter_index("
 "array::find_index("
 "array::first("

--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -195,6 +195,7 @@
 "array::sort("
 "array::sort::asc("
 "array::sort::desc("
+"array::swap("
 "array::transpose("
 "array::union("
 "count("

--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -174,6 +174,7 @@
 "array::group("
 "array::insert("
 "array::intersect("
+"array::is_empty("
 "array::join("
 "array::last("
 "array::len("

--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -182,6 +182,7 @@
 "array::logical_or("
 "array::logical_xor("
 "array::matches("
+"array::map("
 "array::max("
 "array::min("
 "array::pop("

--- a/lib/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_executor.dict
@@ -187,6 +187,7 @@
 "array::push("
 "array::range("
 "array::remove("
+"array::repeat("
 "array::reverse("
 "array::shuffle("
 "array::slice("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -181,6 +181,7 @@
 "array::logical_or("
 "array::logical_xor("
 "array::matches("
+"array::map("
 "array::max("
 "array::min("
 "array::pop("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -194,6 +194,7 @@
 "array::sort("
 "array::sort::asc("
 "array::sort::desc("
+"array::swap("
 "array::transpose("
 "array::union("
 "count("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -184,6 +184,7 @@
 "array::pop("
 "array::prepend("
 "array::push("
+"array::range("
 "array::remove("
 "array::reverse("
 "array::shuffle("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -173,6 +173,7 @@
 "array::group("
 "array::insert("
 "array::intersect("
+"array::is_empty("
 "array::join("
 "array::last("
 "array::len("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -165,6 +165,7 @@
 "array::concat("
 "array::difference("
 "array::distinct("
+"array::fill("
 "array::filter_index("
 "array::find_index("
 "array::first("

--- a/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/lib/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -186,6 +186,7 @@
 "array::push("
 "array::range("
 "array::remove("
+"array::repeat("
 "array::reverse("
 "array::shuffle("
 "array::slice("

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -280,6 +280,31 @@ async fn function_array_distinct() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn function_array_fill() -> Result<(), Error> {
+	let sql = r#"
+		RETURN array::fill([1,2,3,4,5], 10);
+		RETURN array::fill([1,2,3,4,5], 10, 0, 7);
+		RETURN array::fill([1,NONE,NONE,NONE,NONE], 10, 1);
+		RETURN array::fill([1,NONE,3,4,5], 10, 1, 2);
+		RETURN array::fill([1,2,3,4,5], 10, 1, 1);
+		RETURN array::fill([1,2,3,4,5], 10, 7, 7);
+		RETURN array::fill([1,2,3,4,5], 10, 7, 9);
+		RETURN array::fill([1,2,NONE,4,5], 10, -3, -2);
+	"#;
+	//
+	Test::new(sql).await?
+		.expect_val("[10,10,10,10,10]")?
+		.expect_val("[10,10,10,10,10]")?
+		.expect_val("[1,10,10,10,10]")?
+		.expect_val("[1,10,3,4,5]")?
+		.expect_val("[1,2,3,4,5]")?
+		.expect_val("[1,2,3,4,5]")?
+		.expect_val("[1,2,3,4,5]")?
+		.expect_val("[1,2,10,4,5]")?;
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_array_filter_index() -> Result<(), Error> {
 	let sql = r#"RETURN array::filter_index([0, 1, 2], 1);
 RETURN array::filter_index([0, 0, 2], 0);

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -475,6 +475,17 @@ async fn function_array_intersect() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn function_array_is_empty() -> Result<(), Error> {
+	let sql = r#"
+		RETURN array::is_empty([]);
+		RETURN array::is_empty([1,2,3,4,5]);
+	"#;
+	//
+	Test::new(sql).await?.expect_val("true")?.expect_val("false")?;
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_string_join_arr() -> Result<(), Error> {
 	let sql = r#"
 		RETURN array::join([], "");

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -1054,6 +1054,27 @@ async fn function_array_sort_desc() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn function_array_swap() -> Result<(), Error> {
+	let sql = r#"
+		RETURN array::swap([1,2,3,4,5], 1, 2);
+		RETURN array::swap([1,2,3,4,5], 1, 1);
+		RETURN array::swap([1,2,3,4,5], -1, -2);
+		RETURN array::swap([1,2,3,4,5], -5, -4);
+		RETURN array::swap([1,2,3,4,5], 8, 1);
+		RETURN array::swap([1,2,3,4,5], 1, -8);
+	"#;
+	//
+	Test::new(sql).await?
+		.expect_val("[1,3,2,4,5]")?
+		.expect_val("[1,2,3,4,5]")?
+		.expect_val("[1,2,3,5,4]")?
+		.expect_val("[2,1,3,4,5]")?
+		.expect_error("Incorrect arguments for function array::swap(). Argument 1 is out of range. Expected a number between -5 and 5")?
+		.expect_error("Incorrect arguments for function array::swap(). Argument 2 is out of range. Expected a number between -5 and 5")?;
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_array_transpose() -> Result<(), Error> {
 	let sql = r#"
 		RETURN array::transpose([[0, 1], [2, 3]]);

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -832,8 +832,8 @@ async fn function_array_repeat() -> Result<(), Error> {
 		.expect_val(r#"["hello","hello"]"#)?
 		.expect_val("[NONE,NONE,NONE]")?
 		.expect_val("[]")?
-		.expect_error("Incorrect arguments for function array::repeat(). Argument 2 was the wrong type. Expected a positive number but found -1")?
-		.expect_error("Incorrect arguments for function array::repeat(). Argument 2 was the wrong type. Expected a positive number but found -256")?;
+		.expect_error("Incorrect arguments for function array::repeat(). Output must not exceed 1048576 bytes.")?
+		.expect_error("Incorrect arguments for function array::repeat(). Output must not exceed 1048576 bytes.")?;
 	Ok(())
 }
 

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -292,7 +292,8 @@ async fn function_array_fill() -> Result<(), Error> {
 		RETURN array::fill([1,2,NONE,4,5], 10, -3, -2);
 	"#;
 	//
-	Test::new(sql).await?
+	Test::new(sql)
+		.await?
 		.expect_val("[10,10,10,10,10]")?
 		.expect_val("[10,10,10,10,10]")?
 		.expect_val("[1,10,10,10,10]")?

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -605,6 +605,16 @@ RETURN array::logical_xor([0, 1], []);"#,
 }
 
 #[tokio::test]
+async fn function_array_map() -> Result<(), Error> {
+	let sql = r#"
+		RETURN array::map([1,2,3], |$n, $i| $n + $i);
+	"#;
+	//
+	Test::new(sql).await?.expect_val("[1, 3, 5]")?;
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_array_matches() -> Result<(), Error> {
 	test_queries(
 		r#"RETURN array::matches([0, 1, 2], 1);

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -780,6 +780,27 @@ async fn function_array_remove() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn function_array_repeat() -> Result<(), Error> {
+	let sql = r#"
+		RETURN array::repeat(1, 10);
+		RETURN array::repeat("hello", 2);
+		RETURN array::repeat(NONE, 3);
+		RETURN array::repeat(44, 0);
+		RETURN array::repeat(0, -1);
+		RETURN array::repeat(0, -256);
+	"#;
+	//
+	Test::new(sql).await?
+		.expect_val("[1,1,1,1,1,1,1,1,1,1]")?
+		.expect_val(r#"["hello","hello"]"#)?
+		.expect_val("[NONE,NONE,NONE]")?
+		.expect_val("[]")?
+		.expect_error("Incorrect arguments for function array::repeat(). Argument 2 was the wrong type. Expected a positive number but found -1")?
+		.expect_error("Incorrect arguments for function array::repeat(). Argument 2 was the wrong type. Expected a positive number but found -256")?;
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_array_reverse() -> Result<(), Error> {
 	let sql = r#"
 		RETURN array::reverse([]);


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What does this change do?

Add new array functions:
* `array::range` - create a number array from a range (start to begin), inspired by [IEnumerable.Range](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.range?view=net-8.0)
* `array::repeat` - create an array of the same (any) value of N size, inspired by [IEnumerable.Repeat](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.repeat?view=net-8.0)
* `array::fill` - fill an existing array of the same (any) value, inspired by the js [function fill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill#syntax)
* `array::swap` - to swap two items in an array
* `array::is_empty` - check if an array is `[]`, inspired by Rust `is_empty` fn
* `array::map` - Map over array values alongside their respective index

Additionally, where possible, these new methods are available within idiom method chaining too.

## What is your testing strategy?

Unit tests

## Is this related to any issues?

Closes https://github.com/surrealdb/surrealdb/issues/3754

## Does this change need documentation?

- [x] https://github.com/surrealdb/docs.surrealdb.com/pull/657

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
