### PR TITLE
Remove async-recursion as a dependency from core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6158,7 +6158,6 @@ dependencies = [
  "async-channel 1.9.0",
  "async-executor",
  "async-graphql",
- "async-recursion 1.1.0",
  "base64 0.21.7",
  "bcrypt",
  "bincode",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -57,8 +57,7 @@ ammonia = "4.0.0"
 arbitrary = { version = "1.3.2", features = ["derive"], optional = true }
 argon2 = "0.5.2"
 ascii = { version = "0.3.2", package = "any_ascii" }
-async-recursion = "1.0.5"
-base64 = "0.21.5"
+basse64 = "0.21.5"
 bcrypt = "0.15.0"
 blake3 = "1.5.3"
 bincode = "1.3.3"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -57,7 +57,7 @@ ammonia = "4.0.0"
 arbitrary = { version = "1.3.2", features = ["derive"], optional = true }
 argon2 = "0.5.2"
 ascii = { version = "0.3.2", package = "any_ascii" }
-basse64 = "0.21.5"
+base64 = "0.21.5"
 bcrypt = "0.15.0"
 blake3 = "1.5.3"
 bincode = "1.3.3"


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

async-recursion library is no longer used in core

## What does this change do?

removes async-recursion as a dependency from core.

## What is your testing strategy?

Existing tests should suffice.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
