### PR TITLE
feat-4416: Ensure table definition exists on live queries

### DIFF
--- a/core/src/sql/statements/live.rs
+++ b/core/src/sql/statements/live.rs
@@ -111,8 +111,7 @@ impl LiveStatement {
 				// Get the transaction
 				let txn = ctx.tx();
 				// Ensure that the table definition exists
-				let tb_name = &tb.0;
-				txn.ensure_ns_db_tb(opt.ns()?, opt.db()?, tb_name, opt.strict).await?;
+				txn.ensure_ns_db_tb(ns, db, &tb, opt.strict).await?;
 				// Lock the transaction
 				let mut txn = txn.lock().await;
 				// Insert the node live query


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Please provide details on the motivation for why you have made this change.

## What does this change do?

This change ensures that the table definition exists or is created when we run new live queries. 

## What is your testing strategy?

I have added a test in `api/live.rs`. 
This test ensures a table definition is created after a live query is executed. I have also added a create statement just after the live query statement to ensure that the same table definition is being reused.


## Is this related to any issues?

Closes #4416 

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed
- [ ] surrealdb/docs.surrealdb.com#1

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
