### PR TITLE
WIP 1.5.4 lq sess update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6478,9 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -6499,9 +6499,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/core/src/dbs/session.rs
+++ b/core/src/dbs/session.rs
@@ -1,7 +1,9 @@
 use crate::ctx::Context;
 use crate::iam::Auth;
 use crate::iam::{Level, Role};
+use crate::sql::statements::live::MaybeSession;
 use crate::sql::value::Value;
+use crate::sql::Uuid;
 use chrono::Utc;
 use std::sync::Arc;
 
@@ -9,6 +11,9 @@ use std::sync::Arc;
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct Session {
+	/// The session ID, used as a reference on KV store.
+	/// Changes in auth and ns/db/sc should be reflected on KV store.
+	pub sess_id: Uuid,
 	/// The current session [`Auth`] information
 	pub au: Arc<Auth>,
 	/// Whether realtime queries are supported
@@ -147,6 +152,7 @@ impl Session {
 			tk: None,
 			sd: Some(rid),
 			exp: None,
+			sess_id: Uuid::default(),
 		}
 	}
 

--- a/core/src/key/mod.rs
+++ b/core/src/key/mod.rs
@@ -9,6 +9,7 @@
 ///
 /// crate::key::node::all                /${nd}
 /// crate::key::node::lq                 /${nd}!lq{lq}{ns}{db}
+/// crate::key::node::se                 /${nd}!se{se}
 ///
 /// crate::key::namespace::all           /*{ns}
 /// crate::key::namespace::db            /*{ns}!db{db}

--- a/core/src/key/node/mod.rs
+++ b/core/src/key/node/mod.rs
@@ -1,2 +1,3 @@
 pub mod all;
 pub mod lq;
+mod se;

--- a/core/src/key/node/se.rs
+++ b/core/src/key/node/se.rs
@@ -1,0 +1,116 @@
+//! Stores a Session as a reference that is accessed by live queries
+use crate::key::error::KeyCategory;
+use crate::key::key_req::KeyRequirements;
+use derive::Key;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// The Se key is used to quickly update a shared session used by all live queries that share it
+///
+/// The value is the serialised Session that contains authentication and permissions information
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Key)]
+#[non_exhaustive]
+pub struct Se {
+	__: u8,
+	_a: u8,
+	#[serde(with = "uuid::serde::compact")]
+	pub nd: Uuid,
+	_b: u8,
+	_c: u8,
+	_d: u8,
+	#[serde(with = "uuid::serde::compact")]
+	pub se: Uuid,
+}
+
+pub fn new(nd: Uuid, se: Uuid) -> Se {
+	Se::new(nd, se)
+}
+
+pub fn prefix_se(nd: &Uuid) -> Vec<u8> {
+	let mut k = [b'/', b'$'].to_vec();
+	k.extend_from_slice(nd.as_bytes());
+	k.extend_from_slice(&[b'!', b's', b'e', 0x00]);
+	k
+}
+
+pub fn suffix_se(nd: &Uuid) -> Vec<u8> {
+	let mut k = [b'/', b'$'].to_vec();
+	k.extend_from_slice(nd.as_bytes());
+	k.extend_from_slice(&[b'!', b's', b'e']);
+	k.extend_from_slice(&[0xff; 16]);
+	k
+}
+
+impl KeyRequirements for Se {
+	fn key_category(&self) -> KeyCategory {
+		KeyCategory::NodeLiveQuery
+	}
+}
+
+impl Se {
+	pub fn new(nd: Uuid, se: Uuid) -> Self {
+		Self {
+			__: b'/',
+			_a: b'$',
+			nd,
+			_b: b'!',
+			_c: b's',
+			_d: b'e',
+			se,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+
+	#[test]
+	fn key() {
+		use super::*;
+		#[rustfmt::skip]
+        let nd = Uuid::from_bytes([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10]);
+		#[rustfmt::skip]
+        let se = Uuid::from_bytes([0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20]);
+		let val = Se::new(nd, se);
+		let enc = Se::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/$\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\
+			!se\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x20\
+			"
+		);
+
+		let dec = Se::decode(&enc).unwrap();
+		assert_eq!(val, dec);
+	}
+
+	#[test]
+	fn prefix_se() {
+		use super::*;
+		let nd = Uuid::from_bytes([
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+			0x0f, 0x10,
+		]);
+		let val = prefix_se(&nd);
+		assert_eq!(
+			val,
+			b"/$\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x00!se\x00"
+		);
+	}
+
+	#[test]
+	fn suffix_nd() {
+		use super::*;
+		let nd = Uuid::from_bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+		let val = suffix_se(&nd);
+		assert_eq!(
+			val,
+			b"/$\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\xff!se
+		\xff\xff\xff\xff
+		\xff\xff\xff\xff
+		\xff\xff\xff\xff
+		\xff\xff\xff\xff
+		"
+		);
+	}
+}

--- a/core/src/kvs/tests/cluster_init.rs
+++ b/core/src/kvs/tests/cluster_init.rs
@@ -95,6 +95,7 @@ async fn expired_nodes_get_live_queries_archived() {
 		archived: Some(crate::sql::uuid::Uuid::from(old_node)),
 		session: Some(Value::None),
 		auth: Some(Auth::for_root(Role::Owner)),
+		session_id: Default::default(),
 	};
 	let ctx = context::Context::background();
 	let (sender, _) = channel::unbounded();
@@ -177,6 +178,7 @@ async fn single_live_queries_are_garbage_collected() {
 		archived: None,
 		session: Some(Value::None),
 		auth: Some(Auth::for_root(Role::Owner)),
+		session_id: Default::default(),
 	};
 	live_st
 		.compute(&ctx, &options, &tx, None)
@@ -194,6 +196,7 @@ async fn single_live_queries_are_garbage_collected() {
 		archived: None,
 		session: Some(Value::None),
 		auth: Some(Auth::for_root(Role::Owner)),
+		session_id: Default::default(),
 	};
 	live_st
 		.compute(&ctx, &options, &tx, None)
@@ -264,6 +267,7 @@ async fn bootstrap_does_not_error_on_missing_live_queries() {
 		archived: None,
 		session: Some(Value::None),
 		auth: Some(Auth::for_root(Role::Owner)),
+		session_id: Default::default(),
 	};
 	live_st
 		.compute(&ctx, &options, &tx, None)

--- a/core/src/kvs/tests/tblq.rs
+++ b/core/src/kvs/tests/tblq.rs
@@ -29,6 +29,7 @@ async fn write_scan_tblq() {
 			archived: None,
 			session: Some(Value::None),
 			auth: None,
+			session_id: Default::default(),
 		};
 		tx.putc_tblq(ns, db, tb, live_stm, None).await.unwrap();
 		tx.commit().await.unwrap();

--- a/core/src/kvs/tests/tx_test.rs
+++ b/core/src/kvs/tests/tx_test.rs
@@ -26,6 +26,7 @@ async fn live_queries_sent_to_tx_are_received() {
 			archived: None,
 			session: Some(Value::None),
 			auth: None,
+			session_id: Default::default(),
 		},
 	};
 	tx.pre_commit_register_async_event(TrackedResult::LiveQuery(lq_entry.clone())).unwrap();

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -3325,6 +3325,7 @@ mod tx_test {
 				archived: None,
 				session: Some(Value::None),
 				auth: None,
+				session_id: Default::default(),
 			},
 		};
 		tx.pre_commit_register_async_event(TrackedResult::LiveQuery(lq_entry.clone())).unwrap();

--- a/core/src/sql/value/serde/ser/statement/live.rs
+++ b/core/src/sql/value/serde/ser/statement/live.rs
@@ -1,5 +1,6 @@
 use crate::err::Error;
 use crate::iam::Auth;
+use crate::sql::statements::live::MaybeSession;
 use crate::sql::statements::LiveStatement;
 use crate::sql::value::serde::ser;
 use crate::sql::Cond;
@@ -107,6 +108,7 @@ impl serde::ser::SerializeStruct for SerializeLiveStatement {
 			archived: self.archived,
 			session: None,
 			auth: None,
+			session_id: MaybeSession::default(),
 		})
 	}
 }

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -47,28 +47,28 @@ use crate::api::Surreal;
 use crate::dbs::Notification;
 use crate::dbs::Response;
 use crate::dbs::Session;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(any(feature = "ml"))]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::iam::check::check_ns_db;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(any(feature = "ml"))]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::iam::Action;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(any(feature = "ml"))]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::iam::ResourceKind;
 use crate::kvs::Datastore;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(any(feature = "ml"))]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::kvs::{LockType, TransactionType};
 use crate::method::Stats;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(any(feature = "ml"))]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::ml::storage::surml_file::SurMlFile;
 use crate::opt::IntoEndpoint;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(any(feature = "ml"))]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::sql::statements::DefineModelStatement;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(any(feature = "ml"))]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::sql::statements::DefineStatement;
 use crate::sql::statements::KillStatement;
@@ -77,7 +77,7 @@ use crate::sql::Statement;
 use crate::sql::Uuid;
 use crate::sql::Value;
 use channel::Sender;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(any(feature = "ml"))]
 #[cfg(not(target_arch = "wasm32"))]
 use futures::StreamExt;
 use indexmap::IndexMap;
@@ -445,7 +445,7 @@ async fn export(
 	ml_config: Option<MlConfig>,
 ) -> Result<()> {
 	match ml_config {
-		#[cfg(any(feature = "ml", feature = "ml2"))]
+		#[cfg(any(feature = "ml"))]
 		Some(MlConfig::Export {
 			name,
 			version,
@@ -722,7 +722,7 @@ async fn router(
 				}
 			};
 			let responses = match param.ml_config {
-				#[cfg(any(feature = "ml", feature = "ml2"))]
+				#[cfg(any(feature = "ml"))]
 				Some(MlConfig::Import) => {
 					// Ensure a NS and DB are set
 					let (nsv, dbv) = check_ns_db(session)?;

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod wasm;
 
 use crate::api::conn::DbResponse;
 use crate::api::conn::Method;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(any(feature = "ml"))]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::api::conn::MlConfig;
 use crate::api::conn::Param;
@@ -534,7 +534,7 @@ async fn router(
 		#[cfg(not(target_arch = "wasm32"))]
 		Method::Export => {
 			let path = match param.ml_config {
-				#[cfg(any(feature = "ml", feature = "ml2"))]
+				#[cfg(any(feature = "ml"))]
 				Some(MlConfig::Export {
 					name,
 					version,
@@ -552,7 +552,7 @@ async fn router(
 		#[cfg(not(target_arch = "wasm32"))]
 		Method::Import => {
 			let path = match param.ml_config {
-				#[cfg(any(feature = "ml", feature = "ml2"))]
+				#[cfg(any(feature = "ml"))]
 				Some(MlConfig::Import) => base_url.join("ml/import")?,
 				_ => base_url.join(Method::Import.as_str())?,
 			};


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Instead of updating all LQ sessions, update a single KV entry with new sessions info
WIP as 1.5.4 is broken and this is slowing things down/distraction

## What does this change do?

Record session to KV and use session as reference in LQs

## What is your testing strategy?

todo

## Is this related to any issues?

N/A

## Does this change need documentation?


- [x] No documentation needed

## Have you read the Contributing Guidelines?


- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
