### PR TITLE
Remove obsolete `ml2` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5405,7 +5405,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "surreal"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "async-channel 1.9.0",
  "bincode",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "addr",
  "any_ascii",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surreal"
 publish = false
 edition = "2021"
-version = "1.5.2"
+version = "1.5.3"
 license-file = "LICENSE"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surrealdb-core"
 publish = true
 edition = "2021"
-version = "1.5.2"
+version = "1.5.3"
 rust-version = "1.70.0"
 readme = "../lib/CARGO.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,7 +40,7 @@ kv-fdb-7_1 = ["foundationdb/fdb-7_1", "kv-fdb"]
 kv-surrealkv = ["dep:surrealkv", "tokio/time"]
 scripting = ["dep:js"]
 http = ["dep:reqwest"]
-ml = ["dep:surrealml-core1", "dep:ndarray"]
+ml = ["dep:surrealml-core", "dep:ndarray"]
 jwks = ["dep:reqwest"]
 arbitrary = [
     "dep:arbitrary",
@@ -142,7 +142,7 @@ sha2 = "0.10.8"
 snap = "1.1.0"
 speedb = { version = "0.0.4", features = ["lz4", "snappy"], optional = true }
 storekey = "0.5.0"
-surrealml-core1 = { version = "0.1.1", optional = true, package = "surrealml-core" }
+surrealml-core = { version = "0.1.1", optional = true }
 surrealkv = { version = "0.1.3", optional = true }
 thiserror = "1.0.50"
 tikv = { version = "0.2.0-surreal.2", default-features = false, package = "surrealdb-tikv-client", optional = true }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,7 +34,7 @@ pub mod idx;
 pub mod key;
 #[doc(hidden)]
 pub mod kvs;
-#[cfg(any(feature = "ml", feature = "ml2", feature = "jwks"))]
+#[cfg(any(feature = "ml", feature = "jwks"))]
 #[doc(hidden)]
 pub mod obs;
 pub mod options;
@@ -50,12 +50,7 @@ pub mod channel {
 	pub use channel::Sender;
 }
 
-#[cfg(all(feature = "ml", not(feature = "ml2")))]
+#[cfg(feature = "ml")]
 #[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
-pub use surrealml_core1 as ml;
-
-#[cfg(feature = "ml2")]
-#[cfg(not(target_arch = "wasm32"))]
-#[doc(hidden)]
-pub use surrealml_core2 as ml;
+pub use surrealml_core as ml;

--- a/core/src/sql/model.rs
+++ b/core/src/sql/model.rs
@@ -8,22 +8,22 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 use crate::iam::Action;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 use crate::ml::errors::error::SurrealError;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 use crate::ml::execution::compute::ModelComputation;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 use crate::ml::storage::surml_file::SurMlFile;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 use crate::sql::Permission;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 use futures::future::try_join_all;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 use std::collections::HashMap;
 
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 const ARGUMENTS: &str = "The model expects 1 argument. The argument can be either a number, an object, or an array of numbers.";
 
 #[revisioned(revision = 1)]
@@ -49,7 +49,7 @@ impl fmt::Display for Model {
 }
 
 impl Model {
-	#[cfg(any(feature = "ml", feature = "ml2"))]
+	#[cfg(feature = "ml")]
 	pub(crate) async fn compute(
 		&self,
 		ctx: &Context<'_>,
@@ -210,7 +210,7 @@ impl Model {
 		}
 	}
 
-	#[cfg(not(any(feature = "ml", feature = "ml2")))]
+	#[cfg(not(feature = "ml"))]
 	pub(crate) async fn compute(
 		&self,
 		_ctx: &Context<'_>,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surrealdb"
 publish = false
 edition = "2021"
-version = "1.5.2"
+version = "1.5.3"
 rust-version = "1.70.0"
 readme = "CARGO.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]

--- a/lib/src/api/engine/local/mod.rs
+++ b/lib/src/api/engine/local/mod.rs
@@ -46,28 +46,28 @@ use crate::api::Surreal;
 use crate::dbs::Notification;
 use crate::dbs::Response;
 use crate::dbs::Session;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::iam::check::check_ns_db;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::iam::Action;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::iam::ResourceKind;
 use crate::kvs::Datastore;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::kvs::{LockType, TransactionType};
 use crate::method::Stats;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::ml::storage::surml_file::SurMlFile;
 use crate::opt::IntoEndpoint;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::sql::statements::DefineModelStatement;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::sql::statements::DefineStatement;
 use crate::sql::statements::KillStatement;
@@ -79,7 +79,7 @@ use crate::sql::Strand;
 use crate::sql::Uuid;
 use crate::sql::Value;
 use channel::Sender;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 #[cfg(not(target_arch = "wasm32"))]
 use futures::StreamExt;
 use indexmap::IndexMap;
@@ -445,7 +445,7 @@ async fn export(
 	ml_config: Option<MlConfig>,
 ) -> Result<()> {
 	match ml_config {
-		#[cfg(any(feature = "ml", feature = "ml2"))]
+		#[cfg(feature = "ml")]
 		Some(MlConfig::Export {
 			name,
 			version,
@@ -707,7 +707,7 @@ async fn router(
 				}
 			};
 			let responses = match param.ml_config {
-				#[cfg(any(feature = "ml", feature = "ml2"))]
+				#[cfg(feature = "ml")]
 				Some(MlConfig::Import) => {
 					// Ensure a NS and DB are set
 					let (nsv, dbv) = check_ns_db(session)?;

--- a/lib/src/api/engine/remote/http/mod.rs
+++ b/lib/src/api/engine/remote/http/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod wasm;
 
 use crate::api::conn::DbResponse;
 use crate::api::conn::Method;
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 #[cfg(not(target_arch = "wasm32"))]
 use crate::api::conn::MlConfig;
 use crate::api::conn::Param;
@@ -525,7 +525,7 @@ async fn router(
 		#[cfg(not(target_arch = "wasm32"))]
 		Method::Export => {
 			let path = match param.ml_config {
-				#[cfg(any(feature = "ml", feature = "ml2"))]
+				#[cfg(feature = "ml")]
 				Some(MlConfig::Export {
 					name,
 					version,
@@ -543,7 +543,7 @@ async fn router(
 		#[cfg(not(target_arch = "wasm32"))]
 		Method::Import => {
 			let path = match param.ml_config {
-				#[cfg(any(feature = "ml", feature = "ml2"))]
+				#[cfg(feature = "ml")]
 				Some(MlConfig::Import) => base_url.join("ml/import")?,
 				_ => base_url.join(Method::Import.as_str())?,
 			};

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -105,11 +105,6 @@ compile_error!(
 	"`parser2` is currently unstable. You need to enable the `surrealdb_unstable` flag to use it."
 );
 
-#[cfg(all(not(surrealdb_unstable), feature = "ml2"))]
-compile_error!(
-	"`ml2` is currently unstable. You need to enable the `surrealdb_unstable` flag to use it."
-);
-
 #[cfg(all(not(surrealdb_unstable), feature = "jwks"))]
 compile_error!("`jwks` depends on a currently unstable feature, `sql2`. You need to enable the `surrealdb_unstable` flag to use it.");
 

--- a/lib/tests/api/backup.rs
+++ b/lib/tests/api/backup.rs
@@ -31,7 +31,7 @@ async fn export_import() {
 }
 
 #[test_log::test(tokio::test)]
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 async fn ml_export_import() {
 	let (permit, db) = new_db().await;
 	let db_name = Ulid::new().to_string();

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -17,7 +17,7 @@ mod sync;
 mod tracer;
 mod version;
 
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 mod ml;
 
 use crate::cli::CF;
@@ -166,7 +166,7 @@ pub async fn init(ct: CancellationToken) -> Result<(), Error> {
 		.merge(signup::router())
 		.merge(key::router());
 
-	#[cfg(any(feature = "ml", feature = "ml2"))]
+	#[cfg(feature = "ml")]
 	let axum_app = axum_app.merge(ml::router());
 
 	let axum_app = axum_app.layer(service);

--- a/tests/ml_integration.rs
+++ b/tests/ml_integration.rs
@@ -1,7 +1,7 @@
 // RUST_LOG=warn cargo make ci-ml-integration
 mod common;
 
-#[cfg(any(feature = "ml", feature = "ml2"))]
+#[cfg(feature = "ml")]
 mod ml_integration {
 
 	use super::*;


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The `ml2` feature is now obsolete.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It removes the feature from Rust modules.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
