### PR TITLE
Fix Query Planner Ignoring Isolated predicates in WHERE Clause

### DIFF
--- a/core/src/idx/planner/mod.rs
+++ b/core/src/idx/planner/mod.rs
@@ -112,7 +112,15 @@ impl QueryPlanner {
 			tree.knn_condition,
 		)
 		.await?;
-		match PlanBuilder::build(tree.root, params, tree.with_indexes, order)? {
+		match PlanBuilder::build(
+			tree.root,
+			params,
+			tree.with_indexes,
+			order,
+			tree.all_and_groups,
+			tree.all_and,
+			tree.all_expressions_with_index,
+		)? {
 			Plan::SingleIndex(exp, io) => {
 				if io.require_distinct() {
 					self.requires_distinct = true;

--- a/core/src/idx/planner/plan.rs
+++ b/core/src/idx/planner/plan.rs
@@ -17,33 +17,27 @@ pub(super) struct PlanBuilder {
 	has_indexes: bool,
 	/// List of expressions that are not ranges, backed by an index
 	non_range_indexes: Vec<(Arc<Expression>, IndexOption)>,
-	/// List of indexes involved in this plan
-	with_indexes: Vec<IndexRef>,
+	/// List of indexes allowed in this plan
+	with_indexes: Option<Vec<IndexRef>>,
 	/// Group each possible optimisations local to a SubQuery
 	groups: BTreeMap<GroupRef, Group>, // The order matters because we want the plan to be consistent across repeated queries.
-	/// Does a group contains only AND relations?
-	all_and_groups: HashMap<GroupRef, bool>,
-	/// Does the whole query contains only AND relations?
-	all_and: bool,
-	/// Is every expression backed by an index?
-	all_exp_with_index: bool,
 }
 
 impl PlanBuilder {
 	pub(super) fn build(
 		root: Option<Node>,
 		params: &QueryPlannerParams,
-		with_indexes: Vec<IndexRef>,
+		with_indexes: Option<Vec<IndexRef>>,
 		order: Option<IndexOption>,
+		all_and_groups: HashMap<GroupRef, bool>,
+		all_and: bool,
+		all_expressions_with_index: bool,
 	) -> Result<Plan, Error> {
 		let mut b = PlanBuilder {
 			has_indexes: false,
 			non_range_indexes: Default::default(),
 			groups: Default::default(),
 			with_indexes,
-			all_and_groups: Default::default(),
-			all_and: true,
-			all_exp_with_index: true,
 		};
 
 		// If we only count and there are no conditions and no aggregations, then we can only scan keys
@@ -61,7 +55,7 @@ impl PlanBuilder {
 		}
 
 		// If every boolean operator are AND then we can use the single index plan
-		if b.all_and {
+		if all_and {
 			// TODO: This is currently pretty arbitrary
 			// We take the "first" range query if one is available
 			if let Some((_, group)) = b.groups.into_iter().next() {
@@ -79,10 +73,10 @@ impl PlanBuilder {
 			}
 		}
 		// If every expression is backed by an index with can use the MultiIndex plan
-		else if b.all_exp_with_index {
+		else if all_expressions_with_index {
 			let mut ranges = Vec::with_capacity(b.groups.len());
-			for (depth, group) in b.groups {
-				if b.all_and_groups.get(&depth) == Some(&true) {
+			for (gr, group) in b.groups {
+				if all_and_groups.get(&gr) == Some(&true) {
 					group.take_union_ranges(&mut ranges);
 				} else {
 					group.take_intersect_ranges(&mut ranges);
@@ -100,9 +94,11 @@ impl PlanBuilder {
 
 	// Check if we have an explicit list of index we can use
 	fn filter_index_option(&self, io: Option<&IndexOption>) -> Option<IndexOption> {
-		if let Some(io) = &io {
-			if !self.with_indexes.is_empty() && !self.with_indexes.contains(&io.ix_ref()) {
-				return None;
+		if let Some(io) = io {
+			if let Some(wi) = &self.with_indexes {
+				if !wi.contains(&io.ix_ref()) {
+					return None;
+				}
 			}
 		}
 		io.cloned()
@@ -117,11 +113,8 @@ impl PlanBuilder {
 				right,
 				exp,
 			} => {
-				let is_bool = self.check_boolean_operator(*group, exp.operator());
 				if let Some(io) = self.filter_index_option(io.as_ref()) {
 					self.add_index_option(*group, exp.clone(), io);
-				} else if self.all_exp_with_index && !is_bool {
-					self.all_exp_with_index = false;
 				}
 				self.eval_node(left)?;
 				self.eval_node(right)?;
@@ -129,26 +122,6 @@ impl PlanBuilder {
 			}
 			Node::Unsupported(reason) => Err(reason.to_owned()),
 			_ => Ok(()),
-		}
-	}
-
-	fn check_boolean_operator(&mut self, gr: GroupRef, op: &Operator) -> bool {
-		match op {
-			Operator::Neg | Operator::Or => {
-				if self.all_and {
-					self.all_and = false;
-				}
-				self.all_and_groups.entry(gr).and_modify(|b| *b = false).or_insert(false);
-				true
-			}
-			Operator::And => {
-				self.all_and_groups.entry(gr).or_insert(true);
-				true
-			}
-			_ => {
-				self.all_and_groups.entry(gr).or_insert(true);
-				false
-			}
 		}
 	}
 

--- a/sdk/tests/helpers.rs
+++ b/sdk/tests/helpers.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::future::Future;
 use std::sync::Arc;
 use std::thread::Builder;
@@ -313,7 +313,11 @@ impl Test {
 	/// Panics if the expected value is not equal to the actual value.
 	/// Compliant with NaN and Constants.
 	#[allow(dead_code)]
-	pub fn expect_value(&mut self, val: Value) -> Result<&mut Self, Error> {
+	pub fn expect_value_info<I: Display>(
+		&mut self,
+		val: Value,
+		info: I,
+	) -> Result<&mut Self, Error> {
 		let tmp = self.next_value()?;
 		// Then check they are indeed the same values
 		//
@@ -324,12 +328,17 @@ impl Test {
 			val
 		};
 		if val.is_nan() {
-			assert!(tmp.is_nan(), "Expected NaN but got: {tmp}");
+			assert!(tmp.is_nan(), "Expected NaN but got {info}: {tmp}");
 		} else {
-			assert_eq!(tmp, val, "{tmp:#}");
+			assert_eq!(tmp, val, "{info} {tmp:#}");
 		}
 		//
 		Ok(self)
+	}
+
+	#[allow(dead_code)]
+	pub fn expect_value(&mut self, val: Value) -> Result<&mut Self, Error> {
+		self.expect_value_info(val, "")
 	}
 
 	/// Expect values in the given slice to be present in the responses, following the same order.
@@ -344,7 +353,15 @@ impl Test {
 	/// Expect the given value to be equals to the next response.
 	#[allow(dead_code)]
 	pub fn expect_val(&mut self, val: &str) -> Result<&mut Self, Error> {
-		self.expect_value(value(val).unwrap_or_else(|_| panic!("INVALID VALUE:\n{val}")))
+		self.expect_val_info(val, "")
+	}
+
+	#[allow(dead_code)]
+	pub fn expect_val_info<I: Display>(&mut self, val: &str, info: I) -> Result<&mut Self, Error> {
+		self.expect_value_info(
+			value(val).unwrap_or_else(|_| panic!("INVALID VALUE {info}:\n{val}")),
+			info,
+		)
 	}
 
 	#[allow(dead_code)]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The query planner currently ignores predicates that involve isolated predicates.

Eg.: ```SELECT * FROM test WHERE (true OR flag==true);```

In this case, the query planner considers the WHERE clause as being only ```flag = TRUE```, effectively ignoring the first predicate ```TRUE OR```.

Consequently, if an index exists on the `flag` column, it implements an inadequate execution plan involving only the index.
However, it shouldn't do this because `TRUE` implies collecting every record.

## What does this change do?

The parser does not anymore ignore isolated predicates.

## What is your testing strategy?

A test has been written.

## Is this related to any issues?

Fixes #3571 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
