### PR TITLE
Fix importing from 1.x

### DIFF
--- a/core/src/dbs/executor.rs
+++ b/core/src/dbs/executor.rs
@@ -257,11 +257,17 @@ impl<'a> Executor<'a> {
 				}
 				// Begin a new transaction
 				Statement::Begin(_) => {
+					if opt.import {
+						continue;
+					}
 					self.begin(Write).await;
 					continue;
 				}
 				// Cancel a running transaction
 				Statement::Cancel(_) => {
+					if opt.import {
+						continue;
+					}
 					self.cancel(true).await;
 					self.clear(&ctx, recv.clone()).await;
 					buf = buf.into_iter().map(|v| self.buf_cancel(v)).collect();
@@ -272,6 +278,9 @@ impl<'a> Executor<'a> {
 				}
 				// Commit a running transaction
 				Statement::Commit(_) => {
+					if opt.import {
+						continue;
+					}
 					let commit_error = self.commit(true).await.err();
 					buf = buf.into_iter().map(|v| self.buf_commit(v, &commit_error)).collect();
 					self.flush(&ctx, recv.clone()).await;

--- a/core/src/sql/statement.rs
+++ b/core/src/sql/statement.rs
@@ -156,7 +156,7 @@ impl Statement {
 		opt: &Options,
 		doc: Option<&CursorDoc>,
 	) -> Result<Value, Error> {
-		let subject = match (opt.import, self) {
+		let stm = match (opt.import, self) {
 			// All exports in SurrealDB 1.x are done with `UPDATE`, but
 			// because `UPDATE` works different in SurrealDB 2.x, we need
 			// to convert these statements into `UPSERT` statements.
@@ -169,10 +169,10 @@ impl Statement {
 				timeout: stm.timeout.to_owned(),
 				parallel: stm.parallel,
 			}),
-			(_, subject) => subject,
+			(_, stm) => stm,
 		};
 
-		match subject {
+		match stm {
 			Self::Access(v) => v.compute(ctx, opt, doc).await,
 			Self::Alter(v) => v.compute(stk, ctx, opt, doc).await,
 			Self::Analyze(v) => v.compute(ctx, opt, doc).await,

--- a/core/src/sql/statement.rs
+++ b/core/src/sql/statement.rs
@@ -156,7 +156,23 @@ impl Statement {
 		opt: &Options,
 		doc: Option<&CursorDoc>,
 	) -> Result<Value, Error> {
-		match self {
+		let subject = match (opt.import, self) {
+			// All exports in SurrealDB 1.x are done with `UPDATE`, but
+			// because `UPDATE` works different in SurrealDB 2.x, we need
+			// to convert these statements into `UPSERT` statements.
+			(true, Self::Update(stm)) => &Statement::Upsert(UpsertStatement {
+				only: stm.only,
+				what: stm.what.to_owned(),
+				data: stm.data.to_owned(),
+				cond: stm.cond.to_owned(),
+				output: stm.output.to_owned(),
+				timeout: stm.timeout.to_owned(),
+				parallel: stm.parallel,
+			}),
+			(_, subject) => subject,
+		};
+
+		match subject {
 			Self::Access(v) => v.compute(ctx, opt, doc).await,
 			Self::Alter(v) => v.compute(stk, ctx, opt, doc).await,
 			Self::Analyze(v) => v.compute(ctx, opt, doc).await,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

All exports in SurrealDB 1.x are done with `UPDATE`, but because `UPDATE` works different in SurrealDB 2.x, we need to convert these statements into `UPSERT` statements.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR ensures that `UPDATE` statements during imports are treated as `UPSERT` statements. Additionally, transactions are now ignored during imports.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes https://github.com/surrealdb/surrealdb/issues/4691
- [x] Fixes https://github.com/surrealdb/surrealdb/issues/4398
- [x] Fixes https://github.com/surrealdb/surrealdb/issues/4240

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
