### PR TITLE
Detach `Strand` from `sql::Value`

### DIFF
--- a/core/src/cf/writer.rs
+++ b/core/src/cf/writer.rs
@@ -473,7 +473,7 @@ mod tests {
 		let expected_obj_second = Value::Object(Object::from(map! {
 			"id".to_string() => Value::Thing(thing.clone()),
 			"value".to_string() => Value::Number(Number::Int(100)),
-			"new_field".to_string() => Value::Strand(Strand::from("new_value")),
+			"new_field".to_string() => Value::Strand("new_value".to_owned()),
 		}));
 		assert_eq!(r.len(), 2, "{:?}", r);
 		let expected: Vec<ChangeSet> = vec![

--- a/core/src/cf/writer.rs
+++ b/core/src/cf/writer.rs
@@ -163,7 +163,7 @@ mod tests {
 	};
 	use crate::sql::thing::Thing;
 	use crate::sql::value::Value;
-	use crate::sql::{Datetime, Idiom, Number, Object, Operation, Strand};
+	use crate::sql::{Datetime, Idiom, Number, Object, Operation};
 	use crate::vs;
 	use crate::vs::{conv, Versionstamp};
 

--- a/core/src/dbs/iterator.rs
+++ b/core/src/dbs/iterator.rs
@@ -16,7 +16,9 @@ use crate::sql::range::Range;
 use crate::sql::table::Table;
 use crate::sql::thing::Thing;
 use crate::sql::value::Value;
-use reblessive::{tree::Stk, TreeStack};
+use reblessive::tree::Stk;
+#[cfg(not(target_arch = "wasm32"))]
+use reblessive::TreeStack;
 use std::mem;
 
 #[derive(Clone)]

--- a/core/src/fnc/args.rs
+++ b/core/src/fnc/args.rs
@@ -28,7 +28,7 @@ impl FromArg for String {
 
 impl FromArg for Strand {
 	fn from_arg(arg: Value) -> Result<Self, Error> {
-		arg.coerce_to_strand()
+		arg.coerce_to_string().map(Strand)
 	}
 }
 

--- a/core/src/fnc/geo.rs
+++ b/core/src/fnc/geo.rs
@@ -65,6 +65,7 @@ pub mod hash {
 	use crate::fnc::util::geo;
 	use crate::sql::geometry::Geometry;
 	use crate::sql::value::Value;
+	use crate::sql::Strand;
 
 	pub fn encode((point, len): (Value, Option<usize>)) -> Result<Value, Error> {
 		let len = match len {
@@ -84,7 +85,7 @@ pub mod hash {
 
 	pub fn decode((arg,): (Value,)) -> Result<Value, Error> {
 		match arg {
-			Value::Strand(v) => Ok(geo::decode(v).into()),
+			Value::Strand(v) => Ok(geo::decode(Strand(v)).into()),
 			_ => Ok(Value::None),
 		}
 	}

--- a/core/src/fnc/http.rs
+++ b/core/src/fnc/http.rs
@@ -45,7 +45,7 @@ pub async fn delete(_: &Context<'_>, (_, _): (Value, Option<Value>)) -> Result<V
 fn try_as_uri(fn_name: &str, value: Value) -> Result<crate::sql::Strand, Error> {
 	match value {
 		// Pre-check URI.
-		Value::Strand(uri) if crate::fnc::util::http::uri_is_valid(&uri) => Ok(uri),
+		Value::Strand(uri) if crate::fnc::util::http::uri_is_valid(&uri) => Ok(uri.into()),
 		_ => Err(Error::InvalidArguments {
 			name: fn_name.to_owned(),
 			// Assumption is that URI is first argument.

--- a/core/src/fnc/object.rs
+++ b/core/src/fnc/object.rs
@@ -2,15 +2,13 @@ use std::collections::BTreeMap;
 
 use crate::err::Error;
 use crate::sql::value::Value;
-use crate::sql::{Array, Object, Strand};
+use crate::sql::{Array, Object};
 
 pub fn entries((object,): (Object,)) -> Result<Value, Error> {
 	Ok(Value::Array(Array(
 		object
 			.iter()
-			.map(|(k, v)| {
-				Value::Array(Array(vec![Value::Strand(Strand(k.to_owned())), v.to_owned()]))
-			})
+			.map(|(k, v)| Value::Array(Array(vec![Value::Strand(k.to_owned()), v.to_owned()])))
 			.collect(),
 	)))
 }
@@ -23,7 +21,7 @@ pub fn from_entries((array,): (Array,)) -> Result<Value, Error> {
 			Value::Array(Array(entry)) if entry.len() == 2 => {
 				let key = match entry.first() {
 					Some(v) => match v {
-						Value::Strand(v) => v.to_owned().to_raw(),
+						Value::Strand(v) => v.to_owned(),
 						v => v.to_string(),
 					},
 					_ => {
@@ -63,7 +61,7 @@ pub fn len((object,): (Object,)) -> Result<Value, Error> {
 }
 
 pub fn keys((object,): (Object,)) -> Result<Value, Error> {
-	Ok(Value::Array(Array(object.keys().map(|v| Value::Strand(Strand(v.to_owned()))).collect())))
+	Ok(Value::Array(Array(object.keys().map(|v| Value::Strand(v.to_owned())).collect())))
 }
 
 pub fn values((object,): (Object,)) -> Result<Value, Error> {

--- a/core/src/fnc/search.rs
+++ b/core/src/fnc/search.rs
@@ -15,7 +15,7 @@ pub async fn analyze(
 	if let (Some(opt), Value::Strand(az), Value::Strand(val)) = (opt, az, val) {
 		let az: Analyzer =
 			ctx.tx_lock().await.get_db_analyzer(opt.ns()?, opt.db()?, az.as_str()).await?.into();
-		az.analyze(stk, ctx, opt, val.0).await
+		az.analyze(stk, ctx, opt, val).await
 	} else {
 		Ok(Value::None)
 	}

--- a/core/src/fnc/string.rs
+++ b/core/src/fnc/string.rs
@@ -76,10 +76,10 @@ pub fn replace((val, old_or_regexp, new): (String, Value, String)) -> Result<Val
 				let increase = new.len() - old.len();
 				limit(
 					"string::replace",
-					val.len().saturating_add(val.matches(&old.0).count().saturating_mul(increase)),
+					val.len().saturating_add(val.matches(&old).count().saturating_mul(increase)),
 				)?;
 			}
-			Ok(val.replace(&old.0, &new).into())
+			Ok(val.replace(&old, &new).into())
 		}
 		Value::Regex(r) => Ok(r.0.replace_all(&val, new).into_owned().into()),
 		_ => Err(Error::InvalidArguments {
@@ -257,7 +257,7 @@ pub mod is {
 
 	pub fn uuid((arg,): (Value,)) -> Result<Value, Error> {
 		Ok(match arg {
-			Value::Strand(v) => Uuid::parse_str(v.as_string().as_str()).is_ok(),
+			Value::Strand(v) => Uuid::parse_str(v.as_str()).is_ok(),
 			Value::Uuid(_) => true,
 			_ => false,
 		}

--- a/core/src/fnc/type.rs
+++ b/core/src/fnc/type.rs
@@ -7,7 +7,7 @@ use crate::err::Error;
 use crate::sql::table::Table;
 use crate::sql::thing::Thing;
 use crate::sql::value::Value;
-use crate::sql::{Id, Range, Strand};
+use crate::sql::{Id, Range};
 use crate::syn;
 use reblessive::tree::Stk;
 
@@ -84,7 +84,7 @@ pub fn point((val,): (Value,)) -> Result<Value, Error> {
 }
 
 pub fn string((val,): (Value,)) -> Result<Value, Error> {
-	val.convert_to_strand().map(Value::from)
+	val.convert_to_string().map(Value::from)
 }
 
 pub fn table((val,): (Value,)) -> Result<Value, Error> {
@@ -98,12 +98,12 @@ pub fn thing((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 	match (arg1, arg2) {
 		// Empty table name
 		(Value::Strand(arg1), _) if arg1.is_empty() => Err(Error::TbInvalid {
-			value: arg1.as_string(),
+			value: arg1,
 		}),
 
 		// Empty ID part
 		(_, Some(Value::Strand(arg2))) if arg2.is_empty() => Err(Error::IdInvalid {
-			value: arg2.as_string(),
+			value: arg2,
 		}),
 
 		// Handle second argument
@@ -175,8 +175,8 @@ pub fn range(args: Vec<Value>) -> Result<Value, Error> {
 					.to_string(),
 			})?;
 			match x {
-				Value::Strand(Strand(x)) if x == "included" => Bound::Included(start),
-				Value::Strand(Strand(x)) if x == "excluded" => Bound::Excluded(start),
+				Value::Strand(x) if x == "included" => Bound::Included(start),
+				Value::Strand(x) if x == "excluded" => Bound::Excluded(start),
 				x => {
 					return Err(Error::ConvertTo {
 						from: x.clone(),
@@ -193,8 +193,8 @@ pub fn range(args: Vec<Value>) -> Result<Value, Error> {
 				message: "Can't define an inclusion for end if there is no end bound".to_string(),
 			})?;
 			match x {
-				Value::Strand(Strand(x)) if x == "included" => Bound::Included(end),
-				Value::Strand(Strand(x)) if x == "excluded" => Bound::Excluded(end),
+				Value::Strand(x) if x == "included" => Bound::Included(end),
+				Value::Strand(x) if x == "excluded" => Bound::Excluded(end),
 				x => {
 					return Err(Error::ConvertTo {
 						from: x.clone(),

--- a/core/src/idx/ft/analyzer/mod.rs
+++ b/core/src/idx/ft/analyzer/mod.rs
@@ -9,8 +9,8 @@ use crate::idx::ft::postings::TermFrequency;
 use crate::idx::ft::terms::{TermId, TermLen, Terms};
 use crate::sql::statements::DefineAnalyzerStatement;
 use crate::sql::tokenizer::Tokenizer as SqlTokenizer;
+use crate::sql::Function;
 use crate::sql::Value;
-use crate::sql::{Function, Strand};
 use filter::Filter;
 use reblessive::tree::Stk;
 use std::collections::hash_map::Entry;
@@ -241,7 +241,7 @@ impl Analyzer {
 		tks: &mut Vec<Tokens>,
 	) -> Result<(), Error> {
 		match val {
-			Value::Strand(s) => tks.push(self.generate_tokens(stk, ctx, opt, stage, s.0).await?),
+			Value::Strand(s) => tks.push(self.generate_tokens(stk, ctx, opt, stage, s).await?),
 			Value::Number(n) => {
 				tks.push(self.generate_tokens(stk, ctx, opt, stage, n.to_string()).await?)
 			}
@@ -272,10 +272,10 @@ impl Analyzer {
 		mut input: String,
 	) -> Result<Tokens, Error> {
 		if let Some(function_name) = self.function.clone() {
-			let fns = Function::Custom(function_name.clone(), vec![Value::Strand(Strand(input))]);
+			let fns = Function::Custom(function_name.clone(), vec![Value::Strand(input)]);
 			let val = fns.compute(stk, ctx, opt, None).await?;
 			if let Value::Strand(val) = val {
-				input = val.0;
+				input = val;
 			} else {
 				return Err(Error::InvalidFunction {
 					name: function_name,

--- a/core/src/idx/ft/highlighter.rs
+++ b/core/src/idx/ft/highlighter.rs
@@ -62,7 +62,7 @@ impl Highlighter {
 
 	fn extract(val: Value, vals: &mut Vec<String>) {
 		match val {
-			Value::Strand(s) => vals.push(s.0),
+			Value::Strand(s) => vals.push(s),
 			Value::Number(n) => vals.push(n.to_string()),
 			Value::Bool(b) => vals.push(b.to_string()),
 			Value::Array(a) => {

--- a/core/src/kvs/lq_v2_doc.rs
+++ b/core/src/kvs/lq_v2_doc.rs
@@ -80,7 +80,7 @@ mod test {
 	#[test]
 	fn test_construct_document_create() {
 		let thing = Thing::from(("table", "id"));
-		let value = Value::Strand(Strand::from("value"));
+		let value = Value::Strand("value".to_owned());
 		let tb_mutation = TableMutation::Set(thing.clone(), value);
 		let doc = construct_document(&tb_mutation).unwrap();
 		let doc = doc.unwrap();
@@ -107,8 +107,8 @@ mod test {
 	fn test_construct_document_update() {
 		let thing = Thing::from(("table", "id"));
 		let current_value = Value::Object(Object(map! {
-			"first_field".to_string() => Value::Strand(Strand::from("first_value")),
-			"second_field".to_string() => Value::Strand(Strand::from("second_value")),
+			"first_field".to_string() => Value::Strand("first_value".to_owned()),
+			"second_field".to_string() => Value::Strand("second_value".to_owned()),
 		}));
 		let operations = vec![
 			Operation::Remove {
@@ -116,16 +116,16 @@ mod test {
 			},
 			Operation::Replace {
 				path: Idiom::from("second_field"),
-				value: Value::Strand(Strand::from("original_value")),
+				value: Value::Strand("original_value".to_owned()),
 			},
 			Operation::Add {
 				path: Idiom::from("third_field"),
-				value: Value::Strand(Strand::from("third_value")),
+				value: Value::Strand("third_value".to_owned()),
 			},
 		];
 		let expected_original = Value::Object(Object(map! {
-			"second_field".to_string() => Value::Strand(Strand::from("original_value")),
-			"third_field".to_string() => Value::Strand(Strand::from("third_value")),
+			"second_field".to_string() => Value::Strand("original_value".to_owned()),
+			"third_field".to_string() => Value::Strand("third_value".to_owned()),
 		}));
 		let tb_mutation =
 			TableMutation::SetWithDiff(thing.clone(), current_value.clone(), operations);
@@ -163,7 +163,7 @@ mod test {
 		let thing = Thing::from(("table", "id"));
 		let original = Value::Object(Object(map! {
 			"id".to_string() => Value::Thing(thing.clone()),
-			"some_key".to_string() => Value::Strand(Strand::from("some_value")),
+			"some_key".to_string() => Value::Strand("some_value".to_owned()),
 		}));
 		let tb_mutation = TableMutation::DelWithOriginal(thing.clone(), original);
 		let doc = construct_document(&tb_mutation).unwrap();
@@ -267,7 +267,7 @@ mod test_check_lqs_and_send_notifications {
 		// WHEN:
 		// Construct document we are validating
 		let record_id = Thing::from((SETUP.tb.as_str(), "id"));
-		let value = Value::Strand(Strand::from("value"));
+		let value = Value::Strand("value".to_owned());
 		let tb_mutation = TableMutation::Set(record_id.clone(), value);
 		let doc = construct_document(&tb_mutation).unwrap().unwrap();
 
@@ -294,7 +294,7 @@ mod test_check_lqs_and_send_notifications {
 			notification.fuzzy_eq(&Notification::new(
 				Uuid::default(),
 				Action::Create,
-				Value::Strand(Strand::from("value"))
+				Value::Strand("value".to_owned())
 			)),
 			"{:?}",
 			notification
@@ -315,7 +315,7 @@ mod test_check_lqs_and_send_notifications {
 		// WHEN:
 		// Construct document we are validating
 		let record_id = Thing::from((SETUP.tb.as_str(), "id"));
-		let value = Value::Strand(Strand::from("value"));
+		let value = Value::Strand("value".to_owned());
 		let tb_mutation = TableMutation::Set(record_id.clone(), value);
 		let doc = construct_document(&tb_mutation).unwrap().unwrap();
 
@@ -357,9 +357,9 @@ mod test_check_lqs_and_send_notifications {
 	fn a_live_query_statement() -> LiveStatement {
 		let mut stm = LiveStatement::new(Fields::all());
 		let mut session: BTreeMap<String, Value> = BTreeMap::new();
-		session.insert(OBJ_PATH_ACCESS.to_string(), Value::Strand(Strand::from("access")));
-		session.insert(OBJ_PATH_AUTH.to_string(), Value::Strand(Strand::from("auth")));
-		session.insert(OBJ_PATH_TOKEN.to_string(), Value::Strand(Strand::from("token")));
+		session.insert(OBJ_PATH_ACCESS.to_string(), Value::Strand("access".to_owned()));
+		session.insert(OBJ_PATH_AUTH.to_string(), Value::Strand("auth".to_owned()));
+		session.insert(OBJ_PATH_TOKEN.to_string(), Value::Strand("token".to_owned()));
 		let session = Value::Object(Object::from(session));
 		stm.session = Some(session);
 		stm.auth = Some(Auth::for_db(Role::Owner, "namespace", "database"));

--- a/core/src/kvs/lq_v2_doc.rs
+++ b/core/src/kvs/lq_v2_doc.rs
@@ -75,7 +75,7 @@ mod test {
 	use crate::cf::TableMutation;
 	use crate::kvs::lq_v2_doc::construct_document;
 	use crate::sql::statements::DefineTableStatement;
-	use crate::sql::{Idiom, Object, Operation, Strand, Thing, Value};
+	use crate::sql::{Idiom, Object, Operation, Thing, Value};
 
 	#[test]
 	fn test_construct_document_create() {
@@ -212,7 +212,7 @@ mod test_check_lqs_and_send_notifications {
 	use crate::kvs::Datastore;
 	use crate::sql::paths::{OBJ_PATH_ACCESS, OBJ_PATH_AUTH, OBJ_PATH_TOKEN};
 	use crate::sql::statements::{CreateStatement, DeleteStatement, LiveStatement};
-	use crate::sql::{Fields, Object, Strand, Table, Thing, Uuid, Value, Values};
+	use crate::sql::{Fields, Object, Table, Thing, Uuid, Value, Values};
 
 	const SETUP: Lazy<Arc<TestSuite>> = Lazy::new(|| Arc::new(block_on(setup_test_suite_init())));
 

--- a/core/src/kvs/tests/tx_test.rs
+++ b/core/src/kvs/tests/tx_test.rs
@@ -1,7 +1,6 @@
 use crate::key::debug::sprint_key;
 use crate::key::error::KeyCategory;
 use crate::kvs::lq_structs::{KillEntry, LqEntry, TrackedResult};
-use crate::sql::Strand;
 
 #[tokio::test]
 #[serial]

--- a/core/src/kvs/tests/tx_test.rs
+++ b/core/src/kvs/tests/tx_test.rs
@@ -71,11 +71,11 @@ async fn delr_range_correct() {
 
 	// Create some data
 	let mut tx = test.db.transaction(Write, Optimistic).await.unwrap();
-	tx.putc(b"hugh\x00\x10", Value::Strand(Strand::from("0010")), None).await.unwrap();
-	tx.put(KeyCategory::ChangeFeed, b"hugh\x00\x10\x10", Value::Strand(Strand::from("001010")))
+	tx.putc(b"hugh\x00\x10", Value::Strand("0010".to_owned()), None).await.unwrap();
+	tx.put(KeyCategory::ChangeFeed, b"hugh\x00\x10\x10", Value::Strand("001010".to_owned()))
 		.await
 		.unwrap();
-	tx.putc(b"hugh\x00\x20", Value::Strand(Strand::from("0020")), None).await.unwrap();
+	tx.putc(b"hugh\x00\x20", Value::Strand("0020".to_owned()), None).await.unwrap();
 	tx.commit().await.unwrap();
 
 	// Check we have all data

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -1885,7 +1885,7 @@ impl Transaction {
 		let val = self.get(key).await?.ok_or(Error::LqNotFound {
 			value: lq.to_string(),
 		})?;
-		Value::from(val).convert_to_strand()
+		Value::from(val).convert_to_string().map(Strand)
 	}
 
 	/// Retrieve a specific table definition.

--- a/core/src/rpc/basic_context.rs
+++ b/core/src/rpc/basic_context.rs
@@ -55,7 +55,7 @@ impl RpcContext for BasicRpcContext<'_> {
 	}
 
 	fn version_data(&self) -> impl Into<super::Data> {
-		Value::Strand(self.version_string.clone().into())
+		Value::Strand(self.version_string.clone())
 	}
 
 	// reimplimentaions:
@@ -89,7 +89,7 @@ impl RpcContext for BasicRpcContext<'_> {
 		let Ok(Value::Strand(token)) = params.needs_one() else {
 			return Err(RpcError::InvalidParams);
 		};
-		crate::iam::verify::token(self.kvs, &mut self.session, &token.0).await?;
+		crate::iam::verify::token(self.kvs, &mut self.session, &token).await?;
 		Ok(Value::None)
 	}
 }

--- a/core/src/rpc/format/cbor/convert.rs
+++ b/core/src/rpc/format/cbor/convert.rs
@@ -168,7 +168,7 @@ impl TryFrom<Cbor> for Value {
 						},
 						Data::Array(mut v) if v.len() == 2 => {
 							let tb = match Value::try_from(Cbor(v.remove(0))) {
-								Ok(Value::Strand(tb)) => tb.0,
+								Ok(Value::Strand(tb)) => tb,
 								Ok(Value::Table(tb)) => tb.0,
 								_ => return Err(
 									"Expected the tb of a Record Id to be a String or Table value",
@@ -332,7 +332,7 @@ impl TryFrom<Value> for Cbor {
 					Ok(Cbor(Data::Tag(TAG_STRING_DECIMAL, Box::new(Data::Text(v.to_string())))))
 				}
 			},
-			Value::Strand(v) => Ok(Cbor(Data::Text(v.0))),
+			Value::Strand(v) => Ok(Cbor(Data::Text(v))),
 			Value::Duration(v) => {
 				let seconds = v.secs();
 				let nanos = v.subsec_nanos();

--- a/core/src/rpc/format/msgpack/convert.rs
+++ b/core/src/rpc/format/msgpack/convert.rs
@@ -117,7 +117,7 @@ impl TryFrom<Value> for Pack {
 				#[allow(unreachable_patterns)]
 				_ => unreachable!(),
 			},
-			Value::Strand(v) => Ok(Pack(Data::String(v.0.into()))),
+			Value::Strand(v) => Ok(Pack(Data::String(v.into()))),
 			Value::Duration(v) => Ok(Pack(Data::Ext(TAG_DURATION, v.to_raw().as_bytes().to_vec()))),
 			Value::Datetime(v) => Ok(Pack(Data::Ext(TAG_DATETIME, v.to_raw().as_bytes().to_vec()))),
 			Value::Uuid(v) => Ok(Pack(Data::Ext(TAG_UUID, v.to_raw().as_bytes().to_vec()))),

--- a/core/src/rpc/request.rs
+++ b/core/src/rpc/request.rs
@@ -44,7 +44,7 @@ impl TryFrom<Value> for Request {
 		};
 		// Fetch the 'method' argument
 		let method = match val.pick(&*METHOD) {
-			Value::Strand(v) => v.to_raw(),
+			Value::Strand(v) => v,
 			_ => return Err(RpcError::InvalidRequest),
 		};
 		// Fetch the 'params' argument

--- a/core/src/sql/permission.rs
+++ b/core/src/sql/permission.rs
@@ -173,7 +173,7 @@ impl InfoStructure for Permission {
 		match self {
 			Permission::None => Value::Bool(false),
 			Permission::Full => Value::Bool(true),
-			Permission::Specific(v) => Value::Strand(v.to_string().into()),
+			Permission::Specific(v) => Value::Strand(v.to_string()),
 		}
 	}
 }

--- a/core/src/sql/statements/define/access.rs
+++ b/core/src/sql/statements/define/access.rs
@@ -201,7 +201,7 @@ impl InfoStructure for DefineAccessStatement {
 		acc.insert("kind".to_string(), kind.structure());
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		Value::Object(acc)

--- a/core/src/sql/statements/define/analyzer.rs
+++ b/core/src/sql/statements/define/analyzer.rs
@@ -127,7 +127,7 @@ impl InfoStructure for DefineAnalyzerStatement {
 		}
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		Value::Object(acc)

--- a/core/src/sql/statements/define/database.rs
+++ b/core/src/sql/statements/define/database.rs
@@ -104,7 +104,7 @@ impl InfoStructure for DefineDatabaseStatement {
 		acc.insert("name".to_string(), name.structure());
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		Value::Object(acc)

--- a/core/src/sql/statements/define/event.rs
+++ b/core/src/sql/statements/define/event.rs
@@ -107,7 +107,7 @@ impl InfoStructure for DefineEventStatement {
 		);
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		Value::Object(acc)

--- a/core/src/sql/statements/define/field.rs
+++ b/core/src/sql/statements/define/field.rs
@@ -252,7 +252,7 @@ impl InfoStructure for DefineFieldStatement {
 		acc.insert("permissions".to_string(), permissions.structure());
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		Value::Object(acc)

--- a/core/src/sql/statements/define/function.rs
+++ b/core/src/sql/statements/define/function.rs
@@ -127,7 +127,7 @@ impl InfoStructure for DefineFunctionStatement {
 		acc.insert("permissions".to_string(), permissions.structure());
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		Value::Object(acc)

--- a/core/src/sql/statements/define/index.rs
+++ b/core/src/sql/statements/define/index.rs
@@ -149,7 +149,7 @@ impl InfoStructure for DefineIndexStatement {
 		acc.insert("index".to_string(), index.structure());
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		Value::Object(acc)

--- a/core/src/sql/statements/define/model.rs
+++ b/core/src/sql/statements/define/model.rs
@@ -108,7 +108,7 @@ impl InfoStructure for DefineModelStatement {
 		acc.insert("version".to_string(), version.into());
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		acc.insert("permissions".to_string(), permissions.structure());

--- a/core/src/sql/statements/define/namespace.rs
+++ b/core/src/sql/statements/define/namespace.rs
@@ -97,7 +97,7 @@ impl InfoStructure for DefineNamespaceStatement {
 		acc.insert("name".to_string(), name.structure());
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		Value::Object(acc)

--- a/core/src/sql/statements/define/param.rs
+++ b/core/src/sql/statements/define/param.rs
@@ -107,7 +107,7 @@ impl InfoStructure for DefineParamStatement {
 		acc.insert("value".to_string(), value.structure());
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		acc.insert("permissions".to_string(), permissions.structure());

--- a/core/src/sql/statements/define/table.rs
+++ b/core/src/sql/statements/define/table.rs
@@ -249,7 +249,7 @@ impl InfoStructure for DefineTableStatement {
 		}
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		acc.insert("kind".to_string(), kind.structure());

--- a/core/src/sql/statements/define/user.rs
+++ b/core/src/sql/statements/define/user.rs
@@ -279,7 +279,7 @@ impl InfoStructure for DefineUserStatement {
 		acc.insert("duration".to_string(), dur.to_string().into());
 
 		if let Some(comment) = comment {
-			acc.insert("comment".to_string(), comment.into());
+			acc.insert("comment".to_string(), comment.0.into());
 		}
 
 		Value::Object(acc)

--- a/core/src/sql/value/patch.rs
+++ b/core/src/sql/value/patch.rs
@@ -31,10 +31,8 @@ impl Value {
 					if let Value::Strand(p) = value {
 						if let Value::Strand(v) = tmp_val.pick(&path) {
 							let dmp = dmp::new();
-							let pch = dmp.patch_from_text(p.as_string()).map_err(|e| {
-								Error::InvalidPatch {
-									message: format!("{e:?}"),
-								}
+							let pch = dmp.patch_from_text(p).map_err(|e| Error::InvalidPatch {
+								message: format!("{e:?}"),
 							})?;
 							let (txt, _) = dmp.patch_apply(&pch, v.as_str()).map_err(|e| {
 								Error::InvalidPatch {

--- a/core/src/sql/value/serde/de/mod.rs
+++ b/core/src/sql/value/serde/de/mod.rs
@@ -224,7 +224,7 @@ fn into_json(value: Value, simplify: bool) -> JsonValue {
 			Number::Float(float) => float.into(),
 			Number::Decimal(decimal) => json!(decimal),
 		},
-		Value::Strand(strand) => strand.0.into(),
+		Value::Strand(strand) => strand.into(),
 		Value::Duration(duration) => match simplify {
 			true => duration.to_raw().into(),
 			false => json!(duration.0),

--- a/core/src/sql/value/serde/ser/value/mod.rs
+++ b/core/src/sql/value/serde/ser/value/mod.rs
@@ -18,7 +18,6 @@ use crate::sql::Idiom;
 use crate::sql::Param;
 use crate::sql::Query;
 use crate::sql::Statements;
-use crate::sql::Strand;
 use crate::sql::Table;
 use crate::sql::Uuid;
 use map::SerializeValueMap;
@@ -189,7 +188,7 @@ impl ser::Serializer for Serializer {
 	{
 		match name {
 			sql::strand::TOKEN => {
-				Ok(Value::Strand(Strand(value.serialize(ser::string::Serializer.wrap())?)))
+				Ok(Value::Strand(value.serialize(ser::string::Serializer.wrap())?))
 			}
 			sql::block::TOKEN => Ok(Value::Block(Box::new(Block(
 				value.serialize(ser::block::entry::vec::Serializer.wrap())?,
@@ -654,19 +653,19 @@ mod tests {
 	fn strand() {
 		let strand = Strand("foobar".to_owned());
 		let value = to_value(&strand).unwrap();
-		let expected = Value::Strand(strand);
+		let expected = Value::Strand(strand.0);
 		assert_eq!(value, expected);
 		assert_eq!(expected, to_value(&expected).unwrap());
 
 		let strand = "foobar".to_owned();
 		let value = to_value(&strand).unwrap();
-		let expected = Value::Strand(Strand(strand));
+		let expected = Value::Strand(strand);
 		assert_eq!(value, expected);
 		assert_eq!(expected, to_value(&expected).unwrap());
 
 		let strand = "foobar";
 		let value = to_value(strand).unwrap();
-		let expected = Value::Strand(Strand(strand.to_owned()));
+		let expected = Value::Strand(strand.to_owned());
 		assert_eq!(value, expected);
 		assert_eq!(expected, to_value(&expected).unwrap());
 	}

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -5,6 +5,7 @@ use crate::dbs::Options;
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::fnc::util::string::fuzzy::Fuzzy;
+use crate::sql::escape::quote_plain_str;
 use crate::sql::statements::info::InfoStructure;
 use crate::sql::Strand;
 use crate::sql::{
@@ -2554,7 +2555,7 @@ impl fmt::Display for Value {
 			Value::Param(v) => write!(f, "{v}"),
 			Value::Range(v) => write!(f, "{v}"),
 			Value::Regex(v) => write!(f, "{v}"),
-			Value::Strand(v) => write!(f, "{v}"),
+			Value::Strand(v) => write!(f, "{}", quote_plain_str(v)),
 			Value::Query(v) => write!(f, "{v}"),
 			Value::Subquery(v) => write!(f, "{v}"),
 			Value::Table(v) => write!(f, "{v}"),

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -2857,9 +2857,9 @@ mod tests {
 		let enc: Vec<u8> = Value::Bool(false).into();
 		assert_eq!(3, enc.len());
 		let enc: Vec<u8> = Value::from("test").into();
-		assert_eq!(8, enc.len());
+		assert_eq!(7, enc.len());
 		let enc: Vec<u8> = Value::parse("{ hello: 'world' }").into();
-		assert_eq!(19, enc.len());
+		assert_eq!(18, enc.len());
 		let enc: Vec<u8> = Value::parse("{ compact: true, schema: 0 }").into();
 		assert_eq!(27, enc.len());
 	}

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -517,7 +517,7 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
-	use crate::sql::{Expression, Id, Number, Object, Param, Strand, Thing};
+	use crate::sql::{Expression, Id, Number, Object, Param, Thing};
 	use crate::syn::Parse;
 
 	use super::*;

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -1,7 +1,7 @@
 use reblessive::Stk;
 
 use crate::{
-	sql::{Dir, Edges, Field, Fields, Graph, Ident, Idiom, Part, Table, Tables, Value},
+	sql::{Dir, Edges, Field, Fields, Graph, Ident, Idiom, Part, Strand, Table, Tables, Value},
 	syn::token::{t, Span, TokenKind},
 };
 
@@ -282,7 +282,9 @@ impl Parser<'_> {
 				Part::Where(value)
 			}
 			t!("$param") => Part::Value(Value::Param(self.next_token_value()?)),
-			TokenKind::Qoute(_x) => Part::Value(Value::Strand(self.next_token_value()?)),
+			TokenKind::Qoute(_x) => {
+				Part::Value(Value::Strand(self.next_token_value::<Strand>()?.0))
+			}
 			_ => {
 				let idiom = self.parse_basic_idiom()?;
 				Part::Value(Value::Idiom(idiom))
@@ -861,7 +863,7 @@ mod tests {
 					tb: "test".to_owned(),
 					id: Id::Number(1),
 				})),
-				Part::Value(Value::Strand(Strand("foo".to_owned()))),
+				Part::Value(Value::Strand("foo".to_owned())),
 			]))
 		);
 	}

--- a/core/src/syn/parser/json.rs
+++ b/core/src/syn/parser/json.rs
@@ -37,9 +37,9 @@ impl Parser<'_> {
 				self.parse_json_array(ctx, token.span).await.map(Value::Array)
 			}
 			TokenKind::Qoute(QouteKind::Plain | QouteKind::PlainDouble) => {
-				let strand: Strand = self.next_token_value()?;
+				let Strand(strand) = self.next_token_value()?;
 				if self.legacy_strands {
-					if let Some(x) = self.reparse_legacy_strand(ctx, &strand.0).await {
+					if let Some(x) = self.reparse_legacy_strand(ctx, &strand).await {
 						return Ok(x);
 					}
 				}

--- a/core/src/syn/parser/object.rs
+++ b/core/src/syn/parser/object.rs
@@ -128,7 +128,7 @@ impl Parser<'_> {
 					return self
 						.parse_object_from_map(
 							ctx,
-							BTreeMap::from([(key, Value::Strand(type_value.into()))]),
+							BTreeMap::from([(key, Value::Strand(type_value))]),
 							start,
 						)
 						.await
@@ -143,7 +143,7 @@ impl Parser<'_> {
 						.parse_object_from_key(
 							ctx,
 							coord_key,
-							BTreeMap::from([(key, Value::Strand(type_value.into()))]),
+							BTreeMap::from([(key, Value::Strand(type_value))]),
 							start,
 						)
 						.await
@@ -164,7 +164,7 @@ impl Parser<'_> {
 							.parse_object_from_map(
 								ctx,
 								BTreeMap::from([
-									(key, Value::Strand(type_value.into())),
+									(key, Value::Strand(type_value)),
 									(coord_key, value),
 								]),
 								start,
@@ -194,20 +194,20 @@ impl Parser<'_> {
 					}
 
 					return Ok(Value::Object(Object(BTreeMap::from([
-						(key, Value::Strand(type_value.into())),
+						(key, Value::Strand(type_value)),
 						(coord_key, Value::Array(x)),
 					]))));
 				}
 
 				// Couldn't convert so it is a normal object.
 				Ok(Value::Object(Object(BTreeMap::from([
-					(key, Value::Strand(type_value.into())),
+					(key, Value::Strand(type_value)),
 					(coord_key, value),
 				]))))
 			}
 			// key was not one of the allowed keys so it is a normal object.
 			_ => {
-				let object = BTreeMap::from([(key, Value::Strand(type_value.into()))]);
+				let object = BTreeMap::from([(key, Value::Strand(type_value))]);
 
 				if self.eat(t!(",")) {
 					self.parse_object_from_map(ctx, object, start).await.map(Value::Object)
@@ -317,13 +317,13 @@ impl Parser<'_> {
 			self.expect_closing_delimiter(t!("}"), start)?;
 			return Ok(Value::Object(Object(BTreeMap::from([
 				(key, value),
-				(type_key, Value::Strand(type_value.into())),
+				(type_key, Value::Strand(type_value)),
 			]))));
 		}
 
 		self.parse_object_from_map(
 			ctx,
-			BTreeMap::from([(key, value), (type_key, Value::Strand(type_value.into()))]),
+			BTreeMap::from([(key, value), (type_key, Value::Strand(type_value))]),
 			start,
 		)
 		.await
@@ -398,13 +398,13 @@ impl Parser<'_> {
 			self.expect_closing_delimiter(t!("}"), start)?;
 			return Ok(Value::Object(Object(BTreeMap::from([
 				(key, value),
-				(type_key, Value::Strand(type_value.into())),
+				(type_key, Value::Strand(type_value)),
 			]))));
 		}
 
 		self.parse_object_from_map(
 			ctx,
-			BTreeMap::from([(key, value), (type_key, Value::Strand(type_value.into()))]),
+			BTreeMap::from([(key, value), (type_key, Value::Strand(type_value))]),
 			start,
 		)
 		.await
@@ -451,10 +451,7 @@ impl Parser<'_> {
 		if !self.eat(t!(",")) {
 			// there is not second field. not a geometry
 			self.expect_closing_delimiter(t!("}"), start)?;
-			return Ok(Value::Object(Object(BTreeMap::from([(
-				key,
-				Value::Strand(strand.into()),
-			)]))));
+			return Ok(Value::Object(Object(BTreeMap::from([(key, Value::Strand(strand))]))));
 		}
 		let coord_key = self.parse_object_key()?;
 		if coord_key != "coordinates" {
@@ -464,7 +461,7 @@ impl Parser<'_> {
 				.parse_object_from_key(
 					ctx,
 					coord_key,
-					BTreeMap::from([(key, Value::Strand(strand.into()))]),
+					BTreeMap::from([(key, Value::Strand(strand))]),
 					start,
 				)
 				.await
@@ -488,7 +485,7 @@ impl Parser<'_> {
 			return self
 				.parse_object_from_map(
 					ctx,
-					BTreeMap::from([(key, Value::Strand(strand.into())), (coord_key, value)]),
+					BTreeMap::from([(key, Value::Strand(strand)), (coord_key, value)]),
 					start,
 				)
 				.await
@@ -498,7 +495,7 @@ impl Parser<'_> {
 		let Some(v) = capture(&value) else {
 			// failed to match the geometry value, just a plain object.
 			return Ok(Value::Object(Object(BTreeMap::from([
-				(key, Value::Strand(strand.into())),
+				(key, Value::Strand(strand)),
 				(coord_key, value),
 			]))));
 		};

--- a/core/src/syn/parser/prime.rs
+++ b/core/src/syn/parser/prime.rs
@@ -174,13 +174,13 @@ impl Parser<'_> {
 				Value::Uuid(uuid)
 			}
 			t!("'") | t!("\"") | TokenKind::Strand => {
-				let s = self.next_token_value::<Strand>()?;
+				let Strand(strand) = self.next_token_value()?;
 				if self.legacy_strands {
-					if let Some(x) = self.reparse_legacy_strand(ctx, &s.0).await {
+					if let Some(x) = self.reparse_legacy_strand(ctx, &strand).await {
 						return Ok(x);
 					}
 				}
-				Value::Strand(s)
+				Value::Strand(strand)
 			}
 			t!("+") | t!("-") | TokenKind::Number(_) | TokenKind::Digits | TokenKind::Duration => {
 				self.parse_number_like_prime()?

--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -2128,9 +2128,9 @@ fn parse_update() {
 		Statement::Update(UpdateStatement {
 			only: true,
 			what: Values(vec![
-				Value::Future(Box::new(Future(Block(vec![Entry::Value(Value::Strand(Strand(
+				Value::Future(Box::new(Future(Block(vec![Entry::Value(Value::Strand(
 					"text".to_string()
-				)))])))),
+				))])))),
 				Value::Idiom(Idiom(vec![
 					Part::Field(Ident("a".to_string())),
 					Part::Graph(Graph {
@@ -2174,9 +2174,9 @@ fn parse_upsert() {
 		Statement::Upsert(UpsertStatement {
 			only: true,
 			what: Values(vec![
-				Value::Future(Box::new(Future(Block(vec![Entry::Value(Value::Strand(Strand(
+				Value::Future(Box::new(Future(Block(vec![Entry::Value(Value::Strand(
 					"text".to_string()
-				)))])))),
+				))])))),
 				Value::Idiom(Idiom(vec![
 					Part::Field(Ident("a".to_string())),
 					Part::Graph(Graph {

--- a/core/src/syn/parser/test/streaming.rs
+++ b/core/src/syn/parser/test/streaming.rs
@@ -638,9 +638,9 @@ fn statements() -> Vec<Statement> {
 		Statement::Update(UpdateStatement {
 			only: true,
 			what: Values(vec![
-				Value::Future(Box::new(Future(Block(vec![Entry::Value(Value::Strand(Strand(
+				Value::Future(Box::new(Future(Block(vec![Entry::Value(Value::Strand(
 					"text".to_string(),
-				)))])))),
+				))])))),
 				Value::Idiom(Idiom(vec![
 					Part::Field(Ident("a".to_string())),
 					Part::Graph(Graph {
@@ -672,9 +672,9 @@ fn statements() -> Vec<Statement> {
 		Statement::Upsert(UpsertStatement {
 			only: true,
 			what: Values(vec![
-				Value::Future(Box::new(Future(Block(vec![Entry::Value(Value::Strand(Strand(
+				Value::Future(Box::new(Future(Block(vec![Entry::Value(Value::Strand(
 					"text".to_string(),
-				)))])))),
+				))])))),
 				Value::Idiom(Idiom(vec![
 					Part::Field(Ident("a".to_string())),
 					Part::Graph(Graph {

--- a/core/src/syn/parser/test/value.rs
+++ b/core/src/syn/parser/test/value.rs
@@ -3,9 +3,7 @@ use std::collections::BTreeMap;
 use reblessive::Stack;
 
 use crate::{
-	sql::{
-		Array, Constant, Id, Number, Object, Query, Statement, Statements, Strand, Thing, Value,
-	},
+	sql::{Array, Constant, Id, Number, Object, Query, Statement, Statements, Thing, Value},
 	syn::parser::{mac::test_parse, Parser},
 };
 

--- a/core/src/syn/parser/test/value.rs
+++ b/core/src/syn/parser/test/value.rs
@@ -104,7 +104,7 @@ fn parse_record_string_2() {
 		res,
 		Value::Thing(Thing {
 			tb: "a".to_owned(),
-			id: Id::Array(Array(vec![Value::Strand(Strand("foo".to_owned()))]))
+			id: Id::Array(Array(vec![Value::Strand("foo".to_owned())]))
 		})
 	)
 }

--- a/lib/src/api/engine/any/wasm.rs
+++ b/lib/src/api/engine/any/wasm.rs
@@ -18,7 +18,6 @@ use crate::opt::WaitFor;
 use flume::Receiver;
 use std::collections::HashSet;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -519,14 +519,14 @@ async fn router(
 		Method::Use => {
 			match &mut params[..] {
 				[Value::Strand(ns), Value::Strand(db)] => {
-					session.ns = Some(mem::take(&mut ns.0));
-					session.db = Some(mem::take(&mut db.0));
+					session.ns = Some(mem::take(ns));
+					session.db = Some(mem::take(db));
 				}
 				[Value::Strand(ns), Value::None] => {
-					session.ns = Some(mem::take(&mut ns.0));
+					session.ns = Some(mem::take(ns));
 				}
 				[Value::None, Value::Strand(db)] => {
-					session.db = Some(mem::take(&mut db.0));
+					session.db = Some(mem::take(db));
 				}
 				_ => unreachable!(),
 			}
@@ -550,7 +550,7 @@ async fn router(
 		}
 		Method::Authenticate => {
 			let token = match &mut params[..] {
-				[Value::Strand(token)] => mem::take(&mut token.0),
+				[Value::Strand(token)] => mem::take(token),
 				_ => unreachable!(),
 			};
 			crate::iam::verify::token(kvs, session, &token).await?;
@@ -789,7 +789,7 @@ async fn router(
 		Method::Version => Ok(DbResponse::Other(crate::env::VERSION.into())),
 		Method::Set => {
 			let (key, value) = match &mut params[..2] {
-				[Value::Strand(key), value] => (mem::take(&mut key.0), mem::take(value)),
+				[Value::Strand(key), value] => (mem::take(key), mem::take(value)),
 				_ => unreachable!(),
 			};
 			let var = Some(crate::map! {
@@ -804,7 +804,7 @@ async fn router(
 		}
 		Method::Unset => {
 			if let [Value::Strand(key)] = &params[..1] {
-				vars.remove(&key.0);
+				vars.remove(key);
 			}
 			Ok(DbResponse::Other(Value::None))
 		}

--- a/lib/src/api/engine/local/wasm.rs
+++ b/lib/src/api/engine/local/wasm.rs
@@ -28,7 +28,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -360,10 +360,10 @@ async fn router(
 			let mut request = client.post(path).headers(headers.clone());
 			let (ns, db) = match &mut params[..] {
 				[Value::Strand(ns), Value::Strand(db)] => {
-					(Some(mem::take(&mut ns.0)), Some(mem::take(&mut db.0)))
+					(Some(mem::take(ns)), Some(mem::take(db)))
 				}
-				[Value::Strand(ns), Value::None] => (Some(mem::take(&mut ns.0)), None),
-				[Value::None, Value::Strand(db)] => (None, Some(mem::take(&mut db.0))),
+				[Value::Strand(ns), Value::None] => (Some(mem::take(ns)), None),
+				[Value::None, Value::Strand(db)] => (None, Some(mem::take(db))),
 				_ => unreachable!(),
 			};
 			let ns = match ns {
@@ -443,7 +443,7 @@ async fn router(
 		Method::Authenticate => {
 			let path = base_url.join(SQL_PATH)?;
 			let token = match &mut params[..1] {
-				[Value::Strand(token)] => mem::take(&mut token.0),
+				[Value::Strand(token)] => mem::take(token),
 				_ => unreachable!(),
 			};
 			let request =
@@ -587,7 +587,7 @@ async fn router(
 		Method::Set => {
 			let path = base_url.join(SQL_PATH)?;
 			let (key, value) = match &mut params[..2] {
-				[Value::Strand(key), value] => (mem::take(&mut key.0), value.to_string()),
+				[Value::Strand(key), value] => (mem::take(key), value.to_string()),
 				_ => unreachable!(),
 			};
 			let request = client
@@ -602,7 +602,7 @@ async fn router(
 		}
 		Method::Unset => {
 			if let [Value::Strand(key)] = &params[..1] {
-				vars.swap_remove(&key.0);
+				vars.swap_remove(key);
 			}
 			Ok(DbResponse::Other(Value::None))
 		}

--- a/lib/src/api/engine/remote/http/wasm.rs
+++ b/lib/src/api/engine/remote/http/wasm.rs
@@ -18,7 +18,6 @@ use reqwest::header::HeaderMap;
 use reqwest::ClientBuilder;
 use std::collections::HashSet;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;

--- a/lib/src/api/engine/remote/ws/native.rs
+++ b/lib/src/api/engine/remote/ws/native.rs
@@ -242,12 +242,12 @@ pub(crate) fn router(
 							match method {
 								Method::Set => {
 									if let [Value::Strand(key), value] = &params[..2] {
-										var_stash.insert(id, (key.0.clone(), value.clone()));
+										var_stash.insert(id, (key.clone(), value.clone()));
 									}
 								}
 								Method::Unset => {
 									if let [Value::Strand(key)] = &params[..1] {
-										vars.swap_remove(&key.0);
+										vars.swap_remove(key);
 									}
 								}
 								Method::Live => {

--- a/lib/src/api/engine/remote/ws/wasm.rs
+++ b/lib/src/api/engine/remote/ws/wasm.rs
@@ -36,7 +36,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::mem;
 use std::pin::Pin;
 use std::sync::atomic::AtomicI64;
@@ -207,12 +206,12 @@ pub(crate) fn router(
 						match method {
 							Method::Set => {
 								if let [Value::Strand(key), value] = &params[..2] {
-									var_stash.insert(id, (key.0.clone(), value.clone()));
+									var_stash.insert(id, (key.clone(), value.clone()));
 								}
 							}
 							Method::Unset => {
 								if let [Value::Strand(key)] = &params[..1] {
-									vars.swap_remove(&key.0);
+									vars.swap_remove(key);
 								}
 							}
 							Method::Live => {

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -272,7 +272,7 @@ where
 			if let Value::Array(array) = &mut bindings {
 				if let [Value::Strand(key), value] = &mut array.0[..] {
 					let mut map = BTreeMap::new();
-					map.insert(mem::take(&mut key.0), mem::take(value));
+					map.insert(mem::take(key), mem::take(value));
 					bindings = map.into();
 				}
 			}

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -420,7 +420,7 @@ impl RpcContext for Connection {
 		let Ok(Value::Strand(token)) = params.needs_one() else {
 			return Err(RpcError::InvalidParams);
 		};
-		surrealdb::iam::verify::token(DB.get().unwrap(), &mut self.session, &token.0).await?;
+		surrealdb::iam::verify::token(DB.get().unwrap(), &mut self.session, &token).await?;
 		Ok(Value::None)
 	}
 }

--- a/src/rpc/post_context.rs
+++ b/src/rpc/post_context.rs
@@ -97,7 +97,7 @@ impl RpcContext for PostRpcContext<'_> {
 		let Ok(Value::Strand(token)) = params.needs_one() else {
 			return Err(RpcError::InvalidParams);
 		};
-		surrealdb::iam::verify::token(self.kvs, &mut self.session, &token.0).await?;
+		surrealdb::iam::verify::token(self.kvs, &mut self.session, &token).await?;
 		Ok(Value::None)
 	}
 }


### PR DESCRIPTION
## What is the motivation?

To improve serialisation.

## What does this change do?

It removes `Strand` from `Value::Strand`.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
