### PR TITLE
`Ident` should not be escaped for `InfoStructure` impl

### DIFF
--- a/core/src/sql/ident.rs
+++ b/core/src/sql/ident.rs
@@ -62,6 +62,6 @@ impl Display for Ident {
 
 impl InfoStructure for Ident {
 	fn structure(self) -> Value {
-		self.to_string().into()
+		self.to_raw().into()
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Some keys in the `INFO STRUCTURE` output are currently escaped if they contain complex characters. This should not happen

## What does this change do?

Alters the `InfoStructure` implementation on `Ident` to return the raw value instead of the formatted `Display` implementation.

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

No

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
