### PR TITLE
Escape "table" indents

### DIFF
--- a/core/src/syn/lexer/keywords.rs
+++ b/core/src/syn/lexer/keywords.rs
@@ -47,6 +47,7 @@ pub static RESERVED_KEYWORD: phf::Set<UniCase<&'static str>> = phf_set! {
 	UniCase::ascii("TRUE"),
 	UniCase::ascii("FALSE"),
 	UniCase::ascii("WHERE"),
+	UniCase::ascii("TABLE"),
 };
 
 pub fn could_be_reserved(s: &str) -> bool {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

`INFO FOR TABLE` will return incorrect queries when using the table name "table"

## What does this change do?

Adds "table" to the `RESERVED_KEYWORD` list

## What is your testing strategy?

GitHub Actions

## Is this related to any issues?

https://github.com/surrealdb/surrealist/issues/382

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
