### PR TITLE
feat(rpc): add clear rpc method

### DIFF
--- a/core/src/rpc/method.rs
+++ b/core/src/rpc/method.rs
@@ -24,6 +24,7 @@ pub enum Method {
 	Query,
 	Relate,
 	Run,
+	Clear,
 }
 
 impl Method {
@@ -55,6 +56,7 @@ impl Method {
 			"query" => Self::Query,
 			"relate" => Self::Relate,
 			"run" => Self::Run,
+			"clear" => Self::Clear,
 			_ => Self::Unknown,
 		}
 	}
@@ -87,6 +89,7 @@ impl Method {
 			Self::Query => "query",
 			Self::Relate => "relate",
 			Self::Run => "run",
+			Self::Clear => "clear",
 		}
 	}
 }

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -62,6 +62,7 @@ pub trait RpcContext {
 			Method::Query => self.query(params).await.map(Into::into).map_err(Into::into),
 			Method::Relate => self.relate(params).await.map(Into::into).map_err(Into::into),
 			Method::Run => self.run(params).await.map(Into::into).map_err(Into::into),
+			Method::Clear => self.clear().await.map(Into::into).map_err(Into::into),
 			Method::Unknown => Err(RpcError::MethodNotFound),
 		}
 	}
@@ -593,6 +594,22 @@ pub trait RpcContext {
 		res.remove(0).result.map_err(Into::into)
 	}
 
+	// ------------------------------
+	// Methods to clear current session
+	// ------------------------------
+
+	async fn clear(&mut self) -> Result<impl Into<Data>, RpcError> {
+		let session = self.session_mut();
+
+		crate::iam::clear::clear(session)?;
+		session.ns = None;
+		session.db = None;
+		
+		self.vars_mut().clear();
+
+		Ok(Value::None)
+	}
+	
 	// ------------------------------
 	// Private methods
 	// ------------------------------

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -423,4 +423,18 @@ impl RpcContext for Connection {
 		surrealdb::iam::verify::token(DB.get().unwrap(), &mut self.session, &token.0).await?;
 		Ok(Value::None)
 	}
+
+	async fn clear(&mut self) -> Result<impl Into<Data>, RpcError> {
+		LIVE_QUERIES.write().await.retain(|_, v| *v != self.id);
+
+		let session = self.session_mut();
+
+		surrealdb::iam::clear::clear(session)?;
+		session.ns = None;
+		session.db = None;
+		
+		self.vars_mut().clear();
+
+		Ok(Value::None)
+	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Performance improvement for client SDKs. Each time we have a new request, let's say in the context of an HTTP request, we have to create a new RPC connection, which mean creating a new connection by 1. creating a new connection, 2. apply network connect (handshake & so on), 3. set ns/db and 4. apply auth. All of this take quite some time. The best way to mitigate this is to reuse connection.

## What does this change do?

This PR adds a new RPC method called `clear` (not sure of the name, I hesitated with `reset`, please give me feedback on this).
This method clears the RPC session so that the connection can be reused without waiting. This new method does:

* reset NS/DB to None
* reset auth
* unset variables
* kill all live queries  

## What is your testing strategy?

Tested via the .NET SDK

## Does this change need documentation?

- [x] TODO

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)