### PR TITLE
Make `create` API more flexible

### DIFF
--- a/sdk/src/api/method/create.rs
+++ b/sdk/src/api/method/create.rs
@@ -78,17 +78,6 @@ where
 	into_future! {execute_opt}
 }
 
-impl<'r, Client, R> IntoFuture for Create<'r, Client, Vec<R>>
-where
-	Client: Connection,
-	R: DeserializeOwned,
-{
-	type Output = Result<Option<R>>;
-	type IntoFuture = BoxFuture<'r, Self::Output>;
-
-	into_future! {execute_opt}
-}
-
 impl<'r, C> Create<'r, C, Value>
 where
 	C: Connection,
@@ -115,31 +104,6 @@ where
 }
 
 impl<'r, C, R> Create<'r, C, Option<R>>
-where
-	C: Connection,
-{
-	/// Sets content of a record
-	pub fn content<D>(self, data: D) -> Content<'r, C, Option<R>>
-	where
-		D: Serialize + 'static,
-	{
-		Content::from_closure(self.client, || {
-			let content = to_core_value(data)?;
-
-			let data = match content {
-				CoreValue::None | CoreValue::Null => None,
-				content => Some(content),
-			};
-
-			Ok(Command::Create {
-				what: self.resource?,
-				data,
-			})
-		})
-	}
-}
-
-impl<'r, C, R> Create<'r, C, Vec<R>>
 where
 	C: Connection,
 {

--- a/sdk/src/api/method/mod.rs
+++ b/sdk/src/api/method/mod.rs
@@ -92,6 +92,7 @@ pub use use_db::UseDb;
 pub use use_ns::UseNs;
 pub use version::Version;
 
+use super::opt::CreateResource;
 use super::opt::IntoResource;
 
 /// A alias for an often used type of future returned by async methods in this library.
@@ -749,7 +750,7 @@ where
 	/// # Ok(())
 	/// # }
 	/// ```
-	pub fn create<R>(&self, resource: impl IntoResource<R>) -> Create<C, R> {
+	pub fn create<R>(&self, resource: impl CreateResource<R>) -> Create<C, R> {
 		Create {
 			client: Cow::Borrowed(self),
 			resource: resource.into_resource(),

--- a/sdk/src/api/opt/resource.rs
+++ b/sdk/src/api/opt/resource.rs
@@ -315,6 +315,11 @@ pub trait IntoResource<Output> {
 	fn into_resource(self) -> Result<Resource>;
 }
 
+/// A trait for types which can be used as a resource selection for a query that returns an `Option`.
+pub trait CreateResource<Output> {
+	fn into_resource(self) -> Result<Resource>;
+}
+
 fn no_colon(a: &str) -> Result<()> {
 	if a.contains(':') {
 		return Err(Error::TableColonId {
@@ -324,6 +329,8 @@ fn no_colon(a: &str) -> Result<()> {
 	}
 	Ok(())
 }
+
+// IntoResource
 
 impl IntoResource<Value> for Resource {
 	fn into_resource(self) -> Result<Resource> {
@@ -411,5 +418,72 @@ impl<R> IntoResource<Vec<R>> for &String {
 impl<R> IntoResource<Vec<R>> for () {
 	fn into_resource(self) -> Result<Resource> {
 		Ok(Resource::Unspecified)
+	}
+}
+
+// CreateResource
+
+impl CreateResource<Value> for Resource {
+	fn into_resource(self) -> Result<Resource> {
+		Ok(self)
+	}
+}
+
+impl<R> CreateResource<Option<R>> for Object {
+	fn into_resource(self) -> Result<Resource> {
+		Ok(self.into())
+	}
+}
+
+impl<R> CreateResource<Option<R>> for RecordId {
+	fn into_resource(self) -> Result<Resource> {
+		Ok(self.into())
+	}
+}
+
+impl<R> CreateResource<Option<R>> for &RecordId {
+	fn into_resource(self) -> Result<Resource> {
+		Ok(self.clone().into())
+	}
+}
+
+impl<R, T, I> CreateResource<Option<R>> for (T, I)
+where
+	T: Into<String>,
+	I: Into<RecordIdKey>,
+{
+	fn into_resource(self) -> Result<Resource> {
+		Ok(self.into())
+	}
+}
+
+impl<T, R> CreateResource<Option<R>> for Table<T>
+where
+	T: Into<String>,
+{
+	fn into_resource(self) -> Result<Resource> {
+		let t = self.0.into();
+		Ok(t.into())
+	}
+}
+
+impl<R> CreateResource<Option<R>> for &str {
+	fn into_resource(self) -> Result<Resource> {
+		no_colon(self)?;
+		Ok(self.into())
+	}
+}
+
+impl<R> CreateResource<Option<R>> for String {
+	fn into_resource(self) -> Result<Resource> {
+		no_colon(&self)?;
+		Ok(self.into())
+	}
+}
+
+impl<R> CreateResource<Option<R>> for &String {
+	fn into_resource(self) -> Result<Resource> {
+		no_colon(self)?;
+		Ok(self.into())
 	}
 }


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The input for the `create` method is based on the `IntoResource` trait but it has different behaviour from the other CRUD methods. To work around that, we do some creative response type overriding.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It introduces a `CreateResource` trait specifically for the `create` method. That allows our implementation to be more straightforward and more flexible.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
