### PR TITLE
Allow isolated context to read protected params

### DIFF
--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -1,3 +1,4 @@
+use crate::cnf::PROTECTED_PARAM_NAMES;
 use crate::ctx::canceller::Canceller;
 use crate::ctx::reason::Reason;
 #[cfg(feature = "http")]
@@ -371,7 +372,7 @@ impl MutableContext {
 	pub fn value(&self, key: &str) -> Option<&Value> {
 		match self.values.get(key) {
 			Some(v) => Some(v.as_ref()),
-			None if !self.isolated => match &self.parent {
+			None if PROTECTED_PARAM_NAMES.contains(&key) || !self.isolated => match &self.parent {
 				Some(p) => p.value(key),
 				_ => None,
 			},


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

https://github.com/surrealdb/surrealdb/issues/4508

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It fixes defined functions not being able to access protected params, like `$access`, `$auth`, `$token` and `$session`.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #4508

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
