### PR TITLE
Fix immediate insert subquery

### DIFF
--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -185,6 +185,8 @@ impl Parser<'_> {
 						if let Some(x) = self.parse_graph_idiom(ctx, &mut res, Dir::Both).await? {
 							return Ok(x);
 						}
+					} else {
+						break;
 					}
 				}
 				t!("..") => {

--- a/core/src/syn/parser/prime.rs
+++ b/core/src/syn/parser/prime.rs
@@ -288,6 +288,7 @@ impl Parser<'_> {
 			t!("RETURN")
 			| t!("SELECT")
 			| t!("CREATE")
+			| t!("INSERT")
 			| t!("UPSERT")
 			| t!("UPDATE")
 			| t!("DELETE")

--- a/core/src/syn/parser/test/mod.rs
+++ b/core/src/syn/parser/test/mod.rs
@@ -92,3 +92,9 @@ fn escaped_params_backtick() {
 	)
 	.unwrap();
 }
+
+#[test]
+fn parse_immediate_insert_subquery() {
+	let res =
+		test_parse!(parse_query, r#"LET $insert = INSERT INTO t (SELECT true FROM 1);"#).unwrap();
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Immediate insert subqueries, subqueries without `()` don't handle insert statements correctly.

## What does this change do?

Add a missing insert token match breaking immediate insert subqueries.

## What is your testing strategy?

Added a test to unsure the new syntax works.

## Is this related to any issues?

Fixes #4829

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
