### PR TITLE
Fix querying complex edge table

### DIFF
--- a/core/src/dbs/processor.rs
+++ b/core/src/dbs/processor.rs
@@ -456,7 +456,7 @@ impl<'a> Processor<'a> {
 				Dir::In => e
 					.what
 					.iter()
-					.map(|v| v.to_string())
+					.map(|v| v.0.to_owned())
 					.map(|v| {
 						(
 							graph::ftprefix(ns, db, tb, id, &e.dir, &v),
@@ -468,7 +468,7 @@ impl<'a> Processor<'a> {
 				Dir::Out => e
 					.what
 					.iter()
-					.map(|v| v.to_string())
+					.map(|v| v.0.to_owned())
 					.map(|v| {
 						(
 							graph::ftprefix(ns, db, tb, id, &e.dir, &v),
@@ -480,7 +480,7 @@ impl<'a> Processor<'a> {
 				Dir::Both => e
 					.what
 					.iter()
-					.map(|v| v.to_string())
+					.map(|v| v.0.to_owned())
 					.flat_map(|v| {
 						vec![
 							(


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

The keys generated to query edges with a complex table name would escape the table name, causing a mismatch.

## What does this change do?

We now grab the inner string that the Table type stores, to construct the key to scan

## What is your testing strategy?

Added a test

## Is this related to any issues?

Not that I'm aware of

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
