### PR TITLE
type::table: check to see if string can be a record

### DIFF
--- a/core/src/fnc/type.rs
+++ b/core/src/fnc/type.rs
@@ -122,6 +122,10 @@ pub fn string((val,): (Value,)) -> Result<Value, Error> {
 pub fn table((val,): (Value,)) -> Result<Value, Error> {
 	Ok(Value::Table(Table(match val {
 		Value::Thing(t) => t.tb,
+		Value::Strand(s) => match Thing::try_from(s.as_str()) {
+			Ok(record) => record.tb,
+			Err(_) => s.as_string(),
+		},
 		v => v.as_string(),
 	})))
 }

--- a/sdk/tests/function.rs
+++ b/sdk/tests/function.rs
@@ -5569,6 +5569,7 @@ async fn function_type_table() -> Result<(), Error> {
 	let sql = r#"
 		RETURN type::table("person");
 		RETURN type::table("animal");
+		RETURN type::table("person:one);
 	"#;
 	let mut test = Test::new(sql).await?;
 	//
@@ -5578,6 +5579,10 @@ async fn function_type_table() -> Result<(), Error> {
 	//
 	let tmp = test.next()?.result?;
 	let val = Value::Table("animal".into());
+	assert_eq!(tmp, val);
+	//
+	let tmp = test.next()?.result?;
+	let val = Value::Table("person".into());
 	assert_eq!(tmp, val);
 	//
 	Ok(())

--- a/sdk/tests/function.rs
+++ b/sdk/tests/function.rs
@@ -5569,7 +5569,7 @@ async fn function_type_table() -> Result<(), Error> {
 	let sql = r#"
 		RETURN type::table("person");
 		RETURN type::table("animal");
-		RETURN type::table("person:one);
+		RETURN type::table("person:one");
 	"#;
 	let mut test = Test::new(sql).await?;
 	//


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Strings are no longer eagerly evaluated so `type::table("person:tobie")` returns `person:tobie` instead of `person`.

## What does this change do?

It checks a string passed in to see if it matches record ID format.

## What is your testing strategy?

Added a line to an existing test for the function.

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
