### PR TITLE
Fix ensuring that record id matching detects correct edge id

### DIFF
--- a/core/src/doc/check.rs
+++ b/core/src/doc/check.rs
@@ -188,7 +188,7 @@ impl Document {
 					// The out field is a match, so don't error
 					Value::Thing(v) if v.eq(r) => (),
 					// The out is a match, so don't error
-					v if l.id.is(&v) => (),
+					v if r.id.is(&v) => (),
 					// The out field does not match
 					v => {
 						return Err(Error::OutMismatch {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When matching `in` and `out` Record IDs with a `CONTENT` clause which also contains `in` and `out` fields, the Record IDs must match. However currently due to a typo, the wrong edge would be checked for `out` edge ids.

## What does this change do?

Fixes the problem, and ensures that the correct field is compared.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
