### PR TITLE
Implement parsing of method calls on integers

### DIFF
--- a/core/src/syn/lexer/compound/number.rs
+++ b/core/src/syn/lexer/compound/number.rs
@@ -107,8 +107,8 @@ pub fn number_kind(lexer: &mut Lexer, start: Token) -> Result<NumberKind, Syntax
 	let mut kind = NumberKind::Integer;
 
 	let before_mantissa = lexer.reader.offset();
-	// need to test for digit.. which is a range not a floating point number.
-	if lexer.reader.peek1() != Some(b'.') && lexer.eat(b'.') {
+	// need to test for digit.. or digit.foo
+	if lexer.reader.peek1().map(|x| x.is_ascii_digit()).unwrap_or(false) && lexer.eat(b'.') {
 		eat_digits1(lexer, before_mantissa)?;
 		kind = NumberKind::Float;
 	}

--- a/core/src/syn/parser/test/value.rs
+++ b/core/src/syn/parser/test/value.rs
@@ -188,14 +188,14 @@ fn scientific_number() {
 fn number_method() {
 	let res = test_parse!(parse_value_table, r#" 9.7e-5.sin()"#).unwrap();
 	let expected = Value::Idiom(Idiom(vec![
-		Part::Value(Value::Number(Number::Float(9.7e-5))),
+		Part::Start(Value::Number(Number::Float(9.7e-5))),
 		Part::Method("sin".to_string(), vec![]),
 	]));
 	assert_eq!(res, expected);
 
 	let res = test_parse!(parse_value_table, r#" 1.sin()"#).unwrap();
 	let expected = Value::Idiom(Idiom(vec![
-		Part::Value(Value::Number(Number::Int(1))),
+		Part::Start(Value::Number(Number::Int(1))),
 		Part::Method("sin".to_string(), vec![]),
 	]));
 	assert_eq!(res, expected);

--- a/core/src/syn/parser/test/value.rs
+++ b/core/src/syn/parser/test/value.rs
@@ -4,7 +4,8 @@ use reblessive::Stack;
 
 use crate::{
 	sql::{
-		Array, Constant, Id, Number, Object, Query, Statement, Statements, Strand, Thing, Value,
+		Array, Constant, Id, Idiom, Number, Object, Part, Query, Statement, Statements, Strand,
+		Thing, Value,
 	},
 	syn::parser::{mac::test_parse, Parser},
 };
@@ -181,6 +182,23 @@ fn scientific_number() {
 	let res = test_parse!(parse_value_table, r#" 9.7e-5"#).unwrap();
 	assert!(matches!(res, Value::Number(Number::Float(_))));
 	assert_eq!(res.to_string(), "0.000097f")
+}
+
+#[test]
+fn number_method() {
+	let res = test_parse!(parse_value_table, r#" 9.7e-5.sin()"#).unwrap();
+	let expected = Value::Idiom(Idiom(vec![
+		Part::Value(Value::Number(Number::Float(9.7e-5))),
+		Part::Method("sin".to_string(), vec![]),
+	]));
+	assert_eq!(res, expected);
+
+	let res = test_parse!(parse_value_table, r#" 1.sin()"#).unwrap();
+	let expected = Value::Idiom(Idiom(vec![
+		Part::Value(Value::Number(Number::Int(1))),
+		Part::Method("sin".to_string(), vec![]),
+	]));
+	assert_eq!(res, expected);
 }
 
 #[test]

--- a/sdk/tests/script.rs
+++ b/sdk/tests/script.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "scripting")]
 
 mod parse;
-use geo::Extremes;
 use parse::Parse;
 mod helpers;
 use helpers::new_ds;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Support for calls of numbers was added but the parser didn't properly support calls on integers, for example: `1.sin()`

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Implements parsing for integer method calls.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added test to ensure the syntax is properly supported.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
