### PR TITLE
Show ENFORCED keyword in INFO statement

### DIFF
--- a/core/src/sql/statements/define/table.rs
+++ b/core/src/sql/statements/define/table.rs
@@ -203,6 +203,9 @@ impl Display for DefineTableStatement {
 						kind.iter().map(|t| t.0.as_str()).collect::<Vec<_>>().join(" | ")
 					)?;
 				}
+				if rel.enforced {
+					write!(f, " ENFORCED")?;
+				}
 			}
 			TableType::Any => {
 				f.write_str(" ANY")?;

--- a/core/src/sql/table_type.rs
+++ b/core/src/sql/table_type.rs
@@ -31,6 +31,9 @@ impl Display for TableType {
 				if let Some(kind) = &rel.to {
 					write!(f, " OUT {kind}")?;
 				}
+				if rel.enforced {
+					write!(f, " ENFORCED")?;
+				}
 			}
 			TableType::Any => {
 				f.write_str(" ANY")?;

--- a/sdk/tests/relate.rs
+++ b/sdk/tests/relate.rs
@@ -265,6 +265,7 @@ async fn relate_enforced() -> Result<(), Error> {
 		RELATE a:1->edge:1->a:2;
 		CREATE a:1, a:2;
 		RELATE a:1->edge:1->a:2;
+		INFO FOR DB;
 	";
 
 	let mut t = Test::new(sql).await?;
@@ -277,5 +278,18 @@ async fn relate_enforced() -> Result<(), Error> {
 	//
 	t.expect_val("[{ id: edge:1, in: a:1, out: a:2 }]")?;
 	//
+	let info = Value::parse("{
+	accesses: {},
+	analyzers: {},
+	functions: {},
+	models: {},
+	params: {},
+	tables: {
+		a: 'DEFINE TABLE a TYPE ANY SCHEMALESS PERMISSIONS NONE',
+		edge: 'DEFINE TABLE edge TYPE RELATION ENFORCED SCHEMALESS PERMISSIONS NONE'
+	},
+	users: {}
+	}");
+	t.expect_value(info)?;
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

INFO FOR DB doesn't show the word ENFORCED for enforced relation tables yet.

## What does this change do?

It allows this word to display.

## What is your testing strategy?

Added an expected output to an existing test that uses the ENFORCED keyword.

## Is this related to any issues?

- [X ] No related issues

## Does this change need documentation?

- [X ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
