### PR TITLE
Ensure `int` division converts to a `float`

### DIFF
--- a/sdk/tests/function.rs
+++ b/sdk/tests/function.rs
@@ -2256,7 +2256,9 @@ async fn function_math_mean() -> Result<(), Error> {
 	let sql = r#"
 		RETURN math::mean([]);
 		RETURN math::mean([101, 213, 202]);
-		RETURN math::mean([101.5, 213.5, 202.5]);
+		RETURN math::mean([101, 213, 203]);
+		RETURN math::mean([101, 213, 203.4]);
+		RETURN math::mean([101.5, 213.5, 206.5]);
 	"#;
 	let mut test = Test::new(sql).await?;
 	//
@@ -2268,7 +2270,15 @@ async fn function_math_mean() -> Result<(), Error> {
 	assert_eq!(tmp, val);
 	//
 	let tmp = test.next()?.result?;
-	let val = Value::from(172.5);
+	let val = Value::from(172.33333333333334);
+	assert_eq!(tmp, val);
+	//
+	let tmp = test.next()?.result?;
+	let val = Value::from(172.46666666666667);
+	assert_eq!(tmp, val);
+	//
+	let tmp = test.next()?.result?;
+	let val = Value::from(173.83333333333334);
 	assert_eq!(tmp, val);
 	//
 	Ok(())

--- a/sdk/tests/table.rs
+++ b/sdk/tests/table.rs
@@ -23,11 +23,11 @@ async fn define_foreign_table() -> Result<(), Error> {
 			GROUP BY age
 		;
 		INFO FOR TABLE person;
-		UPSERT person:one SET age = 39, score = 70;
+		UPSERT person:one SET age = 39, score = 72;
 		SELECT * FROM person_by_age;
-		UPSERT person:two SET age = 39, score = 80;
+		UPSERT person:two SET age = 39, score = 83;
 		SELECT * FROM person_by_age;
-		UPSERT person:two SET age = 39, score = 90;
+		UPSERT person:two SET age = 39, score = 91;
 		SELECT * FROM person_by_age;
 	";
 	let dbs = new_ds().await?;
@@ -59,7 +59,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 			{
 				age: 39,
 				id: person:one,
-				score: 70,
+				score: 72,
 			}
 		]",
 	);
@@ -70,11 +70,11 @@ async fn define_foreign_table() -> Result<(), Error> {
 		"[
 			{
 				age: 39,
-				average: 70,
+				average: 72,
 				count: 1,
 				id: person_by_age:[39],
-				max: 70,
-				min: 70,
+				max: 72,
+				min: 72,
 				total: 39
 			}
 		]",
@@ -82,7 +82,15 @@ async fn define_foreign_table() -> Result<(), Error> {
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::parse("[{ id: person:two, age: 39, score: 80 }]");
+	let val = Value::parse(
+		"[
+			{
+				age: 39,
+				id: person:two,
+				score: 83,
+			}
+		]",
+	);
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
@@ -90,11 +98,11 @@ async fn define_foreign_table() -> Result<(), Error> {
 		"[
 			{
 				age: 39,
-				average: 75,
+				average: 77.5,
 				count: 2,
 				id: person_by_age:[39],
-				max: 80,
-				min: 70,
+				max: 83,
+				min: 72,
 				total: 78
 			}
 		]",
@@ -102,7 +110,15 @@ async fn define_foreign_table() -> Result<(), Error> {
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
-	let val = Value::parse("[{ id: person:two, age: 39, score: 90 }]");
+	let val = Value::parse(
+		"[
+			{
+				age: 39,
+				id: person:two,
+				score: 91,
+			}
+		]",
+	);
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
@@ -110,11 +126,11 @@ async fn define_foreign_table() -> Result<(), Error> {
 		"[
 			{
 				age: 39,
-				average: 80,
+				average: 81.5,
 				count: 2,
 				id: person_by_age:[39],
-				max: 90,
-				min: 70,
+				max: 91,
+				min: 72,
 				total: 78
 			}
 		]",


### PR DESCRIPTION
## What is the motivation?

Currently if you compute the `math::mean()` of multiple integers, you receive a rounded integer back, not the expected floating point numeric value that is the correct mean of those numbers. As a result when computing the `math::mean()` over records in a table, or as a field in a `DEFINE TABLE ... AS` pre-computed view, then the results are incorrect.

## What does this change do?

This change ensures that the division of `int` numbers is correct, fixing `math::mean()` aggregations on a table select, and `math::mean()` aggregations on a `DEFINE TABLE ... AS` precomputed view.

Insert data:
```sql
BEGIN;
DEFINE TABLE mean AS SELECT math::mean(amt) AS mean FROM test GROUP ALL;
CREATE test SET amt = 1;
CREATE test SET amt = 2;
CREATE test SET amt = 3;
CREATE test SET amt = 4;
CREATE test SET amt = 5;
CREATE test SET amt = 5;
CREATE test SET amt = 5;
RETURN NONE;
COMMIT;
```

Compare results:
```sql
-- Mean result should be 3.5714285714285716f
RETURN math::mean([1, 2, 3, 4, 5, 5, 5]);
-- Mean result should be 3.5714285714285716f
SELECT math::mean(amt) AS mean FROM test GROUP ALL;
-- Mean result should be 3.5714285714285716f
SELECT * FROM mean;
```

## What is your testing strategy?

Updated tests.

## Is this related to any issues?

- [x] Closes #4351 

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
