### PR TITLE
Typo error in `surreal upgrade --help`

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -23,7 +23,7 @@ pub struct UpgradeCommandArguments {
 	/// Install the latest nightly version
 	#[arg(long, conflicts_with = "alpha", conflicts_with = "beta", conflicts_with = "version")]
 	nightly: bool,
-	/// Install the latest beta version
+	/// Install the latest alpha version
 	#[arg(long, conflicts_with = "nightly", conflicts_with = "beta", conflicts_with = "version")]
 	alpha: bool,
 	/// Install the latest beta version


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

There is a typo error in `surreal upgrade --help`. It shows:
```
--alpha              Install the latest beta version
```

## What does this change do?

This should be corrected to:
```
--alpha              Install the latest alpha version
```
