### PR TITLE
Separate supply chain actions on its own workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,47 +66,6 @@ jobs:
       - name: Check workspace
         run: cargo make ci-check
 
-  check-dependencies:
-    name: Check dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: rustfmt
-
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Install cargo-deny
-        run: cargo install --debug --locked cargo-deny@0.14.11
-
-      - name: Install cargo-vet
-        run: cargo install --debug --locked cargo-vet
-
-      - name: Install cargo-acl
-        run: |
-          cargo install --debug --locked cargo-acl
-          sudo apt-get install -y bubblewrap
-
-      - name: Check dependencies for known issues
-        run: cargo deny check
-
-      - name: Check dependencies for untrusted sources
-        run: cargo vet
-
-      - name: Check dependencies for unauthorized access
-        env:
-          RUSTFLAGS: "--cfg surrealdb_unstable"
-        run: cargo acl -n
-
-      - name: Dependency check failure
-        if: failure()
-        run: |
-          echo "## :warning: Dependency check failed" >> $GITHUB_STEP_SUMMARY
-          echo "See instructions in the [supply chain security process](https://github.com/surrealdb/surrealdb/blob/main/supply-chain/README.md#Process)." >> $GITHUB_STEP_SUMMARY
-
   check-fuzzing:
     name: Check fuzzing
     runs-on: ubuntu-latest

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,75 @@
+name: Supply chain security 
+
+run-name: "Supply chain security run '${{ github.head_ref || github.ref_name }}'"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - core/Cargo.toml
+      - lib/Cargo.toml
+      - supply-chain/audits.toml
+      - supply-chain/config.toml
+      - supply-chain/imports.lock
+      - cackle.toml
+    branches:
+      - main
+  pull_request:
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - core/Cargo.toml
+      - lib/Cargo.toml
+      - supply-chain/audits.toml
+      - supply-chain/config.toml
+      - supply-chain/imports.lock
+      - cackle.toml
+  merge_group:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check-dependencies:
+    name: Check dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install cargo-deny
+        run: cargo install --debug --locked cargo-deny@0.14.11
+
+      - name: Install cargo-vet
+        run: cargo install --debug --locked cargo-vet
+
+      - name: Install cargo-acl
+        run: |
+          cargo install --debug --locked cargo-acl
+          sudo apt-get install -y bubblewrap
+
+      - name: Check dependencies for known issues
+        run: cargo deny check
+
+      - name: Check dependencies for untrusted sources
+        run: cargo vet
+
+      - name: Check dependencies for unauthorized access
+        env:
+          RUSTFLAGS: "--cfg surrealdb_unstable"
+        run: cargo acl -n
+
+      - name: Dependency check failure
+        if: failure()
+        run: |
+          echo "## :warning: Dependency check failed" >> $GITHUB_STEP_SUMMARY
+          echo "See instructions in the [supply chain security process](https://github.com/surrealdb/surrealdb/blob/main/supply-chain/README.md#Process)." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -14,6 +14,7 @@ on:
       - supply-chain/config.toml
       - supply-chain/imports.lock
       - cackle.toml
+      - .github/workflows/supply-chain.yml
     branches:
       - main
   pull_request:
@@ -26,6 +27,7 @@ on:
       - supply-chain/config.toml
       - supply-chain/imports.lock
       - cackle.toml
+      - .github/workflows/supply-chain.yml
   merge_group:
 
 defaults:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Install cargo-deny
+        run: cargo install --debug --locked cargo-deny@0.14.11
+
       - name: Check dependencies for known issues
         run: cargo deny check
 

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -33,8 +33,8 @@ defaults:
     shell: bash
 
 jobs:
-  check-dependencies:
-    name: Check dependencies
+  cargo-deny:
+    name: Check dependencies for known issues
     runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain
@@ -46,22 +46,55 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install cargo-deny
-        run: cargo install --debug --locked cargo-deny@0.14.11
+      - name: Check dependencies for known issues
+        run: cargo deny check
+
+      - name: Dependency check failure
+        if: failure()
+        run: |
+          echo "## :warning: Supply chain security check failed" >> $GITHUB_STEP_SUMMARY
+          echo "See instructions in the [supply chain security process](https://github.com/surrealdb/surrealdb/blob/main/supply-chain/README.md#Process)." >> $GITHUB_STEP_SUMMARY
+  cargo-vet:
+    name: Check dependencies for untrusted sources 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
       - name: Install cargo-vet
         run: cargo install --debug --locked cargo-vet
+
+      - name: Check dependencies for untrusted sources
+        run: cargo vet
+
+      - name: Dependency check failure
+        if: failure()
+        run: |
+          echo "## :warning: Supply chain security check failed" >> $GITHUB_STEP_SUMMARY
+          echo "See instructions in the [supply chain security process](https://github.com/surrealdb/surrealdb/blob/main/supply-chain/README.md#Process)." >> $GITHUB_STEP_SUMMARY
+  cargo-acl:
+    name: Check dependencies for unauthorized access
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
       - name: Install cargo-acl
         run: |
           cargo install --debug --locked cargo-acl
           sudo apt-get install -y bubblewrap
-
-      - name: Check dependencies for known issues
-        run: cargo deny check
-
-      - name: Check dependencies for untrusted sources
-        run: cargo vet
 
       - name: Check dependencies for unauthorized access
         env:
@@ -71,5 +104,5 @@ jobs:
       - name: Dependency check failure
         if: failure()
         run: |
-          echo "## :warning: Dependency check failed" >> $GITHUB_STEP_SUMMARY
+          echo "## :warning: Supply chain security check failed" >> $GITHUB_STEP_SUMMARY
           echo "See instructions in the [supply chain security process](https://github.com/surrealdb/surrealdb/blob/main/supply-chain/README.md#Process)." >> $GITHUB_STEP_SUMMARY

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,4 +174,3 @@ assets = [
 ]
 extended-description = "A scalable, distributed, collaborative, document-graph database, for the realtime web."
 license-file = ["LICENSE", "4"]
-# Dummy line, remove after testing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,4 +174,3 @@ assets = [
 ]
 extended-description = "A scalable, distributed, collaborative, document-graph database, for the realtime web."
 license-file = ["LICENSE", "4"]
-# Dummy line

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,3 +174,4 @@ assets = [
 ]
 extended-description = "A scalable, distributed, collaborative, document-graph database, for the realtime web."
 license-file = ["LICENSE", "4"]
+# Dummy line, remove after testing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,3 +174,4 @@ assets = [
 ]
 extended-description = "A scalable, distributed, collaborative, document-graph database, for the realtime web."
 license-file = ["LICENSE", "4"]
+# Dummy line


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To reduce the time that actions take to run by only running the supply chain actions when dependencies change.

## What does this change do?

Separates the supply chain security actions on its own workflow that only runs when the following files are modified:

      - Cargo.lock
      - Cargo.toml
      - core/Cargo.toml
      - lib/Cargo.toml
      - supply-chain/audits.toml
      - supply-chain/config.toml
      - supply-chain/imports.lock
      - cackle.toml
      - .github/workflows/supply-chain.yml

## What is your testing strategy?

Ensure that the workflow runs successfully on main.

## Is this related to any issues?

The pain that every SurrealDB contributor endures while waiting for the dependency checking action to finish.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
