### PR TITLE
Allow defining JWT access at the root level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,9 @@ jobs:
         run: cargo install --debug --locked cargo-make
 
       - name: Test workspace + coverage
-        run: CARGO_BUILD_JOBS=4 cargo make ci-workspace-coverage
+        run: cargo make ci-workspace-coverage
+        env:
+          CARGO_BUILD_JOBS: 4
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,13 +291,8 @@ jobs:
       - name: Install cargo-make
         run: cargo install --debug --locked cargo-make
 
-      - name: Increase swap space
-        uses: actionhippie/swap-space@v1
-        with:
-          size: 10G
-
       - name: Test workspace + coverage
-        run: cargo make ci-workspace-coverage
+        run: CARGO_BUILD_JOBS=4 cargo make ci-workspace-coverage
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,11 @@ jobs:
       - name: Install cargo-make
         run: cargo install --debug --locked cargo-make
 
+      - name: Increase swap space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
       - name: Test workspace + coverage
         run: cargo make ci-workspace-coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,8 +293,6 @@ jobs:
 
       - name: Test workspace + coverage
         run: cargo make ci-workspace-coverage
-        env:
-          CARGO_BUILD_JOBS: 4
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,9 +292,9 @@ jobs:
         run: cargo install --debug --locked cargo-make
 
       - name: Increase swap space
-        uses: pierotofy/set-swap-space@master
+        uses: actionhippie/swap-space@v1
         with:
-          swap-size-gb: 10
+          size: 10G
 
       - name: Test workspace + coverage
         run: cargo make ci-workspace-coverage

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -930,20 +930,20 @@ pub enum Error {
 	Serialization(String),
 
 	/// The requested root access method already exists
-	#[error("The access method '{value}' already exists in root")]
+	#[error("The root access method '{value}' already exists")]
 	AccessRootAlreadyExists {
 		value: String,
 	},
 
 	/// The requested namespace access method already exists
-	#[error("The access method '{value}' already exists in namespace '{ns}'")]
+	#[error("The access method '{value}' already exists in the namespace '{ns}'")]
 	AccessNsAlreadyExists {
 		value: String,
 		ns: String,
 	},
 
 	/// The requested database access method already exists
-	#[error("The access method '{value}' already exists in database '{db}'")]
+	#[error("The access method '{value}' already exists in the database '{db}'")]
 	AccessDbAlreadyExists {
 		value: String,
 		ns: String,
@@ -951,20 +951,20 @@ pub enum Error {
 	},
 
 	/// The requested root access method does not exist
-	#[error("The access method '{value}' does not exist in root")]
+	#[error("The root access method '{value}' does not exist")]
 	AccessRootNotFound {
 		value: String,
 	},
 
 	/// The requested namespace access method does not exist
-	#[error("The access method '{value}' does not exist in namespace '{ns}'")]
+	#[error("The access method '{value}' does not exist in the namespace '{ns}'")]
 	AccessNsNotFound {
 		value: String,
 		ns: String,
 	},
 
 	/// The requested database access method does not exist
-	#[error("The access method '{value}' does not exist in database '{db}'")]
+	#[error("The access method '{value}' does not exist in the database '{db}'")]
 	AccessDbNotFound {
 		value: String,
 		ns: String,

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -298,12 +298,6 @@ pub enum Error {
 		value: String,
 	},
 
-	/// The requested namespace access method does not exist
-	#[error("The namespace access method '{value}' does not exist")]
-	NaNotFound {
-		value: String,
-	},
-
 	/// The requested namespace login does not exist
 	#[error("The namespace login '{value}' does not exist")]
 	NlNotFound {
@@ -313,12 +307,6 @@ pub enum Error {
 	/// The requested database does not exist
 	#[error("The database '{value}' does not exist")]
 	DbNotFound {
-		value: String,
-	},
-
-	/// The requested database access method does not exist
-	#[error("The database access method '{value}' does not exist")]
-	DaNotFound {
 		value: String,
 	},
 
@@ -942,39 +930,45 @@ pub enum Error {
 	Serialization(String),
 
 	/// The requested root access method already exists
-	#[error("The root access method '{value}' already exists")]
+	#[error("The access method '{value}' already exists in root")]
 	AccessRootAlreadyExists {
 		value: String,
 	},
 
 	/// The requested namespace access method already exists
-	#[error("The namespace access method '{value}' already exists")]
+	#[error("The access method '{value}' already exists in namespace '{ns}'")]
 	AccessNsAlreadyExists {
 		value: String,
+		ns: String,
 	},
 
 	/// The requested database access method already exists
-	#[error("The database access method '{value}' already exists")]
+	#[error("The access method '{value}' already exists in database '{db}'")]
 	AccessDbAlreadyExists {
 		value: String,
+		ns: String,
+		db: String,
 	},
 
 	/// The requested root access method does not exist
-	#[error("The root access method '{value}' does not exist")]
+	#[error("The access method '{value}' does not exist in root")]
 	AccessRootNotFound {
 		value: String,
 	},
 
 	/// The requested namespace access method does not exist
-	#[error("The namespace access method '{value}' does not exist")]
+	#[error("The access method '{value}' does not exist in namespace '{ns}'")]
 	AccessNsNotFound {
 		value: String,
+		ns: String,
 	},
 
 	/// The requested database access method does not exist
-	#[error("The database access method '{value}' does not exist")]
+	#[error("The access method '{value}' does not exist in database '{db}'")]
 	AccessDbNotFound {
 		value: String,
+		ns: String,
+		db: String,
 	},
 
 	/// The access method cannot be defined on the requested level

--- a/core/src/key/mod.rs
+++ b/core/src/key/mod.rs
@@ -1,6 +1,7 @@
 //! How the keys are structured in the key value store
 ///
 /// crate::key::root::all                /
+/// crate::key::root::ac                 /!ac{ac}
 /// crate::key::root::hb                 /!hb{ts}/{nd}
 /// crate::key::root::nd                 /!nd{nd}
 /// crate::key::root::ni                 /!ni

--- a/core/src/kvs/cache.rs
+++ b/core/src/kvs/cache.rs
@@ -28,6 +28,7 @@ pub enum Entry {
 	Pa(Arc<DefineParamStatement>),
 	Tb(Arc<DefineTableStatement>),
 	// Multi definitions
+	Acs(Arc<[DefineAccessStatement]>),
 	Azs(Arc<[DefineAnalyzerStatement]>),
 	Dbs(Arc<[DefineDatabaseStatement]>),
 	Das(Arc<[DefineAccessStatement]>),

--- a/core/src/sql/statements/info.rs
+++ b/core/src/sql/statements/info.rs
@@ -91,6 +91,12 @@ impl InfoStatement {
 					tmp.insert(v.name.to_string(), v.to_string().into());
 				}
 				res.insert("users".to_owned(), tmp.into());
+				// Process the accesses
+				let mut tmp = Object::default();
+				for v in run.all_root_accesses().await?.iter() {
+					tmp.insert(v.name.to_string(), v.to_string().into());
+				}
+				res.insert("accesses".to_owned(), tmp.into());
 				// Ok all good
 				Value::from(res).ok()
 			}

--- a/core/src/sql/statements/info.rs
+++ b/core/src/sql/statements/info.rs
@@ -93,7 +93,7 @@ impl InfoStatement {
 				res.insert("users".to_owned(), tmp.into());
 				// Process the accesses
 				let mut tmp = Object::default();
-				for v in run.all_root_accesses().await?.iter() {
+				for v in run.all_root_accesses_redacted().await?.iter() {
 					tmp.insert(v.name.to_string(), v.to_string().into());
 				}
 				res.insert("accesses".to_owned(), tmp.into());

--- a/core/src/syn/parser/stmt/define.rs
+++ b/core/src/syn/parser/stmt/define.rs
@@ -287,6 +287,14 @@ impl Parser<'_> {
 						}
 						t!("RECORD") => {
 							self.pop_peek();
+							// The record access type can only be defined at the database level
+							if !matches!(res.base, Base::Db) {
+								unexpected!(
+									self,
+									t!("RECORD"),
+									"a valid access type at this level"
+								);
+							}
 							let mut ac = access_type::RecordAccess {
 								..Default::default()
 							};

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -29,6 +29,7 @@ async fn define_statement_namespace() -> Result<(), Error> {
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"{
+			accesses: {},
 			namespaces: { test: 'DEFINE NAMESPACE test' },
 			users: {},
 		}",
@@ -1429,6 +1430,48 @@ async fn permissions_checks_define_analyzer() {
 }
 
 #[tokio::test]
+async fn permissions_checks_define_access_root() {
+	let scenario = HashMap::from([
+		("prepare", ""),
+		("test", "DEFINE ACCESS access ON ROOT TYPE JWT ALGORITHM HS512 KEY 'secret'"),
+		("check", "INFO FOR ROOT"),
+	]);
+
+	// Define the expected results for the check statement when the test statement succeeded and when it failed
+	let check_results = [
+        vec!["{ accesses: { access: \"DEFINE ACCESS access ON ROOT TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION FOR TOKEN 1h, FOR SESSION NONE\" }, namespaces: {  }, users: {  } }"],
+		vec!["{ accesses: {  }, namespaces: {  }, users: {  } }"]
+    ];
+
+	let test_cases = [
+		// Root level
+		((().into(), Role::Owner), ("NS", "DB"), true),
+		((().into(), Role::Editor), ("NS", "DB"), false),
+		((().into(), Role::Viewer), ("NS", "DB"), false),
+		// Namespace level
+		((("NS",).into(), Role::Owner), ("NS", "DB"), false),
+		((("NS",).into(), Role::Owner), ("OTHER_NS", "DB"), false),
+		((("NS",).into(), Role::Editor), ("NS", "DB"), false),
+		((("NS",).into(), Role::Editor), ("OTHER_NS", "DB"), false),
+		((("NS",).into(), Role::Viewer), ("NS", "DB"), false),
+		((("NS",).into(), Role::Viewer), ("OTHER_NS", "DB"), false),
+		// Database level
+		((("NS", "DB").into(), Role::Owner), ("NS", "DB"), false),
+		((("NS", "DB").into(), Role::Owner), ("NS", "OTHER_DB"), false),
+		((("NS", "DB").into(), Role::Owner), ("OTHER_NS", "DB"), false),
+		((("NS", "DB").into(), Role::Editor), ("NS", "DB"), false),
+		((("NS", "DB").into(), Role::Editor), ("NS", "OTHER_DB"), false),
+		((("NS", "DB").into(), Role::Editor), ("OTHER_NS", "DB"), false),
+		((("NS", "DB").into(), Role::Viewer), ("NS", "DB"), false),
+		((("NS", "DB").into(), Role::Viewer), ("NS", "OTHER_DB"), false),
+		((("NS", "DB").into(), Role::Viewer), ("OTHER_NS", "DB"), false),
+	];
+
+	let res = iam_check_cases(test_cases.iter(), &scenario, check_results).await;
+	assert!(res.is_ok(), "{}", res.unwrap_err());
+}
+
+#[tokio::test]
 async fn permissions_checks_define_access_ns() {
 	let scenario = HashMap::from([
 		("prepare", ""),
@@ -1522,8 +1565,8 @@ async fn permissions_checks_define_user_root() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-        vec!["{ namespaces: {  }, users: { user: \"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER DURATION FOR TOKEN 15m, FOR SESSION 6h\" } }"],
-		vec!["{ namespaces: {  }, users: {  } }"]
+        vec!["{ accesses: {  }, namespaces: {  }, users: { user: \"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER DURATION FOR TOKEN 15m, FOR SESSION 6h\" } }"],
+		vec!["{ accesses: {  }, namespaces: {  }, users: {  } }"]
     ];
 
 	let test_cases = [

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -1274,8 +1274,8 @@ async fn permissions_checks_define_ns() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-		vec!["{ namespaces: { NS: 'DEFINE NAMESPACE NS' }, users: {  } }"],
-		vec!["{ namespaces: {  }, users: {  } }"],
+		vec!["{ accesses: {  }, namespaces: { NS: 'DEFINE NAMESPACE NS' }, users: {  } }"],
+		vec!["{ accesses: {  }, namespaces: {  }, users: {  } }"],
 	];
 
 	let test_cases = [
@@ -2148,9 +2148,9 @@ async fn define_remove_access() -> Result<(), Error> {
 	let mut t = Test::new(sql).await?;
 	t.skip_ok(1)?;
 	t.expect_val("None")?;
-	t.expect_error("The database access method 'example' already exists")?;
+	t.expect_error("The access method 'example' already exists in the database 'test'")?;
 	t.skip_ok(1)?;
-	t.expect_error("The database access method 'example' does not exist")?;
+	t.expect_error("The access method 'example' does not exist in the database 'test'")?;
 	t.expect_val("None")?;
 	Ok(())
 }

--- a/lib/tests/info.rs
+++ b/lib/tests/info.rs
@@ -628,7 +628,7 @@ async fn access_info_redacted_structure() {
 		assert!(out.is_ok(), "Unexpected error: {:?}", out);
 
 		let out_expected =
-			r#"{ accesses: [{ base: 'DATABASE', duration: { session: 6h, token: 15m }, kind: { jwt: { issuer: { alg: 'HS512', key: '[REDACTED]' }, verify: { alg: 'HS512', key: '[REDACTED]' } }, kind: 'RECORD' }, name: 'access' }], analyzers: {  }, functions: {  }, models: {  }, params: {  }, tables: {  }, users: {  } }"#.to_string();
+			r#"{ accesses: [{ base: 'DATABASE', duration: { session: 6h, token: 15m }, kind: { jwt: { issuer: { alg: 'HS512', key: '[REDACTED]' }, verify: { alg: 'HS512', key: '[REDACTED]' } }, kind: 'RECORD' }, name: 'access' }], analyzers: [], functions: [], models: [], params: [], tables: [], users: [] }"#.to_string();
 		let out_str = out.unwrap().to_string();
 		assert_eq!(
 			out_str, out_expected,

--- a/lib/tests/info.rs
+++ b/lib/tests/info.rs
@@ -12,6 +12,7 @@ async fn info_for_root() {
 	let sql = r#"
         DEFINE NAMESPACE NS;
         DEFINE USER user ON ROOT PASSWORD 'pass';
+        DEFINE ACCESS access ON ROOT TYPE JWT ALGORITHM HS512 KEY 'secret';
         INFO FOR ROOT
     "#;
 	let dbs = new_ds().await.unwrap();
@@ -23,8 +24,10 @@ async fn info_for_root() {
 	let out = res.pop().unwrap().output();
 	assert!(out.is_ok(), "Unexpected error: {:?}", out);
 
-	let output_regex =
-		Regex::new(r"\{ namespaces: \{ NS: .* \}, users: \{ user: .* \} \}").unwrap();
+	let output_regex = Regex::new(
+		r"\{ accesses: \{ access: .* \}, namespaces: \{ NS: .* \}, users: \{ user: .* \} \}",
+	)
+	.unwrap();
 	let out_str = out.unwrap().to_string();
 	assert!(
 		output_regex.is_match(&out_str),

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -758,7 +758,7 @@ async fn permissions_checks_remove_root_access() {
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
 		vec!["{ accesses: {  }, namespaces: {  }, users: {  } }"],
-        vec!["{ accesses: { access: \"DEFINE ACCESS access ON TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION FOR TOKEN 1h, FOR SESSION NONE\" }, namespaces: {  }, users: {  } }"],
+        vec!["{ accesses: { access: \"DEFINE ACCESS access ON ROOT TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION FOR TOKEN 1h, FOR SESSION NONE\" }, namespaces: {  }, users: {  } }"],
     ];
 
 	let test_cases = [

--- a/lib/tests/remove.rs
+++ b/lib/tests/remove.rs
@@ -522,7 +522,7 @@ async fn should_error_when_remove_and_access_does_not_exist() -> Result<(), Erro
 	assert_eq!(res.len(), 1);
 	//
 	let tmp = res.remove(0).result.unwrap_err();
-	assert!(matches!(tmp, Error::DaNotFound { .. }),);
+	assert!(matches!(tmp, Error::AccessDbNotFound { .. }),);
 
 	Ok(())
 }
@@ -589,8 +589,8 @@ async fn permissions_checks_remove_ns() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-		vec!["{ namespaces: {  }, users: {  } }"],
-		vec!["{ namespaces: { NS: 'DEFINE NAMESPACE NS' }, users: {  } }"],
+		vec!["{ accesses: {  }, namespaces: {  }, users: {  } }"],
+		vec!["{ accesses: {  }, namespaces: { NS: 'DEFINE NAMESPACE NS' }, users: {  } }"],
 	];
 
 	let test_cases = [
@@ -748,6 +748,48 @@ async fn permissions_checks_remove_analyzer() {
 }
 
 #[tokio::test]
+async fn permissions_checks_remove_root_access() {
+	let scenario = HashMap::from([
+		("prepare", "DEFINE ACCESS access ON ROOT TYPE JWT ALGORITHM HS512 KEY 'secret'"),
+		("test", "REMOVE ACCESS access ON ROOT"),
+		("check", "INFO FOR ROOT"),
+	]);
+
+	// Define the expected results for the check statement when the test statement succeeded and when it failed
+	let check_results = [
+		vec!["{ accesses: {  }, namespaces: {  }, users: {  } }"],
+        vec!["{ accesses: { access: \"DEFINE ACCESS access ON TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION FOR TOKEN 1h, FOR SESSION NONE\" }, namespaces: {  }, users: {  } }"],
+    ];
+
+	let test_cases = [
+		// Root level
+		((().into(), Role::Owner), ("NS", "DB"), true),
+		((().into(), Role::Editor), ("NS", "DB"), false),
+		((().into(), Role::Viewer), ("NS", "DB"), false),
+		// Namespace level
+		((("NS",).into(), Role::Owner), ("NS", "DB"), false),
+		((("NS",).into(), Role::Owner), ("OTHER_NS", "DB"), false),
+		((("NS",).into(), Role::Editor), ("NS", "DB"), false),
+		((("NS",).into(), Role::Editor), ("OTHER_NS", "DB"), false),
+		((("NS",).into(), Role::Viewer), ("NS", "DB"), false),
+		((("NS",).into(), Role::Viewer), ("OTHER_NS", "DB"), false),
+		// Database level
+		((("NS", "DB").into(), Role::Owner), ("NS", "DB"), false),
+		((("NS", "DB").into(), Role::Owner), ("NS", "OTHER_DB"), false),
+		((("NS", "DB").into(), Role::Owner), ("OTHER_NS", "DB"), false),
+		((("NS", "DB").into(), Role::Editor), ("NS", "DB"), false),
+		((("NS", "DB").into(), Role::Editor), ("NS", "OTHER_DB"), false),
+		((("NS", "DB").into(), Role::Editor), ("OTHER_NS", "DB"), false),
+		((("NS", "DB").into(), Role::Viewer), ("NS", "DB"), false),
+		((("NS", "DB").into(), Role::Viewer), ("NS", "OTHER_DB"), false),
+		((("NS", "DB").into(), Role::Viewer), ("OTHER_NS", "DB"), false),
+	];
+
+	let res = iam_check_cases(test_cases.iter(), &scenario, check_results).await;
+	assert!(res.is_ok(), "{}", res.unwrap_err());
+}
+
+#[tokio::test]
 async fn permissions_checks_remove_ns_access() {
 	let scenario = HashMap::from([
 		("prepare", "DEFINE ACCESS access ON NS TYPE JWT ALGORITHM HS512 KEY 'secret'"),
@@ -841,8 +883,8 @@ async fn permissions_checks_remove_root_user() {
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
 	let check_results = [
-		vec!["{ namespaces: {  }, users: {  } }"],
-        vec!["{ namespaces: {  }, users: { user: \"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER DURATION FOR TOKEN 1h, FOR SESSION NONE\" } }"],
+		vec!["{ accesses: {  }, namespaces: {  }, users: {  } }"],
+        vec!["{ accesses: {  }, namespaces: {  }, users: { user: \"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER DURATION FOR TOKEN 1h, FOR SESSION NONE\" } }"],
     ];
 
 	let test_cases = [

--- a/lib/tests/strict.rs
+++ b/lib/tests/strict.rs
@@ -233,6 +233,7 @@ async fn loose_mode_all_ok() -> Result<(), Error> {
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"{
+			accesses: {},
 			namespaces: { test: 'DEFINE NAMESPACE test' },
 			users: {},
 		}",


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To support users in providing authentication to the root of their SurrealDB instance via JWT.

## What does this change do?

- Supports the definition of access methods at the root level.
- Removes duplicated errors and adds some verbosity to access level errors.
- Ensures that the `RECORD` access type can only be defined `ON DATABASE`.

## What is your testing strategy?

Add tests for parsing, token verification and the `INFO` statement at root level.

## Is this related to any issues?

No.

## Does this change need documentation?

Yes, this will require updating the `DEFINE ACCESS` documentation.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
