### PR TITLE
Ensure `catch!()` and `run!()` macros are consistent

### DIFF
--- a/core/src/kvs/node.rs
+++ b/core/src/kvs/node.rs
@@ -27,7 +27,7 @@ impl Datastore {
 		let key = crate::key::root::nd::Nd::new(id);
 		let now = self.clock_now().await;
 		let val = Node::new(id, now, false);
-		match run!(txn, txn.put(key, val, None)) {
+		match run!(txn, txn.put(key, val, None).await) {
 			Err(Error::TxKeyAlreadyExists) => Err(Error::ClAlreadyExists {
 				value: id.to_string(),
 			}),
@@ -51,7 +51,7 @@ impl Datastore {
 		let key = crate::key::root::nd::new(id);
 		let now = self.clock_now().await;
 		let val = Node::new(id, now, false);
-		run!(txn, txn.set(key, val, None))
+		run!(txn, txn.set(key, val, None).await)
 	}
 
 	/// Deletes a node from the cluster.
@@ -70,7 +70,7 @@ impl Datastore {
 		let key = crate::key::root::nd::new(id);
 		let val = txn.get_node(id).await?;
 		let val = val.as_ref().archive();
-		run!(txn, txn.set(key, val, None))
+		run!(txn, txn.set(key, val, None).await)
 	}
 
 	/// Expires nodes which have timedout from the cluster.

--- a/core/src/mac/mod.rs
+++ b/core/src/mac/mod.rs
@@ -55,7 +55,7 @@ macro_rules! catch {
 /// transaction in an uncommitted state without rolling back.
 macro_rules! run {
 	($txn:ident, $default:expr) => {
-		match $default.await {
+		match $default {
 			Err(e) => {
 				let _ = $txn.cancel().await;
 				Err(e)


### PR DESCRIPTION
## What does this change do?

Minor code adjustments to ensure `catch!()` and `run!()` macros are consistent.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
