### PR TITLE
Use async commit and one-phase commit where possible in TiKV

### DIFF
--- a/core/src/kvs/tikv/mod.rs
+++ b/core/src/kvs/tikv/mod.rs
@@ -84,6 +84,10 @@ impl Datastore {
 		} else {
 			TransactionOptions::new_optimistic()
 		};
+		// Use async commit to determine transaction state earlier
+		opt = opt.use_async_commit();
+		// Try to use one-phase commit if writing to only one region
+		opt = opt.try_one_pc();
 		// Set the behaviour when dropping an unfinished transaction
 		opt = opt.drop_check(CheckLevel::Warn);
 		// Set this transaction as read only if possible


### PR DESCRIPTION
## What does this change do?

Sets transaction configuration options for TiKV in order to use async commit and to attempt to use one-phase commit when operating on only a single region.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
