### PR TITLE
Improve testing for signing in and verifying tokens

### DIFF
--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -778,6 +778,14 @@ mod tests {
 	use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 	use std::collections::HashMap;
 
+	struct TestLevel {
+		level: &'static str,
+		ns: Option<&'static str>,
+		db: Option<&'static str>,
+	}
+
+	const AVAILABLE_ROLES: [Role; 3] = [Role::Viewer, Role::Editor, Role::Owner];
+
 	#[tokio::test]
 	async fn test_signin_record() {
 		// Test with correct credentials
@@ -1059,566 +1067,217 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 	}
 
 	#[tokio::test]
-	async fn test_signin_db_user() {
-		//
-		// Test without roles or expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute("DEFINE USER user ON DB PASSWORD 'pass'", &sess, None).await.unwrap();
-
-			// Signin with the user
-			let mut sess = Session {
-				ns: Some("test".to_string()),
-				db: Some("test".to_string()),
-				..Default::default()
-			};
-			let res = db_user(
-				&ds,
-				&mut sess,
-				"test".to_string(),
-				"test".to_string(),
-				"user".to_string(),
-				"pass".to_string(),
-			)
-			.await;
-
-			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, Some("test".to_string()));
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_db());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), Some("test"));
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
+	async fn test_signin_user() {
+		#[derive(Debug)]
+		struct TestCase {
+			title: &'static str,
+			password: &'static str,
+			roles: Vec<Role>,
+			token_expiration: Option<Duration>,
+			session_expiration: Option<Duration>,
+			expect_ok: bool,
 		}
 
-		//
-		// Test without roles and session expiration disabled
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				"DEFINE USER user ON DB PASSWORD 'pass' DURATION FOR TOKEN 365d, FOR SESSION NONE",
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
+		let test_cases = vec![
+			TestCase {
+				title: "without roles or expiration",
+				password: "pass",
+				roles: vec![Role::Viewer],
+				token_expiration: None,
+				session_expiration: None,
+				expect_ok: true,
+			},
+			TestCase {
+				title: "with roles and expiration",
+				password: "pass",
+				roles: vec![Role::Editor, Role::Owner],
+				token_expiration: Some(Duration::days(365)),
+				session_expiration: Some(Duration::days(1)),
+				expect_ok: true,
+			},
+			TestCase {
+				title: "with invalid password",
+				password: "invalid",
+				roles: vec![],
+				token_expiration: None,
+				session_expiration: None,
+				expect_ok: false,
+			},
+		];
 
-			// Signin with the user
-			let mut sess = Session {
-				db: Some("test".to_string()),
-				ns: Some("test".to_string()),
-				..Default::default()
-			};
-			let res = db_user(
-				&ds,
-				&mut sess,
-				"test".to_string(),
-				"test".to_string(),
-				"user".to_string(),
-				"pass".to_string(),
-			)
-			.await;
+		let test_levels = vec![
+			TestLevel {
+				level: "ROOT",
+				ns: None,
+				db: None,
+			},
+			TestLevel {
+				level: "NS",
+				ns: Some("test"),
+				db: None,
+			},
+			TestLevel {
+				level: "DB",
+				ns: Some("test"),
+				db: Some("test"),
+			},
+		];
 
-			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
-			assert_eq!(sess.db, Some("test".to_string()));
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_db());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), Some("test"));
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			assert_eq!(sess.exp, None, "Session expiration is expected to match defined duration");
-			// Decode token and check that it has been issued as intended
-			if let Ok(tk) = res {
-				// Decode token without validation
-				let token_data = decode::<Claims>(&tk, &DecodingKey::from_secret(&[]), &{
-					let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
-					validation.insecure_disable_signature_validation();
-					validation.validate_nbf = false;
-					validation.validate_exp = false;
-					validation
-				})
-				.unwrap();
-				// Check that token expiration matches the defined duration
-				// Expiration should match the current time plus token duration with some margin
-				let exp = match token_data.claims.exp {
-					Some(exp) => exp,
-					_ => panic!("Token is missing expiration claim"),
+		for level in &test_levels {
+			for case in &test_cases {
+				println!("Test case: {} level {}", level.level, case.title);
+				let ds = Datastore::new("memory").await.unwrap();
+				let sess = Session::owner().with_ns("test").with_db("test");
+
+				let roles_clause = if case.roles.is_empty() {
+					String::new()
+				} else {
+					let roles: Vec<&str> = case
+						.roles
+						.iter()
+						.map(|r| match r {
+							Role::Viewer => "VIEWER",
+							Role::Editor => "EDITOR",
+							Role::Owner => "OWNER",
+						})
+						.collect();
+					format!("ROLES {}", roles.join(", "))
 				};
-				let min_tk_exp =
-					(Utc::now() + Duration::days(365) - Duration::seconds(10)).timestamp();
-				let max_tk_exp =
-					(Utc::now() + Duration::days(365) + Duration::seconds(10)).timestamp();
-				assert!(
-					exp > min_tk_exp && exp < max_tk_exp,
-					"Token expiration is expected to follow the defined duration"
+
+				let mut duration_clause = String::new();
+				if case.token_expiration.is_some() || case.session_expiration.is_some() {
+					duration_clause = format!("DURATION")
+				}
+				if let Some(duration) = case.token_expiration {
+					duration_clause =
+						format!("{} FOR TOKEN {}s", duration_clause, duration.num_seconds())
+				}
+				if let Some(duration) = case.session_expiration {
+					duration_clause =
+						format!("{} FOR SESSION {}s", duration_clause, duration.num_seconds())
+				}
+
+				let define_user_query = format!(
+					"DEFINE USER user ON {} PASSWORD 'pass' {} {}",
+					level.level, roles_clause, duration_clause,
 				);
-				// Check required token claims
-				assert_eq!(token_data.claims.ns, Some("test".to_string()));
-				assert_eq!(token_data.claims.db, Some("test".to_string()));
-				assert_eq!(token_data.claims.id, Some("user".to_string()));
-			} else {
-				panic!("Token could not be extracted from result")
-			}
-		}
 
-		//
-		// Test with roles and expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute("DEFINE USER user ON DB PASSWORD 'pass' ROLES EDITOR, OWNER DURATION FOR TOKEN 15m, FOR SESSION 6h", &sess, None)
-				.await
-				.unwrap();
+				ds.execute(&define_user_query, &sess, None).await.unwrap();
 
-			// Signin with the user
-			let mut sess = Session {
-				ns: Some("test".to_string()),
-				db: Some("test".to_string()),
-				..Default::default()
-			};
-			let res = db_user(
-				&ds,
-				&mut sess,
-				"test".to_string(),
-				"test".to_string(),
-				"user".to_string(),
-				"pass".to_string(),
-			)
-			.await;
-
-			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, Some("test".to_string()));
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_db());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), Some("test"));
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
-			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
-			// Expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::hours(6) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::hours(6) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
-			// Decode token and check that it has been issued as intended
-			if let Ok(tk) = res {
-				// Decode token without validation
-				let token_data = decode::<Claims>(&tk, &DecodingKey::from_secret(&[]), &{
-					let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
-					validation.insecure_disable_signature_validation();
-					validation.validate_nbf = false;
-					validation.validate_exp = false;
-					validation
-				})
-				.unwrap();
-				// Check that token expiration matches the defined duration
-				// Expiration should match the current time plus token duration with some margin
-				let exp = match token_data.claims.exp {
-					Some(exp) => exp,
-					_ => panic!("Token is missing expiration claim"),
+				let mut sess = Session {
+					ns: level.ns.map(String::from),
+					db: level.db.map(String::from),
+					..Default::default()
 				};
-				let min_tk_exp =
-					(Utc::now() + Duration::minutes(15) - Duration::seconds(10)).timestamp();
-				let max_tk_exp =
-					(Utc::now() + Duration::minutes(15) + Duration::seconds(10)).timestamp();
-				assert!(
-					exp > min_tk_exp && exp < max_tk_exp,
-					"Token expiration is expected to follow the defined duration"
-				);
-				// Check required token claims
-				assert_eq!(token_data.claims.ns, Some("test".to_string()));
-				assert_eq!(token_data.claims.db, Some("test".to_string()));
-				assert_eq!(token_data.claims.id, Some("user".to_string()));
-			} else {
-				panic!("Token could not be extracted from result")
-			}
-		}
 
-		// Test invalid password
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute("DEFINE USER user ON DB PASSWORD 'pass'", &sess, None).await.unwrap();
-
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = db_user(
-				&ds,
-				&mut sess,
-				"test".to_string(),
-				"test".to_string(),
-				"user".to_string(),
-				"invalid".to_string(),
-			)
-			.await;
-
-			assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
-		}
-	}
-
-	#[tokio::test]
-	async fn test_signin_ns_user() {
-		//
-		// Test without roles or expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test");
-			ds.execute("DEFINE USER user ON NS PASSWORD 'pass'", &sess, None).await.unwrap();
-
-			// Signin with the user
-			let mut sess = Session {
-				ns: Some("test".to_string()),
-				..Default::default()
-			};
-			let res =
-				ns_user(&ds, &mut sess, "test".to_string(), "user".to_string(), "pass".to_string())
-					.await;
-
-			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_ns());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
-		}
-
-		//
-		// Test without roles and session expiration disabled
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test");
-			ds.execute(
-				"DEFINE USER user ON NS PASSWORD 'pass' DURATION FOR TOKEN 365d, FOR SESSION NONE",
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Signin with the user
-			let mut sess = Session {
-				ns: Some("test".to_string()),
-				..Default::default()
-			};
-			let res =
-				ns_user(&ds, &mut sess, "test".to_string(), "user".to_string(), "pass".to_string())
-					.await;
-
-			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_ns());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			assert_eq!(sess.exp, None, "Session expiration is expected to match defined duration");
-			// Decode token and check that it has been issued as intended
-			if let Ok(tk) = res {
-				// Decode token without validation
-				let token_data = decode::<Claims>(&tk, &DecodingKey::from_secret(&[]), &{
-					let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
-					validation.insecure_disable_signature_validation();
-					validation.validate_nbf = false;
-					validation.validate_exp = false;
-					validation
-				})
-				.unwrap();
-				// Check that token expiration matches the defined duration
-				// Expiration should match the current time plus token duration with some margin
-				let exp = match token_data.claims.exp {
-					Some(exp) => exp,
-					_ => panic!("Token is missing expiration claim"),
+				let res = match level.level {
+					"ROOT" => {
+						root_user(&ds, &mut sess, "user".to_string(), case.password.to_string())
+							.await
+					}
+					"NS" => {
+						ns_user(
+							&ds,
+							&mut sess,
+							level.ns.unwrap().to_string(),
+							"user".to_string(),
+							case.password.to_string(),
+						)
+						.await
+					}
+					"DB" => {
+						db_user(
+							&ds,
+							&mut sess,
+							level.ns.unwrap().to_string(),
+							level.db.unwrap().to_string(),
+							"user".to_string(),
+							case.password.to_string(),
+						)
+						.await
+					}
+					_ => panic!("Unsupported level"),
 				};
-				let min_tk_exp =
-					(Utc::now() + Duration::days(365) - Duration::seconds(10)).timestamp();
-				let max_tk_exp =
-					(Utc::now() + Duration::days(365) + Duration::seconds(10)).timestamp();
-				assert!(
-					exp > min_tk_exp && exp < max_tk_exp,
-					"Token expiration is expected to follow the defined duration"
-				);
-				// Check required token claims
-				assert_eq!(token_data.claims.ns, Some("test".to_string()));
-				assert_eq!(token_data.claims.db, None);
-				assert_eq!(token_data.claims.id, Some("user".to_string()));
-			} else {
-				panic!("Token could not be extracted from result")
+
+				if case.expect_ok {
+					assert!(res.is_ok(), "Failed to signin: {:?}", res);
+					assert_eq!(sess.ns, level.ns.map(|s| s.to_string()));
+					assert_eq!(sess.db, level.db.map(|s| s.to_string()));
+					assert_eq!(sess.au.level().ns(), level.ns);
+					assert_eq!(sess.au.level().db(), level.db);
+					assert_eq!(sess.au.id(), "user");
+
+					// Check auth level
+					match level.level {
+						"ROOT" => assert!(sess.au.is_root()),
+						"NS" => assert!(sess.au.is_ns()),
+						"DB" => assert!(sess.au.is_db()),
+						_ => panic!("Unsupported level"),
+					}
+
+					// Check roles
+					for role in &AVAILABLE_ROLES {
+						let has_role = sess.au.has_role(role);
+						let should_have_role = case.roles.contains(role);
+						assert_eq!(has_role, should_have_role, "Role {:?} check failed", role);
+					}
+
+					// Check session expiration
+					if let Some(exp_duration) = case.session_expiration {
+						let exp = sess.exp.unwrap();
+						let min_exp =
+							(Utc::now() + exp_duration - Duration::seconds(10)).timestamp();
+						let max_exp =
+							(Utc::now() + exp_duration + Duration::seconds(10)).timestamp();
+						assert!(
+							exp > min_exp && exp < max_exp,
+							"Session expiration is expected to match the defined duration"
+						);
+					} else {
+						assert_eq!(sess.exp, None, "Session expiration is expected to be None");
+					}
+
+					// Check issued token
+					if let Ok(tk) = res {
+						// Decode token without validation
+						let token_data = decode::<Claims>(&tk, &DecodingKey::from_secret(&[]), &{
+							let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
+							validation.insecure_disable_signature_validation();
+							validation.validate_nbf = false;
+							validation.validate_exp = false;
+							validation
+						})
+						.unwrap();
+
+						// Check session expiration
+						if let Some(exp_duration) = case.token_expiration {
+							let exp = match token_data.claims.exp {
+								Some(exp) => exp,
+								_ => panic!("Token is missing expiration claim"),
+							};
+							let min_exp =
+								(Utc::now() + exp_duration - Duration::seconds(10)).timestamp();
+							let max_exp =
+								(Utc::now() + exp_duration + Duration::seconds(10)).timestamp();
+							assert!(
+								exp > min_exp && exp < max_exp,
+								"Session expiration is expected to match the defined duration"
+							);
+						} else {
+							assert_eq!(sess.exp, None, "Session expiration is expected to be None");
+						}
+
+						// Check required token claims
+						assert_eq!(token_data.claims.ns, level.ns.map(|s| s.to_string()));
+						assert_eq!(token_data.claims.db, level.db.map(|s| s.to_string()));
+						assert_eq!(token_data.claims.id, Some("user".to_string()));
+					} else {
+						panic!("Token could not be extracted from result")
+					}
+				} else {
+					assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
+				}
 			}
-		}
-
-		//
-		// Test with roles and expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test");
-			ds.execute("DEFINE USER user ON NS PASSWORD 'pass' ROLES EDITOR, OWNER DURATION FOR TOKEN 15m, FOR SESSION 6h", &sess, None)
-				.await
-				.unwrap();
-
-			// Signin with the user
-			let mut sess = Session {
-				ns: Some("test".to_string()),
-				..Default::default()
-			};
-			let res =
-				ns_user(&ds, &mut sess, "test".to_string(), "user".to_string(), "pass".to_string())
-					.await;
-
-			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_ns());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
-			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
-			// Expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::hours(6) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::hours(6) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
-			// Decode token and check that it has been issued as intended
-			if let Ok(tk) = res {
-				// Decode token without validation
-				let token_data = decode::<Claims>(&tk, &DecodingKey::from_secret(&[]), &{
-					let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
-					validation.insecure_disable_signature_validation();
-					validation.validate_nbf = false;
-					validation.validate_exp = false;
-					validation
-				})
-				.unwrap();
-				// Check that token expiration matches the defined duration
-				// Expiration should match the current time plus token duration with some margin
-				let exp = match token_data.claims.exp {
-					Some(exp) => exp,
-					_ => panic!("Token is missing expiration claim"),
-				};
-				let min_tk_exp =
-					(Utc::now() + Duration::minutes(15) - Duration::seconds(10)).timestamp();
-				let max_tk_exp =
-					(Utc::now() + Duration::minutes(15) + Duration::seconds(10)).timestamp();
-				assert!(
-					exp > min_tk_exp && exp < max_tk_exp,
-					"Token expiration is expected to follow the defined duration"
-				);
-				// Check required token claims
-				assert_eq!(token_data.claims.ns, Some("test".to_string()));
-				assert_eq!(token_data.claims.db, None);
-				assert_eq!(token_data.claims.id, Some("user".to_string()));
-			} else {
-				panic!("Token could not be extracted from result")
-			}
-		}
-
-		// Test invalid password
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test");
-			ds.execute("DEFINE USER user ON NS PASSWORD 'pass'", &sess, None).await.unwrap();
-
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = ns_user(
-				&ds,
-				&mut sess,
-				"test".to_string(),
-				"user".to_string(),
-				"invalid".to_string(),
-			)
-			.await;
-
-			assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
-		}
-	}
-
-	#[tokio::test]
-	async fn test_signin_root_user() {
-		//
-		// Test without roles or expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner();
-			ds.execute("DEFINE USER user ON ROOT PASSWORD 'pass'", &sess, None).await.unwrap();
-
-			// Signin with the user
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = root_user(&ds, &mut sess, "user".to_string(), "pass".to_string()).await;
-
-			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_root());
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
-		}
-
-		//
-		// Test without roles and session expiration disabled
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test");
-			ds.execute("DEFINE USER user ON ROOT PASSWORD 'pass' DURATION FOR TOKEN 365d, FOR SESSION NONE", &sess, None).await.unwrap();
-
-			// Signin with the user
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = root_user(&ds, &mut sess, "user".to_string(), "pass".to_string()).await;
-
-			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_root());
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			assert_eq!(sess.exp, None, "Session expiration is expected to match defined duration");
-			// Decode token and check that it has been issued as intended
-			if let Ok(tk) = res {
-				// Decode token without validation
-				let token_data = decode::<Claims>(&tk, &DecodingKey::from_secret(&[]), &{
-					let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
-					validation.insecure_disable_signature_validation();
-					validation.validate_nbf = false;
-					validation.validate_exp = false;
-					validation
-				})
-				.unwrap();
-				// Check that token expiration matches the defined duration
-				// Expiration should match the current time plus token duration with some margin
-				let exp = match token_data.claims.exp {
-					Some(exp) => exp,
-					_ => panic!("Token is missing expiration claim"),
-				};
-				let min_tk_exp =
-					(Utc::now() + Duration::days(365) - Duration::seconds(10)).timestamp();
-				let max_tk_exp =
-					(Utc::now() + Duration::days(365) + Duration::seconds(10)).timestamp();
-				assert!(
-					exp > min_tk_exp && exp < max_tk_exp,
-					"Token expiration is expected to follow the defined duration"
-				);
-				// Check required token claims
-				assert_eq!(token_data.claims.ns, None);
-				assert_eq!(token_data.claims.db, None);
-				assert_eq!(token_data.claims.id, Some("user".to_string()));
-			} else {
-				panic!("Token could not be extracted from result")
-			}
-		}
-
-		//
-		// Test with roles and expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner();
-			ds.execute("DEFINE USER user ON ROOT PASSWORD 'pass' ROLES EDITOR, OWNER DURATION FOR TOKEN 15m, FOR SESSION 6h", &sess, None)
-				.await
-				.unwrap();
-
-			// Signin with the user
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = root_user(&ds, &mut sess, "user".to_string(), "pass".to_string()).await;
-
-			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_root());
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
-			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
-			// Expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::hours(6) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::hours(6) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
-			// Decode token and check that it has been issued as intended
-			if let Ok(tk) = res {
-				// Decode token without validation
-				let token_data = decode::<Claims>(&tk, &DecodingKey::from_secret(&[]), &{
-					let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
-					validation.insecure_disable_signature_validation();
-					validation.validate_nbf = false;
-					validation.validate_exp = false;
-					validation
-				})
-				.unwrap();
-				// Check that token expiration matches the defined duration
-				// Expiration should match the current time plus token duration with some margin
-				let exp = match token_data.claims.exp {
-					Some(exp) => exp,
-					_ => panic!("Token is missing expiration claim"),
-				};
-				let min_tk_exp =
-					(Utc::now() + Duration::minutes(15) - Duration::seconds(10)).timestamp();
-				let max_tk_exp =
-					(Utc::now() + Duration::minutes(15) + Duration::seconds(10)).timestamp();
-				assert!(
-					exp > min_tk_exp && exp < max_tk_exp,
-					"Token expiration is expected to follow the defined duration"
-				);
-				// Check required token claims
-				assert_eq!(token_data.claims.ns, None);
-				assert_eq!(token_data.claims.db, None);
-				assert_eq!(token_data.claims.id, Some("user".to_string()));
-			} else {
-				panic!("Token could not be extracted from result")
-			}
-		}
-
-		// Test invalid password
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test");
-			ds.execute("DEFINE USER user ON ROOT PASSWORD 'pass'", &sess, None).await.unwrap();
-
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = root_user(&ds, &mut sess, "user".to_string(), "invalid".to_string()).await;
-
-			assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
 		}
 	}
 

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -792,8 +792,6 @@ mod tests {
 					level.level, roles_clause, duration_clause,
 				);
 
-				println!("{}", define_user_query);
-
 				ds.execute(&define_user_query, &sess, None).await.unwrap();
 
 				let mut sess = Session {
@@ -817,7 +815,7 @@ mod tests {
 					}
 
 					// Check roles
-					for role in &[Role::Viewer, Role::Editor, Role::Owner] {
+					for role in &AVAILABLE_ROLES {
 						let has_role = sess.au.has_role(role);
 						let should_have_role = case.roles.contains(role);
 						assert_eq!(has_role, should_have_role, "Role {:?} check failed", role);
@@ -953,23 +951,11 @@ mod tests {
 					assert_eq!(sess.db, level.db.map(|s| s.to_string()));
 					assert_eq!(sess.au.id(), "token");
 
-					// Ensure that the session has all expected roles and none of the others
+					// Check roles
 					for role in &AVAILABLE_ROLES {
-						if case.expect_roles.contains(role) {
-							assert!(
-								sess.au.has_role(role),
-								"Auth user expected to have role {:?} in case: {:?}",
-								role,
-								case
-							);
-						} else {
-							assert!(
-								!sess.au.has_role(role),
-								"Auth user not expected to have role {:?} in case: {:?}",
-								role,
-								case
-							);
-						}
+						let has_role = sess.au.has_role(role);
+						let should_have_role = case.expect_roles.contains(role);
+						assert_eq!(has_role, should_have_role, "Role {:?} check failed", role);
 					}
 
 					// Ensure that the expiration is set correctly

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -807,6 +807,8 @@ mod tests {
 					assert_eq!(sess.au.id(), "user");
 
 					// Check auth level
+					assert_eq!(sess.au.level().ns(), level.ns);
+					assert_eq!(sess.au.level().db(), level.db);
 					match level.level {
 						"ROOT" => assert!(sess.au.is_root()),
 						"NS" => assert!(sess.au.is_ns()),
@@ -1660,6 +1662,8 @@ mod tests {
 					assert_eq!(sess.au.id(), "user");
 
 					// Check auth level
+					assert_eq!(sess.au.level().ns(), level.ns);
+					assert_eq!(sess.au.level().db(), level.db);
 					match level.level {
 						"ROOT" => assert!(sess.au.is_root()),
 						"NS" => assert!(sess.au.is_ns()),

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -953,13 +953,23 @@ mod tests {
 					assert_eq!(sess.db, level.db.map(|s| s.to_string()));
 					assert_eq!(sess.au.id(), "token");
 
-					for role in &case.expect_roles {
-						assert!(
-							sess.au.has_role(role),
-							"Auth user expected to have role {:?} in case: {:?}",
-							role,
-							case
-						);
+					// Ensure that the session has all expected roles and none of the others
+					for role in &AVAILABLE_ROLES {
+						if case.expect_roles.contains(role) {
+							assert!(
+								sess.au.has_role(role),
+								"Auth user expected to have role {:?} in case: {:?}",
+								role,
+								case
+							);
+						} else {
+							assert!(
+								!sess.au.has_role(role),
+								"Auth user not expected to have role {:?} in case: {:?}",
+								role,
+								case
+							);
+						}
 					}
 
 					// Ensure that the expiration is set correctly

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -700,264 +700,209 @@ mod tests {
 	use jsonwebtoken::{encode, EncodingKey};
 
 	#[tokio::test]
-	async fn test_basic_root() {
-		//
-		// Test without roles or expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute("DEFINE USER user ON ROOT PASSWORD 'pass'", &sess, None).await.unwrap();
-
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = basic(&ds, &mut sess, "user", "pass", None, None).await;
-
-			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
-			assert_eq!(sess.ns, None);
-			assert_eq!(sess.db, None);
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_root());
-			assert_eq!(sess.au.level().ns(), None);
-			assert_eq!(sess.au.level().db(), None);
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
+	async fn test_basic() {
+		#[derive(Debug)]
+		struct TestLevel {
+			level: &'static str,
+			ns: Option<&'static str>,
+			db: Option<&'static str>,
 		}
 
-		//
-		// Test with roles and expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				"DEFINE USER user ON ROOT PASSWORD 'pass' ROLES EDITOR, OWNER DURATION FOR SESSION 1d",
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
+		let test_levels = vec![
+			TestLevel {
+				level: "ROOT",
+				ns: None,
+				db: None,
+			},
+			TestLevel {
+				level: "NS",
+				ns: Some("test"),
+				db: None,
+			},
+			TestLevel {
+				level: "DB",
+				ns: Some("test"),
+				db: Some("test"),
+			},
+		];
 
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = basic(&ds, &mut sess, "user", "pass", None, None).await;
-
-			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
-			assert_eq!(sess.ns, None);
-			assert_eq!(sess.db, None);
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_root());
-			assert_eq!(sess.au.level().ns(), None);
-			assert_eq!(sess.au.level().db(), None);
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
-			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
-			// Session expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::days(1) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::days(1) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
+		#[derive(Debug)]
+		struct TestCase {
+			title: &'static str,
+			password: &'static str,
+			roles: Vec<Role>,
+			expiration: Option<Duration>,
+			expect_ok: bool,
 		}
 
-		// Test invalid password
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute("DEFINE USER user ON ROOT PASSWORD 'pass'", &sess, None).await.unwrap();
+		let test_cases = vec![
+			TestCase {
+				title: "without roles or expiration",
+				password: "pass",
+				roles: vec![Role::Viewer],
+				expiration: None,
+				expect_ok: true,
+			},
+			TestCase {
+				title: "with roles and expiration",
+				password: "pass",
+				roles: vec![Role::Editor, Role::Owner],
+				expiration: Some(Duration::days(1)),
+				expect_ok: true,
+			},
+			TestCase {
+				title: "with invalid password",
+				password: "invalid",
+				roles: vec![],
+				expiration: None,
+				expect_ok: false,
+			},
+		];
 
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = basic(&ds, &mut sess, "user", "invalid", None, None).await;
+		for level in &test_levels {
+			for case in &test_cases {
+				println!("Test case: {} level {}", level.level, case.title);
+				let ds = Datastore::new("memory").await.unwrap();
+				let sess = Session::owner().with_ns("test").with_db("test");
 
-			assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
-		}
-	}
+				let roles_clause = if case.roles.is_empty() {
+					String::new()
+				} else {
+					let roles: Vec<&str> = case
+						.roles
+						.iter()
+						.map(|r| match r {
+							Role::Viewer => "VIEWER",
+							Role::Editor => "EDITOR",
+							Role::Owner => "OWNER",
+						})
+						.collect();
+					format!("ROLES {}", roles.join(", "))
+				};
 
-	#[tokio::test]
-	async fn test_basic_ns() {
-		//
-		// Test without roles or expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute("DEFINE USER user ON NS PASSWORD 'pass'", &sess, None).await.unwrap();
+				let duration_clause = if let Some(duration) = case.expiration {
+					format!("DURATION FOR SESSION {}s", duration.num_seconds())
+				} else {
+					String::new()
+				};
 
-			let mut sess = Session {
-				ns: Some("test".to_string()),
-				..Default::default()
-			};
-			let res = basic(&ds, &mut sess, "user", "pass", Some("test"), None).await;
+				let define_user_query = format!(
+					"DEFINE USER user ON {} PASSWORD 'pass' {} {}",
+					level.level, roles_clause, duration_clause,
+				);
 
-			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, None);
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_ns());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), None);
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
-		}
+				println!("{}", define_user_query);
 
-		//
-		// Test with roles and expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				"DEFINE USER user ON NS PASSWORD 'pass' ROLES EDITOR, OWNER DURATION FOR SESSION 1d",
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
+				ds.execute(&define_user_query, &sess, None).await.unwrap();
 
-			let mut sess = Session {
-				ns: Some("test".to_string()),
-				..Default::default()
-			};
-			let res = basic(&ds, &mut sess, "user", "pass", Some("test"), None).await;
+				let mut sess = Session {
+					ns: level.ns.map(String::from),
+					db: level.db.map(String::from),
+					..Default::default()
+				};
 
-			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, None);
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_ns());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), None);
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
-			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
-			// Expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::days(1) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::days(1) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
-		}
+				let res = basic(&ds, &mut sess, "user", case.password, level.ns, level.db).await;
 
-		// Test invalid password
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute("DEFINE USER user ON NS PASSWORD 'pass'", &sess, None).await.unwrap();
+				if case.expect_ok {
+					assert!(res.is_ok(), "Failed to signin: {:?}", res);
+					assert_eq!(sess.au.id(), "user");
 
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = basic(&ds, &mut sess, "user", "invalid", Some("test"), None).await;
+					// Check auth level
+					match level.level {
+						"ROOT" => assert!(sess.au.is_root()),
+						"NS" => assert!(sess.au.is_ns()),
+						"DB" => assert!(sess.au.is_db()),
+						_ => panic!("Unsupported level"),
+					}
 
-			assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
+					// Check roles
+					for role in &[Role::Viewer, Role::Editor, Role::Owner] {
+						let has_role = sess.au.has_role(role);
+						let should_have_role = case.roles.contains(role);
+						assert_eq!(has_role, should_have_role, "Role {:?} check failed", role);
+					}
+
+					// Check expiration
+					if let Some(exp_duration) = case.expiration {
+						let exp = sess.exp.unwrap();
+						let min_exp =
+							(Utc::now() + exp_duration - Duration::seconds(10)).timestamp();
+						let max_exp =
+							(Utc::now() + exp_duration + Duration::seconds(10)).timestamp();
+						assert!(
+							exp > min_exp && exp < max_exp,
+							"Session expiration is expected to match the defined duration"
+						);
+					} else {
+						assert_eq!(sess.exp, None, "Expiration is expected to be None");
+					}
+				} else {
+					assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
+				}
+			}
 		}
 	}
 
 	#[tokio::test]
-	async fn test_basic_db() {
-		//
-		// Test without roles or expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute("DEFINE USER user ON DB PASSWORD 'pass'", &sess, None).await.unwrap();
-
-			let mut sess = Session {
-				ns: Some("test".to_string()),
-				db: Some("test".to_string()),
-				..Default::default()
-			};
-			let res = basic(&ds, &mut sess, "user", "pass", Some("test"), Some("test")).await;
-
-			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, Some("test".to_string()));
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_db());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), Some("test"));
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			assert_eq!(sess.exp, None, "Default system user expiration is expected to be None");
+	async fn test_token() {
+		#[derive(Debug)]
+		struct TestLevel {
+			level: &'static str,
+			ns: Option<&'static str>,
+			db: Option<&'static str>,
 		}
 
-		//
-		// Test with roles and expiration defined
-		//
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				"DEFINE USER user ON DB PASSWORD 'pass' ROLES EDITOR, OWNER DURATION FOR SESSION 1d",
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
+		let test_levels = vec![
+			TestLevel {
+				level: "ROOT",
+				ns: None,
+				db: None,
+			},
+			TestLevel {
+				level: "NS",
+				ns: Some("test"),
+				db: None,
+			},
+			TestLevel {
+				level: "DB",
+				ns: Some("test"),
+				db: Some("test"),
+			},
+		];
 
-			let mut sess = Session {
-				ns: Some("test".to_string()),
-				db: Some("test".to_string()),
-				..Default::default()
-			};
-			let res = basic(&ds, &mut sess, "user", "pass", Some("test"), Some("test")).await;
-
-			assert!(res.is_ok(), "Failed to signin with ROOT user: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, Some("test".to_string()));
-			assert_eq!(sess.au.id(), "user");
-			assert!(sess.au.is_db());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), Some("test"));
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
-			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
-			// Expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::days(1) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::days(1) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
+		#[derive(Debug)]
+		struct TestCase {
+			title: &'static str,
+			roles: Option<Vec<&'static str>>,
+			key: &'static str,
+			expect_roles: Vec<Role>,
+			expect_error: bool,
 		}
 
-		// Test invalid password
-		{
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute("DEFINE USER user ON DB PASSWORD 'pass'", &sess, None).await.unwrap();
+		let test_cases = vec![
+			TestCase {
+				title: "with no roles",
+				roles: None,
+				key: "secret",
+				expect_roles: vec![Role::Viewer],
+				expect_error: false,
+			},
+			TestCase {
+				title: "with roles",
+				roles: Some(vec!["editor", "owner"]),
+				key: "secret",
+				expect_roles: vec![Role::Editor, Role::Owner],
+				expect_error: false,
+			},
+			TestCase {
+				title: "with invalid token signature",
+				roles: None,
+				key: "invalid",
+				expect_roles: vec![],
+				expect_error: true,
+			},
+		];
 
-			let mut sess = Session {
-				..Default::default()
-			};
-			let res = basic(&ds, &mut sess, "user", "invalid", Some("test"), Some("test")).await;
-
-			assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
-		}
-	}
-
-	#[tokio::test]
-	async fn test_token_root() {
-		let secret = "jwt_secret";
-		let key = EncodingKey::from_secret(secret.as_ref());
 		let claims = Claims {
 			iss: Some("surrealdb-test".to_string()),
 			iat: Some(Utc::now().timestamp()),
@@ -969,342 +914,73 @@ mod tests {
 
 		let ds = Datastore::new("memory").await.unwrap();
 		let sess = Session::owner().with_ns("test").with_db("test");
-		ds.execute(
-			format!("DEFINE ACCESS token ON ROOT TYPE JWT ALGORITHM HS512 KEY '{secret}' DURATION FOR SESSION 30d").as_str(),
-			&sess,
-			None,
-		)
-		.await
-		.unwrap();
 
-		//
-		// Test without roles defined
-		//
-		{
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, None);
-			assert_eq!(sess.db, None);
-			assert_eq!(sess.au.id(), "token");
-			assert!(sess.au.is_root());
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			// Session expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::days(30) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::days(30) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
-		}
-
-		//
-		// Test with roles defined
-		//
-		{
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = Some(vec!["editor".to_string(), "owner".to_string()]);
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, None);
-			assert_eq!(sess.db, None);
-			assert_eq!(sess.au.id(), "token");
-			assert!(sess.au.is_root());
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
-			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
-			// Session expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::days(30) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::days(30) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
-		}
-
-		//
-		// Test with invalid signature
-		//
-		{
-			// Prepare the claims object
-			let claims = claims.clone();
-			// Create the token
-			let key = EncodingKey::from_secret("invalid".as_ref());
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_err(), "Unexpected success signing in with token: {:?}", res);
-		}
-	}
-
-	#[tokio::test]
-	async fn test_token_ns() {
-		let secret = "jwt_secret";
-		let key = EncodingKey::from_secret(secret.as_ref());
-		let claims = Claims {
-			iss: Some("surrealdb-test".to_string()),
-			iat: Some(Utc::now().timestamp()),
-			nbf: Some(Utc::now().timestamp()),
-			exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-			ac: Some("token".to_string()),
-			ns: Some("test".to_string()),
-			..Claims::default()
-		};
-
-		let ds = Datastore::new("memory").await.unwrap();
-		let sess = Session::owner().with_ns("test").with_db("test");
-		ds.execute(
-			format!("DEFINE ACCESS token ON NS TYPE JWT ALGORITHM HS512 KEY '{secret}' DURATION FOR SESSION 30d").as_str(),
-			&sess,
-			None,
-		)
-		.await
-		.unwrap();
-
-		//
-		// Test without roles defined
-		//
-		{
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, None);
-			assert_eq!(sess.au.id(), "token");
-			assert!(sess.au.is_ns());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			// Session expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::days(30) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::days(30) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
-		}
-
-		//
-		// Test with roles defined
-		//
-		{
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = Some(vec!["editor".to_string(), "owner".to_string()]);
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, None);
-			assert_eq!(sess.au.id(), "token");
-			assert!(sess.au.is_ns());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
-			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
-			// Session expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::days(30) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::days(30) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
-		}
-
-		//
-		// Test with invalid signature
-		//
-		{
-			// Prepare the claims object
-			let claims = claims.clone();
-			// Create the token
-			let key = EncodingKey::from_secret("invalid".as_ref());
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_err(), "Unexpected success signing in with token: {:?}", res);
-		}
-
-		//
-		// Test with valid token invalid ns
-		//
-		{
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.ns = Some("invalid".to_string());
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_err(), "Unexpected success signing in with token: {:?}", res);
-		}
-	}
-
-	#[tokio::test]
-	async fn test_token_db() {
-		let secret = "jwt_secret";
-		let key = EncodingKey::from_secret(secret.as_ref());
-		let claims = Claims {
-			iss: Some("surrealdb-test".to_string()),
-			iat: Some(Utc::now().timestamp()),
-			nbf: Some(Utc::now().timestamp()),
-			exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-			ac: Some("token".to_string()),
-			ns: Some("test".to_string()),
-			db: Some("test".to_string()),
-			..Claims::default()
-		};
-
-		let ds = Datastore::new("memory").await.unwrap();
-		let sess = Session::owner().with_ns("test").with_db("test");
-		ds.execute(
-			format!("DEFINE ACCESS token ON DATABASE TYPE JWT ALGORITHM HS512 KEY '{secret}' DURATION FOR SESSION 30d")
+		for level in &test_levels {
+			// Define the access token for that level
+			ds.execute(
+				format!(
+					r#"
+					DEFINE ACCESS token ON {} TYPE JWT
+						ALGORITHM HS512 KEY 'secret' DURATION FOR SESSION 30d
+					;
+				"#,
+					level.level
+				)
 				.as_str(),
-			&sess,
-			None,
-		)
-		.await
-		.unwrap();
+				&sess,
+				None,
+			)
+			.await
+			.unwrap();
 
-		//
-		// Test without roles defined
-		//
-		{
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
+			for case in &test_cases {
+				println!("Test case: {} level {}", level.level, case.title);
 
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, Some("test".to_string()));
-			assert_eq!(sess.au.id(), "token");
-			assert!(sess.au.is_db());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), Some("test"));
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			// Session expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::days(30) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::days(30) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
-		}
+				// Prepare the claims object
+				let mut claims = claims.clone();
+				claims.ns = level.ns.map(|s| s.to_string());
+				claims.db = level.db.map(|s| s.to_string());
+				claims.roles =
+					case.roles.clone().map(|roles| roles.into_iter().map(String::from).collect());
 
-		//
-		// Test with roles defined
-		//
-		{
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = Some(vec!["editor".to_string(), "owner".to_string()]);
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
+				// Create the token
+				let key = EncodingKey::from_secret(case.key.as_ref());
+				let enc = encode(&HEADER, &claims, &key).unwrap();
 
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, Some("test".to_string()));
-			assert_eq!(sess.au.id(), "token");
-			assert!(sess.au.is_db());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), Some("test"));
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(sess.au.has_role(&Role::Editor), "Auth user expected to have Editor role");
-			assert!(sess.au.has_role(&Role::Owner), "Auth user expected to have Owner role");
-			// Session expiration has been set explicitly
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::days(30) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::days(30) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to match the defined duration"
-			);
-		}
+				// Authenticate with the token
+				let mut sess = Session::default();
+				let res = token(&ds, &mut sess, &enc).await;
 
-		//
-		// Test with invalid signature
-		//
-		{
-			// Prepare the claims object
-			let claims = claims.clone();
-			// Create the token
-			let key = EncodingKey::from_secret("invalid".as_ref());
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
+				if case.expect_error {
+					assert!(res.is_err(), "Unexpected success for case: {:?}", case);
+				} else {
+					assert!(res.is_ok(), "Failed to sign in with token for case: {:?}", case);
+					assert_eq!(sess.ns, level.ns.map(|s| s.to_string()));
+					assert_eq!(sess.db, level.db.map(|s| s.to_string()));
+					assert_eq!(sess.au.id(), "token");
 
-			assert!(res.is_err(), "Unexpected success signing in with token: {:?}", res);
-		}
+					for role in &case.expect_roles {
+						assert!(
+							sess.au.has_role(role),
+							"Auth user expected to have role {:?} in case: {:?}",
+							role,
+							case
+						);
+					}
 
-		//
-		// Test with valid token invalid db
-		//
-		{
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.db = Some("invalid".to_string());
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_err(), "Unexpected success signing in with token: {:?}", res);
+					// Ensure that the expiration is set correctly
+					let exp = sess.exp.unwrap();
+					let min_exp =
+						(Utc::now() + Duration::days(30) - Duration::seconds(10)).timestamp();
+					let max_exp =
+						(Utc::now() + Duration::days(30) + Duration::seconds(10)).timestamp();
+					assert!(
+						exp > min_exp && exp < max_exp,
+						"Session expiration is expected to match the defined duration in case: {:?}",
+						case
+					);
+				}
+			}
 		}
 	}
 
@@ -2243,989 +1919,192 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_token_db_authenticate_clause() {
-		// Test with correct "iss" and "aud" claims
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Single("surrealdb-test".to_string())),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ns: Some("test".to_string()),
-				db: Some("test".to_string()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-    				DEFINE ACCESS user ON DATABASE TYPE JWT
- 				        ALGORITHM HS512 KEY '{secret}'
-    					AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-						DURATION FOR SESSION 2h
-					;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, Some("test".to_string()));
-			assert_eq!(sess.ac, Some("user".to_string()));
-			assert!(sess.au.is_db());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), Some("test"));
-			// Record users should not have roles
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			// Expiration should match the defined duration
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::hours(2) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::hours(2) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to follow the defined duration"
-			);
+	async fn test_token_authenticate_clause() {
+		#[derive(Debug)]
+		struct TestLevel {
+			level: &'static str,
+			ns: Option<&'static str>,
+			db: Option<&'static str>,
 		}
 
-		// Test with correct "iss" and "aud" claims, with multiple audiences
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Multiple(vec![
+		let test_levels = vec![
+			TestLevel {
+				level: "ROOT",
+				ns: None,
+				db: None,
+			},
+			TestLevel {
+				level: "NS",
+				ns: Some("test"),
+				db: None,
+			},
+			TestLevel {
+				level: "DB",
+				ns: Some("test"),
+				db: Some("test"),
+			},
+		];
+
+		#[derive(Debug)]
+		struct TestCase {
+			title: &'static str,
+			iss_claim: Option<&'static str>,
+			aud_claim: Option<Audience>,
+			error_statement: &'static str,
+			expected_error: Option<Error>,
+		}
+
+		let test_cases = vec![
+			TestCase {
+				title: "with correct 'iss' and 'aud' claims",
+				iss_claim: Some("surrealdb-test"),
+				aud_claim: Some(Audience::Single("surrealdb-test".to_string())),
+				error_statement: "THROW",
+				expected_error: None,
+			},
+			TestCase {
+				title: "with correct 'iss' and 'aud' claims, multiple audiences",
+				iss_claim: Some("surrealdb-test"),
+				aud_claim: Some(Audience::Multiple(vec![
 					"invalid".to_string(),
 					"surrealdb-test".to_string(),
 				])),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ns: Some("test".to_string()),
-				db: Some("test".to_string()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-					DEFINE ACCESS user ON DATABASE TYPE JWT
-				        ALGORITHM HS512 KEY '{secret}'
-						AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-						DURATION FOR SESSION 2h
-    				;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, Some("test".to_string()));
-			assert_eq!(sess.ac, Some("user".to_string()));
-			assert!(sess.au.is_db());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), Some("test"));
-			// Record users should not have roles
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			// Expiration should match the defined duration
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::hours(2) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::hours(2) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to follow the defined duration"
-			);
-		}
-
-		// Test with correct "iss" claim but incorrect "aud" claim
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Single("invalid".to_string())),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ns: Some("test".to_string()),
-				db: Some("test".to_string()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-    				DEFINE ACCESS user ON DATABASE TYPE JWT
- 				        ALGORITHM HS512 KEY '{secret}'
-    					AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-    					DURATION FOR SESSION 2h
-					;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			match res {
-				Err(Error::Thrown(e)) if e == "Invalid token audience string" => {} // ok
-				res => panic!(
-				    "Expected authentication to failed due to invalid token audience, but instead received: {:?}",
-					res
-				),
-			}
-		}
-
-		// Test with correct "iss" claim but incorrect "aud" claim, with multiple audiences
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Multiple(vec![
+				error_statement: "THROW",
+				expected_error: None,
+			},
+			TestCase {
+				title: "with correct 'iss' claim but invalid 'aud' claim",
+				iss_claim: Some("surrealdb-test"),
+				aud_claim: Some(Audience::Single("invalid".to_string())),
+				error_statement: "THROW",
+				expected_error: Some(Error::Thrown("Invalid token audience string".to_string())),
+			},
+			TestCase {
+				title: "with correct 'iss' claim but invalid 'aud' claim, multiple audiences",
+				iss_claim: Some("surrealdb-test"),
+				aud_claim: Some(Audience::Multiple(vec![
+					"invalid".to_string(),
 					"surrealdb-test-different".to_string(),
-					"invalid".to_string(),
 				])),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ns: Some("test".to_string()),
-				db: Some("test".to_string()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
+				error_statement: "THROW",
+				expected_error: Some(Error::Thrown("Invalid token audience array".to_string())),
+			},
+			TestCase {
+				title: "with correct 'iss' claim but invalid 'aud' claim, generic error",
+				iss_claim: Some("surrealdb-test"),
+				aud_claim: Some(Audience::Single("invalid".to_string())),
+				error_statement: "RETURN",
+				expected_error: Some(Error::InvalidAuth),
+			},
+		];
 
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-					DEFINE ACCESS user ON DATABASE TYPE JWT
-				        ALGORITHM HS512 KEY '{secret}'
-						AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-						DURATION FOR SESSION 2h
-				"#
+		let secret = "secret";
+		let key = EncodingKey::from_secret(secret.as_ref());
+		let claims = Claims {
+			iat: Some(Utc::now().timestamp()),
+			nbf: Some(Utc::now().timestamp()),
+			exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
+			ac: Some("user".to_string()),
+			..Claims::default()
+		};
+
+		let ds = Datastore::new("memory").await.unwrap();
+		let sess = Session::owner().with_ns("test").with_db("test");
+
+		for level in &test_levels {
+			for case in &test_cases {
+				println!("Test case: {} level {}", level.level, case.title);
+
+				ds.execute(
+					format!(
+						r#"
+						REMOVE ACCESS IF EXISTS user ON {0};
+						DEFINE ACCESS user ON {0} TYPE JWT
+							ALGORITHM HS512 KEY '{1}'
+							AUTHENTICATE {{
+								IF $token.iss != "surrealdb-test" {{ {2} "Invalid token issuer" }};
+								IF type::is::array($token.aud) {{
+									IF "surrealdb-test" NOT IN $token.aud {{ {2} "Invalid token audience array" }}
+								}} ELSE {{
+									IF $token.aud IS NOT "surrealdb-test" {{ {2} "Invalid token audience string" }}
+								}};
+							}}
+							DURATION FOR SESSION 2h
+						;
+					"#,
+						level.level, secret, case.error_statement,
+					)
+					.as_str(),
+					&sess,
+					None,
 				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
+				.await
+				.unwrap();
 
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
+				// Prepare the claims object
+				let mut claims = claims.clone();
+				claims.ns = level.ns.map(|s| s.to_string());
+				claims.db = level.db.map(|s| s.to_string());
+				claims.iss = case.iss_claim.map(|s| s.to_string());
+				claims.aud = case.aud_claim.clone();
 
-			match res {
-				Err(Error::Thrown(e)) if e == "Invalid token audience array" => {} // ok
-				res => panic!(
-				    "Expected authentication to failed due to invalid token audience array, but instead received: {:?}",
-					res
-				),
-			}
-		}
+				// Create the token
+				let enc = encode(&HEADER, &claims, &key).unwrap();
 
-		// Test with correct "iss" claim but incorrect "aud" claim
-		// In this case, something is returned by the clause, which returns a generic error
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Single("invalid".to_string())),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ns: Some("test".to_string()),
-				db: Some("test".to_string()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
+				// Signin with the token
+				let mut sess = Session::default();
+				let res = token(&ds, &mut sess, &enc).await;
 
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-    				DEFINE ACCESS user ON DATABASE TYPE JWT
- 				        ALGORITHM HS512 KEY '{secret}'
-    					AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ RETURN "FAIL" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ RETURN "FAIL" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ RETURN "FAIL" }}
-							}};
-						}}
-    					DURATION FOR SESSION 2h
-    				;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
+				if let Some(expected_err) = &case.expected_error {
+					assert!(res.is_err(), "Unexpected success for case: {:?}", case);
+					let err = res.unwrap_err();
+					match (expected_err, &err) {
+						(Error::InvalidAuth, Error::InvalidAuth) => {}
+						(Error::Thrown(expected_msg), Error::Thrown(msg))
+							if expected_msg == msg => {}
+						_ => panic!("Unexpected error for case: {:?}, got: {:?}", case, err),
+					}
+				} else {
+					assert!(res.is_ok(), "Failed to sign in with token for case: {:?}", case);
+					assert_eq!(sess.ns, level.ns.map(|s| s.to_string()));
+					assert_eq!(sess.db, level.db.map(|s| s.to_string()));
+					assert_eq!(sess.ac, Some("user".to_string()));
+					assert_eq!(sess.au.id(), "user");
 
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
+					// Check auth level
+					match level.level {
+						"ROOT" => assert!(sess.au.is_root()),
+						"NS" => assert!(sess.au.is_ns()),
+						"DB" => assert!(sess.au.is_db()),
+						_ => panic!("Unsupported level"),
+					}
 
-			match res {
-				Err(Error::InvalidAuth) => {} // ok
-				res => panic!(
-					"Expected a generic authentication error, but instead received: {:?}",
-					res
-				),
-			}
-		}
-	}
+					// Check roles
+					assert!(
+						sess.au.has_role(&Role::Viewer),
+						"Auth user expected to have Viewer role"
+					);
+					assert!(
+						!sess.au.has_role(&Role::Editor),
+						"Auth user expected to not have Editor role"
+					);
+					assert!(
+						!sess.au.has_role(&Role::Owner),
+						"Auth user expected to not have Owner role"
+					);
 
-	#[tokio::test]
-	async fn test_token_ns_authenticate_clause() {
-		// Test with correct "iss" and "aud" claims
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Single("surrealdb-test".to_string())),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ns: Some("test".to_string()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-    				DEFINE ACCESS user ON NAMESPACE TYPE JWT
- 				        ALGORITHM HS512 KEY '{secret}'
-    					AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-						DURATION FOR SESSION 2h
-					;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.ac, Some("user".to_string()));
-			assert!(sess.au.is_ns());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), None);
-			// Record users should not have roles
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			// Expiration should match the defined duration
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::hours(2) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::hours(2) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to follow the defined duration"
-			);
-		}
-
-		// Test with correct "iss" and "aud" claims, with multiple audiences
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Multiple(vec![
-					"invalid".to_string(),
-					"surrealdb-test".to_string(),
-				])),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ns: Some("test".to_string()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test");
-			ds.execute(
-				format!(
-					r#"
-					DEFINE ACCESS user ON NAMESPACE TYPE JWT
-				        ALGORITHM HS512 KEY '{secret}'
-						AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-						DURATION FOR SESSION 2h
-    				;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, Some("test".to_string()));
-			assert_eq!(sess.db, None);
-			assert_eq!(sess.ac, Some("user".to_string()));
-			assert!(sess.au.is_ns());
-			assert_eq!(sess.au.level().ns(), Some("test"));
-			assert_eq!(sess.au.level().db(), None);
-			// Record users should not have roles
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			// Expiration should match the defined duration
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::hours(2) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::hours(2) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to follow the defined duration"
-			);
-		}
-
-		// Test with correct "iss" claim but incorrect "aud" claim
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Single("invalid".to_string())),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ns: Some("test".to_string()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-    				DEFINE ACCESS user ON NAMESPACE TYPE JWT
- 				        ALGORITHM HS512 KEY '{secret}'
-    					AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-						DURATION FOR SESSION 2h
-    				;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			match res {
-				Err(Error::Thrown(e)) if e == "Invalid token audience string" => {} // ok
-				res => panic!(
-				    "Expected authentication to failed due to invalid token audience, but instead received: {:?}",
-					res
-				),
-			}
-		}
-
-		// Test with correct "iss" claim but incorrect "aud" claim, with multiple audiences
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Multiple(vec![
-					"surrealdb-test-different".to_string(),
-					"invalid".to_string(),
-				])),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ns: Some("test".to_string()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test");
-			ds.execute(
-				format!(
-					r#"
-					DEFINE ACCESS user ON NAMESPACE TYPE JWT
-				        ALGORITHM HS512 KEY '{secret}'
-						AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-						DURATION FOR SESSION 2h
-					;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			match res {
-				Err(Error::Thrown(e)) if e == "Invalid token audience array" => {} // ok
-				res => panic!(
-				    "Expected authentication to failed due to invalid token audience array, but instead received: {:?}",
-					res
-				),
-			}
-		}
-
-		// Test with correct "iss" claim but incorrect "aud" claim
-		// In this case, something is returned by the clause, which returns a generic error
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Single("invalid".to_string())),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ns: Some("test".to_string()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-    				DEFINE ACCESS user ON NAMESPACE TYPE JWT
- 				        ALGORITHM HS512 KEY '{secret}'
-    					AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ RETURN "FAIL" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ RETURN "FAIL" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ RETURN "FAIL" }}
-							}};
-						}}
-    					DURATION FOR SESSION 2h
-    				;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			match res {
-				Err(Error::InvalidAuth) => {} // ok
-				res => panic!(
-					"Expected a generic authentication error, but instead received: {:?}",
-					res
-				),
-			}
-		}
-	}
-
-	#[tokio::test]
-	async fn test_token_root_authenticate_clause() {
-		// Test with correct "iss" and "aud" claims
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Single("surrealdb-test".to_string())),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-    				DEFINE ACCESS user ON ROOT TYPE JWT
- 				        ALGORITHM HS512 KEY '{secret}'
-    					AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-    					DURATION FOR SESSION 2h
-    				;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ac, Some("user".to_string()));
-			assert!(sess.au.is_root());
-			assert_eq!(sess.au.level().ns(), None);
-			assert_eq!(sess.au.level().db(), None);
-			// Record users should not have roles
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			// Expiration should match the defined duration
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::hours(2) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::hours(2) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to follow the defined duration"
-			);
-		}
-
-		// Test with correct "iss" and "aud" claims, with multiple audiences
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Multiple(vec![
-					"invalid".to_string(),
-					"surrealdb-test".to_string(),
-				])),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner();
-			ds.execute(
-				format!(
-					r#"
-					DEFINE ACCESS user ON ROOT TYPE JWT
-				        ALGORITHM HS512 KEY '{secret}'
-						AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-						DURATION FOR SESSION 2h
-					;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			assert!(res.is_ok(), "Failed to signin with token: {:?}", res);
-			assert_eq!(sess.ns, None);
-			assert_eq!(sess.db, None);
-			assert_eq!(sess.ac, Some("user".to_string()));
-			assert!(sess.au.is_root());
-			assert_eq!(sess.au.level().ns(), None);
-			assert_eq!(sess.au.level().db(), None);
-			// Record users should not have roles
-			assert!(sess.au.has_role(&Role::Viewer), "Auth user expected to have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
-			// Expiration should match the defined duration
-			let exp = sess.exp.unwrap();
-			// Expiration should match the current time plus session duration with some margin
-			let min_exp = (Utc::now() + Duration::hours(2) - Duration::seconds(10)).timestamp();
-			let max_exp = (Utc::now() + Duration::hours(2) + Duration::seconds(10)).timestamp();
-			assert!(
-				exp > min_exp && exp < max_exp,
-				"Session expiration is expected to follow the defined duration"
-			);
-		}
-
-		// Test with correct "iss" claim but incorrect "aud" claim
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Single("invalid".to_string())),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-    				DEFINE ACCESS user ON ROOT TYPE JWT
- 				        ALGORITHM HS512 KEY '{secret}'
-    					AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-    					DURATION FOR SESSION 2h
-    				;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			match res {
-				Err(Error::Thrown(e)) if e == "Invalid token audience string" => {} // ok
-				res => panic!(
-				    "Expected authentication to failed due to invalid token audience, but instead received: {:?}",
-					res
-				),
-			}
-		}
-
-		// Test with correct "iss" claim but incorrect "aud" claim, with multiple audiences
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Multiple(vec![
-					"surrealdb-test-different".to_string(),
-					"invalid".to_string(),
-				])),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner();
-			ds.execute(
-				format!(
-					r#"
-					DEFINE ACCESS user ON ROOT TYPE JWT
-				        ALGORITHM HS512 KEY '{secret}'
-						AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ THROW "Invalid token issuer" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ THROW "Invalid token audience array" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ THROW "Invalid token audience string" }}
-							}};
-						}}
-						DURATION FOR SESSION 2h
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			match res {
-				Err(Error::Thrown(e)) if e == "Invalid token audience array" => {} // ok
-				res => panic!(
-				    "Expected authentication to failed due to invalid token audience array, but instead received: {:?}",
-					res
-				),
-			}
-		}
-
-		// Test with correct "iss" claim but incorrect "aud" claim
-		// In this case, something is returned by the clause, which returns a generic error
-		{
-			let secret = "jwt_secret";
-			let key = EncodingKey::from_secret(secret.as_ref());
-			let claims = Claims {
-				iss: Some("surrealdb-test".to_string()),
-				aud: Some(Audience::Single("invalid".to_string())),
-				iat: Some(Utc::now().timestamp()),
-				nbf: Some(Utc::now().timestamp()),
-				exp: Some((Utc::now() + Duration::hours(1)).timestamp()),
-				ac: Some("user".to_string()),
-				..Claims::default()
-			};
-
-			let ds = Datastore::new("memory").await.unwrap();
-			let sess = Session::owner().with_ns("test").with_db("test");
-			ds.execute(
-				format!(
-					r#"
-    				DEFINE ACCESS user ON ROOT TYPE JWT
- 				        ALGORITHM HS512 KEY '{secret}'
-    					AUTHENTICATE {{
-							IF $token.iss != "surrealdb-test" {{ RETURN "FAIL" }};
-							IF type::is::array($token.aud) {{
-								IF "surrealdb-test" NOT IN $token.aud {{ RETURN "FAIL" }}
-							}} ELSE {{
-								IF $token.aud IS NOT "surrealdb-test" {{ RETURN "FAIL" }}
-							}};
-						}}
-    					DURATION FOR SESSION 2h
-    				;
-				"#
-				)
-				.as_str(),
-				&sess,
-				None,
-			)
-			.await
-			.unwrap();
-
-			// Prepare the claims object
-			let mut claims = claims.clone();
-			claims.roles = None;
-			// Create the token
-			let enc = encode(&HEADER, &claims, &key).unwrap();
-			// Signin with the token
-			let mut sess = Session::default();
-			let res = token(&ds, &mut sess, &enc).await;
-
-			match res {
-				Err(Error::InvalidAuth) => {} // ok
-				res => panic!(
-					"Expected a generic authentication error, but instead received: {:?}",
-					res
-				),
+					// Check expiration
+					let exp = sess.exp.unwrap();
+					let min_exp =
+						(Utc::now() + Duration::hours(2) - Duration::seconds(10)).timestamp();
+					let max_exp =
+						(Utc::now() + Duration::hours(2) + Duration::seconds(10)).timestamp();
+					assert!(
+						exp > min_exp && exp < max_exp,
+						"Session expiration is expected to match the defined duration in case: {:?}",
+						case
+					);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To reduce code duplication in testing for authentication and token verification. This code duplication introduced risks whenever tests were modified or new tests were introduced, where changes may not be made in all tests. This situation also led to an unnecessary amount of test code which was hard to review and understand, making it a challenge to grasp what exactly is being tested and what is not. Note that Github made a mess of the diff, which is not very useful :(

## What does this change do?

Merges individual tests that performed similar tests at different levels. These unified tests now use a vector of `TestLevel` structs to iterate over the possible levels. When suitable, `TestCase` structs are used to describe similar cases that need to be tested.

- Creates the new `iam::signin::tests::test_signin_bearer_for_user` test:
   - Includes the old `iam::signin::tests::test_signin_bearer_for_user_db`
   - Includes the old `iam::signin::tests::test_signin_bearer_for_user_ns`
   - Includes the old `iam::signin::tests::test_signin_bearer_for_user_root`
- Creates the new `iam::verify::tests::test_basic` test:
   - Includes the old `iam::verify::tests::test_basic_db`
   - Includes the old `iam::verify::tests::test_basic_ns`
   - Includes the old `iam::verify::tests::test_basic_root`
   - Each test case is now defined as a `TestCase` struct.
- Creates the new `iam::verify::tests::test_token` test:
   - Includes the old `iam::verify::tests::test_token_db`
   - Includes the old `iam::verify::tests::test_token_ns`
   - Includes the old `iam::verify::tests::test_token_root`
   - Each test case is now defined as a `TestCase` struct.
 - Updates the `iam::verify::tests::test_token_record` test:
    - Each test case is now defined as a `TestCase` struct.
 - Renames the `test_token_db_record_custom_claims` test.
   - The test is now named `test_token_record_custom_claims`
 - Improves and aligns some comments.
 - Correctly checks authentication level everywhere.
 
## What is your testing strategy?

Ensure that the new and updated tests pass.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
