### PR TITLE
Attempt to improve TiKV CI consistency without attempting to write data

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -210,15 +210,20 @@ script = """
 category = "CI - SERVICES"
 script = """
     #!/bin/bash -ex
+	echo "Installing TiKV playground..."
     ${HOME}/.tiup/bin/tiup install pd tikv playground
+	echo "Cleaning TiKV playground..."
+	${HOME}/.tiup/bin/tiup clean --all
+	echo "Starting TiKV playground..."
 	nohup ${HOME}/.tiup/bin/tiup playground --mode tikv-slim --kv 1 --pd 1 --db 0 --ticdc 0 --tiflash 0 --without-monitor > /tmp/tiup.log &
 	set +e
 	tries=0
-	echo "Waiting for tiup playground to be ready..."
+	echo "Waiting for TiKV playground to be ready..."
 	while [[ $tries -lt 10 ]]; do
+		sleep 5
+		echo "Displaying playground status..."
 		if ! ${HOME}/.tiup/bin/tiup playground display >/dev/null; then
 			tries=$((tries + 1));
-			sleep 5;
 			continue
 		fi
 		exit 0;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

TiKV cluster sometimes fails to start correctly. Without attempting to write data, we must attempt to prevent cluster startup failures before running tests.

## What does this change do?

Attempts to improve TiKV CI consistency without attempting to write data.

## What is your testing strategy?

Not applicable.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
