### PR TITLE
Enforced relations

### DIFF
--- a/core/src/doc/relation.rs
+++ b/core/src/doc/relation.rs
@@ -20,7 +20,7 @@ impl Document {
 					return Err(Error::TableCheck {
 						thing: rid.to_string(),
 						relation: false,
-						target_type: tb.kind.clone(),
+						target_type: tb.kind.to_string(),
 					});
 				}
 			}
@@ -29,7 +29,7 @@ impl Document {
 					return Err(Error::TableCheck {
 						thing: rid.to_string(),
 						relation: false,
-						target_type: tb.kind.clone(),
+						target_type: tb.kind.to_string(),
 					});
 				}
 			}
@@ -38,7 +38,7 @@ impl Document {
 					return Err(Error::TableCheck {
 						thing: rid.to_string(),
 						relation: true,
-						target_type: tb.kind.clone(),
+						target_type: tb.kind.to_string(),
 					});
 				}
 			}
@@ -48,7 +48,7 @@ impl Document {
 						return Err(Error::TableCheck {
 							thing: rid.to_string(),
 							relation: true,
-							target_type: tb.kind.clone(),
+							target_type: tb.kind.to_string(),
 						});
 					}
 				}
@@ -57,7 +57,7 @@ impl Document {
 						return Err(Error::TableCheck {
 							thing: rid.to_string(),
 							relation: false,
-							target_type: tb.kind.clone(),
+							target_type: tb.kind.to_string(),
 						});
 					}
 				}

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -5,7 +5,6 @@ use crate::sql::idiom::Idiom;
 use crate::sql::index::Distance;
 use crate::sql::thing::Thing;
 use crate::sql::value::Value;
-use crate::sql::TableType;
 use crate::syn::error::RenderedError as RenderedParserError;
 use crate::vs::Error as VersionstampError;
 use base64::DecodeError as Base64Error;
@@ -575,7 +574,7 @@ pub enum Error {
 	TableCheck {
 		thing: String,
 		relation: bool,
-		target_type: TableType,
+		target_type: String,
 	},
 
 	/// The specified field did not conform to the field type check

--- a/core/src/sql/table_type.rs
+++ b/core/src/sql/table_type.rs
@@ -60,11 +60,13 @@ impl InfoStructure for TableType {
 	}
 }
 
-#[revisioned(revision = 1)]
+#[revisioned(revision = 2)]
 #[derive(Debug, Default, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Relation {
 	pub from: Option<Kind>,
 	pub to: Option<Kind>,
+	#[revision(start = 2)]
+	pub enforced: bool,
 }

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -3116,8 +3116,8 @@ mod tests {
 	#[test]
 	fn check_size() {
 		assert!(64 >= std::mem::size_of::<Value>(), "size of value too big");
-		assert_eq!(112, std::mem::size_of::<Error>());
-		assert_eq!(112, std::mem::size_of::<Result<Value, Error>>());
+		assert_eq!(120, std::mem::size_of::<Error>());
+		assert_eq!(120, std::mem::size_of::<Result<Value, Error>>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::number::Number>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::strand::Strand>());
 		assert_eq!(16, std::mem::size_of::<crate::sql::duration::Duration>());

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -3116,8 +3116,8 @@ mod tests {
 	#[test]
 	fn check_size() {
 		assert!(64 >= std::mem::size_of::<Value>(), "size of value too big");
-		assert_eq!(120, std::mem::size_of::<Error>());
-		assert_eq!(120, std::mem::size_of::<Result<Value, Error>>());
+		assert_eq!(112, std::mem::size_of::<Error>());
+		assert_eq!(112, std::mem::size_of::<Result<Value, Error>>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::number::Number>());
 		assert_eq!(24, std::mem::size_of::<crate::sql::strand::Strand>());
 		assert_eq!(16, std::mem::size_of::<crate::sql::duration::Duration>());

--- a/core/src/syn/lexer/keywords.rs
+++ b/core/src/syn/lexer/keywords.rs
@@ -111,6 +111,7 @@ pub(crate) static KEYWORDS: phf::Map<UniCase<&'static str>, TokenKind> = phf_map
 	UniCase::ascii("EVENT") => TokenKind::Keyword(Keyword::Event),
 	UniCase::ascii("ELSE") => TokenKind::Keyword(Keyword::Else),
 	UniCase::ascii("END") => TokenKind::Keyword(Keyword::End),
+	UniCase::ascii("ENFORCED") => TokenKind::Keyword(Keyword::Enforced),
 	UniCase::ascii("EXISTS") => TokenKind::Keyword(Keyword::Exists),
 	UniCase::ascii("EXPLAIN") => TokenKind::Keyword(Keyword::Explain),
 	UniCase::ascii("EXTEND_CANDIDATES") => TokenKind::Keyword(Keyword::ExtendCandidates),

--- a/core/src/syn/parser/stmt/define.rs
+++ b/core/src/syn/parser/stmt/define.rs
@@ -1208,6 +1208,7 @@ impl Parser<'_> {
 		let mut res = table_type::Relation {
 			from: None,
 			to: None,
+			enforced: false,
 		};
 		loop {
 			match self.peek_kind() {
@@ -1223,6 +1224,9 @@ impl Parser<'_> {
 				}
 				_ => break,
 			}
+		}
+		if self.eat(t!("ENFORCED")) {
+			res.enforced = true;
 		}
 		Ok(res)
 	}

--- a/core/src/syn/token/keyword.rs
+++ b/core/src/syn/token/keyword.rs
@@ -75,6 +75,7 @@ keyword! {
 	Event => "EVENT",
 	Else => "ELSE",
 	End => "END",
+	Enforced => "ENFORCED",
 	Exists => "EXISTS",
 	Explain => "EXPLAIN",
 	ExtendCandidates => "EXTEND_CANDIDATES",

--- a/sdk/tests/relate.rs
+++ b/sdk/tests/relate.rs
@@ -257,3 +257,25 @@ async fn schemafull_relate() -> Result<(), Error> {
 
 	Ok(())
 }
+
+#[tokio::test]
+async fn relate_enforced() -> Result<(), Error> {
+	let sql = "
+	    DEFINE TABLE edge TYPE RELATION ENFORCED;
+		RELATE a:1->edge:1->a:2;
+		CREATE a:1, a:2;
+		RELATE a:1->edge:1->a:2;
+	";
+
+	let mut t = Test::new(sql).await?;
+	//
+	t.skip_ok(1)?;
+	//
+	t.expect_error_func(|e| matches!(e, Error::IdNotFound { .. }))?;
+	//
+	t.expect_val("[{ id: a:1 }, { id: a:2 }]")?;
+	//
+	t.expect_val("[{ id: edge:1, in: a:1, out: a:2 }]")?;
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

It's nice to be able to enforce relations on a relational table without having to do the checks for it manually.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It adds an `ENFORCED` keyword to the `TYPE RELATION IN ... OUT ...` clause on the `DEFINE TABLE` statement, which ensures that for new relations created on the table, SurrealDB will ensure that the in and out for that relation actually exist. This keyword will not affect existing relations on a table.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
