### PR TITLE
Fix: Correctly implement `none` for `Capabilities`

### DIFF
--- a/core/src/dbs/capabilities.rs
+++ b/core/src/dbs/capabilities.rs
@@ -278,6 +278,19 @@ impl Capabilities {
 		}
 	}
 
+	pub fn none() -> Self {
+		Self {
+			scripting: false,
+			guest_access: false,
+			live_query_notifications: false,
+
+			allow_funcs: Arc::new(Targets::None),
+			deny_funcs: Arc::new(Targets::None),
+			allow_net: Arc::new(Targets::None),
+			deny_net: Arc::new(Targets::None),
+		}
+	}
+
 	pub fn with_scripting(mut self, scripting: bool) -> Self {
 		self.scripting = scripting;
 		self

--- a/lib/src/api/opt/capabilities.rs
+++ b/lib/src/api/opt/capabilities.rs
@@ -131,7 +131,7 @@ impl Capabilities {
 	/// Create a builder with all capabilities disabled.
 	pub fn none() -> Self {
 		Capabilities {
-			cap: CoreCapabilities::default(),
+			cap: CoreCapabilities::none(),
 			allow_funcs: Targets::None,
 			deny_funcs: Targets::None,
 			allow_net: Targets::None,

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -809,7 +809,6 @@ mod cli_integration {
 	}
 
 	#[test(tokio::test)]
-	#[ignore]
 	async fn test_capabilities() {
 		// Default capabilities only allow functions
 		info!("* When default capabilities");
@@ -893,11 +892,11 @@ mod cli_integration {
 
 			let query = format!("RETURN http::get('http://{}/version');\n\n", addr);
 			let output = common::run(&cmd).input(&query).output().unwrap();
-			assert!(output.starts_with("['surrealdb"), "unexpected output: {output:?}");
+			assert!(output.contains("['surrealdb-"), "unexpected output: {output:?}");
 
 			let query = "RETURN function() { return '1' };";
 			let output = common::run(&cmd).input(query).output().unwrap();
-			assert!(output.starts_with("['1']"), "unexpected output: {output:?}");
+			assert!(output.contains("['1']"), "unexpected output: {output:?}");
 
 			server.finish().unwrap();
 		}
@@ -969,7 +968,7 @@ mod cli_integration {
 
 			let query = format!("RETURN http::get('http://{}/version');\n\n", addr);
 			let output = common::run(&cmd).input(&query).output().unwrap();
-			assert!(output.starts_with("['surrealdb"), "unexpected output: {output:?}");
+			assert!(output.contains("['surrealdb-"), "unexpected output: {output:?}");
 			server.finish().unwrap();
 		}
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To address an error in https://github.com/surrealdb/surrealdb/pull/4173 which was not caught during review. This resulted in the public API for setting capabilities to `none` to instead use the `default` method from `CoreCapabilities`.

## What does this change do?

Implements the `none` method in `CoreCapabilities` and calls this method when setting capabilites to `none`. The only difference of this change is that live query notifications would previously be enabled even if capabilities were set to `none`.

## What is your testing strategy?

Integration tests for capabilities have been enabled to ensure capabilities remain working as intended.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
