### PR TITLE
Fix record id escaping to match parser

### DIFF
--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -1467,7 +1467,7 @@ mod tests {
 		// Test with generic user identifier
 		//
 		{
-			let resource_id = "user:⟨2k9qnabxuxh8k4d5gfto⟩".to_string();
+			let resource_id = "user:2k9qnabxuxh8k4d5gfto".to_string();
 			// Prepare the claims object
 			let mut claims = claims.clone();
 			claims.id = Some(resource_id.clone());


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The parser allows you to have a record id which starts with a number and continued with non-numeric characters, to be not escaped, like: `bla:1a`. The display implementation on the other hand, currently always escapes the ident in that location if it starts with a numeric character.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

The display implementation now only escapes string id parts when there is a "complex character", or if the string consists of only numeric characters.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Updated tests

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
