### PR TITLE
Decrease default capabilities

### DIFF
--- a/core/src/dbs/capabilities.rs
+++ b/core/src/dbs/capabilities.rs
@@ -256,7 +256,7 @@ impl Default for Capabilities {
 			guest_access: false,
 			live_query_notifications: true,
 
-			allow_funcs: Arc::new(Targets::All),
+			allow_funcs: Arc::new(Targets::None),
 			deny_funcs: Arc::new(Targets::None),
 			allow_net: Arc::new(Targets::None),
 			deny_net: Arc::new(Targets::None),
@@ -274,6 +274,19 @@ impl Capabilities {
 			allow_funcs: Arc::new(Targets::All),
 			deny_funcs: Arc::new(Targets::None),
 			allow_net: Arc::new(Targets::All),
+			deny_net: Arc::new(Targets::None),
+		}
+	}
+
+	pub fn none() -> Self {
+		Self {
+			scripting: false,
+			guest_access: false,
+			live_query_notifications: false,
+
+			allow_funcs: Arc::new(Targets::None),
+			deny_funcs: Arc::new(Targets::None),
+			allow_net: Arc::new(Targets::None),
 			deny_net: Arc::new(Targets::None),
 		}
 	}

--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -331,6 +331,7 @@ pub async fn root_user(
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::dbs::capabilities::{Capabilities, Targets};
 	use crate::iam::Role;
 	use chrono::Duration;
 	use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
@@ -340,7 +341,10 @@ mod tests {
 	async fn test_signin_record() {
 		// Test with correct credentials
 		{
-			let ds = Datastore::new("memory").await.unwrap();
+			let ds = Datastore::new("memory")
+				.await
+				.unwrap()
+				.with_capabilities(Capabilities::default().with_functions(Targets::All));
 			let sess = Session::owner().with_ns("test").with_db("test");
 			ds.execute(
 				r#"
@@ -504,7 +508,10 @@ VBIovic5l0xFkEHskAjFTevO86Fsz1C2aSeRKSqGFoOQ0tmJzBEs1R6KqnHInicD
 TQrKhArgLXX4v3CddjfTRJkFWDbE/CkvKZNOrcf1nhaGCPspRJj2KUkj1Fhl9Cnc
 dn/RsYEONbwQSjIfMPkvxF+8HQ==
 -----END PRIVATE KEY-----"#;
-			let ds = Datastore::new("memory").await.unwrap();
+			let ds = Datastore::new("memory")
+				.await
+				.unwrap()
+				.with_capabilities(Capabilities::default().with_functions(Targets::All));
 			let sess = Session::owner().with_ns("test").with_db("test");
 			ds.execute(
 				&format!(

--- a/core/src/iam/signup.rs
+++ b/core/src/iam/signup.rs
@@ -142,6 +142,7 @@ pub async fn db_access(
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::dbs::capabilities::{Capabilities, Targets};
 	use crate::iam::Role;
 	use chrono::Duration;
 	use std::collections::HashMap;
@@ -150,7 +151,10 @@ mod tests {
 	async fn test_record_signup() {
 		// Test with valid parameters
 		{
-			let ds = Datastore::new("memory").await.unwrap();
+			let ds = Datastore::new("memory")
+				.await
+				.unwrap()
+				.with_capabilities(Capabilities::default().with_functions(Targets::All));
 			let sess = Session::owner().with_ns("test").with_db("test");
 			ds.execute(
 				r#"
@@ -304,7 +308,10 @@ VBIovic5l0xFkEHskAjFTevO86Fsz1C2aSeRKSqGFoOQ0tmJzBEs1R6KqnHInicD
 TQrKhArgLXX4v3CddjfTRJkFWDbE/CkvKZNOrcf1nhaGCPspRJj2KUkj1Fhl9Cnc
 dn/RsYEONbwQSjIfMPkvxF+8HQ==
 -----END PRIVATE KEY-----"#;
-			let ds = Datastore::new("memory").await.unwrap();
+			let ds = Datastore::new("memory")
+				.await
+				.unwrap()
+				.with_capabilities(Capabilities::default().with_functions(Targets::All));
 			let sess = Session::owner().with_ns("test").with_db("test");
 			ds.execute(
 				&format!(

--- a/lib/src/api/opt/capabilities.rs
+++ b/lib/src/api/opt/capabilities.rs
@@ -106,11 +106,11 @@ impl Default for Capabilities {
 impl Capabilities {
 	/// Create a builder with default capabilities enabled.
 	///
-	/// Default capabilities enables live query notifications and all (non-scripting) functions.
+	/// Default capabilities enables live query notifications.
 	pub fn new() -> Self {
 		Capabilities {
 			cap: CoreCapabilities::default(),
-			allow_funcs: Targets::All,
+			allow_funcs: Targets::None,
 			deny_funcs: Targets::None,
 			allow_net: Targets::None,
 			deny_net: Targets::None,
@@ -131,7 +131,7 @@ impl Capabilities {
 	/// Create a builder with all capabilities disabled.
 	pub fn none() -> Self {
 		Capabilities {
-			cap: CoreCapabilities::default(),
+			cap: CoreCapabilities::none(),
 			allow_funcs: Targets::None,
 			deny_funcs: Targets::None,
 			allow_net: Targets::None,

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -65,7 +65,6 @@ Function names must be in the form <family>[::<name>]. For example:
 	#[arg(env = "SURREAL_CAPS_ALLOW_FUNC", long, conflicts_with = "allow_all")]
 	// If the arg is provided without value, then assume it's "", which gets parsed into Targets::All
 	#[arg(default_missing_value_os = "", num_args = 0..)]
-	#[arg(default_value_os = "")] // Allow all functions by default
 	#[arg(value_parser = super::cli::validator::func_targets)]
 	allow_funcs: Option<Targets<FuncTarget>>,
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To decrease default capabilities, more specifically by dropping the capability to run non-scripting functions by default. The  capability to run functions may extend the attack surface of SurrealDB to additional third-party libraries that are used to implement the functions as well as allow users to perform actions that should only be allowed as a result of a conscious decision by the SurrealDB owner, specially when other capabilities such as networking are enabled.

For example, by default, if the networking capability is enabled without any exceptions, an attacker may use the `http` functions to perform requests over the private network in order to achieve lateral movement or privilege escalation using internal network interfaces such as the Docker API, the Kubernetes API or internal cloud endpoints.

This change encourages users to enable the specific functions that their service or application requires instead of relying on a default that enables all functions. Users that require all functions can still decide to enable them.

## What does this change do?

Updates the `default()` setting for both `CoreCapabilities` and the public `Capabilities` interface to not include functions. Creates a new `none()` setting in `CoreCapabilities` which does not include any capability. Updates the public `Capabilities` interface to use `none()` from `CoreCapabilities`.

## What is your testing strategy?

Ensure that existing tests continue passing.

## Is this related to any issues?

Addresses some issues raised on #4173.

## Does this change need documentation?

No. This behavior was actually already the [documented behavior](https://surrealdb.com/docs/surrealdb/2.x/security/capabilities#capabilities-list).

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
