### PR TITLE
4126 bug internal database error ts is less than or equal to the latest ts

### DIFF
--- a/core/src/cf/gc.rs
+++ b/core/src/cf/gc.rs
@@ -57,11 +57,8 @@ pub async fn gc_ns(tx: &Transaction, ts: u64, ns: &str) -> Result<(), Error> {
 		// Calculate the watermark expiry window
 		let watermark_ts = ts - cf_expiry;
 		// Calculate the watermark versionstamp
-		let watermark_vs = tx
-			.lock()
-			.await
-			.get_versionstamp_from_timestamp(watermark_ts, ns, &db.name, true)
-			.await?;
+		let watermark_vs =
+			tx.lock().await.get_versionstamp_from_timestamp(watermark_ts, ns, &db.name).await?;
 		// If a versionstamp exists, then garbage collect
 		if let Some(watermark_vs) = watermark_vs {
 			gc_range(tx, ns, &db.name, watermark_vs).await?;

--- a/core/src/cf/reader.rs
+++ b/core/src/cf/reader.rs
@@ -28,7 +28,7 @@ pub async fn read(
 		ShowSince::Versionstamp(x) => change::prefix_ts(ns, db, vs::u64_to_versionstamp(x)),
 		ShowSince::Timestamp(x) => {
 			let ts = x.0.timestamp() as u64;
-			let vs = tx.lock().await.get_versionstamp_from_timestamp(ts, ns, db, true).await?;
+			let vs = tx.lock().await.get_versionstamp_from_timestamp(ts, ns, db).await?;
 			match vs {
 				Some(vs) => change::prefix_ts(ns, db, vs),
 				None => {

--- a/core/src/cf/writer.rs
+++ b/core/src/cf/writer.rs
@@ -401,8 +401,8 @@ mod tests {
 		.await;
 		ds.tick_at(10).await.unwrap();
 		let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
-		let vs1 = tx.get_versionstamp_from_timestamp(5, NS, DB, false).await.unwrap().unwrap();
-		let vs2 = tx.get_versionstamp_from_timestamp(10, NS, DB, false).await.unwrap().unwrap();
+		let vs1 = tx.get_versionstamp_from_timestamp(5, NS, DB).await.unwrap().unwrap();
+		let vs2 = tx.get_versionstamp_from_timestamp(10, NS, DB).await.unwrap().unwrap();
 		tx.cancel().await.unwrap();
 		let _id2 = record_change_feed_entry(
 			ds.transaction(Write, Optimistic).await.unwrap(),

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -681,6 +681,8 @@ impl Datastore {
 			for db in dbs {
 				let db = db.name.as_str();
 				// TODO(SUR-341): This is incorrect, it's a [ns,db] to vs pair
+				// It's safe for now, as it is unused but either the signature must change
+				// to include {(ns, db): (ts, vs)} mapping, or we don't return it
 				vs = Some(tx.lock().await.set_timestamp_for_versionstamp(ts, ns, db).await?);
 			}
 		}

--- a/core/src/kvs/tests/helper.rs
+++ b/core/src/kvs/tests/helper.rs
@@ -1,4 +1,5 @@
 use crate::dbs::node::Timestamp;
+use crate::dbs::Session;
 use crate::kvs::clock::{FakeClock, SizedClock};
 use crate::kvs::tests::{ClockType, Kvs};
 use crate::kvs::Datastore;

--- a/core/src/kvs/tests/timestamp_to_versionstamp.rs
+++ b/core/src/kvs/tests/timestamp_to_versionstamp.rs
@@ -1,3 +1,5 @@
+use crate::key;
+
 // Timestamp to versionstamp tests
 // This translation mechanism is currently used by the garbage collector to determine which change feed entries to delete.
 //
@@ -42,4 +44,41 @@ async fn timestamp_to_versionstamp() {
 	tx.commit().await.unwrap();
 	assert!(vs1 < vs2);
 	assert!(vs2 < vs3);
+}
+
+#[tokio::test]
+#[serial]
+async fn only_the_latest_ts_is_retained() {
+	// Create a new datastore
+	let node_id = Uuid::parse_str("A905CA25-56ED-49FB-B759-696AEA87C342").unwrap();
+	let clock = Arc::new(SizedClock::Fake(FakeClock::new(Timestamp::default())));
+	let (ds, _) = new_ds(node_id, clock).await;
+
+	// Give the current versionstamp a timestamp of 0
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
+	tx.set_timestamp_for_versionstamp(0, "myns", "mydb", true).await.unwrap();
+	tx.commit().await.unwrap();
+
+	// Get the versionstamp for timestamp 0
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
+	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb", true).await.unwrap().unwrap();
+	tx.commit().await.unwrap();
+
+	// Give the current versionstamp a timestamp of 1
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
+	tx.set_timestamp_for_versionstamp(1, "myns", "mydb", true).await.unwrap();
+	tx.commit().await.unwrap();
+
+	// Get the versionstamp for timestamp 1
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
+	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb", true).await.unwrap().unwrap();
+	tx.commit().await.unwrap();
+
+	// Scan range
+	let start = key::database::ts::new("myns", "mydb", 0);
+	let end = key::database::ts::new("myns", "mydb", u64::MAX);
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
+	let scanned = tx.scan(start..end, u32::MAX).await.unwrap();
+	tx.commit().await.unwrap();
+	assert_eq!(scanned.len(), 1)
 }

--- a/core/src/kvs/tests/timestamp_to_versionstamp.rs
+++ b/core/src/kvs/tests/timestamp_to_versionstamp.rs
@@ -1,5 +1,3 @@
-use crate::key;
-
 // Timestamp to versionstamp tests
 // This translation mechanism is currently used by the garbage collector to determine which change feed entries to delete.
 //
@@ -24,7 +22,7 @@ async fn timestamp_to_versionstamp() {
 	tx.commit().await.unwrap();
 	// Get the versionstamp for timestamp 0
 	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
-	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb", true).await.unwrap().unwrap();
+	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb").await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 	// Give the current versionstamp a timestamp of 1
 	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
@@ -32,7 +30,7 @@ async fn timestamp_to_versionstamp() {
 	tx.commit().await.unwrap();
 	// Get the versionstamp for timestamp 1
 	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
-	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb", true).await.unwrap().unwrap();
+	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb").await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 	// Give the current versionstamp a timestamp of 2
 	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
@@ -40,7 +38,7 @@ async fn timestamp_to_versionstamp() {
 	tx.commit().await.unwrap();
 	// Get the versionstamp for timestamp 2
 	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
-	let vs3 = tx.get_versionstamp_from_timestamp(2, "myns", "mydb", true).await.unwrap().unwrap();
+	let vs3 = tx.get_versionstamp_from_timestamp(2, "myns", "mydb").await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 	assert!(vs1 < vs2);
 	assert!(vs2 < vs3);
@@ -48,37 +46,56 @@ async fn timestamp_to_versionstamp() {
 
 #[tokio::test]
 #[serial]
-async fn only_the_latest_ts_is_retained() {
+async fn writing_ts_again_results_in_following_ts() {
 	// Create a new datastore
 	let node_id = Uuid::parse_str("A905CA25-56ED-49FB-B759-696AEA87C342").unwrap();
 	let clock = Arc::new(SizedClock::Fake(FakeClock::new(Timestamp::default())));
 	let (ds, _) = new_ds(node_id, clock).await;
 
+	// Declare ns/db
+	ds.execute("USE NS myns; USE DB mydb; CREATE record", &Session::owner(), None).await.unwrap();
+
 	// Give the current versionstamp a timestamp of 0
-	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	tx.set_timestamp_for_versionstamp(0, "myns", "mydb", true).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
+	tx.set_timestamp_for_versionstamp(0, "myns", "mydb").await.unwrap();
 	tx.commit().await.unwrap();
 
 	// Get the versionstamp for timestamp 0
-	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb", true).await.unwrap().unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
+	let vs1 = tx.get_versionstamp_from_timestamp(0, "myns", "mydb").await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 
 	// Give the current versionstamp a timestamp of 1
-	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	tx.set_timestamp_for_versionstamp(1, "myns", "mydb", true).await.unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
+	tx.set_timestamp_for_versionstamp(1, "myns", "mydb").await.unwrap();
 	tx.commit().await.unwrap();
 
 	// Get the versionstamp for timestamp 1
-	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb", true).await.unwrap().unwrap();
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
+	let vs2 = tx.get_versionstamp_from_timestamp(1, "myns", "mydb").await.unwrap().unwrap();
 	tx.commit().await.unwrap();
 
+	assert!(vs1 < vs2);
+
 	// Scan range
-	let start = key::database::ts::new("myns", "mydb", 0);
-	let end = key::database::ts::new("myns", "mydb", u64::MAX);
-	let mut tx = ds.transaction(Write, Optimistic).await.unwrap();
-	let scanned = tx.scan(start..end, u32::MAX).await.unwrap();
+	let start = crate::key::database::ts::new("myns", "mydb", 0);
+	let end = crate::key::database::ts::new("myns", "mydb", u64::MAX);
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
+	let scanned = tx.scan(start.clone()..end.clone(), u32::MAX, None).await.unwrap();
 	tx.commit().await.unwrap();
-	assert_eq!(scanned.len(), 1)
+	assert_eq!(scanned.len(), 2);
+	assert_eq!(scanned[0].0, crate::key::database::ts::new("myns", "mydb", 0).encode().unwrap());
+	assert_eq!(scanned[1].0, crate::key::database::ts::new("myns", "mydb", 1).encode().unwrap());
+
+	// Repeating tick
+	ds.tick_at(1).await.unwrap();
+
+	// Validate
+	let mut tx = ds.transaction(Write, Optimistic).await.unwrap().inner();
+	let scanned = tx.scan(start..end, u32::MAX, None).await.unwrap();
+	tx.commit().await.unwrap();
+	assert_eq!(scanned.len(), 3);
+	assert_eq!(scanned[0].0, crate::key::database::ts::new("myns", "mydb", 0).encode().unwrap());
+	assert_eq!(scanned[1].0, crate::key::database::ts::new("myns", "mydb", 1).encode().unwrap());
+	assert_eq!(scanned[2].0, crate::key::database::ts::new("myns", "mydb", 2).encode().unwrap());
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

We use per second granularity when storing timestamps.
The period is 10s, but that only works if 10s is perfect - from #4126 we can see users encountering the same "second" in quick succession. The timer doesn't prevent this, because it happened within the 10s window.
This solves that issue by adding a second to the already recorded value.

## What does this change do?

Add a second to the maximum timestamp recorded instead of erroring out.

## What is your testing strategy?

Integration

## Is this related to any issues?

Closes #4126

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
