### PR TITLE
Make SurrealCS connection pool size configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,24 +3503,17 @@ dependencies = [
 
 [[package]]
 name = "nanoservices-utils"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a95cdb2ba5dc6584099b1aac8da0a6f80e12ad5f9381a19d232c1fee714793"
+checksum = "63a4117f6ebfcfe84722ef283fd6e3bfcaa141718f3ff092343bb6cb98482e03"
 dependencies = [
- "actix-web",
- "bincode",
  "bitcode",
- "bytes",
  "chrono",
  "futures",
- "jsonwebtoken",
  "paste",
  "revision 0.7.1",
  "serde",
- "serde_json",
  "thiserror",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -5990,9 +5983,9 @@ dependencies = [
 
 [[package]]
 name = "surrealcs"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457eb2adc59f9a9ba337e1fa3a6af63e09524e4adf01921b9d7079917cd7f694"
+checksum = "b28a50184a9a743ac180985d8b94ac4c93e4afaa0140f1057d3b11d4d36b9e8b"
 dependencies = [
  "bincode",
  "bytes",
@@ -6011,9 +6004,9 @@ dependencies = [
 
 [[package]]
 name = "surrealcs-kernel"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a79da58bfc886b93a431a463f956184d4b0a9d3672833544a1b718ff86b0df"
+checksum = "ab2a5ba4af373b48fa241a81676d0172fc92e563df217282c472252b90beafee"
 dependencies = [
  "bincode",
  "chrono",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -147,7 +147,7 @@ sha2 = "0.10.8"
 snap = "1.1.0"
 storekey = "0.5.0"
 subtle = "2.6"
-surrealcs = { version = "0.3.1", optional = true }
+surrealcs = { version = "0.3.2", optional = true }
 surrealkv = { version = "0.3.6", optional = true }
 surrealml = { version = "0.1.1", optional = true, package = "surrealml-core" }
 tempfile = { version = "3.10.1", optional = true }

--- a/core/src/kvs/surrealcs/cnf.rs
+++ b/core/src/kvs/surrealcs/cnf.rs
@@ -1,5 +1,4 @@
 use std::sync::LazyLock;
 
-pub static SURREALCS_CONNECTION_POOL_SIZE: LazyLock<i32> =
-	lazy_env_parse_or_else!("SURREAL_SURREALCS_CONNECTION_POOL_SIZE", i32, |_| num_cpus::get()
-		as i32);
+pub static SURREALCS_CONNECTION_POOL_SIZE: LazyLock<usize> =
+	lazy_env_parse_or_else!("SURREAL_SURREALCS_CONNECTION_POOL_SIZE", usize, |_| num_cpus::get());

--- a/core/src/kvs/surrealcs/cnf.rs
+++ b/core/src/kvs/surrealcs/cnf.rs
@@ -1,0 +1,5 @@
+use std::sync::LazyLock;
+
+pub static SURREALCS_CONNECTION_POOL_SIZE: LazyLock<i32> =
+	lazy_env_parse_or_else!("SURREAL_SURREALCS_CONNECTION_POOL_SIZE", i32, |_| num_cpus::get()
+		as i32);

--- a/core/src/kvs/surrealcs/mod.rs
+++ b/core/src/kvs/surrealcs/mod.rs
@@ -74,9 +74,7 @@ impl Drop for Transaction {
 impl Datastore {
 	/// Open a new database
 	pub(crate) async fn new(path: &str) -> Result<Datastore, Error> {
-		match create_connection_pool(path, Some(*cnf::SURREALCS_CONNECTION_POOL_SIZE as usize))
-			.await
-		{
+		match create_connection_pool(path, Some(*cnf::SURREALCS_CONNECTION_POOL_SIZE)).await {
 			Ok(_) => Ok(Datastore {}),
 			Err(_) => {
 				Err(Error::Ds("Cannot connect to the `surrealcs` storage engine".to_string()))

--- a/core/src/kvs/surrealcs/mod.rs
+++ b/core/src/kvs/surrealcs/mod.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "kv-surrealcs")]
 
+mod cnf;
+
 use crate::err::Error;
 use crate::key::debug::Sprintable;
 use crate::kvs::savepoint::{SaveOperation, SavePointImpl, SavePoints};
@@ -72,7 +74,9 @@ impl Drop for Transaction {
 impl Datastore {
 	/// Open a new database
 	pub(crate) async fn new(path: &str) -> Result<Datastore, Error> {
-		match create_connection_pool(path, None).await {
+		match create_connection_pool(path, Some(*cnf::SURREALCS_CONNECTION_POOL_SIZE as usize))
+			.await
+		{
 			Ok(_) => Ok(Datastore {}),
 			Err(_) => {
 				Err(Error::Ds("Cannot connect to the `surrealcs` storage engine".to_string()))


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

SurrealCS connection pool size is currently fixed to the number of CPUs available on the machine on which the database is running.

## What does this change do?

This allows the connection pool size to be determined by an environment variable, falling back to the number of CPUs on the device if no environment variable has been specified. The new environment variable is:

- `SURREAL_SURREALCS_CONNECTION_POOL_SIZE`

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
