### PR TITLE
Fix peeking in `parse_uuid`

### DIFF
--- a/core/src/syn/parser/basic/uuid.rs
+++ b/core/src/syn/parser/basic/uuid.rs
@@ -12,7 +12,7 @@ use crate::{
 impl Parser<'_> {
 	/// Parses a uuid strand.
 	pub fn parse_uuid(&mut self) -> ParseResult<Uuid> {
-		let quote_token = self.peek_whitespace();
+		let quote_token = self.peek();
 
 		let double = match quote_token.kind {
 			t!("u\"") => true,


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To fix a bug that was preventing revoking grants by UUID during parsing in #4302.  

## What does this change do?

Changes `peek_whitespace` to `peek` in `parse_uuid` to allow for a leading space to be correctly parsed.

## What is your testing strategy?

Verify that the `ACCESS ... REVOKE` statement parses correctly in #4302. Ensure that existing tests continue working.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
