### PR TITLE
Geometry point values should be sent as floats in CBOR

### DIFF
--- a/core/src/rpc/format/cbor/convert.rs
+++ b/core/src/rpc/format/cbor/convert.rs
@@ -408,10 +408,7 @@ fn encode_geometry(v: Geometry) -> Result<Data, &'static str> {
 	match v {
 		Geometry::Point(v) => Ok(Data::Tag(
 			TAG_GEOMETRY_POINT,
-			Box::new(Data::Array(vec![
-				Data::Tag(TAG_STRING_DECIMAL, Box::new(Data::Text(v.x().to_string()))),
-				Data::Tag(TAG_STRING_DECIMAL, Box::new(Data::Text(v.y().to_string()))),
-			])),
+			Box::new(Data::Array(vec![Data::Float(v.x()), Data::Float(v.y())])),
 		)),
 		Geometry::Line(v) => {
 			let data = v


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The inner value of geometry points are already floats, there's no point in sending them as decimals. This will be more compact

## What does this change do?

It alters the encoding of geometry points in CBOR to be sent as floats

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

No

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
