### PR TITLE
Make `surrealdb.query()` and `surrealdb.value()` consistent

### DIFF
--- a/core/src/fnc/script/modules/surrealdb/query/classes.rs
+++ b/core/src/fnc/script/modules/surrealdb/query/classes.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::sql::{self, subquery::Subquery, Value as SurValue};
+use crate::sql::{self, Value as SurValue};
 
 use js::{
 	class::Trace,
@@ -13,7 +13,7 @@ use js::{
 #[non_exhaustive]
 pub struct Query {
 	#[qjs(skip_trace)]
-	pub(crate) query: Subquery,
+	pub(crate) query: SurValue,
 	#[qjs(skip_trace)]
 	pub(crate) vars: Option<BTreeMap<String, SurValue>>,
 }
@@ -96,7 +96,7 @@ impl<'js> FromJs<'js> for QueryVariables {
 impl Query {
 	#[qjs(constructor)]
 	pub fn new(ctx: Ctx<'_>, text: String, variables: Opt<QueryVariables>) -> Result<Self> {
-		let query = sql::subquery(&text).map_err(|e| {
+		let query = sql::value(&text).map_err(|e| {
 			let error_text = format!("{}", e);
 			Exception::throw_type(&ctx, &error_text)
 		})?;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently the `surrealdb.value()` function in the JavaScript runtime evaluated any SurrealQL value, but did not allow for paramaters to be passed in.

Conversely, the `surrealdb.query()` function allowed any SurrealQL subquery to be evaluated, and did allow for parameters to be passed in. However, it did not catch special internal errors like `Error::Ignore`, `Error::Break`, `Error::Continue`, and `Error::Returns`.

## What does this change do?

This change does the following:
- Changes `surrealdb.query so that it evaluates and allows for any SurrealQL value or statement, whilst continuing to support the passing of parameters into the query.
- Changes `surrealdb.value()` so that it is an alias for, and behaves the same as, the `surrealdb.query()` function.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #4432

## Does this change need documentation?

- [ ] Documentation to be updated

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
