### PR TITLE
Deprecate missing format inference on RPC protocol

### DIFF
--- a/sdk/src/api/engine/remote/ws/mod.rs
+++ b/sdk/src/api/engine/remote/ws/mod.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 pub(crate) const PATH: &str = "rpc";
 const PING_INTERVAL: Duration = Duration::from_secs(5);
 const REVISION_HEADER: &str = "revision";
+const BINCODE_HEADER: &str = "bincode";
 
 enum RequestEffect {
 	/// Completing this request sets a variable to a give value.

--- a/sdk/src/api/engine/remote/ws/native.rs
+++ b/sdk/src/api/engine/remote/ws/native.rs
@@ -80,6 +80,10 @@ pub(crate) async fn connect(
 		request
 			.headers_mut()
 			.insert(SEC_WEBSOCKET_PROTOCOL, HeaderValue::from_static(super::REVISION_HEADER));
+	} else {
+		request
+			.headers_mut()
+			.insert(SEC_WEBSOCKET_PROTOCOL, HeaderValue::from_static(super::BINCODE_HEADER));
 	}
 
 	#[cfg(any(feature = "native-tls", feature = "rustls"))]

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -38,7 +38,7 @@ pub enum Error {
 	OperationUnsupported,
 
 	#[error("There was a problem parsing the header {0}: {1}")]
-	InvalidHeader(HeaderName, TypedHeaderRejection),
+	InvalidHeader(HeaderName, String),
 
 	#[error("There was a problem with the database: {0}")]
 	Db(#[from] SurrealError),

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -2,7 +2,6 @@ use crate::cli::abstraction::auth::Error as SurrealAuthError;
 use axum::response::{IntoResponse, Response};
 use axum::Error as AxumError;
 use axum::Json;
-use axum_extra::typed_header::TypedHeaderRejection;
 use base64::DecodeError as Base64Error;
 use http::{HeaderName, StatusCode};
 use reqwest::Error as ReqwestError;

--- a/src/net/headers/mod.rs
+++ b/src/net/headers/mod.rs
@@ -58,7 +58,7 @@ where
 		Ok(TypedHeader(val)) => Ok(Some(val.to_string())),
 		Err(e) => match e.reason() {
 			TypedHeaderRejectionReason::Missing => Ok(None),
-			_ => Err(Error::InvalidHeader(H::name().to_owned(), e)),
+			_ => Err(Error::InvalidHeader(H::name().to_owned(), e.to_string())),
 		},
 	}
 }

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -54,8 +54,11 @@ async fn get_handler(
 	State(rpc_state): State<Arc<RpcState>>,
 	headers: HeaderMap,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
+	// Check that a valid header has been specified
 	if headers.get(SEC_WEBSOCKET_PROTOCOL).is_none() {
-		warn!("Recieved upgrade with unspecified protocol, protocol inference is deprecated, please upgrade clients to set the sec-websocket-protocol header");
+		warn!("A connection was made without a specified protocol.");
+		warn!("Automatic inference of the protocol format is deprecated in SurrealDB 2.0 and will be removed in SurrealDB 3.0.");
+		warn!("Please upgrade any client to ensure that the connection format is specified correctly");
 	}
 
 	// Check if there is a connection id header specified

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -58,7 +58,9 @@ async fn get_handler(
 	if headers.get(SEC_WEBSOCKET_PROTOCOL).is_none() {
 		warn!("A connection was made without a specified protocol.");
 		warn!("Automatic inference of the protocol format is deprecated in SurrealDB 2.0 and will be removed in SurrealDB 3.0.");
-		warn!("Please upgrade any client to ensure that the connection format is specified correctly");
+		warn!(
+			"Please upgrade any client to ensure that the connection format is specified correctly"
+		);
 	}
 
 	// Check if there is a connection id header specified

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -58,9 +58,7 @@ async fn get_handler(
 	if headers.get(SEC_WEBSOCKET_PROTOCOL).is_none() {
 		warn!("A connection was made without a specified protocol.");
 		warn!("Automatic inference of the protocol format is deprecated in SurrealDB 2.0 and will be removed in SurrealDB 3.0.");
-		warn!(
-			"Please upgrade any client to ensure that the connection format is specified correctly"
-		);
+		warn!("Please upgrade any client to ensure that the connection format is specified.");
 	}
 
 	// Check if there is a connection id header specified

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -19,7 +19,6 @@ use axum::{
 	response::IntoResponse,
 	Extension, Router,
 };
-use axum_extra::headers::ContentType;
 use axum_extra::headers::Header;
 use axum_extra::TypedHeader;
 use bytes::Bytes;
@@ -35,6 +34,7 @@ use tower_http::request_id::RequestId;
 use uuid::Uuid;
 
 use super::headers::Accept;
+use super::headers::ContentType;
 use super::AppState;
 
 use surrealdb::rpc::rpc_context::RpcContext;
@@ -54,10 +54,8 @@ async fn get_handler(
 	State(rpc_state): State<Arc<RpcState>>,
 	headers: HeaderMap,
 ) -> Result<impl IntoResponse, impl IntoResponse> {
-	error!(?headers);
-
 	if headers.get(SEC_WEBSOCKET_PROTOCOL).is_none() {
-		return Err(Error::InvalidHeader(SEC_WEBSOCKET_PROTOCOL, "Missing".to_string()));
+		warn!("Recieved upgrade with unspecified protocol, protocol inference is deprecated, please upgrade clients to set the sec-websocket-protocol header");
 	}
 
 	// Check if there is a connection id header specified

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -23,7 +23,6 @@ use axum_extra::headers::Header;
 use axum_extra::TypedHeader;
 use bytes::Bytes;
 use http::HeaderMap;
-use http::HeaderValue;
 use surrealdb::dbs::Session;
 use surrealdb::kvs::Datastore;
 use surrealdb::rpc::format::Format;
@@ -119,9 +118,9 @@ async fn handle_socket(
 	id: Uuid,
 ) {
 	// Check if there is a WebSocket protocol specified
-	let format = match ws.protocol().map(HeaderValue::to_str) {
+	let format = match ws.protocol().map(|h| h.to_str().ok()).flatten() {
 		// Any selected protocol will always be a valie value
-		Some(protocol) => protocol.unwrap().into(),
+		Some(protocol) => protocol.into(),
 		// No protocol format was specified
 		_ => Format::None,
 	};

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -285,7 +285,7 @@ impl Connection {
 	/// Handle individual WebSocket messages
 	async fn handle_message(rpc: Arc<RwLock<Connection>>, msg: Message, chn: Sender<Message>) {
 		// Get the current output format
-		let mut fmt = rpc.read().await.format;
+		let fmt = rpc.read().await.format;
 		// Prepare Span and Otel context
 		let span = span_for_request(&rpc.read().await.id);
 		// Acquire concurrent request rate limiter
@@ -293,20 +293,10 @@ impl Connection {
 		// Calculate the length of the message
 		let len = match msg {
 			Message::Text(ref msg) => {
-				// If no format was specified, default to JSON
-				if fmt.is_none() {
-					fmt = Format::Json;
-					rpc.write().await.format = fmt;
-				}
 				// Retrieve the length of the message
 				msg.len()
 			}
 			Message::Binary(ref msg) => {
-				// If no format was specified, default to Bincode
-				if fmt.is_none() {
-					fmt = Format::Bincode;
-					rpc.write().await.format = fmt;
-				}
 				// Retrieve the length of the message
 				msg.len()
 			}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

support for no protocol will be removed in v3.0, this will warn users if their clients will fail on the next version

## What does this change do?

This pull request makes the following changes:

- Ensures that a format header is sent to the server for HTTP and WS connections. This defaults to `revision`, and will be `bincode` on any other connections.
- Throws a warning if a client connects without specifying a desired format. This should be specified in the `Sec-Websocket-Protocol` header, or the `Content-Type` header.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
