### PR TITLE
Fix CBOR Range encoding

### DIFF
--- a/core/src/rpc/format/cbor/convert.rs
+++ b/core/src/rpc/format/cbor/convert.rs
@@ -393,13 +393,13 @@ impl TryFrom<Value> for Cbor {
 						Id::Generate(_) => {
 							return Err("Cannot encode an ungenerated Record ID into CBOR")
 						}
-						Id::Range(v) => Data::try_from(*v)?,
+						Id::Range(v) => Data::Tag(TAG_RANGE, Box::new(Data::try_from(*v)?)),
 					},
 				])),
 			))),
 			Value::Table(v) => Ok(Cbor(Data::Tag(TAG_TABLE, Box::new(Data::Text(v.0))))),
 			Value::Geometry(v) => Ok(Cbor(encode_geometry(v)?)),
-			Value::Range(v) => Ok(Cbor(Data::try_from(*v)?)),
+			Value::Range(v) => Ok(Cbor(Data::Tag(TAG_RANGE, Box::new(Data::try_from(*v)?)))),
 			Value::Future(v) => {
 				let bin = Data::Text(format!("{}", (*v).0));
 				Ok(Cbor(Data::Tag(TAG_FUTURE, Box::new(bin))))


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The inner bounds inside ranges were not wrapped around a tag identifying the range values in the first place, causing them not to be decoded in client libraries

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Fixes the encoding of ranges into CBOR by wrapping them in the `TAG_RANGE` tag.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
