### PR TITLE
Disable default audience validation also for JWKS

### DIFF
--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -60,7 +60,7 @@ fn config(alg: Algorithm, key: &[u8]) -> Result<(DecodingKey, Validation), Error
 
 	// TODO(gguillemas): This keeps the existing behavior as of SurrealDB 2.0.0-alpha.9.
 	// Up to that point, a fork of the "jsonwebtoken" crate in version 8.3.0 was being used.
-	// Now that the audience claim is validated by default, we should allow users to leverage this.
+	// Now that the audience claim is validated by default, we could allow users to leverage this.
 	// This will most likely involve defining an audience string via "DEFINE ACCESS ... TYPE JWT".
 	val.validate_aud = false;
 
@@ -1801,6 +1801,7 @@ mod tests {
 			iss: Some("surrealdb-test".to_string()),
 			iat: Some(Utc::now().timestamp()),
 			nbf: Some(Utc::now().timestamp()),
+			aud: Some(Audience::Single("surrealdb-test".to_string())),
 			exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
 			ns: Some("test".to_string()),
 			db: Some("test".to_string()),


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Since after #4472, the `jsonwebtoken` library validates the audience by default. For this reason, JWKS validation is failing if the token contains an audience string or array not explicitly allowed during validation. In order to keep the existing behavior and delegate audience verification to the user via the `AUTHENTICATE` clause, this default validation is disabled. This change was done for validation with a hardcoded key in #4472 but not for validation with JWKS.

## What does this change do?

Disables the default audience validation from `jsonwebtoken` when using JWKS as well.

## What is your testing strategy?

Ensure that the JWKS token verification test includes an audience and is able to validate the token successfully.

## Is this related to any issues?

This issue was reported by @DrewRidley via Discord.

## Does this change need documentation?

No, this keeps the existing behavior before the dependency update.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
