### PR TITLE
Remove private feature, restore cfg/docker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ performance-profiler = ["dep:pprof"]
 # Special features
 storage-fdb-7_1 = ["surrealdb/kv-fdb-7_1"]
 storage-fdb-7_3 = ["surrealdb/kv-fdb-7_3"]
-# Trigger database upgrade tests
-database-upgrade-tests = []
 
 [workspace]
 members = [
@@ -184,3 +182,6 @@ assets = [
 ]
 extended-description = "A scalable, distributed, collaborative, document-graph database, for the realtime web."
 license-file = ["LICENSE", "4"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docker)'] }

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -110,8 +110,8 @@ run_task = { name = ["start-surrealdb", "test-api-integration", "stop-surrealdb"
 [tasks.test-database-upgrade]
 private = true
 command = "cargo"
-env = { RUST_BACKTRACE = 1, RUST_LOG = "info" }
-args = ["test", "--locked", "--no-default-features", "--features", "database-upgrade-tests,${_TEST_FEATURES}", "--workspace", "--test", "database_upgrade", "--", "database_upgrade", "--show-output"]
+env = { RUST_BACKTRACE = 1, RUST_LOG = "info", RUSTFLAGS = "--cfg docker" }
+args = ["test", "--locked", "--no-default-features", "--features", "${_TEST_FEATURES}", "--workspace", "--test", "database_upgrade", "--", "database_upgrade", "--show-output"]
 
 
 #

--- a/tests/database_upgrade.rs
+++ b/tests/database_upgrade.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-#[cfg(feature = "database-upgrade-tests")]
+#[cfg(docker)]
 mod database_upgrade {
 	use super::common::docker::DockerContainer;
 	use super::common::expected::Expected;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

A private features has been added for database upgrade tests. But cargo does not support them.

## What does this change do?

Until private features are supported by cargo we use custom cfg

## What is your testing strategy?

N/A

## Is this related to any issues?

Follow up #4436 

## Does this change need documentation?


- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
