### PR TITLE
Allow generating ulid and uuid based on a timestamp

### DIFF
--- a/core/src/fnc/rand.rs
+++ b/core/src/fnc/rand.rs
@@ -2,6 +2,7 @@ use crate::cnf::ID_CHARS;
 use crate::err::Error;
 use crate::sql::uuid::Uuid;
 use crate::sql::value::Value;
+use crate::sql::Datetime;
 use chrono::{TimeZone, Utc};
 use nanoid::nanoid;
 use rand::distributions::{Alphanumeric, DistString};
@@ -150,12 +151,21 @@ pub fn time((range,): (Option<(i64, i64)>,)) -> Result<Value, Error> {
 	Ok(Utc.timestamp_opt(val, 0).earliest().unwrap().into())
 }
 
-pub fn ulid(_: ()) -> Result<Value, Error> {
-	Ok(Ulid::new().to_string().into())
+pub fn ulid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
+	let ulid = match timestamp {
+		Some(timestamp) => Ulid::from_datetime(timestamp.0.into()),
+		None => Ulid::new(),
+	};
+
+	Ok(ulid.to_string().into())
 }
 
-pub fn uuid(_: ()) -> Result<Value, Error> {
-	Ok(Uuid::new().into())
+pub fn uuid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
+	let uuid = match timestamp {
+		Some(timestamp) => Uuid::new_v7_from_datetime(timestamp),
+		None => Uuid::new(),
+	};
+	Ok(uuid.into())
 }
 
 pub mod uuid {
@@ -163,12 +173,17 @@ pub mod uuid {
 	use crate::err::Error;
 	use crate::sql::uuid::Uuid;
 	use crate::sql::value::Value;
+	use crate::sql::Datetime;
 
 	pub fn v4(_: ()) -> Result<Value, Error> {
 		Ok(Uuid::new_v4().into())
 	}
 
-	pub fn v7(_: ()) -> Result<Value, Error> {
-		Ok(Uuid::new_v7().into())
+	pub fn v7((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
+		let uuid = match timestamp {
+			Some(timestamp) => Uuid::new_v7_from_datetime(timestamp),
+			None => Uuid::new(),
+		};
+		Ok(uuid.into())
 	}
 }

--- a/core/src/sql/uuid.rs
+++ b/core/src/sql/uuid.rs
@@ -6,6 +6,8 @@ use std::ops::Deref;
 use std::str;
 use std::str::FromStr;
 
+use super::Datetime;
+
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Uuid";
 
 #[revisioned(revision = 1)]
@@ -79,6 +81,15 @@ impl Uuid {
 	/// Generate a new V7 UUID
 	pub fn new_v7() -> Self {
 		Self(uuid::Uuid::now_v7())
+	}
+	/// Generate a new V7 UUID
+	pub fn new_v7_from_datetime(timestamp: Datetime) -> Self {
+		let ts = uuid::Timestamp::from_unix(
+			uuid::NoContext,
+			timestamp.0.timestamp() as u64,
+			timestamp.0.timestamp_subsec_nanos() as u32,
+		);
+		Self(uuid::Uuid::new_v7(ts))
 	}
 	/// Convert the Uuid to a raw String
 	pub fn to_raw(&self) -> String {

--- a/core/src/sql/uuid.rs
+++ b/core/src/sql/uuid.rs
@@ -87,7 +87,7 @@ impl Uuid {
 		let ts = uuid::Timestamp::from_unix(
 			uuid::NoContext,
 			timestamp.0.timestamp() as u64,
-			timestamp.0.timestamp_subsec_nanos() as u32,
+			timestamp.0.timestamp_subsec_nanos(),
 		);
 		Self(uuid::Uuid::new_v7(ts))
 	}

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -2954,6 +2954,39 @@ async fn function_rand_ulid() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn function_rand_ulid_from_datetime() -> Result<(), Error> {
+	let sql = r#"
+        CREATE ONLY test:[rand::ulid()] SET created = time::now(), num = 1;
+        SLEEP 1ms;
+        LET $rec = CREATE ONLY test:[rand::ulid()] SET created = time::now(), num = 2;
+        SLEEP 1ms;
+        CREATE ONLY test:[rand::ulid()] SET created = time::now(), num = 3;
+		SELECT VALUE num FROM test:[rand::ulid($rec.created - 1ms)]..;
+	"#;
+	let mut test = Test::new(sql).await?;
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_object());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_none());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_none());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_none());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_object());
+	//
+	let tmp = test.next()?.result?;
+	assert_eq!(tmp, Value::parse("[2, 3]"));
+	//
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_rand_uuid() -> Result<(), Error> {
 	let sql = r#"
 		RETURN rand::uuid();
@@ -2962,6 +2995,39 @@ async fn function_rand_uuid() -> Result<(), Error> {
 	//
 	let tmp = test.next()?.result?;
 	assert!(tmp.is_uuid());
+	//
+	Ok(())
+}
+
+#[tokio::test]
+async fn function_rand_uuid_from_datetime() -> Result<(), Error> {
+	let sql = r#"
+        CREATE ONLY test:[rand::uuid()] SET created = time::now(), num = 1;
+        SLEEP 1ms;
+        LET $rec = CREATE ONLY test:[rand::uuid()] SET created = time::now(), num = 2;
+        SLEEP 1ms;
+        CREATE ONLY test:[rand::uuid()] SET created = time::now(), num = 3;
+		SELECT VALUE num FROM test:[rand::uuid($rec.created - 1ms)]..;
+	"#;
+	let mut test = Test::new(sql).await?;
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_object());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_none());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_none());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_none());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_object());
+	//
+	let tmp = test.next()?.result?;
+	assert_eq!(tmp, Value::parse("[2, 3]"));
 	//
 	Ok(())
 }
@@ -2988,6 +3054,39 @@ async fn function_rand_uuid_v7() -> Result<(), Error> {
 	//
 	let tmp = test.next()?.result?;
 	assert!(tmp.is_uuid());
+	//
+	Ok(())
+}
+
+#[tokio::test]
+async fn function_rand_uuid_v7_from_datetime() -> Result<(), Error> {
+	let sql = r#"
+        CREATE ONLY test:[rand::uuid::v7()] SET created = time::now(), num = 1;
+        SLEEP 1ms;
+        LET $rec = CREATE ONLY test:[rand::uuid::v7()] SET created = time::now(), num = 2;
+        SLEEP 1ms;
+        CREATE ONLY test:[rand::uuid::v7()] SET created = time::now(), num = 3;
+		SELECT VALUE num FROM test:[rand::uuid::v7($rec.created - 1ms)]..;
+	"#;
+	let mut test = Test::new(sql).await?;
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_object());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_none());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_none());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_none());
+	//
+	let tmp = test.next()?.result?;
+	assert!(tmp.is_object());
+	//
+	let tmp = test.next()?.result?;
+	assert_eq!(tmp, Value::parse("[2, 3]"));
 	//
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

There was a lenghty discussion on Discord from which the outcome was that it would be nice to design their range queries based on ULIDs, as they are lexalogically ordered and guarantee uniqueness. From that came the need to be able to generate ULIDs based on a timestamp.

https://discord.com/channels/902568124350599239/1013527402674139268/1263369330062528523

## What does this change do?

It adds the ability to pass a datetime to the `rand::ulid()`, `rand::uuid()` and `rand::uuid::v7()` methods, to generate them based on a certain timestamp.

## What is your testing strategy?

Added a tests for all functions based on the range query concept

## Is this related to any issues?

See https://discord.com/channels/902568124350599239/1013527402674139268/1263369330062528523

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
