### PR TITLE
Properly revision `RecordAccess` structure

### DIFF
--- a/core/src/sql/access_type.rs
+++ b/core/src/sql/access_type.rs
@@ -260,14 +260,15 @@ pub struct JwtAccessVerifyJwks {
 	pub url: String,
 }
 
-#[revisioned(revision = 1)]
+#[revisioned(revision = 2)]
 #[derive(Debug, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RecordAccess {
 	pub signup: Option<Value>,
 	pub signin: Option<Value>,
-	pub authenticate: Option<Value>,
 	pub jwt: JwtAccess,
+	#[revision(start = 2)]
+	pub authenticate: Option<Value>,
 }
 
 impl Default for RecordAccess {


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To properly prevent a breaking change (#4343) in the datastore with the addition of the `AUTHENTICATE` statement (#4161) in `2.0.0-alpha.4`. Users can now safely update from any version prior to `2.0.0-alpha.4` to `2.0.0-alpha.6`, when released, without having to perform any datastore migrations. Users that did create their datastore precisely on `2.0.0-alpha.4` or `2.0.0-alpha.5` may need to re-create it if it contained access methods.

It is worth noting that, although we will aim to minimize disruption and this breaking change was not intended, some breaking changes should still be expected during the alpha releases.

## What does this change do?

Correctly revisions the `RecordAccess` structure and annotates the `authenticate` field with the second revision.

## What is your testing strategy?

Ensure that a datastore with access methods created on `2.0.0-alpha.3` which could not be queried in  `2.0.0-alpha.5` can be correctly queried with a build that includes the changes in this PR. 

## Is this related to any issues?

- Closes #4343.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
