### PR TITLE
Remove obsolete lifetime and type parameter

### DIFF
--- a/lib/src/api/method/live.rs
+++ b/lib/src/api/method/live.rs
@@ -130,7 +130,7 @@ impl<'r, Client> IntoFuture for Select<'r, Client, Value, Live>
 where
 	Client: Connection,
 {
-	type Output = Result<Stream<'r, Client, Value>>;
+	type Output = Result<Stream<Value>>;
 	type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
 	into_future! {}
@@ -141,7 +141,7 @@ where
 	Client: Connection,
 	R: DeserializeOwned,
 {
-	type Output = Result<Stream<'r, Client, Option<R>>>;
+	type Output = Result<Stream<Option<R>>>;
 	type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
 	into_future! {}
@@ -152,7 +152,7 @@ where
 	Client: Connection,
 	R: DeserializeOwned,
 {
-	type Output = Result<Stream<'r, Client, Vec<R>>>;
+	type Output = Result<Stream<Vec<R>>>;
 	type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
 	into_future! {}
@@ -161,17 +161,16 @@ where
 /// A stream of live query notifications
 #[derive(Debug)]
 #[must_use = "streams do nothing unless you poll them"]
-pub struct Stream<'r, C: Connection, R> {
+pub struct Stream<R> {
 	pub(crate) client: Surreal<Any>,
 	// We no longer need the lifetime and the type parameter
 	// Leaving them in for backwards compatibility
-	pub(crate) engine: PhantomData<&'r C>,
 	pub(crate) id: Value,
 	pub(crate) rx: Option<Receiver<dbs::Notification>>,
 	pub(crate) response_type: PhantomData<R>,
 }
 
-impl<'r, C: Connection, R> Stream<'r, C, R> {
+impl<R> Stream<R> {
 	pub(crate) fn new(
 		client: Surreal<Any>,
 		id: Value,
@@ -182,7 +181,6 @@ impl<'r, C: Connection, R> Stream<'r, C, R> {
 			rx,
 			client,
 			response_type: PhantomData,
-			engine: PhantomData,
 		}
 	}
 }
@@ -202,10 +200,7 @@ macro_rules! poll_next {
 	};
 }
 
-impl<C> futures::Stream for Stream<'_, C, Value>
-where
-	C: Connection,
-{
+impl futures::Stream for Stream<Value> {
 	type Item = Notification<Value>;
 
 	poll_next! {
@@ -232,9 +227,8 @@ macro_rules! poll_next_and_convert {
 	};
 }
 
-impl<C, R> futures::Stream for Stream<'_, C, Option<R>>
+impl<R> futures::Stream for Stream<Option<R>>
 where
-	C: Connection,
 	R: DeserializeOwned + Unpin,
 {
 	type Item = Result<Notification<R>>;
@@ -242,9 +236,8 @@ where
 	poll_next_and_convert! {}
 }
 
-impl<C, R> futures::Stream for Stream<'_, C, Vec<R>>
+impl<R> futures::Stream for Stream<Vec<R>>
 where
-	C: Connection,
 	R: DeserializeOwned + Unpin,
 {
 	type Item = Result<Notification<R>>;
@@ -252,9 +245,8 @@ where
 	poll_next_and_convert! {}
 }
 
-impl<C, R> futures::Stream for Stream<'_, C, Notification<R>>
+impl<R> futures::Stream for Stream<Notification<R>>
 where
-	C: Connection,
 	R: DeserializeOwned + Unpin,
 {
 	type Item = Result<Notification<R>>;
@@ -275,10 +267,7 @@ where
 	});
 }
 
-impl<Client, R> Drop for Stream<'_, Client, R>
-where
-	Client: Connection,
-{
+impl<R> Drop for Stream<R> {
 	/// Close the live query stream
 	///
 	/// This kills the live query process responsible for this stream.

--- a/lib/src/api/method/query.rs
+++ b/lib/src/api/method/query.rs
@@ -295,15 +295,13 @@ pub(crate) type QueryResult = Result<Value>;
 pub struct Response {
 	pub(crate) client: Surreal<Any>,
 	pub(crate) results: IndexMap<usize, (Stats, QueryResult)>,
-	pub(crate) live_queries: IndexMap<usize, Result<Stream<'static, Any, Value>>>,
+	pub(crate) live_queries: IndexMap<usize, Result<Stream<Value>>>,
 }
 
 /// A `LIVE SELECT` stream from the `query` method
 #[derive(Debug)]
 #[must_use = "streams do nothing unless you poll them"]
-pub struct QueryStream<R>(
-	pub(crate) Either<Stream<'static, Any, R>, SelectAll<Stream<'static, Any, R>>>,
-);
+pub struct QueryStream<R>(pub(crate) Either<Stream<R>, SelectAll<Stream<R>>>);
 
 impl futures::Stream for QueryStream<Value> {
 	type Item = Notification<Value>;

--- a/lib/src/api/opt/query.rs
+++ b/lib/src/api/opt/query.rs
@@ -492,7 +492,6 @@ where
 			})?;
 		Ok(method::QueryStream(Either::Left(Stream {
 			client: stream.client.clone(),
-			engine: stream.engine,
 			id: mem::take(&mut stream.id),
 			rx: stream.rx.take(),
 			response_type: PhantomData,
@@ -524,7 +523,6 @@ where
 			};
 			streams.push(Stream {
 				client: stream.client.clone(),
-				engine: stream.engine,
 				id: mem::take(&mut stream.id),
 				rx: stream.rx.take(),
 				response_type: PhantomData,


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

There is an unnecessary lifetime and type parameter on the Stream type, removing them would make it more ergonomic.

## What does this change do?

removes them

## What is your testing strategy?

existing, this pr should cause no change in behaviour

## Is this related to any issues?

If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
