### PR TITLE
Fix failed `authenticate` resulting in session reset

### DIFF
--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -172,9 +172,12 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 		let mut tmp_session = mem::take(self.session_mut());
-		crate::iam::verify::token(self.kvs(), &mut tmp_session, &token.0).await?;
+		let out: Result<(), RpcError> =
+			crate::iam::verify::token(self.kvs(), &mut tmp_session, &token.0)
+				.await
+				.map_err(Into::into);
 		*self.session_mut() = tmp_session;
-		Ok(Value::None.into())
+		out.map(|_| Value::None.into())
 	}
 
 	// ------------------------------


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To address #4813, where any error resulting from a call to `authenticate` would reset the session context.

## What does this change do?

Correctly restores the session before returning an error in the event of token verification failing.

## What is your testing strategy?

Add a test that reproduced the issue and ensure that the test passes after the fix.

## Is this related to any issues?

- Fixes #4813.
- Fixes #4818.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
