### PR TITLE
Fix panic in the parser

### DIFF
--- a/core/src/syn/lexer/byte.rs
+++ b/core/src/syn/lexer/byte.rs
@@ -402,13 +402,20 @@ impl<'a> Lexer<'a> {
 					return self.lex_ident_from_next_byte(b'm');
 				}
 			},
-			b's' => {
-				if self.reader.peek().map(|x| x.is_ascii_alphabetic()).unwrap_or(false) {
-					return self.lex_ident_from_next_byte(b's');
-				} else {
-					t!("s")
+			b's' => match self.reader.peek() {
+				Some(b'"') => {
+					self.reader.next();
+					t!("\"")
 				}
-			}
+				Some(b'\'') => {
+					self.reader.next();
+					t!("'")
+				}
+				Some(x) if x.is_ascii_alphabetic() => {
+					return self.lex_ident_from_next_byte(b's');
+				}
+				_ => t!("s"),
+			},
 			b'h' => {
 				if self.reader.peek().map(|x| x.is_ascii_alphabetic()).unwrap_or(false) {
 					return self.lex_ident_from_next_byte(b'h');

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -217,7 +217,7 @@ impl Parser<'_> {
 
 	/// Returns if the token kind could continua an idiom
 	pub fn continues_idiom(kind: TokenKind) -> bool {
-		dbg!(matches!(kind, t!("->") | t!("<->") | t!("<-") | t!("[") | t!(".") | t!("...")))
+		matches!(kind, t!("->") | t!("<->") | t!("<-") | t!("[") | t!(".") | t!("..."))
 	}
 
 	/// Parse a idiom which can only start with a graph or an identifier.

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -217,7 +217,7 @@ impl Parser<'_> {
 
 	/// Returns if the token kind could continua an idiom
 	pub fn continues_idiom(kind: TokenKind) -> bool {
-		matches!(kind, t!("->") | t!("<->") | t!("<-") | t!("[") | t!(".") | t!("..."))
+		dbg!(matches!(kind, t!("->") | t!("<->") | t!("<-") | t!("[") | t!(".") | t!("...")))
 	}
 
 	/// Parse a idiom which can only start with a graph or an identifier.

--- a/core/src/syn/parser/prime.rs
+++ b/core/src/syn/parser/prime.rs
@@ -180,7 +180,7 @@ impl Parser<'_> {
 						return Ok(x);
 					}
 				}
-				Value::Strand(s)
+				return Ok(Value::Strand(s));
 			}
 			t!("+") | t!("-") | TokenKind::Number(_) | TokenKind::Digits | TokenKind::Duration => {
 				self.parse_number_like_prime()?
@@ -594,13 +594,17 @@ impl Parser<'_> {
 		matches!(
 			kind,
 			t!("ANALYZE")
-				| t!("BEGIN") | t!("BREAK")
-				| t!("CANCEL") | t!("COMMIT")
-				| t!("CONTINUE") | t!("FOR")
-				| t!("INFO") | t!("KILL")
-				| t!("LIVE") | t!("OPTION")
+				| t!("BEGIN")
+				| t!("BREAK")
+				| t!("CANCEL")
+				| t!("COMMIT")
+				| t!("CONTINUE")
+				| t!("FOR") | t!("INFO")
+				| t!("KILL") | t!("LIVE")
+				| t!("OPTION")
 				| t!("LET") | t!("SHOW")
-				| t!("SLEEP") | t!("THROW")
+				| t!("SLEEP")
+				| t!("THROW")
 				| t!("USE")
 		)
 	}
@@ -655,6 +659,12 @@ mod tests {
 		let sql = "(1 + 2 + 3)";
 		let out = Value::parse(sql);
 		assert_eq!("(1 + 2 + 3)", format!("{}", out))
+	}
+
+	#[test]
+	fn invalid_idiom() {
+		let sql = "'hello'.foo";
+		Value::parse(sql).unwrap_err();
 	}
 
 	#[test]

--- a/core/src/syn/parser/prime.rs
+++ b/core/src/syn/parser/prime.rs
@@ -594,17 +594,13 @@ impl Parser<'_> {
 		matches!(
 			kind,
 			t!("ANALYZE")
-				| t!("BEGIN")
-				| t!("BREAK")
-				| t!("CANCEL")
-				| t!("COMMIT")
-				| t!("CONTINUE")
-				| t!("FOR") | t!("INFO")
-				| t!("KILL") | t!("LIVE")
-				| t!("OPTION")
+				| t!("BEGIN") | t!("BREAK")
+				| t!("CANCEL") | t!("COMMIT")
+				| t!("CONTINUE") | t!("FOR")
+				| t!("INFO") | t!("KILL")
+				| t!("LIVE") | t!("OPTION")
 				| t!("LET") | t!("SHOW")
-				| t!("SLEEP")
-				| t!("THROW")
+				| t!("SLEEP") | t!("THROW")
 				| t!("USE")
 		)
 	}

--- a/core/src/syn/parser/prime.rs
+++ b/core/src/syn/parser/prime.rs
@@ -594,13 +594,17 @@ impl Parser<'_> {
 		matches!(
 			kind,
 			t!("ANALYZE")
-				| t!("BEGIN") | t!("BREAK")
-				| t!("CANCEL") | t!("COMMIT")
-				| t!("CONTINUE") | t!("FOR")
-				| t!("INFO") | t!("KILL")
-				| t!("LIVE") | t!("OPTION")
+				| t!("BEGIN")
+				| t!("BREAK")
+				| t!("CANCEL")
+				| t!("COMMIT")
+				| t!("CONTINUE")
+				| t!("FOR") | t!("INFO")
+				| t!("KILL") | t!("LIVE")
+				| t!("OPTION")
 				| t!("LET") | t!("SHOW")
-				| t!("SLEEP") | t!("THROW")
+				| t!("SLEEP")
+				| t!("THROW")
 				| t!("USE")
 		)
 	}
@@ -648,7 +652,7 @@ impl Parser<'_> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::syn::Parse;
+	use crate::syn::{self, Parse};
 
 	#[test]
 	fn subquery_expression_statement() {
@@ -660,7 +664,7 @@ mod tests {
 	#[test]
 	fn invalid_idiom() {
 		let sql = "'hello'.foo";
-		Value::parse(sql).unwrap_err();
+		syn::parse(sql).unwrap_err();
 	}
 
 	#[test]


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The parser would panic if a dot happened after a string in places where an idiom is allowed.

## What does this change do?

Fixes the panic.

## What is your testing strategy?

Added a test for the case where the parser would panic.

## Is this related to any issues?

Fixes #4275

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
