### PR TITLE
Allow unsetting ns/db on rpc

### DIFF
--- a/core/src/rpc/args.rs
+++ b/core/src/rpc/args.rs
@@ -7,6 +7,7 @@ pub trait Take {
 	fn needs_one(self) -> Result<Value, RpcError>;
 	fn needs_two(self) -> Result<(Value, Value), RpcError>;
 	fn needs_three(self) -> Result<(Value, Value, Value), RpcError>;
+	fn needs_zero_one_or_two(self) -> Result<(Value, Value), RpcError>;
 	fn needs_one_or_two(self) -> Result<(Value, Value), RpcError>;
 	fn needs_one_two_or_three(self) -> Result<(Value, Value, Value), RpcError>;
 	fn needs_three_or_four(self) -> Result<(Value, Value, Value, Value), RpcError>;
@@ -45,6 +46,18 @@ impl Take for Array {
 		match (x.next(), x.next(), x.next()) {
 			(Some(a), Some(b), Some(c)) => Ok((a, b, c)),
 			_ => Err(RpcError::InvalidParams),
+		}
+	}
+	/// Convert the array to two arguments
+	fn needs_zero_one_or_two(self) -> Result<(Value, Value), RpcError> {
+		if self.len() > 2 {
+			return Err(RpcError::InvalidParams);
+		}
+		let mut x = self.into_iter();
+		match (x.next(), x.next()) {
+			(Some(a), Some(b)) => Ok((a, b)),
+			(Some(a), None) => Ok((a, Value::None)),
+			(_, _) => Ok((Value::None, Value::None)),
 		}
 	}
 	/// Convert the array to two arguments

--- a/core/src/rpc/args.rs
+++ b/core/src/rpc/args.rs
@@ -7,7 +7,6 @@ pub trait Take {
 	fn needs_one(self) -> Result<Value, RpcError>;
 	fn needs_two(self) -> Result<(Value, Value), RpcError>;
 	fn needs_three(self) -> Result<(Value, Value, Value), RpcError>;
-	fn needs_zero_one_or_two(self) -> Result<(Value, Value), RpcError>;
 	fn needs_one_or_two(self) -> Result<(Value, Value), RpcError>;
 	fn needs_one_two_or_three(self) -> Result<(Value, Value, Value), RpcError>;
 	fn needs_three_or_four(self) -> Result<(Value, Value, Value, Value), RpcError>;
@@ -46,18 +45,6 @@ impl Take for Array {
 		match (x.next(), x.next(), x.next()) {
 			(Some(a), Some(b), Some(c)) => Ok((a, b, c)),
 			_ => Err(RpcError::InvalidParams),
-		}
-	}
-	/// Convert the array to two arguments
-	fn needs_zero_one_or_two(self) -> Result<(Value, Value), RpcError> {
-		if self.len() > 2 {
-			return Err(RpcError::InvalidParams);
-		}
-		let mut x = self.into_iter();
-		match (x.next(), x.next()) {
-			(Some(a), Some(b)) => Ok((a, b)),
-			(Some(a), None) => Ok((a, Value::None)),
-			(_, _) => Ok((Value::None, Value::None)),
 		}
 	}
 	/// Convert the array to two arguments

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -93,8 +93,8 @@ pub trait RpcContext {
 
 	async fn yuse(&mut self, params: Array) -> Result<impl Into<Data>, RpcError> {
 		let (ns, db) = params.needs_two()?;
-		let unset_ns = matches!(ns, Value::Bool(false));
-		let unset_db = matches!(db, Value::Bool(false));
+		let unset_ns = matches!(ns, Value::Null);
+		let unset_db = matches!(db, Value::Null);
 
 		if unset_ns && !unset_db {
 			return Err(RpcError::InvalidParams);

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -92,10 +92,14 @@ pub trait RpcContext {
 	// ------------------------------
 
 	async fn yuse(&mut self, params: Array) -> Result<impl Into<Data>, RpcError> {
+		// For both ns+db, string = change, null = unset, none = do nothing
+		// We need to be able to adjust either ns or db without affecting the other
+		// To be able to select a namespace, and then list resources in that namespace, as an example
 		let (ns, db) = params.needs_two()?;
 		let unset_ns = matches!(ns, Value::Null);
 		let unset_db = matches!(db, Value::Null);
 
+		// If we unset the namespace, we must also unset the database
 		if unset_ns && !unset_db {
 			return Err(RpcError::InvalidParams);
 		}

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -92,13 +92,23 @@ pub trait RpcContext {
 	// ------------------------------
 
 	async fn yuse(&mut self, params: Array) -> Result<impl Into<Data>, RpcError> {
-		let (ns, db) = params.needs_two()?;
-		if let Value::Strand(ns) = ns {
+		let len = params.len();
+		let (ns, db) = params.needs_zero_one_or_two()?;
+
+		if len == 0 {
+			self.session_mut().ns = None;
+			self.session_mut().db = None;
+			return Ok(Value::None);
+		} else if let Value::Strand(ns) = ns {
 			self.session_mut().ns = Some(ns.0);
 		}
-		if let Value::Strand(db) = db {
+
+		if len == 1 {
+			self.session_mut().db = None;
+		} else if let Value::Strand(db) = db {
 			self.session_mut().db = Some(db.0);
 		}
+
 		Ok(Value::None)
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

You can change only the namespace or database on the RPC connection, but once selected, you cannot unset them until reconnecting.

## What does this change do?

Allows the ability to pass `null` for db or both ns and db to unset db or ns+db

```
[null, null] -- unsets ns and db
[none, null] -- unsets db
['test', null] -- changes ns, unsets db
['test', none] -- changes ns
[null, 'test'] -- throws an error (when unsetting ns you also need to unset db)
```

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

No

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
