### PR TITLE
Add partial computation to values

### DIFF
--- a/core/src/doc/lives.rs
+++ b/core/src/doc/lives.rs
@@ -183,6 +183,9 @@ impl<'a> Document<'a> {
 			// document. If it is then we can continue.
 			match self.lq_check(stk, &lqctx, &lqopt, &lq, doc).await {
 				Err(Error::Ignore) => {
+					#[cfg(debug_assertions)]
+					trace!("live query {} did not match the where clause, skipping", lq);
+					#[cfg(not(debug_assertions))]
 					trace!("live query did not match the where clause, skipping");
 					continue;
 				}

--- a/core/src/sql/array.rs
+++ b/core/src/sql/array.rs
@@ -149,6 +149,23 @@ impl Array {
 		Ok(Value::Array(x))
 	}
 
+	pub(crate) async fn partially_compute(
+		&self,
+		stk: &mut Stk,
+		ctx: &Context<'_>,
+		opt: &Options,
+		doc: Option<&CursorDoc<'_>>,
+	) -> Result<Value, Error> {
+		let mut x = Self::with_capacity(self.len());
+		for v in self.iter() {
+			match v.partially_compute(stk, ctx, opt, doc).await {
+				Ok(v) => x.push(v),
+				Err(e) => return Err(e),
+			};
+		}
+		Ok(Value::Array(x))
+	}
+
 	pub(crate) fn is_all_none_or_null(&self) -> bool {
 		self.0.iter().all(|v| v.is_none_or_null())
 	}

--- a/core/src/sql/array.rs
+++ b/core/src/sql/array.rs
@@ -522,7 +522,6 @@ mod test {
 	use crate::kvs::{Datastore, LockType, TransactionType};
 	use crate::sql::{Array, Param, Value};
 	use reblessive::TreeStack;
-	use std::sync::Arc;
 
 	#[tokio::test]
 	async fn array_partial_compute() {

--- a/core/src/sql/graph.rs
+++ b/core/src/sql/graph.rs
@@ -1,3 +1,7 @@
+use crate::ctx::Context;
+use crate::dbs::Options;
+use crate::doc::CursorDoc;
+use crate::err::Error;
 use crate::sql::cond::Cond;
 use crate::sql::dir::Dir;
 use crate::sql::field::Fields;
@@ -8,6 +12,8 @@ use crate::sql::order::Orders;
 use crate::sql::split::Splits;
 use crate::sql::start::Start;
 use crate::sql::table::Tables;
+use crate::sql::Value;
+use reblessive::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter, Write};

--- a/core/src/sql/graph.rs
+++ b/core/src/sql/graph.rs
@@ -1,8 +1,5 @@
 use std::fmt::{self, Display, Formatter, Write};
 
-use revision::revisioned;
-use serde::{Deserialize, Serialize};
-use crate::sql::Cond;
 use crate::sql::dir::Dir;
 use crate::sql::field::Fields;
 use crate::sql::group::Groups;
@@ -12,6 +9,9 @@ use crate::sql::order::Orders;
 use crate::sql::split::Splits;
 use crate::sql::start::Start;
 use crate::sql::table::Tables;
+use crate::sql::Cond;
+use revision::revisioned;
+use serde::{Deserialize, Serialize};
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]

--- a/core/src/sql/graph.rs
+++ b/core/src/sql/graph.rs
@@ -1,8 +1,8 @@
-use crate::ctx::Context;
-use crate::dbs::Options;
-use crate::doc::CursorDoc;
-use crate::err::Error;
-use crate::sql::cond::Cond;
+use std::fmt::{self, Display, Formatter, Write};
+
+use revision::revisioned;
+use serde::{Deserialize, Serialize};
+use crate::sql::Cond;
 use crate::sql::dir::Dir;
 use crate::sql::field::Fields;
 use crate::sql::group::Groups;
@@ -12,11 +12,6 @@ use crate::sql::order::Orders;
 use crate::sql::split::Splits;
 use crate::sql::start::Start;
 use crate::sql::table::Tables;
-use crate::sql::Value;
-use reblessive::Stk;
-use revision::revisioned;
-use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter, Write};
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]

--- a/core/src/sql/idiom.rs
+++ b/core/src/sql/idiom.rs
@@ -215,7 +215,7 @@ impl Idiom {
 					limit: g.limit.clone(),
 					start: match g.clone().start {
 						None => None,
-						Some(s) => Start(s.0.partially_compute(stk, ctx, opt, doc).unwrap()),
+						Some(s) => Some(Start(s.0.partially_compute(stk, ctx, opt, doc).await?)),
 					},
 					alias: g.alias.clone(),
 				}),

--- a/core/src/sql/param.rs
+++ b/core/src/sql/param.rs
@@ -14,7 +14,7 @@ use std::{fmt, ops::Deref, str};
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Param";
 
 /// https://surrealdb.com/docs/surrealdb/surrealql/parameters#reserved-variable-names
-const RESERVED: [&'static str; 11] = [
+const RESERVED: [&str; 11] = [
 	"before", "after", "auth", "event", "input", "parent", "this", "scope", "session", "token",
 	"value",
 ];

--- a/core/src/sql/param.rs
+++ b/core/src/sql/param.rs
@@ -13,6 +13,12 @@ use std::{fmt, ops::Deref, str};
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Param";
 
+/// https://surrealdb.com/docs/surrealdb/surrealql/parameters#reserved-variable-names
+const RESERVED: [&'static str; 11] = [
+	"before", "after", "auth", "event", "input", "parent", "this", "scope", "session", "token",
+	"value",
+];
+
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Param")]
@@ -110,10 +116,114 @@ impl Param {
 			},
 		}
 	}
+
+	/// Evaluate a param if it is not reserved
+	pub(crate) async fn partially_compute(
+		&self,
+		stk: &mut Stk,
+		ctx: &Context<'_>,
+		opt: &Options,
+		doc: Option<&CursorDoc<'_>>,
+	) -> Result<Value, Error> {
+		// Check if the param is reserved
+		if RESERVED.contains(&self.as_str().to_lowercase().as_str()) {
+			// Return the param as a value
+			Ok(Value::Param(self.clone()))
+		} else {
+			// Evaluate the param
+			self.compute(stk, ctx, opt, doc).await
+		}
+	}
 }
 
 impl fmt::Display for Param {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "${}", &self.0 .0)
+	}
+}
+
+#[cfg(test)]
+#[cfg(feature = "kv-mem")]
+mod test {
+	use crate::dbs::Options;
+	use crate::kvs::{Datastore, LockType, TransactionType};
+	use crate::sql::Param;
+
+	#[tokio::test]
+	async fn params_evaluate_except_reserved_in_partial_compute() {
+		use crate::ctx::Context;
+		use crate::sql::Value;
+		use reblessive::TreeStack;
+
+		let ds = Datastore::new("memory").await.unwrap();
+
+		struct Case {
+			param: Param,
+			expected: Value,
+			val: Option<(&'static str, Value)>,
+		};
+		let cases = map! {
+			"normal params get evaluated" => Case{param: Param::from("test"),
+				expected: Value::Number(1.0.into()),
+				val: Some(("test", Value::Number(1.0.into())))},
+			"normal params missing context" => Case{param: Param::from("test"),
+				expected: Value::None,
+				val: None},
+			"reserved - this" => Case{param: "this".into(),
+				expected: Value::Param(Param::from("this")),
+				val: Some(("this", Value::Number(1.0.into())))},
+			"reserved - before" => Case{param: "before".into(),
+				expected: Value::Param(Param::from("before")),
+				val: Some(("before", Value::Number(1.0.into())))},
+			"reserved - after" => Case{param: Param::from("after"),
+				expected: Value::Param(Param::from("after")),
+				val: Some(("after", Value::Number(1.0.into())))},
+			"reserved - auth" => Case{param: Param::from("auth"),
+				expected: Value::Param(Param::from("auth")),
+				val: Some(("auth", Value::Number(1.0.into())))},
+			"reserved - event" => Case{param: Param::from("event"),
+				expected: Value::Param(Param::from("event")),
+				val: Some(("event", Value::Number(1.0.into())))},
+			"reserved - input" => Case{param: Param::from("input"),
+				expected: Value::Param(Param::from("input")),
+				val: Some(("input", Value::Number(1.0.into())))},
+			"reserved - parent" => Case{param: Param::from("parent"),
+				expected: Value::Param(Param::from("parent")),
+				val: Some(("parent", Value::Number(1.0.into())))},
+			"reserved - this" => Case{param: Param::from("this"),
+				expected: Value::Param(Param::from("this")),
+				val: Some(("this", Value::Number(1.0.into())))},
+			"reserved - scope" => Case{param: Param::from("scope"),
+				expected: Value::Param(Param::from("scope")),
+				val: Some(("scope", Value::Number(1.0.into())))},
+			"reserved - session" => Case{param: Param::from("session"),
+				expected: Value::Param(Param::from("session")),
+				val: Some(("session", Value::Number(1.0.into())))},
+			"reserved - token" => Case{param: Param::from("token"),
+				expected: Value::Param(Param::from("token")),
+				val: Some(("token", Value::Number(1.0.into())))},
+			"reserved - value" => Case{param: Param::from("value"),
+				expected: Value::Param(Param::from("value")),
+				val: Some(("value", Value::Number(1.0.into())))},
+		};
+
+		let tx =
+			ds.transaction(TransactionType::Write, LockType::Optimistic).await.unwrap().enclose();
+		let mut stack = TreeStack::new();
+		for (name, case) in cases {
+			let mut ctx = Context::default().set_transaction(tx.clone());
+			let opt = Options::new().with_ns(Some("test".into())).with_db(Some("test".into()));
+			if let Some((k, v)) = case.val {
+				ctx.add_value(k, v);
+			}
+			let param = stack
+				.enter(|stk| async {
+					case.param.partially_compute(stk, &ctx, &opt, None).await.unwrap()
+				})
+				.finish()
+				.await;
+			assert_eq!(param, case.expected, "{}", name);
+		}
+		tx.lock().await.commit().await.unwrap();
 	}
 }

--- a/core/src/sql/param.rs
+++ b/core/src/sql/param.rs
@@ -1,3 +1,4 @@
+use crate::cnf::PROTECTED_PARAM_NAMES;
 use crate::{
 	ctx::Context,
 	dbs::Options,
@@ -14,10 +15,8 @@ use std::{fmt, ops::Deref, str};
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Param";
 
 /// https://surrealdb.com/docs/surrealdb/surrealql/parameters#reserved-variable-names
-const RESERVED: [&str; 11] = [
-	"before", "after", "auth", "event", "input", "parent", "this", "scope", "session", "token",
-	"value",
-];
+const RESERVED: [&str; 8] =
+	["before", "after", "event", "input", "parent", "this", "scope", "value"];
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -126,7 +125,8 @@ impl Param {
 		doc: Option<&CursorDoc<'_>>,
 	) -> Result<Value, Error> {
 		// Check if the param is reserved
-		if RESERVED.contains(&self.as_str().to_lowercase().as_str()) {
+		let normalised = self.as_str().to_lowercase().as_str();
+		if RESERVED.contains(&normalised) || PROTECTED_PARAM_NAMES.contains(&normalised) {
 			// Return the param as a value
 			Ok(Value::Param(self.clone()))
 		} else {

--- a/core/src/sql/param.rs
+++ b/core/src/sql/param.rs
@@ -125,8 +125,10 @@ impl Param {
 		doc: Option<&CursorDoc<'_>>,
 	) -> Result<Value, Error> {
 		// Check if the param is reserved
-		let normalised = self.as_str().to_lowercase().as_str();
-		if RESERVED.contains(&normalised) || PROTECTED_PARAM_NAMES.contains(&normalised) {
+		let normalised = self.as_str().to_lowercase();
+		if RESERVED.contains(&normalised.as_str())
+			|| PROTECTED_PARAM_NAMES.contains(&normalised.as_str())
+		{
 			// Return the param as a value
 			Ok(Value::Param(self.clone()))
 		} else {

--- a/core/src/sql/statements/live.rs
+++ b/core/src/sql/statements/live.rs
@@ -134,6 +134,13 @@ impl LiveStatement {
 			false => {
 				// Claim transaction
 				let mut run = ctx.tx_lock().await;
+				// Process the condition params
+				let condition = match stm.cond.as_mut() {
+					None => None,
+					Some(cond) => Some(Cond(cond.partially_compute(stk, ctx, opt, doc).await?)),
+				};
+				// Overwrite the condition params
+				stm.cond = condition;
 				// Process the live query table
 				match stm.what.compute(stk, ctx, opt, doc).await? {
 					Value::Table(tb) => {

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -2689,14 +2689,9 @@ impl Value {
 			Value::Param(v) => stk.run(|stk| v.compute(stk, ctx, opt, doc)).await,
 			// Anything that contains params gets partially computed
 			Value::Array(v) => stk.run(|stk| v.partially_compute(stk, ctx, opt, doc)).await,
-			// If params cannot exist then it remains un-computed
 			Value::Expression(e) => stk.run(|stk| e.partially_compute(stk, ctx, opt, doc)).await,
-			Value::Idiom(i) => {
-				trace!("Partially compute idiom at {}", i.to_string());
-				Ok(self.to_owned())
-			}
+			// If params cannot exist then it remains un-computed
 			_ => {
-				trace!("Partially compute terminated at {}", self.to_string());
 				Ok(self.to_owned())
 			}
 		}

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -2686,7 +2686,7 @@ impl Value {
 
 		match self {
 			// We only want to process params
-			Value::Param(v) => stk.run(|stk| v.compute(stk, ctx, opt, doc)).await,
+			Value::Param(v) => stk.run(|stk| v.partially_compute(stk, ctx, opt, doc)).await,
 			// Anything that contains params gets partially computed
 			Value::Array(v) => stk.run(|stk| v.partially_compute(stk, ctx, opt, doc)).await,
 			Value::Expression(e) => stk.run(|stk| e.partially_compute(stk, ctx, opt, doc)).await,

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -2690,6 +2690,7 @@ impl Value {
 			// Anything that contains params gets partially computed
 			Value::Array(v) => stk.run(|stk| v.partially_compute(stk, ctx, opt, doc)).await,
 			Value::Expression(e) => stk.run(|stk| e.partially_compute(stk, ctx, opt, doc)).await,
+			Value::Idiom(v) => stk.run(|stk| v.partially_compute(stk, ctx, opt, doc)).await,
 			// If params cannot exist then it remains un-computed
 			_ => Ok(self.to_owned()),
 		}

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -2691,9 +2691,7 @@ impl Value {
 			Value::Array(v) => stk.run(|stk| v.partially_compute(stk, ctx, opt, doc)).await,
 			Value::Expression(e) => stk.run(|stk| e.partially_compute(stk, ctx, opt, doc)).await,
 			// If params cannot exist then it remains un-computed
-			_ => {
-				Ok(self.to_owned())
-			}
+			_ => Ok(self.to_owned()),
 		}
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Live queries can be provided with conditions that include parameters. Evaluating the parameters requires replacing the parameters (computing), while retaining the rest of the expression intact.
This change adds `partial_compute` to process a value, replacing Params and retaining the initial structure.
This allows us to record the semi-evaluated filter on live queries with parameters while not fully evaluating the expression to true/false at the point it is created.

## What does this change do?

Add partial computation of values

## What is your testing strategy?

Integration, unit

## Is this related to any issues?

#2623 

## Does this change need documentation?

- [ ] No documentation needed
- [x] surrealdb/docs.surrealdb.com#653

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
