### PR TITLE
Explicitly check for token expiration error

### DIFF
--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -1539,7 +1539,10 @@ mod tests {
 		let mut sess = Session::default();
 		let res = token(&ds, &mut sess, &enc).await;
 
-		assert!(res.is_err(), "Unexpected success signing in with expired token: {:?}", res);
+		match res {
+			Err(Error::ExpiredToken) => {} // ok
+			res => panic!("Unexpected success signing in with expired token: {:?}", res,),
+		}
 	}
 
 	#[tokio::test]

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -1541,6 +1541,7 @@ mod tests {
 
 		match res {
 			Err(Error::ExpiredToken) => {} // ok
+			Err(err) => panic!("Unexpected error signing in with expired token: {:?}", err),
 			res => panic!("Unexpected success signing in with expired token: {:?}", res),
 		}
 	}

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -1541,7 +1541,7 @@ mod tests {
 
 		match res {
 			Err(Error::ExpiredToken) => {} // ok
-			res => panic!("Unexpected success signing in with expired token: {:?}", res,),
+			res => panic!("Unexpected success signing in with expired token: {:?}", res),
 		}
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To compliment #4821 with a test that ensures the correct error is being returned.

## What does this change do?

Checks that the correct error is returned instead of just any error.

## What is your testing strategy?

Test for the specific error that is being returned.

## Is this related to any issues?

#4821 

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
