### PR TITLE
Update surrealkv version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6155,9 +6155,9 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a2d39e9eea9bd25e9dd9e68c0dc8134653bdabf741fa604533dc1dda732c9"
+checksum = "cd7369cca0403d3c07aba318cedb69dfb787eafda44c7b0c54f05b1fd0438bfe"
 dependencies = [
  "async-channel 2.2.0",
  "bytes",
@@ -7093,9 +7093,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vart"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f8fe507a1dd4f78b79e7c3b08232f4a826c6140252d1fc7a0aa4d8b9992211"
+checksum = "8e19cf5555815b1ebc839ceb17face450eb0346e09c0acc6ad0e3097ec49dcad"
 dependencies = [
  "hashbrown 0.14.5",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -142,7 +142,7 @@ sha1 = "0.10.6"
 sha2 = "0.10.8"
 snap = "1.1.0"
 storekey = "0.5.0"
-surrealkv = { version = "0.2.0", optional = true }
+surrealkv = { version = "0.3.0", optional = true }
 surrealml = { version = "0.1.1", optional = true, package = "surrealml-core" }
 tempfile = { version = "3.10.1", optional = true }
 thiserror = "1.0.50"


### PR DESCRIPTION
## What is the motivation?

Use surrealkv version 0.3.0

## What does this change do?

SurrealKV 0.3.0 includes versioned time travel APIs.

## What is your testing strategy?

Github Actions

## Is this related to any issues?

No

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
