### PR TITLE
4294 bug lq delete notifications missing after 5s

### DIFF
--- a/core/src/kvs/tests/timestamp_to_versionstamp.rs
+++ b/core/src/kvs/tests/timestamp_to_versionstamp.rs
@@ -1,3 +1,5 @@
+use crate::key;
+
 // Timestamp to versionstamp tests
 // This translation mechanism is currently used by the garbage collector to determine which change feed entries to delete.
 //
@@ -42,4 +44,41 @@ async fn timestamp_to_versionstamp() {
 	tx.commit().await.unwrap();
 	assert!(vs1 < vs2);
 	assert!(vs2 < vs3);
+}
+
+#[tokio::test]
+#[serial]
+async fn only_the_latest_ts_is_retained() {
+	// Create a new datastore
+	let node_id = Uuid::parse_str("A905CA25-56ED-49FB-B759-696AEA87C342").unwrap();
+	let clock = Arc::new(SizedClock::Fake(FakeClock::new(Timestamp::default())));
+	let (ds, _) = new_ds(node_id, clock).await;
+
+	// Give the current versionstamp a timestamp of 0
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
+	tx.set_timestamp_for_versionstamp(0, "myns", "mydb", true).await.unwrap();
+	tx.commit().await.unwrap();
+
+	// Get the versionstamp for timestamp 0
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
+	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb", true).await.unwrap().unwrap();
+	tx.commit().await.unwrap();
+
+	// Give the current versionstamp a timestamp of 1
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
+	tx.set_timestamp_for_versionstamp(1, "myns", "mydb", true).await.unwrap();
+	tx.commit().await.unwrap();
+
+	// Get the versionstamp for timestamp 1
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
+	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb", true).await.unwrap().unwrap();
+	tx.commit().await.unwrap();
+
+	// Scan range
+	let start = key::database::ts::new("myns", "mydb", 0);
+	let end = key::database::ts::new("myns", "mydb", u64::MAX);
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
+	let scanned = tx.scan(start..end, u32::MAX).await.unwrap();
+	tx.commit().await.unwrap();
+	assert_eq!(scanned.len(), 1)
 }

--- a/core/src/kvs/tests/timestamp_to_versionstamp.rs
+++ b/core/src/kvs/tests/timestamp_to_versionstamp.rs
@@ -1,5 +1,3 @@
-use crate::key;
-
 // Timestamp to versionstamp tests
 // This translation mechanism is currently used by the garbage collector to determine which change feed entries to delete.
 //
@@ -44,41 +42,4 @@ async fn timestamp_to_versionstamp() {
 	tx.commit().await.unwrap();
 	assert!(vs1 < vs2);
 	assert!(vs2 < vs3);
-}
-
-#[tokio::test]
-#[serial]
-async fn only_the_latest_ts_is_retained() {
-	// Create a new datastore
-	let node_id = Uuid::parse_str("A905CA25-56ED-49FB-B759-696AEA87C342").unwrap();
-	let clock = Arc::new(SizedClock::Fake(FakeClock::new(Timestamp::default())));
-	let (ds, _) = new_ds(node_id, clock).await;
-
-	// Give the current versionstamp a timestamp of 0
-	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	tx.set_timestamp_for_versionstamp(0, "myns", "mydb", true).await.unwrap();
-	tx.commit().await.unwrap();
-
-	// Get the versionstamp for timestamp 0
-	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb", true).await.unwrap().unwrap();
-	tx.commit().await.unwrap();
-
-	// Give the current versionstamp a timestamp of 1
-	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	tx.set_timestamp_for_versionstamp(1, "myns", "mydb", true).await.unwrap();
-	tx.commit().await.unwrap();
-
-	// Get the versionstamp for timestamp 1
-	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb", true).await.unwrap().unwrap();
-	tx.commit().await.unwrap();
-
-	// Scan range
-	let start = key::database::ts::new("myns", "mydb", 0);
-	let end = key::database::ts::new("myns", "mydb", u64::MAX);
-	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	let scanned = tx.scan(start..end, u32::MAX).await.unwrap();
-	tx.commit().await.unwrap();
-	assert_eq!(scanned.len(), 1)
 }

--- a/lib/tests/live.rs
+++ b/lib/tests/live.rs
@@ -97,3 +97,74 @@ async fn live_query_sends_registered_lq_details() -> Result<(), Error> {
 
 	Ok(())
 }
+
+#[tokio::test]
+async fn live_query_does_not_drop_notifications() -> Result<(), Error> {
+	let table = "lq_test_123";
+	const RUNS: u16 = 1_000;
+	let define_stm = match FFLAGS.change_feed_live_queries.enabled() {
+		true => format!("DEFINE TABLE {table} CHANGEFEED 10m INCLUDE ORIGINAL;"),
+		false => format!("DEFINE TABLE {table};"),
+	};
+	let sql = format!(
+		"
+		{define_stm}	
+		LIVE SELECT * FROM lq_test_123;
+	"
+	);
+	let mut stack = reblessive::tree::TreeStack::new();
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test").with_rt(true);
+	let res = &mut dbs.execute(&sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+
+	// Define table didnt fail
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+
+	// Live query returned a valid uuid
+	let actual = res.remove(0).result.unwrap();
+	let live_id = match actual {
+		Value::Uuid(live_id) => live_id,
+		_ => panic!("Expected a UUID"),
+	};
+	assert!(!live_id.is_nil());
+
+	// Create some data
+	for i in 0..RUNS {
+		let test_sql = format!(
+			"
+		CREATE {table}:test_case_{i};
+		UPDATE {table}:test_case_{i} SET name = 'test_case_{i}';
+		DELETE {table}:test_case_{i};
+		"
+		);
+		let res = &mut dbs.execute(&test_sql, &ses, None).await?;
+		// All statements succeed
+		let expected = 3;
+		assert_eq!(res.len(), expected);
+		for _ in 0..expected {
+			let result = res.remove(0);
+			assert!(result.result.is_ok());
+		}
+		// Process the notifications
+		let def = Default::default();
+		stack.enter(|stk| dbs.process_lq_notifications(stk, &def)).finish().await?;
+
+		let notifications_chan = dbs.notifications().unwrap();
+
+		for case in 0..expected {
+			tokio::select! {
+				_ = tokio::time::sleep(tokio::time::Duration::from_millis(1000)) => {
+					panic!("Timeout - Failed at run {} for case {}", i, case);
+				}
+				msg = notifications_chan.recv() => {
+					assert!(msg.is_ok(), "Failed at run {} for case {}", i, case);
+				}
+			}
+		}
+		assert!(notifications_chan.try_recv().is_err());
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

@kearfy saw flaky tests in the js driver around notifications missing.
This adds a test that smashes a lot of notifications in and verifies notifications are returned.

## What does this change do?

Add a passing test that validates 3000 notifications

## What is your testing strategy?

Integration

## Is this related to any issues?

#4294 



## Does this change need documentation?


- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
