### PR TITLE
Add additional chained methods to number values

### DIFF
--- a/core/src/fnc/mod.rs
+++ b/core/src/fnc/mod.rs
@@ -665,6 +665,33 @@ pub async fn idiom(
 				"values" => object::values,
 			)
 		}
+		Value::Number(_) => {
+			dispatch!(
+				name,
+				args.clone(),
+				"no such method found for the number type",
+				//
+				"abs" => math::abs,
+				"acos" => math::acos,
+				"acot" => math::acot,
+				"asin" => math::asin,
+				"atan" => math::atan,
+				"ceil" => math::ceil,
+				"cos" => math::cos,
+				"cot" => math::cot,
+				"deg2rad" => math::deg2rad,
+				"floor" => math::floor,
+				"ln" => math::ln,
+				"log" => math::log,
+				"log10" => math::log10,
+				"log2" => math::log2,
+				"rad2deg" => math::rad2deg,
+				"round" => math::round,
+				"sign" => math::sign,
+				"sin" => math::sin,
+				"tan" => math::tan,
+			)
+		}
 		Value::Strand(_) => {
 			dispatch!(
 				name,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

It is not possible to run queries like the following:

```sql
3.14159.ceil();
```

## What does this change do?

Adds additional chained methods to numeric values (`int`, `float`, and `decimal`). The chained functions are:

- `number.abs()`
- `number.acos()`
- `number.acot()`
- `number.asin()`
- `number.atan()`
- `number.ceil()`
- `number.cos()`
- `number.cot()`
- `number.deg2rad()`
- `number.floor()`
- `number.ln()`
- `number.log()`
- `number.log10()`
- `number.log2()`
- `number.rad2deg()`
- `number.round()`
- `number.sign()`
- `number.sin()`
- `number.tan()`

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [ ] Documentation to be added

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
