### PR TITLE
Skip `ASSERT` for type `option<T>` and value `NONE`

### DIFF
--- a/core/src/doc/field.rs
+++ b/core/src/doc/field.rs
@@ -110,26 +110,32 @@ impl<'a> Document<'a> {
 					})?;
 				}
 				// Check for a ASSERT clause
-				match (&fd.assert, &val, &fd.kind) {
-					(_, Value::None, Some(Kind::Option(_))) => (),
-					(Some(expr), _, _) => {
-						// Configure the context
-						let mut ctx = Context::new(ctx);
-						ctx.add_value("input", &inp);
-						ctx.add_value("value", &val);
-						ctx.add_value("after", &val);
-						ctx.add_value("before", &old);
-						// Process the ASSERT clause
-						if !expr.compute(stk, &ctx, opt, Some(&self.current)).await?.is_truthy() {
-							return Err(Error::FieldValue {
-								thing: rid.to_string(),
-								field: fd.name.clone(),
-								value: val.to_string(),
-								check: expr.to_string(),
-							});
+				if let Some(expr) = &fd.assert {
+					match (&val, &fd.kind) {
+						// The field TYPE is optional, and the field
+						// value was not set or a NONE value was
+						// specified, so let's ignore the ASSERT clause
+						(Value::None, Some(Kind::Option(_))) => (),
+						// Otherwise let's process the ASSERT clause
+						_ => {
+							// Configure the context
+							let mut ctx = Context::new(ctx);
+							ctx.add_value("input", &inp);
+							ctx.add_value("value", &val);
+							ctx.add_value("after", &val);
+							ctx.add_value("before", &old);
+							// Process the ASSERT clause
+							if !expr.compute(stk, &ctx, opt, Some(&self.current)).await?.is_truthy()
+							{
+								return Err(Error::FieldValue {
+									thing: rid.to_string(),
+									field: fd.name.clone(),
+									value: val.to_string(),
+									check: expr.to_string(),
+								});
+							}
 						}
 					}
-					_ => (),
 				}
 				// Check for a PERMISSIONS clause
 				if opt.check_perms(Action::Edit)? {

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -147,8 +147,8 @@ async fn field_definition_option_kind_assert() -> Result<(), Error> {
 		CREATE person:mark SET name = 'mark';
 		CREATE person:bob SET name = 'bob';
 	";
-	let dbs = Datastore::new("memory").await?;
-	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 5);
 	//

--- a/lib/tests/field.rs
+++ b/lib/tests/field.rs
@@ -139,6 +139,60 @@ async fn field_definition_value_assert_success() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn field_definition_option_kind_assert() -> Result<(), Error> {
+	let sql = "
+		DEFINE TABLE person SCHEMAFULL;
+		DEFINE FIELD name ON TABLE person TYPE option<string> ASSERT string::len($value) > 3;
+		CREATE person:test;
+		CREATE person:mark SET name = 'mark';
+		CREATE person:bob SET name = 'bob';
+	";
+	let dbs = Datastore::new("memory").await?;
+	let ses = Session::for_kv().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 5);
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_ok());
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:test
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: person:mark,
+				name: 'mark'
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result;
+	assert!(
+		matches!(
+			&tmp,
+			Err(e) if e.to_string() == "Found 'bob' for field `name`, with record `person:bob`, but field must conform to: string::len($value) > 3"
+		),
+		"{}",
+		tmp.unwrap_err().to_string()
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
 async fn field_definition_empty_nested_objects() -> Result<(), Error> {
 	let sql = "
 		DEFINE TABLE person SCHEMAFULL;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

There's no use in running the `ASSERT` clause for `NONE` values when the type on the field is `option<T>`

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It changes the `ASSERT` clause to not run when the value is `NONE` and the type on the field is `option<T>`

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Closes #2350 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
