### PR TITLE
Make sdk create consistent

### DIFF
--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -337,7 +337,7 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 
-		let one = data.is_single();
+		let one = data.is_thing_single();
 
 		let mut res = match what {
 			Value::None | Value::Null => {
@@ -376,7 +376,7 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 		// Return a single result?
-		let one = what.is_thing_single() || data.is_object();
+		let one = what.is_thing_single() || what.is_table();
 		// Specify the SQL query string
 		let sql = if data.is_none_or_null() {
 			"CREATE $what RETURN AFTER"
@@ -540,7 +540,7 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 		// Return a single result?
-		let one = kind.is_thing_single();
+		let one = from.is_single() && to.is_single();
 		// Specify the SQL query string
 		let sql = if data.is_none_or_null() {
 			"RELATE $from->$kind->$to"

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -375,6 +375,7 @@ pub trait RpcContext {
 		let Ok((what, data)) = params.needs_one_or_two() else {
 			return Err(RpcError::InvalidParams);
 		};
+		let what = what.could_be_table();
 		// Return a single result?
 		let one = what.is_thing_single() || what.is_table();
 		// Specify the SQL query string
@@ -385,7 +386,7 @@ pub trait RpcContext {
 		};
 		// Specify the query parameters
 		let var = Some(map! {
-			String::from("what") => what.could_be_table(),
+			String::from("what") => what,
 			String::from("data") => data,
 			=> &self.vars()
 		});

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -337,7 +337,7 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 
-		let one = data.is_thing_single();
+		let one = what.is_thing_single();
 
 		let mut res = match what {
 			Value::None | Value::Null => {

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -376,7 +376,7 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 		// Return a single result?
-		let one = what.is_thing_single();
+		let one = what.is_thing_single() || data.is_object();
 		// Specify the SQL query string
 		let sql = if data.is_none_or_null() {
 			"CREATE $what RETURN AFTER"

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -1166,10 +1166,7 @@ impl Value {
 	}
 
 	pub fn is_single(&self) -> bool {
-		match self {
-			Value::Array(a) if a.len() != 1 => false,
-			_ => true,
-		}
+		!matches!(self, Value::Array(a) if a.len() != 1)
 	}
 
 	// -----------------------------------

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -1166,7 +1166,11 @@ impl Value {
 	}
 
 	pub fn is_single(&self) -> bool {
-		!matches!(self, Value::Array(a) if a.len() != 1)
+		match self {
+			Value::Object(_) => true,
+			t @ Value::Thing(_) => t.is_thing_single(),
+			_ => false,
+		}
 	}
 
 	// -----------------------------------

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -1167,9 +1167,8 @@ impl Value {
 
 	pub fn is_single(&self) -> bool {
 		match self {
-			Value::Object(_) => true,
-			Value::Array(a) if a.len() == 1 => true,
-			_ => false,
+			Value::Array(a) if a.len() != 1 => false,
+			_ => true,
 		}
 	}
 

--- a/sdk/src/api/engine/local/mod.rs
+++ b/sdk/src/api/engine/local/mod.rs
@@ -547,6 +547,7 @@ async fn router(
 				stmt.what = resource_to_values(what);
 				stmt.data = data.map(Data::ContentExpression);
 				stmt.output = Some(Output::After);
+				stmt.only = true;
 				stmt
 			};
 			query.0 .0 = vec![Statement::Create(statement)];

--- a/sdk/src/api/engine/local/mod.rs
+++ b/sdk/src/api/engine/local/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 		Connect, Response as QueryResponse, Result, Surreal,
 	},
 	method::Stats,
-	opt::{IntoEndpoint, Resource as ApiResource, Table},
+	opt::{IntoEndpoint, Table},
 	value::Notification,
 };
 use channel::Sender;
@@ -559,7 +559,7 @@ async fn router(
 			data,
 		} => {
 			let mut query = Query::default();
-			let one = matches!(what, ApiResource::RecordId(_));
+			let one = what.is_single_recordid();
 			let statement = {
 				let mut stmt = UpsertStatement::default();
 				stmt.what = resource_to_values(what);
@@ -578,7 +578,7 @@ async fn router(
 			data,
 		} => {
 			let mut query = Query::default();
-			let one = matches!(what, ApiResource::RecordId(_));
+			let one = what.is_single_recordid();
 			let statement = {
 				let mut stmt = UpdateStatement::default();
 				stmt.what = resource_to_values(what);
@@ -635,7 +635,7 @@ async fn router(
 			data,
 		} => {
 			let mut query = Query::default();
-			let one = matches!(what, ApiResource::RecordId(_));
+			let one = what.is_single_recordid();
 			let statement = {
 				let mut stmt = UpdateStatement::default();
 				stmt.what = resource_to_values(what);
@@ -654,7 +654,7 @@ async fn router(
 			data,
 		} => {
 			let mut query = Query::default();
-			let one = matches!(what, ApiResource::RecordId(_));
+			let one = what.is_single_recordid();
 			let statement = {
 				let mut stmt = UpdateStatement::default();
 				stmt.what = resource_to_values(what);
@@ -672,7 +672,7 @@ async fn router(
 			what,
 		} => {
 			let mut query = Query::default();
-			let one = matches!(what, ApiResource::RecordId(_));
+			let one = what.is_single_recordid();
 			let statement = {
 				let mut stmt = SelectStatement::default();
 				stmt.what = resource_to_values(what);
@@ -689,7 +689,7 @@ async fn router(
 			what,
 		} => {
 			let mut query = Query::default();
-			let one = matches!(what, ApiResource::RecordId(_));
+			let one = what.is_single_recordid();
 			let statement = {
 				let mut stmt = DeleteStatement::default();
 				stmt.what = resource_to_values(what);

--- a/sdk/src/api/engine/local/mod.rs
+++ b/sdk/src/api/engine/local/mod.rs
@@ -547,7 +547,6 @@ async fn router(
 				stmt.what = resource_to_values(what);
 				stmt.data = data.map(Data::ContentExpression);
 				stmt.output = Some(Output::After);
-				stmt.only = true;
 				stmt
 			};
 			query.0 .0 = vec![Statement::Create(statement)];

--- a/sdk/src/api/opt/resource.rs
+++ b/sdk/src/api/opt/resource.rs
@@ -107,10 +107,7 @@ impl Resource {
 	}
 	pub fn is_single_recordid(&self) -> bool {
 		match self {
-			Resource::RecordId(rid) => match rid.into_inner_ref().id {
-				CoreId::Range(_) => false,
-				_ => true,
-			},
+			Resource::RecordId(rid) => !matches!(rid.into_inner_ref().id, CoreId::Range(_)),
 			_ => false,
 		}
 	}

--- a/sdk/src/api/opt/resource.rs
+++ b/sdk/src/api/opt/resource.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 use std::ops::{self, Bound};
 use surrealdb_core::sql::{
-	Edges as CoreEdges, IdRange as CoreIdRange, Table as CoreTable, Thing as CoreThing,
+	Edges as CoreEdges, Id as CoreId, IdRange as CoreIdRange, Table as CoreTable,
+	Thing as CoreThing,
 };
 
 #[cfg(any(feature = "protocol-ws", feature = "protocol-http"))]
@@ -102,6 +103,15 @@ impl Resource {
 			Resource::Edge(x) => x.into_inner().into(),
 			Resource::Range(x) => x.into_inner().into(),
 			Resource::Unspecified => CoreValue::None,
+		}
+	}
+	pub fn is_single_recordid(&self) -> bool {
+		match self {
+			Resource::RecordId(rid) => match rid.into_inner_ref().id {
+				CoreId::Range(_) => false,
+				_ => true,
+			},
+			_ => false,
 		}
 	}
 }

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -1,6 +1,6 @@
 use super::common::{self, Format, Socket, DB, NS, PASS, USER};
-use http::header::{HeaderMap, HeaderValue};
 use assert_fs::TempDir;
+use http::header::{HeaderMap, HeaderValue};
 use serde_json::json;
 use std::future::Future;
 use std::pin::Pin;
@@ -380,10 +380,9 @@ async fn create() -> Result<(), Box<dyn std::error::Error>> {
 		)
 		.await?;
 	assert!(res.is_object(), "result: {res:?}");
-	assert!(res["result"].is_array(), "result: {res:?}");
-	let res = res["result"].as_array().unwrap();
-	assert_eq!(res.len(), 1, "result: {res:?}");
-	assert_eq!(res[0]["value"], "bar", "result: {res:?}");
+	assert!(res["result"].is_object(), "result: {res:?}");
+	let res = res["result"].as_object().unwrap();
+	assert_eq!(res["value"], "bar", "result: {res:?}");
 	// Verify the data was created
 	let res = socket.send_message_query("SELECT * FROM tester").await?;
 	assert!(res[0]["result"].is_array(), "result: {res:?}");
@@ -1813,7 +1812,8 @@ async fn session_id_defined_generic() {
 	let (addr, mut server) = common::start_server_with_defaults().await.unwrap();
 	// We specify a request identifier via a generic header
 	let mut headers = HeaderMap::new();
-	headers.insert("x-request-id", HeaderValue::from_static("00000000-0000-0000-0000-000000000000"));
+	headers
+		.insert("x-request-id", HeaderValue::from_static("00000000-0000-0000-0000-000000000000"));
 	// Connect to WebSocket
 	let mut socket = Socket::connect_with_headers(&addr, SERVER, FORMAT, headers).await.unwrap();
 	// Authenticate the connection
@@ -1836,7 +1836,8 @@ async fn session_id_defined_both() {
 	// We specify a request identifier via both headers
 	let mut headers = HeaderMap::new();
 	headers.insert("surreal-id", HeaderValue::from_static("00000000-0000-0000-0000-000000000000"));
-	headers.insert("x-request-id", HeaderValue::from_static("aaaaaaaa-aaaa-0000-0000-000000000000"));
+	headers
+		.insert("x-request-id", HeaderValue::from_static("aaaaaaaa-aaaa-0000-0000-000000000000"));
 	// Connect to WebSocket
 	let mut socket = Socket::connect_with_headers(&addr, SERVER, FORMAT, headers).await.unwrap();
 	// Authenticate the connection
@@ -1860,7 +1861,7 @@ async fn session_id_invalid() {
 	// We specify a request identifier via a specific SurrealDB header
 	let mut headers = HeaderMap::new();
 	headers.insert("surreal-id", HeaderValue::from_static("123")); // Not a valid UUIDv4
-	// Connect to WebSocket
+															   // Connect to WebSocket
 	let socket = Socket::connect_with_headers(&addr, SERVER, FORMAT, headers).await;
 	assert!(socket.is_err(), "unexpected success using connecting with invalid id header");
 

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -1812,8 +1812,7 @@ async fn session_id_defined_generic() {
 	let (addr, mut server) = common::start_server_with_defaults().await.unwrap();
 	// We specify a request identifier via a generic header
 	let mut headers = HeaderMap::new();
-	headers
-		.insert("x-request-id", HeaderValue::from_static("00000000-0000-0000-0000-000000000000"));
+	headers.insert("x-request-id", HeaderValue::from_static("00000000-0000-0000-0000-000000000000"));
 	// Connect to WebSocket
 	let mut socket = Socket::connect_with_headers(&addr, SERVER, FORMAT, headers).await.unwrap();
 	// Authenticate the connection
@@ -1836,8 +1835,7 @@ async fn session_id_defined_both() {
 	// We specify a request identifier via both headers
 	let mut headers = HeaderMap::new();
 	headers.insert("surreal-id", HeaderValue::from_static("00000000-0000-0000-0000-000000000000"));
-	headers
-		.insert("x-request-id", HeaderValue::from_static("aaaaaaaa-aaaa-0000-0000-000000000000"));
+	headers.insert("x-request-id", HeaderValue::from_static("aaaaaaaa-aaaa-0000-0000-000000000000"));
 	// Connect to WebSocket
 	let mut socket = Socket::connect_with_headers(&addr, SERVER, FORMAT, headers).await.unwrap();
 	// Authenticate the connection
@@ -1861,7 +1859,7 @@ async fn session_id_invalid() {
 	// We specify a request identifier via a specific SurrealDB header
 	let mut headers = HeaderMap::new();
 	headers.insert("surreal-id", HeaderValue::from_static("123")); // Not a valid UUIDv4
-															   // Connect to WebSocket
+	// Connect to WebSocket
 	let socket = Socket::connect_with_headers(&addr, SERVER, FORMAT, headers).await;
 	assert!(socket.is_err(), "unexpected success using connecting with invalid id header");
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

on rpc create returned an array when it should return an Object

## What does this change do?

return an object when sent a create method with object data

## What is your testing strategy?

testing in sdks which use rpc

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
