### PR TITLE
Fixes bytes formating issue

### DIFF
--- a/core/src/sql/bytes.rs
+++ b/core/src/sql/bytes.rs
@@ -1,4 +1,3 @@
-use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine};
 use revision::revisioned;
 use serde::{
 	de::{self, Visitor},
@@ -35,7 +34,15 @@ impl Deref for Bytes {
 
 impl Display for Bytes {
 	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-		write!(f, "encoding::base64::decode(\"{}\")", STANDARD_NO_PAD.encode(&self.0))
+		writeln!(f, "")?;
+		let len = self.0.len();
+		if len > 0 {
+			for byte in &self.0[..len - 1] {
+				writeln!(f, "    {},", byte)?;
+			}
+			writeln!(f, "    {}", self.0[len - 1])?;
+		}
+		Ok(())
 	}
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

This fixes bytes not getting printed excepted form.

## What does this change do?

Changes fmt to print u8 one bye one. It would be wrong to encode it as text, because not every time bytes are text.

## What is your testing strategy?

I have done manual testing.
<img width="512" alt="suureal_bytes_test" src="https://github.com/user-attachments/assets/87f0aecc-6284-4a6a-a944-e114e74ae224">


## Is this related to any issues?

If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here.

Fixes https://github.com/surrealdb/surrealdb/issues/4396

## Does this change need documentation?
No
<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
