### PR TITLE
Add no-cors capability

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -121,7 +121,14 @@ reqwest = { version = "0.11.22", default-features = false, features = [
     "stream",
     "multipart",
 ], optional = true }
-revision = { version = "0.8.0", features = ["chrono", "geo", "roaring", "regex", "rust_decimal", "uuid"] }
+revision = { version = "0.8.0", features = [
+    "chrono",
+    "geo",
+    "roaring",
+    "regex",
+    "rust_decimal",
+    "uuid",
+] }
 rmpv = "1.0.1"
 roaring = { version = "0.10.2", features = ["serde"] }
 rocksdb = { version = "0.21.0", features = ["lz4", "snappy"], optional = true }

--- a/core/src/dbs/capabilities.rs
+++ b/core/src/dbs/capabilities.rs
@@ -232,6 +232,7 @@ pub struct Capabilities {
 	scripting: bool,
 	guest_access: bool,
 	live_query_notifications: bool,
+	no_cors: bool,
 
 	allow_funcs: Arc<Targets<FuncTarget>>,
 	deny_funcs: Arc<Targets<FuncTarget>>,
@@ -243,8 +244,8 @@ impl fmt::Display for Capabilities {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(
             f,
-            "scripting={}, guest_access={}, live_query_notifications={}, allow_funcs={}, deny_funcs={}, allow_net={}, deny_net={}",
-            self.scripting, self.guest_access, self.live_query_notifications, self.allow_funcs, self.deny_funcs, self.allow_net, self.deny_net
+            "scripting={}, guest_access={}, live_query_notifications={}, no_cors={}, allow_funcs={}, deny_funcs={}, allow_net={}, deny_net={}",
+            self.scripting, self.guest_access, self.live_query_notifications, self.no_cors, self.allow_funcs, self.deny_funcs, self.allow_net, self.deny_net
         )
 	}
 }
@@ -255,6 +256,7 @@ impl Default for Capabilities {
 			scripting: false,
 			guest_access: false,
 			live_query_notifications: true,
+			no_cors: false,
 
 			allow_funcs: Arc::new(Targets::All),
 			deny_funcs: Arc::new(Targets::None),
@@ -270,6 +272,7 @@ impl Capabilities {
 			scripting: true,
 			guest_access: true,
 			live_query_notifications: true,
+			no_cors: true,
 
 			allow_funcs: Arc::new(Targets::All),
 			deny_funcs: Arc::new(Targets::None),
@@ -283,6 +286,7 @@ impl Capabilities {
 			scripting: false,
 			guest_access: false,
 			live_query_notifications: false,
+			no_cors: false,
 
 			allow_funcs: Arc::new(Targets::None),
 			deny_funcs: Arc::new(Targets::None),
@@ -303,6 +307,11 @@ impl Capabilities {
 
 	pub fn with_live_query_notifications(mut self, live_query_notifications: bool) -> Self {
 		self.live_query_notifications = live_query_notifications;
+		self
+	}
+
+	pub fn with_no_cors(mut self, no_cors: bool) -> Self {
+		self.no_cors = no_cors;
 		self
 	}
 
@@ -336,6 +345,10 @@ impl Capabilities {
 
 	pub fn allows_live_query_notifications(&self) -> bool {
 		self.live_query_notifications
+	}
+
+	pub fn allows_no_cors(&self) -> bool {
+		self.no_cors
 	}
 
 	// function is public API so we can't remove it, but you should prefer allows_function_name

--- a/core/src/dbs/capabilities.rs
+++ b/core/src/dbs/capabilities.rs
@@ -232,6 +232,7 @@ pub struct Capabilities {
 	scripting: bool,
 	guest_access: bool,
 	live_query_notifications: bool,
+	#[cfg(target_arch = "wasm32")]
 	no_cors: bool,
 
 	allow_funcs: Arc<Targets<FuncTarget>>,
@@ -243,10 +244,17 @@ pub struct Capabilities {
 impl fmt::Display for Capabilities {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(
-            f,
-            "scripting={}, guest_access={}, live_query_notifications={}, no_cors={}, allow_funcs={}, deny_funcs={}, allow_net={}, deny_net={}",
-            self.scripting, self.guest_access, self.live_query_notifications, self.no_cors, self.allow_funcs, self.deny_funcs, self.allow_net, self.deny_net
-        )
+			f,
+			"scripting={}, guest_access={}, live_query_notifications={}",
+			self.scripting, self.guest_access, self.live_query_notifications
+		)?;
+		#[cfg(target_arch = "wasm32")]
+		write!(f, ", no_cors={}", self.no_cors)?;
+		write!(
+			f,
+			", allow_funcs={}, deny_funcs={}, allow_net={}, deny_net={}",
+			self.allow_funcs, self.deny_funcs, self.allow_net, self.deny_net
+		)
 	}
 }
 
@@ -256,6 +264,7 @@ impl Default for Capabilities {
 			scripting: false,
 			guest_access: false,
 			live_query_notifications: true,
+			#[cfg(target_arch = "wasm32")]
 			no_cors: false,
 
 			allow_funcs: Arc::new(Targets::All),
@@ -272,6 +281,7 @@ impl Capabilities {
 			scripting: true,
 			guest_access: true,
 			live_query_notifications: true,
+			#[cfg(target_arch = "wasm32")]
 			no_cors: true,
 
 			allow_funcs: Arc::new(Targets::All),
@@ -286,6 +296,7 @@ impl Capabilities {
 			scripting: false,
 			guest_access: false,
 			live_query_notifications: false,
+			#[cfg(target_arch = "wasm32")]
 			no_cors: false,
 
 			allow_funcs: Arc::new(Targets::None),
@@ -310,6 +321,7 @@ impl Capabilities {
 		self
 	}
 
+	#[cfg(target_arch = "wasm32")]
 	pub fn with_no_cors(mut self, no_cors: bool) -> Self {
 		self.no_cors = no_cors;
 		self
@@ -347,6 +359,7 @@ impl Capabilities {
 		self.live_query_notifications
 	}
 
+	#[cfg(target_arch = "wasm32")]
 	pub fn allows_no_cors(&self) -> bool {
 		self.no_cors
 	}

--- a/core/src/fnc/util/http/mod.rs
+++ b/core/src/fnc/util/http/mod.rs
@@ -53,6 +53,10 @@ pub async fn head(ctx: &Context<'_>, uri: Strand, opts: impl Into<Object>) -> Re
 	let cli = Client::builder().build()?;
 	// Start a new HEAD request
 	let mut req = cli.head(url);
+	// Disable CORS
+	if ctx.get_capabilities().allows_no_cors() {
+		req = req.fetch_mode_no_cors();
+	}
 	// Add the User-Agent header
 	if cfg!(not(target_arch = "wasm32")) {
 		req = req.header("User-Agent", "SurrealDB");
@@ -82,6 +86,10 @@ pub async fn get(ctx: &Context<'_>, uri: Strand, opts: impl Into<Object>) -> Res
 	let cli = Client::builder().build()?;
 	// Start a new GET request
 	let mut req = cli.get(url);
+	// Disable CORS
+	if ctx.get_capabilities().allows_no_cors() {
+		req = req.fetch_mode_no_cors();
+	}
 	// Add the User-Agent header
 	if cfg!(not(target_arch = "wasm32")) {
 		req = req.header("User-Agent", "SurrealDB");
@@ -113,6 +121,10 @@ pub async fn put(
 	let cli = Client::builder().build()?;
 	// Start a new GET request
 	let mut req = cli.put(url);
+	// Disable CORS
+	if ctx.get_capabilities().allows_no_cors() {
+		req = req.fetch_mode_no_cors();
+	}
 	// Add the User-Agent header
 	if cfg!(not(target_arch = "wasm32")) {
 		req = req.header("User-Agent", "SurrealDB");
@@ -146,6 +158,10 @@ pub async fn post(
 	let cli = Client::builder().build()?;
 	// Start a new GET request
 	let mut req = cli.post(url);
+	// Disable CORS
+	if ctx.get_capabilities().allows_no_cors() {
+		req = req.fetch_mode_no_cors();
+	}
 	// Add the User-Agent header
 	if cfg!(not(target_arch = "wasm32")) {
 		req = req.header("User-Agent", "SurrealDB");
@@ -179,6 +195,10 @@ pub async fn patch(
 	let cli = Client::builder().build()?;
 	// Start a new GET request
 	let mut req = cli.patch(url);
+	// Disable CORS
+	if ctx.get_capabilities().allows_no_cors() {
+		req = req.fetch_mode_no_cors();
+	}
 	// Add the User-Agent header
 	if cfg!(not(target_arch = "wasm32")) {
 		req = req.header("User-Agent", "SurrealDB");
@@ -211,6 +231,10 @@ pub async fn delete(
 	let cli = Client::builder().build()?;
 	// Start a new GET request
 	let mut req = cli.delete(url);
+	// Disable CORS
+	if ctx.get_capabilities().allows_no_cors() {
+		req = req.fetch_mode_no_cors();
+	}
 	// Add the User-Agent header
 	if cfg!(not(target_arch = "wasm32")) {
 		req = req.header("User-Agent", "SurrealDB");

--- a/core/src/fnc/util/http/mod.rs
+++ b/core/src/fnc/util/http/mod.rs
@@ -54,6 +54,7 @@ pub async fn head(ctx: &Context<'_>, uri: Strand, opts: impl Into<Object>) -> Re
 	// Start a new HEAD request
 	let mut req = cli.head(url);
 	// Disable CORS
+	#[cfg(target_arch = "wasm32")]
 	if ctx.get_capabilities().allows_no_cors() {
 		req = req.fetch_mode_no_cors();
 	}
@@ -87,6 +88,7 @@ pub async fn get(ctx: &Context<'_>, uri: Strand, opts: impl Into<Object>) -> Res
 	// Start a new GET request
 	let mut req = cli.get(url);
 	// Disable CORS
+	#[cfg(target_arch = "wasm32")]
 	if ctx.get_capabilities().allows_no_cors() {
 		req = req.fetch_mode_no_cors();
 	}
@@ -122,6 +124,7 @@ pub async fn put(
 	// Start a new GET request
 	let mut req = cli.put(url);
 	// Disable CORS
+	#[cfg(target_arch = "wasm32")]
 	if ctx.get_capabilities().allows_no_cors() {
 		req = req.fetch_mode_no_cors();
 	}
@@ -159,6 +162,7 @@ pub async fn post(
 	// Start a new GET request
 	let mut req = cli.post(url);
 	// Disable CORS
+	#[cfg(target_arch = "wasm32")]
 	if ctx.get_capabilities().allows_no_cors() {
 		req = req.fetch_mode_no_cors();
 	}
@@ -196,6 +200,7 @@ pub async fn patch(
 	// Start a new GET request
 	let mut req = cli.patch(url);
 	// Disable CORS
+	#[cfg(target_arch = "wasm32")]
 	if ctx.get_capabilities().allows_no_cors() {
 		req = req.fetch_mode_no_cors();
 	}
@@ -232,6 +237,7 @@ pub async fn delete(
 	// Start a new GET request
 	let mut req = cli.delete(url);
 	// Disable CORS
+	#[cfg(target_arch = "wasm32")]
 	if ctx.get_capabilities().allows_no_cors() {
 		req = req.fetch_mode_no_cors();
 	}


### PR DESCRIPTION
Thank you for submitting this pull request! We really appreciate you spending the time to work on these changes.

## What is the motivation?

Currently, the `http::*` methods inside the Surrealist Sandbox are restricted by CORS.

## What does this change do?

This PR adds a `no-cors` capability, which we can enable specifically in Surrealist to circumvent this limitation.
There's no way to enable it from the CLI as this CORS issue only affects browsers. Other people may want to have cors enabled when using SurrealDB inside a WASM environment, hence adding it as a capability to allow for granular control.

## What is your testing strategy?

GitHub CI

## Is this related to any issues?

No

<!-- Use 'Closes' or 'Fixes' to mark that this pull request successfully closes an issue. -->

## Does this change need documentation?

If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository, and link to it here.

<!-- Delete one of the following lines as necessary, and enter the correct corresponding issue number. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
