### PR TITLE
Improve consistency of the `run` method API with existing methods

### DIFF
--- a/lib/benches/processor.rs
+++ b/lib/benches/processor.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughpu
 use std::time::Duration;
 use surrealdb::dbs::Session;
 use surrealdb::kvs::Datastore;
-use surrealdb::Value;
+use surrealdb_core::sql::Value;
 use tokio::runtime::Runtime;
 
 fn bench_processor(c: &mut Criterion) {

--- a/lib/src/api/method/run.rs
+++ b/lib/src/api/method/run.rs
@@ -1,30 +1,35 @@
 use crate::api::conn::Command;
+use crate::api::method::BoxFuture;
 use crate::api::Connection;
 use crate::api::Result;
 use crate::method::OnceLockExt;
+use crate::sql::Value;
 use crate::Surreal;
-use crate::Value;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_content::Serializer;
+use serde_content::Value as Content;
 use std::borrow::Cow;
 use std::future::IntoFuture;
-use surrealdb_core::sql::Array as CoreArray;
-
-use super::BoxFuture;
+use std::marker::PhantomData;
+use surrealdb_core::sql::to_value;
+use surrealdb_core::sql::Array;
 
 /// A run future
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Run<'r, C: Connection> {
+pub struct Run<'r, C: Connection, R> {
 	pub(super) client: Cow<'r, Surreal<C>>,
-	pub(super) name: String,
-	pub(super) version: Option<String>,
-	pub(super) args: CoreArray,
+	pub(super) function: Result<(String, Option<String>)>,
+	pub(super) args: serde_content::Result<serde_content::Value<'static>>,
+	pub(super) response_type: PhantomData<R>,
 }
-impl<C> Run<'_, C>
+impl<C, R> Run<'_, C, R>
 where
 	C: Connection,
 {
 	/// Converts to an owned type which can easily be moved to a different thread
-	pub fn into_owned(self) -> Run<'static, C> {
+	pub fn into_owned(self) -> Run<'static, C, R> {
 		Run {
 			client: Cow::Owned(self.client.into_owned()),
 			..self
@@ -32,24 +37,36 @@ where
 	}
 }
 
-impl<'r, Client> IntoFuture for Run<'r, Client>
+impl<'r, Client, R> IntoFuture for Run<'r, Client, R>
 where
 	Client: Connection,
+	R: DeserializeOwned,
 {
-	type Output = Result<Value>;
+	type Output = Result<R>;
 	type IntoFuture = BoxFuture<'r, Self::Output>;
 
 	fn into_future(self) -> Self::IntoFuture {
 		let Run {
 			client,
-			name,
-			version,
+			function,
 			args,
+			..
 		} = self;
 		Box::pin(async move {
 			let router = client.router.extract()?;
+			let (name, version) = function?;
+			let value = match args.map_err(crate::error::Db::from)? {
+				// Tuples are treated as multiple function arguments
+				Content::Tuple(tup) => tup,
+				// Everything else is treated as a single argument
+				content => vec![content],
+			};
+			let args = match to_value(value)? {
+				Value::Array(array) => array,
+				value => Array::from(vec![value]),
+			};
 			router
-				.execute_value(Command::Run {
+				.execute(Command::Run {
 					name,
 					version,
 					args,
@@ -59,132 +76,57 @@ where
 	}
 }
 
-pub trait IntoArgs {
-	fn into_args(self) -> Vec<Value>;
-}
-
-impl IntoArgs for Value {
-	fn into_args(self) -> Vec<Value> {
-		vec![self]
-	}
-}
-
-impl<T> IntoArgs for Vec<T>
+impl<'r, Client, R> Run<'r, Client, R>
 where
-	T: Into<Value>,
+	Client: Connection,
 {
-	fn into_args(self) -> Vec<Value> {
-		self.into_iter().map(Into::into).collect()
+	/// Supply arguments to the function being run.
+	pub fn args(mut self, args: impl Serialize) -> Self {
+		self.args = Serializer::new().serialize(args);
+		self
 	}
 }
 
-impl<T, const N: usize> IntoArgs for [T; N]
-where
-	T: Into<Value>,
-{
-	fn into_args(self) -> Vec<Value> {
-		self.into_iter().map(Into::into).collect()
-	}
-}
-
-impl<T, const N: usize> IntoArgs for &[T; N]
-where
-	T: Into<Value> + Clone,
-{
-	fn into_args(self) -> Vec<Value> {
-		self.iter().cloned().map(Into::into).collect()
-	}
-}
-
-impl<T> IntoArgs for &[T]
-where
-	T: Into<Value> + Clone,
-{
-	fn into_args(self) -> Vec<Value> {
-		self.iter().cloned().map(Into::into).collect()
-	}
-}
-
-macro_rules! impl_args_tuple {
-    ($($i:ident), *$(,)?) => {
-		impl_args_tuple!(@marker $($i,)*);
-    };
-    ($($cur:ident,)* @marker $head:ident, $($tail:ident,)*) => {
-		impl<$($cur: Into<Value>,)*> IntoArgs for ($($cur,)*) {
-			#[allow(non_snake_case)]
-			fn into_args(self) -> Vec<Value> {
-				let ($($cur,)*) = self;
-				vec![$($cur.into(),)*]
-			}
-		}
-
-		impl_args_tuple!($($cur,)* $head, @marker $($tail,)*);
-	};
-    ($($cur:ident,)* @marker ) => {
-		impl<$($cur: Into<Value>,)*> IntoArgs for ($($cur,)*) {
-			#[allow(non_snake_case)]
-			fn into_args(self) -> Vec<Value> {
-				let ($($cur,)*) = self;
-				vec![$($cur.into(),)*]
-			}
-		}
-	}
-}
-
-impl_args_tuple!(A, B, C, D, E, F,);
-
-/* TODO: Removed for now.
- * The detach value PR removed a lot of conversion methods with, pending later request which might
- * add them back depending on how the sdk turns out.
- *
-macro_rules! into_impl {
-	($type:ty) => {
-		impl IntoArgs for $type {
-			fn into_args(self) -> Vec<Value> {
-				vec![Value::from(self)]
-			}
-		}
-	};
-}
-into_impl!(i8);
-into_impl!(i16);
-into_impl!(i32);
-into_impl!(i64);
-into_impl!(i128);
-into_impl!(u8);
-into_impl!(u16);
-into_impl!(u32);
-into_impl!(u64);
-into_impl!(u128);
-into_impl!(usize);
-into_impl!(isize);
-into_impl!(f32);
-into_impl!(f64);
-into_impl!(String);
-into_impl!(&str);
-*/
-
+/// Converts a function into name and version parts
 pub trait IntoFn {
-	fn into_fn(self) -> (String, Option<String>);
+	/// Handles the conversion of the function string
+	fn into_fn(self) -> Result<(String, Option<String>)>;
 }
 
 impl IntoFn for String {
-	fn into_fn(self) -> (String, Option<String>) {
-		(self, None)
-	}
-}
-impl IntoFn for &str {
-	fn into_fn(self) -> (String, Option<String>) {
-		(self.to_owned(), None)
+	fn into_fn(self) -> Result<(String, Option<String>)> {
+		match self.split_once('<') {
+			Some((name, rest)) => match rest.strip_suffix('>') {
+				Some(version) => Ok((name.to_owned(), Some(version.to_owned()))),
+				None => Err(crate::error::Db::InvalidFunction {
+					name: self,
+					message: "function version is missing a clossing '>'".to_owned(),
+				}
+				.into()),
+			},
+			None => Ok((self, None)),
+		}
 	}
 }
 
-impl<S0, S1> IntoFn for (S0, S1)
-where
-	S0: Into<String>,
-	S1: Into<String>,
-{
-	fn into_fn(self) -> (String, Option<String>) {
-		(self.0.into(), Some(self.1.into()))
+impl IntoFn for &str {
+	fn into_fn(self) -> Result<(String, Option<String>)> {
+		match self.split_once('<') {
+			Some((name, rest)) => match rest.strip_suffix('>') {
+				Some(version) => Ok((name.to_owned(), Some(version.to_owned()))),
+				None => Err(crate::error::Db::InvalidFunction {
+					name: self.to_owned(),
+					message: "function version is missing a clossing '>'".to_owned(),
+				}
+				.into()),
+			},
+			None => Ok((self.to_owned(), None)),
+		}
+	}
+}
+
+impl IntoFn for &String {
+	fn into_fn(self) -> Result<(String, Option<String>)> {
+		self.as_str().into_fn()
 	}
 }

--- a/lib/src/api/method/tests/mod.rs
+++ b/lib/src/api/method/tests/mod.rs
@@ -14,7 +14,6 @@ use crate::api::opt::auth::Root;
 use crate::api::opt::PatchOp;
 use crate::api::Response as QueryResponse;
 use crate::api::Surreal;
-use crate::Value;
 use once_cell::sync::Lazy;
 use protocol::Client;
 use protocol::Test;
@@ -170,7 +169,7 @@ async fn api() {
 	let _: Version = DB.version().await.unwrap();
 
 	// run
-	let _: Value = DB.run("foo", ()).await.unwrap();
+	let _: Option<User> = DB.run("foo").await.unwrap();
 }
 
 fn assert_send_sync(_: impl Send + Sync) {}

--- a/lib/tests/api/mod.rs
+++ b/lib/tests/api/mod.rs
@@ -1363,9 +1363,6 @@ async fn return_bool() {
 	assert_eq!(value.into_inner(), CoreValue::Bool(false));
 }
 
-/*
- * TODO: Reenable test.
- * Disabling run test for now as it depends on value conversions which are removed
 #[test_log::test(tokio::test)]
 async fn run() {
 	let (permit, db) = new_db().await;
@@ -1384,24 +1381,23 @@ async fn run() {
 	";
 	let _ = db.query(sql).await;
 
-	let tmp = db.run("fn::foo", ()).await.unwrap();
-	assert_eq!(tmp, Value::from(42));
+	let tmp: i32 = db.run("fn::foo").await.unwrap();
+	assert_eq!(tmp, 42);
 
-	let tmp = db.run("fn::foo", 7).await.unwrap_err();
+	let tmp = db.run::<i32>("fn::foo").args(7).await.unwrap_err();
 	println!("fn::foo res: {tmp}");
 	assert!(tmp.to_string().contains("The function expects 0 arguments."));
 
-	let tmp = db.run("fn::idnotexist", ()).await.unwrap_err();
+	let tmp = db.run::<()>("fn::idnotexist").await.unwrap_err();
 	println!("fn::idontexist res: {tmp}");
 	assert!(tmp.to_string().contains("The function 'fn::idnotexist' does not exist"));
 
-	let tmp = db.run("count", Value::from(vec![1, 2, 3])).await.unwrap();
-	assert_eq!(tmp, Value::from(3));
+	let tmp: usize = db.run("count").args(vec![1, 2, 3]).await.unwrap();
+	assert_eq!(tmp, 3);
 
-	let tmp = db.run("fn::bar", 7).await.unwrap();
-	assert_eq!(tmp, Value::None);
+	let tmp: Option<RecordId> = db.run("fn::bar").args(7).await.unwrap();
+	assert_eq!(tmp, None);
 
-	let tmp = db.run("fn::baz", ()).await.unwrap();
-	assert_eq!(tmp, Value::from(7));
+	let tmp: i32 = db.run("fn::baz").await.unwrap();
+	assert_eq!(tmp, 7);
 }
-*/


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The API of the `run` method is not currently consistent with the rest of the SDK methods.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It adapts the API to make sure it's consistent with the rest of the SDK.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
