### PR TITLE
Fix `cargo doc` warnings

### DIFF
--- a/core/src/syn/parser/mod.rs
+++ b/core/src/syn/parser/mod.rs
@@ -7,21 +7,21 @@
 //! # Implementation Details
 //!
 //! There are a bunch of common patterns for which this module has some confinence functions.
-//! - Whenever only one token can be next you should use the [`expected!`] macro. This macro
+//! - Whenever only one token can be next you should use the `expected!` macro. This macro
 //!     ensures that the given token type is next and if not returns a parser error.
 //! - Whenever a limited set of tokens can be next it is common to match the token kind and then
-//!     have a catch all arm which calles the macro [`unexpected!`]. This macro will raise an parse
+//!     have a catch all arm which calles the macro `unexpected!`. This macro will raise an parse
 //!     error with information about the type of token it recieves and what it expected.
 //! - If a single token can be optionally next use [`Parser::eat`] this function returns a bool
 //!     depending on if the given tokenkind was eaten.
-//! - If a closing delimiting token is expected use [`Parser::expect_closing_delimiter`]. This
+//! - If a closing delimiting token is expected use `Parser::expect_closing_delimiter`. This
 //!     function will raise an error if the expected delimiter isn't the next token. This error will
 //!     also point to which delimiter the parser expected to be closed.
 //!
 //! ## Far Token Peek
 //!
 //! Occasionally the parser needs to check further ahead than peeking allows.
-//! This is done with the [`Parser::peek_token_at`] function. This function peeks a given number
+//! This is done with the `Parser::peek_token_at` function. This function peeks a given number
 //! of tokens further than normal up to 3 tokens further.
 //!
 //! ## WhiteSpace Tokens


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

`cargo doc` is generating warnings as it can't link private items publicly. They need `--document-private-items` in order to be linked.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Removes the links in order to silence the warnings.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Ran `cargo doc`.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
