### PR TITLE
Introduce with or without index benchmark

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -205,3 +205,7 @@ harness = false
 [[bench]]
 name = "hashset_vs_vector"
 harness = false
+
+[[bench]]
+name = "with_or_without_index"
+harness = false

--- a/sdk/benches/with_or_without_index.rs
+++ b/sdk/benches/with_or_without_index.rs
@@ -1,0 +1,82 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use std::collections::BTreeMap;
+use std::time::Duration;
+use surrealdb::dbs::Session;
+use surrealdb::kvs::Datastore;
+use surrealdb_core::dbs::capabilities::{FuncTarget, Targets};
+use surrealdb_core::dbs::Capabilities;
+use surrealdb_core::sql::{Array, Number, Object, Value};
+use tokio::runtime::Runtime;
+
+fn bench_with_or_without_index(c: &mut Criterion) {
+	let rt = Runtime::new().unwrap();
+	let i = rt.block_on(prepare_data());
+
+	let mut group = c.benchmark_group("with_or_without_index");
+	group.throughput(Throughput::Elements(7500));
+	group.sample_size(10);
+	group.measurement_time(Duration::from_secs(15));
+
+	group.bench_function("without index", |b| {
+		b.to_async(Runtime::new().unwrap())
+			.iter(|| run(&i, "SELECT count() FROM t WITH NOINDEX WHERE n > 7499 GROUP ALL", 7500))
+	});
+
+	group.bench_function("with index", |b| {
+		b.to_async(Runtime::new().unwrap())
+			.iter(|| run(&i, "SELECT count() FROM t WHERE n > 7499 GROUP ALL", 7500))
+	});
+
+	group.finish();
+}
+
+struct Input {
+	dbs: Datastore,
+	ses: Session,
+}
+
+async fn prepare_data() -> Input {
+	#[cfg(feature = "kv-mem")]
+	let path = "memory";
+	#[cfg(feature = "kv-rocksdb")]
+	let path = format!(
+		"rocksdb:///tmp/bench-rocksdb-{}.db",
+		std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis()
+	);
+	let dbs = Datastore::new(&path).await.unwrap().with_capabilities(
+		Capabilities::default().with_functions(Targets::<FuncTarget>::All).with_scripting(true),
+	);
+	let ses = Session::owner().with_ns("bench").with_db("bench");
+	let sql = r"
+		DEFINE INDEX idx ON TABLE t COLUMNS n;
+		FOR $i IN function() { return new Array(15000).fill(0).map((_, i)=>i) } {
+			CREATE t CONTENT { n: $i };
+		};"
+	.to_owned();
+	let res = &mut dbs.execute(&sql, &ses, None).await.unwrap();
+	assert_eq!(res.len(), 2);
+	for _ in 0..2 {
+		let r = res.remove(0);
+		assert!(r.result.is_ok(), "{r:?}");
+	}
+	Input {
+		dbs,
+		ses,
+	}
+}
+
+async fn run(i: &Input, q: &str, expected: usize) {
+	let mut r = i.dbs.execute(black_box(q), &i.ses, None).await.unwrap();
+	if cfg!(debug_assertions) {
+		assert_eq!(r.len(), 1);
+		let val = r.remove(0).result.unwrap();
+		let expected = Value::Array(Array::from(vec![Value::Object(Object::from(
+			BTreeMap::from([("count", Value::Number(Number::Int(expected as i64)))]),
+		))]));
+		assert_eq!(format!("{val:#}"), format!("{expected:#}"));
+	}
+	black_box(r);
+}
+
+criterion_group!(benches, bench_with_or_without_index);
+criterion_main!(benches);

--- a/sdk/benches/with_or_without_index.rs
+++ b/sdk/benches/with_or_without_index.rs
@@ -17,12 +17,12 @@ fn bench_with_or_without_index(c: &mut Criterion) {
 	group.sample_size(10);
 	group.measurement_time(Duration::from_secs(15));
 
-	group.bench_function("without index", |b| {
+	group.bench_function("count/filter without index", |b| {
 		b.to_async(Runtime::new().unwrap())
 			.iter(|| run(&i, "SELECT count() FROM t WITH NOINDEX WHERE n > 7499 GROUP ALL", 7500))
 	});
 
-	group.bench_function("with index", |b| {
+	group.bench_function("count/filter with index", |b| {
 		b.to_async(Runtime::new().unwrap())
 			.iter(|| run(&i, "SELECT count() FROM t WHERE n > 7499 GROUP ALL", 7500))
 	});


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

As related in #3178  with v1.x, SELECT queries are slower with an index than without.


## What does this change do?

This PR introduces a benchmark comparing the performances of the same queries with and without indexes.

## What is your testing strategy?

With v2.0, the benchmark shows that using an index improves the query execution times:


With the memory storage engine:


```sh
cargo bench --bench with_or_without_index --package surrealdb --features kv-mem,scripting -- with_or_without_index
...
with_or_without_index/count/filter with index
                        time:   [336.55 ms 340.75 ms 345.51 ms]
                        thrpt:  [144.71 Kelem/s 146.73 Kelem/s 148.57 Kelem/s]
                 change:
                        time:   [-8.6977% -7.1952% -5.6769%] (p = 0.00 < 0.05)
                        thrpt:  [+6.0186% +7.7531% +9.5262%]
                        Performance has improved.
```

With RocksDB:

```
cargo bench --bench with_or_without_index --package surrealdb --features kv-rocksdb,scripting -- with_or_without_index
...

with_or_without_index/count/filter without index
                        time:   [520.67 ms 524.94 ms 527.12 ms]
                        thrpt:  [94.854 Kelem/s 95.249 Kelem/s 96.029 Kelem/s]
                 change:
                        time:   [-6.5803% -5.8267% -5.1341%] (p = 0.00 < 0.05)
                        thrpt:  [+5.4120% +6.1872% +7.0438%]

```

## Is this related to any issues?

This relates to #3178 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
