### PR TITLE
Remove explicit transactions from export

### DIFF
--- a/core/src/kvs/export.rs
+++ b/core/src/kvs/export.rs
@@ -126,13 +126,6 @@ impl Transaction {
 						chn.send(bytes!("")).await?;
 					}
 				}
-				// Start transaction
-				chn.send(bytes!("-- ------------------------------")).await?;
-				chn.send(bytes!("-- TRANSACTION")).await?;
-				chn.send(bytes!("-- ------------------------------")).await?;
-				chn.send(bytes!("")).await?;
-				chn.send(bytes!("BEGIN TRANSACTION;")).await?;
-				chn.send(bytes!("")).await?;
 				// Records to be exported, categorised by the type of INSERT statement
 				let mut records_normal: Vec<String> =
 					Vec::with_capacity(*EXPORT_BATCH_SIZE as usize);
@@ -193,13 +186,6 @@ impl Transaction {
 					}
 					chn.send(bytes!("")).await?;
 				}
-				// Commit transaction
-				chn.send(bytes!("-- ------------------------------")).await?;
-				chn.send(bytes!("-- TRANSACTION")).await?;
-				chn.send(bytes!("-- ------------------------------")).await?;
-				chn.send(bytes!("")).await?;
-				chn.send(bytes!("COMMIT TRANSACTION;")).await?;
-				chn.send(bytes!("")).await?;
 			}
 		}
 		// Everything exported


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When running an import with very large amounts of data the import can fail, due to all of the table data being inserted within a single transaction. In addition, in many other databases, imports do not take place within transactions, rather inserting in batches.

## What does this change do?

This change drops the specific transaction statements which group all table data imports into a single transaction.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
