### PR TITLE
feat-2172: Added tests for live query filtering

### DIFF
--- a/lib/tests/api/live.rs
+++ b/lib/tests/api/live.rs
@@ -421,6 +421,202 @@ async fn live_select_query() {
 	drop(permit);
 }
 
+#[test_log::test(tokio::test)]
+async fn live_select_query_with_filter() {
+	let (permit, db) = new_db().await;
+	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+
+	// A list of objects to be inserted when creating the DB.
+	let record_objects = vec![
+		json!({"value": 10, "name": "A"}),
+		json!({"value": 20, "name": "B"}),
+		json!({"value": 30, "name": "C"}),
+		json!({"value": 40, "name": "D"}),
+		json!({"value": 50, "name": "E"}),
+	];
+
+	// A function to create a record with a given content.
+	let create_record = |table: &str, content: serde_json::Value| {
+		let db = db.clone();
+		let table = table.to_string();
+		async move {
+			let record: Vec<RecordId> = db.create(&table).content(content).await.unwrap();
+			record[0].clone()
+		}
+	};
+
+	fn assert_indices(
+		received_ids: Vec<RecordId>,
+		expected_ids: Vec<RecordId>,
+		where_clause: &str,
+	) {
+		assert_eq!(
+			received_ids.len(),
+			expected_ids.len(),
+			"Wrong number of notifications for '{}': expected {}, got {}",
+			where_clause,
+			expected_ids.len(),
+			received_ids.len()
+		);
+
+		for id in expected_ids {
+			assert!(
+				received_ids.contains(&id),
+				"Expected ID {:?} not found in results for '{}'",
+				id,
+				where_clause
+			);
+		}
+	}
+
+	// Testing Live Query filtering with multiple operators.
+	{
+		let table = format!("table_{}", Ulid::new());
+		if FFLAGS.change_feed_live_queries.enabled() {
+			db.query(format!("DEFINE TABLE {table} CHANGEFEED 10m INCLUDE ORIGINAL"))
+				.await
+				.unwrap();
+		} else {
+			db.query(format!("DEFINE TABLE {table}")).await.unwrap();
+		}
+
+		// Test cases
+		let test_cases = vec![
+			("value > 25", vec![2, 3, 4]),
+			("value >= 51", vec![]),
+			("value < 30", vec![0, 1]),
+			("value <= 30", vec![0, 1, 2]),
+			("value = 20", vec![1]),
+			("value != 30", vec![0, 1, 3, 4]),
+			("name = 'A'", vec![0]),
+			("name != 'B'", vec![0, 2, 3, 4]),
+		];
+
+		for (where_clause, expected_indices) in test_cases {
+			let query = format!("LIVE SELECT * FROM {table} WHERE {where_clause}");
+			info!("Starting live query: {}", query);
+
+			let users: QueryStream<Notification<RecordId>> =
+				db.query(query).await.unwrap().stream::<Notification<_>>(0).unwrap();
+			let users = Arc::new(RwLock::new(users));
+
+			// Create multiple records
+			let mut records: Vec<RecordId> = Vec::new();
+			for obj in &record_objects {
+				records.push(create_record(&table, obj.clone()).await);
+			}
+
+			// Wait for initial notifications
+			let notifications = receive_all_pending_notifications(users.clone(), LQ_TIMEOUT).await;
+
+			// Check if the correct records are returned
+			let received_ids: Vec<_> = notifications.iter().map(|n| n.data.clone()).collect();
+			let expected_ids: Vec<_> =
+				expected_indices.iter().map(|&i| records[i].clone()).collect();
+			assert_indices(received_ids, expected_ids, where_clause);
+		}
+	}
+
+	// Testing Live Query filtering with update and delete operations.
+	{
+		let table = format!("table_{}", Ulid::new());
+		let where_clause = "value >= 30";
+		if FFLAGS.change_feed_live_queries.enabled() {
+			db.query(format!("DEFINE TABLE {table} CHANGEFEED 10m INCLUDE ORIGINAL"))
+				.await
+				.unwrap();
+		} else {
+			db.query(format!("DEFINE TABLE {table}")).await.unwrap();
+		}
+
+		let query = format!("LIVE SELECT * FROM {table} WHERE {where_clause}");
+		info!("Starting live query: {}", query);
+
+		let users: QueryStream<Notification<RecordId>> =
+			db.query(query).await.unwrap().stream::<Notification<_>>(0).unwrap();
+		let users = Arc::new(RwLock::new(users));
+
+		// Create multiple records
+		let mut records: Vec<RecordId> = Vec::new();
+		for obj in &record_objects {
+			records.push(create_record(&table, obj.clone()).await);
+		}
+
+		// Wait for initial notifications
+		let notifications = receive_all_pending_notifications(users.clone(), LQ_TIMEOUT).await;
+		let expected_indices = vec![2, 3, 4];
+
+		// Check if the correct records are returned
+		let received_ids: Vec<_> = notifications.iter().map(|n| n.data.clone()).collect();
+		let expected_ids: Vec<_> = expected_indices.iter().map(|&i| records[i].clone()).collect();
+
+		assert_indices(received_ids.clone(), expected_ids, where_clause);
+
+		// Update the record
+		info!("Updating record");
+		let record_to_update = &records[1];
+		let _: Option<RecordId> = db
+			.update(record_to_update.id.clone())
+			.content(json!({"value": 35, "name": "J"}))
+			.await
+			.unwrap();
+		let notifications = receive_all_pending_notifications(users.clone(), LQ_TIMEOUT).await;
+
+		// We should get a notification for the update
+		assert_eq!(
+			notifications.iter().map(|n| n.action).collect::<Vec<_>>(),
+			[Action::Update],
+			"{:?}",
+			notifications
+		);
+		assert_eq!(notifications[0].data.id, record_to_update.id.clone());
+
+		// Update the record
+		info!("Updating record");
+		let record_to_update = &records[3];
+		let _: Option<RecordId> = db
+			.update(record_to_update.id.clone())
+			.content(json!({"value": 15, "name": "M"}))
+			.await
+			.unwrap();
+
+		let notifications = receive_all_pending_notifications(users.clone(), LQ_TIMEOUT).await;
+
+		// Ensure that we don't get the filtered-out notifications.
+		assert!(notifications.is_empty());
+
+		// Delete the record
+		info!("Deleting record");
+		let record_to_delete = &records[4];
+		let _: Option<RecordId> = db.delete(record_to_delete.id.clone()).await.unwrap();
+
+		// Pull the notification
+		let notifications = receive_all_pending_notifications(users.clone(), LQ_TIMEOUT).await;
+
+		// It should be deleted
+		assert_eq!(
+			notifications.iter().map(|n| n.action).collect::<Vec<_>>(),
+			[Action::Delete],
+			"{:?}",
+			notifications
+		);
+		assert_eq!(notifications[0].data.id, record_to_delete.id.clone());
+
+		// Delete the record
+		info!("Deleting record");
+		let record_to_delete = &records[0];
+		let _: Option<RecordId> = db.delete(record_to_delete.id.clone()).await.unwrap();
+
+		// Pull the notification
+		let notifications = receive_all_pending_notifications(users.clone(), LQ_TIMEOUT).await;
+
+		// Ensure that we don't get the filtered-out notifications.
+		assert!(notifications.is_empty());
+	}
+
+	drop(permit);
+}
+
 async fn receive_all_pending_notifications<
 	S: Stream<Item = Result<Notification<I>, Error>> + Unpin,
 	I,


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Please provide details on the motivation for why you have made this change.

## What does this change do?

I have added test cases for Live queries with filters. This test case covers the live queries operating locally. 

NOTE: I have also added the live query filtering on variables; those tests are failing. So, this should be handled accordingly.

## What is your testing strategy?

I have added two scopes for live query filter tests.
- The first scope covers all the equality and comparison operators.
- The second scope tests the live queries with filters after update and delete statements are called.

## Is this related to any issues?

Closes #2172 

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
