### PR TITLE
Implement insert statements for subqueries

### DIFF
--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -141,7 +141,7 @@ impl fmt::Display for InsertStatement {
 		if let Some(into) = &self.into {
 			write!(f, " INTO {}", into)?;
 		}
-		write!(f, "{}", self.data)?;
+		write!(f, " {}", self.data)?;
 		if let Some(ref v) = self.update {
 			write!(f, " {v}")?
 		}

--- a/core/src/syn/parser/token.rs
+++ b/core/src/syn/parser/token.rs
@@ -115,4 +115,23 @@ impl Parser<'_> {
 	pub(super) fn kind_starts_expression(kind: TokenKind) -> bool {
 		matches!(kind, t!("..") | t!("<") | t!("->")) | Self::kind_starts_prime_value(kind)
 	}
+
+	pub(super) fn starts_disallowed_subquery_statement(kind: TokenKind) -> bool {
+		matches!(
+			kind,
+			t!("ANALYZE")
+				| t!("BEGIN")
+				| t!("BREAK")
+				| t!("CANCEL")
+				| t!("COMMIT")
+				| t!("CONTINUE")
+				| t!("FOR") | t!("INFO")
+				| t!("KILL") | t!("LIVE")
+				| t!("OPTION")
+				| t!("LET") | t!("SHOW")
+				| t!("SLEEP")
+				| t!("THROW")
+				| t!("USE")
+		)
+	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

For some reason I seem to have never implemented `INSERT` as an allowed subquery like it was in the previous parser

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Implements INSERT in subquery positions

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added test for the new syntax.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- Fixes #4433

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
