### PR TITLE
Refactoring: 'STARTUP_MODE' env variable added to emulate server shutdown.

### DIFF
--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -1,6 +1,7 @@
 use super::config::{Config, CF};
 use crate::cli::validator::parser::env_filter::CustomEnvFilter;
 use crate::cli::validator::parser::env_filter::CustomEnvFilterParser;
+use crate::cnf::LOGO;
 use crate::dbs;
 use crate::dbs::StartCommandDbsOptions;
 use crate::env;
@@ -221,7 +222,12 @@ pub async fn init(
 
 	if let Ok(startup_mode_env_value) = std::env::var("STARTUP_MODE") {
 		// Start the web server in one of the StartupModes
-		net::init(datastore.clone(), canceller.clone(), StartupMode::try_from(startup_mode_env_value).unwrap()).await?;
+		net::init(
+			datastore.clone(),
+			canceller.clone(),
+			StartupMode::try_from(startup_mode_env_value).unwrap(),
+		)
+		.await?;
 	} else {
 		// Start the web server as usual
 		net::init(datastore.clone(), canceller.clone(), StartupMode::Normal).await?;

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -11,6 +11,7 @@ mod cli_integration {
 	use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 	use serde::{Deserialize, Serialize};
 	use serde_json::json;
+	use std::collections::HashMap;
 	use std::fs::File;
 	use std::time;
 	use std::time::Duration;
@@ -240,18 +241,18 @@ mod cli_integration {
 
 	#[test(tokio::test)]
 	async fn start_tls() {
-		let (_, server) = common::start_server(StartServerArguments {
+		let (_, mut server) = common::start_server(StartServerArguments {
 			tls: true,
 			wait_is_ready: false,
+			vars: Some(HashMap::from([("STARTUP_MODE".to_string(), "test".to_string())])),
 			..Default::default()
 		})
 		.await
 		.unwrap();
 
-		std::thread::sleep(std::time::Duration::from_millis(5000));
-		let output = server.kill().output().err().unwrap();
+		let output = server.output().unwrap();
 
-		// Test the crt/key args but the keys are self signed so don't actually connect.
+		// Test the crt/key args but the keys are self-signed so don't actually connect.
 		assert!(output.contains("Started web server"), "couldn't start web server: {output}");
 	}
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -243,7 +243,7 @@ mod cli_integration {
 	async fn start_tls() {
 		let (_, mut server) = common::start_server(StartServerArguments {
 			tls: true,
-			wait_is_ready: false,
+			wait_till_ready: false,
 			vars: Some(HashMap::from([("STARTUP_MODE".to_string(), "test".to_string())])),
 			..Default::default()
 		})
@@ -874,7 +874,7 @@ mod cli_integration {
 		let (addr, mut server) = common::start_server(StartServerArguments {
 			auth: false,
 			tls: false,
-			wait_is_ready: true,
+			wait_till_ready: true,
 			..Default::default()
 		})
 		.await

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -158,7 +158,7 @@ pub struct StartServerArguments {
 	pub path: Option<String>,
 	pub auth: bool,
 	pub tls: bool,
-	pub wait_is_ready: bool,
+	pub wait_till_ready: bool,
 	pub temporary_directory: Option<String>,
 	pub args: String,
 	pub vars: Option<HashMap<String, String>>,
@@ -170,7 +170,7 @@ impl Default for StartServerArguments {
 			path: None,
 			auth: true,
 			tls: false,
-			wait_is_ready: true,
+			wait_till_ready: true,
 			temporary_directory: None,
 			args: "".to_string(),
 			vars: None,
@@ -244,7 +244,7 @@ pub async fn start_server(
 		path,
 		auth,
 		tls,
-		wait_is_ready,
+		wait_till_ready,
 		temporary_directory,
 		args,
 		vars,
@@ -286,7 +286,7 @@ pub async fn start_server(
 		// Configure where the logs go when running the test
 		let server = run_internal::<String>(&start_args, None, vars.clone());
 
-		if !wait_is_ready {
+		if !wait_till_ready {
 			return Ok((addr, server));
 		}
 

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -255,6 +255,7 @@ pub async fn start_server(
 	let path = path.unwrap_or("memory".to_string());
 
 	let mut extra_args = args.clone();
+
 	if tls {
 		// Test the crt/key args but the keys are self signed so don't actually connect.
 		let crt_path = tmp_file("crt.crt");

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -255,7 +255,6 @@ pub async fn start_server(
 	let path = path.unwrap_or("memory".to_string());
 
 	let mut extra_args = args.clone();
-
 	if tls {
 		// Test the crt/key args but the keys are self signed so don't actually connect.
 		let crt_path = tmp_file("crt.crt");


### PR DESCRIPTION
## What is the motivation?

There is spurious failure inside `cli_integration.start_tls()` test. The test relies on the following code:
```
std::thread::sleep(std::time::Duration::from_millis(5000));
let output = server.kill().output().err().unwrap();
```
which is bad practice and on my laptop sometimes 5second not enough to start the server, so test is failed.

## What does this change do?

I propose to introduce new startup mode for server, `StartupMode = [Normal | Test]` that will be passed as an additional ENV variable. In `Test` mode, the server starts and then shuts down right away, without waiting for a socket connection. This helps us write more predictable integration tests.

## What is your testing strategy?

```
cargo test
```

## Is this related to any issues?

- [ v ] No related issues

## Does this change need documentation?

- [ v ] No documentation needed

## Have you read the Contributing Guidelines?

- [ v ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
