### PR TITLE
Fix closure "either" type display implementation

### DIFF
--- a/core/src/sql/closure.rs
+++ b/core/src/sql/closure.rs
@@ -71,7 +71,11 @@ impl fmt::Display for Closure {
 			if i > 0 {
 				f.write_str(", ")?;
 			}
-			write!(f, "${name}: {kind}")?;
+			write!(f, "${name}: ")?;
+			match kind {
+				k @ Kind::Either(_) => write!(f, "<{}>", k)?,
+				k => write!(f, "{}", k)?,
+			}
 		}
 		f.write_str("|")?;
 		if let Some(returns) = &self.returns {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Syntax for arguments with an either type were not properly being displayed

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Fixes the display implementation

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
