### PR TITLE
Add Mega to comment link moderation

### DIFF
--- a/.github/workflows/automoderator.yaml
+++ b/.github/workflows/automoderator.yaml
@@ -28,7 +28,7 @@ jobs:
           const regexReplacements = [
             // File Sharing
             {
-              pattern: /(www\.)?(box|dropbox|mediafire|sugarsync|tresorit|hightail|opentext|sharefile|citrixsharefile|icloud|onedrive|1drv)\.com\/[^\s\)]+/g,
+              pattern: /(www\.)?(box|dropbox|mediafire|sugarsync|tresorit|hightail|opentext|sharefile|citrixsharefile|icloud|onedrive|1drv|mega)(\.com|\.co\.nz)\/[^\s\)]+/g,
               replacement: '[REDACTED]'
             },
             // Google Drive


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To combat an ongoing automated malware spam campaign going on [here](https://github.com/surrealdb/surrealdb/issues/4834#issuecomment-2360539518).

## What does this change do?

Adds Mega.co.nz to the list of moderated file sharing hosts.

## What is your testing strategy?

NA

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
