### PR TITLE
Fix "specific" match statement exiting early

### DIFF
--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -74,7 +74,7 @@ macro_rules! dispatch {
 					$($wrapper)*(|| $($function_path)::+($($ctx_arg,)* args))()$(.$await)*
 				},)+
 				_ => {
-					return Err($crate::err::Error::InvalidFunction{
+					Err($crate::err::Error::InvalidFunction{
 						name: String::from($name),
 						message: $message.to_string()
 					})

--- a/lib/tests/function.rs
+++ b/lib/tests/function.rs
@@ -6237,6 +6237,9 @@ async fn function_idiom_chaining() -> Result<(), Error> {
 		true.is_bool();
 		true.doesnt_exist();
 		field.bla.nested.is_none();
+		// String is one of the types in the initial match statement,
+		// this test ensures that the dispatch macro does not exit early
+		"string".is_bool();
 	"#;
 	Test::new(sql)
 		.await?
@@ -6245,6 +6248,7 @@ async fn function_idiom_chaining() -> Result<(), Error> {
 		.expect_val("false")?
 		.expect_val("true")?
         .expect_error("There was a problem running the doesnt_exist() function. no such method found for the bool type")?
-	    .expect_val("true")?;
+	    .expect_val("true")?
+		.expect_val("false")?;
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See #4486

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

The match statement for type specific methods was exiting early due to an unneeded `return` statement. This PR removes the `return` statement.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

This PR adds a test to ensure that shared idiom methods will be tried if not type specific method was found.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Closes #4486 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
