### PR TITLE
Add a warning about TLS crates

### DIFF
--- a/sdk/src/api/opt/tls.rs
+++ b/sdk/src/api/opt/tls.rs
@@ -1,4 +1,7 @@
 /// TLS Configuration
+///
+/// WARNING: `native-tls` and `rustls` are not stable yet. As we may need to upgrade those dependencies
+/// from time to time to keep up with their security fixes, this type is excluded from our stability guarantee.
 #[cfg(any(feature = "native-tls", feature = "rustls"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls"))))]
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Rust TLS crates are not stable yet but we have to expose them as part of our public API.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It adds a warning to Rust docs about those crates.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

```bash
cargo doc --package surrealdb --open
```

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
