### PR TITLE
Idiom Optional Part

### DIFF
--- a/core/src/idx/planner/rewriter.rs
+++ b/core/src/idx/planner/rewriter.rs
@@ -152,7 +152,8 @@ impl<'a> KnnConditionRewriter<'a> {
 			| Part::Last
 			| Part::First
 			| Part::Field(_)
-			| Part::Index(_) => Some(p.clone()),
+			| Part::Index(_)
+			| Part::Optional => Some(p.clone()),
 			Part::Where(v) => self.eval_value(v).map(Part::Where),
 			Part::Graph(_) => None,
 			Part::Value(v) => self.eval_value(v).map(Part::Value),

--- a/core/src/sql/part.rs
+++ b/core/src/sql/part.rs
@@ -25,6 +25,7 @@ pub enum Part {
 	Method(#[serde(with = "no_nul_bytes")] String, Vec<Value>),
 	#[revision(start = 2)]
 	Destructure(Vec<DestructurePart>),
+	Optional,
 }
 
 impl From<i32> for Part {
@@ -128,6 +129,7 @@ impl fmt::Display for Part {
 					f.write_str(" }")
 				}
 			}
+			Part::Optional => write!(f, "?"),
 		}
 	}
 }

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -135,6 +135,10 @@ impl Parser<'_> {
 		let mut res = start;
 		loop {
 			match self.peek_kind() {
+				t!("?") => {
+					self.pop_peek();
+					res.push(Part::Optional);
+				}
 				t!("...") => {
 					self.pop_peek();
 					res.push(Part::Flatten);

--- a/lib/tests/idiom.rs
+++ b/lib/tests/idiom.rs
@@ -1,0 +1,14 @@
+mod helpers;
+mod parse;
+use helpers::Test;
+use surrealdb::err::Error;
+
+#[tokio::test]
+async fn idiom_chain_part_optional() -> Result<(), Error> {
+	let sql = r#"
+		{}.prop.is_bool();
+		{}.prop?.is_bool();
+	"#;
+	Test::new(sql).await?.expect_val("false")?.expect_val("None")?;
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Ability to exit an idiom path early when the result is `NONE`.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Introduces a new "Optional" part:
```
{}.prop.other.is_bool()  -- false
{}.prop?.other.is_bool() -- none

LET $maybe_double = |$v: option<array>| $v?.map(|$v| $v * 2);
$maybe_double([1, 2, 3]) -- [2, 4, 6]
$maybe_double()          -- NONE
``` 

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
