### PR TITLE
Fix retrieving multiple columns from the same response

### DIFF
--- a/sdk/src/api/method/query.rs
+++ b/sdk/src/api/method/query.rs
@@ -917,6 +917,31 @@ mod tests {
 	}
 
 	#[test]
+	fn take_key_multi() {
+		let article = Article {
+			title: "Lorem Ipsum".to_owned(),
+			body: "Lorem Ipsum Lorem Ipsum".to_owned(),
+		};
+		let value = to_value(article.clone()).unwrap();
+
+		let mut response = Response {
+			results: to_map(vec![Ok(value.clone().into_inner())]),
+			..Response::new()
+		};
+		let title: Vec<String> = response.take("title").unwrap();
+		assert_eq!(title, vec![article.title.clone()]);
+		let body: Vec<String> = response.take("body").unwrap();
+		assert_eq!(body, vec![article.body]);
+
+		let mut response = Response {
+			results: to_map(vec![Ok(value.clone().into_inner())]),
+			..Response::new()
+		};
+		let vec: Vec<String> = response.take("title").unwrap();
+		assert_eq!(vec, vec![article.title]);
+	}
+
+	#[test]
 	fn take_partial_records() {
 		let mut response = Response {
 			results: to_map(vec![Ok(vec![true, false].into())]),

--- a/sdk/src/api/opt/query.rs
+++ b/sdk/src/api/opt/query.rs
@@ -403,7 +403,7 @@ where
 				Err(error) => {
 					let error = mem::replace(error, Error::ConnectionUninitialised.into());
 					response.results.swap_remove(&index);
-					return Err(error);
+					Err(error)
 				}
 			},
 			None => Ok(vec![]),

--- a/sdk/src/api/opt/query.rs
+++ b/sdk/src/api/opt/query.rs
@@ -377,13 +377,27 @@ where
 {
 	fn query_result(self, response: &mut QueryResponse) -> Result<Vec<T>> {
 		let (index, key) = self;
-		let mut response = match response.results.get_mut(&index) {
+		match response.results.get_mut(&index) {
 			Some((_, result)) => match result {
 				Ok(val) => match val {
-					CoreValue::Array(vec) => mem::take(&mut vec.0),
+					CoreValue::Array(vec) => {
+						let mut responses = Vec::with_capacity(vec.len());
+						for value in vec.iter_mut() {
+							if let CoreValue::Object(object) = value {
+								if let Some(value) = object.remove(key) {
+									responses.push(value);
+								}
+							}
+						}
+						from_core_value(responses.into()).map_err(Into::into)
+					}
 					val => {
-						let val = mem::take(val);
-						vec![val]
+						if let CoreValue::Object(object) = val {
+							if let Some(value) = object.remove(key) {
+								return from_core_value(vec![value].into()).map_err(Into::into);
+							}
+						}
+						Ok(vec![])
 					}
 				},
 				Err(error) => {
@@ -392,19 +406,8 @@ where
 					return Err(error);
 				}
 			},
-			None => {
-				return Ok(vec![]);
-			}
-		};
-		let mut vec = Vec::with_capacity(response.len());
-		for value in response.iter_mut() {
-			if let CoreValue::Object(object) = value {
-				if let Some(value) = object.remove(key) {
-					vec.push(value);
-				}
-			}
+			None => Ok(vec![]),
 		}
-		from_core_value(vec.into()).map_err(Into::into)
 	}
 
 	fn stats(&self, response: &QueryResponse) -> Option<Stats> {


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The SDK is designed to allow retrieving multiple columns from the same query response. While this works when retrieving into an `Option`, it doesn't work when using a `Vec`.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It updates the implementation to ensure this behaviour is supported for `Vec`.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Add both unit and integration tests.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Fixes #3682.

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
