### PR TITLE
Ensure correct error is caught

### DIFF
--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -1608,7 +1608,7 @@ impl Transaction {
 						val
 					}
 					// Check to see that the hierarchy exists
-					Err(Error::TbNotFound {
+					Err(Error::DbNotFound {
 						value,
 					}) if strict => {
 						self.get_ns(ns).await?;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

This change ensures that the correct error type is being caught. This doesn't actually change any behaviour, as the error was surfaced anyway, but the message might have been inaccurate as to which schema definition was not defined, when required.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
