### PR TITLE
Replace ok_or with ok_or_else

### DIFF
--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -790,7 +790,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::NdNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::NdNotFound {
 					value: id.to_string(),
 				})?;
 				let val: Node = val.into();
@@ -810,7 +810,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::UserRootNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::UserRootNotFound {
 					value: us.to_owned(),
 				})?;
 				let val: DefineUserStatement = val.into();
@@ -830,7 +830,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::AccessRootNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::AccessRootNotFound {
 					ac: ra.to_owned(),
 				})?;
 				let val: DefineAccessStatement = val.into();
@@ -854,10 +854,11 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::AccessGrantRootNotFound {
-					ac: ac.to_owned(),
-					gr: gr.to_owned(),
-				})?;
+				let val =
+					self.get(key, None).await?.ok_or_else(|| Error::AccessGrantRootNotFound {
+						ac: ac.to_owned(),
+						gr: gr.to_owned(),
+					})?;
 				let val: AccessGrant = val.into();
 				let val = Entry::Any(Arc::new(val));
 				let _ = cache.insert(val.clone());
@@ -875,7 +876,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::NsNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::NsNotFound {
 					value: ns.to_owned(),
 				})?;
 				let val: DefineNamespaceStatement = val.into();
@@ -895,7 +896,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::UserNsNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::UserNsNotFound {
 					value: us.to_owned(),
 					ns: ns.to_owned(),
 				})?;
@@ -920,7 +921,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::AccessNsNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::AccessNsNotFound {
 					ac: na.to_owned(),
 					ns: ns.to_owned(),
 				})?;
@@ -946,11 +947,12 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::AccessGrantNsNotFound {
-					ac: ac.to_owned(),
-					gr: gr.to_owned(),
-					ns: ns.to_owned(),
-				})?;
+				let val =
+					self.get(key, None).await?.ok_or_else(|| Error::AccessGrantNsNotFound {
+						ac: ac.to_owned(),
+						gr: gr.to_owned(),
+						ns: ns.to_owned(),
+					})?;
 				let val: AccessGrant = val.into();
 				let val = Entry::Any(Arc::new(val));
 				let _ = cache.insert(val.clone());
@@ -968,7 +970,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::DbNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::DbNotFound {
 					value: db.to_owned(),
 				})?;
 				let val: DefineDatabaseStatement = val.into();
@@ -993,7 +995,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::UserDbNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::UserDbNotFound {
 					value: us.to_owned(),
 					ns: ns.to_owned(),
 					db: db.to_owned(),
@@ -1020,7 +1022,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::AccessDbNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::AccessDbNotFound {
 					ac: da.to_owned(),
 					ns: ns.to_owned(),
 					db: db.to_owned(),
@@ -1048,12 +1050,13 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::AccessGrantDbNotFound {
-					ac: ac.to_owned(),
-					gr: gr.to_owned(),
-					ns: ns.to_owned(),
-					db: db.to_owned(),
-				})?;
+				let val =
+					self.get(key, None).await?.ok_or_else(|| Error::AccessGrantDbNotFound {
+						ac: ac.to_owned(),
+						gr: gr.to_owned(),
+						ns: ns.to_owned(),
+						db: db.to_owned(),
+					})?;
 				let val: AccessGrant = val.into();
 				let val = Entry::Any(Arc::new(val));
 				let _ = cache.insert(val.clone());
@@ -1077,7 +1080,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::MlNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::MlNotFound {
 					value: format!("{ml}<{vn}>"),
 				})?;
 				let val: DefineModelStatement = val.into();
@@ -1102,7 +1105,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::AzNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::AzNotFound {
 					value: az.to_owned(),
 				})?;
 				let val: DefineAnalyzerStatement = val.into();
@@ -1127,7 +1130,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::FcNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::FcNotFound {
 					value: fc.to_owned(),
 				})?;
 				let val: DefineFunctionStatement = val.into();
@@ -1152,7 +1155,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::PaNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::PaNotFound {
 					value: pa.to_owned(),
 				})?;
 				let val: DefineParamStatement = val.into();
@@ -1177,7 +1180,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::TbNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::TbNotFound {
 					value: tb.to_owned(),
 				})?;
 				let val: DefineTableStatement = val.into();
@@ -1203,7 +1206,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::EvNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::EvNotFound {
 					value: ev.to_owned(),
 				})?;
 				let val: DefineEventStatement = val.into();
@@ -1229,7 +1232,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::FdNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::FdNotFound {
 					value: fd.to_owned(),
 				})?;
 				let val: DefineFieldStatement = val.into();
@@ -1255,7 +1258,7 @@ impl Transaction {
 		Ok(match res {
 			Ok(val) => val,
 			Err(cache) => {
-				let val = self.get(key, None).await?.ok_or(Error::IxNotFound {
+				let val = self.get(key, None).await?.ok_or_else(|| Error::IxNotFound {
 					value: ix.to_owned(),
 				})?;
 				let val: DefineIndexStatement = val.into();
@@ -1445,7 +1448,7 @@ impl Transaction {
 			// The entry is not in the cache
 			Err(cache) => {
 				// Try to fetch the value from the datastore
-				let res = self.get(&key, None).await?.ok_or(Error::NsNotFound {
+				let res = self.get(&key, None).await?.ok_or_else(|| Error::NsNotFound {
 					value: ns.to_owned(),
 				});
 				// Check whether the value exists in the datastore
@@ -1498,7 +1501,7 @@ impl Transaction {
 			// The entry is not in the cache
 			Err(cache) => {
 				// Try to fetch the value from the datastore
-				let res = self.get(&key, None).await?.ok_or(Error::DbNotFound {
+				let res = self.get(&key, None).await?.ok_or_else(|| Error::DbNotFound {
 					value: db.to_owned(),
 				});
 				// Check whether the value exists in the datastore
@@ -1566,7 +1569,7 @@ impl Transaction {
 			// The entry is not in the cache
 			Err(cache) => {
 				// Try to fetch the value from the datastore
-				let res = self.get(&key, None).await?.ok_or(Error::TbNotFound {
+				let res = self.get(&key, None).await?.ok_or_else(|| Error::TbNotFound {
 					value: tb.to_owned(),
 				});
 				// Check whether the value exists in the datastore


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Replace [ok_or](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or) with [ok_or_else](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or_else) in the `Tx` module to prevent unnecessary String allocations in the happy path.  

## What does this change do?

Replaces `ok_or` with `ok_or_else`.

## What is your testing strategy?

CI.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
