### PR TITLE
Fix bug with `Number` ordering

### DIFF
--- a/core/src/fnc/util/math/nearestrank.rs
+++ b/core/src/fnc/util/math/nearestrank.rs
@@ -17,6 +17,6 @@ impl Nearestrank for Sorted<&Vec<Number>> {
 			return Number::NAN;
 		}
 		let idx = self.0.len() as f64 * (perc * (1.0 / 100.0));
-		self.0[(idx as usize).min(self.0.len() - 1)].clone()
+		self.0[(idx as usize).min(self.0.len() - 1)]
 	}
 }

--- a/core/src/idx/planner/knn.rs
+++ b/core/src/idx/planner/knn.rs
@@ -87,12 +87,12 @@ impl Inner {
 			let dl = docs.len();
 			if dl > left {
 				for doc_id in docs.iter().take(left) {
-					result.insert(doc_id.clone(), dist.clone());
+					result.insert(doc_id.clone(), *dist);
 				}
 				break;
 			}
 			for doc_id in docs {
-				result.insert(doc_id.clone(), dist.clone());
+				result.insert(doc_id.clone(), *dist);
 			}
 			left -= dl;
 			// We don't expect anymore result, we can leave

--- a/core/src/sql/geometry.rs
+++ b/core/src/sql/geometry.rs
@@ -257,7 +257,7 @@ impl Geometry {
 		let Value::Number(ref b) = v.0[1] else {
 			return None;
 		};
-		Some(Point::from((a.clone().try_into().ok()?, b.clone().try_into().ok()?)))
+		Some(Point::from(((*a).try_into().ok()?, (*b).try_into().ok()?)))
 	}
 }
 

--- a/core/src/sql/number.rs
+++ b/core/src/sql/number.rs
@@ -613,19 +613,11 @@ impl Ord for Number {
 			(Number::Decimal(v), Number::Decimal(w)) => v.cmp(w),
 			// ------------------------------
 			(Number::Int(v), Number::Float(w)) => {
-				if w >= &(i64::MAX as f64) {
-					Ordering::Less
-				} else if w <= &(i64::MIN as f64) {
-					Ordering::Greater
-				} else {
-					match (v.cmp(&(*w as i64)), w.fract() == 0.0, w.is_positive()) {
-						(c, true, _) => c,
-						// eg 1 cmp 1.1 should be less
-						(Ordering::Equal, false, true) => Ordering::Less,
-						// eg -1 cmp -1.1 should be greater
-						(Ordering::Equal, false, false) => Ordering::Greater,
-						(c @ Ordering::Greater | c @ Ordering::Less, false, _) => c,
-					}
+				let l = *v as i128;
+				let r = *w as i128;
+				match l.cmp(&r) {
+					Ordering::Equal => w.fract().total_cmp(&0.0),
+					ordering => ordering,
 				}
 			}
 			(v @ Number::Float(_), w @ Number::Int(_)) => w.cmp(v).reverse(),

--- a/core/src/sql/number.rs
+++ b/core/src/sql/number.rs
@@ -2,7 +2,7 @@ use super::value::{TryAdd, TryDiv, TryFloatDiv, TryMul, TryNeg, TryPow, TryRem, 
 use crate::err::Error;
 use crate::fnc::util::math::ToFloat;
 use crate::sql::strand::Strand;
-use crate::sql::{Order, Value};
+use crate::sql::Value;
 use revision::revisioned;
 use rust_decimal::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -169,7 +169,7 @@ impl TryFrom<&Number> for f32 {
 
 	fn try_from(n: &Number) -> Result<Self, Self::Error> {
 		n.to_float().to_f32().ok_or_else(|| Error::ConvertTo {
-			from: Value::Number(n.clone()),
+			from: Value::Number(*n),
 			into: "f32".to_string(),
 		})
 	}
@@ -187,7 +187,7 @@ impl TryFrom<&Number> for i32 {
 
 	fn try_from(n: &Number) -> Result<Self, Self::Error> {
 		n.to_int().to_i32().ok_or_else(|| Error::ConvertTo {
-			from: Value::Number(n.clone()),
+			from: Value::Number(*n),
 			into: "i32".to_string(),
 		})
 	}
@@ -198,7 +198,7 @@ impl TryFrom<&Number> for i16 {
 
 	fn try_from(n: &Number) -> Result<Self, Self::Error> {
 		n.to_int().to_i16().ok_or_else(|| Error::ConvertTo {
-			from: Value::Number(n.clone()),
+			from: Value::Number(*n),
 			into: "i16".to_string(),
 		})
 	}

--- a/core/src/sql/number.rs
+++ b/core/src/sql/number.rs
@@ -631,14 +631,6 @@ impl Ord for Number {
 				}
 			}
 			(Number::Decimal(v), Number::Float(w)) => {
-				// if let Some(w) = Decimal::from_f64_retain(*w) {
-				// 	Decimal::cmp(&v, &w) // in range
-				// } else if w.is_sign_positive() {
-				// 	Ordering::Less // inf, +NaN, pos overflow
-				// } else {
-				// 	Ordering::Greater // -inf, -NaN, neg overflow
-				// }
-
 				Number::cmp(&Number::Float(*w), &Number::Decimal(*v)).reverse()
 			}
 		}

--- a/core/src/sql/number.rs
+++ b/core/src/sql/number.rs
@@ -616,7 +616,7 @@ impl Ord for Number {
 				let l = *v as i128;
 				let r = *w as i128;
 				match l.cmp(&r) {
-					Ordering::Equal => w.fract().total_cmp(&0.0),
+					Ordering::Equal => 0.0f64.total_cmp(&w.fract()),
 					ordering => ordering,
 				}
 			}

--- a/core/src/sql/number.rs
+++ b/core/src/sql/number.rs
@@ -616,7 +616,7 @@ impl Ord for Number {
 				let l = *v as i128;
 				let r = *w as i128;
 				match l.cmp(&r) {
-					Ordering::Equal => 0.0f64.total_cmp(&w.fract()),
+					Ordering::Equal => f64::default().total_cmp(&w.fract()),
 					ordering => ordering,
 				}
 			}

--- a/core/src/sql/value/patch.rs
+++ b/core/src/sql/value/patch.rs
@@ -22,7 +22,7 @@ impl Value {
 							Part::Index(i) => match new.pick(left) {
 								Value::Array(mut v) => match v.len() > i.clone().as_usize() {
 									true => {
-										v.insert(i.clone().as_usize(), value);
+										v.insert((*i).as_usize(), value);
 										new.put(left, Value::Array(v));
 									}
 									false => {

--- a/core/src/sql/value/patch.rs
+++ b/core/src/sql/value/patch.rs
@@ -20,7 +20,7 @@ impl Value {
 						// Check what the last path part is
 						Some((last, left)) => match last {
 							Part::Index(i) => match new.pick(left) {
-								Value::Array(mut v) => match v.len() > i.clone().as_usize() {
+								Value::Array(mut v) => match v.len() > i.as_usize() {
 									true => {
 										v.insert((*i).as_usize(), value);
 										new.put(left, Value::Array(v));

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -848,7 +848,7 @@ impl TryFrom<&Value> for Number {
 	type Error = Error;
 	fn try_from(value: &Value) -> Result<Self, Self::Error> {
 		match value {
-			Value::Number(x) => Ok(x.clone()),
+			Value::Number(x) => Ok(*x),
 			_ => Err(Error::TryFrom(value.to_string(), "Number")),
 		}
 	}

--- a/sdk/tests/table.rs
+++ b/sdk/tests/table.rs
@@ -100,7 +100,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 		"[
 			{
 				age: 39,
-				average: 77.5,
+				average: 77.5dec,
 				count: 2,
 				id: person_by_age:[39],
 				max: 83,
@@ -128,7 +128,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 		"[
 			{
 				age: 39,
-				average: 81.5,
+				average: 81.5dec,
 				count: 2,
 				id: person_by_age:[39],
 				max: 91,
@@ -147,7 +147,7 @@ async fn define_foreign_table() -> Result<(), Error> {
 		"[
 			{
 				age: 39,
-				average: 81.5,
+				average: 81.5dec,
 				count: 2,
 				id: person_by_age:[39],
 				max: 91,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

current implementation could cause inconsistent behaviour because of loss of precision  

## What does this change do?

This change is technically breaking as it changes the semantics for check equality between decimals and floats.
After this change a float and a decimal can only be equal if they are both integers, but ordering is done correctly.

## What is your testing strategy?

adding new tests, to enforce the correct order, and fuzzing, as well as specific tests for edge cases

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
