### PR TITLE
Fix typo in uppercase filter

### DIFF
--- a/core/src/idx/ft/analyzer/filter.rs
+++ b/core/src/idx/ft/analyzer/filter.rs
@@ -116,7 +116,7 @@ impl Filter {
 
 	#[inline]
 	fn uppercase(c: &str) -> FilterResult {
-		Self::check_term(c, c.to_lowercase())
+		Self::check_term(c, c.to_uppercase())
 	}
 
 	#[inline]
@@ -831,6 +831,34 @@ mod tests {
 					chars: (5, 5, 10),
 					bytes: (6, 11),
 					term: "iacta".to_string(),
+					len: 5,
+				},
+				Token::Ref {
+					chars: (10, 10, 11),
+					bytes: (11, 12),
+					len: 1,
+				},
+			],
+		)
+		.await;
+	}
+
+	#[tokio::test]
+	async fn test_uppercase_tokens() {
+		test_analyzer_tokens(
+			"ANALYZER test TOKENIZERS blank,class FILTERS uppercase",
+			"Ālea IactA!",
+			&[
+				Token::String {
+					chars: (0, 0, 4),
+					bytes: (0, 5),
+					term: "ĀLEA".to_string(),
+					len: 4,
+				},
+				Token::String {
+					chars: (5, 5, 10),
+					bytes: (6, 11),
+					term: "IACTA".to_string(),
 					len: 5,
 				},
 				Token::Ref {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The uppercase filter for DEFINE ANALYZER currently calls .to_lowercase() instead of .to_uppercase().

## What does this change do?

It fixes the typo so that the right function is called.

## What is your testing strategy?

Adds a test identical to the one to test lowercase tokens except that it expects an uppercase output.

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
