### PR TITLE
Support allowlisting of specific capabilities via the SurrealDB CLI

### DIFF
--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -422,22 +422,20 @@ impl MutableContext {
 
 	/// Check if a network target is allowed
 	#[cfg(feature = "http")]
-	pub fn check_allowed_net(&self, target: &Url) -> Result<(), Error> {
-		match target.host() {
+	pub fn check_allowed_net(&self, url: &Url) -> Result<(), Error> {
+		match url.host() {
 			Some(host) => {
-				if !self.capabilities.allows_network_target(&NetTarget::Host(
-					host.to_owned(),
-					target.port_or_known_default(),
-				)) {
+				let target = &NetTarget::Host(host.to_owned(), url.port_or_known_default());
+				if !self.capabilities.allows_network_target(target) {
 					warn!(
-						"Capabilities denied outgoing network connection attempt, target: '{host}'"
+						"Capabilities denied outgoing network connection attempt, target: '{target}'",
 					);
 					return Err(Error::NetTargetNotAllowed(target.to_string()));
 				}
-				trace!("Capabilities allowed outgoing network connection, target: '{host}'");
+				trace!("Capabilities allowed outgoing network connection, target: '{target}'",);
 				Ok(())
 			}
-			_ => Err(Error::InvalidUrl(target.to_string())),
+			_ => Err(Error::InvalidUrl(url.to_string())),
 		}
 	}
 }

--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -424,19 +424,20 @@ impl MutableContext {
 	#[cfg(feature = "http")]
 	pub fn check_allowed_net(&self, target: &Url) -> Result<(), Error> {
 		match target.host() {
-			Some(host)
-				if self.capabilities.allows_network_target(&NetTarget::Host(
+			Some(host) => {
+				if !self.capabilities.allows_network_target(&NetTarget::Host(
 					host.to_owned(),
 					target.port_or_known_default(),
-				)) =>
-			{
-				trace!("Capabilities allowed outgoing network connection, target '{target}'");
+				)) {
+					warn!(
+						"Capabilities denied outgoing network connection attempt, target: '{host}'"
+					);
+					return Err(Error::NetTargetNotAllowed(target.to_string()));
+				}
+				trace!("Capabilities allowed outgoing network connection, target: '{host}'");
 				Ok(())
 			}
-			_ => {
-				warn!("Capabilities denied outgoing network connection attempt, target '{target}'");
-				Err(Error::NetTargetNotAllowed(target.to_string()))
-			}
+			_ => Err(Error::InvalidUrl(target.to_string())),
 		}
 	}
 }

--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -403,16 +403,20 @@ impl MutableContext {
 	#[allow(dead_code)]
 	pub fn check_allowed_scripting(&self) -> Result<(), Error> {
 		if !self.capabilities.allows_scripting() {
+			warn!("Capabilities denied scripting attempt");
 			return Err(Error::ScriptingNotAllowed);
 		}
+		trace!("Capabilities allowed scripting");
 		Ok(())
 	}
 
 	/// Check if a function is allowed
 	pub fn check_allowed_function(&self, target: &str) -> Result<(), Error> {
 		if !self.capabilities.allows_function_name(target) {
+			warn!("Capabilities denied function execution attempt, target: '{target}'");
 			return Err(Error::FunctionNotAllowed(target.to_string()));
 		}
+		trace!("Capabilities allowed function execution, target: '{target}'");
 		Ok(())
 	}
 
@@ -426,9 +430,13 @@ impl MutableContext {
 					target.port_or_known_default(),
 				)) =>
 			{
+				trace!("Capabilities allowed outgoing network connection, target '{target}'");
 				Ok(())
 			}
-			_ => Err(Error::NetTargetNotAllowed(target.to_string())),
+			_ => {
+				warn!("Capabilities denied outgoing network connection attempt, target '{target}'");
+				Err(Error::NetTargetNotAllowed(target.to_string()))
+			}
 		}
 	}
 }

--- a/core/src/ctx/context.rs
+++ b/core/src/ctx/context.rs
@@ -428,11 +428,11 @@ impl MutableContext {
 				let target = &NetTarget::Host(host.to_owned(), url.port_or_known_default());
 				if !self.capabilities.allows_network_target(target) {
 					warn!(
-						"Capabilities denied outgoing network connection attempt, target: '{target}'",
+						"Capabilities denied outgoing network connection attempt, target: '{target}'"
 					);
 					return Err(Error::NetTargetNotAllowed(target.to_string()));
 				}
-				trace!("Capabilities allowed outgoing network connection, target: '{target}'",);
+				trace!("Capabilities allowed outgoing network connection, target: '{target}'");
 				Ok(())
 			}
 			_ => Err(Error::InvalidUrl(url.to_string())),

--- a/core/src/fnc/script/tests/fetch.rs
+++ b/core/src/fnc/script/tests/fetch.rs
@@ -196,7 +196,7 @@ async fn test_fetch_denied() {
 
 	assert!(
 		res.to_string()
-			.contains(&format!("Access to network target '{}/hello' is not allowed", server.uri())),
+			.contains(&format!("Access to network target '{}' is not allowed", server.address())),
 		"Unexpected result: {:?}",
 		res
 	);

--- a/core/src/iam/jwks.rs
+++ b/core/src/iam/jwks.rs
@@ -226,11 +226,9 @@ pub(super) async fn config(
 async fn find_jwk_from_url(kvs: &Datastore, url: &str, kid: &str) -> Result<Jwk, Error> {
 	// Check that the datastore capabilities allow connections to the URL host
 	if let Err(err) = check_capabilities_url(kvs, url) {
-		warn!("Capabilities denied outgoing network connection attempt, target: '{url}'");
 		warn!("Network access to JWKS location is not allowed: '{}'", err);
 		return Err(Error::InvalidAuth); // Return opaque error
 	}
-	trace!("Capabilities allowed outgoing network connection, target: '{url}'");
 
 	// Retrieve JWKS cache
 	let cache = kvs.jwks_cache();
@@ -281,8 +279,10 @@ fn check_capabilities_url(kvs: &Datastore, url: &str) -> Result<(), Error> {
 		}
 	};
 	if !kvs.allows_network_target(&target) {
+		warn!("Capabilities denied outgoing network connection attempt, target: '{target}'");
 		return Err(Error::InvalidUrl(url.to_string()));
 	}
+	trace!("Capabilities allowed outgoing network connection, target: '{target}'");
 
 	Ok(())
 }

--- a/core/src/iam/jwks.rs
+++ b/core/src/iam/jwks.rs
@@ -225,10 +225,12 @@ pub(super) async fn config(
 // Attempts to find a relevant JWK object inside a JWKS object fetched from the remote location
 async fn find_jwk_from_url(kvs: &Datastore, url: &str, kid: &str) -> Result<Jwk, Error> {
 	// Check that the datastore capabilities allow connections to the URL host
-	if let Err(err) = check_capabilities_url(kvs, url) {
+	if let Err(err) = kvs.check_capabilities_url(kvs, url) {
+		warn!("Capabilities denied outgoing network connection attempt, target: '{url}'");
 		warn!("Network access to JWKS location is not allowed: '{}'", err);
 		return Err(Error::InvalidAuth); // Return opaque error
 	}
+	trace!("Capabilities allowed outgoing network connection, target: '{url}'");
 
 	// Retrieve JWKS cache
 	let cache = kvs.jwks_cache();

--- a/core/src/iam/jwks.rs
+++ b/core/src/iam/jwks.rs
@@ -225,7 +225,7 @@ pub(super) async fn config(
 // Attempts to find a relevant JWK object inside a JWKS object fetched from the remote location
 async fn find_jwk_from_url(kvs: &Datastore, url: &str, kid: &str) -> Result<Jwk, Error> {
 	// Check that the datastore capabilities allow connections to the URL host
-	if let Err(err) = kvs.check_capabilities_url(kvs, url) {
+	if let Err(err) = check_capabilities_url(kvs, url) {
 		warn!("Capabilities denied outgoing network connection attempt, target: '{url}'");
 		warn!("Network access to JWKS location is not allowed: '{}'", err);
 		return Err(Error::InvalidAuth); // Return opaque error

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -216,9 +216,9 @@ impl DbsCapabilities {
 		// Allowed functions already consider a global deny and a general deny for functions
 		// On top of what is allowed, we only deny what is specifically denied
 		match &self.deny_funcs {
-			Some(Targets::Some(_)) => return self.deny_funcs.clone().unwrap_or(Targets::None),
-			Some(_) => return Targets::None,
-			None => return Targets::None,
+			Some(Targets::Some(_)) => self.deny_funcs.clone().unwrap_or(Targets::None),
+			Some(_) => Targets::None,
+			None => Targets::None,
 		}
 	}
 
@@ -226,9 +226,9 @@ impl DbsCapabilities {
 		// Allowed networks already consider a global deny and a general deny for networks
 		// On top of what is allowed, we only deny what is specifically denied
 		match &self.deny_net {
-			Some(Targets::Some(_)) => return self.deny_net.clone().unwrap_or(Targets::None),
-			Some(_) => return Targets::None,
-			None => return Targets::None,
+			Some(Targets::Some(_)) => self.deny_net.clone().unwrap_or(Targets::None),
+			Some(_) => Targets::None,
+			None => Targets::None,
 		}
 	}
 

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -156,17 +156,17 @@ impl DbsCapabilities {
 		// If there was a global deny, we allow if there is a general allow or some specific allows for functions
 		if self.deny_all {
 			match &self.allow_funcs {
-				Some(Targets::Some(_)) => return self.allow_funcs.clone().unwrap_or(Targets::None),
+				Some(Targets::Some(_)) => return self.allow_funcs.clone().unwrap(), // We already checked for Some
 				Some(Targets::All) => return Targets::All,
 				Some(_) => return Targets::None,
 				None => return Targets::None,
 			}
 		}
 
-		// If there was a general allow for functions, we allow if there are specific allows for functions
+		// If there was a general deny for functions, we allow if there are specific allows for functions
 		if let Some(Targets::All) = self.deny_funcs {
 			match &self.allow_funcs {
-				Some(Targets::Some(_)) => return self.allow_funcs.clone().unwrap_or(Targets::None),
+				Some(Targets::Some(_)) => return self.allow_funcs.clone().unwrap(), // We already checked for Some
 				Some(_) => return Targets::None,
 				None => return Targets::None,
 			}
@@ -177,8 +177,8 @@ impl DbsCapabilities {
 			return Targets::All;
 		}
 
-		// If there are no high level denies and no global allow, we allow the provided functions
-		// If nothing was provided and there is no global allow, we allow functions by default (Targets::All)
+		// If there are no high level, we allow the provided functions
+		// If nothing was provided, we allow functions by default (Targets::All)
 		self.allow_funcs.clone().unwrap_or(Targets::All) // Functions are enabled by default for the server
 	}
 
@@ -186,17 +186,17 @@ impl DbsCapabilities {
 		// If there was a global deny, we allow if there is a general allow or some specific allows for networks
 		if self.deny_all {
 			match &self.allow_net {
-				Some(Targets::Some(_)) => return self.allow_net.clone().unwrap_or(Targets::None),
+				Some(Targets::Some(_)) => return self.allow_net.clone().unwrap(), // We already checked for Some
 				Some(Targets::All) => return Targets::All,
 				Some(_) => return Targets::None,
 				None => return Targets::None,
 			}
 		}
 
-		// If there was a general allow for networks, we allow if there are specific allows for networks
+		// If there was a general deny for networks, we allow if there are specific allows for networks
 		if let Some(Targets::All) = self.deny_net {
 			match &self.allow_net {
-				Some(Targets::Some(_)) => return self.allow_net.clone().unwrap_or(Targets::None),
+				Some(Targets::Some(_)) => return self.allow_net.clone().unwrap(), // We already checked for Some
 				Some(_) => return Targets::None,
 				None => return Targets::None,
 			}
@@ -207,14 +207,14 @@ impl DbsCapabilities {
 			return Targets::All;
 		}
 
-		// If there are no high level denies and no global allow, we allow the provided networks
-		// If nothing was provided and there is no global allow, then don't allow anything (Targets::None)
+		// If there are no high level denies, we allow the provided networks
+		// If nothing was provided, we do not allow network by default (Targets::None)
 		self.allow_net.clone().unwrap_or(Targets::None)
 	}
 
 	fn get_deny_funcs(&self) -> Targets<FuncTarget> {
 		// Allowed functions already consider a global deny and a general deny for functions
-		// On top of what is allowed, we only deny what is specifically denied
+		// On top of what is explicitly allowed, we deny what is specifically denied
 		match &self.deny_funcs {
 			Some(Targets::Some(_)) => self.deny_funcs.clone().unwrap_or(Targets::None),
 			Some(_) => Targets::None,
@@ -224,7 +224,7 @@ impl DbsCapabilities {
 
 	fn get_deny_net(&self) -> Targets<NetTarget> {
 		// Allowed networks already consider a global deny and a general deny for networks
-		// On top of what is allowed, we only deny what is specifically denied
+		// On top of what is explicitly allowed, we deny what is specifically denied
 		match &self.deny_net {
 			Some(Targets::Some(_)) => self.deny_net.clone().unwrap_or(Targets::None),
 			Some(_) => Targets::None,

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -215,13 +215,21 @@ impl DbsCapabilities {
 	fn get_deny_funcs(&self) -> Targets<FuncTarget> {
 		// Allowed functions already consider a global deny and a general deny for functions
 		// On top of what is allowed, we only deny what is specifically denied
-		self.deny_funcs.clone().unwrap_or(Targets::None)
+		match &self.deny_funcs {
+			Some(Targets::Some(_)) => return self.deny_funcs.clone().unwrap_or(Targets::None),
+			Some(_) => return Targets::None,
+			None => return Targets::None,
+		}
 	}
 
 	fn get_deny_net(&self) -> Targets<NetTarget> {
 		// Allowed networks already consider a global deny and a general deny for networks
 		// On top of what is allowed, we only deny what is specifically denied
-		self.deny_net.clone().unwrap_or(Targets::None)
+		match &self.deny_net {
+			Some(Targets::Some(_)) => return self.deny_net.clone().unwrap_or(Targets::None),
+			Some(_) => return Targets::None,
+			None => return Targets::None,
+		}
 	}
 
 	fn get_deny_all(&self) -> bool {

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -273,7 +273,7 @@ pub async fn init(
 	}
 	// Warn about the impact of denying all capabilities
 	if capabilities.get_deny_all() {
-		warn!("⚠️ We recommend denying all capabilities by default. However, beware that any new capabilities will also be denied.");
+		warn!("You are denying all capabilities by default. Although this is recommended, beware that any new capabilities will also be denied.");
 	}
 	// Convert the capabilities
 	let capabilities = capabilities.into();

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -53,8 +53,9 @@ struct DbsCapabilities {
 	allow_guests: bool,
 
 	#[arg(
-		help = "Allow execution of all functions. Optionally, you can provide a comma-separated list of function names to allow",
-		long_help = r#"Allow execution of functions. Optionally, you can provide a comma-separated list of function names to allow.
+		help = "Allow execution of all functions except for functions that are specifically denied. Alternatively, you can provide a comma-separated list of function names to allow",
+		long_help = r#"Allow execution of all functions except for functions that are specifically denied. Alternatively, you can provide a comma-separated list of function names to allow
+Specifically denied functions and function families prevail over any other allowed function execution.
 Function names must be in the form <family>[::<name>]. For example:
  - 'http' or 'http::*' -> Include all functions in the 'http' family
  - 'http::get' -> Include only the 'get' function in the 'http' family
@@ -67,8 +68,9 @@ Function names must be in the form <family>[::<name>]. For example:
 	allow_funcs: Option<Targets<FuncTarget>>,
 
 	#[arg(
-		help = "Allow all outbound network access. Optionally, you can provide a comma-separated list of targets to allow",
-		long_help = r#"Allow all outbound network access. Optionally, you can provide a comma-separated list of targets to allow.
+		help = "Allow all outbound network access except for network targets that are specifically denied. Alternatively, you can provide a comma-separated list of network targets to allow",
+		long_help = r#"Allow all outbound network access except for network targets that are specifically denied. Alternatively, you can provide a comma-separated list of network targets to allow
+Specifically denied network targets prevail over any other allowed outbound network access.
 Targets must be in the form of <host>[:<port>], <ipv4|ipv6>[/<mask>]. For example:
  - 'surrealdb.com', '127.0.0.1' or 'fd00::1' -> Match outbound connections to these hosts on any port
  - 'surrealdb.com:80', '127.0.0.1:80' or 'fd00::1:80' -> Match outbound connections to these hosts on port 80

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -226,7 +226,7 @@ impl DbsCapabilities {
 	}
 
 	fn get_deny_all(&self) -> bool {
-		return self.deny_all;
+		self.deny_all
 	}
 }
 

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -84,7 +84,7 @@ Targets must be in the form of <host>[:<port>], <ipv4|ipv6>[/<mask>]. For exampl
 	//
 	// Deny
 	//
-	#[arg(help = "Deny all capabilities except for capabilities that are specifically allowed")]
+	#[arg(help = "Deny all capabilities except for those that are specifically allowed")]
 	#[arg(env = "SURREAL_CAPS_DENY_ALL", short = 'D', long, conflicts_with = "allow_all")]
 	deny_all: bool,
 
@@ -99,7 +99,7 @@ Targets must be in the form of <host>[:<port>], <ipv4|ipv6>[/<mask>]. For exampl
 
 	#[arg(
 		help = "Deny execution of all functions except for functions that are specifically allowed. Alternatively, you can provide a comma-separated list of function names to deny",
-		long_help = r#"Deny execution of functions except for functions that are specifically allowed. Alternatively, you can provide a comma-separated list of function names to deny.
+		long_help = r#"Deny execution of all functions except for functions that are specifically allowed. Alternatively, you can provide a comma-separated list of function names to deny.
 Specifically allowed functions and function families prevail over a general denial of function execution.
 Function names must be in the form <family>[::<name>]. For example:
  - 'http' or 'http::*' -> Include all functions in the 'http' family
@@ -113,8 +113,8 @@ Function names must be in the form <family>[::<name>]. For example:
 	deny_funcs: Option<Targets<FuncTarget>>,
 
 	#[arg(
-		help = "Deny all outbound network access except for networks that are specifically allowed. Alternatively, you can provide a comma-separated list of network targets to deny",
-		long_help = r#"Deny all outbound network access except for networks that are specifically allowed. Alternatively, you can provide a comma-separated list of network targets to deny.
+		help = "Deny all outbound network access except for network targets that are specifically allowed. Alternatively, you can provide a comma-separated list of network targets to deny",
+		long_help = r#"Deny all outbound network access except for network targets that are specifically allowed. Alternatively, you can provide a comma-separated list of network targets to deny.
 Specifically allowed network targets prevail over a general denial of network access.
 Targets must be in the form of <host>[:<port>], <ipv4|ipv6>[/<mask>]. For example:
  - 'surrealdb.com', '127.0.0.1' or 'fd00::1' -> Match outbound connections to these hosts on any port

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -63,7 +63,6 @@ Function names must be in the form <family>[::<name>]. For example:
 	#[arg(env = "SURREAL_CAPS_ALLOW_FUNC", long)]
 	// If the arg is provided without value, then assume it's "", which gets parsed into Targets::All
 	#[arg(default_missing_value_os = "", num_args = 0..)]
-	#[arg(default_value_os = "")] // Allow all functions by default
 	#[arg(value_parser = super::cli::validator::func_targets)]
 	allow_funcs: Option<Targets<FuncTarget>>,
 
@@ -179,8 +178,8 @@ impl DbsCapabilities {
 		}
 
 		// If there are no high level denies and no global allow, we allow the provided functions
-		// If nothing was provided and there is no global allow, then don't allow anything (Targets::None)
-		self.allow_funcs.clone().unwrap_or(Targets::None)
+		// If nothing was provided and there is no global allow, we allow functions by default (Targets::All)
+		self.allow_funcs.clone().unwrap_or(Targets::All) // Functions are enabled by default for the server
 	}
 
 	fn get_allow_net(&self) -> Targets<NetTarget> {

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -39,7 +39,7 @@ struct DbsCapabilities {
 	//
 	// Allow
 	//
-	#[arg(help = "Allow all capabilities")]
+	#[arg(help = "Allow all capabilities except for those more specifically denied")]
 	#[arg(env = "SURREAL_CAPS_ALLOW_ALL", short = 'A', long, conflicts_with = "deny_all")]
 	allow_all: bool,
 
@@ -68,9 +68,9 @@ Function names must be in the form <family>[::<name>]. For example:
 	allow_funcs: Option<Targets<FuncTarget>>,
 
 	#[arg(
-		help = "Allow all outbound network access except for network targets that are specifically denied. Alternatively, you can provide a comma-separated list of network targets to allow",
-		long_help = r#"Allow all outbound network access except for network targets that are specifically denied. Alternatively, you can provide a comma-separated list of network targets to allow
-Specifically denied network targets prevail over any other allowed outbound network access.
+		help = "Allow all outbound network connections except for network targets that are specifically denied. Alternatively, you can provide a comma-separated list of network targets to allow",
+		long_help = r#"Allow all outbound network connections except for network targets that are specifically denied. Alternatively, you can provide a comma-separated list of network targets to allow
+Specifically denied network targets prevail over any other allowed outbound network connections.
 Targets must be in the form of <host>[:<port>], <ipv4|ipv6>[/<mask>]. For example:
  - 'surrealdb.com', '127.0.0.1' or 'fd00::1' -> Match outbound connections to these hosts on any port
  - 'surrealdb.com:80', '127.0.0.1:80' or 'fd00::1:80' -> Match outbound connections to these hosts on port 80
@@ -86,7 +86,7 @@ Targets must be in the form of <host>[:<port>], <ipv4|ipv6>[/<mask>]. For exampl
 	//
 	// Deny
 	//
-	#[arg(help = "Deny all capabilities except for those that are specifically allowed")]
+	#[arg(help = "Deny all capabilities except for those more specifically allowed")]
 	#[arg(env = "SURREAL_CAPS_DENY_ALL", short = 'D', long, conflicts_with = "allow_all")]
 	deny_all: bool,
 
@@ -115,9 +115,9 @@ Function names must be in the form <family>[::<name>]. For example:
 	deny_funcs: Option<Targets<FuncTarget>>,
 
 	#[arg(
-		help = "Deny all outbound network access except for network targets that are specifically allowed. Alternatively, you can provide a comma-separated list of network targets to deny",
-		long_help = r#"Deny all outbound network access except for network targets that are specifically allowed. Alternatively, you can provide a comma-separated list of network targets to deny.
-Specifically allowed network targets prevail over a general denial of network access.
+		help = "Deny all outbound network connections except for network targets that are specifically allowed. Alternatively, you can provide a comma-separated list of network targets to deny",
+		long_help = r#"Deny all outbound network connections except for network targets that are specifically allowed. Alternatively, you can provide a comma-separated list of network targets to deny.
+Specifically allowed network targets prevail over a general denial of outbound network connections.
 Targets must be in the form of <host>[:<port>], <ipv4|ipv6>[/<mask>]. For example:
  - 'surrealdb.com', '127.0.0.1' or 'fd00::1' -> Match outbound connections to these hosts on any port
  - 'surrealdb.com:80', '127.0.0.1:80' or 'fd00::1:80' -> Match outbound connections to these hosts on port 80

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -569,7 +569,7 @@ mod tests {
 				Session::owner(),
 				format!("RETURN http::get('{}')", server1.uri()),
 				false,
-				format!("Access to network target '{}/' is not allowed", server1.uri()),
+				format!("Access to network target '{}' is not allowed", server1.address()),
 			),
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
@@ -589,7 +589,7 @@ mod tests {
 				Session::owner(),
 				"RETURN http::get('http://1.1.1.1')".to_string(),
 				false,
-				"Access to network target 'http://1.1.1.1/' is not allowed".to_string(),
+				"Access to network target '1.1.1.1:80' is not allowed".to_string(),
 			),
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1264,7 +1264,7 @@ mod cli_integration {
 				throwaway = Ulid::new()
 			);
 
-			let query = format!("RETURN string::len('123');\n\n");
+			let query = "RETURN string::len('123');\n\n".to_string();
 			let output = common::run(&cmd).input(&query).output().unwrap();
 			assert!(output.contains("[3]"), "unexpected output: {output:?}");
 
@@ -1285,7 +1285,7 @@ mod cli_integration {
 				throwaway = Ulid::new()
 			);
 
-			let query = format!("RETURN string::len('123');\n\n");
+			let query = "RETURN string::len('123');\n\n".to_string();
 			let output = common::run(&cmd).input(&query).output().unwrap();
 			assert!(output.contains("[3]"), "unexpected output: {output:?}");
 
@@ -1306,7 +1306,7 @@ mod cli_integration {
 				throwaway = Ulid::new()
 			);
 
-			let query = format!("RETURN string::len('123');\n\n");
+			let query = "RETURN string::len('123');\n\n".to_string();
 			let output = common::run(&cmd).input(&query).output().unwrap();
 			assert!(output.contains("[3]"), "unexpected output: {output:?}");
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1153,7 +1153,7 @@ mod cli_integration {
 			let query = "RETURN http::get('http://127.0.0.1/');\n\n";
 			let output = common::run(&cmd).input(query).output().unwrap();
 			assert!(
-				output.contains("Access to network target 'http://127.0.0.1/' is not allowed"),
+				output.contains("Access to network target '127.0.0.1:80' is not allowed"),
 				"unexpected output: {output:?}"
 			);
 
@@ -1516,10 +1516,8 @@ mod cli_integration {
 			let query = format!("RETURN http::get('http://{addr}/version');\n\n");
 			let output = common::run(&cmd).input(&query).output().unwrap();
 			assert!(
-				output.contains(
-					format!("Access to network target 'http://{addr}/version' is not allowed")
-						.as_str()
-				),
+				output
+					.contains(format!("Access to network target '{addr}' is not allowed").as_str()),
 				"unexpected output: {output:?}"
 			);
 			server.finish().unwrap();
@@ -1542,10 +1540,8 @@ mod cli_integration {
 			let query = format!("RETURN http::get('http://{addr}/version');\n\n");
 			let output = common::run(&cmd).input(&query).output().unwrap();
 			assert!(
-				output.contains(
-					format!("Access to network target 'http://{addr}/version' is not allowed")
-						.as_str()
-				),
+				output
+					.contains(format!("Access to network target '{addr}' is not allowed").as_str()),
 				"unexpected output: {output:?}"
 			);
 			server.finish().unwrap();
@@ -1588,10 +1584,8 @@ mod cli_integration {
 			let query = format!("RETURN http::get('http://{addr}/version');\n\n");
 			let output = common::run(&cmd).input(&query).output().unwrap();
 			assert!(
-				output.contains(
-					format!("Access to network target 'http://{addr}/version' is not allowed")
-						.as_str()
-				),
+				output
+					.contains(format!("Access to network target '{addr}' is not allowed").as_str()),
 				"unexpected output: {output:?}"
 			);
 			server.finish().unwrap();
@@ -1636,10 +1630,8 @@ mod cli_integration {
 			let query = format!("RETURN http::get('http://{addr}/version');\n\n");
 			let output = common::run(&cmd).input(&query).output().unwrap();
 			assert!(
-				output.contains(
-					format!("Access to network target 'http://{addr}/version' is not allowed")
-						.as_str()
-				),
+				output
+					.contains(format!("Access to network target '{addr}' is not allowed").as_str()),
 				"unexpected output: {output:?}"
 			);
 			server.finish().unwrap();
@@ -1662,10 +1654,8 @@ mod cli_integration {
 			let query = format!("RETURN http::get('http://{addr}/version');\n\n");
 			let output = common::run(&cmd).input(&query).output().unwrap();
 			assert!(
-				output.contains(
-					format!("Access to network target 'http://{addr}/version' is not allowed")
-						.as_str()
-				),
+				output
+					.contains(format!("Access to network target '{addr}' is not allowed").as_str()),
 				"unexpected output: {output:?}"
 			);
 			server.finish().unwrap();


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To allow users to use capabilities with an allowlist approach rather than the current denylist approach. This means that users who wish to only allow specific functionality will be able to run SurrealDB with `--deny-all` and allow only the specific capabilities that they wish to use (e.g. `--allow-funcs` or `--allow-funcs crypto`) afterwards. Previously, this was not possible as denies would always prevail over allows. This change also will support doing so with specific capabilities, such as denying functions generally with `--deny-funcs` and then allowing calling specific functions such as with `--allow-funcs crypto`.

## What does this change do?

This change modifies the CLI logic with which the capabilities passed to the database server are constructed. This new logic ensures that specific allows (e.g. `--allow-funcs crypto`) are able to override general denies (e.g. `--deny-funcs`) and global denies (i.e. `--deny-all`). At the same level, deny rules still rule over allow rules, so `--deny-all` still rules over `--allow-all`, `--deny-funcs` still rules over `--allow-funcs`, and `--deny-funcs crypto` still rules over `--allow-funcs crypto`. This new behavior is documented in help messages for the CLI flags. This new behavior also makes some capabilities flags no longer conflict.

At the most specific level, it is possible to have both allow and deny rules, where the deny rules will always prevail when in conflict. For example, having `--allow-funcs crypto` and `--deny-funcs crypto::md5` will result in users being able to call any cryptographic function except for `crypto::md5`. On the other hand, having `--deny-funcs crypto` and `--allow-funcs crypto::md5` will still result in users not being able to call any cryptographic function, including `crypto::md5`, as the deny rule prevails.

This PR also adds warning messages every time that an action is denied by capabilities so that users of allowlisting policies are able to identify any missing capabilities that are required by their queries. Trace logging has also been added to every time that an action requiring a specific capability is allowed.  Additionally, the PR adds a warning for users of `--deny-all` that newer capabilities released in the future will also be denied at server start.

## What is your testing strategy?

Updating existing integration tests and adding new integration tests for this specific behavior.

## Is this related to any issues?

No.

## Does this change need documentation?

Yes, this change will require updating the Capabilities page as well as the CLI documentation page.

Changes implemented here: https://github.com/surrealdb/docs.surrealdb.com/pull/852

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
