### PR TITLE
Yield remote fields without needing to clear the original field value

### DIFF
--- a/core/src/sql/value/set.rs
+++ b/core/src/sql/value/set.rs
@@ -151,6 +151,11 @@ impl Value {
 						Ok(())
 					}
 				},
+				// Current value at path is a record
+				Value::Thing(_) => {
+					*self = Value::base();
+					stk.run(|stk| self.set(stk, ctx, opt, path, val)).await
+				}
 				// Current value at path is empty
 				Value::Null => {
 					*self = Value::base();


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When selecting a remote record field after using a `SELECT *`,  the remote field will not be added to the output result, instead leaving the Record ID which is set as the value of the field. For more information see #3013.

## What does this change do?

This test allows remote record fields to be selected without having to first remove the field on the output result.

```sql
INSERT {
    address: {
        address_line_1: '304 Harvey',
        address_line_2: NONE,
        city: 'Huntly',
        coordinates: [
            -24.661277f,
            87.308485f
        ],
        country: 'Northern Ireland',
        post_code: 'VF9M 1CO'
    },
    company_name: NONE,
    email: 'singles2048@example.org',
    first_name: 'Thad',
    id: artist:73z6oc419v1c5v34j20x,
    last_name: 'Michael',
    name: 'Thad Michael',
    phone: '056 2985 5626'
};

INSERT {
    id: review:00a0ic854u4j7z02s00v,
    artist: artist:73z6oc419v1c5v34j20x,
    rating: 3,
    review_text: 'some text'
};

SELECT *, artist.{ email, name } FROM review limit 1;

SELECT *, artist.email, artist.name FROM review limit 1;
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #3013

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
