### PR TITLE
Improve aggregate function argument checks

### DIFF
--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -229,6 +229,14 @@ pub enum Error {
 	},
 
 	/// The wrong quantity or magnitude of arguments was given for the specified function
+	#[error("Incorrect arguments for aggregate function {name}() on table '{table}'. {message}")]
+	InvalidAggregation {
+		name: String,
+		table: String,
+		message: String,
+	},
+
+	/// The wrong quantity or magnitude of arguments was given for the specified function
 	#[error("There was a problem running the {name} function. Expected this function to return a value of type {check}, but found {value}")]
 	FunctionCheck {
 		name: String,


### PR DESCRIPTION
## What is the motivation?

Currently when inserting non-numeric types into table fields which are used in `DEFINE TABLE ... AS` views, you will get an error about the incorrect type not being able to be added or divided by another number. However this isn't totally clear where the error is happening.

## What does this change do?

It ensures that the correct types are inserted into fields which are used in a foreign table view. For example if the `age` field is used in a `DEFINE TABLE ... AS` view which uses the `math::mean()` function, then the value type inserted into the `age` field must be a `number`. 

- `math::min()` expects only `number` types
- `math::max()` expects only `number` types
- `math::sum()` expects only `number` types
- `math::mean()` expects only `number` types
- `time::min()` expects only `datetime` types
- `time::max()` expects only `datetime` types

In addition, previously the error would be:
```
Expected a decimal but cannot convert 'test' into a decimal"
```

Now however, the error which is thrown will be:
```
Incorrect arguments for aggregate function math::mean() on table 'average_age'. This function expects a number but found 'test'
```

## What is your testing strategy?

Modified tests to check for the thrown error.

## Is this related to any issues?

- [x] Improves upon #4390

## Does this change need documentation?

- [ ] Documentation to be added

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
