### PR TITLE
Implement conversions for bytes and geometries in script functions

### DIFF
--- a/core/src/fnc/script/from.rs
+++ b/core/src/fnc/script/from.rs
@@ -55,8 +55,8 @@ fn try_object_to_geom(object: &Object) -> Option<Geometry> {
 		"MultiPolygon" => {
 			return object
 				.get("coordinates")
-				.and_then(Geometry::array_to_multiline)
-				.map(Geometry::MultiLine)
+				.and_then(Geometry::array_to_multipolygon)
+				.map(Geometry::MultiPolygon)
 		}
 		"GeometryCollection" => {
 			let Some(Value::Array(x)) = object.get("geometries") else {

--- a/core/src/fnc/script/from.rs
+++ b/core/src/fnc/script/from.rs
@@ -3,7 +3,10 @@ use crate::sql::array::Array;
 use crate::sql::datetime::Datetime;
 use crate::sql::object::Object;
 use crate::sql::value::Value;
+use crate::sql::Bytes;
+use crate::sql::Geometry;
 use crate::sql::Id;
+use crate::sql::Strand;
 use chrono::{TimeZone, Utc};
 use js::prelude::This;
 use js::Coerced;
@@ -19,6 +22,60 @@ fn check_nul(s: &str) -> Result<(), Error> {
 		Err(Error::InvalidString(std::ffi::CString::new(s).unwrap_err()))
 	} else {
 		Ok(())
+	}
+}
+
+fn try_object_to_geom(object: &Object) -> Option<Geometry> {
+	if object.len() != 2 {
+		return None;
+	}
+
+	let Some(Value::Strand(Strand(key))) = object.get("type") else {
+		return None;
+	};
+
+	match key.as_str() {
+		"Point" => {
+			object.get("coordinates").and_then(Geometry::array_to_point).map(Geometry::Point)
+		}
+		"LineString" => {
+			object.get("coordinates").and_then(Geometry::array_to_line).map(Geometry::Line)
+		}
+		"Polygon" => {
+			object.get("coordinates").and_then(Geometry::array_to_polygon).map(Geometry::Polygon)
+		}
+		"MultiPoint" => object
+			.get("coordinates")
+			.and_then(Geometry::array_to_multipoint)
+			.map(Geometry::MultiPoint),
+		"MultiLineString" => object
+			.get("coordinates")
+			.and_then(Geometry::array_to_multiline)
+			.map(Geometry::MultiLine),
+		"MultiPolygon" => {
+			return object
+				.get("coordinates")
+				.and_then(Geometry::array_to_multiline)
+				.map(Geometry::MultiLine)
+		}
+		"GeometryCollection" => {
+			let Some(Value::Array(x)) = object.get("geometries") else {
+				return None;
+			};
+
+			let mut res = Vec::with_capacity(x.len());
+
+			for x in x.iter() {
+				let Value::Geometry(x) = x else {
+					return None;
+				};
+				res.push(x.clone());
+			}
+
+			Some(Geometry::Collection(res))
+		}
+
+		_ => None,
 	}
 }
 
@@ -89,6 +146,19 @@ impl<'js> FromJs<'js> for Value {
 						None => Ok(Value::None),
 					};
 				}
+
+				if let Some(v) = v.as_typed_array::<u8>() {
+					let Some(data) = v.as_bytes() else {
+						return Err(Error::new_from_js_message(
+							"Uint8Array",
+							"Bytes",
+							"Uint8Array data was consumed.",
+						));
+					};
+
+					return Ok(Value::Bytes(Bytes(data.to_vec())));
+				}
+
 				// Check to see if this object is a date
 				let date: js::Object = ctx.globals().get(js::atom::PredefinedAtom::Date)?;
 				if (v).is_instance_of(&date) {
@@ -97,6 +167,7 @@ impl<'js> FromJs<'js> for Value {
 					let d = Utc.timestamp_millis_opt(m).unwrap();
 					return Ok(Datetime::from(d).into());
 				}
+
 				// Check to see if this object is an array
 				if let Some(v) = v.as_array() {
 					let mut x = Array::with_capacity(v.len());
@@ -107,6 +178,7 @@ impl<'js> FromJs<'js> for Value {
 					}
 					return Ok(x.into());
 				}
+
 				// Check to see if this object is a function
 				if v.as_function().is_some() {
 					return Ok(Value::None);
@@ -120,6 +192,11 @@ impl<'js> FromJs<'js> for Value {
 					let v = Value::from_js(ctx, v)?;
 					x.insert(k, v);
 				}
+
+				if let Some(x) = try_object_to_geom(&x) {
+					return Ok(x.into());
+				}
+
 				Ok(x.into())
 			}
 			_ => Ok(Value::Null),

--- a/core/src/sql/geometry.rs
+++ b/core/src/sql/geometry.rs
@@ -119,6 +119,7 @@ impl Geometry {
 			Self::Collection(v) => collection(v),
 		}
 	}
+
 	/// Get the GeoJSON object representation for this geometry
 	pub fn as_object(&self) -> Object {
 		let mut obj = BTreeMap::<String, Value>::new();
@@ -133,6 +134,88 @@ impl Geometry {
 		);
 
 		obj.into()
+	}
+
+	/// Converts a surreal value to a MultiPolygon if the array matches to a MultiPolygon.
+	pub(crate) fn array_to_multipolygon(v: &Value) -> Option<MultiPolygon<f64>> {
+		let mut res = Vec::new();
+		let Value::Array(v) = v else {
+			return None;
+		};
+		for x in v.iter() {
+			res.push(Self::array_to_polygon(x)?);
+		}
+		Some(MultiPolygon::new(res))
+	}
+
+	/// Converts a surreal value to a MultiLine if the array matches to a MultiLine.
+	pub(crate) fn array_to_multiline(v: &Value) -> Option<MultiLineString<f64>> {
+		let mut res = Vec::new();
+		let Value::Array(v) = v else {
+			return None;
+		};
+		for x in v.iter() {
+			res.push(Self::array_to_line(x)?);
+		}
+		Some(MultiLineString::new(res))
+	}
+
+	/// Converts a surreal value to a MultiPoint if the array matches to a MultiPoint.
+	pub(crate) fn array_to_multipoint(v: &Value) -> Option<MultiPoint<f64>> {
+		let mut res = Vec::new();
+		let Value::Array(v) = v else {
+			return None;
+		};
+		for x in v.iter() {
+			res.push(Self::array_to_point(x)?);
+		}
+		Some(MultiPoint::new(res))
+	}
+
+	/// Converts a surreal value to a Polygon if the array matches to a Polygon.
+	pub(crate) fn array_to_polygon(v: &Value) -> Option<Polygon<f64>> {
+		let mut res = Vec::new();
+		let Value::Array(v) = v else {
+			return None;
+		};
+		if v.is_empty() {
+			return None;
+		}
+		let first = Self::array_to_line(&v[0])?;
+		for x in &v[1..] {
+			res.push(Self::array_to_line(x)?);
+		}
+		Some(Polygon::new(first, res))
+	}
+
+	/// Converts a surreal value to a LineString if the array matches to a LineString.
+	pub(crate) fn array_to_line(v: &Value) -> Option<LineString<f64>> {
+		let mut res = Vec::new();
+		let Value::Array(v) = v else {
+			return None;
+		};
+		for x in v.iter() {
+			res.push(Self::array_to_point(x)?);
+		}
+		Some(LineString::from(res))
+	}
+
+	/// Converts a surreal value to a Point if the array matches to a point.
+	pub(crate) fn array_to_point(v: &Value) -> Option<Point<f64>> {
+		let Value::Array(v) = v else {
+			return None;
+		};
+		if v.len() != 2 {
+			return None;
+		}
+		// FIXME: This truncates decimals and large integers into a f64.
+		let Value::Number(ref a) = v.0[0] else {
+			return None;
+		};
+		let Value::Number(ref b) = v.0[1] else {
+			return None;
+		};
+		Some(Point::from((a.clone().try_into().ok()?, b.clone().try_into().ok()?)))
 	}
 }
 

--- a/sdk/tests/script.rs
+++ b/sdk/tests/script.rs
@@ -401,7 +401,7 @@ async fn script_bytes() -> Result<(), Error> {
 	};
 
 	for i in 0..8 {
-		assert_eq!(b[0], i as u8)
+		assert_eq!(b[i], i as u8)
 	}
 
 	Ok(())
@@ -538,7 +538,7 @@ async fn script_geometry_multi_line() -> Result<(), Error> {
 	let sql = r#"
 		RETURN function() {
 			return {
-				type: "Polygon",
+				type: "MultiLineString",
 				coordinates: [
 					[
 						[1.0,2.0],
@@ -600,8 +600,9 @@ async fn script_geometry_multi_polygon() -> Result<(), Error> {
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 1);
 
-	let Value::Geometry(Geometry::MultiPolygon(x)) = res.remove(0).result? else {
-		panic!("not a geometry");
+	let v = res.remove(0).result?;
+	let Value::Geometry(Geometry::MultiPolygon(x)) = v else {
+		panic!("{:?} is not the right geometry", v);
 	};
 
 	assert_eq!(x.0[0].exterior().0[0].x, 1.0);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Some conversions between SurQL types and JS types are missing.

## What does this change do?

Implements the conversions for bytes and geometry objects.

## What is your testing strategy?

Added tests for the conversions.
## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Fixes #4331

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
