### PR TITLE
Avoid calling the storage engine when range scan is invalid

### DIFF
--- a/core/src/kvs/tikv/mod.rs
+++ b/core/src/kvs/tikv/mod.rs
@@ -394,7 +394,7 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// TiKV does not support verisoned queries.
+		// TiKV does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}

--- a/core/src/kvs/tr.rs
+++ b/core/src/kvs/tr.rs
@@ -352,7 +352,7 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.into();
 		let end: Key = rng.end.into();
-		if beg >= end {
+		if beg > end {
 			return Ok(vec![]);
 		}
 		expand_inner!(&mut self.inner, v => { v.scan(beg..end, limit, version).await })

--- a/core/src/kvs/tr.rs
+++ b/core/src/kvs/tr.rs
@@ -352,6 +352,9 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.into();
 		let end: Key = rng.end.into();
+		if beg >= end {
+			return Ok(vec![]);
+		}
 		expand_inner!(&mut self.inner, v => { v.scan(beg..end, limit, version).await })
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Transaction::scan panics when the lower bound is larger than the upper bound.

```
thread 'surrealdb-worker' panicked at /rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/alloc/src/collections/btree/search.rs:120:21:
range start is greater than range end in BTreeMap
stack backtrace:
   0:     0x55bfcf9df736 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h9c4bd387f9f3f544
   1:     0x55bfcfa10d00 - core::fmt::write::h938c332fdab924eb
   2:     0x55bfcf9dba1f - std::io::Write::write_fmt::h4a694b02e44e6363
   3:     0x55bfcf9df514 - std::sys_common::backtrace::print::ha888e6736b0bc71f
   4:     0x55bfcf9e0c17 - std::panicking::default_hook::{{closure}}::he19a7f79f7beab5e
   5:     0x55bfcf9e0979 - std::panicking::default_hook::h67efe04e9a5d446e
   6:     0x55bfcf9e10a8 - std::panicking::rust_panic_with_hook::h49021cdbc4b22349
   7:     0x55bfcf9e0f49 - std::panicking::begin_panic_handler::{{closure}}::hfbf601f3d8c62d13
   8:     0x55bfcf9dfc36 - std::sys_common::backtrace::__rust_end_short_backtrace::h98dd020b6e913806
   9:     0x55bfcf9e0cd4 - rust_begin_unwind
  10:     0x55bfca7a6005 - core::panicking::panic_fmt::h0d3f1893e38be419
  11:     0x55bfcc9b7175 - alloc::collections::btree::search::<impl alloc::collections::btree::node::NodeRef<BorrowType,K,V,alloc::collections::btree::node::marker::LeafOrInternal>>::search_tree_for_bifurcation::hc64be5120721b6fa
  12:     0x55bfcc9c4344 - alloc::collections::btree::navigate::<impl alloc::collections::btree::node::NodeRef<BorrowType,K,V,alloc::collections::btree::node::marker::LeafOrInternal>>::find_leaf_edges_spanning_range::ha18f8e4e9ec7c923
  13:     0x55bfcc77233a - alloc::collections::btree::map::BTreeMap<K,V,A>::range::h600a632c73372dc7
  14:     0x55bfcd387b98 - tikv_client::transaction::buffer::Buffer::scan_and_fetch::{{closure}}::h7d57b3364c5a4f3d
  15:     0x55bfcc8df84e - tikv_client::transaction::transaction::Transaction<PdC>::scan_inner::{{closure}}::hdbb4fd8659747376
  16:     0x55bfcc8e5fe6 - tikv_client::transaction::transaction::Transaction<PdC>::scan::{{closure}}::hd2e63ffc2d24c54b
  17:     0x55bfcc4aa31e - <surrealdb_core::kvs::tikv::Transaction as surrealdb_core::kvs::api::Transaction>::scan::{{closure}}::{{closure}}::he6e2ab0c2d6dd4b3
  18:     0x55bfcc4a9d10 - <surrealdb_core::kvs::tikv::Transaction as surrealdb_core::kvs::api::Transaction>::scan::{{closure}}::he8f137230c3b69c4
  19:     0x55bfcbc863ae - surrealdb_core::kvs::tr::Transactor::scan::{{closure}}::{{closure}}::he9a51e582f720481
  20:     0x55bfcbc857bb - surrealdb_core::kvs::tr::Transactor::scan::{{closure}}::h2a891e1c3334d7ef
  21:     0x55bfcc6e4a4a - surrealdb_core::kvs::tx::Transaction::scan::{{closure}}::{{closure}}::h43abfce16f22ad5b
  22:     0x55bfcc6e444a - surrealdb_core::kvs::tx::Transaction::scan::{{closure}}::hd3630558e8e1320d
  23:     0x55bfcbbbd38d - surrealdb_core::idx::planner::iterators::IndexRangeThingIterator::next_batch::{{closure}}::hb5136a1d9b6ec237
```

## What does this change do?

Transaction::scan returns an empty result rather than failing when the lower bound is larger than the upper bound.

## What is your testing strategy?

Code covered by existing tests.

## Is this related to any issues?

Closes #4578 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
