### PR TITLE
Fix certain identifier characters not being parsed correctly

### DIFF
--- a/core/src/syn/parser/test/mod.rs
+++ b/core/src/syn/parser/test/mod.rs
@@ -1,6 +1,9 @@
 use nom::AsBytes;
 
-use crate::{sql, syn::parser::mac::test_parse};
+use crate::{
+	sql::{self, Id, Statement, Thing, Value},
+	syn::parser::mac::test_parse,
+};
 
 mod limit;
 mod stmt;
@@ -11,6 +14,37 @@ mod value;
 fn multiple_semicolons() {
 	let res = test_parse!(parse_query, r#";;"#).unwrap();
 	let expected = sql::Query(sql::Statements(vec![]));
+	assert_eq!(res, expected);
+}
+
+#[test]
+fn glued_identifiers() {
+	let res = test_parse!(parse_query, r#"T:1"#).unwrap();
+	let expected = sql::Query(sql::Statements(vec![Statement::Value(Value::Thing(Thing {
+		tb: "T".to_string(),
+		id: Id::Number(1),
+	}))]));
+	assert_eq!(res, expected);
+
+	let res = test_parse!(parse_query, r#"T9T9T9T:1"#).unwrap();
+	let expected = sql::Query(sql::Statements(vec![Statement::Value(Value::Thing(Thing {
+		tb: "T9T9T9T".to_string(),
+		id: Id::Number(1),
+	}))]));
+	assert_eq!(res, expected);
+
+	let res = test_parse!(parse_query, r#"Z:1"#).unwrap();
+	let expected = sql::Query(sql::Statements(vec![Statement::Value(Value::Thing(Thing {
+		tb: "Z".to_string(),
+		id: Id::Number(1),
+	}))]));
+	assert_eq!(res, expected);
+
+	let res = test_parse!(parse_query, r#"Z9Z9Z9Z:1"#).unwrap();
+	let expected = sql::Query(sql::Statements(vec![Statement::Value(Value::Thing(Thing {
+		tb: "Z9Z9Z9Z".to_string(),
+		id: Id::Number(1),
+	}))]));
 	assert_eq!(res, expected);
 }
 

--- a/core/src/syn/parser/token.rs
+++ b/core/src/syn/parser/token.rs
@@ -29,10 +29,14 @@ impl Parser<'_> {
 				| TokenKind::DurationSuffix(
 					// All except Micro unicode
 					DurationSuffix::Nano
-						| DurationSuffix::Micro | DurationSuffix::Milli
-						| DurationSuffix::Second | DurationSuffix::Minute
-						| DurationSuffix::Hour | DurationSuffix::Day
-						| DurationSuffix::Week | DurationSuffix::Year
+						| DurationSuffix::Micro
+						| DurationSuffix::Milli
+						| DurationSuffix::Second
+						| DurationSuffix::Minute
+						| DurationSuffix::Hour
+						| DurationSuffix::Day
+						| DurationSuffix::Week
+						| DurationSuffix::Year
 				)
 		)
 	}
@@ -50,17 +54,18 @@ impl Parser<'_> {
 				| TokenKind::DatetimeChars(_)
 				| TokenKind::Exponent
 				| TokenKind::NumberSuffix(_)
-				| TokenKind::NaN | TokenKind::DurationSuffix(
-				// All except Micro unicode
-				DurationSuffix::Nano
-					| DurationSuffix::Micro
-					| DurationSuffix::Milli
-					| DurationSuffix::Second
-					| DurationSuffix::Minute
-					| DurationSuffix::Hour
-					| DurationSuffix::Day
-					| DurationSuffix::Week
-			)
+				| TokenKind::NaN
+				| TokenKind::DurationSuffix(
+					// All except Micro unicode
+					DurationSuffix::Nano
+						| DurationSuffix::Micro
+						| DurationSuffix::Milli
+						| DurationSuffix::Second
+						| DurationSuffix::Minute
+						| DurationSuffix::Hour
+						| DurationSuffix::Day
+						| DurationSuffix::Week
+				)
 		)
 	}
 
@@ -128,6 +133,11 @@ impl Parser<'_> {
 
 				self.span_str(start.span).to_owned()
 			}
+			TokenKind::DatetimeChars(_) => {
+				self.pop_peek();
+
+				self.span_str(start.span).to_owned()
+			}
 			_ => return Ok(start),
 		};
 
@@ -168,7 +178,7 @@ impl Parser<'_> {
 					break;
 				}
 				// These tokens might have some more parts following them
-				TokenKind::Exponent => {
+				TokenKind::Exponent | TokenKind::DatetimeChars(_) | TokenKind::Digits => {
 					self.pop_peek();
 					let str = self.span_str(p.span);
 					token_buffer.push_str(str);
@@ -181,12 +191,6 @@ impl Parser<'_> {
 						return Err(ParseError::new(ParseErrorKind::InvalidIdent, p.span));
 					}
 					token_buffer.push_str(suffix.as_str());
-					prev = p;
-				}
-				TokenKind::Digits => {
-					self.pop_peek();
-					let str = self.span_str(p.span);
-					token_buffer.push_str(str);
 					prev = p;
 				}
 				_ => break,

--- a/core/src/syn/parser/token.rs
+++ b/core/src/syn/parser/token.rs
@@ -29,14 +29,10 @@ impl Parser<'_> {
 				| TokenKind::DurationSuffix(
 					// All except Micro unicode
 					DurationSuffix::Nano
-						| DurationSuffix::Micro
-						| DurationSuffix::Milli
-						| DurationSuffix::Second
-						| DurationSuffix::Minute
-						| DurationSuffix::Hour
-						| DurationSuffix::Day
-						| DurationSuffix::Week
-						| DurationSuffix::Year
+						| DurationSuffix::Micro | DurationSuffix::Milli
+						| DurationSuffix::Second | DurationSuffix::Minute
+						| DurationSuffix::Hour | DurationSuffix::Day
+						| DurationSuffix::Week | DurationSuffix::Year
 				)
 		)
 	}
@@ -54,18 +50,17 @@ impl Parser<'_> {
 				| TokenKind::DatetimeChars(_)
 				| TokenKind::Exponent
 				| TokenKind::NumberSuffix(_)
-				| TokenKind::NaN
-				| TokenKind::DurationSuffix(
-					// All except Micro unicode
-					DurationSuffix::Nano
-						| DurationSuffix::Micro
-						| DurationSuffix::Milli
-						| DurationSuffix::Second
-						| DurationSuffix::Minute
-						| DurationSuffix::Hour
-						| DurationSuffix::Day
-						| DurationSuffix::Week
-				)
+				| TokenKind::NaN | TokenKind::DurationSuffix(
+				// All except Micro unicode
+				DurationSuffix::Nano
+					| DurationSuffix::Micro
+					| DurationSuffix::Milli
+					| DurationSuffix::Second
+					| DurationSuffix::Minute
+					| DurationSuffix::Hour
+					| DurationSuffix::Day
+					| DurationSuffix::Week
+			)
 		)
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The characters `T` and `Z` could cause problems when used alone in an identifier due to a bug in the parser.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Fixes the problem in the parser

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->
 
Added a test for identifiers which triggered this bug.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
