### PR TITLE
4258 bug panic on live select as non root user

### DIFF
--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -248,8 +248,15 @@ impl<'a> Context<'a> {
 		self
 	}
 
+	pub fn get_transaction(&self) -> Option<&Transaction> {
+		self.transaction.as_ref()
+	}
+
 	pub(crate) fn tx_lock(&self) -> MutexLockFuture<'_, kvs::Transaction> {
-		self.transaction.as_ref().map(|txn| txn.lock()).unwrap_or_else(|| unreachable!())
+		self.transaction
+			.as_ref()
+			.map(|txn| txn.lock())
+			.unwrap_or_else(|| unreachable!("The context was not associated with a transaction"))
 	}
 
 	/// Get the timeout for this operation, if any. This is useful for

--- a/core/src/doc/lives.rs
+++ b/core/src/doc/lives.rs
@@ -159,9 +159,9 @@ impl<'a> Document<'a> {
 			// of the user who created the LIVE query.
 			let lqctx = Context::background();
 			let mut lqctx =
-				lqctx.set_transaction(ctx.get_transaction().map(|tx| tx.clone()).unwrap_or_else(
-					|| unreachable!("Expected transaction to be available in parent context"),
-				));
+				lqctx.set_transaction(ctx.get_transaction().cloned().unwrap_or_else(|| {
+					unreachable!("Expected transaction to be available in parent context")
+				}));
 			lqctx.add_value("access", sess.pick(AC.as_ref()));
 			lqctx.add_value("auth", sess.pick(RD.as_ref()));
 			lqctx.add_value("token", sess.pick(TK.as_ref()));

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -862,9 +862,10 @@ impl Datastore {
 	pub async fn process_lq_notifications(
 		&self,
 		stk: &mut Stk,
+		ctx: &Context<'_>,
 		opt: &Options,
 	) -> Result<(), Error> {
-		process_lq_notifications(self, stk, opt).await
+		process_lq_notifications(self, ctx, stk, opt).await
 	}
 
 	/// Add and kill live queries being track on the datastore
@@ -1227,6 +1228,8 @@ impl Datastore {
 		let ctx = vars.attach(ctx)?;
 		// Start a new transaction
 		let txn = self.transaction(val.writeable().into(), Optimistic).await?.enclose();
+		// Set the context transaction
+		let ctx = ctx.set_transaction(txn.clone());
 		// Compute the value
 		let res = stack.enter(|stk| val.compute(stk, &ctx, &opt, None)).finish().await;
 		// Store any data

--- a/core/src/kvs/lq_v2_fut.rs
+++ b/core/src/kvs/lq_v2_fut.rs
@@ -1,5 +1,6 @@
 use crate::cf;
 use crate::cf::ChangeSet;
+use crate::ctx::Context;
 use crate::dbs::{Options, Statement};
 use crate::err::Error;
 use crate::fflags::FFLAGS;
@@ -19,6 +20,7 @@ use tokio::sync::RwLock;
 /// Poll change feeds for live query notifications
 pub async fn process_lq_notifications(
 	ds: &Datastore,
+	ctx: &Context<'_>,
 	stk: &mut Stk,
 	opt: &Options,
 ) -> Result<(), Error> {
@@ -68,7 +70,7 @@ pub async fn process_lq_notifications(
 				.join("\n")
 		);
 		for change_set in change_sets {
-			process_change_set_for_notifications(ds, stk, opt, change_set, &lq_pairs).await?;
+			process_change_set_for_notifications(ds, ctx, stk, opt, change_set, &lq_pairs).await?;
 		}
 	}
 	trace!("Finished process lq successfully");
@@ -131,6 +133,7 @@ async fn populate_relevant_changesets(
 
 async fn process_change_set_for_notifications(
 	ds: &Datastore,
+	ctx: &Context<'_>,
 	stk: &mut Stk,
 	opt: &Options,
 	change_set: ChangeSet,
@@ -165,6 +168,7 @@ async fn process_change_set_for_notifications(
 							channel::bounded(notification_capacity);
 						doc.check_lqs_and_send_notifications(
 							stk,
+							ctx,
 							opt,
 							&Statement::Live(&lq_value.stm),
 							[&lq_value.stm].as_slice(),

--- a/lib/tests/live.rs
+++ b/lib/tests/live.rs
@@ -6,6 +6,7 @@ use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::fflags::FFLAGS;
 use surrealdb::sql::Value;
+use surrealdb_core::dbs::Options;
 
 #[tokio::test]
 async fn live_query_fails_if_no_change_feed() -> Result<(), Error> {
@@ -87,8 +88,9 @@ async fn live_query_sends_registered_lq_details() -> Result<(), Error> {
 	let result = res.remove(0);
 	assert!(result.result.is_ok());
 
-	let def = Default::default();
-	stack.enter(|stk| dbs.process_lq_notifications(stk, &def)).finish().await?;
+	let ctx = Default::default();
+	let opt = Options::default();
+	stack.enter(|stk| dbs.process_lq_notifications(stk, &ctx, &opt)).finish().await?;
 
 	let notifications_chan = dbs.notifications().unwrap();
 
@@ -148,8 +150,9 @@ async fn live_query_does_not_drop_notifications() -> Result<(), Error> {
 			assert!(result.result.is_ok());
 		}
 		// Process the notifications
-		let def = Default::default();
-		stack.enter(|stk| dbs.process_lq_notifications(stk, &def)).finish().await?;
+		let ctx = Default::default();
+		let opt = Options::default();
+		stack.enter(|stk| dbs.process_lq_notifications(stk, &ctx, &opt)).finish().await?;
 
 		let notifications_chan = dbs.notifications().unwrap();
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Transactions are now passed around in a context and live queries could be evaluated without a transaction associated with the context, causing a panic.
This should remove the panic.

## What does this change do?

Inject transaction to context in ds and ds tasks.

## What is your testing strategy?

Unit, integration

## Is this related to any issues?

#4258 

## Does this change need documentation?

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
