### PR TITLE
3987 Reduce read lock duration

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -56,14 +56,14 @@ pub(crate) async fn notifications(state: Arc<RpcState>, canceller: CancellationT
 					// Find which WebSocket the notification belongs to
 					let found_ws = {
 						// We remove the lock asap
-						state.live_queries.read().await.get(&notification.id).map(|borrow| *borrow)
+						state.live_queries.read().await.get(&notification.id).cloned()
 					};
 					if let Some(id) = found_ws {
 						// Check to see if the WebSocket exists
 						let maybe_ws = {
 							// We remove the lock ASAP
 							// WS is an Arc anyway
-							state.web_sockets.read().await.get(&id).map(|borrow| borrow.clone())
+							state.web_sockets.read().await.get(&id).cloned()
 						};
 						if let Some(rpc) = maybe_ws {
 							// Serialize the message to send

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -54,9 +54,18 @@ pub(crate) async fn notifications(state: Arc<RpcState>, canceller: CancellationT
 				// Receive a notification on the channel
 				Ok(notification) = channel.recv() => {
 					// Find which WebSocket the notification belongs to
-					if let Some(id) = state.live_queries.read().await.get(&notification.id) {
+					let found_ws = {
+						// We remove the lock asap
+						state.live_queries.read().await.get(&notification.id).map(|borrow| *borrow)
+					};
+					if let Some(id) = found_ws {
 						// Check to see if the WebSocket exists
-						if let Some(rpc) = state.web_sockets.read().await.get(id) {
+						let maybe_ws = {
+							// We remove the lock ASAP
+							// WS is an Arc anyway
+							state.web_sockets.read().await.get(&id).map(|borrow| borrow.clone())
+						};
+						if let Some(rpc) = maybe_ws {
 							// Serialize the message to send
 							let message = success(None, notification);
 							// Add metrics


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Sometimes we get deadlocks in connections. By reducing the duration a lock is held we reduce the footprint for locks.

## What does this change do?

Clone an arc and copy a uuid so that we don't hold onto the locks while processing connection messages.

## What is your testing strategy?

N/A

## Is this related to any issues?

#3987 

## Does this change need documentation?

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
