### PR TITLE
Update bug_report.yml to encourage the user to add data, queries, screenschots, videos and/or surrealist embed links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,8 +22,10 @@ body:
     attributes:
       label: Steps to reproduce
       description: What are the steps necessary to reproduce this bug?
-      placeholder: Detail the steps taken to reproduce the behaviour.
-    validations:
+      placeholder: |
+        Detail the steps taken to reproduce the behaviour.
+        Remember to include any useful data, queries, screenshots or videos of the issue. 
+        Feel free to use [Surrealist Embeds](https://surrealdb.com/docs/surrealist/embeds) and share a link!
       required: true
   - type: textarea
     id: expected

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,6 +26,7 @@ body:
         Detail the steps taken to reproduce the behaviour.
         Remember to include any useful data, queries, screenshots or videos of the issue. 
         Feel free to use [Surrealist Embeds](https://surrealdb.com/docs/surrealist/embeds) and share a link!
+    validations:
       required: true
   - type: textarea
     id: expected


### PR DESCRIPTION
## What is the motivation?
We often find incomplete Bug reports and we want to encourage contributors to include data, queries, screenshots, videos and/or Surrealist Embed links to help us reproduce the issue.

## What does this change do?
Edits the placeholder in the Steps to reproduce section of the Bug Report Template

## What is your testing strategy?
N/A

## Is this related to any issues?
All new bugs on this repo

## Does this change need documentation?
- [x] No documentation needed

## Have you read the Contributing Guidelines?
- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
