### PR TITLE
Drop SDK APIs already deprecated in v1

### DIFF
--- a/sdk/src/api/opt/config.rs
+++ b/sdk/src/api/opt/config.rs
@@ -8,7 +8,6 @@ use surrealdb_core::{dbs::Capabilities as CoreCapabilities, iam::Level};
 #[derive(Debug, Clone, Default)]
 pub struct Config {
 	pub(crate) strict: bool,
-	pub(crate) notifications: bool,
 	pub(crate) query_timeout: Option<Duration>,
 	pub(crate) transaction_timeout: Option<Duration>,
 	#[cfg(any(feature = "native-tls", feature = "rustls"))]
@@ -42,26 +41,6 @@ impl Config {
 	/// Enables `strict` server mode
 	pub fn strict(mut self) -> Self {
 		self.strict = true;
-		self
-	}
-
-	/// Set the notifications value of the config to the supplied value
-	#[deprecated(
-		since = "1.1.0",
-		note = "Moved to `Capabilities::with_live_query_notifications()`"
-	)]
-	pub fn set_notifications(mut self, notifications: bool) -> Self {
-		self.notifications = notifications;
-		self
-	}
-
-	/// Set the config to use notifications
-	#[deprecated(
-		since = "1.1.0",
-		note = "Moved to `Capabilities::with_live_query_notifications()`"
-	)]
-	pub fn notifications(mut self) -> Self {
-		self.notifications = true;
 		self
 	}
 


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

These were deprecated in v1.1 so they have had sufficient time to warn users.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It simply deletes them.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
