### PR TITLE
Ensure failures are caught and transactions rolledback

### DIFF
--- a/core/src/kvs/node.rs
+++ b/core/src/kvs/node.rs
@@ -242,7 +242,7 @@ impl Datastore {
 							// Check that the node for this query is archived
 							if expired.contains(&stm.node) {
 								// Get the key for this node live query
-								let tlq = catch!(txn, crate::key::table::lq::Lq::decode(k));
+								let tlq = sync_catch!(txn, crate::key::table::lq::Lq::decode(k));
 								// Get the key for this table live query
 								let nlq = crate::key::node::lq::new(nid, lid);
 								// Delete the node live query

--- a/core/src/kvs/node.rs
+++ b/core/src/kvs/node.rs
@@ -87,7 +87,7 @@ impl Datastore {
 		// Open transaction and fetch nodes
 		let txn = self.transaction(Write, Optimistic).await?;
 		let now = self.clock_now().await;
-		let nds = catch!(txn, txn.all_nodes());
+		let nds = catch!(txn, txn.all_nodes().await);
 		for nd in nds.iter() {
 			// Check that the node is active
 			if nd.is_active() {
@@ -100,7 +100,7 @@ impl Datastore {
 					// Get the key for the node entry
 					let key = crate::key::root::nd::new(nd.id);
 					// Update the node entry
-					catch!(txn, txn.set(key, val, None));
+					catch!(txn, txn.set(key, val, None).await);
 				}
 			}
 		}
@@ -122,7 +122,7 @@ impl Datastore {
 		// Fetch all of the expired nodes
 		let expired = {
 			let txn = self.transaction(Read, Optimistic).await?;
-			let nds = catch!(txn, txn.all_nodes());
+			let nds = catch!(txn, txn.all_nodes().await);
 			// Filter the archived nodes
 			nds.iter().filter_map(Node::archived).collect::<Vec<_>>()
 		};
@@ -137,21 +137,21 @@ impl Datastore {
 				let end = crate::key::node::lq::suffix(*id);
 				let mut next = Some(beg..end);
 				while let Some(rng) = next {
-					let res = catch!(txn, txn.batch(rng, *NORMAL_FETCH_SIZE, true));
+					let res = catch!(txn, txn.batch(rng, *NORMAL_FETCH_SIZE, true).await);
 					next = res.next;
 					for (k, v) in res.values.iter() {
 						// Decode the data for this live query
 						let val: Live = v.into();
 						// Get the key for this node live query
-						let nlq = crate::key::node::lq::Lq::decode(k)?;
+						let nlq = catch!(txn, crate::key::node::lq::Lq::decode(k));
 						// Check that the node for this query is archived
 						if expired.contains(&nlq.nd) {
 							// Get the key for this table live query
 							let tlq = crate::key::table::lq::new(&val.ns, &val.db, &val.tb, nlq.lq);
 							// Delete the table live query
-							catch!(txn, txn.del(tlq));
+							catch!(txn, txn.del(tlq).await);
 							// Delete the node live query
-							catch!(txn, txn.del(nlq));
+							catch!(txn, txn.del(nlq).await);
 						}
 					}
 				}
@@ -169,7 +169,7 @@ impl Datastore {
 				// Get the key for the node entry
 				let key = crate::key::root::nd::new(*id);
 				// Delete the cluster node entry
-				catch!(txn, txn.del(key));
+				catch!(txn, txn.del(key).await);
 			}
 			// Commit the changes
 			txn.commit().await?;
@@ -195,14 +195,14 @@ impl Datastore {
 		// Fetch expired nodes
 		let expired = {
 			let txn = self.transaction(Read, Optimistic).await?;
-			let nds = catch!(txn, txn.all_nodes());
+			let nds = catch!(txn, txn.all_nodes().await);
 			// Filter the archived nodes
 			nds.iter().filter_map(Node::archived).collect::<Vec<_>>()
 		};
 		// Fetch all namespaces
 		let nss = {
 			let txn = self.transaction(Read, Optimistic).await?;
-			catch!(txn, txn.all_ns())
+			catch!(txn, txn.all_ns().await)
 		};
 		// Loop over all namespaces
 		for ns in nss.iter() {
@@ -211,7 +211,7 @@ impl Datastore {
 			// Fetch all databases
 			let dbs = {
 				let txn = self.transaction(Read, Optimistic).await?;
-				catch!(txn, txn.all_db(&ns.name))
+				catch!(txn, txn.all_db(&ns.name).await)
 			};
 			// Loop over all databases
 			for db in dbs.iter() {
@@ -220,7 +220,7 @@ impl Datastore {
 				// Fetch all tables
 				let tbs = {
 					let txn = self.transaction(Read, Optimistic).await?;
-					catch!(txn, txn.all_tb(&ns.name, &db.name))
+					catch!(txn, txn.all_tb(&ns.name, &db.name).await)
 				};
 				// Loop over all tables
 				for tb in tbs.iter() {
@@ -232,7 +232,7 @@ impl Datastore {
 					let end = crate::key::table::lq::suffix(&ns.name, &db.name, &tb.name);
 					let mut next = Some(beg..end);
 					while let Some(rng) = next {
-						let res = catch!(txn, txn.batch(rng, *NORMAL_FETCH_SIZE, true));
+						let res = catch!(txn, txn.batch(rng, *NORMAL_FETCH_SIZE, true).await);
 						next = res.next;
 						for (k, v) in res.values.iter() {
 							// Decode the LIVE query statement
@@ -242,13 +242,13 @@ impl Datastore {
 							// Check that the node for this query is archived
 							if expired.contains(&stm.node) {
 								// Get the key for this node live query
-								let tlq = sync_catch!(txn, crate::key::table::lq::Lq::decode(k));
+								let tlq = catch!(txn, crate::key::table::lq::Lq::decode(k));
 								// Get the key for this table live query
 								let nlq = crate::key::node::lq::new(nid, lid);
 								// Delete the node live query
-								catch!(txn, txn.del(nlq));
+								catch!(txn, txn.del(nlq).await);
 								// Delete the table live query
-								catch!(txn, txn.del(tlq));
+								catch!(txn, txn.del(tlq).await);
 							}
 						}
 					}
@@ -280,7 +280,7 @@ impl Datastore {
 			// Get the key for this node live query
 			let nlq = crate::key::node::lq::new(self.id(), id);
 			// Fetch the LIVE meta data node entry
-			if let Some(val) = catch!(txn, txn.get(nlq, None)) {
+			if let Some(val) = catch!(txn, txn.get(nlq, None).await) {
 				// Decode the data for this live query
 				let lq: Live = val.into();
 				// Get the key for this node live query
@@ -288,9 +288,9 @@ impl Datastore {
 				// Get the key for this table live query
 				let tlq = crate::key::table::lq::new(&lq.ns, &lq.db, &lq.tb, id);
 				// Delete the table live query
-				catch!(txn, txn.del(tlq));
+				catch!(txn, txn.del(tlq).await);
 				// Delete the node live query
-				catch!(txn, txn.del(nlq));
+				catch!(txn, txn.del(nlq).await);
 			}
 		}
 		// Commit the changes

--- a/core/src/kvs/node.rs
+++ b/core/src/kvs/node.rs
@@ -237,12 +237,12 @@ impl Datastore {
 						for (k, v) in res.values.iter() {
 							// Decode the LIVE query statement
 							let stm: LiveStatement = v.into();
-							// Get the key for this node live query
-							let tlq = crate::key::table::lq::Lq::decode(k)?;
 							// Get the node id and the live query id
 							let (nid, lid) = (stm.node.0, stm.id.0);
 							// Check that the node for this query is archived
 							if expired.contains(&stm.node) {
+								// Get the key for this node live query
+								let tlq = catch!(txn, crate::key::table::lq::Lq::decode(k));
 								// Get the key for this table live query
 								let nlq = crate::key::node::lq::new(nid, lid);
 								// Delete the node live query

--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -46,6 +46,18 @@ macro_rules! catch {
 		}
 	};
 }
+/// Same as above for synchronous functions
+macro_rules! sync_catch {
+	($txn:ident, $default:expr) => {
+		match $default {
+			Err(e) => {
+				let _ = $txn.cancel().await;
+				return Err(e);
+			}
+			Ok(v) => v,
+		}
+	};
+}
 
 /// Runs a method on a transaction, ensuring that the transaction
 /// is cancelled and rolled back if the initial function fails, or

--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -37,18 +37,6 @@ macro_rules! get_cfg {
 /// a transaction in an uncommitted state without rolling back.
 macro_rules! catch {
 	($txn:ident, $default:expr) => {
-		match $default.await {
-			Err(e) => {
-				let _ = $txn.cancel().await;
-				return Err(e);
-			}
-			Ok(v) => v,
-		}
-	};
-}
-/// Same as above for synchronous functions
-macro_rules! sync_catch {
-	($txn:ident, $default:expr) => {
 		match $default {
 			Err(e) => {
 				let _ = $txn.cancel().await;


### PR DESCRIPTION
## What is the motivation?

In the case of deserialisation failures when periodic nodes operations are taking place, we need to ensure that any errors are caught and the transaction rolledback. As a result we can't use the Rust `?` operator to catch errors, but need to instead use a macros to ensure that the transaction is handled correctly before exiting from the function.

## What does this change do?

Catches any errors, and rolls back transactions.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
