### PR TITLE
Fix decimal parsing

### DIFF
--- a/core/src/syn/lexer/compound/number.rs
+++ b/core/src/syn/lexer/compound/number.rs
@@ -82,8 +82,15 @@ pub fn numeric(lexer: &mut Lexer, start: Token) -> Result<Numeric, SyntaxError> 
 	match start.kind {
 		t!("-") | t!("+") => number(lexer, start).map(Numeric::Number),
 		TokenKind::Digits => match lexer.reader.peek() {
-			Some(b'n' | b'm' | b's' | b'h' | b'y' | b'd' | b'w') => {
+			Some(b'n' | b'm' | b's' | b'h' | b'y' | b'w') => {
 				duration(lexer, start).map(Numeric::Duration)
+			}
+			Some(b'd') => {
+				if lexer.reader.peek1() == Some(b'e') {
+					number(lexer, start).map(Numeric::Number)
+				} else {
+					duration(lexer, start).map(Numeric::Duration)
+				}
 			}
 			Some(x) if !x.is_ascii() => duration(lexer, start).map(Numeric::Duration),
 			_ => number(lexer, start).map(Numeric::Number),

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -185,6 +185,8 @@ impl Parser<'_> {
 						if let Some(x) = self.parse_graph_idiom(ctx, &mut res, Dir::Both).await? {
 							return Ok(x);
 						}
+					} else {
+						break;
 					}
 				}
 				t!("..") => {

--- a/core/src/syn/parser/test/mod.rs
+++ b/core/src/syn/parser/test/mod.rs
@@ -10,6 +10,11 @@ mod streaming;
 mod value;
 
 #[test]
+fn parse_large_test_file() {
+	test_parse!(parse_query, include_str!("../../../../test.surql")).unwrap();
+}
+
+#[test]
 fn multiple_semicolons() {
 	let res = test_parse!(parse_query, r#";;"#).unwrap();
 	let expected = sql::Query(sql::Statements(vec![]));

--- a/core/src/syn/parser/test/value.rs
+++ b/core/src/syn/parser/test/value.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use reblessive::Stack;
+use rust_decimal::Decimal;
 
 use crate::{
 	sql::{
@@ -154,6 +155,12 @@ fn parse_i64() {
 
 	let res = test_parse!(parse_value_table, r#" 9223372036854775807 "#).unwrap();
 	assert_eq!(res, Value::Number(Number::Int(i64::MAX)));
+}
+
+#[test]
+fn parse_decimal() {
+	let res = test_parse!(parse_value_field, r#" 0dec "#).unwrap();
+	assert_eq!(res, Value::Number(Number::Decimal(Decimal::ZERO)));
 }
 
 #[test]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Plain decimals failed to parse properly.

## What does this change do?

Fixes decimal parsing

## What is your testing strategy?

Added a test for parsing decimal.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
