### PR TITLE
Inline push and len method for MemoryCollector

### DIFF
--- a/core/src/dbs/store.rs
+++ b/core/src/dbs/store.rs
@@ -7,6 +7,7 @@ use std::mem;
 pub(super) struct MemoryCollector(Vec<Value>);
 
 impl MemoryCollector {
+	#[inline]
 	pub(super) fn push(&mut self, val: Value) {
 		self.0.push(val);
 	}
@@ -15,6 +16,7 @@ impl MemoryCollector {
 		self.0.sort_by(|a, b| orders.compare(a, b));
 	}
 
+	#[inline]
 	pub(super) fn len(&self) -> usize {
 		self.0.len()
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Memory allocator has the push and len method called frequently. To reduce the function call overhead, I added the inline attribute.

## What does this change do?

Reduce the function call overhead for len() and push() methods in the Memory allocator

## What is your testing strategy?

Running the existing test cases after inlining this method proves it works correctly.

## Is this related to any issues?

No

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?


<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
