### PR TITLE
Fix `PatchOp::change` API

### DIFF
--- a/sdk/src/api/opt/mod.rs
+++ b/sdk/src/api/opt/mod.rs
@@ -1,5 +1,5 @@
 //! The different options and types for use in API functions
-use dmp::Diff;
+
 use serde::Serialize;
 
 pub mod auth;
@@ -126,10 +126,10 @@ impl PatchOp {
 	}
 
 	/// Changes a value
-	pub fn change(path: &str, diff: Diff) -> Self {
+	pub fn change(path: &str, diff: String) -> Self {
 		Self(Serializer::new().serialize(UnitOp::Change {
 			path,
-			value: diff.text,
+			value: diff,
 		}))
 	}
 }


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Make `PatchOp::change` easier to use and remove `dmp` from the public API.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It makes `PatchOp::change` take a `String` instead of `dmp::Diff`.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
