### PR TITLE
Refactor migrating away from once cell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.79.0
+          toolchain: 1.80.1
           components: rustfmt
 
       - name: Checkout sources
@@ -273,7 +273,7 @@ jobs:
 
   test:
     name: Test workspace
-    runs-on: [ "self-hosted", "arm64", "builder" ]
+    runs-on: ["self-hosted", "arm64", "builder"]
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -37,7 +37,7 @@ on:
       rust_version:
         required: false
         type: string
-        default: "1.77.1"
+        default: "1.80.1"
         description: "The Rust version to use for building binaries"
       onnx_version:
         required: false
@@ -223,7 +223,7 @@ jobs:
 
   test:
     name: Test
-    needs: [ prepare-vars ]
+    needs: [prepare-vars]
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Install stable toolchain
@@ -268,7 +268,7 @@ jobs:
 
   lint:
     name: Lint
-    needs: [ prepare-vars ]
+    needs: [prepare-vars]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -301,7 +301,7 @@ jobs:
   docker-builder:
     name: Prepare docker builder
     runs-on: ubuntu-latest
-    needs: [ prepare-vars ]
+    needs: [prepare-vars]
     outputs:
       name: ${{ steps.image.outputs.name }}
       tag: ${{ steps.image.outputs.tag }}
@@ -353,7 +353,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.arch }} binary
-    needs: [ prepare-vars, docker-builder ]
+    needs: [prepare-vars, docker-builder]
     strategy:
       fail-fast: false
       matrix:
@@ -414,7 +414,7 @@ jobs:
 
           # Linux amd64
           - arch: x86_64-unknown-linux-gnu
-            runner: [ "self-hosted", "amd64", "builder" ]
+            runner: ["self-hosted", "amd64", "builder"]
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
               # Build
@@ -450,7 +450,7 @@ jobs:
 
           # Linux arm64
           - arch: aarch64-unknown-linux-gnu
-            runner: [ "self-hosted", "arm64", "builder" ]
+            runner: ["self-hosted", "arm64", "builder"]
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-arm64
             build-step: |
               set -x
@@ -597,7 +597,7 @@ jobs:
 
   publish:
     name: Publish crate and artifacts binaries
-    needs: [ prepare-vars, test, lint, build ]
+    needs: [prepare-vars, test, lint, build]
     if: ${{ inputs.publish }}
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
@@ -758,7 +758,7 @@ jobs:
 
   docker:
     name: Docker images
-    needs: [ prepare-vars, publish ]
+    needs: [prepare-vars, publish]
     uses: ./.github/workflows/reusable_docker.yml
     with:
       git-ref: ${{ needs.prepare-vars.outputs.git-ref }}
@@ -770,7 +770,7 @@ jobs:
 
   package-macos:
     name: Package and publish macOS universal binary
-    needs: [ prepare-vars, publish ]
+    needs: [prepare-vars, publish]
     runs-on: macos-latest
     env:
       FILE: surreal-${{ needs.prepare-vars.outputs.name }}.darwin-universal
@@ -810,7 +810,7 @@ jobs:
   propagate:
     name: Propagate binaries to all regions
     if: ${{ inputs.publish }}
-    needs: [ publish, package-macos ]
+    needs: [publish, package-macos]
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -223,7 +223,7 @@ jobs:
 
   test:
     name: Test
-    needs: [prepare-vars]
+    needs: [ prepare-vars ]
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Install stable toolchain
@@ -268,7 +268,7 @@ jobs:
 
   lint:
     name: Lint
-    needs: [prepare-vars]
+    needs: [ prepare-vars ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -301,7 +301,7 @@ jobs:
   docker-builder:
     name: Prepare docker builder
     runs-on: ubuntu-latest
-    needs: [prepare-vars]
+    needs: [ prepare-vars ]
     outputs:
       name: ${{ steps.image.outputs.name }}
       tag: ${{ steps.image.outputs.tag }}
@@ -353,7 +353,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.arch }} binary
-    needs: [prepare-vars, docker-builder]
+    needs: [ prepare-vars, docker-builder ]
     strategy:
       fail-fast: false
       matrix:
@@ -414,7 +414,7 @@ jobs:
 
           # Linux amd64
           - arch: x86_64-unknown-linux-gnu
-            runner: ["self-hosted", "amd64", "builder"]
+            runner: [ "self-hosted", "amd64", "builder" ]
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
               # Build
@@ -450,7 +450,7 @@ jobs:
 
           # Linux arm64
           - arch: aarch64-unknown-linux-gnu
-            runner: ["self-hosted", "arm64", "builder"]
+            runner: [ "self-hosted", "arm64", "builder" ]
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-arm64
             build-step: |
               set -x
@@ -597,7 +597,7 @@ jobs:
 
   publish:
     name: Publish crate and artifacts binaries
-    needs: [prepare-vars, test, lint, build]
+    needs: [ prepare-vars, test, lint, build ]
     if: ${{ inputs.publish }}
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
@@ -758,7 +758,7 @@ jobs:
 
   docker:
     name: Docker images
-    needs: [prepare-vars, publish]
+    needs: [ prepare-vars, publish ]
     uses: ./.github/workflows/reusable_docker.yml
     with:
       git-ref: ${{ needs.prepare-vars.outputs.git-ref }}
@@ -770,7 +770,7 @@ jobs:
 
   package-macos:
     name: Package and publish macOS universal binary
-    needs: [prepare-vars, publish]
+    needs: [ prepare-vars, publish ]
     runs-on: macos-latest
     env:
       FILE: surreal-${{ needs.prepare-vars.outputs.name }}.darwin-universal
@@ -810,7 +810,7 @@ jobs:
   propagate:
     name: Propagate binaries to all regions
     if: ${{ inputs.publish }}
-    needs: [publish, package-macos]
+    needs: [ publish, package-macos ]
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,6 @@ name = "actix-example"
 version = "0.1.0"
 dependencies = [
  "actix-web",
- "once_cell",
  "serde",
  "surrealdb",
  "thiserror",
@@ -6027,7 +6026,6 @@ dependencies = [
  "jsonwebtoken",
  "mimalloc",
  "nix 0.27.1",
- "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-proto",
@@ -6088,7 +6086,6 @@ dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "native-tls",
- "once_cell",
  "path-clean",
  "pharos",
  "pprof",
@@ -6195,7 +6192,6 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "object_store",
- "once_cell",
  "pbkdf2",
  "pharos",
  "phf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ http = "1.1.0"
 http-body = "1.0.0"
 http-body-util = "0.1.1"
 hyper = "1.2.0"
-once_cell = "1.18.0"
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/cackle.toml
+++ b/cackle.toml
@@ -263,9 +263,6 @@ allow_unsafe = true
 [pkg.futures-core]
 allow_unsafe = true
 
-[pkg.once_cell]
-allow_unsafe = true
-
 [pkg.serde]
 build.allow_apis = ["process"]
 allow_unsafe = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,7 +3,7 @@ name = "surrealdb-core"
 publish = true
 edition = "2021"
 version = "2.0.0"
-rust-version = "1.77.0"
+rust-version = "1.80.1"
 readme = "../sdk/CARGO.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 description = "A scalable, distributed, collaborative, document-graph database, for the realtime web"
@@ -106,7 +106,6 @@ ndarray-stats = "=0.5.1"
 num-traits = "0.2.18"
 num_cpus = "1.16.0"
 object_store = { version = "0.10.2", optional = false }
-once_cell = "1.18.0"
 pbkdf2 = { version = "0.12.2", features = ["simple"] }
 phf = { version = "0.11.2", features = ["macros", "unicase"] }
 pin-project-lite = "0.2.13"

--- a/core/src/cnf/mod.rs
+++ b/core/src/cnf/mod.rs
@@ -1,4 +1,4 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 /// The characters which are supported in server record IDs.
 pub const ID_CHARS: [char; 36] = [
@@ -14,33 +14,34 @@ pub const PROTECTED_PARAM_NAMES: &[&str] = &["access", "auth", "token", "session
 
 /// Specifies how many concurrent jobs can be buffered in the worker channel.
 #[cfg(not(target_arch = "wasm32"))]
-pub static MAX_CONCURRENT_TASKS: Lazy<usize> =
+pub static MAX_CONCURRENT_TASKS: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_MAX_CONCURRENT_TASKS", usize, 64);
 
 /// Specifies how deep computation recursive call will go before en error is returned.
-pub static MAX_COMPUTATION_DEPTH: Lazy<u32> =
+pub static MAX_COMPUTATION_DEPTH: LazyLock<u32> =
 	lazy_env_parse!("SURREAL_MAX_COMPUTATION_DEPTH", u32, 120);
 
 /// Specifies the number of items which can be cached within a single transaction.
-pub static TRANSACTION_CACHE_SIZE: Lazy<usize> =
+pub static TRANSACTION_CACHE_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_TRANSACTION_CACHE_SIZE", usize, 10_000);
 
 /// The maximum number of keys that should be scanned at once in general queries.
-pub static NORMAL_FETCH_SIZE: Lazy<u32> = lazy_env_parse!("SURREAL_NORMAL_FETCH_SIZE", u32, 50);
+pub static NORMAL_FETCH_SIZE: LazyLock<u32> = lazy_env_parse!("SURREAL_NORMAL_FETCH_SIZE", u32, 50);
 
 /// The maximum number of keys that should be scanned at once for export queries.
-pub static EXPORT_BATCH_SIZE: Lazy<u32> = lazy_env_parse!("SURREAL_EXPORT_BATCH_SIZE", u32, 1000);
+pub static EXPORT_BATCH_SIZE: LazyLock<u32> =
+	lazy_env_parse!("SURREAL_EXPORT_BATCH_SIZE", u32, 1000);
 
 /// The maximum number of keys that should be fetched when streaming range scans in a Scanner.
-pub static MAX_STREAM_BATCH_SIZE: Lazy<u32> =
+pub static MAX_STREAM_BATCH_SIZE: LazyLock<u32> =
 	lazy_env_parse!("SURREAL_MAX_STREAM_BATCH_SIZE", u32, 1000);
 
 /// The maximum number of keys that should be scanned at once per concurrent indexing batch.
-pub static INDEXING_BATCH_SIZE: Lazy<u32> =
+pub static INDEXING_BATCH_SIZE: LazyLock<u32> =
 	lazy_env_parse!("SURREAL_INDEXING_BATCH_SIZE", u32, 250);
 
 /// Forward all signup/signin/authenticate query errors to a client performing authentication. Do not use in production.
-pub static INSECURE_FORWARD_ACCESS_ERRORS: Lazy<bool> =
+pub static INSECURE_FORWARD_ACCESS_ERRORS: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_INSECURE_FORWARD_ACCESS_ERRORS", bool, false);
 
 #[cfg(any(
@@ -52,23 +53,23 @@ pub static INSECURE_FORWARD_ACCESS_ERRORS: Lazy<bool> =
 ))]
 /// Specifies the buffer limit for external sorting.
 /// If the environment variable is not present or cannot be parsed, a default value of 50,000 is used.
-pub static EXTERNAL_SORTING_BUFFER_LIMIT: Lazy<usize> =
+pub static EXTERNAL_SORTING_BUFFER_LIMIT: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_EXTERNAL_SORTING_BUFFER_LIMIT", usize, 50_000);
 
-pub static GRAPHQL_ENABLE: Lazy<bool> =
+pub static GRAPHQL_ENABLE: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_EXPERIMENTAL_GRAPHQL", bool, false);
 
 /// Enable experimental bearer access and stateful access grant management. Still under active development.
 /// Using this experimental feature may introduce risks related to breaking changes and security issues.
 #[cfg(not(test))]
-pub static EXPERIMENTAL_BEARER_ACCESS: Lazy<bool> =
+pub static EXPERIMENTAL_BEARER_ACCESS: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_EXPERIMENTAL_BEARER_ACCESS", bool, false);
 // Run tests with bearer access enabled as it introduces new functionality that needs to be tested.
 #[cfg(test)]
-pub static EXPERIMENTAL_BEARER_ACCESS: Lazy<bool> = Lazy::new(|| true);
+pub static EXPERIMENTAL_BEARER_ACCESS: LazyLock<bool> = LazyLock::new(|| true);
 
 /// Used to limit allocation for builtin functions
-pub static GENERATION_ALLOCATION_LIMIT: Lazy<usize> = once_cell::sync::Lazy::new(|| {
+pub static GENERATION_ALLOCATION_LIMIT: LazyLock<usize> = LazyLock::new(|| {
 	let n = std::env::var("SURREAL_GENERATION_ALLOCATION_LIMIT")
 		.map(|s| s.parse::<u32>().unwrap_or(20))
 		.unwrap_or(20);

--- a/core/src/exe/spawn.rs
+++ b/core/src/exe/spawn.rs
@@ -1,12 +1,12 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use executor::{Executor, Task};
-use once_cell::sync::Lazy;
 use std::future::Future;
 use std::panic::catch_unwind;
+use std::sync::LazyLock;
 
 pub fn spawn<T: Send + 'static>(future: impl Future<Output = T> + Send + 'static) -> Task<T> {
-	static GLOBAL: Lazy<Executor<'_>> = Lazy::new(|| {
+	static GLOBAL: LazyLock<Executor<'_>> = LazyLock::new(|| {
 		std::thread::spawn(|| {
 			catch_unwind(|| {
 				futures::executor::block_on(GLOBAL.run(futures::future::pending::<()>()))

--- a/core/src/fnc/string.rs
+++ b/core/src/fnc/string.rs
@@ -185,16 +185,16 @@ pub mod is {
 	use crate::sql::value::Value;
 	use crate::sql::{Datetime, Thing};
 	use chrono::NaiveDateTime;
-	use once_cell::sync::Lazy;
 	use regex::Regex;
 	use semver::Version;
 	use std::char;
 	use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+	use std::sync::LazyLock;
 	use url::Url;
 	use uuid::Uuid;
 
-	#[rustfmt::skip] static LATITUDE_RE: Lazy<Regex> = Lazy::new(|| Regex::new("^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$").unwrap());
-	#[rustfmt::skip] static LONGITUDE_RE: Lazy<Regex> = Lazy::new(|| Regex::new("^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$").unwrap());
+	#[rustfmt::skip] static LATITUDE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$").unwrap());
+	#[rustfmt::skip] static LONGITUDE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$").unwrap());
 
 	pub fn alphanum((arg,): (String,)) -> Result<Value, Error> {
 		Ok(arg.chars().all(char::is_alphanumeric).into())

--- a/core/src/fnc/util/string/fuzzy.rs
+++ b/core/src/fnc/util/string/fuzzy.rs
@@ -1,8 +1,8 @@
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
-static MATCHER: Lazy<SkimMatcherV2> = Lazy::new(|| SkimMatcherV2::default().ignore_case());
+static MATCHER: LazyLock<SkimMatcherV2> = LazyLock::new(|| SkimMatcherV2::default().ignore_case());
 
 pub trait Fuzzy {
 	/// Retrieve the fuzzy similarity score of this &str compared to another &str

--- a/core/src/fnc/util/string/slug.rs
+++ b/core/src/fnc/util/string/slug.rs
@@ -1,9 +1,9 @@
 use ascii::any_ascii as ascii;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
-static SIMPLES: Lazy<Regex> = Lazy::new(|| Regex::new("[^a-z0-9-_]").unwrap());
-static HYPHENS: Lazy<Regex> = Lazy::new(|| Regex::new("-+").unwrap());
+static SIMPLES: LazyLock<Regex> = LazyLock::new(|| Regex::new("[^a-z0-9-_]").unwrap());
+static HYPHENS: LazyLock<Regex> = LazyLock::new(|| Regex::new("-+").unwrap());
 
 pub fn slug<S: AsRef<str>>(s: S) -> String {
 	// Get a reference

--- a/core/src/iam/entities/schema.rs
+++ b/core/src/iam/entities/schema.rs
@@ -1,7 +1,7 @@
 use cedar_policy::Schema;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
-pub static DEFAULT_CEDAR_SCHEMA: Lazy<serde_json::Value> = Lazy::new(|| {
+pub static DEFAULT_CEDAR_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
 	serde_json::json!(
 		{
 			"": {

--- a/core/src/iam/jwks.rs
+++ b/core/src/iam/jwks.rs
@@ -6,13 +6,13 @@ use jsonwebtoken::jwk::{
 	AlgorithmParameters::*, Jwk, JwkSet, KeyAlgorithm, KeyOperations, PublicKeyUse,
 };
 use jsonwebtoken::{Algorithm::*, DecodingKey, Validation};
-use once_cell::sync::Lazy;
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use tokio::sync::RwLock;
 
 pub(crate) type JwksCache = HashMap<String, JwksCacheEntry>;
@@ -23,10 +23,10 @@ pub(crate) struct JwksCacheEntry {
 }
 
 #[cfg(test)]
-static CACHE_EXPIRATION: Lazy<chrono::Duration> = Lazy::new(|| Duration::seconds(1));
+static CACHE_EXPIRATION: LazyLock<chrono::Duration> = LazyLock::new(|| Duration::seconds(1));
 #[cfg(not(test))]
-static CACHE_EXPIRATION: Lazy<chrono::Duration> =
-	Lazy::new(|| match std::env::var("SURREAL_JWKS_CACHE_EXPIRATION_SECONDS") {
+static CACHE_EXPIRATION: LazyLock<chrono::Duration> =
+	LazyLock::new(|| match std::env::var("SURREAL_JWKS_CACHE_EXPIRATION_SECONDS") {
 		Ok(seconds_str) => {
 			let seconds = seconds_str.parse::<u64>().expect(
 				"Expected a valid number of seconds for SURREAL_JWKS_CACHE_EXPIRATION_SECONDS",
@@ -39,10 +39,10 @@ static CACHE_EXPIRATION: Lazy<chrono::Duration> =
 	});
 
 #[cfg(test)]
-static CACHE_COOLDOWN: Lazy<chrono::Duration> = Lazy::new(|| Duration::seconds(300));
+static CACHE_COOLDOWN: LazyLock<chrono::Duration> = LazyLock::new(|| Duration::seconds(300));
 #[cfg(not(test))]
-static CACHE_COOLDOWN: Lazy<chrono::Duration> =
-	Lazy::new(|| match std::env::var("SURREAL_JWKS_CACHE_COOLDOWN_SECONDS") {
+static CACHE_COOLDOWN: LazyLock<chrono::Duration> =
+	LazyLock::new(|| match std::env::var("SURREAL_JWKS_CACHE_COOLDOWN_SECONDS") {
 		Ok(seconds_str) => {
 			let seconds = seconds_str.parse::<u64>().expect(
 				"Expected a valid number of seconds for SURREAL_JWKS_CACHE_COOLDOWN_SECONDS",
@@ -55,8 +55,8 @@ static CACHE_COOLDOWN: Lazy<chrono::Duration> =
 	});
 
 #[cfg(not(target_arch = "wasm32"))]
-static REMOTE_TIMEOUT: Lazy<chrono::Duration> =
-	Lazy::new(|| match std::env::var("SURREAL_JWKS_REMOTE_TIMEOUT_MILLISECONDS") {
+static REMOTE_TIMEOUT: LazyLock<chrono::Duration> =
+	LazyLock::new(|| match std::env::var("SURREAL_JWKS_REMOTE_TIMEOUT_MILLISECONDS") {
 		Ok(milliseconds_str) => {
 			let milliseconds = milliseconds_str
 				.parse::<u64>()
@@ -365,7 +365,7 @@ mod tests {
 		rng.sample_iter(&Alphanumeric).take(8).map(char::from).collect()
 	}
 
-	static DEFAULT_JWKS: Lazy<JwkSet> = Lazy::new(|| {
+	static DEFAULT_JWKS: LazyLock<JwkSet> = LazyLock::new(|| {
 		JwkSet{
 		keys: vec![Jwk{
 			common: jsonwebtoken::jwk::CommonParameters {

--- a/core/src/iam/policies/policy_set.rs
+++ b/core/src/iam/policies/policy_set.rs
@@ -1,9 +1,9 @@
 use std::str::FromStr;
 
 use cedar_policy::PolicySet;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
-pub static POLICY_SET: Lazy<PolicySet> = Lazy::new(|| {
+pub static POLICY_SET: LazyLock<PolicySet> = LazyLock::new(|| {
 	PolicySet::from_str(
     r#"
     // All roles can view all resources on the same level hierarchy or below

--- a/core/src/iam/token.rs
+++ b/core/src/iam/token.rs
@@ -2,11 +2,11 @@ use crate::sql::json;
 use crate::sql::Object;
 use crate::sql::Value;
 use jsonwebtoken::{Algorithm, Header};
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
-pub static HEADER: Lazy<Header> = Lazy::new(|| Header::new(Algorithm::HS512));
+pub static HEADER: LazyLock<Header> = LazyLock::new(|| Header::new(Algorithm::HS512));
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(untagged)]

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -11,9 +11,9 @@ use crate::syn;
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
 use chrono::Utc;
 use jsonwebtoken::{decode, DecodingKey, Validation};
-use once_cell::sync::Lazy;
 use std::str::{self, FromStr};
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 fn config(alg: Algorithm, key: &[u8]) -> Result<(DecodingKey, Validation), Error> {
 	let (dec, mut val) = match alg {
@@ -67,9 +67,9 @@ fn config(alg: Algorithm, key: &[u8]) -> Result<(DecodingKey, Validation), Error
 	Ok((dec, val))
 }
 
-static KEY: Lazy<DecodingKey> = Lazy::new(|| DecodingKey::from_secret(&[]));
+static KEY: LazyLock<DecodingKey> = LazyLock::new(|| DecodingKey::from_secret(&[]));
 
-static DUD: Lazy<Validation> = Lazy::new(|| {
+static DUD: LazyLock<Validation> = LazyLock::new(|| {
 	let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
 	validation.insecure_disable_signature_validation();
 	validation.validate_nbf = false;

--- a/core/src/kvs/fdb/cnf.rs
+++ b/core/src/kvs/fdb/cnf.rs
@@ -1,10 +1,10 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
-pub static FOUNDATIONDB_TRANSACTION_TIMEOUT: Lazy<i32> =
+pub static FOUNDATIONDB_TRANSACTION_TIMEOUT: LazyLock<i32> =
 	lazy_env_parse_or_else!("SURREAL_FOUNDATIONDB_TRANSACTION_TIMEOUT", i32, |_| { 5000 });
 
-pub static FOUNDATIONDB_TRANSACTION_RETRY_LIMIT: Lazy<i32> =
+pub static FOUNDATIONDB_TRANSACTION_RETRY_LIMIT: LazyLock<i32> =
 	lazy_env_parse_or_else!("SURREAL_FOUNDATIONDB_TRANSACTION_RETRY_LIMIT", i32, |_| { 5 });
 
-pub static FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY: Lazy<i32> =
+pub static FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY: LazyLock<i32> =
 	lazy_env_parse_or_else!("SURREAL_FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY", i32, |_| { 500 });

--- a/core/src/kvs/fdb/mod.rs
+++ b/core/src/kvs/fdb/mod.rs
@@ -14,10 +14,10 @@ use foundationdb::Database;
 use foundationdb::RangeOption;
 use foundationdb::Transaction as Tx;
 use futures::StreamExt;
-use once_cell::sync::Lazy;
 use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 const TIMESTAMP: [u8; 10] = [0x00; 10];
 
@@ -91,8 +91,8 @@ impl Datastore {
 	/// for more information on cluster connection files.
 	pub(crate) async fn new(path: &str) -> Result<Datastore, Error> {
 		// Initialize the FoundationDB Client API
-		static FDBNET: Lazy<Arc<foundationdb::api::NetworkAutoStop>> =
-			Lazy::new(|| Arc::new(unsafe { foundationdb::boot() }));
+		static FDBNET: LazyLock<Arc<foundationdb::api::NetworkAutoStop>> =
+			LazyLock::new(|| Arc::new(unsafe { foundationdb::boot() }));
 		// Store the network cancellation handle
 		let _fdbnet = (*FDBNET).clone();
 		// Configure and setup the database

--- a/core/src/kvs/rocksdb/cnf.rs
+++ b/core/src/kvs/rocksdb/cnf.rs
@@ -1,28 +1,28 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
-pub static ROCKSDB_THREAD_COUNT: Lazy<i32> =
+pub static ROCKSDB_THREAD_COUNT: LazyLock<i32> =
 	lazy_env_parse_or_else!("SURREAL_ROCKSDB_THREAD_COUNT", i32, |_| num_cpus::get() as i32);
 
-pub static ROCKSDB_WRITE_BUFFER_SIZE: Lazy<usize> =
+pub static ROCKSDB_WRITE_BUFFER_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_ROCKSDB_WRITE_BUFFER_SIZE", usize, 256 * 1024 * 1024);
 
-pub static ROCKSDB_TARGET_FILE_SIZE_BASE: Lazy<u64> =
+pub static ROCKSDB_TARGET_FILE_SIZE_BASE: LazyLock<u64> =
 	lazy_env_parse!("SURREAL_ROCKSDB_TARGET_FILE_SIZE_BASE", u64, 512 * 1024 * 1024);
 
-pub static ROCKSDB_MAX_WRITE_BUFFER_NUMBER: Lazy<i32> =
+pub static ROCKSDB_MAX_WRITE_BUFFER_NUMBER: LazyLock<i32> =
 	lazy_env_parse!("SURREAL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER", i32, 32);
 
-pub static ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE: Lazy<i32> =
+pub static ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE: LazyLock<i32> =
 	lazy_env_parse!("SURREAL_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE", i32, 4);
 
-pub static ROCKSDB_ENABLE_PIPELINED_WRITES: Lazy<bool> =
+pub static ROCKSDB_ENABLE_PIPELINED_WRITES: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_PIPELINED_WRITES", bool, true);
 
-pub static ROCKSDB_ENABLE_BLOB_FILES: Lazy<bool> =
+pub static ROCKSDB_ENABLE_BLOB_FILES: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_BLOB_FILES", bool, true);
 
-pub static ROCKSDB_MIN_BLOB_SIZE: Lazy<u64> =
+pub static ROCKSDB_MIN_BLOB_SIZE: LazyLock<u64> =
 	lazy_env_parse!("SURREAL_ROCKSDB_MIN_BLOB_SIZE", u64, 4 * 1024);
 
-pub static ROCKSDB_KEEP_LOG_FILE_NUM: Lazy<usize> =
+pub static ROCKSDB_KEEP_LOG_FILE_NUM: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_ROCKSDB_KEEP_LOG_FILE_NUM", usize, 20);

--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -83,12 +83,12 @@ macro_rules! run {
 ///
 /// # Return Value
 ///
-/// A lazy static variable of type `once_cell::sync::Lazy`, which holds the parsed value
+/// A lazy static variable of type `std::sync::LazyLock`, which holds the parsed value
 /// from the environment variable or the default value.
 #[macro_export]
 macro_rules! lazy_env_parse {
 	($key:expr, $t:ty, $default:expr) => {
-		once_cell::sync::Lazy::new(|| {
+		std::sync::LazyLock::new(|| {
 			std::env::var($key)
 				.and_then(|s| Ok(s.parse::<$t>().unwrap_or($default)))
 				.unwrap_or($default)
@@ -111,7 +111,7 @@ macro_rules! lazy_env_parse {
 #[macro_export]
 macro_rules! lazy_env_parse_or_else {
 	($key:expr, $t:ty, $default:expr) => {
-		once_cell::sync::Lazy::new(|| {
+		std::sync::LazyLock::new(|| {
 			std::env::var($key)
 				.and_then(|s| Ok(s.parse::<$t>().unwrap_or_else($default)))
 				.unwrap_or_else($default)

--- a/core/src/obs/mod.rs
+++ b/core/src/obs/mod.rs
@@ -10,11 +10,11 @@ use object_store::memory::InMemory;
 use object_store::parse_url;
 use object_store::path::Path;
 use object_store::ObjectStore;
-use once_cell::sync::Lazy;
 use sha1::{Digest, Sha1};
 use std::env;
 use std::fs;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use url::Url;
 
 fn initialize_store(env_var: &str, default_dir: &str) -> Arc<dyn ObjectStore> {
@@ -46,11 +46,11 @@ fn initialize_store(env_var: &str, default_dir: &str) -> Arc<dyn ObjectStore> {
 	}
 }
 
-static STORE: Lazy<Arc<dyn ObjectStore>> =
-	Lazy::new(|| initialize_store("SURREAL_OBJECT_STORE", "store"));
+static STORE: LazyLock<Arc<dyn ObjectStore>> =
+	LazyLock::new(|| initialize_store("SURREAL_OBJECT_STORE", "store"));
 
-static CACHE: Lazy<Arc<dyn ObjectStore>> =
-	Lazy::new(|| initialize_store("SURREAL_CACHE_STORE", "cache"));
+static CACHE: LazyLock<Arc<dyn ObjectStore>> =
+	LazyLock::new(|| initialize_store("SURREAL_CACHE_STORE", "cache"));
 
 /// Streams the file from the local system or memory object storage.
 pub async fn stream(

--- a/core/src/rpc/request.rs
+++ b/core/src/rpc/request.rs
@@ -3,11 +3,11 @@ use crate::rpc::format::msgpack::Pack;
 use crate::rpc::RpcError;
 use crate::sql::Part;
 use crate::sql::{Array, Value};
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
-pub static ID: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("id")]);
-pub static METHOD: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("method")]);
-pub static PARAMS: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("params")]);
+pub static ID: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("id")]);
+pub static METHOD: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("method")]);
+pub static PARAMS: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("params")]);
 
 #[derive(Debug)]
 pub struct Request {

--- a/core/src/sql/paths.rs
+++ b/core/src/sql/paths.rs
@@ -1,30 +1,30 @@
 use crate::sql::part::Part;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 pub const OBJ_PATH_ACCESS: &str = "ac";
 pub const OBJ_PATH_AUTH: &str = "rd";
 pub const OBJ_PATH_TOKEN: &str = "tk";
 
-pub static ID: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("id")]);
+pub static ID: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("id")]);
 
-pub static IP: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("ip")]);
+pub static IP: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("ip")]);
 
-pub static NS: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("ns")]);
+pub static NS: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("ns")]);
 
-pub static DB: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("db")]);
+pub static DB: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("db")]);
 
-pub static AC: Lazy<[Part; 1]> = Lazy::new(|| [Part::from(OBJ_PATH_ACCESS)]);
+pub static AC: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from(OBJ_PATH_ACCESS)]);
 
-pub static RD: Lazy<[Part; 1]> = Lazy::new(|| [Part::from(OBJ_PATH_AUTH)]);
+pub static RD: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from(OBJ_PATH_AUTH)]);
 
-pub static OR: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("or")]);
+pub static OR: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("or")]);
 
-pub static TK: Lazy<[Part; 1]> = Lazy::new(|| [Part::from(OBJ_PATH_TOKEN)]);
+pub static TK: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from(OBJ_PATH_TOKEN)]);
 
-pub static IN: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("in")]);
+pub static IN: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("in")]);
 
-pub static OUT: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("out")]);
+pub static OUT: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("out")]);
 
-pub static META: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("__")]);
+pub static META: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("__")]);
 
-pub static EDGE: Lazy<[Part; 1]> = Lazy::new(|| [Part::from("__")]);
+pub static EDGE: LazyLock<[Part; 1]> = LazyLock::new(|| [Part::from("__")]);

--- a/core/src/sql/regex.rs
+++ b/core/src/sql/regex.rs
@@ -1,4 +1,3 @@
-use once_cell::sync::Lazy;
 use quick_cache::sync::{Cache, GuardResult};
 use revision::revisioned;
 use serde::{
@@ -10,6 +9,7 @@ use std::fmt::Debug;
 use std::fmt::{self, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
+use std::sync::LazyLock;
 use std::{env, str};
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Regex";
@@ -27,7 +27,7 @@ impl Regex {
 }
 
 fn regex_new(str: &str) -> Result<regex::Regex, regex::Error> {
-	static REGEX_CACHE: Lazy<Cache<String, regex::Regex>> = Lazy::new(|| {
+	static REGEX_CACHE: LazyLock<Cache<String, regex::Regex>> = LazyLock::new(|| {
 		let cache_size: usize = env::var("SURREAL_REGEX_CACHE_SIZE")
 			.map_or(1000, |v| v.parse().unwrap_or(1000))
 			.max(10); // The minimum cache size is 10

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ FROM docker.io/rockylinux:8 as builder
 RUN yum install -y gcc-toolset-13 git cmake llvm-toolset patch zlib-devel python3.11
 
 # Install rust
-ARG RUST_VERSION=1.77.0
+ARG RUST_VERSION=1.80.1
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh
 RUN bash /tmp/rustup.sh -y --default-toolchain ${RUST_VERSION}
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -79,7 +79,6 @@ futures = "0.3.29"
 geo = { version = "0.27.0", features = ["use-serde"] }
 indexmap = { version = "2.1.0", features = ["serde"] }
 native-tls = { version = "0.2.11", optional = true }
-once_cell = "1.18.0"
 path-clean = "1.0.1"
 revision = { version = "0.9.0", features = [
     "chrono",

--- a/sdk/benches/sdb_benches/mod.rs
+++ b/sdk/benches/sdb_benches/mod.rs
@@ -1,19 +1,21 @@
 use criterion::Criterion;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 
 mod lib;
 mod sdk;
 
-static NUM_OPS: Lazy<usize> =
-	Lazy::new(|| std::env::var("BENCH_NUM_OPS").unwrap_or("1000".to_string()).parse().unwrap());
-static DURATION_SECS: Lazy<u64> =
-	Lazy::new(|| std::env::var("BENCH_DURATION").unwrap_or("30".to_string()).parse().unwrap());
-static SAMPLE_SIZE: Lazy<usize> =
-	Lazy::new(|| std::env::var("BENCH_SAMPLE_SIZE").unwrap_or("30".to_string()).parse().unwrap());
-static WORKER_THREADS: Lazy<usize> =
-	Lazy::new(|| std::env::var("BENCH_WORKER_THREADS").unwrap_or("1".to_string()).parse().unwrap());
+static NUM_OPS: LazyLock<usize> =
+	LazyLock::new(|| std::env::var("BENCH_NUM_OPS").unwrap_or("1000".to_string()).parse().unwrap());
+static DURATION_SECS: LazyLock<u64> =
+	LazyLock::new(|| std::env::var("BENCH_DURATION").unwrap_or("30".to_string()).parse().unwrap());
+static SAMPLE_SIZE: LazyLock<usize> = LazyLock::new(|| {
+	std::env::var("BENCH_SAMPLE_SIZE").unwrap_or("30".to_string()).parse().unwrap()
+});
+static WORKER_THREADS: LazyLock<usize> = LazyLock::new(|| {
+	std::env::var("BENCH_WORKER_THREADS").unwrap_or("1".to_string()).parse().unwrap()
+});
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
 fn rt() -> &'static Runtime {

--- a/sdk/benches/sdb_benches/sdk/mod.rs
+++ b/sdk/benches/sdb_benches/sdk/mod.rs
@@ -1,12 +1,12 @@
 use criterion::{Criterion, Throughput};
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 use std::time::Duration;
 use surrealdb::{engine::any::Any, sql::Id, Surreal};
 
 mod routines;
 
-static DB: Lazy<Surreal<Any>> = Lazy::new(Surreal::init);
+static DB: LazyLock<Surreal<Any>> = LazyLock::new(Surreal::init);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Record {

--- a/sdk/examples/actix/Cargo.toml
+++ b/sdk/examples/actix/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 actix-web = { version = "4.4.0", features = ["macros"] }
-once_cell = "1.18.0"
 serde = { version = "1.0.193", features = ["derive"] }
 surrealdb = { path = "../.." }
 thiserror = "1.0.50"

--- a/sdk/examples/actix/src/main.rs
+++ b/sdk/examples/actix/src/main.rs
@@ -2,13 +2,13 @@ mod error;
 mod person;
 
 use actix_web::{App, HttpServer};
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use surrealdb::engine::remote::ws::Client;
 use surrealdb::engine::remote::ws::Ws;
 use surrealdb::opt::auth::Root;
 use surrealdb::Surreal;
 
-static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
+static DB: LazyLock<Surreal<Client>> = LazyLock::new(Surreal::init);
 
 #[actix_web::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/sdk/examples/concurrency/main.rs
+++ b/sdk/examples/concurrency/main.rs
@@ -1,10 +1,10 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use surrealdb::engine::remote::ws::Client;
 use surrealdb::engine::remote::ws::Ws;
 use surrealdb::Surreal;
 use tokio::sync::mpsc;
 
-static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
+static DB: LazyLock<Surreal<Client>> = LazyLock::new(Surreal::init);
 
 const NUM: usize = 100_000;
 

--- a/sdk/fuzz/Cargo.lock
+++ b/sdk/fuzz/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "addr"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +201,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-graphql"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b76aba2f176af685c2229633881a3adeae51f87ae1811781e73910b7001c93e"
+dependencies = [
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
+ "async-stream",
+ "async-trait",
+ "base64 0.22.0",
+ "bytes",
+ "fnv",
+ "futures-util",
+ "http",
+ "indexmap 2.2.6",
+ "mime",
+ "multer",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "static_assertions_next",
+ "thiserror",
+]
+
+[[package]]
+name = "async-graphql-derive"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e2e26a6b44bc61df3ca8546402cf9204c28e30c06084cc8e75cd5e34d4f150"
+dependencies = [
+ "Inflector",
+ "async-graphql-parser",
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "strum",
+ "syn 2.0.58",
+ "thiserror",
+]
+
+[[package]]
+name = "async-graphql-parser"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f801451484b4977d6fe67b29030f81353cabdcbb754e5a064f39493582dac0cf"
+dependencies = [
+ "async-graphql-value",
+ "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69117c43c01d81a69890a9f5dd6235f2f027ca8d1ec62d6d3c5e01ca0edb4f2b"
+dependencies = [
+ "bytes",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +287,28 @@ name = "async-recursion"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -365,6 +474,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82033247fd8e890df8f740e407ad4d038debb9eb1f40533fffb32e7d17dc6f7"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,15 +574,28 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -592,6 +727,12 @@ checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation-sys"
@@ -812,6 +953,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1186,6 +1336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,6 +1375,23 @@ dependencies = [
  "quote",
  "syn 2.0.58",
 ]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "humantime"
@@ -1359,9 +1532,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -1579,10 +1752,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
+name = "mime"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1591,6 +1764,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1653,16 +1843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978fe6e6ebc0bf53de533cd456ca2d9de13de13856eda1518a285d7705a213af"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1837,6 +2017,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,7 +2174,6 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
  "version_check",
 ]
 
@@ -2234,30 +2424,25 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98b99dba8f2787c9af2e46b17ff38437d213d46c8970b550e6b79b862bf7629"
+checksum = "4beb55556e5a2e13e796d4a58750c4c802d1766bcfc15035163ecf575a38a77e"
 dependencies = [
- "bincode",
  "chrono",
  "geo 0.26.0",
  "regex",
  "revision-derive",
  "roaring",
  "rust_decimal",
- "serde",
- "thiserror",
  "uuid",
 ]
 
 [[package]]
 name = "revision-derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3721b4a8e52f9e52c54f74f482a4f550601f5c44cb7876606a2ab79cb09469c1"
+checksum = "d9336dc6ce3c5ece8d1eb44103d5483c68efbc4b3ac54263316eec2f57f57fec"
 dependencies = [
- "darling",
- "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -2379,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -2429,6 +2614,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+dependencies = [
+ "web-time",
 ]
 
 [[package]]
@@ -2502,18 +2696,27 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.197"
+name = "serde-content"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e255eaf9f3814135df4f959c9f404ebb2e67238bae0ed412da10518d0629e7c9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.209"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2527,6 +2730,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -2583,6 +2798,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simdutf8"
@@ -2648,7 +2869,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2701,6 +2922,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions_next"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
 name = "storekey"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2745,15 +2972,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "subtle"
-version = "2.5.0"
+name = "strum"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
 version = "2.0.0"
 dependencies = [
+ "arrayvec",
  "async-channel",
  "bincode",
  "chrono",
@@ -2761,15 +3011,16 @@ dependencies = [
  "futures",
  "geo 0.27.0",
  "indexmap 2.2.6",
- "once_cell",
  "path-clean",
  "pharos",
  "reblessive",
  "revision",
  "ring",
  "rust_decimal",
+ "rustls-pki-types",
  "semver",
  "serde",
+ "serde-content",
  "serde_json",
  "surrealdb-core",
  "thiserror",
@@ -2794,11 +3045,14 @@ dependencies = [
  "argon2",
  "async-channel",
  "async-executor",
+ "async-graphql",
  "async-recursion",
  "base64 0.21.7",
  "bcrypt",
  "bincode",
+ "blake3",
  "bytes",
+ "castaway",
  "cedar-policy",
  "chrono",
  "ciborium",
@@ -2821,11 +3075,9 @@ dependencies = [
  "nanoid",
  "ndarray",
  "ndarray-stats",
- "nom",
  "num-traits",
  "num_cpus",
  "object_store",
- "once_cell",
  "pbkdf2",
  "pharos",
  "phf",
@@ -2845,11 +3097,13 @@ dependencies = [
  "scrypt",
  "semver",
  "serde",
+ "serde-content",
  "serde_json",
  "sha1",
  "sha2",
  "snap",
  "storekey",
+ "subtle",
  "surrealdb-derive",
  "tempfile",
  "thiserror",
@@ -3133,6 +3387,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "ulid"

--- a/sdk/src/api/engine/any/mod.rs
+++ b/sdk/src/api/engine/any/mod.rs
@@ -218,11 +218,11 @@ impl Surreal<Any> {
 	/// # Examples
 	///
 	/// ```no_run
-	/// use once_cell::sync::Lazy;
+	/// use std::sync::LazyLock;
 	/// use surrealdb::Surreal;
 	/// use surrealdb::engine::any::Any;
 	///
-	/// static DB: Lazy<Surreal<Any>> = Lazy::new(Surreal::init);
+	/// static DB: LazyLock<Surreal<Any>> = LazyLock::new(Surreal::init);
 	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {

--- a/sdk/src/api/engine/local/mod.rs
+++ b/sdk/src/api/engine/local/mod.rs
@@ -92,12 +92,12 @@ const DEFAULT_TICK_INTERVAL: Duration = Duration::from_secs(10);
 /// Instantiating a global instance
 ///
 /// ```
-/// use once_cell::sync::Lazy;
+/// use std::sync::LazyLock;
 /// use surrealdb::{Result, Surreal};
 /// use surrealdb::engine::local::Db;
 /// use surrealdb::engine::local::Mem;
 ///
-/// static DB: Lazy<Surreal<Db>> = Lazy::new(Surreal::init);
+/// static DB: LazyLock<Surreal<Db>> = LazyLock::new(Surreal::init);
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<()> {

--- a/sdk/src/api/engine/remote/http/mod.rs
+++ b/sdk/src/api/engine/remote/http/mod.rs
@@ -68,12 +68,12 @@ impl Surreal<Client> {
 	/// # Examples
 	///
 	/// ```no_run
-	/// use once_cell::sync::Lazy;
+	/// use std::sync::LazyLock;
 	/// use surrealdb::Surreal;
 	/// use surrealdb::engine::remote::http::Client;
 	/// use surrealdb::engine::remote::http::Http;
 	///
-	/// static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
+	/// static DB: LazyLock<Surreal<Client>> = LazyLock::new(Surreal::init);
 	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {

--- a/sdk/src/api/engine/remote/ws/mod.rs
+++ b/sdk/src/api/engine/remote/ws/mod.rs
@@ -113,12 +113,12 @@ impl Surreal<Client> {
 	/// # Examples
 	///
 	/// ```no_run
-	/// use once_cell::sync::Lazy;
+	/// use std::sync::LazyLock;
 	/// use surrealdb::Surreal;
 	/// use surrealdb::engine::remote::ws::Client;
 	/// use surrealdb::engine::remote::ws::Ws;
 	///
-	/// static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
+	/// static DB: LazyLock<Surreal<Client>> = LazyLock::new(Surreal::init);
 	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {

--- a/sdk/src/api/method/mod.rs
+++ b/sdk/src/api/method/mod.rs
@@ -131,7 +131,7 @@ where
 	/// Using a static, compile-time scheme
 	///
 	/// ```no_run
-	/// use once_cell::sync::Lazy;
+	/// use std::sync::LazyLock;
 	/// use serde::{Serialize, Deserialize};
 	/// use surrealdb::Surreal;
 	/// use surrealdb::opt::auth::Root;
@@ -139,7 +139,7 @@ where
 	/// use surrealdb::engine::remote::ws::Client;
 	///
 	/// // Creates a new static instance of the client
-	/// static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
+	/// static DB: LazyLock<Surreal<Client>> = LazyLock::new(Surreal::init);
 	///
 	/// #[derive(Serialize, Deserialize)]
 	/// struct Person {
@@ -173,14 +173,14 @@ where
 	/// Using a dynamic, run-time scheme
 	///
 	/// ```no_run
-	/// use once_cell::sync::Lazy;
+	/// use std::sync::LazyLock;
 	/// use serde::{Serialize, Deserialize};
 	/// use surrealdb::Surreal;
 	/// use surrealdb::engine::any::Any;
 	/// use surrealdb::opt::auth::Root;
 	///
 	/// // Creates a new static instance of the client
-	/// static DB: Lazy<Surreal<Any>> = Lazy::new(Surreal::init);
+	/// static DB: LazyLock<Surreal<Any>> = LazyLock::new(Surreal::init);
 	///
 	/// #[derive(Serialize, Deserialize)]
 	/// struct Person {

--- a/sdk/src/api/method/tests/mod.rs
+++ b/sdk/src/api/method/tests/mod.rs
@@ -14,16 +14,16 @@ use crate::api::opt::auth::Root;
 use crate::api::opt::PatchOp;
 use crate::api::Response as QueryResponse;
 use crate::api::Surreal;
-use once_cell::sync::Lazy;
 use protocol::Client;
 use protocol::Test;
 use semver::Version;
 use std::ops::Bound;
+use std::sync::LazyLock;
 use surrealdb_core::sql::statements::{BeginStatement, CommitStatement};
 use types::User;
 use types::USER;
 
-static DB: Lazy<Surreal<Client>> = Lazy::new(Surreal::init);
+static DB: LazyLock<Surreal<Client>> = LazyLock::new(Surreal::init);
 
 #[tokio::test]
 async fn api() {

--- a/sdk/tests/api.rs
+++ b/sdk/tests/api.rs
@@ -1,7 +1,6 @@
 #[allow(unused_imports, dead_code)]
 mod api_integration {
 	use chrono::DateTime;
-	use once_cell::sync::Lazy;
 	use semver::Version;
 	use serde::Deserialize;
 	use serde::Serialize;
@@ -10,6 +9,7 @@ mod api_integration {
 	use std::borrow::Cow;
 	use std::ops::Bound;
 	use std::sync::Arc;
+	use std::sync::LazyLock;
 	use std::sync::Mutex;
 	use std::time::Duration;
 	use surrealdb::error::Api as ApiError;

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -1,4 +1,4 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use std::time::Duration;
 use surrealdb::{lazy_env_parse, lazy_env_parse_or_else};
 
@@ -32,19 +32,19 @@ pub const APP_ENDPOINT: &str = "https://surrealdb.com/app";
 pub const WEBSOCKET_PING_FREQUENCY: Duration = Duration::from_secs(5);
 
 /// What is the maximum WebSocket frame size (defaults to 16 MiB)
-pub static WEBSOCKET_MAX_FRAME_SIZE: Lazy<usize> =
+pub static WEBSOCKET_MAX_FRAME_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_FRAME_SIZE", usize, 16 << 20);
 
 /// What is the maximum WebSocket message size (defaults to 128 MiB)
-pub static WEBSOCKET_MAX_MESSAGE_SIZE: Lazy<usize> =
+pub static WEBSOCKET_MAX_MESSAGE_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE", usize, 128 << 20);
 
 /// How many concurrent tasks can be handled on each WebSocket (defaults to 24)
-pub static WEBSOCKET_MAX_CONCURRENT_REQUESTS: Lazy<usize> =
+pub static WEBSOCKET_MAX_CONCURRENT_REQUESTS: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS", usize, 24);
 
 /// What is the runtime thread memory stack size (defaults to 10MiB)
-pub static RUNTIME_STACK_SIZE: Lazy<usize> =
+pub static RUNTIME_STACK_SIZE: LazyLock<usize> =
 	lazy_env_parse_or_else!("SURREAL_RUNTIME_STACK_SIZE", usize, |_| {
 		// Stack frames are generally larger in debug mode.
 		if cfg!(debug_assertions) {
@@ -55,17 +55,18 @@ pub static RUNTIME_STACK_SIZE: Lazy<usize> =
 	});
 
 /// How many threads which can be started for blocking operations (defaults to 512)
-pub static RUNTIME_MAX_BLOCKING_THREADS: Lazy<usize> =
+pub static RUNTIME_MAX_BLOCKING_THREADS: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_RUNTIME_MAX_BLOCKING_THREADS", usize, 512);
 
 /// The version identifier of this build
-pub static PKG_VERSION: Lazy<String> = Lazy::new(|| match option_env!("SURREAL_BUILD_METADATA") {
-	Some(metadata) if !metadata.trim().is_empty() => {
-		let version = env!("CARGO_PKG_VERSION");
-		format!("{version}+{metadata}")
-	}
-	_ => env!("CARGO_PKG_VERSION").to_owned(),
-});
+pub static PKG_VERSION: LazyLock<String> =
+	LazyLock::new(|| match option_env!("SURREAL_BUILD_METADATA") {
+		Some(metadata) if !metadata.trim().is_empty() => {
+			let version = env!("CARGO_PKG_VERSION");
+			format!("{version}+{metadata}")
+		}
+		_ => env!("CARGO_PKG_VERSION").to_owned(),
+	});
 
-pub static GRAPHQL_ENABLE: Lazy<bool> =
+pub static GRAPHQL_ENABLE: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_EXPERIMENTAL_GRAPHQL", bool, false);

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,11 +1,11 @@
 use crate::cnf::PKG_VERSION;
 use crate::err::Error;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use surrealdb::env::{arch, os};
 
 /// Stores the current release identifier
-pub static RELEASE: Lazy<String> =
-	Lazy::new(|| format!("{} for {} on {}", *PKG_VERSION, os(), arch()));
+pub static RELEASE: LazyLock<String> =
+	LazyLock::new(|| format!("{} for {} on {}", *PKG_VERSION, os(), arch()));
 
 pub async fn init() -> Result<(), Error> {
 	// Log version

--- a/src/telemetry/metrics/http/mod.rs
+++ b/src/telemetry/metrics/http/mod.rs
@@ -1,14 +1,14 @@
 pub(super) mod tower_layer;
 
-use once_cell::sync::Lazy;
 use opentelemetry::global;
 use opentelemetry::metrics::{Histogram, Meter, MetricsError, UpDownCounter};
+use std::sync::LazyLock;
 
 use self::tower_layer::HttpCallMetricTracker;
 
-static METER: Lazy<Meter> = Lazy::new(|| global::meter("surrealdb.http"));
+static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("surrealdb.http"));
 
-pub static HTTP_SERVER_DURATION: Lazy<Histogram<u64>> = Lazy::new(|| {
+pub static HTTP_SERVER_DURATION: LazyLock<Histogram<u64>> = LazyLock::new(|| {
 	METER
 		.u64_histogram("http.server.duration")
 		.with_description("The HTTP server duration in milliseconds.")
@@ -16,14 +16,14 @@ pub static HTTP_SERVER_DURATION: Lazy<Histogram<u64>> = Lazy::new(|| {
 		.init()
 });
 
-pub static HTTP_SERVER_ACTIVE_REQUESTS: Lazy<UpDownCounter<i64>> = Lazy::new(|| {
+pub static HTTP_SERVER_ACTIVE_REQUESTS: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
 	METER
 		.i64_up_down_counter("http.server.active_requests")
 		.with_description("The number of active HTTP requests.")
 		.init()
 });
 
-pub static HTTP_SERVER_REQUEST_SIZE: Lazy<Histogram<u64>> = Lazy::new(|| {
+pub static HTTP_SERVER_REQUEST_SIZE: LazyLock<Histogram<u64>> = LazyLock::new(|| {
 	METER
 		.u64_histogram("http.server.request.size")
 		.with_description("Measures the size of HTTP request messages.")
@@ -31,7 +31,7 @@ pub static HTTP_SERVER_REQUEST_SIZE: Lazy<Histogram<u64>> = Lazy::new(|| {
 		.init()
 });
 
-pub static HTTP_SERVER_RESPONSE_SIZE: Lazy<Histogram<u64>> = Lazy::new(|| {
+pub static HTTP_SERVER_RESPONSE_SIZE: LazyLock<Histogram<u64>> = LazyLock::new(|| {
 	METER
 		.u64_histogram("http.server.response.size")
 		.with_description("Measures the size of HTTP response messages.")

--- a/src/telemetry/metrics/ws/mod.rs
+++ b/src/telemetry/metrics/ws/mod.rs
@@ -1,16 +1,16 @@
 use std::time::Instant;
 
-use once_cell::sync::Lazy;
 use opentelemetry::metrics::Meter;
 use opentelemetry::{global, KeyValue};
 use opentelemetry::{
 	metrics::{Histogram, MetricsError, UpDownCounter},
 	Context as TelemetryContext,
 };
+use std::sync::LazyLock;
 
-static METER: Lazy<Meter> = Lazy::new(|| global::meter("surrealdb.rpc"));
+static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("surrealdb.rpc"));
 
-pub static RPC_SERVER_DURATION: Lazy<Histogram<u64>> = Lazy::new(|| {
+pub static RPC_SERVER_DURATION: LazyLock<Histogram<u64>> = LazyLock::new(|| {
 	METER
 		.u64_histogram("rpc.server.duration")
 		.with_description("Measures duration of inbound RPC requests in milliseconds.")
@@ -18,14 +18,14 @@ pub static RPC_SERVER_DURATION: Lazy<Histogram<u64>> = Lazy::new(|| {
 		.init()
 });
 
-pub static RPC_SERVER_ACTIVE_CONNECTIONS: Lazy<UpDownCounter<i64>> = Lazy::new(|| {
+pub static RPC_SERVER_ACTIVE_CONNECTIONS: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
 	METER
 		.i64_up_down_counter("rpc.server.active_connections")
 		.with_description("The number of active WebSocket connections.")
 		.init()
 });
 
-pub static RPC_SERVER_REQUEST_SIZE: Lazy<Histogram<u64>> = Lazy::new(|| {
+pub static RPC_SERVER_REQUEST_SIZE: LazyLock<Histogram<u64>> = LazyLock::new(|| {
 	METER
 		.u64_histogram("rpc.server.request.size")
 		.with_description("Measures the size of HTTP request messages.")
@@ -33,7 +33,7 @@ pub static RPC_SERVER_REQUEST_SIZE: Lazy<Histogram<u64>> = Lazy::new(|| {
 		.init()
 });
 
-pub static RPC_SERVER_RESPONSE_SIZE: Lazy<Histogram<u64>> = Lazy::new(|| {
+pub static RPC_SERVER_RESPONSE_SIZE: LazyLock<Histogram<u64>> = LazyLock::new(|| {
 	METER
 		.u64_histogram("rpc.server.response.size")
 		.with_description("Measures the size of HTTP response messages.")

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -3,7 +3,6 @@ pub mod metrics;
 pub mod traces;
 
 use crate::cli::validator::parser::env_filter::CustomEnvFilter;
-use once_cell::sync::Lazy;
 use opentelemetry::metrics::MetricsError;
 use opentelemetry::Context;
 use opentelemetry::KeyValue;
@@ -11,6 +10,7 @@ use opentelemetry_sdk::resource::{
 	EnvResourceDetector, SdkProvidedResourceDetector, TelemetryResourceDetector,
 };
 use opentelemetry_sdk::Resource;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tracing::{Level, Subscriber};
 use tracing_subscriber::filter::ParseError;
@@ -18,7 +18,7 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
-pub static OTEL_DEFAULT_RESOURCE: Lazy<Resource> = Lazy::new(|| {
+pub static OTEL_DEFAULT_RESOURCE: LazyLock<Resource> = LazyLock::new(|| {
 	let res = Resource::from_detectors(
 		Duration::from_secs(5),
 		vec![

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1035,10 +1035,6 @@ criteria = "safe-to-deploy"
 version = "0.10.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.once_cell]]
-version = "1.19.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.oorandom]]
 version = "11.1.3"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## What is the motivation?
No need to take in an extra depenency for once_cell as `std::sync::LazyLock` is a drop in replacement for `once_cell::sync::Lazy`.

## What does this change do?
Replace all instances of `once_cell::sync::Lazy` with `std::sync::LazyLock`.
Update all rust versions (workflow,docker etc) to 1.80.1.

## What is your testing strategy?

`cargo test` completed without issues.

## Is this related to any issues?
- [] Closes  #4441, as it was incomplete and abandoned.

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [ x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
