### PR TITLE
Async indexing: support of multiple compute nodes

### DIFF
--- a/core/src/key/category.rs
+++ b/core/src/key/category.rs
@@ -138,6 +138,8 @@ pub enum Category {
 	IndexAppendings,
 	/// crate::key::index::ip                /*{ns}*{db}*{tb}+{ix}!ip{id}
 	IndexPrimaryAppending,
+	/// crate::key::index::is                /*{ns}*{db}*{tb}+{ix}!is
+	IndexBuildingStatus,
 	/// crate::key::index                    /*{ns}*{db}*{tb}+{ix}*{fd}{id}
 	Index,
 	///
@@ -215,6 +217,7 @@ impl Display for Category {
 			Self::IndexHnswVec => "IndexHnswVec",
 			Self::IndexAppendings => "IndexAppendings",
 			Self::IndexPrimaryAppending => "IndexPrimaryAppending",
+			Self::IndexBuildingStatus => "IndexBuildingStatus",
 			Self::Index => "Index",
 			Self::ChangeFeed => "ChangeFeed",
 			Self::Thing => "Thing",

--- a/core/src/key/index/is.rs
+++ b/core/src/key/index/is.rs
@@ -1,0 +1,60 @@
+//! Store appended records for concurrent index building
+use derive::Key;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Key)]
+#[non_exhaustive]
+pub struct Is<'a> {
+	__: u8,
+	_a: u8,
+	pub ns: &'a str,
+	_b: u8,
+	pub db: &'a str,
+	_c: u8,
+	pub tb: &'a str,
+	_d: u8,
+	pub ix: &'a str,
+	_e: u8,
+	_f: u8,
+	_g: u8,
+}
+
+impl<'a> Is<'a> {
+	pub fn new(ns: &'a str, db: &'a str, tb: &'a str, ix: &'a str) -> Self {
+		Self {
+			__: b'/',
+			_a: b'*',
+			ns,
+			_b: b'*',
+			db,
+			_c: b'*',
+			tb,
+			_d: b'+',
+			ix,
+			_e: b'!',
+			_f: b'i',
+			_g: b's',
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+
+	#[test]
+	fn key() {
+		use super::*;
+		let val = Is::new("testns", "testdb", "testtb", "testix");
+		let enc = Is::encode(&val).unwrap();
+		assert_eq!(
+			enc,
+			b"/*testns\0*testdb\0*testtb\0+testix\0!is",
+			"{}",
+			String::from_utf8_lossy(&enc)
+		);
+
+		let dec = Is::decode(&enc).unwrap();
+		assert_eq!(val, dec);
+	}
+}

--- a/core/src/key/index/mod.rs
+++ b/core/src/key/index/mod.rs
@@ -19,6 +19,7 @@ pub mod hs;
 pub mod hv;
 pub mod ia;
 pub mod ip;
+pub mod is;
 pub mod vm;
 
 use crate::key::category::Categorise;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The initial implementation of asynchronous indexing has been implemented for a single SurrealDB compute instance.


## What does this change do?

- The building status is stored in the KV store.
- The status includes the ID of the node that is in charge of building the index.
- If the index is deleted (by any node), the building process is stopped.

## What is your testing strategy?

Dedicated tests have been written.

## Is this related to any issues?

Follow up #4480 and #4622 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
