### PR TITLE
Bump to rustc 1.80.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
 
   test:
     name: Test workspace
-    runs-on: ["self-hosted", "arm64", "builder"]
+    runs-on: [ "self-hosted", "arm64", "builder" ]
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.79.0
           components: rustfmt
 
       - name: Checkout sources

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,4 +1,4 @@
-name: Supply chain security 
+name: Supply chain security
 
 run-name: "Supply chain security run '${{ github.head_ref || github.ref_name }}'"
 
@@ -60,7 +60,7 @@ jobs:
           echo "## :warning: Supply chain security check failed" >> $GITHUB_STEP_SUMMARY
           echo "See instructions in the [supply chain security process](https://github.com/surrealdb/surrealdb/blob/main/supply-chain/README.md#Process)." >> $GITHUB_STEP_SUMMARY
   cargo-vet:
-    name: Check dependencies for untrusted sources 
+    name: Check dependencies for untrusted sources
     runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install cargo-deny
-        run: cargo install --debug --locked cargo-deny@0.14.11
+        run: cargo install --debug --locked cargo-deny@0.15.1
 
       - name: Check dependencies for known issues
         run: cargo deny check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3664,16 +3673,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.8.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2524735495ea1268be33d200e1ee97455096a0846295a21548cd2f3541de7050"
+checksum = "e6da452820c715ce78221e8202ccc599b4a52f3e1eb3eedb487b680c81a8e3f3"
 dependencies = [
  "async-trait",
  "bytes",
  "chrono",
  "futures",
  "humantime",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "parking_lot",
  "percent-encoding",
  "snafu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ performance-profiler = ["dep:pprof"]
 # Special features
 storage-fdb-7_1 = ["surrealdb/kv-fdb-7_1"]
 storage-fdb-7_3 = ["surrealdb/kv-fdb-7_3"]
+# Trigger database upgrade tests
+database-upgrade-tests = []
 
 [workspace]
 members = [

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -111,7 +111,7 @@ run_task = { name = ["start-surrealdb", "test-api-integration", "stop-surrealdb"
 private = true
 command = "cargo"
 env = { RUST_BACKTRACE = 1, RUST_LOG = "info" }
-args = ["test", "--locked", "--no-default-features", "--features", "database-upgrade-test,${_TEST_FEATURES}", "--workspace", "--test", "database_upgrade", "--", "database_upgrade", "--show-output"]
+args = ["test", "--locked", "--no-default-features", "--features", "database-upgrade-tests,${_TEST_FEATURES}", "--workspace", "--test", "database_upgrade", "--", "database_upgrade", "--show-output"]
 
 
 #

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -30,7 +30,7 @@ args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,
 [tasks.ci-http-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-env = { RUST_BACKTRACE = 1,  RUST_LOG = { value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
+env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
 args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks", "--workspace", "--test", "http_integration", "--", "http_integration"]
 
 [tasks.ci-ws-integration]
@@ -110,8 +110,8 @@ run_task = { name = ["start-surrealdb", "test-api-integration", "stop-surrealdb"
 [tasks.test-database-upgrade]
 private = true
 command = "cargo"
-env = { RUST_BACKTRACE = 1, RUST_LOG = "info", RUSTFLAGS = "--cfg docker" }
-args = ["test", "--locked", "--no-default-features", "--features", "${_TEST_FEATURES}", "--workspace", "--test", "database_upgrade", "--", "database_upgrade", "--show-output"]
+env = { RUST_BACKTRACE = 1, RUST_LOG = "info" }
+args = ["test", "--locked", "--no-default-features", "--features", "database-upgrade-test,${_TEST_FEATURES}", "--workspace", "--test", "database_upgrade", "--", "database_upgrade", "--show-output"]
 
 
 #

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -105,7 +105,7 @@ ndarray-stats = "=0.5.1"
 num-traits = "0.2.18"
 nom = { version = "7.1.3", features = ["alloc"] }
 num_cpus = "1.16.0"
-object_store = { version = "0.8.0", optional = false }
+object_store = { version = "0.10.2", optional = false }
 once_cell = "1.18.0"
 pbkdf2 = { version = "0.12.2", features = ["simple"] }
 phf = { version = "0.11.2", features = ["macros", "unicase"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -154,7 +154,7 @@ pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
 serial_test = "2.0.0"
 temp-dir = "0.1.11"
 test-log = { version = "0.2.13", features = ["trace"] }
-time = { version = "0.3.30", features = ["serde"] }
+time = { version = "0.3.36", features = ["serde"] }
 tokio = { version = "1.34.0", features = ["macros", "sync", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 wiremock = "0.5.22"

--- a/core/src/idx/planner/executor.rs
+++ b/core/src/idx/planner/executor.rs
@@ -102,6 +102,7 @@ impl IteratorEntry {
 }
 impl InnerQueryExecutor {
 	#[allow(clippy::too_many_arguments)]
+	#[allow(clippy::mutable_key_type)]
 	pub(super) async fn new(
 		stk: &mut Stk,
 		ctx: &Context<'_>,

--- a/core/src/idx/planner/rewriter.rs
+++ b/core/src/idx/planner/rewriter.rs
@@ -10,6 +10,7 @@ pub(super) struct KnnConditionRewriter<'a>(&'a KnnExpressions);
 
 impl<'a> KnnConditionRewriter<'a> {
 	// This function rebuild the same condition, but replaces any KnnExpression by a `true` value
+	#[allow(clippy::mutable_key_type)]
 	pub(super) fn build(expressions: &'a KnnExpressions, cond: &Cond) -> Option<Cond> {
 		let b = Self(expressions);
 		b.eval_value(&cond.0).map(Cond)

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -26,7 +26,6 @@ use std::fmt;
 #[cfg(any(
 	feature = "kv-mem",
 	feature = "kv-surrealkv",
-	feature = "kv-file",
 	feature = "kv-rocksdb",
 	feature = "kv-fdb",
 	feature = "kv-tikv",

--- a/core/src/obs/mod.rs
+++ b/core/src/obs/mod.rs
@@ -68,7 +68,7 @@ pub async fn get(file: &str) -> Result<Vec<u8>, Error> {
 		Ok(data) => Ok(data.bytes().await?.to_vec()),
 		_ => {
 			let data = STORE.get(&Path::from(file)).await?;
-			CACHE.put(&Path::from(file), data.bytes().await?).await?;
+			CACHE.put(&Path::from(file), data.bytes().await?.into()).await?;
 			Ok(CACHE.get(&Path::from(file)).await?.bytes().await?.to_vec())
 		}
 	}
@@ -76,7 +76,7 @@ pub async fn get(file: &str) -> Result<Vec<u8>, Error> {
 
 /// Puts the file into the local file system or memory object storage.
 pub async fn put(file: &str, data: Vec<u8>) -> Result<(), Error> {
-	let _ = STORE.put(&Path::from(file), Bytes::from(data)).await?;
+	let _ = STORE.put(&Path::from(file), Bytes::from(data).into()).await?;
 	Ok(())
 }
 

--- a/core/src/sql/array.rs
+++ b/core/src/sql/array.rs
@@ -484,6 +484,7 @@ pub(crate) trait Uniq<T> {
 
 impl Uniq<Array> for Array {
 	fn uniq(mut self) -> Array {
+		#[allow(clippy::mutable_key_type)]
 		let mut set: HashSet<&Value> = HashSet::new();
 		let mut to_remove: Vec<usize> = Vec::new();
 		for (i, item) in self.iter().enumerate() {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -115,7 +115,7 @@ regex = "1.10.2"
 serial_test = "2.0.0"
 temp-dir = "0.1.11"
 test-log = { version = "0.2.13", features = ["trace"] }
-time = { version = "0.3.30", features = ["serde"] }
+time = { version = "0.3.36", features = ["serde"] }
 tokio = { version = "1.34.0", features = ["macros", "sync", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 ulid = { version = "1.1.0", features = ["serde"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -115,7 +115,7 @@ regex = "1.10.2"
 serial_test = "2.0.0"
 temp-dir = "0.1.11"
 test-log = { version = "0.2.13", features = ["trace"] }
-time = { version = "0.3.36", features = ["serde"] }
+time = { version = "0.3.30", features = ["serde"] }
 tokio = { version = "1.34.0", features = ["macros", "sync", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 ulid = { version = "1.1.0", features = ["serde"] }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -611,10 +611,6 @@ criteria = "safe-to-deploy"
 version = "1.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.flume]]
-version = "0.11.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.foundationdb]]
 version = "0.9.0"
 criteria = "safe-to-deploy"
@@ -641,18 +637,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.futf]]
 version = "0.1.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.futures]]
-version = "0.3.30"
-criteria = "safe-to-deploy"
-
-[[exemptions.futures-executor]]
-version = "0.3.30"
-criteria = "safe-to-deploy"
-
-[[exemptions.futures-io]]
-version = "0.3.30"
 criteria = "safe-to-deploy"
 
 [[exemptions.futures-lite]]
@@ -879,6 +863,10 @@ criteria = "safe-to-deploy"
 version = "0.11.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.itertools]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.jemalloc-sys]]
 version = "0.5.4+5.3.0-patched"
 criteria = "safe-to-deploy"
@@ -1043,10 +1031,6 @@ criteria = "safe-to-deploy"
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.nanorand]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.ndarray]]
 version = "0.15.6"
 criteria = "safe-to-deploy"
@@ -1096,7 +1080,7 @@ version = "0.32.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.object_store]]
-version = "0.8.0"
+version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.once_cell]]
@@ -1806,14 +1790,6 @@ criteria = "safe-to-run"
 [[exemptions.test-log-macros]]
 version = "0.2.15"
 criteria = "safe-to-run"
-
-[[exemptions.thiserror]]
-version = "1.0.61"
-criteria = "safe-to-deploy"
-
-[[exemptions.thiserror-impl]]
-version = "1.0.61"
-criteria = "safe-to-deploy"
 
 [[exemptions.time]]
 version = "0.3.36"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -114,9 +114,23 @@ user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
+[[publisher.revision]]
+version = "0.8.0"
+when = "2024-07-09"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
 [[publisher.revision-derive]]
 version = "0.7.0"
 when = "2024-04-17"
+user-id = 145457
+user-login = "tobiemh"
+user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.revision-derive]]
+version = "0.8.0"
+when = "2024-07-09"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -339,6 +353,17 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.3.27"
 notes = "Unsafe used to implement a concurrency primitive AtomicWaker. Well-commented and not obviously incorrect. Like my other audits of these concurrency primitives inside the futures family, I couldn't certify that it is correct without formal methods, but that is out of scope for this vetting."
+
+[[audits.bytecode-alliance.audits.futures-executor]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.27"
+notes = "Unsafe used to implement the unpark mutex, which is well commented and not obviously incorrect. Like with futures-channel I wouldn't be able to certify it as correct without formal methods."
+
+[[audits.bytecode-alliance.audits.futures-io]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.27"
 
 [[audits.bytecode-alliance.audits.heck]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -617,6 +642,18 @@ criteria = "safe-to-deploy"
 version = "1.0.1"
 notes = "No unsafe usage or ambient capabilities"
 
+[[audits.embark-studios.audits.thiserror]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.40"
+notes = "Wrapper over implementation crate, found no unsafe or ambient capabilities used"
+
+[[audits.embark-studios.audits.thiserror-impl]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.40"
+notes = "Found no unsafe or ambient capabilities used"
+
 [[audits.embark-studios.audits.utf8parse]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -759,6 +796,16 @@ version = "1.9.0"
 notes = """
 `does-not-implement-crypto` is certified because this crate explicitly says
 that the RNG here is not cryptographically secure.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.futures]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.3.28"
+notes = """
+`futures` has no logic other than tests - it simply `pub use`s things from
+other crates.
 """
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
@@ -1119,6 +1166,16 @@ who = "Ameer Ghani <inahga@divviup.org>"
 criteria = "safe-to-deploy"
 version = "1.12.1"
 
+[[audits.isrg.audits.thiserror]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.40 -> 1.0.43"
+
+[[audits.isrg.audits.thiserror-impl]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "1.0.40 -> 1.0.43"
+
 [[audits.isrg.audits.untrusted]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
@@ -1381,6 +1438,18 @@ delta = "0.3.27 -> 0.3.28"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.futures-core]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.27 -> 0.3.28"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.futures-executor]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.27 -> 0.3.28"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.futures-io]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.27 -> 0.3.28"
@@ -1764,6 +1833,13 @@ criteria = "safe-to-deploy"
 delta = "2.0.1 -> 2.0.2"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
+[[audits.zcash.audits.futures]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.28 -> 0.3.30"
+notes = "Only sub-crate updates and corresponding changes to tests."
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
 [[audits.zcash.audits.futures-channel]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -1789,6 +1865,18 @@ criteria = "safe-to-deploy"
 delta = "0.3.29 -> 0.3.30"
 notes = "Removes `build.rs` now that it can rely on the `target_has_atomic` attribute."
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.futures-executor]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.28 -> 0.3.30"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.futures-io]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.3.28 -> 0.3.30"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.inout]]
 who = "Daira Hopwood <daira@jacaranda.org>"
@@ -1924,6 +2012,96 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "2.1.0 -> 2.2.0"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.43 -> 1.0.48"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.48 -> 1.0.51"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.51 -> 1.0.52"
+notes = "Reruns the build script if the `RUSTC_BOOTSTRAP` env variable changes."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.52 -> 1.0.56"
+notes = """
+Build script changes are to refactor the existing probe into a separate file
+(which removes a filesystem write), and adjust how it gets rerun in response to
+changes in the build environment.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.56 -> 1.0.58"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.58 -> 1.0.60"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.60 -> 1.0.61"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.43 -> 1.0.48"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.48 -> 1.0.51"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.51 -> 1.0.52"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.52 -> 1.0.56"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.56 -> 1.0.58"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.58 -> 1.0.60"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.60 -> 1.0.61"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.thread_local]]
 who = "Jack Grigg <jack@z.cash>"

--- a/tests/database_upgrade.rs
+++ b/tests/database_upgrade.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-#[cfg(docker)]
+#[cfg(feature = "database-upgrade-tests")]
 mod database_upgrade {
 	use super::common::docker::DockerContainer;
 	use super::common::expected::Expected;


### PR DESCRIPTION
## What is the motivation?

RustC 1.80.0 is available.

## What does this change do?

Fixes compilation, security and clippy issues.

## What is your testing strategy?

N/A

## Is this related to any issues?

No

## Does this change need documentation?

- [x] No documentation needed


## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
