### PR TITLE
Use new runner for ci / test workspace

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,7 +31,9 @@ defaults:
 jobs:
   common:
     name: Bench common
-    runs-on: [ runner-arm64-xlarge ]
+    runs-on:
+      - self-hosted
+      - benches
     timeout-minutes: 60
     steps:
       - name: Install stable toolchain
@@ -92,7 +94,9 @@ jobs:
 
   engines:
     name: Benchmark engines
-    runs-on: [ runner-arm64-xlarge ]
+    runs-on:
+      - self-hosted
+      - benches
     timeout-minutes: 60
     permissions:
       id-token: write

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,9 +31,7 @@ defaults:
 jobs:
   common:
     name: Bench common
-    runs-on:
-      - self-hosted
-      - benches
+    runs-on: [ runner-arm64-2xlarge ]
     timeout-minutes: 60
     steps:
       - name: Install stable toolchain
@@ -94,9 +92,7 @@ jobs:
 
   engines:
     name: Benchmark engines
-    runs-on:
-      - self-hosted
-      - benches
+    runs-on: [ runner-arm64-2xlarge ]
     timeout-minutes: 60
     permissions:
       id-token: write

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,7 +31,7 @@ defaults:
 jobs:
   common:
     name: Bench common
-    runs-on: [ runner-arm64-2xlarge ]
+    runs-on: [ runner-arm64-xlarge ]
     timeout-minutes: 60
     steps:
       - name: Install stable toolchain
@@ -92,7 +92,7 @@ jobs:
 
   engines:
     name: Benchmark engines
-    runs-on: [ runner-arm64-2xlarge ]
+    runs-on: [ runner-arm64-xlarge ]
     timeout-minutes: 60
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
 
   test:
     name: Test workspace
-    runs-on: [ "self-hosted", "arm64", "builder" ]
+    runs-on: [ runner-arm64-2xlarge ]
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Stability of CI build.

## What does this change do?

New self-hosted infrastructure based on k8s for `ci / test workspace` and `benches`.

## What is your testing strategy?

N/A

## Is this related to any issues?
- [x] No related issues

## Does this change need documentation?


- [x] No documentation needed

## Have you read the Contributing Guidelines?


- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
