### PR TITLE
Idiom destructuring

### DIFF
--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1013,6 +1013,12 @@ pub enum Error {
 	Return {
 		value: Value,
 	},
+
+	/// A destructuring variant was used in a context where it is not supported
+	#[error("{variant} destructuring method is not supported here")]
+	UnsupportedDestructure {
+		variant: String,
+	},
 }
 
 impl From<Error> for String {

--- a/core/src/idx/planner/rewriter.rs
+++ b/core/src/idx/planner/rewriter.rs
@@ -72,14 +72,12 @@ impl<'a> KnnConditionRewriter<'a> {
 
 	fn eval_destructure_part(&self, part: &DestructurePart) -> Option<DestructurePart> {
 		match part {
-			DestructurePart::Aliased(f, v) => match self.eval_idiom(v) {
-				Some(v) => Some(DestructurePart::Aliased(f.clone(), v)),
-				None => None,
-			},
-			DestructurePart::Destructure(f, v) => match self.eval_destructure_parts(v) {
-				Some(v) => Some(DestructurePart::Destructure(f.clone(), v)),
-				None => None,
-			},
+			DestructurePart::Aliased(f, v) => {
+				self.eval_idiom(v).map(|v| DestructurePart::Aliased(f.clone(), v))
+			}
+			DestructurePart::Destructure(f, v) => {
+				self.eval_destructure_parts(v).map(|v| DestructurePart::Destructure(f.clone(), v))
+			}
 			p => Some(p.clone()),
 		}
 	}
@@ -87,7 +85,7 @@ impl<'a> KnnConditionRewriter<'a> {
 	fn eval_destructure_parts(&self, parts: &[DestructurePart]) -> Option<Vec<DestructurePart>> {
 		let mut new_vec = Vec::with_capacity(parts.len());
 		for part in parts {
-			if let Some(part) = self.eval_destructure_part(&part) {
+			if let Some(part) = self.eval_destructure_part(part) {
 				new_vec.push(part);
 			} else {
 				return None;

--- a/core/src/idx/planner/rewriter.rs
+++ b/core/src/idx/planner/rewriter.rs
@@ -71,17 +71,16 @@ impl<'a> KnnConditionRewriter<'a> {
 	}
 
 	fn eval_destructure_part(&self, part: &DestructurePart) -> Option<DestructurePart> {
-		if let Some(aliased) = &part.aliased {
-			if let Some(aliased) = self.eval_idiom(aliased) {
-				Some(DestructurePart {
-					aliased: Some(aliased),
-					..part.clone()
-				})
-			} else {
-				None
-			}
-		} else {
-			Some(part.clone())
+		match part {
+			DestructurePart::Aliased(f, v) => match self.eval_idiom(v) {
+				Some(v) => Some(DestructurePart::Aliased(f.clone(), v)),
+				None => None,
+			},
+			DestructurePart::Destructure(f, v) => match self.eval_destructure_parts(v) {
+				Some(v) => Some(DestructurePart::Destructure(f.clone(), v)),
+				None => None,
+			},
+			p => Some(p.clone()),
 		}
 	}
 

--- a/core/src/sql/geometry.rs
+++ b/core/src/sql/geometry.rs
@@ -10,8 +10,11 @@ use geo_types::{MultiLineString, MultiPoint, MultiPolygon};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::iter::once;
 use std::{fmt, hash};
+
+use super::Object;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Geometry";
 
@@ -115,6 +118,21 @@ impl Geometry {
 			Self::MultiPolygon(v) => multipolygon(v),
 			Self::Collection(v) => collection(v),
 		}
+	}
+	/// Get the GeoJSON object representation for this geometry
+	pub fn as_object(&self) -> Object {
+		let mut obj = BTreeMap::<String, Value>::new();
+		obj.insert("type".into(), self.as_type().into());
+		obj.insert(
+			match self {
+				Self::Collection(_) => "geometries",
+				_ => "coordinates",
+			}
+			.into(),
+			self.as_coordinates(),
+		);
+
+		obj.into()
 	}
 }
 

--- a/core/src/sql/part.rs
+++ b/core/src/sql/part.rs
@@ -163,10 +163,10 @@ pub enum DestructurePart {
 impl DestructurePart {
 	pub fn field(&self) -> &Ident {
 		match self {
-			DestructurePart::All(v) => &v,
-			DestructurePart::Field(v) => &v,
-			DestructurePart::Aliased(v, _) => &v,
-			DestructurePart::Destructure(v, _) => &v,
+			DestructurePart::All(v) => v,
+			DestructurePart::Field(v) => v,
+			DestructurePart::Aliased(v, _) => v,
+			DestructurePart::Destructure(v, _) => v,
 		}
 	}
 
@@ -174,7 +174,7 @@ impl DestructurePart {
 		match self {
 			DestructurePart::All(v) => vec![Part::Field(v.clone()), Part::All],
 			DestructurePart::Field(v) => vec![Part::Field(v.clone())],
-			DestructurePart::Aliased(_, v) => v.0.clone().into(),
+			DestructurePart::Aliased(_, v) => v.0.clone(),
 			DestructurePart::Destructure(f, d) => {
 				vec![Part::Field(f.clone()), Part::Destructure(d.clone())]
 			}

--- a/core/src/sql/value/fetch.rs
+++ b/core/src/sql/value/fetch.rs
@@ -42,11 +42,7 @@ impl Value {
 					Part::All => stk.run(|stk| self.fetch(stk, ctx, opt, path.next())).await,
 					Part::Destructure(p) => {
 						for p in p.iter() {
-							let path = match &p.aliased {
-								Some(i) => [&i.0.as_slice(), path].concat(),
-								None => [&[Part::Field(p.field.clone())], path].concat(),
-							};
-
+							let path = [&p.path().as_slice(), path].concat();
 							stk.run(|stk| self.fetch(stk, ctx, opt, &path)).await?;
 						}
 

--- a/core/src/sql/value/fetch.rs
+++ b/core/src/sql/value/fetch.rs
@@ -40,6 +40,18 @@ impl Value {
 						None => Ok(()),
 					},
 					Part::All => stk.run(|stk| self.fetch(stk, ctx, opt, path.next())).await,
+					Part::Destructure(p) => {
+						for p in p.iter() {
+							let path = match &p.aliased {
+								Some(i) => [&i.0.as_slice(), path].concat(),
+								None => [&[Part::Field(p.field.clone())], path].concat(),
+							};
+
+							stk.run(|stk| self.fetch(stk, ctx, opt, &path)).await?;
+						}
+
+						Ok(())
+					}
 					_ => Ok(()),
 				},
 				// Current path part is an array

--- a/core/src/sql/value/fetch.rs
+++ b/core/src/sql/value/fetch.rs
@@ -42,7 +42,7 @@ impl Value {
 					Part::All => stk.run(|stk| self.fetch(stk, ctx, opt, path.next())).await,
 					Part::Destructure(p) => {
 						for p in p.iter() {
-							let path = [&p.path().as_slice(), path].concat();
+							let path = [(p.path().as_slice()), path].concat();
 							stk.run(|stk| self.fetch(stk, ctx, opt, &path)).await?;
 						}
 

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -124,18 +124,11 @@ impl Value {
 					Part::Destructure(p) => {
 						let mut obj = BTreeMap::<String, Value>::new();
 						for p in p.iter() {
-							let v = match &p.aliased {
-								Some(i) => {
-									stk.run(|stk| self.get(stk, ctx, opt, doc, &i.0.as_slice()))
-										.await?
-								}
-								None => {
-									let path = [Part::Field(p.field.clone())];
-									stk.run(|stk| self.get(stk, ctx, opt, doc, &path)).await?
-								}
-							};
-
-							obj.insert(p.field.to_raw(), v);
+							let path = p.path();
+							let v = stk
+								.run(|stk| self.get(stk, ctx, opt, doc, path.as_slice()))
+								.await?;
+							obj.insert(p.field().to_raw(), v);
 						}
 
 						let obj = Value::from(obj);

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use crate::cnf::MAX_COMPUTATION_DEPTH;
 use crate::ctx::Context;
 use crate::dbs::Options;
@@ -50,6 +52,10 @@ impl Value {
 					Part::Field(f) if f.is_geometries() && v.is_collection() => {
 						let v = v.as_coordinates();
 						stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
+					}
+					Part::Destructure(_) => {
+						let obj = Value::Object(v.as_object());
+						stk.run(|stk| obj.get(stk, ctx, opt, doc, path)).await
 					}
 					// Otherwise return none
 					_ => Ok(Value::None),
@@ -115,6 +121,26 @@ impl Value {
 						_ => Ok(Value::None),
 					},
 					Part::All => stk.run(|stk| self.get(stk, ctx, opt, doc, path.next())).await,
+					Part::Destructure(p) => {
+						let mut obj = BTreeMap::<String, Value>::new();
+						for p in p.iter() {
+							let v = match &p.aliased {
+								Some(i) => {
+									stk.run(|stk| self.get(stk, ctx, opt, doc, &i.0.as_slice()))
+										.await?
+								}
+								None => {
+									let path = [Part::Field(p.field.clone())];
+									stk.run(|stk| self.get(stk, ctx, opt, doc, &path)).await?
+								}
+							};
+
+							obj.insert(p.field.to_raw(), v);
+						}
+
+						let obj = Value::from(obj);
+						stk.run(|stk| obj.get(stk, ctx, opt, doc, path.next())).await
+					}
 					_ => Ok(Value::None),
 				},
 				// Current value at path is an array

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -268,6 +268,11 @@ impl Parser<'_> {
 		let start = self.last_span();
 		let mut destructured: Vec<DestructurePart> = Vec::new();
 		loop {
+			if self.eat(t!("}")) {
+				// We've reached the end of the destructure
+				break;
+			}
+
 			let field: Ident = self.next_token_value()?;
 			let part = match self.peek_kind() {
 				t!(":") => {
@@ -299,12 +304,6 @@ impl Parser<'_> {
 			if !self.eat(t!(",")) {
 				// We've reached the end of the destructure
 				self.expect_closing_delimiter(t!("}"), start)?;
-				break;
-			}
-
-			// destructuring supports leftover comma's
-			if self.eat(t!("}")) {
-				// We've reached the end of the destructure
 				break;
 			}
 		}

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -281,6 +281,12 @@ impl Parser<'_> {
 					if matches!(self.peek_kind(), t!(":")) {
 						self.pop_peek();
 						part.aliased = Some(self.parse_local_idiom()?);
+					} else if matches!(self.peek_kind(), t!(".")) {
+						self.pop_peek();
+						part.aliased = Some(Idiom(vec![
+							Part::Field(part.field.clone()),
+							self.parse_dot_part()?,
+						]));
 					}
 
 					self.eat(t!(","));

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -301,6 +301,12 @@ impl Parser<'_> {
 				self.expect_closing_delimiter(t!("}"), start)?;
 				break;
 			}
+
+			// destructuring supports leftover comma's
+			if self.eat(t!("}")) {
+				// We've reached the end of the destructure
+				break;
+			}
 		}
 
 		Ok(Part::Destructure(destructured))


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

It would be nice to be able to destructure objects within idiom paths

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It implements idiom destructuring

```sql
CREATE person:1 SET name = "John", age = 21;

LET $obj = {
  a: 1,
  b: {
    c: 2,
    d: 3,
    e: 4,
  },
  link: person: 1
};

// On any value which represents an object
$obj.{ 
  a, 
  b.{ c, e },
  link.*,
  partial: link.{ name }
};
```

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test under the `select` tests which covers `get` and `del` implementations

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] #3374

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] surrealdb/docs.surrealdb.com#720

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
