### PR TITLE
Fix like operator not being implemented

### DIFF
--- a/core/src/syn/lexer/byte.rs
+++ b/core/src/syn/lexer/byte.rs
@@ -138,6 +138,7 @@ impl<'a> Lexer<'a> {
 			b'(' => t!("("),
 			b';' => t!(";"),
 			b',' => t!(","),
+			b'~' => t!("~"),
 			b'@' => t!("@"),
 			byte::CR | byte::FF | byte::LF | byte::SP | byte::VT | byte::TAB => {
 				self.eat_whitespace();

--- a/core/src/syn/parser/test/value.rs
+++ b/core/src/syn/parser/test/value.rs
@@ -15,6 +15,11 @@ fn parse_coordinate() {
 }
 
 #[test]
+fn parse_like_operator() {
+	test_parse!(parse_value, "a ~ b").unwrap();
+}
+
+#[test]
 fn parse_large_depth_object() {
 	let mut text = String::new();
 	let start = r#" { foo: "#;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The like operator was not being parser properly.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Fixes the like operator not being parsed.


## What is your testing strategy?

Added a test to ensure parsing works.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
