### PR TITLE
Uses Config::tick_interval

### DIFF
--- a/core/src/options.rs
+++ b/core/src/options.rs
@@ -23,3 +23,10 @@ impl Default for EngineOptions {
 		}
 	}
 }
+
+impl EngineOptions {
+	pub fn with_tick_interval(mut self, tick_interval: Duration) -> Self {
+		self.tick_interval = tick_interval;
+		self
+	}
+}

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -4,7 +4,6 @@ use std::{net::SocketAddr, path::PathBuf};
 
 pub static CF: OnceLock<Config> = OnceLock::new();
 
-use std::time::Duration;
 use surrealdb::options::EngineOptions;
 
 #[derive(Clone, Debug)]
@@ -16,7 +15,6 @@ pub struct Config {
 	pub pass: Option<String>,
 	pub crt: Option<PathBuf>,
 	pub key: Option<PathBuf>,
-	pub tick_interval: Duration,
 	pub engine: Option<EngineOptions>,
 	pub no_identification_headers: bool,
 }

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use surrealdb::engine::any::IntoEndpoint;
 use surrealdb::engine::tasks::start_tasks;
+use surrealdb::options::EngineOptions;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Args, Debug)]
@@ -177,7 +178,7 @@ pub async fn init(
 		no_identification_headers,
 		crt: web.as_ref().and_then(|x| x.web_crt.clone()),
 		key: web.as_ref().and_then(|x| x.web_key.clone()),
-		engine: None,
+		engine: Some(EngineOptions::default().with_tick_interval(tick_interval)),
 	});
 	// This is the cancellation token propagated down to
 	// all the async functions that needs to be stopped gracefully.
@@ -187,9 +188,10 @@ pub async fn init(
 	// Start the kvs server
 	dbs::init(dbs).await?;
 	// Start the node agent
-	let mut opt = config::CF.get().unwrap().engine.unwrap_or_default();
-	opt.tick_interval = tick_interval;
-	let (tasks, task_chans) = start_tasks(&opt, DB.get().unwrap().clone());
+	let (tasks, task_chans) = start_tasks(
+		&config::CF.get().unwrap().engine.unwrap_or_default(),
+		DB.get().unwrap().clone(),
+	);
 	// Start the web server
 	net::init(ct.clone()).await?;
 	// Shutdown and stop closed tasks

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -174,7 +174,6 @@ pub async fn init(
 		path,
 		user,
 		pass,
-		tick_interval,
 		no_identification_headers,
 		crt: web.as_ref().and_then(|x| x.web_crt.clone()),
 		key: web.as_ref().and_then(|x| x.web_key.clone()),
@@ -188,10 +187,9 @@ pub async fn init(
 	// Start the kvs server
 	dbs::init(dbs).await?;
 	// Start the node agent
-	let (tasks, task_chans) = start_tasks(
-		&config::CF.get().unwrap().engine.unwrap_or_default(),
-		DB.get().unwrap().clone(),
-	);
+	let mut opt = config::CF.get().unwrap().engine.unwrap_or_default();
+	opt.tick_interval = tick_interval;
+	let (tasks, task_chans) = start_tasks(&opt, DB.get().unwrap().clone());
 	// Start the web server
 	net::init(ct.clone()).await?;
 	// Shutdown and stop closed tasks


### PR DESCRIPTION
## What is the motivation?

`tick-interval` is ignored when set from the command line.

## What does this change do?

Make sure tick-interval is set.

## What is your testing strategy?

No additional test - clippy issue

## Is this related to any issues?

#4124 

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
