### PR TITLE
Fix `cargo` dependency loading issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -199,7 +199,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -571,7 +571,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.58",
+ "syn 2.0.77",
  "thiserror",
 ]
 
@@ -629,7 +629,7 @@ checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -651,7 +651,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -668,7 +668,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -695,15 +695,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
 dependencies = [
  "bytemuck",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -867,7 +858,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -973,7 +964,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -995,7 +986,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.58",
+ "syn 2.0.77",
  "which",
 ]
 
@@ -1105,7 +1096,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
  "syn_derive",
 ]
 
@@ -1409,7 +1400,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1579,12 +1570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,7 +1631,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1657,7 +1642,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1735,7 +1720,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1787,7 +1772,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2178,7 +2163,7 @@ checksum = "f8db6653cbc621a3810d95d55bd342be3e71181d6df21a4eb29ef986202d3f9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
  "try_map",
 ]
 
@@ -2283,7 +2268,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2350,41 +2335,6 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1645cf1d7fea7dac1a66f7357f3df2677ada708b8d9db8e9b043878930095a96"
-dependencies = [
- "earcutr",
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "log",
- "num-traits",
- "robust",
- "rstar 0.11.0",
- "serde",
-]
-
-[[package]]
-name = "geo"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4841b40fdbccd4b7042bd6195e4de91da54af34c50632e371bcbfcdfb558b873"
-dependencies = [
- "earcutr",
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "log",
- "num-traits",
- "robust",
- "rstar 0.11.0",
- "serde",
- "spade",
-]
-
-[[package]]
-name = "geo"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
@@ -2396,7 +2346,8 @@ dependencies = [
  "log",
  "num-traits",
  "robust",
- "rstar 0.12.0",
+ "rstar",
+ "serde",
  "spade",
 ]
 
@@ -2409,8 +2360,7 @@ dependencies = [
  "approx 0.5.1",
  "arbitrary",
  "num-traits",
- "rstar 0.11.0",
- "rstar 0.12.0",
+ "rstar",
  "serde",
 ]
 
@@ -2469,7 +2419,7 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2547,15 +2497,6 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -2608,24 +2549,11 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32 0.2.1",
- "rustc_version",
- "spin 0.9.8",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32 0.3.1",
+ "hash32",
  "stable_deref_trait",
 ]
 
@@ -2682,7 +2610,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3145,7 +3073,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3449,7 +3377,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3799,7 +3727,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3998,7 +3926,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4054,7 +3982,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4138,7 +4066,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
  "unicase",
 ]
 
@@ -4184,7 +4112,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4311,7 +4239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4359,9 +4287,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -4374,7 +4302,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
  "version_check",
  "yansi",
 ]
@@ -4430,7 +4358,7 @@ dependencies = [
  "prost 0.12.3",
  "prost-types",
  "regex",
- "syn 2.0.58",
+ "syn 2.0.77",
  "tempfile",
  "which",
 ]
@@ -4445,7 +4373,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4458,7 +4386,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4587,9 +4515,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -4772,19 +4700,19 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -4804,7 +4732,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -4815,9 +4743,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 dependencies = [
  "arbitrary",
 ]
@@ -4902,14 +4830,14 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4beb55556e5a2e13e796d4a58750c4c802d1766bcfc15035163ecf575a38a77e"
+checksum = "22f53179a035f881adad8c4d58a2c599c6b4a8325b989c68d178d7a34d1b1e4c"
 dependencies = [
  "chrono",
- "geo 0.26.0",
+ "geo",
  "regex",
- "revision-derive 0.9.0",
+ "revision-derive 0.10.0",
  "roaring",
  "rust_decimal",
  "uuid",
@@ -4925,18 +4853,18 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "revision-derive"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9336dc6ce3c5ece8d1eb44103d5483c68efbc4b3ac54263316eec2f57f57fec"
+checksum = "5f0ec466e5d8dca9965eb6871879677bef5590cf7525ad96cae14376efb75073"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5056,9 +4984,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c77081a55300e016cb86f2864415b7518741879db925b8d488a0ee0d2da6bf"
+checksum = "8f4b84ba6e838ceb47b41de5194a60244fac43d9fe03b71dbe8c5a201081d6d1"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -5131,7 +5059,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.58",
+ "syn 2.0.77",
  "unicode-xid",
  "version_check",
 ]
@@ -5209,7 +5137,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rquickjs-core",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5224,22 +5152,11 @@ dependencies = [
 
 [[package]]
 name = "rstar"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73111312eb7a2287d229f06c00ff35b51ddee180f017ab6dec1f69d62ac098d6"
-dependencies = [
- "heapless 0.7.17",
- "num-traits",
- "smallvec",
-]
-
-[[package]]
-name = "rstar"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133315eb94c7b1e8d0cb097e5a710d850263372fd028fff18969de708afc7008"
 dependencies = [
- "heapless 0.8.0",
+ "heapless",
  "num-traits",
  "smallvec",
 ]
@@ -5442,7 +5359,7 @@ checksum = "5a32af5427251d2e4be14fc151eabe18abb4a7aad5efee7044da9f096c906a43"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5558,9 +5475,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
@@ -5585,13 +5502,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5609,9 +5526,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -5678,7 +5595,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5703,7 +5620,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5861,9 +5778,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "stable-pattern"
@@ -5989,7 +5903,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6016,7 +5930,7 @@ dependencies = [
  "env_logger 0.10.2",
  "futures",
  "futures-util",
- "geo 0.28.0",
+ "geo",
  "geo-types",
  "glob",
  "http 1.1.0",
@@ -6037,7 +5951,7 @@ dependencies = [
  "rand 0.8.5",
  "rcgen",
  "reqwest",
- "revision 0.9.0",
+ "revision 0.10.0",
  "rmp-serde",
  "rmpv",
  "rust_decimal",
@@ -6084,7 +5998,7 @@ dependencies = [
  "env_logger 0.10.2",
  "flate2",
  "futures",
- "geo 0.27.0",
+ "geo",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "native-tls",
@@ -6097,7 +6011,7 @@ dependencies = [
  "reblessive",
  "regex",
  "reqwest",
- "revision 0.9.0",
+ "revision 0.10.0",
  "ring 0.17.8",
  "rust_decimal",
  "rustls 0.23.12",
@@ -6179,7 +6093,7 @@ dependencies = [
  "fst",
  "futures",
  "fuzzy-matcher",
- "geo 0.27.0",
+ "geo",
  "geo-types",
  "hex",
  "indxdb",
@@ -6205,9 +6119,9 @@ dependencies = [
  "rand 0.8.5",
  "reblessive",
  "regex",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
  "reqwest",
- "revision 0.9.0",
+ "revision 0.10.0",
  "ring 0.17.8",
  "rmpv",
  "roaring",
@@ -6363,9 +6277,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6381,7 +6295,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6513,27 +6427,27 @@ checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6648,7 +6562,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6932,7 +6846,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7222,12 +7136,11 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "arbitrary",
- "atomic 0.5.3",
  "getrandom 0.2.12",
  "serde",
  "wasm-bindgen",
@@ -7332,7 +7245,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -7366,7 +7279,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7757,7 +7670,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ axum-extra = { version = "0.9.2", features = [
 axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
 base64 = "0.21.5"
 bytes = "1.5.0"
-chrono = "0.4.31"
+chrono = "0.4.38"
 ciborium = "0.2.1"
 clap = { version = "4.4.11", features = [
     "env",
@@ -103,7 +103,7 @@ reqwest = { version = "0.12.5", default-features = false, features = [
     "gzip",
     "http2",
 ] }
-revision = { version = "0.9.0", features = [
+revision = { version = "0.10.0", features = [
     "chrono",
     "geo",
     "roaring",
@@ -115,8 +115,8 @@ rmpv = "1.0.1"
 rust_decimal = "1.36.0"
 rustyline = { version = "12.0.0", features = ["derive"] }
 semver = "1.0.20"
-serde = { version = "1.0.193", features = ["derive"] }
-serde_json = "1.0.108"
+serde = { version = "1.0.209", features = ["derive"] }
+serde_json = "1.0.127"
 serde_pack = { version = "1.1.2", package = "rmp-serde" }
 surrealdb = { version = "2", path = "sdk", features = [
     "protocol-http",
@@ -125,7 +125,7 @@ surrealdb = { version = "2", path = "sdk", features = [
 ] }
 surrealdb-core = { version = "2", path = "core" }
 tempfile = "3.8.1"
-thiserror = "1.0.50"
+thiserror = "1.0.63"
 tokio = { version = "1.34.0", features = ["macros", "signal"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7.10", features = ["io"] }
@@ -145,7 +145,7 @@ tower-http = { version = "0.5.2", features = [
 ] }
 tower-service = "0.3.2"
 urlencoding = "2.1.3"
-uuid = { version = "1.6.1", features = ["serde", "js", "v4", "v7"] }
+uuid = { version = "1.10.0", features = ["serde", "js", "v4", "v7"] }
 tokio-tungstenite = "0.23.0"
 async-graphql-axum = { package = "surrealdb-async-graphql-axum", version = "7.0.7-surrealdb.1" }
 async-graphql = { version = "7.0.7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ inherits = "dev"
 
 [dependencies]
 argon2 = "0.5.2"
+async-graphql = { version = "7.0.7", default-features = false }
+async-graphql-axum = { package = "surrealdb-async-graphql-axum", version = "7.0.7-surrealdb.1" }
 axum = { version = "0.7.4", features = ["tracing", "ws"] }
 axum-extra = { version = "0.9.2", features = [
     "query",
@@ -81,17 +83,9 @@ http-body = "1.0.0"
 http-body-util = "0.1.1"
 hyper = "1.2.0"
 once_cell = "1.18.0"
-
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-# OpenTelemetry versions are dependant on tracing-opentelemetry. See https://github.com/open-telemetry/opentelemetry-rust/issues/1571
-# Make sure to update the versions of the OpenTelemetry crates if you update the version of tracing-opentelemetry.
-# See matching versions here: https://github.com/tokio-rs/tracing-opentelemetry/blob/v0.1.x/Cargo.toml
-tracing-opentelemetry = "0.25.0"
 opentelemetry = { version = "0.24" }
 opentelemetry_sdk = { version = "0.24", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.17.0", features = ["metrics"] }
-
 pin-project-lite = "0.2.13"
 pprof = { version = "0.13.0", features = [
     "flamegraph",
@@ -128,6 +122,7 @@ tempfile = "3.8.1"
 thiserror = "1.0.63"
 tokio = { version = "1.34.0", features = ["macros", "signal"] }
 tokio-stream = "0.1"
+tokio-tungstenite = "0.23.0"
 tokio-util = { version = "0.7.10", features = ["io"] }
 tower = "0.4.13"
 tower-http = { version = "0.5.2", features = [
@@ -144,11 +139,11 @@ tower-http = { version = "0.5.2", features = [
     "compression-full",
 ] }
 tower-service = "0.3.2"
+tracing = "0.1"
+tracing-opentelemetry = "0.25.0"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 urlencoding = "2.1.3"
 uuid = { version = "1.10.0", features = ["serde", "js", "v4", "v7"] }
-tokio-tungstenite = "0.23.0"
-async-graphql-axum = { package = "surrealdb-async-graphql-axum", version = "7.0.7-surrealdb.1" }
-async-graphql = { version = "7.0.7", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.27.1", features = ["user"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -65,7 +65,7 @@ bytes = "1.5.0"
 ciborium = "0.2.1"
 cedar-policy = "2.4.2"
 channel = { version = "1.9.0", package = "async-channel" }
-chrono = { version = "0.4.31", features = ["serde"] }
+chrono = { version = "0.4.38", features = ["serde"] }
 dashmap = "5.5.3"
 derive = { version = "0.12.0", package = "surrealdb-derive" }
 deunicode = "1.4.1"
@@ -79,8 +79,8 @@ foundationdb = { version = "0.9.0", default-features = false, features = [
 fst = "0.4.7"
 futures = "0.3.29"
 fuzzy-matcher = "0.3.7"
-geo = { version = "0.27.0", features = ["use-serde"] }
-geo-types = { version = "0.7.12", features = ["arbitrary"] }
+geo = { version = "0.28.0", features = ["use-serde"] }
+geo-types = { version = "0.7.13", features = ["arbitrary"] }
 hex = { version = "0.4.3" }
 indxdb = { version = "0.5.0", optional = true }
 ipnet = "2.9.0"
@@ -113,14 +113,14 @@ quick_cache = "0.5.1"
 radix_trie = { version = "0.2.1", features = ["serde"] }
 rand = "0.8.5"
 reblessive = { version = "0.4.0", features = ["tree"] }
-regex = "1.10.2"
-regex-syntax = { version = "0.8.2", optional = true, features = ["arbitrary"] }
+regex = "1.10.6"
+regex-syntax = { version = "0.8.4", optional = true, features = ["arbitrary"] }
 reqwest = { version = "0.12.5", default-features = false, features = [
     "json",
     "stream",
     "multipart",
 ], optional = true }
-revision = { version = "0.9.0", features = [
+revision = { version = "0.10.0", features = [
     "chrono",
     "geo",
     "roaring",
@@ -129,14 +129,14 @@ revision = { version = "0.9.0", features = [
     "uuid",
 ] }
 rmpv = "1.0.1"
-roaring = { version = "0.10.2", features = ["serde"] }
+roaring = { version = "0.10.6", features = ["serde"] }
 rocksdb = { version = "0.21.0", features = ["lz4", "snappy"], optional = true }
 rust_decimal = { version = "1.36.0", features = ["maths", "serde-str"] }
 rust-stemmers = "1.2.0"
 scrypt = "0.11.0"
 semver = { version = "1.0.20", features = ["serde"] }
-serde = { version = "1.0.193", features = ["derive"] }
-serde_json = "1.0.108"
+serde = { version = "1.0.209", features = ["derive"] }
+serde_json = "1.0.127"
 sha1 = "0.10.6"
 sha2 = "0.10.8"
 snap = "1.1.0"
@@ -145,7 +145,7 @@ subtle = "2.6"
 surrealkv = { version = "0.3.4", optional = true }
 surrealml = { version = "0.1.1", optional = true, package = "surrealml-core" }
 tempfile = { version = "3.10.1", optional = true }
-thiserror = "1.0.50"
+thiserror = "1.0.63"
 tikv = { version = "0.3.0-surreal.1", default-features = false, package = "surrealdb-tikv-client", optional = true }
 tracing = "0.1.40"
 trice = "0.4.0"
@@ -178,7 +178,7 @@ tokio = { version = "1.34.0", default-features = false, features = [
     "rt",
     "sync",
 ] }
-uuid = { version = "1.6.1", features = ["serde", "js", "v4", "v7"] }
+uuid = { version = "1.10.0", features = ["serde", "js", "v4", "v7"] }
 wasm-bindgen-futures = "0.4.39"
 wasmtimer = { version = "0.2.0", default-features = false, features = [
     "tokio",
@@ -196,7 +196,7 @@ tokio = { version = "1.34.0", default-features = false, features = [
     "sync",
 ] }
 tokio-tungstenite = { version = "0.21.0", optional = true }
-uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }
+uuid = { version = "1.10.0", features = ["serde", "v4", "v7"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(surrealdb_unstable)'] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -57,15 +57,17 @@ ammonia = "4.0.0"
 arbitrary = { version = "1.3.2", features = ["derive"], optional = true }
 argon2 = "0.5.2"
 ascii = { version = "0.3.2", package = "any_ascii" }
+async-graphql = { version = "7.0.7", default-features = false, features = ["dynamic-schema"] }
 base64 = "0.21.5"
 bcrypt = "0.15.0"
-blake3 = "1.5.3"
 bincode = "1.3.3"
+blake3 = "1.5.3"
 bytes = "1.5.0"
-ciborium = "0.2.1"
+castaway = "0.2.3"
 cedar-policy = "2.4.2"
 channel = { version = "1.9.0", package = "async-channel" }
 chrono = { version = "0.4.38", features = ["serde"] }
+ciborium = "0.2.1"
 dashmap = "5.5.3"
 derive = { version = "0.12.0", package = "surrealdb-derive" }
 deunicode = "1.4.1"
@@ -102,8 +104,8 @@ md-5 = "0.10.6"
 nanoid = "0.4.0"
 ndarray = { version = "=0.15.6" }
 ndarray-stats = "=0.5.1"
-num-traits = "0.2.18"
 num_cpus = "1.16.0"
+num-traits = "0.2.18"
 object_store = { version = "0.10.2", optional = false }
 once_cell = "1.18.0"
 pbkdf2 = { version = "0.12.2", features = ["simple"] }
@@ -137,6 +139,7 @@ scrypt = "0.11.0"
 semver = { version = "1.0.20", features = ["serde"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
+serde-content = "0.1.0"
 sha1 = "0.10.6"
 sha2 = "0.10.8"
 snap = "1.1.0"
@@ -152,11 +155,6 @@ trice = "0.4.0"
 ulid = { version = "1.1.0", features = ["serde"] }
 unicase = "2.7.0"
 url = "2.5.0"
-async-graphql = { version = "7.0.7", default-features = false, features = [
-    "dynamic-schema",
-] }
-castaway = "0.2.3"
-serde-content = "0.1.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["async_tokio"] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -66,11 +66,6 @@ features = [
 targets = []
 
 [dependencies]
-reqwest = { version = "0.12.5", default-features = false, features = [
-    "json",
-    "multipart",
-    "stream",
-], optional = true }
 bincode = "1.3.3"
 channel = { version = "1.9.0", package = "async-channel" }
 chrono = { version = "0.4.38", features = ["serde"] }
@@ -81,6 +76,11 @@ indexmap = { version = "2.1.0", features = ["serde"] }
 native-tls = { version = "0.2.11", optional = true }
 once_cell = "1.18.0"
 path-clean = "1.0.1"
+reqwest = { version = "0.12.5", default-features = false, features = [
+    "json",
+    "multipart",
+    "stream",
+], optional = true }
 revision = { version = "0.10.0", features = [
     "chrono",
     "geo",
@@ -96,19 +96,19 @@ rustls = { version = "0.23.12", default-features = false, features = [
     "std",
     "tls12",
 ], optional = true }
+arrayvec = "=0.7.4"
+reblessive = { version = "0.4.0", features = ["tree"] }
 rustls-pki-types = { version = "1.7.0", features = ["web"] }
 semver = { version = "1.0.20", features = ["serde"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
+serde-content = "0.1.0"
 surrealdb-core = { version = "2", default-features = false, path = "../core", package = "surrealdb-core" }
 thiserror = "1.0.63"
 tokio-util = { version = "0.7.10", optional = true, features = ["compat"] }
 tracing = "0.1.40"
 trice = { version = "0.4.0", optional = true }
 url = "2.5.0"
-reblessive = { version = "0.4.0", features = ["tree"] }
-serde-content = "0.1.0"
-arrayvec = "=0.7.4"
 
 [dev-dependencies]
 ciborium = "0.2.1"
@@ -117,8 +117,8 @@ env_logger = "0.10.1"
 flate2 = "1.0.28"
 hashbrown = "0.14.5"
 pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
-rand = "0.8.5"
 radix_trie = "0.2.1"
+rand = "0.8.5"
 regex = "1.10.6"
 serial_test = "2.0.0"
 temp-dir = "0.1.11"

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -73,15 +73,15 @@ reqwest = { version = "0.12.5", default-features = false, features = [
 ], optional = true }
 bincode = "1.3.3"
 channel = { version = "1.9.0", package = "async-channel" }
-chrono = { version = "0.4.31", features = ["serde"] }
+chrono = { version = "0.4.38", features = ["serde"] }
 dmp = "0.2.0"
 futures = "0.3.29"
-geo = { version = "0.27.0", features = ["use-serde"] }
+geo = { version = "0.28.0", features = ["use-serde"] }
 indexmap = { version = "2.1.0", features = ["serde"] }
 native-tls = { version = "0.2.11", optional = true }
 once_cell = "1.18.0"
 path-clean = "1.0.1"
-revision = { version = "0.9.0", features = [
+revision = { version = "0.10.0", features = [
     "chrono",
     "geo",
     "roaring",
@@ -98,10 +98,10 @@ rustls = { version = "0.23.12", default-features = false, features = [
 ], optional = true }
 rustls-pki-types = { version = "1.7.0", features = ["web"] }
 semver = { version = "1.0.20", features = ["serde"] }
-serde = { version = "1.0.193", features = ["derive"] }
-serde_json = "1.0.108"
+serde = { version = "1.0.209", features = ["derive"] }
+serde_json = "1.0.127"
 surrealdb-core = { version = "2", default-features = false, path = "../core", package = "surrealdb-core" }
-thiserror = "1.0.50"
+thiserror = "1.0.63"
 tokio-util = { version = "0.7.10", optional = true, features = ["compat"] }
 tracing = "0.1.40"
 trice = { version = "0.4.0", optional = true }
@@ -119,7 +119,7 @@ hashbrown = "0.14.5"
 pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }
 rand = "0.8.5"
 radix_trie = "0.2.1"
-regex = "1.10.2"
+regex = "1.10.6"
 serial_test = "2.0.0"
 temp-dir = "0.1.11"
 test-log = { version = "0.2.13", features = ["trace"] }
@@ -136,7 +136,7 @@ tokio = { version = "1.34.0", default-features = false, features = [
     "rt",
     "sync",
 ] }
-uuid = { version = "1.6.1", features = ["serde", "js", "v4", "v7"] }
+uuid = { version = "1.10.0", features = ["serde", "js", "v4", "v7"] }
 wasm-bindgen-futures = "0.4.39"
 wasmtimer = { version = "0.2.0", default-features = false, features = [
     "tokio",
@@ -154,7 +154,7 @@ tokio = { version = "1.34.0", default-features = false, features = [
     "sync",
 ] }
 tokio-tungstenite = { version = "0.23.1", optional = true, features = ["url"] }
-uuid = { version = "1.6.1", features = ["serde", "v4", "v7"] }
+uuid = { version = "1.10.0", features = ["serde", "v4", "v7"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(surrealdb_unstable)'] }

--- a/sdk/examples/actix/Cargo.toml
+++ b/sdk/examples/actix/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 [dependencies]
 actix-web = { version = "4.4.0", features = ["macros"] }
 once_cell = "1.18.0"
-serde = { version = "1.0.193", features = ["derive"] }
+serde = { version = "1.0.209", features = ["derive"] }
 surrealdb = { path = "../.." }
-thiserror = "1.0.50"
+thiserror = "1.0.63"

--- a/sdk/examples/axum/Cargo.toml
+++ b/sdk/examples/axum/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 axum = "0.7.2"
-serde = { version = "1.0.193", features = ["derive"] }
+serde = { version = "1.0.209", features = ["derive"] }
 surrealdb = { path = "../.." ,features = ["kv-mem"]}
-thiserror = "1.0.50"
+thiserror = "1.0.63"
 tokio = { version = "1.34.0", features = ["macros", "rt-multi-thread"] }

--- a/sdk/examples/rocket/Cargo.toml
+++ b/sdk/examples/rocket/Cargo.toml
@@ -4,10 +4,8 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 rocket = { version = "0.5.0", features = ["json"] }
 surrealdb = { path = "../..", features = ["kv-mem"]}
-serde_json = "1.0"
-thiserror = "1.0.50"
+serde_json = "1.0.127"
+thiserror = "1.0.63"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -22,6 +22,12 @@ user-id = 3987 # Rushmore Mushambi (rushmorem)
 start = "2021-02-25"
 end = "2025-01-24"
 
+[[trusted.aho-corasick]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-03-28"
+end = "2025-08-31"
+
 [[trusted.anyhow]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
@@ -34,6 +40,18 @@ user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-07-23"
 end = "2025-08-06"
 
+[[trusted.bstr]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-04-02"
+end = "2025-08-31"
+
+[[trusted.byteorder]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-09"
+end = "2025-08-31"
+
 [[trusted.dmp]]
 criteria = "safe-to-deploy"
 user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
@@ -45,6 +63,18 @@ criteria = "safe-to-deploy"
 user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
 start = "2022-01-27"
 end = "2025-01-24"
+
+[[trusted.fst]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-20"
+end = "2025-08-31"
+
+[[trusted.globset]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-04-15"
+end = "2025-08-31"
 
 [[trusted.h2]]
 criteria = "safe-to-deploy"
@@ -106,6 +136,12 @@ user-id = 359 # Sean McArthur (seanmonstar)
 start = "2022-01-15"
 end = "2025-08-06"
 
+[[trusted.ignore]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-04-15"
+end = "2025-08-31"
+
 [[trusted.indxdb]]
 criteria = "safe-to-deploy"
 user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
@@ -117,6 +153,12 @@ criteria = "safe-to-deploy"
 user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
 start = "2023-03-26"
 end = "2025-01-24"
+
+[[trusted.memchr]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-07"
+end = "2025-08-31"
 
 [[trusted.mime]]
 criteria = "safe-to-deploy"
@@ -160,6 +202,24 @@ user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-05-05"
 end = "2025-08-06"
 
+[[trusted.regex]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-02-27"
+end = "2025-08-31"
+
+[[trusted.regex-automata]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-02-25"
+end = "2025-08-31"
+
+[[trusted.regex-syntax]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-03-30"
+end = "2025-08-31"
+
 [[trusted.reqwest]]
 criteria = "safe-to-deploy"
 user-id = 359 # Sean McArthur (seanmonstar)
@@ -183,6 +243,12 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-05-02"
 end = "2025-08-06"
+
+[[trusted.same-file]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-16"
+end = "2025-08-31"
 
 [[trusted.serde]]
 criteria = "safe-to-deploy"
@@ -213,6 +279,12 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-08-20"
 end = "2025-08-06"
+
+[[trusted.snap]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2020-02-14"
+end = "2025-08-31"
 
 [[trusted.storekey]]
 criteria = "safe-to-deploy"
@@ -280,6 +352,12 @@ user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
 start = "2022-02-17"
 end = "2025-01-24"
 
+[[trusted.ucd-trie]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-07-21"
+end = "2025-08-31"
+
 [[trusted.unicase]]
 criteria = "safe-to-deploy"
 user-id = 359 # Sean McArthur (seanmonstar)
@@ -291,3 +369,15 @@ criteria = "safe-to-deploy"
 user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
 start = "2024-01-16"
 end = "2025-02-10"
+
+[[trusted.walkdir]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2019-06-09"
+end = "2025-08-31"
+
+[[trusted.winapi-util]]
+criteria = "safe-to-deploy"
+user-id = 189 # Andrew Gallant (BurntSushi)
+start = "2020-01-11"
+end = "2025-08-31"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -680,14 +680,6 @@ version = "0.14.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.geo]]
-version = "0.26.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.geo]]
-version = "0.27.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.geo]]
 version = "0.28.0"
 criteria = "safe-to-deploy"
 
@@ -1316,7 +1308,7 @@ version = "0.4.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex]]
-version = "1.10.4"
+version = "1.10.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-automata]]
@@ -1328,11 +1320,7 @@ version = "0.4.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-syntax]]
-version = "0.6.29"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-syntax]]
-version = "0.8.3"
+version = "0.8.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.relative-path]]
@@ -1380,7 +1368,7 @@ version = "1.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.roaring]]
-version = "0.10.3"
+version = "0.10.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.robust]]
@@ -1884,7 +1872,7 @@ version = "0.7.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
-version = "1.8.0"
+version = "1.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.vswhom]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -87,10 +87,6 @@ criteria = "safe-to-deploy"
 version = "0.8.11"
 criteria = "safe-to-deploy"
 
-[[exemptions.aho-corasick]]
-version = "1.1.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.alloc-no-stdlib]]
 version = "2.0.4"
 criteria = "safe-to-deploy"
@@ -227,10 +223,6 @@ criteria = "safe-to-deploy"
 version = "0.6.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.atomic-polyfill]]
-version = "1.0.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.atomic-waker]]
 version = "1.1.2"
 criteria = "safe-to-deploy"
@@ -327,20 +319,12 @@ criteria = "safe-to-deploy"
 version = "2.5.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.bstr]]
-version = "1.9.1"
-criteria = "safe-to-run"
-
 [[exemptions.bytecheck]]
 version = "0.6.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytecheck_derive]]
 version = "0.6.12"
-criteria = "safe-to-deploy"
-
-[[exemptions.byteorder]]
-version = "1.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytes]]
@@ -461,10 +445,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.criterion-plot]]
 version = "0.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.critical-section]]
-version = "1.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-deque]]
@@ -635,10 +615,6 @@ criteria = "safe-to-deploy"
 version = "0.9.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.fst]]
-version = "0.4.7"
-criteria = "safe-to-deploy"
-
 [[exemptions.funty]]
 version = "2.0.0"
 criteria = "safe-to-deploy"
@@ -703,10 +679,6 @@ criteria = "safe-to-deploy"
 version = "0.28.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.globset]]
-version = "0.4.14"
-criteria = "safe-to-run"
-
 [[exemptions.globwalk]]
 version = "0.9.1"
 criteria = "safe-to-run"
@@ -720,15 +692,7 @@ version = "5.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.hash32]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.hash32]]
 version = "0.3.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.heapless]]
-version = "0.7.17"
 criteria = "safe-to-deploy"
 
 [[exemptions.heapless]]
@@ -766,10 +730,6 @@ criteria = "safe-to-deploy"
 [[exemptions.iana-time-zone]]
 version = "0.1.60"
 criteria = "safe-to-deploy"
-
-[[exemptions.ignore]]
-version = "0.4.22"
-criteria = "safe-to-run"
 
 [[exemptions.imbl]]
 version = "2.0.3"
@@ -933,10 +893,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.md-5]]
 version = "0.10.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.memchr]]
-version = "2.7.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.memmap2]]
@@ -1307,22 +1263,6 @@ criteria = "safe-to-deploy"
 version = "0.4.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.regex]]
-version = "1.10.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-automata]]
-version = "0.1.10"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-automata]]
-version = "0.4.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.regex-syntax]]
-version = "0.8.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.relative-path]]
 version = "1.9.2"
 criteria = "safe-to-deploy"
@@ -1408,10 +1348,6 @@ version = "0.6.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.rstar]]
-version = "0.11.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rstar]]
 version = "0.12.0"
 criteria = "safe-to-deploy"
 
@@ -1473,10 +1409,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.salsa20]]
 version = "0.10.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.same-file]]
-version = "1.0.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.schannel]]
@@ -1581,10 +1513,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.snafu-derive]]
 version = "0.7.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.snap]]
-version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.socket2]]
@@ -1835,10 +1763,6 @@ criteria = "safe-to-deploy"
 version = "0.10.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.ucd-trie]]
-version = "0.1.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.ulid]]
 version = "1.1.2"
 criteria = "safe-to-deploy"
@@ -1881,10 +1805,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.vswhom-sys]]
 version = "0.1.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.walkdir]]
-version = "2.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasi]]
@@ -1941,10 +1861,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.winapi-i686-pc-windows-gnu]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.winapi-util]]
-version = "0.1.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.winapi-x86_64-pc-windows-gnu]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -16,6 +16,13 @@ user-id = 3987
 user-login = "rushmorem"
 user-name = "Rushmore Mushambi"
 
+[[publisher.aho-corasick]]
+version = "1.1.3"
+when = "2024-03-20"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.anyhow]]
 version = "1.0.81"
 when = "2024-03-12"
@@ -37,12 +44,26 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.bstr]]
+version = "1.9.1"
+when = "2024-02-24"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.bumpalo]]
 version = "3.15.4"
 when = "2024-03-07"
 user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
+
+[[publisher.byteorder]]
+version = "1.5.0"
+when = "2023-10-06"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.cexpr]]
 version = "0.6.0"
@@ -92,6 +113,20 @@ when = "2023-08-23"
 user-id = 4484
 user-login = "hsivonen"
 user-name = "Henri Sivonen"
+
+[[publisher.fst]]
+version = "0.4.7"
+when = "2021-06-06"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.globset]]
+version = "0.4.14"
+when = "2023-11-26"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.h2]]
 version = "0.3.26"
@@ -184,6 +219,13 @@ user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
+[[publisher.ignore]]
+version = "0.4.22"
+when = "2024-01-06"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.indxdb]]
 version = "0.5.0"
 when = "2024-06-10"
@@ -197,6 +239,13 @@ when = "2023-03-26"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.memchr]]
+version = "2.7.2"
+when = "2024-03-27"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.mime]]
 version = "0.3.17"
@@ -247,6 +296,41 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.regex]]
+version = "1.10.6"
+when = "2024-08-02"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.regex-automata]]
+version = "0.1.10"
+when = "2021-06-01"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.regex-automata]]
+version = "0.4.6"
+when = "2024-03-04"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.regex-syntax]]
+version = "0.6.29"
+when = "2023-03-21"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.regex-syntax]]
+version = "0.8.4"
+when = "2024-06-09"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.reqwest]]
 version = "0.12.5"
 when = "2024-06-17"
@@ -262,8 +346,8 @@ user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.revision]]
-version = "0.8.0"
-when = "2024-07-09"
+version = "0.10.0"
+when = "2024-08-31"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -276,8 +360,8 @@ user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.revision-derive]]
-version = "0.8.0"
-when = "2024-07-09"
+version = "0.10.0"
+when = "2024-08-31"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -289,9 +373,16 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.same-file]]
+version = "1.0.6"
+when = "2020-01-11"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
 [[publisher.serde]]
-version = "1.0.208"
-when = "2024-08-15"
+version = "1.0.209"
+when = "2024-08-24"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -304,22 +395,15 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_derive]]
-version = "1.0.208"
-when = "2024-08-15"
+version = "1.0.209"
+when = "2024-08-24"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.serde_json]]
-version = "1.0.122"
-when = "2024-08-01"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.serde_json]]
-version = "1.0.125"
-when = "2024-08-15"
+version = "1.0.127"
+when = "2024-08-23"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -330,6 +414,13 @@ when = "2024-03-09"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
+
+[[publisher.snap]]
+version = "1.1.1"
+when = "2023-12-05"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.storekey]]
 version = "0.5.0"
@@ -374,8 +465,8 @@ user-login = "mumoshu"
 user-name = "Yusuke Kuoka"
 
 [[publisher.surrealkv]]
-version = "0.3.3"
-when = "2024-08-14"
+version = "0.3.4"
+when = "2024-08-20"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -395,8 +486,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.syn]]
-version = "2.0.58"
-when = "2024-04-03"
+version = "2.0.77"
+when = "2024-08-31"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -407,6 +498,13 @@ when = "2024-01-04"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.ucd-trie]]
+version = "0.1.6"
+when = "2023-07-07"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[publisher.unicase]]
 version = "2.7.0"
@@ -442,6 +540,20 @@ when = "2024-07-04"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
+
+[[publisher.walkdir]]
+version = "2.5.0"
+when = "2024-03-01"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
+
+[[publisher.winapi-util]]
+version = "0.1.6"
+when = "2023-09-20"
+user-id = 189
+user-login = "BurntSushi"
+user-name = "Andrew Gallant"
 
 [[audits.bytecode-alliance.wildcard-audits.arbitrary]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -713,11 +825,6 @@ notes = """
 No `unsafe` additions or anything outside of the purview of the crate in this
 change.
 """
-
-[[audits.bytecode-alliance.audits.quote]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.23 -> 1.0.27"
 
 [[audits.bytecode-alliance.audits.rustc-demangle]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -1165,91 +1272,82 @@ criteria = "safe-to-deploy"
 delta = "1.0.78 -> 1.0.79"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.serde]]
+[[audits.google.audits.proc-macro2]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.79 -> 1.0.80"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.80 -> 1.0.81"
+notes = "Comment changes only"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj <danakj@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.81 -> 1.0.82"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.82 -> 1.0.83"
+notes = "Substantive change is replacing String with Box<str>, saving memory."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
-version = "1.0.197"
+delta = "1.0.83 -> 1.0.84"
+notes = "Only doc comment changes in `src/lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "danakj@chromium.org"
+criteria = "safe-to-deploy"
+delta = "1.0.84 -> 1.0.85"
+notes = "Test-only changes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.proc-macro2]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.85 -> 1.0.86"
 notes = """
-Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`, `'\bunsafe\b'`.
-
-There were some hits for `net`, but they were related to serialization and
-not actually opening any connections or anything like that.
-
-There were 2 hits of `unsafe` when grepping:
-* In `fn as_str` in `impl Buf`
-* In `fn serialize` in `impl Serialize for net::Ipv4Addr`
-
-Unsafe review comments can be found in https://crrev.com/c/5350573/2 (this
-review also covered `serde_json_lenient`).
-
-Version 1.0.130 of the crate has been added to Chromium in
-https://crrev.com/c/3265545.  The CL description contains a link to a
-(Google-internal, sorry) document with a mini security review.
+Comment-only changes in `build.rs`.
+Reordering of `Cargo.toml` entries.
+Just bumping up the version number in `lib.rs`.
+Config-related changes in `test_size.rs`.
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.serde]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.197 -> 1.0.198"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.serde]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.198 -> 1.0.201"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.serde]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.201 -> 1.0.202"
-notes = "Trivial changes"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.serde]]
+[[audits.google.audits.quote]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
-delta = "1.0.202 -> 1.0.203"
-notes = "s/doc_cfg/docsrs/ + tuple_impls/tuple_impl_body-related changes"
+version = "1.0.35"
+notes = """
+Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits
+(except for benign \"net\" hit in tests and \"fs\" hit in README.md)
+"""
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.serde]]
+[[audits.google.audits.quote]]
 who = "Adrian Taylor <adetaylor@chromium.org>"
 criteria = "safe-to-deploy"
-delta = "1.0.203 -> 1.0.204"
+delta = "1.0.35 -> 1.0.36"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.serde_derive]]
+[[audits.google.audits.quote]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
-version = "1.0.197"
-notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.serde_derive]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.197 -> 1.0.201"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.serde_derive]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.201 -> 1.0.202"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.serde_derive]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.202 -> 1.0.203"
-notes = "Grepped for \"unsafe\", \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.serde_derive]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.203 -> 1.0.204"
+delta = "1.0.36 -> 1.0.37"
+notes = """
+The delta just 1) inlines/expands `impl ToTokens` that used to be handled via
+`primitive!` macro and 2) adds `impl ToTokens` for `CStr` and `CString`.
+"""
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.serial_test]]
@@ -1858,48 +1956,6 @@ criteria = "safe-to-deploy"
 delta = "0.11.9 -> 0.12.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.quote]]
-who = "Nika Layzell <nika@thelayzells.com>"
-criteria = "safe-to-deploy"
-version = "1.0.18"
-notes = """
-`quote` is a utility crate used by proc-macros to generate TokenStreams
-conveniently from source code. The bulk of the logic is some complex
-interlocking `macro_rules!` macros which are used to parse and build the
-`TokenStream` within the proc-macro.
-
-This crate contains no unsafe code, and the internal logic, while difficult to
-read, is generally straightforward. I have audited the the quote macros, ident
-formatter, and runtime logic.
-"""
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.18 -> 1.0.21"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.21 -> 1.0.23"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.27 -> 1.0.28"
-notes = "Enabled on wasm targets"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.quote]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.28 -> 1.0.31"
-notes = "Minimal changes and removal of the build.rs"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.rand_core]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -2228,18 +2284,6 @@ criteria = "safe-to-deploy"
 delta = "0.12.1 -> 0.12.3"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
-[[audits.zcash.audits.quote]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.31 -> 1.0.33"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
-[[audits.zcash.audits.quote]]
-who = "Jack Grigg <jack@electriccoin.co>"
-criteria = "safe-to-deploy"
-delta = "1.0.33 -> 1.0.35"
-aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
-
 [[audits.zcash.audits.rustc-demangle]]
 who = "Sean Bowe <ewillbefull@gmail.com>"
 criteria = "safe-to-deploy"
@@ -2388,6 +2432,12 @@ criteria = "safe-to-deploy"
 delta = "1.0.60 -> 1.0.61"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
+[[audits.zcash.audits.thiserror]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.61 -> 1.0.63"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
 [[audits.zcash.audits.thiserror-impl]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -2428,6 +2478,12 @@ aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/sup
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "1.0.60 -> 1.0.61"
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.thiserror-impl]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "1.0.61 -> 1.0.63"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.thread_local]]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Since upgrading to `rust_decimal 1.36.0` there is a dependency conflict with the `rust_decimal` version in the `revision` crate.

## What does this change do?

Upgrades `revision` and upgrades a number of dependencies to be inline with the `revision crate.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #4590

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
