### PR TITLE
Remove unnecessary backticks from `INFO FOR` statement output

### DIFF
--- a/core/src/sql/statements/info.rs
+++ b/core/src/sql/statements/info.rs
@@ -89,14 +89,14 @@ impl InfoStatement {
 						"accesses".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_root_accesses().await?.iter().map(|v| v.redacted()) {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"namespaces".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_ns().await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
@@ -110,7 +110,7 @@ impl InfoStatement {
 						"users".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_root_users().await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
@@ -135,21 +135,21 @@ impl InfoStatement {
 						"accesses".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_ns_accesses(ns).await?.iter().map(|v| v.redacted()) {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"databases".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_db(ns).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"users".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_ns_users(ns).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
@@ -179,49 +179,49 @@ impl InfoStatement {
 						"accesses".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_db_accesses(ns, db).await?.iter().map(|v| v.redacted()) {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"analyzers".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_db_analyzers(ns, db).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"functions".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_db_functions(ns, db).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"models".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_db_models(ns, db).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"params".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_db_params(ns, db).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"tables".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_tb(ns, db).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"users".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_db_users(ns, db).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
@@ -249,7 +249,7 @@ impl InfoStatement {
 						"events".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_tb_events(ns, db, tb).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
@@ -263,21 +263,21 @@ impl InfoStatement {
 						"indexes".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_tb_indexes(ns, db, tb).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"lives".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_tb_lives(ns, db, tb).await?.iter() {
-								out.insert(v.id.to_string(), v.to_string().into());
+								out.insert(v.id.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},
 						"tables".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_tb_views(ns, db, tb).await?.iter() {
-								out.insert(v.name.to_string(), v.to_string().into());
+								out.insert(v.name.to_raw(), v.to_string().into());
 							}
 							out.into()
 						},


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Some named definitions in the `INFO FOR` JSON output would be surrounded by unnecessary backticks, which would have to be stripped on the client side.

## What does this change do?

Removes unnecessary surrounding backticks from the `INFO FOR` JSON representation.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

No.

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
