### PR TITLE
Fix `NONE` and `NULL` less than or greater than bugs

### DIFF
--- a/core/src/doc/table.rs
+++ b/core/src/doc/table.rs
@@ -458,8 +458,12 @@ impl Document {
 					Value::Subquery(Box::new(Subquery::Ifelse(IfelseStatement {
 						exprs: vec![(
 							Value::Expression(Box::new(Expression::Binary {
-								l: Value::Idiom(key.clone()),
-								o: Operator::And,
+								l: Value::Expression(Box::new(Expression::Binary {
+									l: Value::Idiom(key.clone()),
+									o: Operator::Exact,
+									r: Value::None,
+								})),
+								o: Operator::Or,
 								r: Value::Expression(Box::new(Expression::Binary {
 									l: Value::Idiom(key.clone()),
 									o: Operator::MoreThan,
@@ -509,8 +513,12 @@ impl Document {
 					Value::Subquery(Box::new(Subquery::Ifelse(IfelseStatement {
 						exprs: vec![(
 							Value::Expression(Box::new(Expression::Binary {
-								l: Value::Idiom(key.clone()),
-								o: Operator::And,
+								l: Value::Expression(Box::new(Expression::Binary {
+									l: Value::Idiom(key.clone()),
+									o: Operator::Exact,
+									r: Value::None,
+								})),
+								o: Operator::Or,
 								r: Value::Expression(Box::new(Expression::Binary {
 									l: Value::Idiom(key.clone()),
 									o: Operator::LessThan,

--- a/core/src/doc/table.rs
+++ b/core/src/doc/table.rs
@@ -459,8 +459,12 @@ impl Document {
 						exprs: vec![(
 							Value::Expression(Box::new(Expression::Binary {
 								l: Value::Idiom(key.clone()),
-								o: Operator::MoreThan,
-								r: val.clone(),
+								o: Operator::And,
+								r: Value::Expression(Box::new(Expression::Binary {
+									l: Value::Idiom(key.clone()),
+									o: Operator::MoreThan,
+									r: val.clone(),
+								})),
 							})),
 							val,
 						)],
@@ -506,8 +510,12 @@ impl Document {
 						exprs: vec![(
 							Value::Expression(Box::new(Expression::Binary {
 								l: Value::Idiom(key.clone()),
-								o: Operator::LessThan,
-								r: val.clone(),
+								o: Operator::And,
+								r: Value::Expression(Box::new(Expression::Binary {
+									l: Value::Idiom(key.clone()),
+									o: Operator::LessThan,
+									r: val.clone(),
+								})),
 							})),
 							val,
 						)],

--- a/core/src/fnc/operate.rs
+++ b/core/src/fnc/operate.rs
@@ -105,19 +105,19 @@ pub fn any_like(a: &Value, b: &Value) -> Result<Value, Error> {
 }
 
 pub fn less_than(a: &Value, b: &Value) -> Result<Value, Error> {
-	Ok((a.is_none_or_null() || b.is_none_or_null() || a.lt(b)).into())
+	Ok(a.lt(b).into())
 }
 
 pub fn less_than_or_equal(a: &Value, b: &Value) -> Result<Value, Error> {
-	Ok((a.is_none_or_null() || b.is_none_or_null() || a.le(b)).into())
+	Ok(a.le(b).into())
 }
 
 pub fn more_than(a: &Value, b: &Value) -> Result<Value, Error> {
-	Ok((a.is_none_or_null() || b.is_none_or_null() || a.gt(b)).into())
+	Ok(a.gt(b).into())
 }
 
 pub fn more_than_or_equal(a: &Value, b: &Value) -> Result<Value, Error> {
-	Ok((a.is_none_or_null() || b.is_none_or_null() || a.ge(b)).into())
+	Ok(a.ge(b).into())
 }
 
 pub fn contain(a: &Value, b: &Value) -> Result<Value, Error> {

--- a/sdk/tests/table.rs
+++ b/sdk/tests/table.rs
@@ -54,7 +54,15 @@ async fn define_foreign_table() -> Result<(), Error> {
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::parse("[{ id: person:one, age: 39, score: 70 }]");
+	let val = Value::parse(
+		"[
+			{
+				age: 39,
+				id: person:one,
+				score: 70,
+			}
+		]",
+	);
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;


### PR DESCRIPTION
## What is the motivation?

Currently, `NONE` and `NULL` are both `< 1` and `> 1`. In SurrealDB `NONE` is always the first item to sort, then `NULL`. And these will always sort less than a number.

## What does this change do?

Fixes this bug, ensuring that `NONE` and `NULL` are always `<` any other value type.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #4477

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
