### PR TITLE
Fix flaky tests in LQs due to timeout

### DIFF
--- a/lib/tests/api/live.rs
+++ b/lib/tests/api/live.rs
@@ -12,7 +12,7 @@ use surrealdb_core::sql::Object;
 use tokio::sync::RwLock;
 use tracing::info;
 
-const LQ_TIMEOUT: Duration = Duration::from_secs(1);
+const LQ_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_NOTIFICATIONS: usize = 100;
 
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To fix some tests related to live queries that have recently become flaky. Some examples:
https://github.com/surrealdb/surrealdb/actions/runs/10178169020/job/28151256948#step:6:496
https://github.com/surrealdb/surrealdb/actions/runs/10162996148/job/28104838723#step:6:120
https://github.com/surrealdb/surrealdb/actions/runs/10163644023/job/28107073180#step:6:113

## What does this change do?

Increases the timeout duration for awaiting a result from 1 second to 5 seconds.

## What is your testing strategy?

Trigger the complete test suite several times and ensure that these tests no longer fail unexpectedly.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
