### PR TITLE
Remove faulty flatten

### DIFF
--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -253,10 +253,17 @@ impl Value {
 										let res = stk
 											.run(|stk| v.get(stk, ctx, opt, None, path.next()))
 											.await?;
-										match path[1] {
-											Part::Graph(_) => res.flatten().ok(),
-											_ => res.ok(),
-										}
+										// We only want to flatten the results if the next part
+										// is a graph part. Reason being that if we flatten fields,
+										// the results of those fields (which could be arrays) will
+										// be merged into each other. So [1, 2, 3], [4, 5, 6] would
+										// become [1, 2, 3, 4, 5, 6]. This slice access won't panic
+										// as we have already checked the length of the path.
+										Ok(if let Part::Graph(_) = path[1] {
+											res.flatten()
+										} else {
+											res
+										})
 									}
 								}
 							}

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -242,7 +242,6 @@ impl Value {
 											.all();
 										stk.run(|stk| v.get(stk, ctx, opt, None, ID.as_ref()))
 											.await?
-											.flatten()
 											.ok()
 									}
 									_ => {
@@ -252,7 +251,6 @@ impl Value {
 											.all();
 										stk.run(|stk| v.get(stk, ctx, opt, None, path.next()))
 											.await?
-											.flatten()
 											.ok()
 									}
 								}

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -242,6 +242,7 @@ impl Value {
 											.all();
 										stk.run(|stk| v.get(stk, ctx, opt, None, ID.as_ref()))
 											.await?
+											.flatten()
 											.ok()
 									}
 									_ => {
@@ -249,9 +250,13 @@ impl Value {
 											.run(|stk| stm.compute(stk, ctx, opt, None))
 											.await?
 											.all();
-										stk.run(|stk| v.get(stk, ctx, opt, None, path.next()))
-											.await?
-											.ok()
+										let res = stk
+											.run(|stk| v.get(stk, ctx, opt, None, path.next()))
+											.await?;
+										match path[1] {
+											Part::Graph(_) => res.flatten().ok(),
+											_ => res.ok(),
+										}
 									}
 								}
 							}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

In the last query, the field selected from the graph traversal is incorrectly flattened:
```sql
delete a, b;

create a:1, a:2;

relate a:1->b:1->a:2 set list = [1, 2, 3];
relate a:1->b:2->a:2 set list = [4, 5, 6];

select value ->b.list from a:1;
```

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This alters the flattening behaviour to check if the next part in the path is actually a graph part, which is the only part we want to flatten there.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
