### PR TITLE
SCHEMAFULL table should be TYPE NORMAL by default

### DIFF
--- a/core/src/sql/fmt.rs
+++ b/core/src/sql/fmt.rs
@@ -293,8 +293,8 @@ mod tests {
 	#[test]
 	fn pretty_define_query() {
 		let query = parse("DEFINE TABLE test SCHEMAFULL PERMISSIONS FOR create, update, delete NONE FOR select WHERE public = true;").unwrap();
-		assert_eq!(format!("{}", query), "DEFINE TABLE test TYPE ANY SCHEMAFULL PERMISSIONS FOR select WHERE public = true, FOR create, update, delete NONE;");
-		assert_eq!(format!("{:#}", query), "DEFINE TABLE test TYPE ANY SCHEMAFULL\n\tPERMISSIONS\n\t\tFOR select\n\t\t\tWHERE public = true\n\t\tFOR create, update, delete NONE\n;");
+		assert_eq!(format!("{}", query), "DEFINE TABLE test TYPE NORMAL SCHEMAFULL PERMISSIONS FOR select WHERE public = true, FOR create, update, delete NONE;");
+		assert_eq!(format!("{:#}", query), "DEFINE TABLE test TYPE NORMAL SCHEMAFULL\n\tPERMISSIONS\n\t\tFOR select\n\t\t\tWHERE public = true\n\t\tFOR create, update, delete NONE\n;");
 	}
 
 	#[test]

--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -1410,7 +1410,7 @@ fn parse_define_table() {
 			comment: None,
 			if_not_exists: false,
 			overwrite: false,
-			kind: TableType::Any,
+			kind: TableType::Normal,
 		}))
 	);
 }

--- a/core/src/syn/parser/test/streaming.rs
+++ b/core/src/syn/parser/test/streaming.rs
@@ -279,7 +279,7 @@ fn statements() -> Vec<Statement> {
 			comment: None,
 			if_not_exists: false,
 			overwrite: false,
-			kind: TableType::Any,
+			kind: TableType::Normal,
 		})),
 		Statement::Define(DefineStatement::Event(DefineEventStatement {
 			name: Ident("event".to_owned()),

--- a/lib/tests/define.rs
+++ b/lib/tests/define.rs
@@ -179,7 +179,7 @@ async fn define_statement_table_schemafull() -> Result<(), Error> {
 			functions: {},
 			models: {},
 			params: {},
-			tables: { test: 'DEFINE TABLE test TYPE ANY SCHEMAFULL PERMISSIONS NONE' },
+			tables: { test: 'DEFINE TABLE test TYPE NORMAL SCHEMAFULL PERMISSIONS NONE' },
 			users: {},
 		}",
 	)?;
@@ -208,7 +208,7 @@ async fn define_statement_table_schemaful() -> Result<(), Error> {
 			functions: {},
 			models: {},
 			params: {},
-			tables: { test: 'DEFINE TABLE test TYPE ANY SCHEMAFULL PERMISSIONS NONE' },
+			tables: { test: 'DEFINE TABLE test TYPE NORMAL SCHEMAFULL PERMISSIONS NONE' },
 			users: {},
 		}",
 	);
@@ -248,7 +248,7 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 			models: {},
 			params: {},
 			tables: {
-				test: 'DEFINE TABLE test TYPE ANY SCHEMAFULL PERMISSIONS NONE',
+				test: 'DEFINE TABLE test TYPE NORMAL SCHEMAFULL PERMISSIONS NONE',
 				view: 'DEFINE TABLE view TYPE ANY SCHEMALESS AS SELECT count() FROM test GROUP ALL PERMISSIONS NONE',
 			},
 			users: {},
@@ -280,7 +280,7 @@ async fn define_statement_table_foreigntable() -> Result<(), Error> {
 			models: {},
 			params: {},
 			tables: {
-				test: 'DEFINE TABLE test TYPE ANY SCHEMAFULL PERMISSIONS NONE',
+				test: 'DEFINE TABLE test TYPE NORMAL SCHEMAFULL PERMISSIONS NONE',
 			},
 			users: {},
 		}",


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

If you define a `SCHEMAFULL` table without explicitly setting `TYPE RELATION`, we found it to make more sense not to accept relations on that table by default, unless specified otherwise. 

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR changes the default table type to be `NORMAL` when defining a `SCHEMAFULL` table, unless specified otherwise.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Updated tests, GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] TBD

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
