### PR TITLE
Allow bridge networking connectivity from host

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,4 +82,8 @@ FROM cgr.dev/chainguard/glibc-dynamic:latest as prod
 
 COPY --from=dev /surreal /surreal
 
+# Allow connectivity from the host with bridge networking
+# This still requires publishing the port when running the container
+ENV SURREAL_BIND="0.0.0.0:8000"
+
 ENTRYPOINT ["/surreal"]


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To allow users that run the SurrealDB container in Docker with the default `bridge` networking to be able to publish the SurrealDB ports so that it becomes accessible from the host. By default, SurrealDB now listens to `localhost` (#4054), which in the case of Docker means that the service is only accessible from within the container or in the specific case that the user is running Docker or this specific container in the `host` networking mode. This provides a similar experience from directly starting SurrealDB from the CLI, especially when trying SurrealDB.

## What does this change do?

Sets the `SURREAL_BIND` environment variable to `0.0.0.0:8000` in the container. This delegates the level of exposure of the SurrealDB interface to the Docker configuration as was previously the case, but allows users to connect to SurrealDB using the default Docker networking mode. Users relying on other networking modes by default (e.g. `host`) should change this default if they do not wish to expose the service. This can be done by changing the environment variable or providing a different value to the `--bind` flag of the `start` subcommand.

## What is your testing strategy?

Ensure that the Docker image builds correctly and listens to the expected interface.

## Is this related to any issues?

No.

## Does this change need documentation?

Yes. https://github.com/surrealdb/docs.surrealdb.com/pull/634.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
