### PR TITLE
Fix allowing `any` to be used for optional arguments

### DIFF
--- a/core/src/sql/function.rs
+++ b/core/src/sql/function.rs
@@ -275,6 +275,7 @@ impl Function {
 				// Check for any final optional arguments
 				val.args.iter().rev().for_each(|(_, kind)| match kind {
 					Kind::Option(_) if min_args_len == 0 => {}
+					Kind::Any if min_args_len == 0 => {}
 					_ => min_args_len += 1,
 				});
 				// Check the necessary arguments are passed


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Specifying an argument as `any` in a custom defined function would not allow the argument to be optional or `NONE`.

## What does this change do?

Allows the `any` type to also act as an optional type, allowing for arguments to be unspecified or set to `NONE`.

```sql
DEFINE FUNCTION OVERWRITE fn::test($arg: any) {
    RETURN $arg || 'test';
};
-- Returns 'test'
fn::test();
-- Returns 'other'
fn::test('other');
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #4650

## Does this change need documentation?

- [ ] Documentation to be added

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
