### PR TITLE
Fix selecting directly from an edge graph

### DIFF
--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -282,8 +282,8 @@ impl Value {
 								what: Values(vec![Value::from(val)]),
 								..SelectStatement::default()
 							};
-							let v = stk.run(|stk| stm.compute(stk, ctx, opt, None)).await?.first();
-							stk.run(|stk| v.get(stk, ctx, opt, None, path)).await
+							let v = stk.run(|stk| stm.compute(stk, ctx, opt, None)).await?.all();
+							stk.run(|stk| v.get(stk, ctx, opt, None, path)).await?.flatten().ok()
 						}
 					}
 				}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Selecting from an edge graph (`person:tobie->purchased->item`) currently fails to select all of the primary edges, instead pulling out the first edge only, and then continuing to traverse from there.

## What does this change do?

Ensures that all edges are iterated over correctly, before continuing to traversing the graph subsequently.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #3296.
- [x] Closes #3373.

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
