### PR TITLE
Fix bug with object array-indexed string field names appearing with quotation marks

### DIFF
--- a/core/src/sql/value/set.rs
+++ b/core/src/sql/value/set.rs
@@ -65,7 +65,7 @@ impl Value {
 							_ => {
 								let mut obj = Value::base();
 								stk.run(|stk| obj.set(stk, ctx, opt, path.next(), val)).await?;
-								v.insert(f.to_string(), obj);
+								v.insert(f.to_raw(), obj);
 								Ok(())
 							}
 						},

--- a/sdk/tests/update.rs
+++ b/sdk/tests/update.rs
@@ -282,6 +282,46 @@ async fn update_with_return_clause() -> Result<(), Error> {
 	Ok(())
 }
 
+#[tokio::test]
+async fn update_with_object_array_string_field_names() -> Result<(), Error> {
+	let sql = "
+		UPSERT person:one SET field.key = 'value';
+		UPSERT person:two SET field['key'] = 'value';
+	";
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				field: {
+					key: 'value'
+				},
+				id: person:one
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				field: {
+					key: 'value'
+				},
+				id: person:one
+			}
+		]",
+	);
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
 //
 // Permissions
 //

--- a/sdk/tests/update.rs
+++ b/sdk/tests/update.rs
@@ -313,7 +313,7 @@ async fn update_with_object_array_string_field_names() -> Result<(), Error> {
 				field: {
 					key: 'value'
 				},
-				id: person:one
+				id: person:two
 			}
 		]",
 	);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When inserting field names with object array-indexed notation and using string, the field name is stored with the enclosing quotation marks:

```sql
UPSERT person:test SET field["key"] = "value";
-- Outputs:
[
    {
        field: {
            "'key'": 'value'
        },
        id: person:test
    }
]
```

## What does this change do?

This fixes the error, ensuring that the following is now:

```sql
UPSERT person:test SET field["key"] = "value";
-- Outputs:
[
    {
        field: {
            key: 'value'
        },
        id: person:test
    }
]
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #4633

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
