### PR TITLE
Add warnings to `rustls` and `native_tls` methods

### DIFF
--- a/sdk/src/api/opt/config.rs
+++ b/sdk/src/api/opt/config.rs
@@ -86,6 +86,9 @@ impl Config {
 	}
 
 	/// Use Rustls to configure TLS connections
+	///
+	/// WARNING: `rustls` is not stable yet. As we may need to upgrade this dependency from time to time
+	/// to keep up with its security fixes, this method is excluded from our stability guarantee.
 	#[cfg(feature = "rustls")]
 	#[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
 	pub fn rustls(mut self, config: rustls::ClientConfig) -> Self {
@@ -94,6 +97,9 @@ impl Config {
 	}
 
 	/// Use native TLS to configure TLS connections
+	///
+	/// WARNING: `native-tls` is not stable yet. As we may need to upgrade this dependency from time to time
+	/// to keep up with its security fixes, this method is excluded from our stability guarantee.
 	#[cfg(feature = "native-tls")]
 	#[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
 	pub fn native_tls(mut self, config: native_tls::TlsConnector) -> Self {


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

I forgot to add include these in a [previous PR](https://github.com/surrealdb/surrealdb/pull/4788).

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Adds warnings to those methods as well.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

```bash
cargo doc --open
```

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
