### PR TITLE
Allow transferring raw futures over cbor

### DIFF
--- a/core/src/dbs/executor.rs
+++ b/core/src/dbs/executor.rs
@@ -243,6 +243,7 @@ impl<'a> Executor<'a> {
 						} else {
 							Force::None
 						}),
+						"FUTURES" => opt.with_futures(stm.what),
 						_ => break,
 					};
 					// Continue

--- a/core/src/dbs/executor.rs
+++ b/core/src/dbs/executor.rs
@@ -243,7 +243,13 @@ impl<'a> Executor<'a> {
 						} else {
 							Force::None
 						}),
-						"FUTURES" => opt.with_futures(stm.what),
+						"FUTURES" => {
+							if stm.what {
+								opt.with_futures(true)
+							} else {
+								opt.with_futures_never()
+							}
+						}
 						_ => break,
 					};
 					// Continue

--- a/core/src/dbs/options.rs
+++ b/core/src/dbs/options.rs
@@ -544,4 +544,22 @@ mod tests {
 				.unwrap();
 		}
 	}
+
+	#[test]
+	pub fn execute_futures() {
+		let mut opts = Options::default()
+			.with_futures(false);
+
+		// Futures should be disabled
+		assert!(matches!(opts.futures, Futures::Disabled));
+
+		// Allow setting to true
+		opts = opts.with_futures(true);
+		assert!(matches!(opts.futures, Futures::Enabled));
+
+		// Set to never and disallow setting to true
+		opts = opts.with_futures_never();
+		opts = opts.with_futures(true);
+		assert!(matches!(opts.futures, Futures::Never));
+	}
 }

--- a/core/src/dbs/options.rs
+++ b/core/src/dbs/options.rs
@@ -41,7 +41,7 @@ pub struct Options {
 	/// Should we process field queries?
 	pub import: bool,
 	/// Should we process function futures?
-	pub futures: bool,
+	pub futures: Futures,
 	/// Should we process variable field projections?
 	pub projections: bool,
 	/// The channel over which we send notifications
@@ -57,6 +57,13 @@ pub enum Force {
 	None,
 	Table(Arc<[DefineTableStatement]>),
 	Index(Arc<[DefineIndexStatement]>),
+}
+
+#[derive(Clone, Debug)]
+pub enum Futures {
+	Disabled,
+	Enabled,
+	Never,
 }
 
 impl Default for Options {
@@ -78,7 +85,7 @@ impl Options {
 			force: Force::None,
 			strict: false,
 			import: false,
-			futures: false,
+			futures: Futures::Disabled,
 			projections: false,
 			auth_enabled: true,
 			sender: None,
@@ -189,7 +196,20 @@ impl Options {
 
 	/// Specify if we should process futures
 	pub fn with_futures(mut self, futures: bool) -> Self {
-		self.futures = futures;
+		if matches!(self.futures, Futures::Never) {
+			return self;
+		}
+
+		self.futures = match futures {
+			true => Futures::Enabled,
+			false => Futures::Disabled,
+		};
+		self
+	}
+
+	/// Specify if we should never process futures
+	pub fn with_futures_never(mut self) -> Self {
+		self.futures = Futures::Never;
 		self
 	}
 
@@ -221,6 +241,7 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
+			futures: self.futures.clone(),
 			perms,
 			..*self
 		}
@@ -233,6 +254,7 @@ impl Options {
 			auth: self.auth.clone(),
 			ns: self.ns.clone(),
 			db: self.db.clone(),
+			futures: self.futures.clone(),
 			force,
 			..*self
 		}
@@ -246,6 +268,7 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
+			futures: self.futures.clone(),
 			strict,
 			..*self
 		}
@@ -259,6 +282,7 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
+			futures: self.futures.clone(),
 			import,
 			..*self
 		}
@@ -272,7 +296,13 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
-			futures,
+			futures: match self.futures {
+				Futures::Never => Futures::Never,
+				_ => match futures {
+					true => Futures::Enabled,
+					false => Futures::Disabled,
+				},
+			},
 			..*self
 		}
 	}
@@ -285,6 +315,7 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
+			futures: self.futures.clone(),
 			projections,
 			..*self
 		}
@@ -297,6 +328,7 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
+			futures: self.futures.clone(),
 			sender: Some(sender),
 			..*self
 		}
@@ -326,6 +358,7 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
+			futures: self.futures.clone(),
 			dive: self.dive - cost as u32,
 			..*self
 		})

--- a/core/src/dbs/options.rs
+++ b/core/src/dbs/options.rs
@@ -547,8 +547,7 @@ mod tests {
 
 	#[test]
 	pub fn execute_futures() {
-		let mut opts = Options::default()
-			.with_futures(false);
+		let mut opts = Options::default().with_futures(false);
 
 		// Futures should be disabled
 		assert!(matches!(opts.futures, Futures::Disabled));

--- a/core/src/rpc/format/cbor/convert.rs
+++ b/core/src/rpc/format/cbor/convert.rs
@@ -35,6 +35,7 @@ const TAG_STRING_DECIMAL: u64 = 10;
 const TAG_CUSTOM_DATETIME: u64 = 12;
 const TAG_STRING_DURATION: u64 = 13;
 const TAG_CUSTOM_DURATION: u64 = 14;
+const TAG_FUTURE: u64 = 15;
 
 // Ranges
 const TAG_RANGE: u64 = 49;
@@ -395,6 +396,11 @@ impl TryFrom<Value> for Cbor {
 			Value::Table(v) => Ok(Cbor(Data::Tag(TAG_TABLE, Box::new(Data::Text(v.0))))),
 			Value::Geometry(v) => Ok(Cbor(encode_geometry(v)?)),
 			Value::Range(v) => Ok(Cbor(Data::try_from(*v)?)),
+			Value::Future(v) => {
+				let bin = Data::Text(format!("{}", (*v).0));
+
+				Ok(Cbor(Data::Tag(TAG_FUTURE, Box::new(bin))))
+			}
 			// We shouldn't reach here
 			_ => Err("Found unsupported SurrealQL value being encoded into a CBOR value"),
 		}

--- a/core/src/sql/future.rs
+++ b/core/src/sql/future.rs
@@ -1,9 +1,9 @@
-use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::sql::block::Block;
 use crate::sql::value::Value;
+use crate::{ctx::Context, dbs::Futures};
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
@@ -35,8 +35,8 @@ impl Future {
 	) -> Result<Value, Error> {
 		// Process the future if enabled
 		match opt.futures {
-			true => stk.run(|stk| self.0.compute(stk, ctx, opt, doc)).await?.ok(),
-			false => Ok(self.clone().into()),
+			Futures::Enabled => stk.run(|stk| self.0.compute(stk, ctx, opt, doc)).await?.ok(),
+			_ => Ok(self.clone().into()),
 		}
 	}
 }

--- a/core/src/syn/parser/object.rs
+++ b/core/src/syn/parser/object.rs
@@ -637,7 +637,7 @@ impl Parser<'_> {
 	/// # Parser State
 	/// Expects the starting `{` to have already been eaten and its span to be handed to this
 	/// functions as the `start` parameter.
-	pub(super) async fn parse_block(&mut self, ctx: &mut Stk, start: Span) -> ParseResult<Block> {
+	pub async fn parse_block(&mut self, ctx: &mut Stk, start: Span) -> ParseResult<Block> {
 		let mut statements = Vec::new();
 		loop {
 			while self.eat(t!(";")) {}

--- a/lib/tests/future.rs
+++ b/lib/tests/future.rs
@@ -68,6 +68,24 @@ async fn future_function_arguments() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn future_disabled() -> Result<(), Error> {
+	let sql = "
+	    OPTION FUTURES = false;
+		<future> { 123 };
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 1);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse("<future> { 123 }");
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
 async fn concurrency() -> Result<(), Error> {
 	// cargo test --package surrealdb --test future --features kv-mem --release -- concurrency --nocapture
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Modifying records in the Surrealist explorer view causes any futures to compute into their values. When saved, the futures will now be overridden with their computed values, unless the user manually places the <future> back again

https://github.com/surrealdb/surrealist/issues/190

## What does this change do?

- Exposes the futures option to the `OPTION` statement
- Added an internal "never" value for the futures option
- Cbor encoding for futures 

## What is your testing strategy?

Added test

## Is this related to any issues?

https://github.com/surrealdb/surrealist/issues/190

## Does this change need documentation?

Option statement is not documented so no

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
