### PR TITLE
Bugfix 4082 cli version check

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,6 +29,7 @@ use start::StartCommandArguments;
 use std::ops::Deref;
 use std::process::ExitCode;
 use std::time::Duration;
+use tracing_subscriber::{fmt, EnvFilter};
 use upgrade::UpgradeCommandArguments;
 use validate::ValidateCommandArguments;
 use version::VersionCommandArguments;
@@ -90,35 +91,51 @@ enum Commands {
 }
 
 pub async fn init() -> ExitCode {
-	// Start a new CPU profiler
-	#[cfg(feature = "performance-profiler")]
-	let guard = pprof::ProfilerGuardBuilder::default()
-		.frequency(1000)
-		.blocklist(&["libc", "libgcc", "pthread", "vdso"])
-		.build()
-		.unwrap();
-	// Parse the CLI arguments
 	let args = Cli::parse();
+	let subscriber = fmt::Subscriber::builder().with_env_filter(EnvFilter::new("warn")).finish();
 
-	#[cfg(debug_assertions)]
-	println!("{DEBUG_BUILD_WARNING}");
+	tracing::subscriber::with_default(subscriber, || {
+		// Start a new CPU profiler
+		#[cfg(feature = "performance-profiler")]
+		let guard = pprof::ProfilerGuardBuilder::default()
+			.frequency(1000)
+			.blocklist(&["libc", "libgcc", "pthread", "vdso"])
+			.build()
+			.unwrap();
+		// Parse the CLI arguments
 
-	// After parsing arguments, we check the version online
-	if args.online_version_check {
-		let client = version_client::new(Some(Duration::from_millis(500))).unwrap();
-		if let Err(opt_version) = check_upgrade(&client, PKG_VERSION.deref()).await {
-			match opt_version {
-				None => {
-					warn!("A new version of SurrealDB may be available.");
-				}
-				Some(new_version) => {
-					warn!("A new version of SurrealDB is available: {}", new_version);
-				}
-			}
-			// TODO ansi_term crate?
-			warn!("You can upgrade using the {} command", "surreal upgrade");
+		#[cfg(debug_assertions)]
+		println!("{DEBUG_BUILD_WARNING}");
+
+		// After parsing arguments, we check the version online
+		println!("Checking online version... {}", args.online_version_check);
+		if args.online_version_check {
+			println!("Online version check code reached");
+			let client = version_client::new(Some(Duration::from_millis(500))).unwrap();
+			tokio::task::block_in_place(|| {
+				tokio::runtime::Handle::current().block_on(async {
+					if let Err(opt_version) = check_upgrade(&client, PKG_VERSION.deref()).await {
+						println!("Reached0 {:?}", opt_version);
+						match opt_version {
+							None => {
+								println!("Reached1");
+								warn!("A new version of SurrealDB may be available.");
+							}
+							Some(new_version) => {
+								println!("Reached2");
+								warn!("A new version of SurrealDB is available: {}", new_version);
+							}
+						}
+						// TODO ansi_term crate?
+						warn!("You can upgrade using the {} command", "surreal upgrade");
+					}
+				});
+			});
+			println!("Reached3");
+			warn!("Reached warning");
 		}
-	}
+	});
+
 	// After version warning we can run the respective command
 	let output = match args.command {
 		Commands::Start(args) => start::init(args).await,
@@ -147,6 +164,7 @@ pub async fn init() -> ExitCode {
 		profile.encode(&mut content).unwrap();
 		file.write_all(&content).unwrap();
 	};
+
 	// Error and exit the programme
 	if let Err(e) = output {
 		error!("{}", e);
@@ -163,6 +181,8 @@ async fn check_upgrade<C: VersionClient>(
 	client: &C,
 	pkg_version: &str,
 ) -> Result<(), Option<Version>> {
+	// Simulate old version
+	return Err(Some(Version::new(1,5,1)));
 	if let Ok(version) = client.fetch("latest").await {
 		// Request was successful, compare against current
 		let old_version = upgrade::parse_version(pkg_version).unwrap();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -54,7 +54,7 @@ struct Cli {
 	#[command(subcommand)]
 	command: Commands,
 	#[arg(help = "Whether to allow web check for client version upgrades at start")]
-	#[arg(env = "SURREAL_ONLINE_VERSION_CHECK", long)]
+	#[arg(env = "SURREAL_ONLINE_VERSION_CHECK", global = true, long, action = clap::ArgAction::Set)]
 	#[arg(default_value_t = true)]
 	online_version_check: bool,
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

This PR aims to fix 2 issues:
1. The `--online-version-check` flag could not be set at the command level and also could not be set to false.
2. When `--online-version-check` flag was set to true, no logs appeared. This is because we only initialise the logger at the command level so no logger has yet been initialised when calling `warn!` ... so nothing logs.

## What does this change do?

To handle (1), the flag was set to global so it applied to commands as well and I enabled setting the boolean value of `--online-version-check`.
To handle (2), I considered a couple of solutions, noting the tricky bit to solve is that I can't simply instantiate a global logger at the init func because the logger can't be initialised twice):
1. Initialising a reloadable logger using a [reload_handle](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/reload/index.html) and then updating the logger to become immutable at the command level. I think this is the most elegant solution.
2. Buffering the logs in a `vec`, passing it to the command function and then flushing the logs once the global logger has been initialised.
3. Creating a scoped logger that isn't global that is used before the command funcs are called.
4. Move the shared logic that logs whether the version needs to be updated into a function and call it after the logger is initialised in each command function.

In this PR I've opted for (3) because it felt like the simplest to me. (1) feels like the most elegant but does require a bit of code to implement and (2) is a bit hacky and also requires a bit of boilerplate to implement the flushing. (4) is likely the easiest to do but requires remembering to call the function in each command. It also requires passing down the argument to the command, which may not necessarily be what we want to do for other command line options.

The main issue with my implementation of (3) is that I reference the `tracing` crate from `mod.rs`, which isn't ideal but I had some issues with getting it to work when I moved the closure into another function. I am thinking it is caused by the logger being present on a different thread to where the code is actually being run and figured I should check if I'm on the right track before continuing.

## What is your testing strategy?

Manually and with unit tests.

## Is this related to any issues?

Closes #4082 

## Does this change need documentation?

I will add documentation updates later. Please review my code first!

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

I will run `cargo fmt` once the pr has been reviewed.

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
