### PR TITLE
Fix complex Record IDs from being output incorrectly within JavaScript functions

### DIFF
--- a/core/src/fnc/script/classes/record.rs
+++ b/core/src/fnc/script/classes/record.rs
@@ -21,6 +21,7 @@ impl Record {
 					Value::Array(v) => v.into(),
 					Value::Object(v) => v.into(),
 					Value::Number(v) => v.into(),
+					Value::Uuid(v) => v.into(),
 					v => v.as_string().into(),
 				},
 			},
@@ -33,8 +34,8 @@ impl Record {
 	}
 
 	#[qjs(get)]
-	pub fn id(&self) -> String {
-		self.value.id.to_raw()
+	pub fn id(&self) -> Value {
+		self.value.id.clone().into()
 	}
 	// Compare two Record instances
 	pub fn is(a: &Record, b: &Record) -> bool {

--- a/sdk/tests/script.rs
+++ b/sdk/tests/script.rs
@@ -150,6 +150,12 @@ async fn script_function_types() -> Result<(), Error> {
 			manager = function() {
 				return new Record('user', 'joanna');
 			},
+			organisation = function() {
+				return new Record('organisation', {
+					alias: 'acme',
+					name: 'Acme Inc',
+				});
+			},
 			identifier = function() {
 				return new Uuid('03412258-988f-47cd-82db-549902cdaffe');
 			}
@@ -168,6 +174,7 @@ async fn script_function_types() -> Result<(), Error> {
 				created_at: d'1995-12-17T03:24:00Z',
 				next_signin: 1w2d6h,
 				manager: user:joanna,
+				organisation: organisation:{ alias: 'acme', name: 'Acme Inc' },
 				identifier: u'03412258-988f-47cd-82db-549902cdaffe',
 			}
 		]",


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When specifying complex Record IDs within JavaScript functions, and retrieving the `id` property, any object or array IDs are output as strings.

## What does this change do?

This change ensures that the `id` part of a complex Record ID are output as objects or arrays (and not strigs), ensuring that the output is correct and consistent with SurrealQL and surrealdb.js.

```sql
function(){
    let record = new Record('test', { some: 'thing', else: 'complex'});
    return [typeof record.id, record.id];
}
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #4386

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
