### PR TITLE
Fixes ULID/UUID gen, programmatically generating ranges, RETURN inside FOR/IF and improves arithmetic operations

### DIFF
--- a/core/src/dbs/executor.rs
+++ b/core/src/dbs/executor.rs
@@ -387,8 +387,12 @@ impl<'a> Executor<'a> {
 									.await;
 								ctx = MutableContext::unfreeze(c)?;
 								// Check if this is a RETURN statement
-								let can_return =
-									matches!(stm, Statement::Output(_) | Statement::Value(_));
+								let can_return = matches!(
+									stm,
+									Statement::Output(_)
+										| Statement::Value(_) | Statement::IfElse(_)
+										| Statement::Foreach(_)
+								);
 								// Catch global timeout
 								let res = match ctx.is_timedout() {
 									true => Err(Error::QueryTimedout),

--- a/core/src/dbs/executor.rs
+++ b/core/src/dbs/executor.rs
@@ -390,7 +390,7 @@ impl<'a> Executor<'a> {
 								let can_return = matches!(
 									stm,
 									Statement::Output(_)
-										| Statement::Value(_) | Statement::IfElse(_)
+										| Statement::Value(_) | Statement::Ifelse(_)
 										| Statement::Foreach(_)
 								);
 								// Catch global timeout

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1151,7 +1151,7 @@ pub enum Error {
 	NonComputed,
 
 	/// Represents a failure in timestamp arithmetic related to database internals
-	#[error("Failed to compute: \"{0}\", but one or both operands are too big.")]
+	#[error("Failed to compute: \"{0}\", as the operation results in an overflow.")]
 	ArithmeticOverflow(String),
 }
 

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1149,6 +1149,10 @@ pub enum Error {
 
 	#[error("Found a non-computed value where they are not allowed")]
 	NonComputed,
+
+	/// Represents a failure in timestamp arithmetic related to database internals
+	#[error("Failed to compute: \"{0}\", but one or both operands are too big.")]
+	ArithmeticOverflow(String),
 }
 
 impl From<Error> for String {

--- a/core/src/fnc/rand.rs
+++ b/core/src/fnc/rand.rs
@@ -3,7 +3,7 @@ use crate::err::Error;
 use crate::sql::uuid::Uuid;
 use crate::sql::value::Value;
 use crate::sql::Datetime;
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{TimeZone, Utc};
 use nanoid::nanoid;
 use rand::distributions::{Alphanumeric, DistString};
 use rand::prelude::IteratorRandom;

--- a/core/src/fnc/rand.rs
+++ b/core/src/fnc/rand.rs
@@ -9,8 +9,6 @@ use rand::distributions::{Alphanumeric, DistString};
 use rand::prelude::IteratorRandom;
 use rand::Rng;
 use ulid::Ulid;
-#[cfg(target_arch = "wasm32")]
-use wasmtimer::std::UNIX_EPOCH;
 
 pub fn rand(_: ()) -> Result<Value, Error> {
 	Ok(rand::random::<f64>().into())
@@ -157,7 +155,7 @@ pub fn ulid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
 	let ulid = match timestamp {
 		Some(timestamp) => {
 			#[cfg(target_arch = "wasm32")]
-			if timestamp.0 < UNIX_EPOCH {
+			if timestamp.0 < wasmtimer::std::UNIX_EPOCH {
 				return Err(Error::InvalidArguments {
 					name: String::from("rand::ulid"),
 					message: format!(
@@ -178,7 +176,7 @@ pub fn uuid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
 	let uuid = match timestamp {
 		Some(timestamp) => {
 			#[cfg(target_arch = "wasm32")]
-			if timestamp.0 < UNIX_EPOCH {
+			if timestamp.0 < wasmtimer::std::UNIX_EPOCH {
 				return Err(Error::InvalidArguments {
 					name: String::from("rand::ulid"),
 					message: format!(
@@ -209,7 +207,7 @@ pub mod uuid {
 		let uuid = match timestamp {
 			Some(timestamp) => {
 				#[cfg(target_arch = "wasm32")]
-				if timestamp.0 < UNIX_EPOCH {
+				if timestamp.0 < wasmtimer::std::UNIX_EPOCH {
 					return Err(Error::InvalidArguments {
 						name: String::from("rand::ulid"),
 						message: format!(

--- a/core/src/fnc/rand.rs
+++ b/core/src/fnc/rand.rs
@@ -3,7 +3,7 @@ use crate::err::Error;
 use crate::sql::uuid::Uuid;
 use crate::sql::value::Value;
 use crate::sql::Datetime;
-use chrono::{TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use nanoid::nanoid;
 use rand::distributions::{Alphanumeric, DistString};
 use rand::prelude::IteratorRandom;
@@ -153,7 +153,19 @@ pub fn time((range,): (Option<(i64, i64)>,)) -> Result<Value, Error> {
 
 pub fn ulid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
 	let ulid = match timestamp {
-		Some(timestamp) => Ulid::from_datetime(timestamp.0.into()),
+		Some(timestamp) => {
+			#[cfg(target_arch = "wasm32")]
+			if timestamp.0 < DateTime::UNIX_EPOCH {
+				return Err(Error::InvalidArguments {
+					name: String::from("rand::ulid"),
+					message: format!(
+						"To generate a ULID from a datetime, it must be a time beyond EPOCH."
+					),
+				});
+			}
+
+			Ulid::from_datetime(timestamp.0.into())
+		}
 		None => Ulid::new(),
 	};
 
@@ -162,7 +174,19 @@ pub fn ulid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
 
 pub fn uuid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
 	let uuid = match timestamp {
-		Some(timestamp) => Uuid::new_v7_from_datetime(timestamp),
+		Some(timestamp) => {
+			#[cfg(target_arch = "wasm32")]
+			if timestamp.0 < DateTime::UNIX_EPOCH {
+				return Err(Error::InvalidArguments {
+					name: String::from("rand::ulid"),
+					message: format!(
+						"To generate a ULID from a datetime, it must be a time beyond EPOCH."
+					),
+				});
+			}
+
+			Uuid::new_v7_from_datetime(timestamp)
+		}
 		None => Uuid::new(),
 	};
 	Ok(uuid.into())
@@ -181,7 +205,19 @@ pub mod uuid {
 
 	pub fn v7((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
 		let uuid = match timestamp {
-			Some(timestamp) => Uuid::new_v7_from_datetime(timestamp),
+			Some(timestamp) => {
+				#[cfg(target_arch = "wasm32")]
+				if timestamp.0 < DateTime::UNIX_EPOCH {
+					return Err(Error::InvalidArguments {
+						name: String::from("rand::ulid"),
+						message: format!(
+							"To generate a ULID from a datetime, it must be a time beyond EPOCH."
+						),
+					});
+				}
+
+				Uuid::new_v7_from_datetime(timestamp)
+			}
 			None => Uuid::new(),
 		};
 		Ok(uuid.into())

--- a/core/src/fnc/rand.rs
+++ b/core/src/fnc/rand.rs
@@ -9,6 +9,8 @@ use rand::distributions::{Alphanumeric, DistString};
 use rand::prelude::IteratorRandom;
 use rand::Rng;
 use ulid::Ulid;
+#[cfg(target_arch = "wasm32")]
+use wasmtimer::std::UNIX_EPOCH;
 
 pub fn rand(_: ()) -> Result<Value, Error> {
 	Ok(rand::random::<f64>().into())
@@ -155,11 +157,11 @@ pub fn ulid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
 	let ulid = match timestamp {
 		Some(timestamp) => {
 			#[cfg(target_arch = "wasm32")]
-			if timestamp.0 < DateTime::UNIX_EPOCH {
+			if timestamp.0 < UNIX_EPOCH {
 				return Err(Error::InvalidArguments {
 					name: String::from("rand::ulid"),
 					message: format!(
-						"To generate a ULID from a datetime, it must be a time beyond EPOCH."
+						"To generate a ULID from a datetime, it must be a time beyond UNIX epoch."
 					),
 				});
 			}
@@ -176,11 +178,11 @@ pub fn uuid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
 	let uuid = match timestamp {
 		Some(timestamp) => {
 			#[cfg(target_arch = "wasm32")]
-			if timestamp.0 < DateTime::UNIX_EPOCH {
+			if timestamp.0 < UNIX_EPOCH {
 				return Err(Error::InvalidArguments {
 					name: String::from("rand::ulid"),
 					message: format!(
-						"To generate a ULID from a datetime, it must be a time beyond EPOCH."
+						"To generate a ULID from a datetime, it must be a time beyond UNIX epoch."
 					),
 				});
 			}
@@ -207,11 +209,11 @@ pub mod uuid {
 		let uuid = match timestamp {
 			Some(timestamp) => {
 				#[cfg(target_arch = "wasm32")]
-				if timestamp.0 < DateTime::UNIX_EPOCH {
+				if timestamp.0 < UNIX_EPOCH {
 					return Err(Error::InvalidArguments {
 						name: String::from("rand::ulid"),
 						message: format!(
-							"To generate a ULID from a datetime, it must be a time beyond EPOCH."
+							"To generate a ULID from a datetime, it must be a time beyond UNIX epoch."
 						),
 					});
 				}

--- a/core/src/fnc/rand.rs
+++ b/core/src/fnc/rand.rs
@@ -155,7 +155,7 @@ pub fn ulid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
 	let ulid = match timestamp {
 		Some(timestamp) => {
 			#[cfg(target_arch = "wasm32")]
-			if timestamp.0 < wasmtimer::std::UNIX_EPOCH {
+			if timestamp.0 < chrono::DateTime::UNIX_EPOCH {
 				return Err(Error::InvalidArguments {
 					name: String::from("rand::ulid"),
 					message: format!(
@@ -176,7 +176,7 @@ pub fn uuid((timestamp,): (Option<Datetime>,)) -> Result<Value, Error> {
 	let uuid = match timestamp {
 		Some(timestamp) => {
 			#[cfg(target_arch = "wasm32")]
-			if timestamp.0 < wasmtimer::std::UNIX_EPOCH {
+			if timestamp.0 < chrono::DateTime::UNIX_EPOCH {
 				return Err(Error::InvalidArguments {
 					name: String::from("rand::ulid"),
 					message: format!(
@@ -207,7 +207,7 @@ pub mod uuid {
 		let uuid = match timestamp {
 			Some(timestamp) => {
 				#[cfg(target_arch = "wasm32")]
-				if timestamp.0 < wasmtimer::std::UNIX_EPOCH {
+				if timestamp.0 < chrono::DateTime::UNIX_EPOCH {
 					return Err(Error::InvalidArguments {
 						name: String::from("rand::ulid"),
 						message: format!(

--- a/core/src/fnc/type.rs
+++ b/core/src/fnc/type.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::doc::CursorDoc;
@@ -146,6 +148,7 @@ pub fn thing((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 				Value::Array(v) => v.into(),
 				Value::Object(v) => v.into(),
 				Value::Number(v) => v.into(),
+				Value::Range(v) => v.deref().to_owned().try_into()?,
 				v => v.as_string().into(),
 			},
 		})),

--- a/core/src/sql/datetime.rs
+++ b/core/src/sql/datetime.rs
@@ -1,3 +1,4 @@
+use crate::err::Error;
 use crate::sql::duration::Duration;
 use crate::sql::strand::Strand;
 use crate::syn;
@@ -11,6 +12,7 @@ use std::str;
 use std::str::FromStr;
 
 use super::escape::quote_str;
+use super::value::TrySub;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Datetime";
 
@@ -105,6 +107,16 @@ impl ops::Sub<Self> for Datetime {
 		match (self.0 - other.0).to_std() {
 			Ok(d) => Duration::from(d),
 			Err(_) => Duration::default(),
+		}
+	}
+}
+
+impl TrySub for Datetime {
+	type Output = Duration;
+	fn try_sub(self, other: Self) -> Result<Duration, Error> {
+		match (self.0 - other.0).to_std() {
+			Ok(d) => Ok(Duration::from(d)),
+			Err(_) => Err(Error::ArithmeticOverflow(format!("{self} - {other}"))),
 		}
 	}
 }

--- a/core/src/sql/datetime.rs
+++ b/core/src/sql/datetime.rs
@@ -114,9 +114,9 @@ impl ops::Sub<Self> for Datetime {
 impl TrySub for Datetime {
 	type Output = Duration;
 	fn try_sub(self, other: Self) -> Result<Duration, Error> {
-		match (self.0 - other.0).to_std() {
-			Ok(d) => Ok(Duration::from(d)),
-			Err(_) => Err(Error::ArithmeticOverflow(format!("{self} - {other}"))),
-		}
+		(self.0 - other.0)
+			.to_std()
+			.map_err(|_| Error::ArithmeticOverflow(format!("{self} - {other}")))
+			.map(Duration::from)
 	}
 }

--- a/core/src/sql/duration.rs
+++ b/core/src/sql/duration.rs
@@ -241,10 +241,10 @@ impl ops::Add for Duration {
 impl TryAdd for Duration {
 	type Output = Self;
 	fn try_add(self, other: Self) -> Result<Self, Error> {
-		match self.0.checked_add(other.0) {
-			Some(v) => Ok(Duration::from(v)),
-			None => Err(Error::ArithmeticOverflow(format!("{self} + {other}"))),
-		}
+		self.0
+			.checked_add(other.0)
+			.ok_or_else(|| Error::ArithmeticOverflow(format!("{self} + {other}")))
+			.map(Duration::from)
 	}
 }
 
@@ -261,10 +261,10 @@ impl<'a, 'b> ops::Add<&'b Duration> for &'a Duration {
 impl<'a, 'b> TryAdd<&'b Duration> for &'a Duration {
 	type Output = Duration;
 	fn try_add(self, other: &'b Duration) -> Result<Duration, Error> {
-		match self.0.checked_add(other.0) {
-			Some(v) => Ok(Duration::from(v)),
-			None => Err(Error::ArithmeticOverflow(format!("{self} + {other}"))),
-		}
+		self.0
+			.checked_add(other.0)
+			.ok_or_else(|| Error::ArithmeticOverflow(format!("{self} + {other}")))
+			.map(Duration::from)
 	}
 }
 
@@ -281,10 +281,10 @@ impl ops::Sub for Duration {
 impl TrySub for Duration {
 	type Output = Self;
 	fn try_sub(self, other: Self) -> Result<Self, Error> {
-		match self.0.checked_sub(other.0) {
-			Some(v) => Ok(Duration::from(v)),
-			None => Err(Error::ArithmeticOverflow(format!("{self} - {other}"))),
-		}
+		self.0
+			.checked_sub(other.0)
+			.ok_or_else(|| Error::ArithmeticOverflow(format!("{self} - {other}")))
+			.map(Duration::from)
 	}
 }
 
@@ -301,10 +301,10 @@ impl<'a, 'b> ops::Sub<&'b Duration> for &'a Duration {
 impl<'a, 'b> TrySub<&'b Duration> for &'a Duration {
 	type Output = Duration;
 	fn try_sub(self, other: &'b Duration) -> Result<Duration, Error> {
-		match self.0.checked_sub(other.0) {
-			Some(v) => Ok(Duration::from(v)),
-			None => Err(Error::ArithmeticOverflow(format!("{self} - {other}"))),
-		}
+		self.0
+			.checked_sub(other.0)
+			.ok_or_else(|| Error::ArithmeticOverflow(format!("{self} - {other}")))
+			.map(Duration::from)
 	}
 }
 

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -2981,10 +2981,10 @@ impl TryAdd for Value {
 	fn try_add(self, other: Self) -> Result<Self, Error> {
 		Ok(match (self, other) {
 			(Self::Number(v), Self::Number(w)) => Self::Number(v.try_add(w)?),
-			(Self::Strand(v), Self::Strand(w)) => Self::Strand(v + w),
-			(Self::Datetime(v), Self::Duration(w)) => Self::Datetime(w + v),
-			(Self::Duration(v), Self::Datetime(w)) => Self::Datetime(v + w),
-			(Self::Duration(v), Self::Duration(w)) => Self::Duration(v + w),
+			(Self::Strand(v), Self::Strand(w)) => Self::Strand(v.try_add(w)?),
+			(Self::Datetime(v), Self::Duration(w)) => Self::Datetime(w.try_add(v)?),
+			(Self::Duration(v), Self::Datetime(w)) => Self::Datetime(v.try_add(w)?),
+			(Self::Duration(v), Self::Duration(w)) => Self::Duration(v.try_add(w)?),
 			(v, w) => return Err(Error::TryAdd(v.to_raw_string(), w.to_raw_string())),
 		})
 	}
@@ -2994,7 +2994,7 @@ impl TryAdd for Value {
 
 pub(crate) trait TrySub<Rhs = Self> {
 	type Output;
-	fn try_sub(self, v: Self) -> Result<Self::Output, Error>;
+	fn try_sub(self, v: Rhs) -> Result<Self::Output, Error>;
 }
 
 impl TrySub for Value {
@@ -3002,10 +3002,10 @@ impl TrySub for Value {
 	fn try_sub(self, other: Self) -> Result<Self, Error> {
 		Ok(match (self, other) {
 			(Self::Number(v), Self::Number(w)) => Self::Number(v.try_sub(w)?),
-			(Self::Datetime(v), Self::Datetime(w)) => Self::Duration(v - w),
-			(Self::Datetime(v), Self::Duration(w)) => Self::Datetime(w - v),
-			(Self::Duration(v), Self::Datetime(w)) => Self::Datetime(v - w),
-			(Self::Duration(v), Self::Duration(w)) => Self::Duration(v - w),
+			(Self::Datetime(v), Self::Datetime(w)) => Self::Duration(v.try_sub(w)?),
+			(Self::Datetime(v), Self::Duration(w)) => Self::Datetime(w.try_sub(v)?),
+			(Self::Duration(v), Self::Datetime(w)) => Self::Datetime(v.try_sub(w)?),
+			(Self::Duration(v), Self::Duration(w)) => Self::Duration(v.try_sub(w)?),
 			(v, w) => return Err(Error::TrySub(v.to_raw_string(), w.to_raw_string())),
 		})
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

- Generating a ULID or UUID based on a datetime before EPOCH, currently causes a panic inside WASM.
- It's currently not possible to generate a range record id
- for and ifelse statements don't correctly handle return statements

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

- It prevents generation of ULIDs and UUIDs within WASM for datetimes before EPOCH
- It improves handling of duration, datetime and string additions/subtractions
- Allows you to generate a range record id with the `type::thing()` method
- Ensures the internal `Error::Return` error is properly catched by upper level for and ifelse statements.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
