### PR TITLE
Display function return types

### DIFF
--- a/core/src/sql/statements/define/function.rs
+++ b/core/src/sql/statements/define/function.rs
@@ -90,6 +90,9 @@ impl fmt::Display for DefineFunctionStatement {
 			write!(f, "${name}: {kind}")?;
 		}
 		f.write_str(") ")?;
+		if let Some(ref v) = self.returns {
+			write!(f, "-> {v} ")?;
+		}
 		Display::fmt(&self.block, f)?;
 		if let Some(ref v) = self.comment {
 			write!(f, " COMMENT {v}")?


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

`INFO FOR DB` does not contain function return types

## What does this change do?

Update Display trait

## What is your testing strategy?

GitHub Actions

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
