### PR TITLE
Make it easy to run cargo test locally

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -110,7 +110,7 @@ run_task = { name = ["start-surrealdb", "test-api-integration", "stop-surrealdb"
 [tasks.test-database-upgrade]
 private = true
 command = "cargo"
-env = { RUST_BACKTRACE = 1, RUST_LOG = "info" }
+env = { RUST_BACKTRACE = 1, RUST_LOG = "info", RUSTFLAGS = "--cfg docker" }
 args = ["test", "--locked", "--no-default-features", "--features", "${_TEST_FEATURES}", "--workspace", "--test", "database_upgrade", "--", "database_upgrade", "--show-output"]
 
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1109,6 +1109,7 @@ mod cli_integration {
 		}
 
 		info!("* The path is a valid directory");
+		#[cfg(feature = "storage-surrealkv")]
 		{
 			let path = format!("surrealkv:{}", tempfile::tempdir().unwrap().path().display());
 			let temp_dir = tempfile::tempdir().unwrap();

--- a/tests/database_upgrade.rs
+++ b/tests/database_upgrade.rs
@@ -3,6 +3,7 @@
 
 mod common;
 
+#[cfg(docker)]
 mod database_upgrade {
 	use super::common::docker::DockerContainer;
 	use super::common::expected::Expected;


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Currently it's not that straightforward to run `cargo test` locally, because one of the cli integration tests depends on a non-default feature, and the database upgrade tests require Docker which might not be installed.

## What does this change do?

- Hide `"* The path is a valid directory"` cli integration test  behind `storage-surrealkv` feature.
- Define a custom Rust flag `docker` to be passed via `RUSTFLAGS` env var in the `test-database-upgrade` task. Make the database upgrade tests hidden behind this new flag.

## What is your testing strategy?

Successful local run of `cargo test` and CI.

## Is this related to any issues?

No.

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

No.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [x] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
