### PR TITLE
Fix params not supporting delimiters

### DIFF
--- a/core/src/syn/lexer/byte.rs
+++ b/core/src/syn/lexer/byte.rs
@@ -6,6 +6,8 @@ use crate::syn::{
 	token::{t, DatetimeChars, Token, TokenKind},
 };
 
+use super::CharError;
+
 impl<'a> Lexer<'a> {
 	/// Eats a single line comment.
 	pub fn eat_single_line_comment(&mut self) {
@@ -311,13 +313,28 @@ impl<'a> Lexer<'a> {
 				}
 				_ => t!(":"),
 			},
-			b'$' => {
-				if self.reader.peek().map(|x| x.is_ascii_alphabetic() || x == b'_').unwrap_or(false)
-				{
-					return self.lex_param();
+			b'$' => match self.reader.peek() {
+				Some(b'_') => return self.lex_param(),
+				Some(b'`') => {
+					self.reader.next();
+					return self.lex_surrounded_param(true);
 				}
-				t!("$")
-			}
+				Some(x) if x.is_ascii_alphabetic() => return self.lex_param(),
+				Some(x) if !x.is_ascii() => {
+					let backup = self.reader.offset();
+					self.reader.next();
+					match self.reader.complete_char(x) {
+						Ok('⟨') => return self.lex_surrounded_param(false),
+						Err(CharError::Eof) => return self.invalid_token(Error::InvalidUtf8),
+						Err(CharError::Unicode) => return self.invalid_token(Error::InvalidUtf8),
+						_ => {
+							self.reader.backup(backup);
+							t!("$")
+						}
+					}
+				}
+				_ => t!("$"),
+			},
 			b'#' => {
 				self.eat_single_line_comment();
 				TokenKind::WhiteSpace

--- a/core/src/syn/lexer/reader.rs
+++ b/core/src/syn/lexer/reader.rs
@@ -76,10 +76,12 @@ impl<'a> BytesReader<'a> {
 	pub fn peek(&self) -> Option<u8> {
 		self.remaining().first().copied()
 	}
+
 	#[inline]
 	pub fn span(&self, span: Span) -> &'a [u8] {
 		&self.data[(span.offset as usize)..(span.offset as usize + span.len as usize)]
 	}
+
 	#[inline]
 	pub fn next_continue_byte(&mut self) -> Result<u8, CharError> {
 		const CONTINUE_BYTE_PREFIX_MASK: u8 = 0b1100_0000;
@@ -87,7 +89,7 @@ impl<'a> BytesReader<'a> {
 
 		let byte = self.next().ok_or(CharError::Eof)?;
 		if byte & CONTINUE_BYTE_PREFIX_MASK != 0b1000_0000 {
-			return Err(CharError::Eof);
+			return Err(CharError::Unicode);
 		}
 
 		Ok(byte & CONTINUE_BYTE_MASK)

--- a/core/src/syn/parser/mac.rs
+++ b/core/src/syn/parser/mac.rs
@@ -140,7 +140,7 @@ macro_rules! expected_whitespace {
 #[cfg(test)]
 #[macro_export]
 macro_rules! test_parse {
-	($func:ident$( ( $($e:expr),* $(,)? ))? , $t:literal) => {{
+	($func:ident$( ( $($e:expr),* $(,)? ))? , $t:expr) => {{
 		let mut parser = $crate::syn::parser::Parser::new($t.as_bytes());
 		let mut stack = reblessive::Stack::new();
 		stack.enter(|ctx| parser.$func(ctx,$($($e),*)*)).finish()

--- a/core/src/syn/parser/test/mod.rs
+++ b/core/src/syn/parser/test/mod.rs
@@ -1,3 +1,5 @@
+use nom::AsBytes;
+
 use crate::{sql, syn::parser::mac::test_parse};
 
 mod limit;
@@ -10,4 +12,26 @@ fn multiple_semicolons() {
 	let res = test_parse!(parse_query, r#";;"#).unwrap();
 	let expected = sql::Query(sql::Statements(vec![]));
 	assert_eq!(res, expected);
+}
+
+#[test]
+fn escaped_params() {
+	let src = r#"LET $⟨R-_fYU8Wa31kg7tz0JI6Kme⟩ = 5;
+		RETURN  $⟨R-_fYU8Wa31kg7tz0JI6Kme⟩"#;
+
+	for (idx, b) in src.as_bytes().iter().enumerate() {
+		println!("{:0>4}: {:0>8b}", idx, b);
+	}
+
+	test_parse!(parse_query, src).unwrap();
+}
+
+#[test]
+fn escaped_params_backtick() {
+	test_parse!(
+		parse_query,
+		r#"LET $`R-_fYU8Wa31kg7tz0JI6Kme` = 5;
+		RETURN  $`R-_fYU8Wa31kg7tz0JI6Kme`"#
+	)
+	.unwrap();
 }


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

There is a regression in the parser where delimited parameters are no longer supported in the new parser.

## What does this change do?

Implement delimited parameters in the parser.

## What is your testing strategy?

Added new tests to ensure the new parameters are properly parsed.

## Is this related to any issues?

Fixes #4380 

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
