### PR TITLE
Default to true for WHEN on DEFINE EVENT statement

### DIFF
--- a/core/src/syn/parser/stmt/define.rs
+++ b/core/src/syn/parser/stmt/define.rs
@@ -3,6 +3,7 @@ use reblessive::Stk;
 use crate::cnf::EXPERIMENTAL_BEARER_ACCESS;
 use crate::sql::access_type::JwtAccessVerify;
 use crate::sql::index::HnswParams;
+use crate::sql::Value;
 use crate::{
 	sql::{
 		access_type,
@@ -738,6 +739,7 @@ impl Parser<'_> {
 		let mut res = DefineEventStatement {
 			name,
 			what,
+			when: Value::Bool(true),
 			if_not_exists,
 			overwrite,
 			..Default::default()

--- a/sdk/tests/define.rs
+++ b/sdk/tests/define.rs
@@ -344,6 +344,32 @@ async fn define_statement_event() -> Result<(), Error> {
 	Ok(())
 }
 
+// Confirms that a DEFINE EVENT with no WHERE clause will produce WHEN true
+#[tokio::test]
+async fn define_statement_event_no_when_clause() -> Result<(), Error> {
+	let sql = "
+		DEFINE EVENT some_event ON TABLE user THEN {};
+		INFO FOR TABLE user;
+	";
+	let mut t = Test::new(sql).await?;
+	//
+	t.skip_ok(1)?;
+	let val = Value::parse(
+		"{
+	events: {
+		some_event: 'DEFINE EVENT some_event ON user WHEN true THEN {  }'
+	},
+	fields: {},
+	indexes: {},
+	lives: {},
+	tables: {}
+}",
+	);
+	t.expect_value(val)?;
+	//
+	Ok(())
+}
+
 #[tokio::test]
 async fn define_statement_event_when_event() -> Result<(), Error> {
 	let sql = "


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Events without a WHERE clause currently add a `WHEN NONE` from DefineStatement::Default(), making it into an event that is never activated.

```
DEFINE EVENT track_everything ON person THEN {
    CREATE track_everything_event SET info = "Something happened to a person record!";
};

track_everything: 'DEFINE EVENT track_everything ON person WHEN NONE THEN
```
## What does this change do?

It adds a line in the same way this PR from @tobiemh did last year in the old parser. https://github.com/surrealdb/surrealdb/pull/2502/files

## What is your testing strategy?

Adds one test to assert that `WHEN true` is produced.

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
