### PR TITLE
Convert `unreachable!()` code to `Error::Unreachable` errors in core

### DIFF
--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -179,7 +179,7 @@ impl MutableContext {
 	pub(crate) fn unfreeze(ctx: Context) -> Result<MutableContext, Error> {
 		match Arc::try_unwrap(ctx) {
 			Ok(inner) => Ok(inner),
-			Err(_) => Err(Error::Unreachable("Context::unfreeze")),
+			Err(_) => Err(fail!("Tried to unfreeze a non-existent Context")),
 		}
 	}
 

--- a/core/src/dbs/group.rs
+++ b/core/src/dbs/group.rs
@@ -140,7 +140,7 @@ impl GroupsCollector {
 										let x = if matches!(a, OptimisedAggregate::None) {
 											// The aggregation is not optimised, let's compute it with the values
 											let vals = agr.take();
-											f.aggregate(vals).compute(stk, ctx, opt, None).await?
+											f.aggregate(vals)?.compute(stk, ctx, opt, None).await?
 										} else {
 											// The aggregation is optimised, just get the value
 											agr.compute(a)?
@@ -264,7 +264,7 @@ impl Aggregator {
 			*c += 1;
 		}
 		if let Some((ref f, ref mut c)) = self.count_function {
-			if f.aggregate(val.clone()).compute(stk, ctx, opt, None).await?.is_truthy() {
+			if f.aggregate(val.clone())?.compute(stk, ctx, opt, None).await?.is_truthy() {
 				*c += 1;
 			}
 		}

--- a/core/src/dbs/options.rs
+++ b/core/src/dbs/options.rs
@@ -369,7 +369,7 @@ impl Options {
 	/// Get current Node ID
 	#[inline(always)]
 	pub fn id(&self) -> Result<Uuid, Error> {
-		self.id.ok_or(Error::Unreachable("No Node ID is specified"))
+		self.id.ok_or_else(|| fail!("No Node ID is specified"))
 	}
 
 	/// Get currently selected NS

--- a/core/src/doc/compute.rs
+++ b/core/src/doc/compute.rs
@@ -43,7 +43,7 @@ impl Document {
 				Statement::Relate(_) => doc.relate(stk, ctx, opt, stm).await,
 				Statement::Delete(_) => doc.delete(stk, ctx, opt, stm).await,
 				Statement::Insert(_) => doc.insert(stk, ctx, opt, stm).await,
-				_ => unreachable!(),
+				_ => return Err(fail!("Unexpected statement type")),
 			};
 			// Check the result
 			let res = match res {

--- a/core/src/doc/process.rs
+++ b/core/src/doc/process.rs
@@ -37,7 +37,7 @@ impl Document {
 				Statement::Relate(_) => doc.relate(stk, ctx, opt, stm).await,
 				Statement::Delete(_) => doc.delete(stk, ctx, opt, stm).await,
 				Statement::Insert(_) => doc.insert(stk, ctx, opt, stm).await,
-				_ => unreachable!(),
+				stm => return Err(fail!("Unexpected statement type: {stm:?}")),
 			};
 			// Check the result
 			let res = match res {

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -48,7 +48,7 @@ pub enum Error {
 
 	/// The database encountered unreachable logic
 	#[error("The database encountered unreachable logic: {0}")]
-	Unreachable(&'static str),
+	Unreachable(String),
 
 	/// Statement has been deprecated
 	#[error("{0}")]

--- a/core/src/idx/trees/bkeys.rs
+++ b/core/src/idx/trees/bkeys.rs
@@ -103,7 +103,7 @@ impl BKeys for FstKeys {
 	}
 
 	fn collect_with_prefix(&self, _prefix_key: &Key) -> Result<VecDeque<(Key, Payload)>, Error> {
-		Err(Error::Unreachable("BKeys/FSTKeys::collect_with_prefix"))
+		Err(fail!("BKeys/FSTKeys::collect_with_prefix"))
 	}
 
 	fn insert(&mut self, key: Key, payload: Payload) -> Option<Payload> {
@@ -159,7 +159,7 @@ impl BKeys for FstKeys {
 				median_payload: s.median_payload,
 			})
 		} else {
-			Err(Error::Unreachable("BKeys/FSTKeys::split_keys"))
+			Err(fail!("BKeys/FSTKeys::split_keys"))
 		}
 	}
 
@@ -377,7 +377,7 @@ impl BKeys for TrieKeys {
 		let (median_key, median_payload) = if let Some((k, v)) = s.next() {
 			(k.clone(), *v)
 		} else {
-			return Err(Error::Unreachable("BKeys/TrieKeys::split_keys"));
+			return Err(fail!("BKeys/TrieKeys::split_keys"));
 		};
 		let mut right = Trie::default();
 		for (key, val) in s {

--- a/core/src/idx/trees/btree.rs
+++ b/core/src/idx/trees/btree.rs
@@ -571,7 +571,7 @@ where
 								if let Some(root_id) = self.state.root {
 									// Delete the old root node
 									if root_id != node.id {
-										return Err(Error::Unreachable("BTree::delete"));
+										return Err(fail!("BTree::delete"));
 									}
 								}
 								store.remove_node(node.id, node.key).await?;
@@ -684,7 +684,7 @@ where
 				}
 				BTreeNode::Leaf(k) => {
 					let (key, payload) =
-						k.get_last_key().ok_or(Error::Unreachable("BTree::find_highest(1)"))?;
+						k.get_last_key().ok_or_else(|| fail!("BTree::find_highest(1)"))?;
 					#[cfg(debug_assertions)]
 					debug!("Find highest: {} - node: {}", String::from_utf8_lossy(&key), node);
 					store.set_node(node, false).await?;
@@ -692,7 +692,7 @@ where
 				}
 			}
 		}
-		Err(Error::Unreachable("BTree::find_highest(2)"))
+		Err(fail!("BTree::find_highest(2)"))
 	}
 
 	async fn find_lowest(
@@ -712,7 +712,7 @@ where
 				}
 				BTreeNode::Leaf(k) => {
 					let (key, payload) =
-						k.get_first_key().ok_or(Error::Unreachable("BTree::find_lowest(1)"))?;
+						k.get_first_key().ok_or_else(|| fail!("BTree::find_lowest(1)"))?;
 					#[cfg(debug_assertions)]
 					debug!("Find lowest: {} - node: {}", String::from_utf8_lossy(&key), node.id);
 					store.set_node(node, false).await?;
@@ -720,7 +720,7 @@ where
 				}
 			}
 		}
-		Err(Error::Unreachable("BTree::find_lowest(2)"))
+		Err(fail!("BTree::find_lowest(2)"))
 	}
 
 	async fn deleted_traversal(

--- a/core/src/idx/trees/hnsw/layer.rs
+++ b/core/src/idx/trees/hnsw/layer.rs
@@ -389,8 +389,7 @@ where
 		// Load the chunks
 		for i in 0..st.chunks {
 			let key = self.ikb.new_hl_key(self.level, i);
-			let chunk =
-				tx.get(key, None).await?.ok_or_else(|| Error::Unreachable("Missing chunk"))?;
+			let chunk = tx.get(key, None).await?.ok_or_else(|| fail!("Missing chunk"))?;
 			val.extend(chunk);
 		}
 		// Rebuild the graph

--- a/core/src/idx/trees/mtree.rs
+++ b/core/src/idx/trees/mtree.rs
@@ -225,7 +225,7 @@ impl MTree {
 			{
 				debug!("Visit node id: {}", id);
 				if visited_nodes.insert(id, node.n.len()).is_some() {
-					return Err(Error::Unreachable("MTree::knn_search"));
+					return Err(fail!("MTree::knn_search"));
 				}
 			}
 			match node.n {
@@ -552,7 +552,7 @@ impl MTree {
 		if let Some((o, p)) = closest {
 			Ok((o, p))
 		} else {
-			Err(Error::Unreachable("MTree::find_closest"))
+			Err(fail!("MTree::find_closest"))
 		}
 	}
 
@@ -659,7 +659,7 @@ impl MTree {
 
 		#[cfg(debug_assertions)]
 		if p1.node == p2.node {
-			return Err(Error::Unreachable("MTree::split_node"));
+			return Err(fail!("MTree::split_node"));
 		}
 		Ok((o1, p1, o2, p2))
 	}
@@ -702,7 +702,7 @@ impl MTree {
 			assert_eq!(dist_cache.len(), n * n - n);
 		}
 		match promo {
-			None => Err(Error::Unreachable("MTree::compute_distances_and_promoted_objects")),
+			None => Err(fail!("MTree::compute_distances_and_promoted_objects")),
 			Some((p1, p2)) => Ok((DistanceCache(dist_cache), p1, p2)),
 		}
 	}
@@ -771,7 +771,7 @@ impl MTree {
 						}
 						1 => {
 							store.remove_node(sn.id, sn.key).await?;
-							let e = n.values().next().ok_or(Error::Unreachable("MTree::delete"))?;
+							let e = n.values().next().ok_or_else(|| fail!("MTree::delete"))?;
 							self.set_root(Some(e.node));
 							return Ok(deleted);
 						}
@@ -1217,13 +1217,13 @@ impl MTreeNode {
 	fn internal(self) -> Result<InternalNode, Error> {
 		match self {
 			MTreeNode::Internal(n) => Ok(n),
-			MTreeNode::Leaf(_) => Err(Error::Unreachable("MTreeNode::internal")),
+			MTreeNode::Leaf(_) => Err(fail!("MTreeNode::internal")),
 		}
 	}
 
 	fn leaf(self) -> Result<LeafNode, Error> {
 		match self {
-			MTreeNode::Internal(_) => Err(Error::Unreachable("MTreeNode::lead")),
+			MTreeNode::Internal(_) => Err(fail!("MTreeNode::lead")),
 			MTreeNode::Leaf(n) => Ok(n),
 		}
 	}
@@ -1238,7 +1238,7 @@ impl MTreeNode {
 				Self::merge_leaf(s, o);
 				Ok(())
 			}
-			(_, _) => Err(Error::Unreachable("MTreeNode::merge")),
+			(_, _) => Err(fail!("MTreeNode::merge")),
 		}
 	}
 
@@ -1309,7 +1309,7 @@ impl NodeVectors for LeafNode {
 		let mut r = 0f64;
 		for o in a {
 			let mut props =
-				self.remove(&o).ok_or(Error::Unreachable("NodeVectors/LeafNode::extract_node)"))?;
+				self.remove(&o).ok_or_else(|| fail!("NodeVectors/LeafNode::extract_node)"))?;
 			let dist = *distances.0.get(&(o.clone(), p.clone())).unwrap_or(&0f64);
 			if dist > r {
 				r = dist;
@@ -1343,9 +1343,8 @@ impl NodeVectors for InternalNode {
 		let mut n = InternalNode::new();
 		let mut max_r = 0f64;
 		for o in a {
-			let mut props = self
-				.remove(&o)
-				.ok_or(Error::Unreachable("NodeVectors/InternalNode::extract_node"))?;
+			let mut props =
+				self.remove(&o).ok_or_else(|| fail!("NodeVectors/InternalNode::extract_node"))?;
 			let dist = *distances.0.get(&(o.clone(), p.clone())).unwrap_or(&0f64);
 			let r = dist + props.radius;
 			if r > max_r {

--- a/core/src/idx/trees/store/mod.rs
+++ b/core/src/idx/trees/store/mod.rs
@@ -52,7 +52,7 @@ where
 	) -> Result<StoredNode<N>, Error> {
 		match self {
 			Self::Write(w) => w.get_node_mut(tx, node_id).await,
-			_ => Err(Error::Unreachable("TreeStore::get_node_mut")),
+			_ => Err(fail!("TreeStore::get_node_mut")),
 		}
 	}
 
@@ -63,7 +63,7 @@ where
 	) -> Result<Arc<StoredNode<N>>, Error> {
 		match self {
 			Self::Read(r) => r.get_node(tx, node_id).await,
-			_ => Err(Error::Unreachable("TreeStore::get_node")),
+			_ => Err(fail!("TreeStore::get_node")),
 		}
 	}
 
@@ -77,7 +77,7 @@ where
 				let tx = ctx.tx();
 				r.get_node(&tx, node_id).await
 			}
-			_ => Err(Error::Unreachable("TreeStore::get_node_txn")),
+			_ => Err(fail!("TreeStore::get_node_txn")),
 		}
 	}
 
@@ -88,14 +88,14 @@ where
 	) -> Result<(), Error> {
 		match self {
 			Self::Write(w) => w.set_node(node, updated),
-			_ => Err(Error::Unreachable("TreeStore::set_node")),
+			_ => Err(fail!("TreeStore::set_node")),
 		}
 	}
 
 	pub(in crate::idx) fn new_node(&mut self, id: NodeId, node: N) -> Result<StoredNode<N>, Error> {
 		match self {
 			Self::Write(w) => Ok(w.new_node(id, node)),
-			_ => Err(Error::Unreachable("TreeStore::new_node")),
+			_ => Err(fail!("TreeStore::new_node")),
 		}
 	}
 
@@ -106,7 +106,7 @@ where
 	) -> Result<(), Error> {
 		match self {
 			Self::Write(w) => w.remove_node(node_id, node_key),
-			_ => Err(Error::Unreachable("TreeStore::remove_node")),
+			_ => Err(fail!("TreeStore::remove_node")),
 		}
 	}
 

--- a/core/src/idx/trees/store/tree.rs
+++ b/core/src/idx/trees/store/tree.rs
@@ -48,7 +48,7 @@ where
 		{
 			self.out.insert(node_id);
 			if self.removed.contains_key(&node_id) {
-				return Err(Error::Unreachable("TreeTransactionWrite::get_node_mut"));
+				return Err(fail!("TreeTransactionWrite::get_node_mut"));
 			}
 		}
 		if let Some(n) = self.nodes.remove(&node_id) {
@@ -68,7 +68,7 @@ where
 			self.cached.remove(&node.id);
 		}
 		if self.removed.contains_key(&node.id) {
-			return Err(Error::Unreachable("TreeTransactionWrite::set_node(2)"));
+			return Err(fail!("TreeTransactionWrite::set_node(2)"));
 		}
 		self.nodes.insert(node.id, node);
 		Ok(())
@@ -85,7 +85,7 @@ where
 		#[cfg(debug_assertions)]
 		{
 			if self.nodes.contains_key(&node_id) {
-				return Err(Error::Unreachable("TreeTransactionWrite::remove_node"));
+				return Err(fail!("TreeTransactionWrite::remove_node"));
 			}
 			self.out.remove(&node_id);
 		}
@@ -99,7 +99,7 @@ where
 		#[cfg(debug_assertions)]
 		{
 			if !self.out.is_empty() {
-				return Err(Error::Unreachable("TreeTransactionWrite::finish(1)"));
+				return Err(fail!("TreeTransactionWrite::finish(1)"));
 			}
 		}
 		if self.updated.is_empty() && self.removed.is_empty() {
@@ -116,7 +116,7 @@ where
 				// Update the cache with updated entries.
 				new_cache.set_node(node).await;
 			} else {
-				return Err(Error::Unreachable("TreeTransactionWrite::finish(2)"));
+				return Err(fail!("TreeTransactionWrite::finish(2)"));
 			}
 		}
 		let removed = mem::take(&mut self.removed);

--- a/core/src/kvs/api.rs
+++ b/core/src/kvs/api.rs
@@ -268,11 +268,13 @@ pub trait Transaction {
 					}),
 					values: res,
 				}),
-				// We have checked the length above,
-				// so there is guaranteed to always
-				// be a last item in the vector.
-				// This is therefore unreachable.
-				None => unreachable!(),
+				// We have checked the length above, so
+				// there should be a last item in the
+				// vector, so we shouldn't arrive here
+				None => Ok(Batch {
+					next: None,
+					values: res,
+				}),
 			}
 		}
 	}

--- a/core/src/kvs/cache.rs
+++ b/core/src/kvs/cache.rs
@@ -1,5 +1,6 @@
 use super::Key;
 use crate::dbs::node::Node;
+use crate::err::Error;
 use crate::sql::statements::AccessGrant;
 use crate::sql::statements::DefineAccessStatement;
 use crate::sql::statements::DefineAnalyzerStatement;
@@ -97,194 +98,196 @@ pub(super) enum Entry {
 impl Entry {
 	/// Converts this cache entry into a single entry of arbitrary type.
 	/// This panics if called on a cache entry that is not an [`Entry::Any`].
-	pub(super) fn into_type<T: Send + Sync + 'static>(self: Entry) -> Arc<T> {
+	pub(super) fn try_into_type<T: Send + Sync + 'static>(self: Entry) -> Result<Arc<T>, Error> {
 		match self {
-			Entry::Any(v) => v.downcast::<T>().unwrap(),
-			_ => unreachable!(),
+			Entry::Any(v) => v
+				.downcast::<T>()
+				.map_err(|_| Error::Unreachable("Unable to convert type into Entry::Any")),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Any")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`Node`].
 	/// This panics if called on a cache entry that is not an [`Entry::Nds`].
-	pub(super) fn into_nds(self) -> Arc<[Node]> {
+	pub(super) fn try_into_nds(self) -> Result<Arc<[Node]>, Error> {
 		match self {
-			Entry::Nds(v) => v,
-			_ => unreachable!(),
+			Entry::Nds(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Nds")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineUserStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Rus`].
-	pub(super) fn into_rus(self) -> Arc<[DefineUserStatement]> {
+	pub(super) fn try_into_rus(self) -> Result<Arc<[DefineUserStatement]>, Error> {
 		match self {
-			Entry::Rus(v) => v,
-			_ => unreachable!(),
+			Entry::Rus(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Rus")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineAccessStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Ras`].
-	pub(super) fn into_ras(self) -> Arc<[DefineAccessStatement]> {
+	pub(super) fn try_into_ras(self) -> Result<Arc<[DefineAccessStatement]>, Error> {
 		match self {
-			Entry::Ras(v) => v,
-			_ => unreachable!(),
+			Entry::Ras(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Ras")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`AccessGrant`].
 	/// This panics if called on a cache entry that is not an [`Entry::Rag`].
-	pub(super) fn into_rag(self) -> Arc<[AccessGrant]> {
+	pub(super) fn try_into_rag(self) -> Result<Arc<[AccessGrant]>, Error> {
 		match self {
-			Entry::Rag(v) => v,
-			_ => unreachable!(),
+			Entry::Rag(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Rag")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineNamespaceStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Nss`].
-	pub(super) fn into_nss(self) -> Arc<[DefineNamespaceStatement]> {
+	pub(super) fn try_into_nss(self) -> Result<Arc<[DefineNamespaceStatement]>, Error> {
 		match self {
-			Entry::Nss(v) => v,
-			_ => unreachable!(),
+			Entry::Nss(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Nss")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineAccessStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Nas`].
-	pub(super) fn into_nas(self) -> Arc<[DefineAccessStatement]> {
+	pub(super) fn try_into_nas(self) -> Result<Arc<[DefineAccessStatement]>, Error> {
 		match self {
-			Entry::Nas(v) => v,
-			_ => unreachable!(),
+			Entry::Nas(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Nas")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`AccessGrant`].
 	/// This panics if called on a cache entry that is not an [`Entry::Nag`].
-	pub(super) fn into_nag(self) -> Arc<[AccessGrant]> {
+	pub(super) fn try_into_nag(self) -> Result<Arc<[AccessGrant]>, Error> {
 		match self {
-			Entry::Nag(v) => v,
-			_ => unreachable!(),
+			Entry::Nag(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Nag")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineUserStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Nus`].
-	pub(super) fn into_nus(self) -> Arc<[DefineUserStatement]> {
+	pub(super) fn try_into_nus(self) -> Result<Arc<[DefineUserStatement]>, Error> {
 		match self {
-			Entry::Nus(v) => v,
-			_ => unreachable!(),
+			Entry::Nus(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Nus")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineDatabaseStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Dbs`].
-	pub(super) fn into_dbs(self) -> Arc<[DefineDatabaseStatement]> {
+	pub(super) fn try_into_dbs(self) -> Result<Arc<[DefineDatabaseStatement]>, Error> {
 		match self {
-			Entry::Dbs(v) => v,
-			_ => unreachable!(),
+			Entry::Dbs(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Dbs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineAccessStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Das`].
-	pub(super) fn into_das(self) -> Arc<[DefineAccessStatement]> {
+	pub(super) fn try_into_das(self) -> Result<Arc<[DefineAccessStatement]>, Error> {
 		match self {
-			Entry::Das(v) => v,
-			_ => unreachable!(),
+			Entry::Das(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Das")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`AccessGrant`].
 	/// This panics if called on a cache entry that is not an [`Entry::Dag`].
-	pub(super) fn into_dag(self) -> Arc<[AccessGrant]> {
+	pub(super) fn try_into_dag(self) -> Result<Arc<[AccessGrant]>, Error> {
 		match self {
-			Entry::Dag(v) => v,
-			_ => unreachable!(),
+			Entry::Dag(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Dag")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineUserStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Dus`].
-	pub(super) fn into_dus(self) -> Arc<[DefineUserStatement]> {
+	pub(super) fn try_into_dus(self) -> Result<Arc<[DefineUserStatement]>, Error> {
 		match self {
-			Entry::Dus(v) => v,
-			_ => unreachable!(),
+			Entry::Dus(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Dus")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineAnalyzerStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Azs`].
-	pub(super) fn into_azs(self) -> Arc<[DefineAnalyzerStatement]> {
+	pub(super) fn try_into_azs(self) -> Result<Arc<[DefineAnalyzerStatement]>, Error> {
 		match self {
-			Entry::Azs(v) => v,
-			_ => unreachable!(),
+			Entry::Azs(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Azs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineFunctionStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Fcs`].
-	pub(super) fn into_fcs(self) -> Arc<[DefineFunctionStatement]> {
+	pub(super) fn try_into_fcs(self) -> Result<Arc<[DefineFunctionStatement]>, Error> {
 		match self {
-			Entry::Fcs(v) => v,
-			_ => unreachable!(),
+			Entry::Fcs(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Fcs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineParamStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Pas`].
-	pub(super) fn into_pas(self) -> Arc<[DefineParamStatement]> {
+	pub(super) fn try_into_pas(self) -> Result<Arc<[DefineParamStatement]>, Error> {
 		match self {
-			Entry::Pas(v) => v,
-			_ => unreachable!(),
+			Entry::Pas(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Pas")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineModelStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Mls`].
-	pub(super) fn into_mls(self) -> Arc<[DefineModelStatement]> {
+	pub(super) fn try_into_mls(self) -> Result<Arc<[DefineModelStatement]>, Error> {
 		match self {
-			Entry::Mls(v) => v,
-			_ => unreachable!(),
+			Entry::Mls(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Mls")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineTableStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Tbs`].
-	pub(super) fn into_tbs(self) -> Arc<[DefineTableStatement]> {
+	pub(super) fn try_into_tbs(self) -> Result<Arc<[DefineTableStatement]>, Error> {
 		match self {
-			Entry::Tbs(v) => v,
-			_ => unreachable!(),
+			Entry::Tbs(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Tbs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineEventStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Evs`].
-	pub(super) fn into_evs(self) -> Arc<[DefineEventStatement]> {
+	pub(super) fn try_into_evs(self) -> Result<Arc<[DefineEventStatement]>, Error> {
 		match self {
-			Entry::Evs(v) => v,
-			_ => unreachable!(),
+			Entry::Evs(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Evs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineFieldStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Fds`].
-	pub(super) fn into_fds(self) -> Arc<[DefineFieldStatement]> {
+	pub(super) fn try_into_fds(self) -> Result<Arc<[DefineFieldStatement]>, Error> {
 		match self {
-			Entry::Fds(v) => v,
-			_ => unreachable!(),
+			Entry::Fds(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Fds")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineIndexStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Ixs`].
-	pub(super) fn into_ixs(self) -> Arc<[DefineIndexStatement]> {
+	pub(super) fn try_into_ixs(self) -> Result<Arc<[DefineIndexStatement]>, Error> {
 		match self {
-			Entry::Ixs(v) => v,
-			_ => unreachable!(),
+			Entry::Ixs(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Ixs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineTableStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Fts`].
-	pub(super) fn into_fts(self) -> Arc<[DefineTableStatement]> {
+	pub(super) fn try_into_fts(self) -> Result<Arc<[DefineTableStatement]>, Error> {
 		match self {
-			Entry::Fts(v) => v,
-			_ => unreachable!(),
+			Entry::Fts(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Fts")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`LiveStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Lvs`].
-	pub(super) fn into_lvs(self) -> Arc<[LiveStatement]> {
+	pub(super) fn try_into_lvs(self) -> Result<Arc<[LiveStatement]>, Error> {
 		match self {
-			Entry::Lvs(v) => v,
-			_ => unreachable!(),
+			Entry::Lvs(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Lvs")),
 		}
 	}
 	/// Converts this cache entry into a single [`Value`].
 	/// This panics if called on a cache entry that is not an [`Entry::Val`].
-	pub(super) fn into_val(self) -> Arc<Value> {
+	pub(super) fn try_into_val(self) -> Result<Arc<Value>, Error> {
 		match self {
-			Entry::Val(v) => v,
-			_ => unreachable!(),
+			Entry::Val(v) => Ok(v),
+			_ => Err(Error::Unreachable("Unable to convert type into Entry::Val")),
 		}
 	}
 }

--- a/core/src/kvs/cache.rs
+++ b/core/src/kvs/cache.rs
@@ -100,10 +100,10 @@ impl Entry {
 	/// This panics if called on a cache entry that is not an [`Entry::Any`].
 	pub(super) fn try_into_type<T: Send + Sync + 'static>(self: Entry) -> Result<Arc<T>, Error> {
 		match self {
-			Entry::Any(v) => v
-				.downcast::<T>()
-				.map_err(|_| Error::Unreachable("Unable to convert type into Entry::Any")),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Any")),
+			Entry::Any(v) => {
+				v.downcast::<T>().map_err(|_| fail!("Unable to convert type into Entry::Any"))
+			}
+			_ => Err(fail!("Unable to convert type into Entry::Any")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`Node`].
@@ -111,7 +111,7 @@ impl Entry {
 	pub(super) fn try_into_nds(self) -> Result<Arc<[Node]>, Error> {
 		match self {
 			Entry::Nds(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Nds")),
+			_ => Err(fail!("Unable to convert type into Entry::Nds")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineUserStatement`].
@@ -119,7 +119,7 @@ impl Entry {
 	pub(super) fn try_into_rus(self) -> Result<Arc<[DefineUserStatement]>, Error> {
 		match self {
 			Entry::Rus(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Rus")),
+			_ => Err(fail!("Unable to convert type into Entry::Rus")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineAccessStatement`].
@@ -127,7 +127,7 @@ impl Entry {
 	pub(super) fn try_into_ras(self) -> Result<Arc<[DefineAccessStatement]>, Error> {
 		match self {
 			Entry::Ras(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Ras")),
+			_ => Err(fail!("Unable to convert type into Entry::Ras")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`AccessGrant`].
@@ -135,7 +135,7 @@ impl Entry {
 	pub(super) fn try_into_rag(self) -> Result<Arc<[AccessGrant]>, Error> {
 		match self {
 			Entry::Rag(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Rag")),
+			_ => Err(fail!("Unable to convert type into Entry::Rag")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineNamespaceStatement`].
@@ -143,7 +143,7 @@ impl Entry {
 	pub(super) fn try_into_nss(self) -> Result<Arc<[DefineNamespaceStatement]>, Error> {
 		match self {
 			Entry::Nss(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Nss")),
+			_ => Err(fail!("Unable to convert type into Entry::Nss")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineAccessStatement`].
@@ -151,7 +151,7 @@ impl Entry {
 	pub(super) fn try_into_nas(self) -> Result<Arc<[DefineAccessStatement]>, Error> {
 		match self {
 			Entry::Nas(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Nas")),
+			_ => Err(fail!("Unable to convert type into Entry::Nas")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`AccessGrant`].
@@ -159,7 +159,7 @@ impl Entry {
 	pub(super) fn try_into_nag(self) -> Result<Arc<[AccessGrant]>, Error> {
 		match self {
 			Entry::Nag(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Nag")),
+			_ => Err(fail!("Unable to convert type into Entry::Nag")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineUserStatement`].
@@ -167,7 +167,7 @@ impl Entry {
 	pub(super) fn try_into_nus(self) -> Result<Arc<[DefineUserStatement]>, Error> {
 		match self {
 			Entry::Nus(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Nus")),
+			_ => Err(fail!("Unable to convert type into Entry::Nus")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineDatabaseStatement`].
@@ -175,7 +175,7 @@ impl Entry {
 	pub(super) fn try_into_dbs(self) -> Result<Arc<[DefineDatabaseStatement]>, Error> {
 		match self {
 			Entry::Dbs(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Dbs")),
+			_ => Err(fail!("Unable to convert type into Entry::Dbs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineAccessStatement`].
@@ -183,7 +183,7 @@ impl Entry {
 	pub(super) fn try_into_das(self) -> Result<Arc<[DefineAccessStatement]>, Error> {
 		match self {
 			Entry::Das(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Das")),
+			_ => Err(fail!("Unable to convert type into Entry::Das")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`AccessGrant`].
@@ -191,7 +191,7 @@ impl Entry {
 	pub(super) fn try_into_dag(self) -> Result<Arc<[AccessGrant]>, Error> {
 		match self {
 			Entry::Dag(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Dag")),
+			_ => Err(fail!("Unable to convert type into Entry::Dag")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineUserStatement`].
@@ -199,7 +199,7 @@ impl Entry {
 	pub(super) fn try_into_dus(self) -> Result<Arc<[DefineUserStatement]>, Error> {
 		match self {
 			Entry::Dus(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Dus")),
+			_ => Err(fail!("Unable to convert type into Entry::Dus")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineAnalyzerStatement`].
@@ -207,7 +207,7 @@ impl Entry {
 	pub(super) fn try_into_azs(self) -> Result<Arc<[DefineAnalyzerStatement]>, Error> {
 		match self {
 			Entry::Azs(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Azs")),
+			_ => Err(fail!("Unable to convert type into Entry::Azs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineFunctionStatement`].
@@ -215,7 +215,7 @@ impl Entry {
 	pub(super) fn try_into_fcs(self) -> Result<Arc<[DefineFunctionStatement]>, Error> {
 		match self {
 			Entry::Fcs(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Fcs")),
+			_ => Err(fail!("Unable to convert type into Entry::Fcs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineParamStatement`].
@@ -223,7 +223,7 @@ impl Entry {
 	pub(super) fn try_into_pas(self) -> Result<Arc<[DefineParamStatement]>, Error> {
 		match self {
 			Entry::Pas(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Pas")),
+			_ => Err(fail!("Unable to convert type into Entry::Pas")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineModelStatement`].
@@ -231,7 +231,7 @@ impl Entry {
 	pub(super) fn try_into_mls(self) -> Result<Arc<[DefineModelStatement]>, Error> {
 		match self {
 			Entry::Mls(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Mls")),
+			_ => Err(fail!("Unable to convert type into Entry::Mls")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineTableStatement`].
@@ -239,7 +239,7 @@ impl Entry {
 	pub(super) fn try_into_tbs(self) -> Result<Arc<[DefineTableStatement]>, Error> {
 		match self {
 			Entry::Tbs(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Tbs")),
+			_ => Err(fail!("Unable to convert type into Entry::Tbs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineEventStatement`].
@@ -247,7 +247,7 @@ impl Entry {
 	pub(super) fn try_into_evs(self) -> Result<Arc<[DefineEventStatement]>, Error> {
 		match self {
 			Entry::Evs(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Evs")),
+			_ => Err(fail!("Unable to convert type into Entry::Evs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineFieldStatement`].
@@ -255,7 +255,7 @@ impl Entry {
 	pub(super) fn try_into_fds(self) -> Result<Arc<[DefineFieldStatement]>, Error> {
 		match self {
 			Entry::Fds(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Fds")),
+			_ => Err(fail!("Unable to convert type into Entry::Fds")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineIndexStatement`].
@@ -263,7 +263,7 @@ impl Entry {
 	pub(super) fn try_into_ixs(self) -> Result<Arc<[DefineIndexStatement]>, Error> {
 		match self {
 			Entry::Ixs(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Ixs")),
+			_ => Err(fail!("Unable to convert type into Entry::Ixs")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`DefineTableStatement`].
@@ -271,7 +271,7 @@ impl Entry {
 	pub(super) fn try_into_fts(self) -> Result<Arc<[DefineTableStatement]>, Error> {
 		match self {
 			Entry::Fts(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Fts")),
+			_ => Err(fail!("Unable to convert type into Entry::Fts")),
 		}
 	}
 	/// Converts this cache entry into a slice of [`LiveStatement`].
@@ -279,7 +279,7 @@ impl Entry {
 	pub(super) fn try_into_lvs(self) -> Result<Arc<[LiveStatement]>, Error> {
 		match self {
 			Entry::Lvs(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Lvs")),
+			_ => Err(fail!("Unable to convert type into Entry::Lvs")),
 		}
 	}
 	/// Converts this cache entry into a single [`Value`].
@@ -287,7 +287,7 @@ impl Entry {
 	pub(super) fn try_into_val(self) -> Result<Arc<Value>, Error> {
 		match self {
 			Entry::Val(v) => Ok(v),
-			_ => Err(Error::Unreachable("Unable to convert type into Entry::Val")),
+			_ => Err(fail!("Unable to convert type into Entry::Val")),
 		}
 	}
 }

--- a/core/src/kvs/fdb/mod.rs
+++ b/core/src/kvs/fdb/mod.rs
@@ -188,7 +188,11 @@ impl super::api::Transaction for Transaction {
 		// Cancel this transaction
 		match self.inner.take() {
 			Some(inner) => inner.cancel().reset(),
-			None => unreachable!(),
+			None => {
+				return Err(Error::Unreachable(
+					"Unable to take and cancel an already taken FoundationDB transaction",
+				))
+			}
 		};
 		// Continue
 		Ok(())
@@ -210,7 +214,11 @@ impl super::api::Transaction for Transaction {
 		// Commit this transaction
 		match self.inner.take() {
 			Some(inner) => inner.commit().await?,
-			None => unreachable!(),
+			None => {
+				return Err(Error::Unreachable(
+					"Unable to take and commit an already taken FoundationDB transaction",
+				))
+			}
 		};
 		// Continue
 		Ok(())

--- a/core/src/kvs/fdb/mod.rs
+++ b/core/src/kvs/fdb/mod.rs
@@ -188,11 +188,7 @@ impl super::api::Transaction for Transaction {
 		// Cancel this transaction
 		match self.inner.take() {
 			Some(inner) => inner.cancel().reset(),
-			None => {
-				return Err(Error::Unreachable(
-					"Unable to take and cancel an already taken FoundationDB transaction",
-				))
-			}
+			None => return Err(fail!("Unable to cancel an already taken transaction")),
 		};
 		// Continue
 		Ok(())
@@ -214,11 +210,7 @@ impl super::api::Transaction for Transaction {
 		// Commit this transaction
 		match self.inner.take() {
 			Some(inner) => inner.commit().await?,
-			None => {
-				return Err(Error::Unreachable(
-					"Unable to take and commit an already taken FoundationDB transaction",
-				))
-			}
+			None => return Err(fail!("Unable to commit an already taken transaction")),
 		};
 		// Continue
 		Ok(())

--- a/core/src/kvs/rocksdb/mod.rs
+++ b/core/src/kvs/rocksdb/mod.rs
@@ -188,7 +188,11 @@ impl super::api::Transaction for Transaction {
 		// Cancel this transaction
 		match self.inner.as_ref() {
 			Some(inner) => inner.rollback()?,
-			None => unreachable!(),
+			None => {
+				return Err(Error::Unreachable(
+					"Unable to take and cancel an already taken RocksDB transaction",
+				))
+			}
 		};
 		// Continue
 		Ok(())
@@ -210,7 +214,11 @@ impl super::api::Transaction for Transaction {
 		// Commit this transaction
 		match self.inner.take() {
 			Some(inner) => inner.commit()?,
-			None => unreachable!(),
+			None => {
+				return Err(Error::Unreachable(
+					"Unable to take and commit an already taken RocksDB transaction",
+				))
+			}
 		};
 		// Continue
 		Ok(())

--- a/core/src/kvs/rocksdb/mod.rs
+++ b/core/src/kvs/rocksdb/mod.rs
@@ -188,11 +188,7 @@ impl super::api::Transaction for Transaction {
 		// Cancel this transaction
 		match self.inner.as_ref() {
 			Some(inner) => inner.rollback()?,
-			None => {
-				return Err(Error::Unreachable(
-					"Unable to take and cancel an already taken RocksDB transaction",
-				))
-			}
+			None => return Err(fail!("Unable to cancel an already taken transaction")),
 		};
 		// Continue
 		Ok(())
@@ -214,11 +210,7 @@ impl super::api::Transaction for Transaction {
 		// Commit this transaction
 		match self.inner.take() {
 			Some(inner) => inner.commit()?,
-			None => {
-				return Err(Error::Unreachable(
-					"Unable to take and commit an already taken RocksDB transaction",
-				))
-			}
+			None => return Err(fail!("Unable to commit an already taken transaction")),
 		};
 		// Continue
 		Ok(())

--- a/core/src/kvs/tr.rs
+++ b/core/src/kvs/tr.rs
@@ -132,9 +132,7 @@ macro_rules! expand_inner {
 			#[cfg(feature = "kv-surrealcs")]
 			Inner::SurrealCS($arm) => $b,
 			#[allow(unreachable_patterns)]
-			_ => {
-				unreachable!();
-			}
+			_ => unreachable!(),
 		}
 	};
 }

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -311,7 +311,7 @@ impl Transaction {
 	pub async fn all_nodes(&self) -> Result<Arc<[Node]>, Error> {
 		let key = crate::key::root::nd::prefix();
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::root::nd::suffix();
@@ -322,7 +322,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_nds()?)
+		.try_into_nds()
 	}
 
 	/// Retrieve all ROOT level users in a datastore.
@@ -330,7 +330,7 @@ impl Transaction {
 	pub async fn all_root_users(&self) -> Result<Arc<[DefineUserStatement]>, Error> {
 		let key = crate::key::root::us::prefix();
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::root::us::suffix();
@@ -341,7 +341,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_rus()?)
+		.try_into_rus()
 	}
 
 	/// Retrieve all ROOT level accesses in a datastore.
@@ -349,7 +349,7 @@ impl Transaction {
 	pub async fn all_root_accesses(&self) -> Result<Arc<[DefineAccessStatement]>, Error> {
 		let key = crate::key::root::ac::prefix();
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::root::ac::suffix();
@@ -360,7 +360,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_ras()?)
+		.try_into_ras()
 	}
 
 	/// Retrieve all root access grants in a datastore.
@@ -368,7 +368,7 @@ impl Transaction {
 	pub async fn all_root_access_grants(&self, ra: &str) -> Result<Arc<[AccessGrant]>, Error> {
 		let key = crate::key::root::access::gr::prefix(ra);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::root::access::gr::suffix(ra);
@@ -379,7 +379,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_rag()?)
+		.try_into_rag()
 	}
 
 	/// Retrieve all namespace definitions in a datastore.
@@ -387,7 +387,7 @@ impl Transaction {
 	pub async fn all_ns(&self) -> Result<Arc<[DefineNamespaceStatement]>, Error> {
 		let key = crate::key::root::ns::prefix();
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::root::ns::suffix();
@@ -398,7 +398,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_nss()?)
+		.try_into_nss()
 	}
 
 	/// Retrieve all namespace user definitions for a specific namespace.
@@ -406,7 +406,7 @@ impl Transaction {
 	pub async fn all_ns_users(&self, ns: &str) -> Result<Arc<[DefineUserStatement]>, Error> {
 		let key = crate::key::namespace::us::prefix(ns);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::namespace::us::suffix(ns);
@@ -417,7 +417,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_nus()?)
+		.try_into_nus()
 	}
 
 	/// Retrieve all namespace access definitions for a specific namespace.
@@ -425,7 +425,7 @@ impl Transaction {
 	pub async fn all_ns_accesses(&self, ns: &str) -> Result<Arc<[DefineAccessStatement]>, Error> {
 		let key = crate::key::namespace::ac::prefix(ns);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::namespace::ac::suffix(ns);
@@ -436,7 +436,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_nas()?)
+		.try_into_nas()
 	}
 
 	/// Retrieve all namespace access grants for a specific namespace.
@@ -448,7 +448,7 @@ impl Transaction {
 	) -> Result<Arc<[AccessGrant]>, Error> {
 		let key = crate::key::namespace::access::gr::prefix(ns, na);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::namespace::access::gr::suffix(ns, na);
@@ -459,7 +459,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_nag()?)
+		.try_into_nag()
 	}
 
 	/// Retrieve all database definitions for a specific namespace.
@@ -467,7 +467,7 @@ impl Transaction {
 	pub async fn all_db(&self, ns: &str) -> Result<Arc<[DefineDatabaseStatement]>, Error> {
 		let key = crate::key::namespace::db::prefix(ns);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::namespace::db::suffix(ns);
@@ -478,7 +478,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_dbs()?)
+		.try_into_dbs()
 	}
 
 	/// Retrieve all database user definitions for a specific database.
@@ -490,7 +490,7 @@ impl Transaction {
 	) -> Result<Arc<[DefineUserStatement]>, Error> {
 		let key = crate::key::database::us::prefix(ns, db);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::database::us::suffix(ns, db);
@@ -501,7 +501,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_dus()?)
+		.try_into_dus()
 	}
 
 	/// Retrieve all database access definitions for a specific database.
@@ -513,7 +513,7 @@ impl Transaction {
 	) -> Result<Arc<[DefineAccessStatement]>, Error> {
 		let key = crate::key::database::ac::prefix(ns, db);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::database::ac::suffix(ns, db);
@@ -524,7 +524,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_das()?)
+		.try_into_das()
 	}
 
 	/// Retrieve all database access grants for a specific database.
@@ -537,7 +537,7 @@ impl Transaction {
 	) -> Result<Arc<[AccessGrant]>, Error> {
 		let key = crate::key::database::access::gr::prefix(ns, db, da);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::database::access::gr::suffix(ns, db, da);
@@ -548,7 +548,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_dag()?)
+		.try_into_dag()
 	}
 
 	/// Retrieve all analyzer definitions for a specific database.
@@ -560,7 +560,7 @@ impl Transaction {
 	) -> Result<Arc<[DefineAnalyzerStatement]>, Error> {
 		let key = crate::key::database::az::prefix(ns, db);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::database::az::suffix(ns, db);
@@ -571,7 +571,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_azs()?)
+		.try_into_azs()
 	}
 
 	/// Retrieve all function definitions for a specific database.
@@ -583,7 +583,7 @@ impl Transaction {
 	) -> Result<Arc<[DefineFunctionStatement]>, Error> {
 		let key = crate::key::database::fc::prefix(ns, db);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::database::fc::suffix(ns, db);
@@ -594,7 +594,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_fcs()?)
+		.try_into_fcs()
 	}
 
 	/// Retrieve all param definitions for a specific database.
@@ -606,7 +606,7 @@ impl Transaction {
 	) -> Result<Arc<[DefineParamStatement]>, Error> {
 		let key = crate::key::database::pa::prefix(ns, db);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::database::pa::suffix(ns, db);
@@ -617,7 +617,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_pas()?)
+		.try_into_pas()
 	}
 
 	/// Retrieve all model definitions for a specific database.
@@ -629,7 +629,7 @@ impl Transaction {
 	) -> Result<Arc<[DefineModelStatement]>, Error> {
 		let key = crate::key::database::ml::prefix(ns, db);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::database::ml::suffix(ns, db);
@@ -640,7 +640,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_mls()?)
+		.try_into_mls()
 	}
 
 	/// Retrieve all table definitions for a specific database.
@@ -648,7 +648,7 @@ impl Transaction {
 	pub async fn all_tb(&self, ns: &str, db: &str) -> Result<Arc<[DefineTableStatement]>, Error> {
 		let key = crate::key::database::tb::prefix(ns, db);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::database::tb::suffix(ns, db);
@@ -659,7 +659,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_tbs()?)
+		.try_into_tbs()
 	}
 
 	/// Retrieve all event definitions for a specific table.
@@ -672,7 +672,7 @@ impl Transaction {
 	) -> Result<Arc<[DefineEventStatement]>, Error> {
 		let key = crate::key::table::ev::prefix(ns, db, tb);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::table::ev::suffix(ns, db, tb);
@@ -683,7 +683,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_evs()?)
+		.try_into_evs()
 	}
 
 	/// Retrieve all field definitions for a specific table.
@@ -696,7 +696,7 @@ impl Transaction {
 	) -> Result<Arc<[DefineFieldStatement]>, Error> {
 		let key = crate::key::table::fd::prefix(ns, db, tb);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::table::fd::suffix(ns, db, tb);
@@ -707,7 +707,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_fds()?)
+		.try_into_fds()
 	}
 
 	/// Retrieve all index definitions for a specific table.
@@ -720,7 +720,7 @@ impl Transaction {
 	) -> Result<Arc<[DefineIndexStatement]>, Error> {
 		let key = crate::key::table::ix::prefix(ns, db, tb);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::table::ix::suffix(ns, db, tb);
@@ -731,7 +731,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_ixs()?)
+		.try_into_ixs()
 	}
 
 	/// Retrieve all view definitions for a specific table.
@@ -744,7 +744,7 @@ impl Transaction {
 	) -> Result<Arc<[DefineTableStatement]>, Error> {
 		let key = crate::key::table::ft::prefix(ns, db, tb);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::table::ft::suffix(ns, db, tb);
@@ -755,7 +755,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_fts()?)
+		.try_into_fts()
 	}
 
 	/// Retrieve all live definitions for a specific table.
@@ -768,7 +768,7 @@ impl Transaction {
 	) -> Result<Arc<[LiveStatement]>, Error> {
 		let key = crate::key::table::lq::prefix(ns, db, tb);
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let end = crate::key::table::lq::suffix(ns, db, tb);
@@ -779,7 +779,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_lvs()?)
+		.try_into_lvs()
 	}
 
 	/// Retrieve a specific namespace definition.
@@ -787,7 +787,7 @@ impl Transaction {
 	pub async fn get_node(&self, id: Uuid) -> Result<Arc<Node>, Error> {
 		let key = crate::key::root::nd::new(id).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::NdNotFound {
@@ -799,7 +799,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific root user definition.
@@ -807,7 +807,7 @@ impl Transaction {
 	pub async fn get_root_user(&self, us: &str) -> Result<Arc<DefineUserStatement>, Error> {
 		let key = crate::key::root::us::new(us).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::UserRootNotFound {
@@ -819,7 +819,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific root access definition.
@@ -827,7 +827,7 @@ impl Transaction {
 	pub async fn get_root_access(&self, ra: &str) -> Result<Arc<DefineAccessStatement>, Error> {
 		let key = crate::key::root::ac::new(ra).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::AccessRootNotFound {
@@ -839,7 +839,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific root access grant.
@@ -851,7 +851,7 @@ impl Transaction {
 	) -> Result<Arc<AccessGrant>, Error> {
 		let key = crate::key::root::access::gr::new(ac, gr).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val =
@@ -865,7 +865,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific namespace definition.
@@ -873,7 +873,7 @@ impl Transaction {
 	pub async fn get_ns(&self, ns: &str) -> Result<Arc<DefineNamespaceStatement>, Error> {
 		let key = crate::key::root::ns::new(ns).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::NsNotFound {
@@ -885,7 +885,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific namespace user definition.
@@ -893,7 +893,7 @@ impl Transaction {
 	pub async fn get_ns_user(&self, ns: &str, us: &str) -> Result<Arc<DefineUserStatement>, Error> {
 		let key = crate::key::namespace::us::new(ns, us).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::UserNsNotFound {
@@ -906,7 +906,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific namespace access definition.
@@ -918,7 +918,7 @@ impl Transaction {
 	) -> Result<Arc<DefineAccessStatement>, Error> {
 		let key = crate::key::namespace::ac::new(ns, na).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::AccessNsNotFound {
@@ -931,7 +931,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific namespace access grant.
@@ -944,7 +944,7 @@ impl Transaction {
 	) -> Result<Arc<AccessGrant>, Error> {
 		let key = crate::key::namespace::access::gr::new(ns, ac, gr).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val =
@@ -959,7 +959,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific database definition.
@@ -967,7 +967,7 @@ impl Transaction {
 	pub async fn get_db(&self, ns: &str, db: &str) -> Result<Arc<DefineDatabaseStatement>, Error> {
 		let key = crate::key::namespace::db::new(ns, db).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::DbNotFound {
@@ -979,7 +979,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific user definition from a database.
@@ -992,7 +992,7 @@ impl Transaction {
 	) -> Result<Arc<DefineUserStatement>, Error> {
 		let key = crate::key::database::us::new(ns, db, us).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::UserDbNotFound {
@@ -1006,7 +1006,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific database access definition.
@@ -1019,7 +1019,7 @@ impl Transaction {
 	) -> Result<Arc<DefineAccessStatement>, Error> {
 		let key = crate::key::database::ac::new(ns, db, da).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::AccessDbNotFound {
@@ -1033,7 +1033,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific database access grant.
@@ -1047,7 +1047,7 @@ impl Transaction {
 	) -> Result<Arc<AccessGrant>, Error> {
 		let key = crate::key::database::access::gr::new(ns, db, ac, gr).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val =
@@ -1063,7 +1063,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific model definition from a database.
@@ -1077,7 +1077,7 @@ impl Transaction {
 	) -> Result<Arc<DefineModelStatement>, Error> {
 		let key = crate::key::database::ml::new(ns, db, ml, vn).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::MlNotFound {
@@ -1089,7 +1089,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific analyzer definition.
@@ -1102,7 +1102,7 @@ impl Transaction {
 	) -> Result<Arc<DefineAnalyzerStatement>, Error> {
 		let key = crate::key::database::az::new(ns, db, az).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::AzNotFound {
@@ -1114,7 +1114,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific function definition from a database.
@@ -1127,7 +1127,7 @@ impl Transaction {
 	) -> Result<Arc<DefineFunctionStatement>, Error> {
 		let key = crate::key::database::fc::new(ns, db, fc).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::FcNotFound {
@@ -1139,7 +1139,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific function definition from a database.
@@ -1152,7 +1152,7 @@ impl Transaction {
 	) -> Result<Arc<DefineParamStatement>, Error> {
 		let key = crate::key::database::pa::new(ns, db, pa).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::PaNotFound {
@@ -1164,7 +1164,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a specific table definition.
@@ -1177,7 +1177,7 @@ impl Transaction {
 	) -> Result<Arc<DefineTableStatement>, Error> {
 		let key = crate::key::database::tb::new(ns, db, tb).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::TbNotFound {
@@ -1189,7 +1189,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve an event for a table.
@@ -1203,7 +1203,7 @@ impl Transaction {
 	) -> Result<Arc<DefineEventStatement>, Error> {
 		let key = crate::key::table::ev::new(ns, db, tb, ev).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::EvNotFound {
@@ -1215,7 +1215,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve a field for a table.
@@ -1229,7 +1229,7 @@ impl Transaction {
 	) -> Result<Arc<DefineFieldStatement>, Error> {
 		let key = crate::key::table::fd::new(ns, db, tb, fd).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::FdNotFound {
@@ -1241,7 +1241,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Retrieve an index for a table.
@@ -1255,7 +1255,7 @@ impl Transaction {
 	) -> Result<Arc<DefineIndexStatement>, Error> {
 		let key = crate::key::table::ix::new(ns, db, tb, ix).encode()?;
 		let res = self.cache.get_value_or_guard_async(&key).await;
-		Ok(match res {
+		match res {
 			Ok(val) => val,
 			Err(cache) => {
 				let val = self.get(key, None).await?.ok_or_else(|| Error::IxNotFound {
@@ -1267,7 +1267,7 @@ impl Transaction {
 				val
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Fetch a specific record value.
@@ -1442,7 +1442,7 @@ impl Transaction {
 		let key = crate::key::root::ns::new(ns);
 		let enc = crate::key::root::ns::new(ns).encode()?;
 		let res = self.cache.get_value_or_guard_async(&enc).await;
-		Ok(match res {
+		match res {
 			// The entry is in the cache
 			Ok(val) => val,
 			// The entry is not in the cache
@@ -1480,7 +1480,7 @@ impl Transaction {
 				}
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Get or add a database with a default configuration, only if we are in dynamic mode.
@@ -1495,7 +1495,7 @@ impl Transaction {
 		let key = crate::key::namespace::db::new(ns, db);
 		let enc = crate::key::namespace::db::new(ns, db).encode()?;
 		let res = self.cache.get_value_or_guard_async(&enc).await;
-		Ok(match res {
+		match res {
 			// The entry is in the cache
 			Ok(val) => val,
 			// The entry is not in the cache
@@ -1547,7 +1547,7 @@ impl Transaction {
 				}
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 
 	/// Get or add a table with a default configuration, only if we are in dynamic mode.
@@ -1563,7 +1563,7 @@ impl Transaction {
 		let key = crate::key::database::tb::new(ns, db, tb);
 		let enc = crate::key::database::tb::new(ns, db, tb).encode()?;
 		let res = self.cache.get_value_or_guard_async(&enc).await;
-		Ok(match res {
+		match res {
 			// The entry is in the cache
 			Ok(val) => val,
 			// The entry is not in the cache
@@ -1617,6 +1617,6 @@ impl Transaction {
 				}
 			}
 		}
-		.try_into_type()?)
+		.try_into_type()
 	}
 }

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -322,7 +322,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_nds())
+		.try_into_nds()?)
 	}
 
 	/// Retrieve all ROOT level users in a datastore.
@@ -341,7 +341,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_rus())
+		.try_into_rus()?)
 	}
 
 	/// Retrieve all ROOT level accesses in a datastore.
@@ -360,7 +360,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_ras())
+		.try_into_ras()?)
 	}
 
 	/// Retrieve all root access grants in a datastore.
@@ -379,7 +379,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_rag())
+		.try_into_rag()?)
 	}
 
 	/// Retrieve all namespace definitions in a datastore.
@@ -398,7 +398,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_nss())
+		.try_into_nss()?)
 	}
 
 	/// Retrieve all namespace user definitions for a specific namespace.
@@ -417,7 +417,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_nus())
+		.try_into_nus()?)
 	}
 
 	/// Retrieve all namespace access definitions for a specific namespace.
@@ -436,7 +436,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_nas())
+		.try_into_nas()?)
 	}
 
 	/// Retrieve all namespace access grants for a specific namespace.
@@ -459,7 +459,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_nag())
+		.try_into_nag()?)
 	}
 
 	/// Retrieve all database definitions for a specific namespace.
@@ -478,7 +478,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_dbs())
+		.try_into_dbs()?)
 	}
 
 	/// Retrieve all database user definitions for a specific database.
@@ -501,7 +501,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_dus())
+		.try_into_dus()?)
 	}
 
 	/// Retrieve all database access definitions for a specific database.
@@ -524,7 +524,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_das())
+		.try_into_das()?)
 	}
 
 	/// Retrieve all database access grants for a specific database.
@@ -548,7 +548,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_dag())
+		.try_into_dag()?)
 	}
 
 	/// Retrieve all analyzer definitions for a specific database.
@@ -571,7 +571,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_azs())
+		.try_into_azs()?)
 	}
 
 	/// Retrieve all function definitions for a specific database.
@@ -594,7 +594,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_fcs())
+		.try_into_fcs()?)
 	}
 
 	/// Retrieve all param definitions for a specific database.
@@ -617,7 +617,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_pas())
+		.try_into_pas()?)
 	}
 
 	/// Retrieve all model definitions for a specific database.
@@ -640,7 +640,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_mls())
+		.try_into_mls()?)
 	}
 
 	/// Retrieve all table definitions for a specific database.
@@ -659,7 +659,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_tbs())
+		.try_into_tbs()?)
 	}
 
 	/// Retrieve all event definitions for a specific table.
@@ -683,7 +683,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_evs())
+		.try_into_evs()?)
 	}
 
 	/// Retrieve all field definitions for a specific table.
@@ -707,7 +707,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_fds())
+		.try_into_fds()?)
 	}
 
 	/// Retrieve all index definitions for a specific table.
@@ -731,7 +731,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_ixs())
+		.try_into_ixs()?)
 	}
 
 	/// Retrieve all view definitions for a specific table.
@@ -755,7 +755,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_fts())
+		.try_into_fts()?)
 	}
 
 	/// Retrieve all live definitions for a specific table.
@@ -779,7 +779,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_lvs())
+		.try_into_lvs()?)
 	}
 
 	/// Retrieve a specific namespace definition.
@@ -799,7 +799,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific root user definition.
@@ -819,7 +819,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific root access definition.
@@ -839,7 +839,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific root access grant.
@@ -865,7 +865,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific namespace definition.
@@ -885,7 +885,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific namespace user definition.
@@ -906,7 +906,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific namespace access definition.
@@ -931,7 +931,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific namespace access grant.
@@ -959,7 +959,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific database definition.
@@ -979,7 +979,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific user definition from a database.
@@ -1006,7 +1006,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific database access definition.
@@ -1033,7 +1033,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific database access grant.
@@ -1063,7 +1063,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific model definition from a database.
@@ -1089,7 +1089,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific analyzer definition.
@@ -1114,7 +1114,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific function definition from a database.
@@ -1139,7 +1139,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific function definition from a database.
@@ -1164,7 +1164,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a specific table definition.
@@ -1189,7 +1189,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve an event for a table.
@@ -1215,7 +1215,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve a field for a table.
@@ -1241,7 +1241,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Retrieve an index for a table.
@@ -1267,7 +1267,7 @@ impl Transaction {
 				val
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Fetch a specific record value.
@@ -1283,14 +1283,14 @@ impl Transaction {
 		let res = self.cache.get_value_or_guard_async(&key).await;
 		match res {
 			// The entry is in the cache
-			Ok(val) => Ok(val.into_val()),
+			Ok(val) => val.try_into_val(),
 			// The entry is not in the cache
 			Err(cache) => match self.get(key, None).await? {
 				// The value exists in the datastore
 				Some(val) => {
 					let val = Entry::Val(Arc::new(val.into()));
 					let _ = cache.insert(val.clone());
-					Ok(val.into_val())
+					val.try_into_val()
 				}
 				// The value is not in the datastore
 				None => Ok(Arc::new(Value::None)),
@@ -1480,7 +1480,7 @@ impl Transaction {
 				}
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Get or add a database with a default configuration, only if we are in dynamic mode.
@@ -1547,7 +1547,7 @@ impl Transaction {
 				}
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 
 	/// Get or add a table with a default configuration, only if we are in dynamic mode.
@@ -1617,6 +1617,6 @@ impl Transaction {
 				}
 			}
 		}
-		.into_type())
+		.try_into_type()?)
 	}
 }

--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -1,7 +1,7 @@
 /// Throws an unreachable error with location details
 macro_rules! fail {
-	($msg: literal) => {
-		$crate::err::Error::Unreachable(concat!(file!(), ":", line!(), ": ", $msg))
+	($($arg:tt)+) => {
+		$crate::err::Error::Unreachable(format!("{}:{}: {}", file!(), line!(), std::format_args!($($arg)+)))
 	};
 }
 
@@ -252,10 +252,18 @@ mod test {
 	}
 
 	#[test]
-	fn fail() {
+	fn fail_literal() {
 		let Error::Unreachable(msg) = fail!("Reached unreachable code") else {
 			panic!()
 		};
 		assert_eq!("core/src/mac/mod.rs:256: Reached unreachable code", msg);
+	}
+
+	#[test]
+	fn fail_arguments() {
+		let Error::Unreachable(msg) = fail!("Found {} but expected {}", "test", "other") else {
+			panic!()
+		};
+		assert_eq!("core/src/mac/mod.rs:264: Found test but expected other", msg);
 	}
 }

--- a/core/src/rpc/format/msgpack/convert.rs
+++ b/core/src/rpc/format/msgpack/convert.rs
@@ -114,8 +114,6 @@ impl TryFrom<Value> for Pack {
 				Number::Decimal(v) => {
 					Ok(Pack(Data::Ext(TAG_DECIMAL, v.to_string().as_bytes().to_vec())))
 				}
-				#[allow(unreachable_patterns)]
-				_ => unreachable!(),
 			},
 			Value::Strand(v) => Ok(Pack(Data::String(v.0.into()))),
 			Value::Duration(v) => Ok(Pack(Data::Ext(TAG_DURATION, v.to_raw().as_bytes().to_vec()))),

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -802,7 +802,7 @@ pub trait RpcContext {
 		let res = match query {
 			Value::Query(sql) => self.kvs().process(sql, self.session(), vars).await?,
 			Value::Strand(sql) => self.kvs().execute(&sql, self.session(), vars).await?,
-			_ => unreachable!(),
+			_ => return Err(fail!("Unexpected query type: {query:?}").into()),
 		};
 
 		// Post-process hooks for web layer

--- a/core/src/sql/expression.rs
+++ b/core/src/sql/expression.rs
@@ -104,93 +104,94 @@ impl Expression {
 		opt: &Options,
 		doc: Option<&CursorDoc>,
 	) -> Result<Value, Error> {
-		let (l, o, r) = match self {
+		// Check the type of expression
+		match self {
+			// This is a unary expression: !test
 			Self::Unary {
 				o,
 				v,
-			} => {
-				let operand = v.compute(stk, ctx, opt, doc).await?;
-				return match o {
-					Operator::Neg => fnc::operate::neg(operand),
-					// TODO: Check if it is a number?
-					Operator::Add => Ok(operand),
-					Operator::Not => fnc::operate::not(operand),
-					op => unreachable!("{op:?} is not a unary op"),
-				};
-			}
+			} => match o {
+				Operator::Add => Ok(v.compute(stk, ctx, opt, doc).await?),
+				Operator::Neg => fnc::operate::neg(v.compute(stk, ctx, opt, doc).await?),
+				Operator::Not => fnc::operate::not(v.compute(stk, ctx, opt, doc).await?),
+				o => Err(fail!("Invalid operator '{o:?}' encountered")),
+			},
+			// This is a binary expression: test != NONE
 			Self::Binary {
 				l,
 				o,
 				r,
-			} => (l, o, r),
-		};
-
-		let l = l.compute(stk, ctx, opt, doc).await?;
-		match o {
-			Operator::Or => {
-				if l.is_truthy() {
-					return Ok(l);
+			} => {
+				let l = l.compute(stk, ctx, opt, doc).await?;
+				match o {
+					Operator::Or => {
+						if l.is_truthy() {
+							return Ok(l);
+						}
+					}
+					Operator::And => {
+						if !l.is_truthy() {
+							return Ok(l);
+						}
+					}
+					Operator::Tco => {
+						if l.is_truthy() {
+							return Ok(l);
+						}
+					}
+					Operator::Nco => {
+						if l.is_some() {
+							return Ok(l);
+						}
+					}
+					_ => {} // Continue
+				}
+				let r = r.compute(stk, ctx, opt, doc).await?;
+				match o {
+					Operator::Or => fnc::operate::or(l, r),
+					Operator::And => fnc::operate::and(l, r),
+					Operator::Tco => fnc::operate::tco(l, r),
+					Operator::Nco => fnc::operate::nco(l, r),
+					Operator::Add => fnc::operate::add(l, r),
+					Operator::Sub => fnc::operate::sub(l, r),
+					Operator::Mul => fnc::operate::mul(l, r),
+					Operator::Div => fnc::operate::div(l, r),
+					Operator::Rem => fnc::operate::rem(l, r),
+					Operator::Pow => fnc::operate::pow(l, r),
+					Operator::Equal => fnc::operate::equal(&l, &r),
+					Operator::Exact => fnc::operate::exact(&l, &r),
+					Operator::NotEqual => fnc::operate::not_equal(&l, &r),
+					Operator::AllEqual => fnc::operate::all_equal(&l, &r),
+					Operator::AnyEqual => fnc::operate::any_equal(&l, &r),
+					Operator::Like => fnc::operate::like(&l, &r),
+					Operator::NotLike => fnc::operate::not_like(&l, &r),
+					Operator::AllLike => fnc::operate::all_like(&l, &r),
+					Operator::AnyLike => fnc::operate::any_like(&l, &r),
+					Operator::LessThan => fnc::operate::less_than(&l, &r),
+					Operator::LessThanOrEqual => fnc::operate::less_than_or_equal(&l, &r),
+					Operator::MoreThan => fnc::operate::more_than(&l, &r),
+					Operator::MoreThanOrEqual => fnc::operate::more_than_or_equal(&l, &r),
+					Operator::Contain => fnc::operate::contain(&l, &r),
+					Operator::NotContain => fnc::operate::not_contain(&l, &r),
+					Operator::ContainAll => fnc::operate::contain_all(&l, &r),
+					Operator::ContainAny => fnc::operate::contain_any(&l, &r),
+					Operator::ContainNone => fnc::operate::contain_none(&l, &r),
+					Operator::Inside => fnc::operate::inside(&l, &r),
+					Operator::NotInside => fnc::operate::not_inside(&l, &r),
+					Operator::AllInside => fnc::operate::inside_all(&l, &r),
+					Operator::AnyInside => fnc::operate::inside_any(&l, &r),
+					Operator::NoneInside => fnc::operate::inside_none(&l, &r),
+					Operator::Outside => fnc::operate::outside(&l, &r),
+					Operator::Intersects => fnc::operate::intersects(&l, &r),
+					Operator::Matches(_) => {
+						fnc::operate::matches(stk, ctx, opt, doc, self, l, r).await
+					}
+					Operator::Knn(_, _) | Operator::Ann(_, _) => {
+						fnc::operate::knn(stk, ctx, opt, doc, self).await
+					}
+					o => Err(fail!("Invalid operator '{o:?}' encountered")),
 				}
 			}
-			Operator::And => {
-				if !l.is_truthy() {
-					return Ok(l);
-				}
-			}
-			Operator::Tco => {
-				if l.is_truthy() {
-					return Ok(l);
-				}
-			}
-			Operator::Nco => {
-				if l.is_some() {
-					return Ok(l);
-				}
-			}
-			_ => {} // Continue
-		}
-		let r = r.compute(stk, ctx, opt, doc).await?;
-		match o {
-			Operator::Or => fnc::operate::or(l, r),
-			Operator::And => fnc::operate::and(l, r),
-			Operator::Tco => fnc::operate::tco(l, r),
-			Operator::Nco => fnc::operate::nco(l, r),
-			Operator::Add => fnc::operate::add(l, r),
-			Operator::Sub => fnc::operate::sub(l, r),
-			Operator::Mul => fnc::operate::mul(l, r),
-			Operator::Div => fnc::operate::div(l, r),
-			Operator::Rem => fnc::operate::rem(l, r),
-			Operator::Pow => fnc::operate::pow(l, r),
-			Operator::Equal => fnc::operate::equal(&l, &r),
-			Operator::Exact => fnc::operate::exact(&l, &r),
-			Operator::NotEqual => fnc::operate::not_equal(&l, &r),
-			Operator::AllEqual => fnc::operate::all_equal(&l, &r),
-			Operator::AnyEqual => fnc::operate::any_equal(&l, &r),
-			Operator::Like => fnc::operate::like(&l, &r),
-			Operator::NotLike => fnc::operate::not_like(&l, &r),
-			Operator::AllLike => fnc::operate::all_like(&l, &r),
-			Operator::AnyLike => fnc::operate::any_like(&l, &r),
-			Operator::LessThan => fnc::operate::less_than(&l, &r),
-			Operator::LessThanOrEqual => fnc::operate::less_than_or_equal(&l, &r),
-			Operator::MoreThan => fnc::operate::more_than(&l, &r),
-			Operator::MoreThanOrEqual => fnc::operate::more_than_or_equal(&l, &r),
-			Operator::Contain => fnc::operate::contain(&l, &r),
-			Operator::NotContain => fnc::operate::not_contain(&l, &r),
-			Operator::ContainAll => fnc::operate::contain_all(&l, &r),
-			Operator::ContainAny => fnc::operate::contain_any(&l, &r),
-			Operator::ContainNone => fnc::operate::contain_none(&l, &r),
-			Operator::Inside => fnc::operate::inside(&l, &r),
-			Operator::NotInside => fnc::operate::not_inside(&l, &r),
-			Operator::AllInside => fnc::operate::inside_all(&l, &r),
-			Operator::AnyInside => fnc::operate::inside_any(&l, &r),
-			Operator::NoneInside => fnc::operate::inside_none(&l, &r),
-			Operator::Outside => fnc::operate::outside(&l, &r),
-			Operator::Intersects => fnc::operate::intersects(&l, &r),
-			Operator::Matches(_) => fnc::operate::matches(stk, ctx, opt, doc, self, l, r).await,
-			Operator::Knn(_, _) | Operator::Ann(_, _) => {
-				fnc::operate::knn(stk, ctx, opt, doc, self).await
-			}
-			_ => unreachable!(),
 		}
 	}
 }

--- a/core/src/sql/function.rs
+++ b/core/src/sql/function.rs
@@ -79,7 +79,7 @@ impl Function {
 		}
 	}
 	/// Convert this function to an aggregate
-	pub fn aggregate(&self, val: Value) -> Self {
+	pub fn aggregate(&self, val: Value) -> Result<Self, Error> {
 		match self {
 			Self::Normal(n, a) => {
 				let mut a = a.to_owned();
@@ -90,9 +90,9 @@ impl Function {
 						a.insert(0, val);
 					}
 				}
-				Self::Normal(n.to_owned(), a)
+				Ok(Self::Normal(n.to_owned(), a))
 			}
-			_ => unreachable!(),
+			_ => Err(fail!("Encountered a non-aggregate function: {self:?}")),
 		}
 	}
 	/// Check if this function is a custom function

--- a/core/src/sql/id/mod.rs
+++ b/core/src/sql/id/mod.rs
@@ -243,11 +243,11 @@ impl Id {
 			Id::Uuid(v) => Ok(Id::Uuid(*v)),
 			Id::Array(v) => match v.compute(stk, ctx, opt, doc).await? {
 				Value::Array(v) => Ok(Id::Array(v)),
-				_ => unreachable!(),
+				v => return Err(fail!("Expected a Value::Array but found {v:?}")),
 			},
 			Id::Object(v) => match v.compute(stk, ctx, opt, doc).await? {
 				Value::Object(v) => Ok(Id::Object(v)),
-				_ => unreachable!(),
+				v => return Err(fail!("Expected a Value::Object but found {v:?}")),
 			},
 			Id::Generate(v) => match v {
 				Gen::Rand => Ok(Self::rand()),

--- a/core/src/sql/id/mod.rs
+++ b/core/src/sql/id/mod.rs
@@ -243,11 +243,11 @@ impl Id {
 			Id::Uuid(v) => Ok(Id::Uuid(*v)),
 			Id::Array(v) => match v.compute(stk, ctx, opt, doc).await? {
 				Value::Array(v) => Ok(Id::Array(v)),
-				v => return Err(fail!("Expected a Value::Array but found {v:?}")),
+				v => Err(fail!("Expected a Value::Array but found {v:?}")),
 			},
 			Id::Object(v) => match v.compute(stk, ctx, opt, doc).await? {
 				Value::Object(v) => Ok(Id::Object(v)),
-				v => return Err(fail!("Expected a Value::Object but found {v:?}")),
+				v => Err(fail!("Expected a Value::Object but found {v:?}")),
 			},
 			Id::Generate(v) => match v {
 				Gen::Rand => Ok(Self::rand()),

--- a/core/src/sql/statement.rs
+++ b/core/src/sql/statement.rs
@@ -145,7 +145,7 @@ impl Statement {
 			Self::Upsert(v) => v.writeable(),
 			Self::Update(v) => v.writeable(),
 			Self::Use(_) => false,
-			_ => unreachable!(),
+			_ => false,
 		}
 	}
 	/// Process this type returning a computed simple Value
@@ -188,7 +188,7 @@ impl Statement {
 				// Process the output value
 				v.compute_unbordered(stk, ctx, opt, doc).await
 			}
-			_ => unreachable!(),
+			_ => Err(fail!("Unexpected statement type encountered: {self:?}")),
 		}
 	}
 }

--- a/core/src/sql/statements/define/index.rs
+++ b/core/src/sql/statements/define/index.rs
@@ -125,7 +125,7 @@ impl DefineIndexStatement {
 
 	#[cfg(not(target_arch = "wasm32"))]
 	fn async_index(&self, ctx: &Context, opt: &Options) -> Result<(), Error> {
-		ctx.get_index_builder().ok_or(Error::Unreachable("No Index Builder"))?.build(
+		ctx.get_index_builder().ok_or_else(|| fail!("No Index Builder"))?.build(
 			ctx,
 			opt.clone(),
 			self.clone().into(),

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -105,7 +105,7 @@ impl InsertStatement {
 					}
 				}
 			}
-			_ => unreachable!(),
+			v => return Err(fail!("Unknown data clause type in INSERT statement: {v:?}")),
 		}
 		// Assign the statement
 		let stm = Statement::from(self);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently, due to potential developer error, it may be possible in the future to reach an `unreachable!()` code path.

## What does this change do?

To prevent presumed `unreachable!()` code from being executed in certain situations, this pull request changes all `unreachable!()` code to `Error::Unreachable` errors. These shouldn't ever occur, but in the unlikely event that they do, the server will not panic, but will instead throw an error to the user.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
