### PR TITLE
Remove eager parsing of `"false"` truthiness

### DIFF
--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -3164,7 +3164,7 @@ mod tests {
 		assert!(Value::from(1.1).is_truthy());
 		assert!(Value::from(-1.1).is_truthy());
 		assert!(Value::from("true").is_truthy());
-		assert!(!Value::from("false").is_truthy());
+		assert!(Value::from("false").is_truthy());
 		assert!(Value::from("falsey").is_truthy());
 		assert!(Value::from("something").is_truthy());
 		assert!(Value::from(Uuid::new()).is_truthy());

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -961,7 +961,7 @@ impl Value {
 			Value::Geometry(_) => true,
 			Value::Array(v) => !v.is_empty(),
 			Value::Object(v) => !v.is_empty(),
-			Value::Strand(v) => !v.is_empty() && !v.eq_ignore_ascii_case("false"),
+			Value::Strand(v) => !v.is_empty(),
 			Value::Number(v) => v.is_truthy(),
 			Value::Duration(v) => v.as_nanos() > 0,
 			Value::Datetime(v) => v.timestamp() > 0,

--- a/sdk/tests/function.rs
+++ b/sdk/tests/function.rs
@@ -627,7 +627,7 @@ async fn function_array_logical_xor() -> Result<(), Error> {
 	test_queries(
 		r#"
 		RETURN array::logical_xor([true, false, true, false], [true, true, false, false]);
-		RETURN array::logical_xor([1, 0, 1, 0], [true, true, false", false]);
+		RETURN array::logical_xor([1, 0, 1, 0], [true, true, false, false]);
 		RETURN array::logical_xor([0, 1], []);"#,
 		&["[false, true, true, false]", r#"[false, true, 1, 0]"#, "[0, 1]"],
 	)

--- a/sdk/tests/function.rs
+++ b/sdk/tests/function.rs
@@ -599,10 +599,11 @@ async fn function_array_len() -> Result<(), Error> {
 #[tokio::test]
 async fn function_array_logical_and() -> Result<(), Error> {
 	test_queries(
-		r#"RETURN array::logical_and([true, false, true, false], [true, true, false, false]);
-RETURN array::logical_and([1, 0, 1, 0], ["true", "true", "false", "false"]);
-RETURN array::logical_and([0, 1], []);"#,
-		&["[true, false, false, false]", r#"[1, 0, "false", 0]"#, "[0, null]"],
+		r#"
+		RETURN array::logical_and([true, false, true, false], [true, true, false, false]);
+		RETURN array::logical_and([1, 0, 1, 0], [true, true, false, false]);
+		RETURN array::logical_and([0, 1], []);"#,
+		&["[true, false, false, false]", r#"[1, 0, false, 0]"#, "[0, null]"],
 	)
 	.await?;
 	Ok(())
@@ -611,10 +612,11 @@ RETURN array::logical_and([0, 1], []);"#,
 #[tokio::test]
 async fn function_array_logical_or() -> Result<(), Error> {
 	test_queries(
-		r#"RETURN array::logical_or([true, false, true, false], [true, true, false, false]);
-RETURN array::logical_or([1, 0, 1, 0], ["true", "true", "false", "false"]);
-RETURN array::logical_or([0, 1], []);"#,
-		&["[true, true, true, false]", r#"[1, "true", 1, 0]"#, "[0, 1]"],
+		r#"
+		RETURN array::logical_or([true, false, true, false], [true, true, false, false]);
+		RETURN array::logical_or([1, 0, 1, 0], [true, true, false, false]);
+		RETURN array::logical_or([0, 1], []);"#,
+		&["[true, true, true, false]", r#"[1, true, 1, 0]"#, "[0, 1]"],
 	)
 	.await?;
 	Ok(())
@@ -623,10 +625,11 @@ RETURN array::logical_or([0, 1], []);"#,
 #[tokio::test]
 async fn function_array_logical_xor() -> Result<(), Error> {
 	test_queries(
-		r#"RETURN array::logical_xor([true, false, true, false], [true, true, false, false]);
-RETURN array::logical_xor([1, 0, 1, 0], ["true", "true", "false", "false"]);
-RETURN array::logical_xor([0, 1], []);"#,
-		&["[false, true, true, false]", r#"[false, "true", 1, 0]"#, "[0, 1]"],
+		r#"
+		RETURN array::logical_xor([true, false, true, false], [true, true, false, false]);
+		RETURN array::logical_xor([1, 0, 1, 0], [true, true, false", false]);
+		RETURN array::logical_xor([0, 1], []);"#,
+		&["[false, true, true, false]", r#"[false, true, 1, 0]"#, "[0, 1]"],
 	)
 	.await?;
 	Ok(())


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

"false" is currently being eagerly parsed a untruthy, which can lead to unexpected behaviour. e.g.

```
[NONE, "true", "false"].filter(|$v| !!$v);

[
	'true'
]
```

A user would not expect "false" to be filtered out.

## What does this change do?

It changes "false" to truthy.

## What is your testing strategy?

There are three tests that pass in arrays of boolean strings ("true" and "false") to test logical AND, OR, and XOR, which now fail. These strings have been changed to booleans.

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
