### PR TITLE
Fixes to the SurrealDB Rust API for public consumption

### DIFF
--- a/core/src/dbs/capabilities.rs
+++ b/core/src/dbs/capabilities.rs
@@ -338,13 +338,6 @@ impl Capabilities {
 		self.live_query_notifications
 	}
 
-	// function is public API so we can't remove it, but you should prefer allows_function_name
-	pub fn allows_function(&self, target: &FuncTarget) -> bool {
-		self.allow_funcs.matches(target) && !self.deny_funcs.matches(target)
-	}
-
-	// doc hidden so we don't extend api in the library.
-	#[doc(hidden)]
 	pub fn allows_function_name(&self, target: &str) -> bool {
 		self.allow_funcs.matches(target) && !self.deny_funcs.matches(target)
 	}
@@ -620,8 +613,8 @@ mod tests {
 			let caps = Capabilities::default()
 				.with_functions(Targets::<FuncTarget>::All)
 				.without_functions(Targets::<FuncTarget>::None);
-			assert!(caps.allows_function(&FuncTarget::from_str("http::get").unwrap()));
-			assert!(caps.allows_function(&FuncTarget::from_str("http::post").unwrap()));
+			assert!(caps.allows_function_name("http::get"));
+			assert!(caps.allows_function_name("http::post"));
 		}
 
 		// When all funcs are allowed and denied at the same time
@@ -629,8 +622,8 @@ mod tests {
 			let caps = Capabilities::default()
 				.with_functions(Targets::<FuncTarget>::All)
 				.without_functions(Targets::<FuncTarget>::All);
-			assert!(!caps.allows_function(&FuncTarget::from_str("http::get").unwrap()));
-			assert!(!caps.allows_function(&FuncTarget::from_str("http::post").unwrap()));
+			assert!(!caps.allows_function_name("http::get"));
+			assert!(!caps.allows_function_name("http::post"));
 		}
 
 		// When some funcs are allowed and some are denied, deny overrides the allow rules
@@ -642,9 +635,9 @@ mod tests {
 				.without_functions(Targets::<FuncTarget>::Some(
 					[FuncTarget::from_str("http::post").unwrap()].into(),
 				));
-			assert!(caps.allows_function(&FuncTarget::from_str("http::get").unwrap()));
-			assert!(caps.allows_function(&FuncTarget::from_str("http::put").unwrap()));
-			assert!(!caps.allows_function(&FuncTarget::from_str("http::post").unwrap()));
+			assert!(caps.allows_function_name("http::get"));
+			assert!(caps.allows_function_name("http::put"));
+			assert!(!caps.allows_function_name("http::post"));
 		}
 	}
 }

--- a/core/src/syn/parser/mac.rs
+++ b/core/src/syn/parser/mac.rs
@@ -138,6 +138,7 @@ macro_rules! expected_whitespace {
 }
 
 #[cfg(test)]
+#[doc(hidden)]
 #[macro_export]
 macro_rules! test_parse {
 	($func:ident$( ( $($e:expr),* $(,)? ))? , $t:expr) => {{
@@ -147,6 +148,7 @@ macro_rules! test_parse {
 	}};
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! enter_object_recursion {
 	($name:ident = $this:expr => { $($t:tt)* }) => {{

--- a/sdk/src/api/opt/capabilities.rs
+++ b/sdk/src/api/opt/capabilities.rs
@@ -183,7 +183,7 @@ impl Capabilities {
 	}
 
 	/// Set the deny list to deny all functions
-	pub fn with_deny_all_function(mut self) -> Self {
+	pub fn with_deny_all_functions(mut self) -> Self {
 		self.deny_all_functions();
 		self
 	}
@@ -309,7 +309,7 @@ impl Capabilities {
 	}
 
 	/// Set the deny list to deny all net targets
-	pub fn with_deny_all_net_target(mut self) -> Self {
+	pub fn with_deny_all_net_targets(mut self) -> Self {
 		self.deny_all_net_targets();
 		self
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To make some small fixes the SurrealDB Rust API such as:
- Hide accidentally exposed macros from the `core` documentation.
- Fix a typo in capabilities methods which were not pluralized.
- Remove a legacy capabilities method from `1.X`.

## What does this change do?

- Hides accidentally exposed macros from the `core` documentation.
- Fixes a typo in capabilities methods which were not pluralized.
- Removes a legacy capabilities method from `1.X`.

## What is your testing strategy?

Update tests accordingly and ensure that existing tests pass.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
