### PR TITLE
Handle `f32` as a part of UUID

### DIFF
--- a/core/src/syn/parser/basic/uuid.rs
+++ b/core/src/syn/parser/basic/uuid.rs
@@ -92,7 +92,7 @@ impl Parser<'_> {
 				| TokenKind::NumberSuffix(NumberSuffix::Float) => {
 					cur = self.pop_peek();
 				}
-				TokenKind::Language(_) | TokenKind::Keyword(_) => {
+				TokenKind::Language(_) | TokenKind::Keyword(_) | TokenKind::VectorType(_) => {
 					// there are some keywords and languages keywords which could be part of the
 					// hex section.
 					if !self.span_bytes(next.span).iter().all(|x| x.is_ascii_hexdigit()) {
@@ -166,6 +166,7 @@ mod test {
 		assert_uuid_parses("d0531951-20ec-4575-bb68-3e6b49d813fa");
 		assert_uuid_parses("e0531951-20ec-4575-bb68-3e6b49d813fa");
 		assert_uuid_parses("a0531951-20ec-4575-bb68-3e6b49d813fa");
+		assert_uuid_parses("b98839b9-0471-4dbb-aae0-14780e848f32");
 	}
 
 	#[test]

--- a/core/src/syn/parser/basic/uuid.rs
+++ b/core/src/syn/parser/basic/uuid.rs
@@ -5,7 +5,7 @@ use crate::{
 			mac::{expected_whitespace, unexpected},
 			ParseError, ParseErrorKind, ParseResult, Parser,
 		},
-		token::{t, DurationSuffix, NumberSuffix, TokenKind},
+		token::{t, DurationSuffix, NumberSuffix, TokenKind, VectorTypeKind},
 	},
 };
 
@@ -92,7 +92,9 @@ impl Parser<'_> {
 				| TokenKind::NumberSuffix(NumberSuffix::Float) => {
 					cur = self.pop_peek();
 				}
-				TokenKind::Language(_) | TokenKind::Keyword(_) | TokenKind::VectorType(_) => {
+				TokenKind::Language(_)
+				| TokenKind::Keyword(_)
+				| TokenKind::VectorType(VectorTypeKind::F64 | VectorTypeKind::F32) => {
 					// there are some keywords and languages keywords which could be part of the
 					// hex section.
 					if !self.span_bytes(next.span).iter().all(|x| x.is_ascii_hexdigit()) {

--- a/core/src/syn/parser/token.rs
+++ b/core/src/syn/parser/token.rs
@@ -29,10 +29,14 @@ impl Parser<'_> {
 				| TokenKind::DurationSuffix(
 					// All except Micro unicode
 					DurationSuffix::Nano
-						| DurationSuffix::Micro | DurationSuffix::Milli
-						| DurationSuffix::Second | DurationSuffix::Minute
-						| DurationSuffix::Hour | DurationSuffix::Day
-						| DurationSuffix::Week | DurationSuffix::Year
+						| DurationSuffix::Micro
+						| DurationSuffix::Milli
+						| DurationSuffix::Second
+						| DurationSuffix::Minute
+						| DurationSuffix::Hour
+						| DurationSuffix::Day
+						| DurationSuffix::Week
+						| DurationSuffix::Year
 				)
 		)
 	}
@@ -50,17 +54,18 @@ impl Parser<'_> {
 				| TokenKind::DatetimeChars(_)
 				| TokenKind::Exponent
 				| TokenKind::NumberSuffix(_)
-				| TokenKind::NaN | TokenKind::DurationSuffix(
-				// All except Micro unicode
-				DurationSuffix::Nano
-					| DurationSuffix::Micro
-					| DurationSuffix::Milli
-					| DurationSuffix::Second
-					| DurationSuffix::Minute
-					| DurationSuffix::Hour
-					| DurationSuffix::Day
-					| DurationSuffix::Week
-			)
+				| TokenKind::NaN
+				| TokenKind::DurationSuffix(
+					// All except Micro unicode
+					DurationSuffix::Nano
+						| DurationSuffix::Micro
+						| DurationSuffix::Milli
+						| DurationSuffix::Second
+						| DurationSuffix::Minute
+						| DurationSuffix::Hour
+						| DurationSuffix::Day
+						| DurationSuffix::Week
+				)
 		)
 	}
 
@@ -87,6 +92,7 @@ impl Parser<'_> {
 			TokenKind::Exponent
 			| TokenKind::NumberSuffix(_)
 			| TokenKind::DurationSuffix(_)
+			| TokenKind::VectorType(_)
 			| TokenKind::DatetimeChars(_) => self.glue_ident(false),
 			TokenKind::Digits => self.glue_numeric(),
 			t!("\"") | t!("'") => {
@@ -128,7 +134,7 @@ impl Parser<'_> {
 
 				self.span_str(start.span).to_owned()
 			}
-			TokenKind::DatetimeChars(_) => {
+			TokenKind::DatetimeChars(_) | TokenKind::VectorType(_) => {
 				self.pop_peek();
 
 				self.span_str(start.span).to_owned()

--- a/core/src/syn/parser/token.rs
+++ b/core/src/syn/parser/token.rs
@@ -29,14 +29,10 @@ impl Parser<'_> {
 				| TokenKind::DurationSuffix(
 					// All except Micro unicode
 					DurationSuffix::Nano
-						| DurationSuffix::Micro
-						| DurationSuffix::Milli
-						| DurationSuffix::Second
-						| DurationSuffix::Minute
-						| DurationSuffix::Hour
-						| DurationSuffix::Day
-						| DurationSuffix::Week
-						| DurationSuffix::Year
+						| DurationSuffix::Micro | DurationSuffix::Milli
+						| DurationSuffix::Second | DurationSuffix::Minute
+						| DurationSuffix::Hour | DurationSuffix::Day
+						| DurationSuffix::Week | DurationSuffix::Year
 				)
 		)
 	}
@@ -54,18 +50,17 @@ impl Parser<'_> {
 				| TokenKind::DatetimeChars(_)
 				| TokenKind::Exponent
 				| TokenKind::NumberSuffix(_)
-				| TokenKind::NaN
-				| TokenKind::DurationSuffix(
-					// All except Micro unicode
-					DurationSuffix::Nano
-						| DurationSuffix::Micro
-						| DurationSuffix::Milli
-						| DurationSuffix::Second
-						| DurationSuffix::Minute
-						| DurationSuffix::Hour
-						| DurationSuffix::Day
-						| DurationSuffix::Week
-				)
+				| TokenKind::NaN | TokenKind::DurationSuffix(
+				// All except Micro unicode
+				DurationSuffix::Nano
+					| DurationSuffix::Micro
+					| DurationSuffix::Milli
+					| DurationSuffix::Second
+					| DurationSuffix::Minute
+					| DurationSuffix::Hour
+					| DurationSuffix::Day
+					| DurationSuffix::Week
+			)
 		)
 	}
 

--- a/core/src/syn/token/mod.rs
+++ b/core/src/syn/token/mod.rs
@@ -456,6 +456,7 @@ impl TokenKind {
 				| TokenKind::Language(_)
 				| TokenKind::Algorithm(_)
 				| TokenKind::DatetimeChars(_)
+				| TokenKind::VectorType(_)
 				| TokenKind::Distance(_),
 		)
 	}


### PR DESCRIPTION
## What is the motivation?

Got a LQ test failing with

`2024-08-26T10:40:10.760051Z DEBUG rpc/call: surreal::telemetry::traces::rpc: src/telemetry/traces/rpc.rs:5: close time.busy=438µs time.idle=26.5µs otel.kind="server" ws.id=d0a2c503-fc8b-40a2-a074-31d2c5de3793 rpc.service="surrealdb" rpc.method="query" otel.name="surrealdb.rpc/query" rpc.request_id="7" otel.status_code="Error" otel.status_message="code: -32000, message: There was a problem with the database: Parse error: Unexpected token 'an identifier' expected UUID hex digits\n  |\n1 | KILL u'b98839b9-0471-4dbb-aae0-14780e848f32'\n  |                                         ^^^ \n" rpc.error_code=-32000 rpc.error_message="There was a problem with the database: Parse error: Unexpected token 'an identifier' expected UUID hex digits\n  |\n1 | KILL u'b98839b9-0471-4dbb-aae0-14780e848f32'\n  |                                         ^^^ \n"
`

## What does this change do?

Adds `VectorType` in the list of valid token kinds, as `UUID` can end with `f64`, `f32`, etc.

## What is your testing strategy?

Extended `uuid_parsing` test.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
