### PR TITLE
Entry should be exported so we can match on it

### DIFF
--- a/core/src/sql/mod.rs
+++ b/core/src/sql/mod.rs
@@ -84,6 +84,7 @@ pub use self::algorithm::Algorithm;
 pub use self::array::Array;
 pub use self::base::Base;
 pub use self::block::Block;
+pub use self::block::Entry;
 pub use self::bytes::Bytes;
 pub use self::cast::Cast;
 pub use self::changefeed::ChangeFeed;


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?
Need to match on entry in order to generate types for SurrealDB custom functions


## What does this change do?

Exports an enum

## What is your testing strategy?

Not required

## Is this related to any issues?

No

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
