### PR TITLE
add descriptions to graphql

### DIFF
--- a/core/src/gql/schema.rs
+++ b/core/src/gql/schema.rs
@@ -389,7 +389,7 @@ pub async fn generate_schema(
 				}
 			})
 		})
-		.description(format!("allows fetching arbitrary records"))
+		.description("allows fetching arbitrary records".to_string())
 		.argument(id_input!()),
 	);
 

--- a/core/src/gql/schema.rs
+++ b/core/src/gql/schema.rs
@@ -98,8 +98,16 @@ pub async fn generate_schema(
 
 		let table_orderable_name = format!("_orderable_{tb_name}");
 		let mut table_orderable = Enum::new(&table_orderable_name).item("id");
+		table_orderable = table_orderable.description(format!(
+			"Generated from `{}` the fields which a query can be ordered by",
+			tb.name
+		));
 		let table_order_name = format!("_order_{tb_name}");
 		let table_order = InputObject::new(&table_order_name)
+			.description(format!(
+				"Generated from `{}` an object representing a query ordering",
+				tb.name
+			))
 			.field(InputValue::new("asc", TypeRef::named(&table_orderable_name)))
 			.field(InputValue::new("desc", TypeRef::named(&table_orderable_name)))
 			.field(InputValue::new("then", TypeRef::named(&table_order_name)));
@@ -242,6 +250,7 @@ pub async fn generate_schema(
 					})
 				},
 			)
+			.description(format!("Generated from table `{}`{}\nallows querying a table with filters", tb.name, if let Some(ref c) = &tb.comment {format!("\n{c}")} else {"".to_string()}))
 			.argument(limit_input!())
 			.argument(start_input!())
 			.argument(InputValue::new("order", TypeRef::named(&table_order_name)))
@@ -285,6 +294,15 @@ pub async fn generate_schema(
 					})
 				},
 			)
+			.description(format!(
+				"Generated from table `{}`{}\nallows querying a single record in a table by id",
+				tb.name,
+				if let Some(ref c) = &tb.comment {
+					format!("\n{c}")
+				} else {
+					"".to_string()
+				}
+			))
 			.argument(id_input!()),
 		);
 
@@ -371,6 +389,7 @@ pub async fn generate_schema(
 				}
 			})
 		})
+		.description(format!("allows fetching arbitrary records"))
 		.argument(id_input!()),
 	);
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

surrealql supports comments on table definitions so they should be reflected in the graphql schema 

## What does this change do?

adds descriptions to the generated schema including comments

## What is your testing strategy?

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- fixes #4538

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
