### PR TITLE
GraphQL comments without appending and fields

### DIFF
--- a/core/src/gql/schema.rs
+++ b/core/src/gql/schema.rs
@@ -185,7 +185,7 @@ pub async fn generate_schema(
 									let desc = current.get("desc");
 									match (asc, desc) {
 										(Some(_), Some(_)) => {
-											return Err("Found both asc and desc in order".into());
+											return Err("Found both ASC and DESC in order".into());
 										}
 										(Some(GqlValue::Enum(a)), None) => {
 											orders.push(order!(asc, a.as_str()))
@@ -281,7 +281,7 @@ pub async fn generate_schema(
 					})
 				},
 			)
-			.description(format!("Generated from table `{}`{}\nallows querying a table with filters", tb.name, if let Some(ref c) = &tb.comment {format!("\n{c}")} else {"".to_string()}))
+			.description(format!("{}", if let Some(ref c) = &tb.comment { format!("{c}") } else { format!("Generated from table `{}`\nallows querying a table with filters", tb.name) }))
 			.argument(limit_input!())
 			.argument(start_input!())
 			.argument(InputValue::new("order", TypeRef::named(&table_order_name)))
@@ -329,12 +329,11 @@ pub async fn generate_schema(
 				},
 			)
 			.description(format!(
-				"Generated from table `{}`{}\nallows querying a single record in a table by id",
-				tb.name,
+				"{}",
 				if let Some(ref c) = &tb.comment {
-					format!("\n{c}")
+					format!("{c}")
 				} else {
-					"".to_string()
+					format!("Generated from table `{}`\nallows querying a single record in a table by ID", tb.name)
 				}
 			))
 			.argument(id_input!()),
@@ -371,11 +370,20 @@ pub async fn generate_schema(
 			table_filter = table_filter
 				.field(InputValue::new(fd.name.to_string(), TypeRef::named(type_filter_name)));
 
-			table_ty_obj = table_ty_obj.field(Field::new(
-				fd.name.to_string(),
-				fd_type,
-				make_table_field_resolver(fd_name.as_str(), fd.kind.clone()),
-			));
+			table_ty_obj = table_ty_obj
+				.field(Field::new(
+					fd.name.to_string(),
+					fd_type,
+					make_table_field_resolver(fd_name.as_str(), fd.kind.clone()),
+				))
+				.description(format!(
+					"{}",
+					if let Some(ref c) = fd.comment {
+						format!("{c}")
+					} else {
+						"".to_string()
+					}
+				));
 		}
 
 		types.push(Type::Object(table_ty_obj));
@@ -421,7 +429,7 @@ pub async fn generate_schema(
 				}
 			})
 		})
-		.description("allows fetching arbitrary records".to_string())
+		.description("Allows fetching arbitrary records".to_string())
 		.argument(id_input!()),
 	);
 
@@ -476,7 +484,7 @@ pub async fn generate_schema(
 		schema,
 		"uuid",
 		Kind::Uuid,
-		"a string encoded uuid",
+		"String encoded UUID",
 		"https://datatracker.ietf.org/doc/html/rfc4122"
 	);
 


### PR DESCRIPTION
## What is the motivation?

Descriptions weren't adequate for usage of the GraphQL layer as an external API service.

## What does this change do?

Makes GraphQL description exactly match the comments set by the user, and also adds GraphQL descriptions at field level for table's fields. However since `Functions` don't seem to be added this PR doesn't cover comments / descriptions for those yet.

## What is your testing strategy?

N/A

## Is this related to any issues?

- Closes #4802 
- Closes #4801

## Does this change need documentation?

No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
