### PR TITLE
Fix fields not being allowed to end a subquery.

### DIFF
--- a/core/src/syn/v1/ending.rs
+++ b/core/src/syn/v1/ending.rs
@@ -97,6 +97,8 @@ pub fn field(i: &str) -> IResult<&str, ()> {
 			),
 		),
 		value((), char(';')),
+		value((), char(')')),
+		value((), char('}')),
 		value((), eof),
 	)))(i)
 }

--- a/core/src/syn/v1/subquery.rs
+++ b/core/src/syn/v1/subquery.rs
@@ -152,6 +152,6 @@ mod tests {
 		let res = subquery(sql);
 		assert!(res.is_ok());
 		let out = res.unwrap().1;
-		assert_eq!("(CREATE ONLY Person SET name='foo' RETURN VALUE id)", format!("{}", out))
+		assert_eq!("(CREATE ONLY Person SET name = 'foo' RETURN VALUE id)", format!("{}", out))
 	}
 }

--- a/core/src/syn/v1/subquery.rs
+++ b/core/src/syn/v1/subquery.rs
@@ -145,4 +145,13 @@ mod tests {
 		let out = res.unwrap().1;
 		assert_eq!("(REMOVE EVENT foo_event ON foo)", format!("{}", out))
 	}
+
+	#[test]
+	fn subquery_create_with_return() {
+		let sql = "(CREATE ONLY Person SET name='foo' RETURN VALUE id)";
+		let res = subquery(sql);
+		assert!(res.is_ok());
+		let out = res.unwrap().1;
+		assert_eq!("(CREATE ONLY Person SET name='foo' RETURN VALUE id)", format!("{}", out))
+	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

A fields production was not allowed to end a subquery.
For example `let $v = (CREATE person SET v=1 RETURN VALUE f);` was not allowed.

## What does this change do?

Allow fields production to end a subquery.

## What is your testing strategy?

Added a test to test if the syntax is now allowed

## Is this related to any issues?

Fixes #4178 

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?


<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
