### PR TITLE
Split out FoundationDB tests and make engines tasks consistent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
   # Use github.ref on other branches, so it's unique per branch
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-  
+
 defaults:
   run:
     shell: bash
@@ -647,7 +647,7 @@ jobs:
           ps auxf
 
   fdb-engine-7-3:
-    name: FoundationDB engine
+    name: FoundationDB engine 7.3
     runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,33 +217,6 @@ jobs:
       - name: Run HTTP integration tests
         run: cargo make ci-http-integration
 
-  ml-support:
-    name: ML integration tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get -y update
-
-      - name: Install cargo-make
-        run: cargo install --debug --locked cargo-make
-
-      - name: Run ML integration tests
-        run: cargo make ci-ml-integration
-
   ws-server:
     name: WebSocket integration tests
     runs-on: ubuntu-latest
@@ -270,6 +243,33 @@ jobs:
 
       - name: Run WS integration tests
         run: cargo make ci-ws-integration
+
+  ml-support:
+    name: ML integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y update
+
+      - name: Install cargo-make
+        run: cargo install --debug --locked cargo-make
+
+      - name: Run ML integration tests
+        run: cargo make ci-ml-integration
 
   test:
     name: Test workspace
@@ -373,7 +373,6 @@ jobs:
           free -m
           df -h
           ps auxf
-          cat /tmp/surrealdb.log || true
 
   http-engine:
     name: HTTP engine
@@ -409,7 +408,6 @@ jobs:
           free -m
           df -h
           ps auxf
-          cat /tmp/surrealdb.log || true
 
   any-engine:
     name: Any engine
@@ -445,7 +443,6 @@ jobs:
           free -m
           df -h
           ps auxf
-          cat /tmp/surrealdb.log || true
 
   mem-engine:
     name: Memory engine
@@ -470,6 +467,14 @@ jobs:
       - name: Test mem engine
         run: cargo make ci-api-integration-mem
 
+      - name: Debug info
+        if: always()
+        run: |
+          set -x
+          free -m
+          df -h
+          ps auxf
+
   file-engine:
     name: File engine
     runs-on: ubuntu-latest
@@ -493,6 +498,14 @@ jobs:
       - name: Test file engine
         run: cargo make ci-api-integration-file
 
+      - name: Debug info
+        if: always()
+        run: |
+          set -x
+          free -m
+          df -h
+          ps auxf
+
   rocksdb-engine:
     name: RocksDB engine
     runs-on: ubuntu-latest
@@ -515,6 +528,45 @@ jobs:
 
       - name: Test rocksdb engine
         run: cargo make ci-api-integration-rocksdb
+
+      - name: Debug info
+        if: always()
+        run: |
+          set -x
+          free -m
+          df -h
+          ps auxf
+
+  surrealkv-engine:
+    name: SurrealKV engine
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install cargo-make
+        run: cargo install --debug --locked cargo-make
+
+      - name: Test surrealkv engine
+        run: cargo make ci-api-integration-surrealkv
+
+      - name: Debug info
+        if: always()
+        run: |
+          set -x
+          free -m
+          df -h
+          ps auxf
 
   tikv-engine:
     name: TiKV engine
@@ -557,10 +609,9 @@ jobs:
           free -m
           df -h
           ps auxf
-          cat /tmp/surrealdb.log || true
 
-  fdb-engine:
-    name: FoundationDB engine
+  fdb-engine-7-1:
+    name: FoundationDB engine 7.1
     runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain
@@ -587,14 +638,6 @@ jobs:
       - name: Test fdb engine
         run: cargo make ci-api-integration-fdb-7_1
 
-      - name: Setup FoundationDB
-        uses: foundationdb-rs/foundationdb-actions-install@v.2.2.0
-        with:
-          version: "7.3.47"
-
-      - name: Test fdb engine
-        run: cargo make ci-api-integration-fdb-7_3
-
       - name: Debug info
         if: always()
         run: |
@@ -602,10 +645,9 @@ jobs:
           free -m
           df -h
           ps auxf
-          cat /tmp/surrealdb.log || true
 
-  surrealkv-engine:
-    name: SurrealKV engine
+  fdb-engine-7-3:
+    name: FoundationDB engine
     runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain
@@ -624,8 +666,13 @@ jobs:
       - name: Install cargo-make
         run: cargo install --debug --locked cargo-make
 
-      - name: Test surrealkv engine
-        run: cargo make ci-api-integration-surrealkv
+      - name: Setup FoundationDB
+        uses: foundationdb-rs/foundationdb-actions-install@v.2.2.0
+        with:
+          version: "7.3.47"
+
+      - name: Test fdb engine
+        run: cargo make ci-api-integration-fdb-7_3
 
       - name: Debug info
         if: always()
@@ -634,7 +681,6 @@ jobs:
           free -m
           df -h
           ps auxf
-          cat /tmp/surrealdb.log || true
 
   db-upgrade:
     name: Database Upgrade from previous versions


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Different FoundationDB version tests within GitHub Actions are currently run within a single task. In addition some engines were inconsistent with the data that they reported.

## What does this change do?

This ensures that all of the engines report the same behaviour, and splits the different FoundationDB version tests in to separate CI tasks.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
