### PR TITLE
fix: remove `single` check for rpc insert

### DIFF
--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -300,7 +300,7 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 		// Return a single result?
-		let one = what.is_thing_single();
+		let one = matches!(data, Value::Object(_));
 		// Specify the SQL query string
 
 		let mut res = match what {
@@ -337,7 +337,7 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 
-		let one = what.is_thing_single();
+		let one = matches!(data, Value::Object(_));
 
 		let mut res = match what {
 			Value::None | Value::Null => {

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -299,8 +299,6 @@ pub trait RpcContext {
 		let Ok((what, data)) = params.needs_two() else {
 			return Err(RpcError::InvalidParams);
 		};
-		// Return a single result?
-		let one = data.is_object();
 		// Specify the SQL query string
 
 		let mut res = match what {
@@ -323,11 +321,7 @@ pub trait RpcContext {
 			}
 		};
 
-		// Extract the first query result
-		let res = match one {
-			true => res.remove(0).result?.first(),
-			false => res.remove(0).result?,
-		};
+		let res = res.remove(0).result?;
 		// Return the result to the client
 		Ok(res.into())
 	}
@@ -336,8 +330,6 @@ pub trait RpcContext {
 		let Ok((what, data)) = params.needs_two() else {
 			return Err(RpcError::InvalidParams);
 		};
-
-		let one = data.is_object();
 
 		let mut res = match what {
 			Value::None | Value::Null => {
@@ -360,10 +352,7 @@ pub trait RpcContext {
 			_ => return Err(RpcError::InvalidParams),
 		};
 
-		let res = match one {
-			true => res.remove(0).result?.first(),
-			false => res.remove(0).result?,
-		};
+		let res = res.remove(0).result?;
 		Ok(res)
 	}
 

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -300,7 +300,7 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 		// Return a single result?
-		let one = matches!(data, Value::Object(_));
+		let one = data.is_object();
 		// Specify the SQL query string
 
 		let mut res = match what {
@@ -337,7 +337,7 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 
-		let one = matches!(data, Value::Object(_));
+		let one = data.is_object();
 
 		let mut res = match what {
 			Value::None | Value::Null => {

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -343,18 +343,48 @@ async fn insert() -> Result<(), Box<dyn std::error::Error>> {
 		)
 		.await?;
 	assert!(res.is_object(), "result: {res:?}");
+	assert!(res["result"].is_object(), "result: {res:?}");
+	let res = res["result"].as_object().unwrap();
+	assert_eq!(res["name"], "foo", "result: {res:?}");
+	assert_eq!(res["value"], "bar", "result: {res:?}");
+	// Send INSERT command trying to create multiple records
+	let res = socket
+		.send_request(
+			"insert",
+			json!([
+				"tester",
+				[
+					{
+						"name": "foo",
+						"value": "bar",
+					},
+					{
+						"name": "foo",
+						"value": "bar",
+					}
+				]
+			]),
+		)
+		.await?;
+	assert!(res.is_object(), "result: {res:?}");
 	assert!(res["result"].is_array(), "result: {res:?}");
 	let res = res["result"].as_array().unwrap();
-	assert_eq!(res.len(), 1, "result: {res:?}");
+	assert_eq!(res.len(), 2, "result: {res:?}");
 	assert_eq!(res[0]["name"], "foo", "result: {res:?}");
 	assert_eq!(res[0]["value"], "bar", "result: {res:?}");
+	assert_eq!(res[1]["name"], "foo", "result: {res:?}");
+	assert_eq!(res[1]["value"], "bar", "result: {res:?}");
 	// Verify the data was inserted and can be queried
 	let res = socket.send_message_query("SELECT * FROM tester").await?;
 	assert!(res[0]["result"].is_array(), "result: {res:?}");
 	let res = res[0]["result"].as_array().unwrap();
-	assert_eq!(res.len(), 1, "result: {res:?}");
+	assert_eq!(res.len(), 3, "result: {res:?}");
 	assert_eq!(res[0]["name"], "foo", "result: {res:?}");
 	assert_eq!(res[0]["value"], "bar", "result: {res:?}");
+	assert_eq!(res[1]["name"], "foo", "result: {res:?}");
+	assert_eq!(res[1]["value"], "bar", "result: {res:?}");
+	assert_eq!(res[2]["name"], "foo", "result: {res:?}");
+	assert_eq!(res[2]["value"], "bar", "result: {res:?}");
 	// Test passed
 	server.finish().unwrap();
 	Ok(())

--- a/tests/common/tests.rs
+++ b/tests/common/tests.rs
@@ -343,10 +343,11 @@ async fn insert() -> Result<(), Box<dyn std::error::Error>> {
 		)
 		.await?;
 	assert!(res.is_object(), "result: {res:?}");
-	assert!(res["result"].is_object(), "result: {res:?}");
-	let res = res["result"].as_object().unwrap();
-	assert_eq!(res["name"], "foo", "result: {res:?}");
-	assert_eq!(res["value"], "bar", "result: {res:?}");
+	assert!(res["result"].is_array(), "result: {res:?}");
+	let res = res["result"].as_array().unwrap();
+	assert_eq!(res.len(), 1, "result: {res:?}");
+	assert_eq!(res[0]["name"], "foo", "result: {res:?}");
+	assert_eq!(res[0]["value"], "bar", "result: {res:?}");
 	// Send INSERT command trying to create multiple records
 	let res = socket
 		.send_request(


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

RPC insert check for a single result worked based on if `what` was a record id, while you cannot pass a record id to the `INTO` clause.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR removes the check as it's useless.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added some extra tests

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
