### PR TITLE
Refactoring: 'SHUTDOWN_AFTER' env variable added to emulate server shutdown.

### DIFF
--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -11,6 +11,7 @@ mod cli_integration {
 	use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 	use serde::{Deserialize, Serialize};
 	use serde_json::json;
+	use std::collections::HashMap;
 	use std::fs::File;
 	use std::time;
 	use std::time::Duration;
@@ -244,18 +245,18 @@ mod cli_integration {
 
 	#[test(tokio::test)]
 	async fn start_tls() {
-		let (_, server) = common::start_server(StartServerArguments {
+		let (_, mut server) = common::start_server(StartServerArguments {
 			tls: true,
 			wait_is_ready: false,
+			vars: Some(HashMap::from([("SHUTDOWN_AFTER".to_string(), "5000".to_string())])),
 			..Default::default()
 		})
 		.await
 		.unwrap();
 
-		std::thread::sleep(std::time::Duration::from_millis(5000));
-		let output = server.kill().output().err().unwrap();
+		let output = server.output().unwrap();
 
-		// Test the crt/key args but the keys are self signed so don't actually connect.
+		// Test the crt/key args but the keys are self-signed so don't actually connect.
 		assert!(output.contains("Started web server"), "couldn't start web server: {output}");
 	}
 

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -247,6 +247,7 @@ pub async fn start_server(
 	let path = path.unwrap_or("memory".to_string());
 
 	let mut extra_args = args.clone();
+
 	if tls {
 		// Test the crt/key args but the keys are self signed so don't actually connect.
 		let crt_path = tmp_file("crt.crt");


### PR DESCRIPTION
'SHUTDOWN_AFTER' env variable added to emulate server shutdown after initial delay.

## What is the motivation?
I encountered intermittent issues during the integration tests, specifically with `cli_integration.start_tls()`. The test failed because it was set to wait for 5 seconds (5000 ms) before sending a kill signal. However, on my laptop, the server doesn't always start within that 5-second window, causing the test to fail unpredictably."

## What does this change do?
I added a 'SHUTDOWN_AFTER' environment variable to simulate a graceful server shutdown after an initial delay. This makes the integration tests cleaner and can also be used for other end-to-end tests.

## What is your testing strategy?

```
cargo test
```

## Is this related to any issues?

- [ v ] No related issues

## Does this change need documentation?

- [ v ] No documentation needed

## Have you read the Contributing Guidelines?

- [ v ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
