### PR TITLE
Restore bench-sdk-surrealkv

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -316,9 +316,9 @@ category = "CI - BENCHMARK - SurrealDB Target"
 env = { BENCH_DATASTORE_TARGET = "sdk-rocksdb" }
 run_task = { name = ["bench-target"] }
 
-[tasks.bench-lib-surrealkv]
+[tasks.bench-sdk-surrealkv]
 category = "CI - BENCHMARK - SurrealDB Target"
-env = { BENCH_DATASTORE_TARGET = "lib-surrealkv" }
+env = { BENCH_DATASTORE_TARGET = "sdk-surrealkv" }
 run_task = { name = ["bench-target"] }
 
 [tasks.bench-sdk-ws]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The bench `bench-sdk-surrealkv` does not run anymore

[bench-sdk-surrealkv](https://github.com/surrealdb/surrealdb/actions/runs/10167579259/job/28120295461)

## What does this change do?

The makefile was looking for `lib-surrealkv` rather than `sdk-surrealkv`.

## What is your testing strategy?

N/A

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?


- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
