### PR TITLE
Fix ensuring unreachable code returns an error instead of panicking

### DIFF
--- a/core/src/dbs/iterator.rs
+++ b/core/src/dbs/iterator.rs
@@ -35,18 +35,21 @@ pub(crate) enum Iterable {
 	Index(Table, IteratorRef),
 }
 
+#[derive(Debug)]
 pub(crate) struct Processed {
 	pub(crate) rid: Option<Arc<Thing>>,
 	pub(crate) ir: Option<Arc<IteratorRecord>>,
 	pub(crate) val: Operable,
 }
 
+#[derive(Debug)]
 pub(crate) enum Operable {
 	Value(Arc<Value>),
 	Mergeable(Arc<Value>, Arc<Value>),
 	Relatable(Thing, Arc<Value>, Thing, Option<Arc<Value>>),
 }
 
+#[derive(Debug)]
 pub(crate) enum Workable {
 	Normal,
 	Insert(Arc<Value>),

--- a/core/src/doc/compute.rs
+++ b/core/src/doc/compute.rs
@@ -80,9 +80,16 @@ impl Document {
 			// Send back the result
 			let _ = chn.send(res).await;
 			// Break the loop
-			break;
+			return Ok(());
 		}
-		// Everything went ok
+		// We shouldn't really reach this part, but if we
+		// did it was probably due to the fact that we
+		// encountered two Err::RetryWithId errors due to
+		// two separtate UNIQUE index definitions, and it
+		// wasn't possible to detect which record was the
+		// correct one to be updated
+		let _ = chn.send(Err(Error::Unreachable("Internal error"))).await;
+		// Break the loop
 		Ok(())
 	}
 }

--- a/core/src/doc/process.rs
+++ b/core/src/doc/process.rs
@@ -74,7 +74,12 @@ impl Document {
 			// Send back the result
 			return res;
 		}
-		// We should never get here
-		unreachable!()
+		// We shouldn't really reach this part, but if we
+		// did it was probably due to the fact that we
+		// encountered two Err::RetryWithId errors due to
+		// two separtate UNIQUE index definitions, and it
+		// wasn't possible to detect which record was the
+		// correct one to be updated
+		Err(Error::Unreachable("Internal error"))
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

A current issue with `UNIQUE` indexes causes the server to reach a presumed `unreachable!()` code path.

## What does this change do?

Ensures that unreachable code does not panic and shut down the SurrealDB server.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Related to #3810

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
