### PR TITLE
Fix display formats for access methods

### DIFF
--- a/core/src/sql/access_type.rs
+++ b/core/src/sql/access_type.rs
@@ -192,13 +192,7 @@ impl Display for AccessType {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			AccessType::Jwt(ac) => {
-				f.write_str("JWT")?;
-				match &ac.verify {
-					JwtAccessVerify::Key(ref v) => {
-						write!(f, " ALGORITHM {} KEY {}", v.alg, quote_str(&v.key))?
-					}
-					JwtAccessVerify::Jwks(ref v) => write!(f, " URL {}", quote_str(&v.url))?,
-				}
+				write!(f, "JWT {}", ac)?;
 			}
 			AccessType::Record(ac) => {
 				f.write_str("RECORD")?;
@@ -247,7 +241,7 @@ impl Display for JwtAccess {
 				write!(f, "ALGORITHM {} KEY {}", v.alg, quote_str(&v.key))?;
 			}
 			JwtAccessVerify::Jwks(ref v) => {
-				write!(f, "JWKS {}", quote_str(&v.url),)?;
+				write!(f, "URL {}", quote_str(&v.url),)?;
 			}
 		}
 		if let Some(iss) = &self.issue {

--- a/core/src/sql/access_type.rs
+++ b/core/src/sql/access_type.rs
@@ -197,7 +197,7 @@ impl Display for AccessType {
 					JwtAccessVerify::Key(ref v) => {
 						write!(f, " ALGORITHM {} KEY {}", v.alg, quote_str(&v.key))?
 					}
-					JwtAccessVerify::Jwks(ref v) => write!(f, " JWKS {}", quote_str(&v.url))?,
+					JwtAccessVerify::Jwks(ref v) => write!(f, " URL {}", quote_str(&v.url))?,
 				}
 			}
 			AccessType::Record(ac) => {
@@ -208,6 +208,7 @@ impl Display for AccessType {
 				if let Some(ref v) = ac.signin {
 					write!(f, " SIGNIN {v}")?
 				}
+				write!(f, " WITH JWT {}", ac.jwt)?;
 			}
 		}
 		Ok(())
@@ -265,7 +266,7 @@ impl InfoStructure for JwtAccess {
 				acc.insert("key".to_string(), v.key.into());
 			}
 			JwtAccessVerify::Jwks(v) => {
-				acc.insert("jwks".to_string(), v.url.into());
+				acc.insert("url".to_string(), v.url.into());
 			}
 		}
 		if let Some(v) = self.issue {

--- a/core/src/sql/access_type.rs
+++ b/core/src/sql/access_type.rs
@@ -192,7 +192,7 @@ impl Display for AccessType {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			AccessType::Jwt(ac) => {
-				f.write_str(" JWT")?;
+				f.write_str("JWT")?;
 				match &ac.verify {
 					JwtAccessVerify::Key(ref v) => {
 						write!(f, " ALGORITHM {} KEY {}", v.alg, quote_str(&v.key))?
@@ -201,7 +201,7 @@ impl Display for AccessType {
 				}
 			}
 			AccessType::Record(ac) => {
-				f.write_str(" RECORD")?;
+				f.write_str("RECORD")?;
 				if let Some(ref v) = ac.signup {
 					write!(f, " SIGNUP {v}")?
 				}

--- a/core/src/sql/statements/define/access.rs
+++ b/core/src/sql/statements/define/access.rs
@@ -131,22 +131,8 @@ impl Display for DefineAccessStatement {
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?
 		}
-		write!(f, " {} ON {}", self.name, self.base)?;
-		match &self.kind {
-			AccessType::Jwt(ac) => {
-				write!(f, " TYPE JWT {}", ac)?;
-			}
-			AccessType::Record(ac) => {
-				write!(f, " TYPE RECORD")?;
-				if let Some(ref v) = ac.signup {
-					write!(f, " SIGNUP {v}")?
-				}
-				if let Some(ref v) = ac.signin {
-					write!(f, " SIGNIN {v}")?
-				}
-				write!(f, " WITH JWT {}", ac.jwt)?;
-			}
-		}
+		// The specific access method definition is displayed by AccessType
+		write!(f, " {} ON {} TYPE {}", self.name, self.base, self.kind)?;
 		// Always print relevant durations so defaults can be changed in the future
 		// If default values were not printed, exports would not be forward compatible
 		// None values need to be printed, as they are different from the default values

--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -1130,6 +1130,7 @@ fn parse_define_access_record() {
 	}
 }
 
+#[test]
 fn parse_define_access_record_with_jwt() {
 	let res = test_parse!(
 		parse_stmt,


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To show consistent output, both query and structured, for access methods defined with `DEFINE ACCESS`. Previously, remote JWKS verification was defined with the `URL` clause but printed using the `JWKS` clause. Additionally, this PR removes some unnecessary code duplication in this logic, improving maintainability.

## What does this change do?

- Reference JWKS location with the `URL` clause and the `url` structured field.
- Remove code duplication and rely on the `AccessType` display instead.

## What is your testing strategy?

Ensure that existing tests continue passing.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
