### PR TITLE
Bump version to v1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5405,7 +5405,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "surreal"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-channel 1.9.0",
  "bincode",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "addr",
  "any_ascii",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surreal"
 publish = false
 edition = "2021"
-version = "1.5.0"
+version = "1.5.1"
 license-file = "LICENSE"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surrealdb-core"
 publish = true
 edition = "2021"
-version = "1.5.0"
+version = "1.5.1"
 rust-version = "1.70.0"
 readme = "../lib/CARGO.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surrealdb"
 publish = false
 edition = "2021"
-version = "1.5.0"
+version = "1.5.1"
 rust-version = "1.70.0"
 readme = "CARGO.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]


### PR DESCRIPTION
## What is the motivation?

To prepare for `sql1` release.

## What does this change do?

It bumps `sql1` version to `1.5.1`.

## What is your testing strategy?

Github Actions.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
