### PR TITLE
Fix warnings for release builds

### DIFF
--- a/core/src/fnc/script/error.rs
+++ b/core/src/fnc/script/error.rs
@@ -12,10 +12,7 @@ impl From<js::CaughtError<'_>> for Error {
 							Some(file) => format!(" at {file}:{line}"),
 							None => String::default(),
 						},
-						match e.message() {
-							Some(message) => message,
-							None => String::default(),
-						},
+						e.message().unwrap_or_default(),
 						match e.stack() {
 							Some(stack) => format!("\n{stack}"),
 							None => String::default(),

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -29,6 +29,7 @@ use crate::dbs::node::ClusterMembership;
 use crate::dbs::node::Timestamp;
 use crate::err::Error;
 use crate::idg::u32::U32;
+#[cfg(debug_assertions)]
 use crate::key::debug::sprint_key;
 use crate::key::error::KeyCategory;
 use crate::key::key_req::KeyRequirements;
@@ -45,8 +46,10 @@ use crate::sql::paths::OUT;
 use crate::sql::thing::Thing;
 use crate::sql::Strand;
 use crate::sql::Value;
+#[cfg(debug_assertions)]
+use crate::vs::conv;
+use crate::vs::Oracle;
 use crate::vs::Versionstamp;
-use crate::vs::{conv, Oracle};
 
 use super::kv::Add;
 use super::kv::Convert;

--- a/core/src/options.rs
+++ b/core/src/options.rs
@@ -23,3 +23,10 @@ impl Default for EngineOptions {
 		}
 	}
 }
+
+impl EngineOptions {
+	pub fn with_tick_interval(mut self, tick_interval: Duration) -> Self {
+		self.tick_interval = tick_interval;
+		self
+	}
+}

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -4,7 +4,6 @@ use std::{net::SocketAddr, path::PathBuf};
 
 pub static CF: OnceLock<Config> = OnceLock::new();
 
-use std::time::Duration;
 use surrealdb::options::EngineOptions;
 
 #[derive(Clone, Debug)]
@@ -16,6 +15,5 @@ pub struct Config {
 	pub pass: Option<String>,
 	pub crt: Option<PathBuf>,
 	pub key: Option<PathBuf>,
-	pub tick_interval: Duration,
 	pub engine: Option<EngineOptions>,
 }

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use surrealdb::engine::any::IntoEndpoint;
 use surrealdb::engine::tasks::start_tasks;
+use surrealdb::options::EngineOptions;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Args, Debug)]
@@ -170,10 +171,9 @@ pub async fn init(
 		path,
 		user,
 		pass,
-		tick_interval,
 		crt: web.as_ref().and_then(|x| x.web_crt.clone()),
 		key: web.as_ref().and_then(|x| x.web_key.clone()),
-		engine: None,
+		engine: Some(EngineOptions::default().with_tick_interval(tick_interval)),
 	});
 	// This is the cancellation token propagated down to
 	// all the async functions that needs to be stopped gracefully.


### PR DESCRIPTION
## What is the motivation?

Release builds currently print these warnings

```
warning: unused import: `crate::key::debug::sprint_key`
  --> core/src/kvs/tx.rs:32:5
   |
32 | use crate::key::debug::sprint_key;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `conv`
  --> core/src/kvs/tx.rs:49:17
   |
49 | use crate::vs::{conv, Oracle};
   |                 ^^^^

warning: `surrealdb-core` (lib) generated 2 warnings (run `cargo fix --lib -p surrealdb-core` to apply 2 suggestions)
```

This is because these imports are only used in debug builds.

## What does this change do?

It ensures the imports are only done for debug builds.

## What is your testing strategy?

Tested via `cargo check`.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
