### PR TITLE
Simplify `cfg` attributes around codebase

### DIFF
--- a/core/src/cnf/mod.rs
+++ b/core/src/cnf/mod.rs
@@ -51,14 +51,7 @@ pub static SCRIPTING_MAX_MEMORY_LIMIT: Lazy<usize> =
 pub static INSECURE_FORWARD_ACCESS_ERRORS: Lazy<bool> =
 	lazy_env_parse!("SURREAL_INSECURE_FORWARD_ACCESS_ERRORS", bool, false);
 
-#[cfg(any(
-	feature = "kv-mem",
-	feature = "kv-surrealkv",
-	feature = "kv-rocksdb",
-	feature = "kv-fdb",
-	feature = "kv-tikv",
-	feature = "kv-surrealcs",
-))]
+#[cfg(storage)]
 /// Specifies the buffer limit for external sorting.
 pub static EXTERNAL_SORTING_BUFFER_LIMIT: Lazy<usize> =
 	lazy_env_parse!("SURREAL_EXTERNAL_SORTING_BUFFER_LIMIT", usize, 50_000);

--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -16,14 +16,7 @@ use channel::Sender;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
-#[cfg(any(
-	feature = "kv-mem",
-	feature = "kv-surrealkv",
-	feature = "kv-rocksdb",
-	feature = "kv-fdb",
-	feature = "kv-tikv",
-	feature = "kv-surrealcs",
-))]
+#[cfg(storage)]
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -71,14 +64,7 @@ pub struct MutableContext {
 	index_builder: Option<IndexBuilder>,
 	// Capabilities
 	capabilities: Arc<Capabilities>,
-	#[cfg(any(
-		feature = "kv-mem",
-		feature = "kv-surrealkv",
-		feature = "kv-rocksdb",
-		feature = "kv-fdb",
-		feature = "kv-tikv",
-		feature = "kv-surrealcs",
-	))]
+	#[cfg(storage)]
 	// The temporary directory
 	temporary_directory: Option<Arc<PathBuf>>,
 	// An optional transaction
@@ -118,15 +104,7 @@ impl MutableContext {
 		capabilities: Capabilities,
 		index_stores: IndexStores,
 		#[cfg(not(target_arch = "wasm32"))] index_builder: IndexBuilder,
-		#[cfg(any(
-			feature = "kv-mem",
-			feature = "kv-surrealkv",
-			feature = "kv-rocksdb",
-			feature = "kv-fdb",
-			feature = "kv-tikv",
-			feature = "kv-surrealcs",
-		))]
-		temporary_directory: Option<Arc<PathBuf>>,
+		#[cfg(storage)] temporary_directory: Option<Arc<PathBuf>>,
 	) -> Result<MutableContext, Error> {
 		let mut ctx = Self {
 			values: HashMap::default(),
@@ -141,14 +119,7 @@ impl MutableContext {
 			index_stores,
 			#[cfg(not(target_arch = "wasm32"))]
 			index_builder: Some(index_builder),
-			#[cfg(any(
-				feature = "kv-mem",
-				feature = "kv-surrealkv",
-				feature = "kv-rocksdb",
-				feature = "kv-fdb",
-				feature = "kv-tikv",
-				feature = "kv-surrealcs",
-			))]
+			#[cfg(storage)]
 			temporary_directory,
 			transaction: None,
 			isolated: false,
@@ -173,14 +144,7 @@ impl MutableContext {
 			index_stores: IndexStores::default(),
 			#[cfg(not(target_arch = "wasm32"))]
 			index_builder: None,
-			#[cfg(any(
-				feature = "kv-mem",
-				feature = "kv-surrealkv",
-				feature = "kv-rocksdb",
-				feature = "kv-fdb",
-				feature = "kv-tikv",
-				feature = "kv-surrealcs",
-			))]
+			#[cfg(storage)]
 			temporary_directory: None,
 			transaction: None,
 			isolated: false,
@@ -201,14 +165,7 @@ impl MutableContext {
 			index_stores: parent.index_stores.clone(),
 			#[cfg(not(target_arch = "wasm32"))]
 			index_builder: parent.index_builder.clone(),
-			#[cfg(any(
-				feature = "kv-mem",
-				feature = "kv-surrealkv",
-				feature = "kv-rocksdb",
-				feature = "kv-fdb",
-				feature = "kv-tikv",
-				feature = "kv-surrealcs",
-			))]
+			#[cfg(storage)]
 			temporary_directory: parent.temporary_directory.clone(),
 			transaction: parent.transaction.clone(),
 			isolated: false,
@@ -240,6 +197,7 @@ impl MutableContext {
 			index_stores: parent.index_stores.clone(),
 			#[cfg(not(target_arch = "wasm32"))]
 			index_builder: parent.index_builder.clone(),
+			//TODO: is there a reason these shouldn't include kv-surrealcs
 			#[cfg(any(
 				feature = "kv-mem",
 				feature = "kv-surrealkv",
@@ -409,14 +367,7 @@ impl MutableContext {
 		matches!(self.done(), Some(Reason::Timedout))
 	}
 
-	#[cfg(any(
-		feature = "kv-mem",
-		feature = "kv-surrealkv",
-		feature = "kv-rocksdb",
-		feature = "kv-fdb",
-		feature = "kv-tikv",
-		feature = "kv-surrealcs",
-	))]
+	#[cfg(storage)]
 	/// Return the location of the temporary directory if any
 	pub fn temporary_directory(&self) -> Option<&Arc<PathBuf>> {
 		self.temporary_directory.as_ref()

--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -197,14 +197,7 @@ impl MutableContext {
 			index_stores: parent.index_stores.clone(),
 			#[cfg(not(target_arch = "wasm32"))]
 			index_builder: parent.index_builder.clone(),
-			//TODO: is there a reason these shouldn't include kv-surrealcs
-			#[cfg(any(
-				feature = "kv-mem",
-				feature = "kv-surrealkv",
-				feature = "kv-rocksdb",
-				feature = "kv-fdb",
-				feature = "kv-tikv",
-			))]
+			#[cfg(storage)]
 			temporary_directory: parent.temporary_directory.clone(),
 			transaction: parent.transaction.clone(),
 			isolated: true,
@@ -226,13 +219,7 @@ impl MutableContext {
 			index_stores: from.index_stores.clone(),
 			#[cfg(not(target_arch = "wasm32"))]
 			index_builder: from.index_builder.clone(),
-			#[cfg(any(
-				feature = "kv-mem",
-				feature = "kv-surrealkv",
-				feature = "kv-rocksdb",
-				feature = "kv-fdb",
-				feature = "kv-tikv",
-			))]
+			#[cfg(storage)]
 			temporary_directory: from.temporary_directory.clone(),
 			transaction: None,
 			isolated: false,

--- a/core/src/dbs/iterator.rs
+++ b/core/src/dbs/iterator.rs
@@ -301,14 +301,7 @@ impl Iterator {
 		self.setup_start(stk, &cancel_ctx, opt, stm).await?;
 		// Prepare the results with possible optimisations on groups
 		self.results = self.results.prepare(
-			#[cfg(any(
-				feature = "kv-mem",
-				feature = "kv-surrealkv",
-				feature = "kv-rocksdb",
-				feature = "kv-fdb",
-				feature = "kv-tikv",
-				feature = "kv-surrealcs",
-			))]
+			#[cfg(storage)]
 			ctx,
 			stm,
 		)?;

--- a/core/src/dbs/statement.rs
+++ b/core/src/dbs/statement.rs
@@ -246,14 +246,7 @@ impl<'a> Statement<'a> {
 
 	/// Returns any TEMPFILES clause if specified
 	#[inline]
-	#[cfg(any(
-		feature = "kv-mem",
-		feature = "kv-surrealkv",
-		feature = "kv-rocksdb",
-		feature = "kv-fdb",
-		feature = "kv-tikv",
-		feature = "kv-surrealcs",
-	))]
+	#[cfg(storage)]
 	pub fn tempfiles(&self) -> bool {
 		match self {
 			Statement::Select(v) => v.tempfiles,

--- a/core/src/dbs/store.rs
+++ b/core/src/dbs/store.rs
@@ -53,14 +53,7 @@ impl From<Vec<Value>> for MemoryCollector {
 	}
 }
 
-#[cfg(any(
-	feature = "kv-mem",
-	feature = "kv-surrealkv",
-	feature = "kv-rocksdb",
-	feature = "kv-fdb",
-	feature = "kv-tikv",
-	feature = "kv-surrealcs",
-))]
+#[cfg(storage)]
 pub(super) mod file_store {
 	use crate::cnf::EXTERNAL_SORTING_BUFFER_LIMIT;
 	use crate::dbs::plan::Explanation;

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -9,14 +9,7 @@ use crate::syn::error::RenderedError as RenderedParserError;
 use crate::vs::Error as VersionstampError;
 use base64::DecodeError as Base64Error;
 use bincode::Error as BincodeError;
-#[cfg(any(
-	feature = "kv-mem",
-	feature = "kv-surrealkv",
-	feature = "kv-rocksdb",
-	feature = "kv-fdb",
-	feature = "kv-tikv",
-	feature = "kv-surrealcs",
-))]
+#[cfg(storage)]
 use ext_sort::SortError;
 use fst::Error as FstError;
 use jsonwebtoken::errors::Error as JWTError;
@@ -1209,14 +1202,7 @@ impl From<reqwest::Error> for Error {
 	}
 }
 
-#[cfg(any(
-	feature = "kv-mem",
-	feature = "kv-surrealkv",
-	feature = "kv-rocksdb",
-	feature = "kv-fdb",
-	feature = "kv-tikv",
-	feature = "kv-surrealcs",
-))]
+#[cfg(storage)]
 impl<S, D, I> From<SortError<S, D, I>> for Error
 where
 	S: std::error::Error,

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -259,13 +259,7 @@ impl Datastore {
 			index_builder: IndexBuilder::new(self.transaction_factory.clone()),
 			#[cfg(feature = "jwks")]
 			jwks_cache: Arc::new(Default::default()),
-			#[cfg(any(
-				feature = "kv-mem",
-				feature = "kv-surrealkv",
-				feature = "kv-rocksdb",
-				feature = "kv-fdb",
-				feature = "kv-tikv",
-			))]
+			#[cfg(storage)]
 			temporary_directory: self.temporary_directory,
 			transaction_factory: self.transaction_factory,
 		}

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -27,14 +27,7 @@ use channel::{Receiver, Sender};
 use futures::Future;
 use reblessive::TreeStack;
 use std::fmt;
-#[cfg(any(
-	feature = "kv-mem",
-	feature = "kv-surrealkv",
-	feature = "kv-rocksdb",
-	feature = "kv-fdb",
-	feature = "kv-tikv",
-	feature = "kv-surrealcs",
-))]
+#[cfg(storage)]
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -83,14 +76,7 @@ pub struct Datastore {
 	#[cfg(feature = "jwks")]
 	// The JWKS object cache
 	jwks_cache: Arc<RwLock<JwksCache>>,
-	#[cfg(any(
-		feature = "kv-mem",
-		feature = "kv-surrealkv",
-		feature = "kv-rocksdb",
-		feature = "kv-fdb",
-		feature = "kv-tikv",
-		feature = "kv-surrealcs",
-	))]
+	#[cfg(storage)]
 	// The temporary directory
 	temporary_directory: Option<Arc<PathBuf>>,
 }
@@ -439,14 +425,7 @@ impl Datastore {
 				index_builder: IndexBuilder::new(tf),
 				#[cfg(feature = "jwks")]
 				jwks_cache: Arc::new(RwLock::new(JwksCache::new())),
-				#[cfg(any(
-					feature = "kv-mem",
-					feature = "kv-surrealkv",
-					feature = "kv-rocksdb",
-					feature = "kv-fdb",
-					feature = "kv-tikv",
-					feature = "kv-surrealcs",
-				))]
+				#[cfg(storage)]
 				temporary_directory: None,
 			}
 		})
@@ -494,14 +473,7 @@ impl Datastore {
 		self
 	}
 
-	#[cfg(any(
-		feature = "kv-mem",
-		feature = "kv-surrealkv",
-		feature = "kv-rocksdb",
-		feature = "kv-fdb",
-		feature = "kv-tikv",
-		feature = "kv-surrealcs",
-	))]
+	#[cfg(storage)]
 	/// Set a temporary directory for ordering of large result sets
 	pub fn with_temporary_directory(mut self, path: Option<PathBuf>) -> Self {
 		self.temporary_directory = path.map(Arc::new);
@@ -856,14 +828,7 @@ impl Datastore {
 			self.index_stores.clone(),
 			#[cfg(not(target_arch = "wasm32"))]
 			self.index_builder.clone(),
-			#[cfg(any(
-				feature = "kv-mem",
-				feature = "kv-surrealkv",
-				feature = "kv-rocksdb",
-				feature = "kv-fdb",
-				feature = "kv-tikv",
-				feature = "kv-surrealcs",
-			))]
+			#[cfg(storage)]
 			self.temporary_directory.clone(),
 		)?;
 		// Setup the notification channel

--- a/sdk/src/api/engine/local/native.rs
+++ b/sdk/src/api/engine/local/native.rs
@@ -108,14 +108,7 @@ pub(crate) async fn run_router(
 		.with_transaction_timeout(address.config.transaction_timeout)
 		.with_capabilities(address.config.capabilities);
 
-	#[cfg(any(
-		feature = "kv-mem",
-		feature = "kv-surrealkv",
-		feature = "kv-rocksdb",
-		feature = "kv-fdb",
-		feature = "kv-tikv",
-		feature = "kv-surrealcs",
-	))]
+	#[cfg(storage)]
 	let kvs = kvs.with_temporary_directory(address.config.temporary_directory);
 
 	let kvs = Arc::new(kvs);

--- a/sdk/src/api/opt/config.rs
+++ b/sdk/src/api/opt/config.rs
@@ -1,12 +1,5 @@
 use crate::opt::capabilities::Capabilities;
-#[cfg(any(
-	feature = "kv-mem",
-	feature = "kv-surrealkv",
-	feature = "kv-rocksdb",
-	feature = "kv-fdb",
-	feature = "kv-tikv",
-	feature = "kv-surrealcs",
-))]
+#[cfg(storage)]
 use std::path::PathBuf;
 use std::time::Duration;
 use surrealdb_core::{dbs::Capabilities as CoreCapabilities, iam::Level};
@@ -27,14 +20,7 @@ pub struct Config {
 	pub(crate) password: String,
 	pub(crate) tick_interval: Option<Duration>,
 	pub(crate) capabilities: CoreCapabilities,
-	#[cfg(any(
-		feature = "kv-mem",
-		feature = "kv-surrealkv",
-		feature = "kv-rocksdb",
-		feature = "kv-fdb",
-		feature = "kv-tikv",
-		feature = "kv-surrealcs",
-	))]
+	#[cfg(storage)]
 	pub(crate) temporary_directory: Option<PathBuf>,
 }
 
@@ -124,14 +110,7 @@ impl Config {
 		self
 	}
 
-	#[cfg(any(
-		feature = "kv-mem",
-		feature = "kv-surrealkv",
-		feature = "kv-rocksdb",
-		feature = "kv-fdb",
-		feature = "kv-tikv",
-		feature = "kv-surrealcs",
-	))]
+	#[cfg(storage)]
 	pub fn temporary_directory(mut self, path: Option<PathBuf>) -> Self {
 		self.temporary_directory = path;
 		self


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

there is frequent use of a cfg with 6 items, and which needs to be updated if a new storage engine is added, but an equivalent custom cfg is already generated.

## What does this change do?

switches to #[cfg(storage)]

## What is your testing strategy?

existing tests

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
