### PR TITLE
chore: bump surrealkv version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4478,18 +4478,6 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1380629287ed1247c1e0fcc6d43efdcec508b65382c9ab775cc8f3df7ca07b0"
-dependencies = [
- "ahash 0.8.11",
- "equivalent",
- "hashbrown 0.14.5",
- "parking_lot",
-]
-
-[[package]]
-name = "quick_cache"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "347e1a588d1de074eeb3c00eadff93db4db65aeb62aee852b1efd0949fe65b6c"
@@ -4808,9 +4796,9 @@ checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "revision"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588784c1d9453cfd2ce1b7aff06c903513677cf0e63779a0a3085ee8a44f5b17"
+checksum = "4df61cfb2522f24fd6aa90ce3489c2c8660a181075e7bac3ae7bdf22287d238f"
 dependencies = [
  "bincode",
  "chrono",
@@ -6060,7 +6048,7 @@ dependencies = [
  "phf",
  "pin-project-lite",
  "pprof",
- "quick_cache 0.5.1",
+ "quick_cache",
  "radix_trie",
  "rand 0.8.5",
  "reblessive",
@@ -6167,9 +6155,9 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cea631ab9dde241b2fd2cbc2938c2a2ee0232034df132250ec47c200b9a1777"
+checksum = "563a2d39e9eea9bd25e9dd9e68c0dc8134653bdabf741fa604533dc1dda732c9"
 dependencies = [
  "async-channel 2.2.0",
  "bytes",
@@ -6181,7 +6169,8 @@ dependencies = [
  "hashbrown 0.14.5",
  "lru",
  "parking_lot",
- "quick_cache 0.4.2",
+ "quick_cache",
+ "revision",
  "sha2",
  "tokio",
  "vart",
@@ -7104,9 +7093,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vart"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c07dbb7140d0a8fa046a25eabaaad09f4082076ccb8f157d9fe2b13dc9ae570"
+checksum = "b9f8fe507a1dd4f78b79e7c3b08232f4a826c6140252d1fc7a0aa4d8b9992211"
 dependencies = [
  "hashbrown 0.14.5",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -142,7 +142,7 @@ sha1 = "0.10.6"
 sha2 = "0.10.8"
 snap = "1.1.0"
 storekey = "0.5.0"
-surrealkv = { version = "0.1.5", optional = true }
+surrealkv = { version = "0.2.0", optional = true }
 surrealml = { version = "0.1.1", optional = true, package = "surrealml-core" }
 tempfile = { version = "3.10.1", optional = true }
 thiserror = "1.0.50"


### PR DESCRIPTION
## What is the motivation?

Use surrealkv version 0.2.0

## What does this change do?

SurrealKV 0.2.0 implements a new disk layout format to make compaction easier.

## What is your testing strategy?

Github Actions

## Is this related to any issues?

No

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
