### PR TITLE
Add path for time::epoch constant

### DIFF
--- a/core/src/syn/parser/builtin.rs
+++ b/core/src/syn/parser/builtin.rs
@@ -458,6 +458,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("math::PI") => PathKind::Constant(Constant::MathPi),
 		UniCase::ascii("math::SQRT_2") => PathKind::Constant(Constant::MathSqrt2),
 		UniCase::ascii("math::TAU") => PathKind::Constant(Constant::MathTau),
+		UniCase::ascii("time::EPOCH") => PathKind::Constant(Constant::TimeEpoch)
 };
 
 impl Parser<'_> {

--- a/core/src/syn/parser/test/value.rs
+++ b/core/src/syn/parser/test/value.rs
@@ -144,6 +144,9 @@ fn constant_lowercase() {
 
 	let out = test_parse!(parse_value_table, r#" math::neg_inf "#).unwrap();
 	assert_eq!(out, Value::Constant(Constant::MathNegInf));
+
+	let out = test_parse!(parse_value_table, r#" time::epoch "#).unwrap();
+	assert_eq!(out, Value::Constant(Constant::TimeEpoch));
 }
 
 #[test]
@@ -156,6 +159,9 @@ fn constant_uppercase() {
 
 	let out = test_parse!(parse_value_table, r#" MATH::NEG_INF "#).unwrap();
 	assert_eq!(out, Value::Constant(Constant::MathNegInf));
+
+	let out = test_parse!(parse_value_table, r#" TIME::EPOCH "#).unwrap();
+	assert_eq!(out, Value::Constant(Constant::TimeEpoch));
 }
 
 #[test]
@@ -168,6 +174,9 @@ fn constant_mixedcase() {
 
 	let out = test_parse!(parse_value_table, r#" MaTh::Neg_Inf "#).unwrap();
 	assert_eq!(out, Value::Constant(Constant::MathNegInf));
+
+	let out = test_parse!(parse_value_table, r#" TiME::ePoCH "#).unwrap();
+	assert_eq!(out, Value::Constant(Constant::TimeEpoch));
 }
 
 #[test]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The source code has a const called `time::epoch` that is ready to go aside from now having a path set up to access it.

## What does this change do?

It adds a path so that users can type `time::epoch` to get the return value `d'1970-01-01T00:00:00Z'`.

## What is your testing strategy?

Added this const to some existing tests.

## Is this related to any issues?

Not directly, but peripherally related to issue 832 just below.

## Does this change need documentation?

Yes, is being taken care of along with other consts here https://github.com/surrealdb/docs.surrealdb.com/issues/832

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
