### PR TITLE
Add automated comment moderation action

### DIFF
--- a/.github/workflows/automoderator.yaml
+++ b/.github/workflows/automoderator.yaml
@@ -1,0 +1,74 @@
+name: Automatically Moderate Github Comments
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  automoderator:
+    runs-on: ubuntu-latest
+    steps:
+    # This stage contains code from "Comment-Filter", licensed under MIT by Martin Leduc
+    # Source: https://github.com/DecimalTurn/Comment-Filter/blob/v0.1.0/LICENSE
+    - name: Redact Malicious Messages
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          const comment = context.payload.comment
+          const { owner, repo } = context.repo
+
+          console.log('Repository owner:', owner)
+          console.log('Repository name:', repo)
+          console.log('Comment body:', comment.body)
+
+          // Array of regex patterns and their replacements
+          const regexReplacements = [
+            // File Sharing
+            {
+              pattern: /(www\.)?(box|dropbox|mediafire|sugarsync|tresorit|hightail|opentext|sharefile|citrixsharefile|icloud|onedrive|1drv)\.com\/[^\s\)]+/g,
+              replacement: '[REDACTED]'
+            },
+            // Google Drive
+            {
+              pattern: /drive\.google\.com\/[^\s\)]+/g,
+              replacement: '[REDACTED]'
+            },
+            // Link Shorteners
+            {
+              pattern: /(www\.)?(bit\.ly|t\.co|tinyurl\.com|goo\.gl|ow\.ly|buff\.ly|is\.gd|soo\.gd|t2mio|bl\.ink|clck\.ru|shorte\.st|cutt\.ly|v\.gd|qr\.ae|rb\.gy|rebrand\.ly|tr\.im|shorturl\.at|lnkd\.in)\/[^\s\)]+/g,
+              replacement: '[REDACTED]'
+            },
+          ];
+
+          // Iterate through each regex and replace matches in the comment body
+          let updatedBody = comment.body;
+          regexReplacements.forEach(({ pattern, replacement }) => {
+            if (pattern.test(updatedBody)) {
+              console.log(`Pattern found: ${pattern}`);
+              updatedBody = updatedBody.replace(pattern, replacement);
+            }
+          });
+
+          // If the comment body was updated, edit the comment
+          if (updatedBody !== comment.body) {
+            console.log('Updated comment body:', updatedBody);
+
+            // Append edition notice to the body
+            updatedBody = updatedBody + '\n\n' +
+              '**NOTICE**: This comment has been automatically edited by SurrealDB ' +
+              'to redact some links in order to protect users from potentially malicious content. ' +
+              'Please, let us know if you believe this action may have been a mistake.'
+
+            // Edit the comment with the updated body
+            await github.rest.issues.updateComment({
+              owner: owner,
+              repo: repo,
+              comment_id: comment.id,
+              body: updatedBody
+            });
+          } else {
+            console.log('No suspicious links found.')
+          }

--- a/.github/workflows/automoderator.yaml
+++ b/.github/workflows/automoderator.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   automoderator:
-    runs-on: ["runner-arm64-small"]
+    runs-on: ["ubuntu-latest"]
     steps:
     - name: Redact Suspicious Links
       # This step contains code from "Comment-Filter", licensed under MIT by Martin Leduc

--- a/.github/workflows/automoderator.yaml
+++ b/.github/workflows/automoderator.yaml
@@ -11,9 +11,9 @@ jobs:
   automoderator:
     runs-on: ["runner-arm64-medium"]
     steps:
-    # This stage contains code from "Comment-Filter", licensed under MIT by Martin Leduc
-    # Source: https://github.com/DecimalTurn/Comment-Filter/blob/v0.1.0/LICENSE
-    - name: Redact Malicious Messages
+    - name: Redact Suspicious Links
+      # This step contains code from "Comment-Filter", licensed under MIT by Martin Leduc
+      # Source: https://github.com/DecimalTurn/Comment-Filter/blob/v0.1.0/LICENSE
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |

--- a/.github/workflows/automoderator.yaml
+++ b/.github/workflows/automoderator.yaml
@@ -58,7 +58,7 @@ jobs:
 
             // Append edition notice to the body
             updatedBody = updatedBody + '\n\n' +
-              '**NOTICE**: This comment has been automatically edited by SurrealDB ' +
+              '**NOTICE**: This comment has been automatically edited by a bot ' +
               'to redact some links in order to protect users from potentially malicious content. ' +
               'Please, let us know if you believe this action may have been a mistake.'
 

--- a/.github/workflows/automoderator.yaml
+++ b/.github/workflows/automoderator.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   automoderator:
-    runs-on: ["runner-arm64-medium"]
+    runs-on: ["runner-arm64-small"]
     steps:
     - name: Redact Suspicious Links
       # This step contains code from "Comment-Filter", licensed under MIT by Martin Leduc

--- a/.github/workflows/automoderator.yaml
+++ b/.github/workflows/automoderator.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   automoderator:
-    runs-on: ubuntu-latest
+    runs-on: ["runner-arm64-medium"]
     steps:
     # This stage contains code from "Comment-Filter", licensed under MIT by Martin Leduc
     # Source: https://github.com/DecimalTurn/Comment-Filter/blob/v0.1.0/LICENSE


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To mitigate the impact to our users from a widespread malware campaign [[1](https://news.ycombinator.com/item?id=41365950), [2](https://www.reddit.com/r/github/comments/1f2n2qs/psa_lummac2_trojan_stealer_spreading_on_github/)] which is using Github comments in recently created issues to distribute malware. Although repository moderation was temporarily enabled as a mitigation, that prevented interactions from users who are not already contributors. Implementing a comment moderation action will allow us to disable repository moderation and allow users to continue interacting with the repository without restrictions. This action will redact any potentially malicious links and allow us to implement custom rules that may be required in the future.

## What does this change do?

Deploys a version of the [Comment-Filter](https://github.com/DecimalTurn/Comment-Filter) action [created by Martin Leduc](https://github.com/DecimalTurn/Comment-Filter/blob/v0.1.0/LICENSE) in [response to this incident](https://x.com/DecimalTurn/status/1828499251564798355). The modified action adds an edition notice to the message to warn users that the message has been automatically edited and slightly modifies the regular expressions to match a wider array of potentially malicious links.

## What is your testing strategy?

I have deployed and tested the action with the malicious comments in a private repository.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
