### PR TITLE
Fix inconsitent numeric object key

### DIFF
--- a/core/src/sql/escape.rs
+++ b/core/src/sql/escape.rs
@@ -79,15 +79,12 @@ pub fn escape_ident(s: &str) -> Cow<'_, str> {
 
 #[inline]
 pub fn escape_normal<'a>(s: &'a str, l: char, r: char, e: &str) -> Cow<'a, str> {
-	// Loop over each character
-	for x in s.bytes() {
-		// Check if character is allowed
-		if !(x.is_ascii_alphanumeric() || x == b'_') {
-			return Cow::Owned(format!("{l}{}{r}", s.replace(r, e)));
-		}
+	// Is there no need to escape the value?
+	if s.bytes().all(|x| x.is_ascii_alphanumeric() || x == b'_') {
+		return Cow::Borrowed(s);
 	}
 	// Output the value
-	Cow::Borrowed(s)
+	Cow::Owned(format!("{l}{}{r}", s.replace(r, e)))
 }
 
 pub fn escape_reserved_keyword(s: &str) -> Option<String> {

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -185,6 +185,8 @@ impl Parser<'_> {
 						if let Some(x) = self.parse_graph_idiom(ctx, &mut res, Dir::Both).await? {
 							return Ok(x);
 						}
+					} else {
+						break;
 					}
 				}
 				t!("..") => {

--- a/core/src/syn/parser/object.rs
+++ b/core/src/syn/parser/object.rs
@@ -6,6 +6,7 @@ use crate::{
 	sql::{Block, Geometry, Number, Object, Strand, Value},
 	syn::{
 		error::bail,
+		lexer::compound,
 		parser::{enter_object_recursion, mac::expected, ParseResult, Parser},
 		token::{t, Glued, Span, TokenKind},
 	},
@@ -602,10 +603,8 @@ impl Parser<'_> {
 		match token.kind {
 			x if Self::kind_is_keyword_like(x) => {
 				self.pop_peek();
-				let str = self.lexer.reader.span(token.span);
-				// Lexer should ensure that the token is valid utf-8
-				let str = std::str::from_utf8(str).unwrap().to_owned();
-				Ok(str)
+				let str = self.lexer.span_str(token.span);
+				Ok(str.to_string())
 			}
 			TokenKind::Identifier => {
 				self.pop_peek();
@@ -616,9 +615,16 @@ impl Parser<'_> {
 				let str = self.next_token_value::<Strand>()?.0;
 				Ok(str)
 			}
-			TokenKind::Digits | TokenKind::Glued(Glued::Number) => {
-				let number = self.next_token_value::<Number>()?.to_string();
-				Ok(number)
+			TokenKind::Digits => {
+				self.pop_peek();
+				let span = self.lexer.lex_compound(token, compound::number)?.span;
+				let str = self.lexer.span_str(span);
+				Ok(str.to_string())
+			}
+			TokenKind::Glued(Glued::Number) => {
+				self.pop_peek();
+				let str = self.lexer.span_str(token.span);
+				Ok(str.to_string())
 			}
 			_ => unexpected!(self, token, "an object key"),
 		}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Object key parsing is somewhat inconsistent.
Take the object `{ "00":0 }`.
The key her is a string, but since surrealql object keys can be digits this is exported as `{ 00: 0 }`.
When this is then parsed again it is first parsed as a number and then turned into a string resulting in the object `{ 0: 0 }`.
This is somewhat unintuitive behavior and can cause problems when exporting and importing.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Makes numeric key parse as their exact written value.
Making `{ 00: 0 }` always end up as the object `{ 00: 0 }`, the extra zero is not removed.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

To be added.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
