### PR TITLE
Pin the core library

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -103,7 +103,7 @@ semver = { version = "1.0.20", features = ["serde"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 serde-content = "0.1.0"
-surrealdb-core = { version = "2", default-features = false, path = "../core", package = "surrealdb-core" }
+surrealdb-core = { version = "=2.0.0", default-features = false, path = "../core", package = "surrealdb-core" }
 thiserror = "1.0.63"
 tokio-util = { version = "0.7.11", optional = true, features = ["compat"] }
 tracing = "0.1.40"


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

In v1, there has been cases where the SDK pulled in an incompatible core library. This can happen because the SDK uses undocumented APIs from the core library and those are not guaranteed to be stable.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It pins the core library in the SDK so we can ensure the exact library that will end up being used.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
