### PR TITLE
build: time 0.3.34 -> 0.3.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6478,9 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -6499,9 +6499,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
Fixes build breakage on rust `1.80.1`:

```
error[E0282]: type annotations needed for `Box<_>`
```

## What is the motivation?

`surrealdb` package broken in Nix after rust toolchain upgraded to `1.80.1`

## What does this change do?

Updates the `time` dependency so that it will build on rust `1.80.1`

## What is your testing strategy?

Referenced my forked branch from my local copy of nixpkgs and was able to successfully build.

## Is this related to any issues?

- [x] No related issues

*NOTE*: Chose to file this PR instead of an issue, but note that as of now `1.x` is broken with rust `1.80.1`.

I recommend releasing `1.5.5` with this fix.

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
