### PR TITLE
upgrade rust_decimal to 1.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5261,9 +5261,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arbitrary",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ revision = { version = "0.8.0", features = [
     "uuid",
 ] }
 rmpv = "1.0.1"
-rust_decimal = "1.35.0"
+rust_decimal = "1.36.0"
 rustyline = { version = "12.0.0", features = ["derive"] }
 semver = "1.0.20"
 serde = { version = "1.0.193", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -132,7 +132,7 @@ revision = { version = "0.8.0", features = [
 rmpv = "1.0.1"
 roaring = { version = "0.10.2", features = ["serde"] }
 rocksdb = { version = "0.21.0", features = ["lz4", "snappy"], optional = true }
-rust_decimal = { version = "1.33.1", features = ["maths", "serde-str"] }
+rust_decimal = { version = "1.36.0", features = ["maths", "serde-str"] }
 rust-stemmers = "1.2.0"
 scrypt = "0.11.0"
 semver = { version = "1.0.20", features = ["serde"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -89,7 +89,7 @@ revision = { version = "0.8.0", features = [
     "rust_decimal",
     "uuid",
 ] }
-rust_decimal = { version = "1.33.1", features = ["maths", "serde-str"] }
+rust_decimal = { version = "1.36.0", features = ["maths", "serde-str"] }
 rustls = { version = "0.23.12", default-features = false, features = [
     "ring",
     "logging",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1432,7 +1432,7 @@ version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rust_decimal]]
-version = "1.35.0"
+version = "1.36.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustc_lexer]]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

>  Compilation of rust_decimal is broken, 1.36.0 fixes it. Details in https://github.com/paupino/rust-decimal/issues/669

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

> Update rust_decimal to 1.36.0

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- Closes https://github.com/surrealdb/surrealdb/issues/4529

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
