### PR TITLE
Allow bridge connectivity in all images built

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,16 +47,24 @@ COPY ${ARTIFACT_PREFIX}.${TARGETOS}-${TARGETARCH}/surreal /surreal
 
 RUN chmod +x /surreal
 
+# Allow connectivity from the host with bridge networking
+# This still requires publishing the port when running the container
+ENV SURREAL_BIND="0.0.0.0:8000"
+
 ENTRYPOINT ["/surreal"]
 
 #
-# Development image (built on the CI environment)
+# Production image (built on the CI environment)
 #
 FROM --platform=$TARGETPLATFORM cgr.dev/chainguard/glibc-dynamic:latest as prod-ci
 
 ARG TARGETPLATFORM
 
 COPY --from=dev-ci /surreal /surreal
+
+# Allow connectivity from the host with bridge networking
+# This still requires publishing the port when running the container
+ENV SURREAL_BIND="0.0.0.0:8000"
 
 ENTRYPOINT ["/surreal"]
 
@@ -72,6 +80,10 @@ COPY ${SURREALDB_BINARY} /surreal
 RUN chmod +x /surreal
 
 USER root
+
+# Allow connectivity from the host with bridge networking
+# This still requires publishing the port when running the container
+ENV SURREAL_BIND="0.0.0.0:8000"
 
 ENTRYPOINT ["/surreal"]
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

To correctly implement #4276 for all the Docker images built for SurrealDB. The current issue was that production images published to Dockerhub would still not bind to all interfaces and would not allow connectivity from the host by default.

## What does this change do?

Sets the `SURREAL_BIND` environment variable to `0.0.0.0:8000` for all images built, including production images built on CI, which are the ones published to Dockerhub. It also fixes a copy-paste error in a comment.

## What is your testing strategy?

Ensure that tests and actions pass and that images for `2.0.0-alpha.6` are built to include the environment variable.

## Is this related to any issues?

This is related to an issue reported via Discord.

## Does this change need documentation?

No. It was already updated in https://github.com/surrealdb/docs.surrealdb.com/pull/634.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
