### PR TITLE
Remove unnecessary cloning of  DefineStatementAnalyzer

### DIFF
--- a/core/src/fnc/search.rs
+++ b/core/src/fnc/search.rs
@@ -13,8 +13,7 @@ pub async fn analyze(
 	(az, val): (Value, Value),
 ) -> Result<Value, Error> {
 	if let (Some(opt), Value::Strand(az), Value::Strand(val)) = (opt, az, val) {
-		// TODO: @emmanuel-keller this `into()` is expansive and clones the value
-		let az: Analyzer = ctx.tx().get_db_analyzer(opt.ns()?, opt.db()?, &az).await?.into();
+		let az = Analyzer::new(ctx.tx().get_db_analyzer(opt.ns()?, opt.db()?, &az).await?);
 		az.analyze(stk, ctx, opt, val.0).await
 	} else {
 		Ok(Value::None)

--- a/core/src/idx/ft/analyzer/filter.rs
+++ b/core/src/idx/ft/analyzer/filter.rs
@@ -20,13 +20,13 @@ pub(super) enum Filter {
 	Uppercase,
 }
 
-impl From<SqlFilter> for Filter {
-	fn from(f: SqlFilter) -> Self {
+impl From<&SqlFilter> for Filter {
+	fn from(f: &SqlFilter) -> Self {
 		match f {
 			SqlFilter::Ascii => Filter::Ascii,
-			SqlFilter::EdgeNgram(min, max) => Filter::EdgeNgram(min, max),
+			SqlFilter::EdgeNgram(min, max) => Filter::EdgeNgram(*min, *max),
 			SqlFilter::Lowercase => Filter::Lowercase,
-			SqlFilter::Ngram(min, max) => Filter::Ngram(min, max),
+			SqlFilter::Ngram(min, max) => Filter::Ngram(*min, *max),
 			SqlFilter::Snowball(l) => {
 				let a = match l {
 					Language::Arabic => Stemmer::create(Algorithm::Arabic),
@@ -55,9 +55,9 @@ impl From<SqlFilter> for Filter {
 }
 
 impl Filter {
-	pub(super) fn from(fs: Option<Vec<SqlFilter>>) -> Option<Vec<Filter>> {
+	pub(super) fn from(fs: &Option<Vec<SqlFilter>>) -> Option<Vec<Filter>> {
 		if let Some(fs) = fs {
-			let r = fs.into_iter().map(|f| f.into()).collect();
+			let r = fs.iter().map(|f| f.into()).collect();
 			Some(r)
 		} else {
 			None

--- a/core/src/idx/planner/executor.rs
+++ b/core/src/idx/planner/executor.rs
@@ -702,7 +702,7 @@ struct FtEntry(Arc<Inner>);
 struct Inner {
 	index_option: IndexOption,
 	doc_ids: Arc<RwLock<DocIds>>,
-	analyzer: Arc<Analyzer>,
+	analyzer: Analyzer,
 	query_terms_set: TermsSet,
 	query_terms_list: TermsList,
 	terms: Arc<RwLock<Terms>>,


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Every instance of `Analyzer` is cloning `DefineStatementAnalyzer`, which is a costly operation

## What does this change do?

The analyzer embeds the `Arc<DefineStatementAnalyzer>` and uses its properties (rather than using a copy). 

## What is your testing strategy?

Tests are existing.

## Is this related to any issues?

No


## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed


## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
