### PR TITLE
Some small parser bug fixes.

### DIFF
--- a/core/src/syn/lexer/byte.rs
+++ b/core/src/syn/lexer/byte.rs
@@ -402,13 +402,20 @@ impl<'a> Lexer<'a> {
 					return self.lex_ident_from_next_byte(b'm');
 				}
 			},
-			b's' => {
-				if self.reader.peek().map(|x| x.is_ascii_alphabetic()).unwrap_or(false) {
-					return self.lex_ident_from_next_byte(b's');
-				} else {
-					t!("s")
+			b's' => match self.reader.peek() {
+				Some(b'"') => {
+					self.reader.next();
+					t!("\"")
 				}
-			}
+				Some(b'\'') => {
+					self.reader.next();
+					t!("'")
+				}
+				Some(x) if x.is_ascii_alphabetic() => {
+					return self.lex_ident_from_next_byte(b's');
+				}
+				_ => t!("s"),
+			},
 			b'h' => {
 				if self.reader.peek().map(|x| x.is_ascii_alphabetic()).unwrap_or(false) {
 					return self.lex_ident_from_next_byte(b'h');

--- a/core/src/syn/lexer/byte.rs
+++ b/core/src/syn/lexer/byte.rs
@@ -312,7 +312,8 @@ impl<'a> Lexer<'a> {
 				_ => t!(":"),
 			},
 			b'$' => {
-				if self.reader.peek().map(|x| x.is_ascii_alphabetic()).unwrap_or(false) {
+				if self.reader.peek().map(|x| x.is_ascii_alphabetic() || x == b'_').unwrap_or(false)
+				{
 					return self.lex_param();
 				}
 				t!("$")

--- a/core/src/syn/parser/prime.rs
+++ b/core/src/syn/parser/prime.rs
@@ -594,17 +594,13 @@ impl Parser<'_> {
 		matches!(
 			kind,
 			t!("ANALYZE")
-				| t!("BEGIN")
-				| t!("BREAK")
-				| t!("CANCEL")
-				| t!("COMMIT")
-				| t!("CONTINUE")
-				| t!("FOR") | t!("INFO")
-				| t!("KILL") | t!("LIVE")
-				| t!("OPTION")
+				| t!("BEGIN") | t!("BREAK")
+				| t!("CANCEL") | t!("COMMIT")
+				| t!("CONTINUE") | t!("FOR")
+				| t!("INFO") | t!("KILL")
+				| t!("LIVE") | t!("OPTION")
 				| t!("LET") | t!("SHOW")
-				| t!("SLEEP")
-				| t!("THROW")
+				| t!("SLEEP") | t!("THROW")
 				| t!("USE")
 		)
 	}

--- a/core/src/syn/parser/prime.rs
+++ b/core/src/syn/parser/prime.rs
@@ -594,13 +594,17 @@ impl Parser<'_> {
 		matches!(
 			kind,
 			t!("ANALYZE")
-				| t!("BEGIN") | t!("BREAK")
-				| t!("CANCEL") | t!("COMMIT")
-				| t!("CONTINUE") | t!("FOR")
-				| t!("INFO") | t!("KILL")
-				| t!("LIVE") | t!("OPTION")
+				| t!("BEGIN")
+				| t!("BREAK")
+				| t!("CANCEL")
+				| t!("COMMIT")
+				| t!("CONTINUE")
+				| t!("FOR") | t!("INFO")
+				| t!("KILL") | t!("LIVE")
+				| t!("OPTION")
 				| t!("LET") | t!("SHOW")
-				| t!("SLEEP") | t!("THROW")
+				| t!("SLEEP")
+				| t!("THROW")
 				| t!("USE")
 		)
 	}
@@ -724,5 +728,16 @@ mod tests {
 			panic!()
 		};
 		assert_eq!(regex, r"(?i)test/[a-z]+/\s\d\w{1}.*".parse().unwrap());
+	}
+
+	#[test]
+	fn plain_string() {
+		let sql = r#""hello""#;
+		let out = Value::parse(sql);
+		assert_eq!(r#""hello""#, format!("{}", out));
+
+		let sql = r#"s"hello""#;
+		let out = Value::parse(sql);
+		assert_eq!(r#""hello""#, format!("{}", out));
 	}
 }

--- a/core/src/syn/parser/prime.rs
+++ b/core/src/syn/parser/prime.rs
@@ -594,13 +594,17 @@ impl Parser<'_> {
 		matches!(
 			kind,
 			t!("ANALYZE")
-				| t!("BEGIN") | t!("BREAK")
-				| t!("CANCEL") | t!("COMMIT")
-				| t!("CONTINUE") | t!("FOR")
-				| t!("INFO") | t!("KILL")
-				| t!("LIVE") | t!("OPTION")
+				| t!("BEGIN")
+				| t!("BREAK")
+				| t!("CANCEL")
+				| t!("COMMIT")
+				| t!("CONTINUE")
+				| t!("FOR") | t!("INFO")
+				| t!("KILL") | t!("LIVE")
+				| t!("OPTION")
 				| t!("LET") | t!("SHOW")
-				| t!("SLEEP") | t!("THROW")
+				| t!("SLEEP")
+				| t!("THROW")
 				| t!("USE")
 		)
 	}
@@ -730,10 +734,25 @@ mod tests {
 	fn plain_string() {
 		let sql = r#""hello""#;
 		let out = Value::parse(sql);
-		assert_eq!(r#""hello""#, format!("{}", out));
+		assert_eq!(r#"'hello'"#, format!("{}", out));
 
 		let sql = r#"s"hello""#;
 		let out = Value::parse(sql);
-		assert_eq!(r#""hello""#, format!("{}", out));
+		assert_eq!(r#"'hello'"#, format!("{}", out));
+
+		let sql = r#"s'hello'"#;
+		let out = Value::parse(sql);
+		assert_eq!(r#"'hello'"#, format!("{}", out));
+	}
+
+	#[test]
+	fn params() {
+		let sql = "$hello";
+		let out = Value::parse(sql);
+		assert_eq!("$hello", format!("{}", out));
+
+		let sql = "$__hello";
+		let out = Value::parse(sql);
+		assert_eq!("$__hello", format!("{}", out));
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The `s` string prefix is not supported in the new parser. To ease transition between the parser it should probably be implemented.

A bug caused params to not properly be lexed when an underscore would be the first character after the dollar sign.

## What does this change do?

Implements the `s` string prefix, fixes bug with underscore.

## What is your testing strategy?

Added tests to test the newly allowed syntax.

## Is this related to any issues?

None 
## Does this change need documentation?


- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
