### PR TITLE
Fix JWT 'aud' array

### DIFF
--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -88,7 +88,7 @@ impl From<Claims> for Value {
 		// Add aud field if set
 		if let Some(aud) = v.aud {
 			match aud {
-				Audience::Single(s) => out.insert("aud".to_string(), s.into()),
+				Audience::Single(v) => out.insert("aud".to_string(), v.into()),
 				Audience::Multiple(v) => out.insert("aud".to_string(), v.into()),
 			};
 		}

--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -4,7 +4,6 @@ use crate::sql::Value;
 use jsonwebtoken::{Algorithm, Header};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 use std::collections::HashMap;
 
 pub static HEADER: Lazy<Header> = Lazy::new(|| Header::new(Algorithm::HS512));
@@ -89,7 +88,7 @@ impl From<Claims> for Value {
 		// Add aud field if set
 		if let Some(aud) = v.aud {
 			match aud {
-				Audience::Single(s) => out.insert("aud".to_string(), vec![s].into()),
+				Audience::Single(s) => out.insert("aud".to_string(), s.into()),
 				Audience::Multiple(v) => out.insert("aud".to_string(), v.into()),
 			};
 		}

--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -21,6 +21,7 @@ pub struct Claims {
 	pub iss: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub sub: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(deserialize_with = "deserialize_aud")]
 	pub aud: Option<Vec<String>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -70,10 +71,10 @@ fn deserialize_aud<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Er
 where
 	D: Deserializer<'de>,
 {
-	let value: serde_json::Value = Deserialize::deserialize(deserializer)?;
+	let value: Option<serde_json::Value> = Deserialize::deserialize(deserializer)?;
 	match value {
-		serde_json::Value::String(s) => Ok(Some(vec![s])),
-		serde_json::Value::Array(arr) => {
+		Some(serde_json::Value::String(s)) => Ok(Some(vec![s])),
+		Some(serde_json::Value::Array(arr)) => {
 			let result: Result<Vec<String>, _> = arr
 				.into_iter()
 				.map(|val| {
@@ -84,7 +85,8 @@ where
 				.collect();
 			result.map(Some)
 		}
-		_ => Err(serde::de::Error::custom("invalid type for aud")),
+		Some(_) => Err(serde::de::Error::custom("invalid type for aud")),
+		None => Ok(None), // Handle the case where aud is not present
 	}
 }
 

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -691,7 +691,7 @@ async fn authenticate_jwt(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::iam::token::HEADER;
+	use crate::iam::token::{Audience, HEADER};
 	use argon2::password_hash::{PasswordHasher, SaltString};
 	use chrono::Duration;
 	use jsonwebtoken::{encode, EncodingKey};
@@ -2246,7 +2246,7 @@ mod tests {
 			let key = EncodingKey::from_secret(secret.as_ref());
 			let claims = Claims {
 				iss: Some("surrealdb-test".to_string()),
-				aud: Some("surrealdb-test".to_string()),
+				aud: Some(Audience::Single("surrealdb-test".to_string())),
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
@@ -2315,7 +2315,7 @@ mod tests {
 			let key = EncodingKey::from_secret(secret.as_ref());
 			let claims = Claims {
 				iss: Some("surrealdb-test".to_string()),
-				aud: Some("invalid".to_string()),
+				aud: Some(Audience::Single("invalid".to_string())),
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
@@ -2372,7 +2372,7 @@ mod tests {
 			let key = EncodingKey::from_secret(secret.as_ref());
 			let claims = Claims {
 				iss: Some("surrealdb-test".to_string()),
-				aud: Some("invalid".to_string()),
+				aud: Some(Audience::Single("invalid".to_string())),
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
@@ -2431,7 +2431,7 @@ mod tests {
 			let key = EncodingKey::from_secret(secret.as_ref());
 			let claims = Claims {
 				iss: Some("surrealdb-test".to_string()),
-				aud: Some("surrealdb-test".to_string()),
+				aud: Some(Audience::Single("surrealdb-test".to_string())),
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
@@ -2498,7 +2498,7 @@ mod tests {
 			let key = EncodingKey::from_secret(secret.as_ref());
 			let claims = Claims {
 				iss: Some("surrealdb-test".to_string()),
-				aud: Some("invalid".to_string()),
+				aud: Some(Audience::Single("invalid".to_string())),
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
@@ -2554,7 +2554,7 @@ mod tests {
 			let key = EncodingKey::from_secret(secret.as_ref());
 			let claims = Claims {
 				iss: Some("surrealdb-test".to_string()),
-				aud: Some("invalid".to_string()),
+				aud: Some(Audience::Single("invalid".to_string())),
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
@@ -2612,7 +2612,7 @@ mod tests {
 			let key = EncodingKey::from_secret(secret.as_ref());
 			let claims = Claims {
 				iss: Some("surrealdb-test".to_string()),
-				aud: Some("surrealdb-test".to_string()),
+				aud: Some(Audience::Single("surrealdb-test".to_string())),
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
@@ -2677,7 +2677,7 @@ mod tests {
 			let key = EncodingKey::from_secret(secret.as_ref());
 			let claims = Claims {
 				iss: Some("surrealdb-test".to_string()),
-				aud: Some("invalid".to_string()),
+				aud: Some(Audience::Single("invalid".to_string())),
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
@@ -2732,7 +2732,7 @@ mod tests {
 			let key = EncodingKey::from_secret(secret.as_ref());
 			let claims = Claims {
 				iss: Some("surrealdb-test".to_string()),
-				aud: Some("invalid".to_string()),
+				aud: Some(Audience::Single("invalid".to_string())),
 				iat: Some(Utc::now().timestamp()),
 				nbf: Some(Utc::now().timestamp()),
 				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The `aud` field on a JWT claim is not correctly decoded in the case where it is an array. The JWT specification allows it to be an array or a string.

## What does this change do?

Implements a custom decoder so the aud can be a single string or array.

## What is your testing strategy?

Running locally with a JWT, it no longer fails with absent logging. It was ran against both a single JWT and array. There should not be any side-effects as the JWT audience is already converted to an array of strings for the `AUTHENTICATE` clause.

## Is this related to any issues?
Closes #4487.


## Does this change need documentation?
- No

## Have you read the Contributing Guidelines?
- Yes