### PR TITLE
Add aliases for complex feature flag combinations

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -1,0 +1,17 @@
+fn main() {
+	if cfg!(target_arch = "wasm32") {
+		println!("cargo:rustc-cfg=wasm");
+		println!("cargo::rustc-check-cfg=cfg(wasm)");
+	}
+	if cfg!(any(
+		feature = "kv-mem",
+		feature = "kv-fdb",
+		feature = "kv-tikv",
+		feature = "kv-rocksdb",
+		feature = "kv-surrealkv",
+		feature = "kv-surrealcs",
+	)) {
+		println!("cargo:rustc-cfg=storage");
+		println!("cargo::rustc-check-cfg=cfg(storage)");
+	}
+}

--- a/core/build.rs
+++ b/core/build.rs
@@ -9,7 +9,6 @@ fn main() {
 		feature = "kv-tikv",
 		feature = "kv-rocksdb",
 		feature = "kv-surrealkv",
-		feature = "kv-surrealcs",
 	)) {
 		println!("cargo:rustc-cfg=storage");
 		println!("cargo::rustc-check-cfg=cfg(storage)");

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -1,0 +1,17 @@
+fn main() {
+	if cfg!(target_arch = "wasm32") {
+		println!("cargo:rustc-cfg=wasm");
+		println!("cargo::rustc-check-cfg=cfg(wasm)");
+	}
+	if cfg!(any(
+		feature = "kv-mem",
+		feature = "kv-fdb",
+		feature = "kv-tikv",
+		feature = "kv-rocksdb",
+		feature = "kv-surrealkv",
+		feature = "kv-surrealcs",
+	)) {
+		println!("cargo:rustc-cfg=storage");
+		println!("cargo::rustc-check-cfg=cfg(storage)");
+	}
+}

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -9,7 +9,6 @@ fn main() {
 		feature = "kv-tikv",
 		feature = "kv-rocksdb",
 		feature = "kv-surrealkv",
-		feature = "kv-surrealcs",
 	)) {
 		println!("cargo:rustc-cfg=storage");
 		println!("cargo::rustc-check-cfg=cfg(storage)");


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently there are a number of locations around the codebase where complex feature flag combinations are used. These can be simplified by using a feature flag alias. For example in a number of locations the following cfg attribute check is necessary:

```rs
#[cfg(any(
    feature = "kv-mem",
    feature = "kv-surrealkv",
    feature = "kv-rocksdb",
    feature = "kv-fdb",
    feature = "kv-tikv",
))]
```

## What does this change do?

This change adds an alias for the combined key-value-storage feature flags so that the following can be used instead:

```rs
#[cfg(storage)]
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
