### PR TITLE
Fix `Datastore.compute()` authentication check

### DIFF
--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -1192,7 +1192,7 @@ impl Datastore {
 
 		// Check if anonymous actors can compute values when auth is enabled
 		// TODO(sgirones): Check this as part of the authorisation layer
-		if self.auth_enabled && !self.capabilities.allows_guest_access() {
+		if self.auth_enabled && !self.capabilities.allows_guest_access() && sess.au.is_anon() {
 			return Err(IamError::NotAllowed {
 				actor: "anonymous".to_string(),
 				action: "compute".to_string(),

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -1192,7 +1192,7 @@ impl Datastore {
 
 		// Check if anonymous actors can compute values when auth is enabled
 		// TODO(sgirones): Check this as part of the authorisation layer
-		if self.auth_enabled && !self.capabilities.allows_guest_access() && sess.au.is_anon() {
+		if sess.au.is_anon() && self.auth_enabled && !self.capabilities.allows_guest_access() {
 			return Err(IamError::NotAllowed {
 				actor: "anonymous".to_string(),
 				action: "compute".to_string(),

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -185,6 +185,14 @@ pub async fn start_server_with_functions() -> Result<(String, Child), Box<dyn Er
 	.await
 }
 
+pub async fn start_server_with_guests() -> Result<(String, Child), Box<dyn Error>> {
+	start_server(StartServerArguments {
+		args: "--allow-guests".to_string(),
+		..Default::default()
+	})
+	.await
+}
+
 pub async fn start_server_with_defaults() -> Result<(String, Child), Box<dyn Error>> {
 	start_server(StartServerArguments::default()).await
 }

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -164,7 +164,7 @@ impl Default for StartServerArguments {
 			wait_is_ready: true,
 			tick_interval: time::Duration::new(1, 0),
 			temporary_directory: None,
-			args: "--allow-all".to_string(),
+			args: "".to_string(),
 		}
 	}
 }
@@ -172,6 +172,14 @@ impl Default for StartServerArguments {
 pub async fn start_server_without_auth() -> Result<(String, Child), Box<dyn Error>> {
 	start_server(StartServerArguments {
 		auth: false,
+		..Default::default()
+	})
+	.await
+}
+
+pub async fn start_server_with_functions() -> Result<(String, Child), Box<dyn Error>> {
+	start_server(StartServerArguments {
+		args: "--allow-funcs".to_string(),
 		..Default::default()
 	})
 	.await

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -1476,7 +1476,7 @@ async fn session_reauthentication_expired() {
 #[test(tokio::test)]
 async fn run_functions() {
 	// Setup database server
-	let (addr, mut server) = common::start_server_with_defaults().await.unwrap();
+	let (addr, mut server) = common::start_server_with_functions().await.unwrap();
 	// Connect to WebSocket
 	let mut socket = Socket::connect(&addr, SERVER, FORMAT).await.unwrap();
 	// Authenticate the connection

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -211,12 +211,11 @@ async fn invalidate() -> Result<(), Box<dyn std::error::Error>> {
 	// Send INVALIDATE command
 	socket.send_request("invalidate", json!([])).await?;
 	// Verify we have an invalidated session
-	let res = socket.send_message_query("DEFINE NAMESPACE test").await?;
-	assert_eq!(res[0]["status"], "ERR", "result: {:?}", res);
+	let res = socket.send_request("query", json!(["DEFINE NAMESPACE test"])).await?;
 	assert_eq!(
-		res[0]["result"], "IAM error: Not enough permissions to perform this action",
-		"result: {:?}",
-		res
+		res["error"]["message"],
+		"There was a problem with the database: IAM error: Not enough permissions to perform this action",
+		"result: {:?}", res
 	);
 	// Test passed
 	server.finish().unwrap();

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -15,7 +15,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn basic_auth() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let url = &format!("http://{addr}/sql");
 
 		// Prepare HTTP client
@@ -211,7 +211,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn bearer_auth() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let url = &format!("http://{addr}/sql");
 
 		let ns = Ulid::new().to_string();
@@ -776,7 +776,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn sql_endpoint() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let url = &format!("http://{addr}/sql");
 
 		// Prepare HTTP client
@@ -997,7 +997,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn key_endpoint_select_all() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let table_name = "table";
 		let num_records = 50;
 		let url = &format!("http://{addr}/key/{table_name}");
@@ -1088,7 +1088,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn key_endpoint_create_all() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 
 		// Prepare HTTP client
 		let mut headers = reqwest::header::HeaderMap::new();
@@ -1150,7 +1150,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn key_endpoint_update_all() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let table_name = "table";
 		let num_records = 10;
 		let url = &format!("http://{addr}/key/{table_name}");
@@ -1219,7 +1219,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn key_endpoint_modify_all() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let table_name = Ulid::new().to_string();
 		let num_records = 10;
 		let url = &format!("http://{addr}/key/{table_name}");
@@ -1288,7 +1288,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn key_endpoint_delete_all() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let table_name = "table";
 		let num_records = 10;
 		let url = &format!("http://{addr}/key/{table_name}");
@@ -1341,7 +1341,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn key_endpoint_select_one() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let table_name = "table";
 		let url = &format!("http://{addr}/key/{table_name}/1");
 
@@ -1381,7 +1381,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn key_endpoint_create_one() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let table_name = "table";
 
 		// Prepare HTTP client
@@ -1477,7 +1477,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn key_endpoint_update_one() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let table_name = "table";
 		let url = &format!("http://{addr}/key/{table_name}/1");
 
@@ -1553,7 +1553,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn key_endpoint_modify_one() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let table_name = "table";
 		let url = &format!("http://{addr}/key/{table_name}/1");
 
@@ -1630,7 +1630,7 @@ mod http_integration {
 
 	#[test(tokio::test)]
 	async fn key_endpoint_delete_one() -> Result<(), Box<dyn std::error::Error>> {
-		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+		let (addr, _server) = common::start_server_with_guests().await.unwrap();
 		let table_name = "table";
 		let base_url = &format!("http://{addr}/key/{table_name}");
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

You previously were not able to set a parameter on a websocket RPC session as a root user

## What does this change do?

It fixes the authentication check that broke this behaviour to only trigger for anonymous users

## What is your testing strategy?

Write your test plan here. Please provide us with clear instructions on how you verified your changes work.

## Is this related to any issues?

If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
