### PR TITLE
Add `fail!()` macro and test

### DIFF
--- a/core/src/doc/compute.rs
+++ b/core/src/doc/compute.rs
@@ -88,7 +88,7 @@ impl Document {
 		// two separtate UNIQUE index definitions, and it
 		// wasn't possible to detect which record was the
 		// correct one to be updated
-		let _ = chn.send(Err(Error::Unreachable("Internal error"))).await;
+		let _ = chn.send(Err(fail!("Internal error"))).await;
 		// Break the loop
 		Ok(())
 	}

--- a/core/src/doc/process.rs
+++ b/core/src/doc/process.rs
@@ -80,6 +80,6 @@ impl Document {
 		// two separtate UNIQUE index definitions, and it
 		// wasn't possible to detect which record was the
 		// correct one to be updated
-		Err(Error::Unreachable("Internal error"))
+		Err(fail!("Internal error"))
 	}
 }

--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -119,6 +119,13 @@ macro_rules! lazy_env_parse_or_else {
 	};
 }
 
+#[macro_export]
+macro_rules! err_unreachable {
+	($msg: literal) => {
+		crate::err::Error::Unreachable(concat!(file!(), ":", line!(), ": ", $msg))
+	};
+}
+
 #[cfg(test)]
 macro_rules! async_defer{
 	(let $bind:ident = ($capture:expr) defer { $($d:tt)* } after { $($t:tt)* }) => {
@@ -203,6 +210,8 @@ macro_rules! async_defer{
 
 #[cfg(test)]
 mod test {
+	use crate::err::Error;
+
 	#[tokio::test]
 	async fn async_defer_basic() {
 		let mut counter = 0;
@@ -240,5 +249,13 @@ mod test {
 			panic!("this panic should be caught")
 		})
 		.await;
+	}
+
+	#[test]
+	fn err_unreachable() {
+		let Error::Unreachable(msg) = err_unreachable!("unreachable") else {
+			panic!()
+		};
+		assert_eq!("core/src/mac/mod.rs:256: unreachable", msg);
 	}
 }

--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -122,7 +122,7 @@ macro_rules! lazy_env_parse_or_else {
 #[macro_export]
 macro_rules! err_unreachable {
 	($msg: literal) => {
-		crate::err::Error::Unreachable(concat!(file!(), ":", line!(), ": ", $msg))
+		$crate::err::Error::Unreachable(concat!(file!(), ":", line!(), ": ", $msg))
 	};
 }
 

--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -1,3 +1,10 @@
+/// Throws an unreachable error with location details
+macro_rules! fail {
+	($msg: literal) => {
+		$crate::err::Error::Unreachable(concat!(file!(), ":", line!(), ": ", $msg))
+	};
+}
+
 /// Converts some text into a new line byte string
 macro_rules! bytes {
 	($expression:expr) => {
@@ -116,13 +123,6 @@ macro_rules! lazy_env_parse_or_else {
 				.and_then(|s| Ok(s.parse::<$t>().unwrap_or_else($default)))
 				.unwrap_or_else($default)
 		})
-	};
-}
-
-#[macro_export]
-macro_rules! err_unreachable {
-	($msg: literal) => {
-		$crate::err::Error::Unreachable(concat!(file!(), ":", line!(), ": ", $msg))
 	};
 }
 
@@ -252,10 +252,10 @@ mod test {
 	}
 
 	#[test]
-	fn err_unreachable() {
-		let Error::Unreachable(msg) = err_unreachable!("unreachable") else {
+	fn fail() {
+		let Error::Unreachable(msg) = fail!("Reached unreachable code") else {
 			panic!()
 		};
-		assert_eq!("core/src/mac/mod.rs:256: unreachable", msg);
+		assert_eq!("core/src/mac/mod.rs:256: Reached unreachable code", msg);
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

panics should be avoided when possible, but they have an advantage of making it clear where the error is occurring which aids in debugging.

## What does this change do?

provide the err_unreachable! macro, which generates an Error::Unreachable with the provided string and the file/line of the macro invocation.

## What is your testing strategy?

test that the macro produces an error with file/line

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
