### PR TITLE
Limit number of jobs during tests with coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,8 @@ jobs:
 
       - name: Test workspace + coverage
         run: cargo make ci-workspace-coverage
+        env:
+          CARGO_BUILD_JOBS: 4
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To resolve the fact that Github Actions runners are being terminated during the build at the "Test workspace + coverage" stage. This is almost certainly related to memory usage and the termination seems to be due to the healthcheck failing and the runner receiving a termination signal from the runner scheduler.

## What does this change do?

Limits the number of jobs to four. This is the same configuration that I use in my laptop with 16GB of RAM. The runners that we use also have 16GB of RAM. This change seems to reliably allow the stage to run.

## What is your testing strategy?

Repeatedly trigger the stage to ensure that it no longer fails.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
