### PR TITLE
Fix for enum Entry by importing it to sql/mod.rs

### DIFF
--- a/core/src/sql/mod.rs
+++ b/core/src/sql/mod.rs
@@ -84,6 +84,7 @@ pub use self::algorithm::Algorithm;
 pub use self::array::Array;
 pub use self::base::Base;
 pub use self::block::Block;
+pub use self::block::Entry;
 pub use self::bytes::Bytes;
 pub use self::cast::Cast;
 pub use self::changefeed::ChangeFeed;


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

This is to solve bug  **Bug: Entry enum is not imported in src/sql/mod.rs** #4374

## What does this change do?

This will allow importing of Entry enum that is need to construct DefineFunctionStatement.

## What is your testing strategy?

GithubCI

## Is this related to any issues?

Yes

- Fixes Bug: Entry enum is not imported in src/sql/mod.rs #4374

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
