### PR TITLE
Ensure `VERSION` is applied to all queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,15 +3503,15 @@ dependencies = [
 
 [[package]]
 name = "nanoservices-utils"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a4117f6ebfcfe84722ef283fd6e3bfcaa141718f3ff092343bb6cb98482e03"
+checksum = "3c947dd523c885be700bf0ca6c46c83d6fd85a3673b49ca70cdd630493efd925"
 dependencies = [
  "bitcode",
  "chrono",
  "futures",
  "paste",
- "revision 0.7.1",
+ "revision 0.10.0",
  "serde",
  "thiserror",
 ]
@@ -5983,11 +5983,10 @@ dependencies = [
 
 [[package]]
 name = "surrealcs"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28a50184a9a743ac180985d8b94ac4c93e4afaa0140f1057d3b11d4d36b9e8b"
+checksum = "ea51d3d99664888ee0fa5ca02c5f1ccc6aef8ab8f8ab273cc7a55e81bbd013f0"
 dependencies = [
- "bincode",
  "bytes",
  "chrono",
  "futures",
@@ -6004,13 +6003,14 @@ dependencies = [
 
 [[package]]
 name = "surrealcs-kernel"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2a5ba4af373b48fa241a81676d0172fc92e563df217282c472252b90beafee"
+checksum = "9d13005eb13f1b16338ac31a29aa7eda53316008b1f55994da5cc8ccefa5fb58"
 dependencies = [
  "bincode",
  "chrono",
  "nanoservices-utils",
+ "revision 0.10.0",
  "serde",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5983,9 +5983,9 @@ dependencies = [
 
 [[package]]
 name = "surrealcs"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea51d3d99664888ee0fa5ca02c5f1ccc6aef8ab8f8ab273cc7a55e81bbd013f0"
+checksum = "134e46db1610c967ba2205d0cd28988086c7675661f1d2129a16225fece82f0a"
 dependencies = [
  "bytes",
  "chrono",
@@ -6003,9 +6003,9 @@ dependencies = [
 
 [[package]]
 name = "surrealcs-kernel"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d13005eb13f1b16338ac31a29aa7eda53316008b1f55994da5cc8ccefa5fb58"
+checksum = "723ea8fe7300e72a10d3f3e3e277fd1b08c011ed2f5acc6a8b528b9ec5d7c20d"
 dependencies = [
  "bincode",
  "chrono",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -147,7 +147,7 @@ sha2 = "0.10.8"
 snap = "1.1.0"
 storekey = "0.5.0"
 subtle = "2.6"
-surrealcs = { version = "0.3.2", optional = true }
+surrealcs = { version = "0.4.0", optional = true }
 surrealkv = { version = "0.3.6", optional = true }
 surrealml = { version = "0.1.1", optional = true, package = "surrealml-core" }
 tempfile = { version = "3.10.1", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -147,7 +147,7 @@ sha2 = "0.10.8"
 snap = "1.1.0"
 storekey = "0.5.0"
 subtle = "2.6"
-surrealcs = { version = "0.4.0", optional = true }
+surrealcs = { version = "0.4.1", optional = true }
 surrealkv = { version = "0.3.6", optional = true }
 surrealml = { version = "0.1.1", optional = true, package = "surrealml-core" }
 tempfile = { version = "3.10.1", optional = true }

--- a/core/src/doc/edges.rs
+++ b/core/src/doc/edges.rs
@@ -43,14 +43,14 @@ impl Document {
 			) {
 				// Check that the `in` record exists
 				let key = crate::key::thing::new(opt.ns()?, opt.db()?, &l.tb, &l.id);
-				if !txn.exists(key).await? {
+				if !txn.exists(key, None).await? {
 					return Err(Error::IdNotFound {
 						value: l.to_string(),
 					});
 				}
 				// Check that the `out` record exists
 				let key = crate::key::thing::new(opt.ns()?, opt.db()?, &r.tb, &r.id);
-				if !txn.exists(key).await? {
+				if !txn.exists(key, None).await? {
 					return Err(Error::IdNotFound {
 						value: r.to_string(),
 					});

--- a/core/src/kvs/api.rs
+++ b/core/src/kvs/api.rs
@@ -50,7 +50,7 @@ pub trait Transaction {
 	async fn commit(&mut self) -> Result<(), Error>;
 
 	/// Check if a key exists in the datastore.
-	async fn exists<K>(&mut self, key: K) -> Result<bool, Error>
+	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
 	where
 		K: Into<Key> + Sprintable + Debug;
 
@@ -91,7 +91,12 @@ pub trait Transaction {
 	/// Retrieve a specific range of keys from the datastore.
 	///
 	/// This function fetches the full range of keys without values, in a single request to the underlying datastore.
-	async fn keys<K>(&mut self, rng: Range<K>, limit: u32) -> Result<Vec<Key>, Error>
+	async fn keys<K>(
+		&mut self,
+		rng: Range<K>,
+		limit: u32,
+		version: Option<u64>,
+	) -> Result<Vec<Key>, Error>
 	where
 		K: Into<Key> + Sprintable + Debug;
 
@@ -257,7 +262,7 @@ pub trait Transaction {
 		let res = if values {
 			self.scan(beg..end.clone(), batch, version).await?
 		} else {
-			self.keys(beg..end.clone(), batch)
+			self.keys(beg..end.clone(), batch, version)
 				.await?
 				.into_iter()
 				.map(|k| (k, vec![]))

--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -548,7 +548,7 @@ impl Datastore {
 			None => {
 				// Fetch any keys immediately following the version key
 				let rng = crate::key::version::proceeding();
-				let keys = catch!(txn, txn.keys(rng, 1).await);
+				let keys = catch!(txn, txn.keys(rng, 1, None).await);
 				// Check the storage if there are any other keys set
 				let val = if keys.is_empty() {
 					// There are no keys set in storage, so this is a new database

--- a/core/src/kvs/fdb/mod.rs
+++ b/core/src/kvs/fdb/mod.rs
@@ -222,7 +222,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Check if a key exists
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn exists<K>(&mut self, key: K) -> Result<bool, Error>
+	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
@@ -502,7 +502,12 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieve a range of keys from the databases
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keys<K>(&mut self, rng: Range<K>, limit: u32) -> Result<Vec<Key>, Error>
+	async fn keys<K>(
+		&mut self,
+		rng: Range<K>,
+		limit: u32,
+		version: Option<u64>,
+	) -> Result<Vec<Key>, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{

--- a/core/src/kvs/fdb/mod.rs
+++ b/core/src/kvs/fdb/mod.rs
@@ -226,6 +226,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// FoundationDB does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -242,11 +246,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// FDB does not support versioned queries.
+		// FoundationDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -270,11 +273,10 @@ impl super::api::Transaction for Transaction {
 		K: Into<Key> + Sprintable + Debug,
 		V: Into<Val> + Debug,
 	{
-		// FDB does not support versioned queries.
+		// FoundationDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -308,11 +310,10 @@ impl super::api::Transaction for Transaction {
 		K: Into<Key> + Sprintable + Debug,
 		V: Into<Val> + Debug,
 	{
-		// FDB does not support versioned queries.
+		// FoundationDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -505,6 +506,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// FoundationDB does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -546,11 +551,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// FDB does not support versioned queries.
+		// FoundationDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);

--- a/core/src/kvs/indxdb/mod.rs
+++ b/core/src/kvs/indxdb/mod.rs
@@ -141,10 +141,14 @@ impl super::api::Transaction for Transaction {
 
 	/// Check if a key exists
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn exists<K>(&mut self, key: K) -> Result<bool, Error>
+	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// IndxDB does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -161,11 +165,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// IndexDB does not support versioned queries.
+		// IndxDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -183,11 +186,10 @@ impl super::api::Transaction for Transaction {
 		K: Into<Key> + Sprintable + Debug,
 		V: Into<Val> + Debug,
 	{
-		// IndexDB does not support versioned queries.
+		// IndxDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -209,11 +211,10 @@ impl super::api::Transaction for Transaction {
 		K: Into<Key> + Sprintable + Debug,
 		V: Into<Val> + Debug,
 	{
-		// IndexDB does not support versioned queries.
+		// IndxDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -292,10 +293,19 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieve a range of keys from the databases
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keys<K>(&mut self, rng: Range<K>, limit: u32) -> Result<Vec<Key>, Error>
+	async fn keys<K>(
+		&mut self,
+		rng: Range<K>,
+		limit: u32,
+		version: Option<u64>,
+	) -> Result<Vec<Key>, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// IndxDB does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -322,11 +332,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// IndexDB does not support versioned queries.
+		// IndxDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);

--- a/core/src/kvs/mem/mod.rs
+++ b/core/src/kvs/mem/mod.rs
@@ -138,10 +138,14 @@ impl super::api::Transaction for Transaction {
 
 	/// Check if a key exists
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn exists<K>(&mut self, key: K) -> Result<bool, Error>
+	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// EchoDB does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -158,11 +162,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// MemDB does not support versioned queries.
+		// EchoDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -180,11 +183,10 @@ impl super::api::Transaction for Transaction {
 		K: Into<Key> + Sprintable + Debug,
 		V: Into<Val> + Debug,
 	{
-		// MemDB does not support versioned queries.
+		// EchoDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -218,7 +220,7 @@ impl super::api::Transaction for Transaction {
 		K: Into<Key> + Sprintable + Debug,
 		V: Into<Val> + Debug,
 	{
-		// MemDB does not support versioned queries.
+		// EchoDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
@@ -349,10 +351,19 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieve a range of keys from the databases
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keys<K>(&mut self, rng: Range<K>, limit: u32) -> Result<Vec<Key>, Error>
+	async fn keys<K>(
+		&mut self,
+		rng: Range<K>,
+		limit: u32,
+		version: Option<u64>,
+	) -> Result<Vec<Key>, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// EchoDB does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -379,11 +390,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// MemDB does not support versioned queries.
+		// EchoDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);

--- a/core/src/kvs/rocksdb/mod.rs
+++ b/core/src/kvs/rocksdb/mod.rs
@@ -218,10 +218,14 @@ impl super::api::Transaction for Transaction {
 
 	/// Check if a key exists
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn exists<K>(&mut self, key: K) -> Result<bool, Error>
+	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// RocksDB does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -242,7 +246,6 @@ impl super::api::Transaction for Transaction {
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -264,7 +267,6 @@ impl super::api::Transaction for Transaction {
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -290,7 +292,6 @@ impl super::api::Transaction for Transaction {
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -396,10 +397,19 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieve a range of keys from the databases
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keys<K>(&mut self, rng: Range<K>, limit: u32) -> Result<Vec<Key>, Error>
+	async fn keys<K>(
+		&mut self,
+		rng: Range<K>,
+		limit: u32,
+		version: Option<u64>,
+	) -> Result<Vec<Key>, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// RocksDB does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -458,7 +468,6 @@ impl super::api::Transaction for Transaction {
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);

--- a/core/src/kvs/scanner.rs
+++ b/core/src/kvs/scanner.rs
@@ -136,7 +136,7 @@ impl<'a> Stream for Scanner<'a, Key> {
 			// Clone the range to use when scanning
 			let range = self.range.clone();
 			// Prepare a future to scan for results
-			self.future = Some(Box::pin(self.store.keys(range, num)));
+			self.future = Some(Box::pin(self.store.keys(range, num, self.version)));
 		}
 		// Try to resolve the future
 		match self.future.as_mut().unwrap().poll_unpin(cx) {

--- a/core/src/kvs/surrealkv/mod.rs
+++ b/core/src/kvs/surrealkv/mod.rs
@@ -143,7 +143,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Checks if a key exists in the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn exists<K>(&mut self, key: K) -> Result<bool, Error>
+	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
@@ -312,7 +312,12 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieves a range of key-value pairs from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keys<K>(&mut self, rng: Range<K>, limit: u32) -> Result<Vec<Key>, Error>
+	async fn keys<K>(
+		&mut self,
+		rng: Range<K>,
+		limit: u32,
+		version: Option<u64>,
+	) -> Result<Vec<Key>, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{

--- a/core/src/kvs/tests/raw.rs
+++ b/core/src/kvs/tests/raw.rs
@@ -19,9 +19,9 @@ async fn exists() {
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
 	let mut tx = ds.transaction(Read, Optimistic).await.unwrap().inner();
-	let val = tx.exists("test").await.unwrap();
+	let val = tx.exists("test", None).await.unwrap();
 	assert!(val);
-	let val = tx.exists("none").await.unwrap();
+	let val = tx.exists("none", None).await.unwrap();
 	assert!(!val);
 	tx.cancel().await.unwrap();
 }
@@ -206,7 +206,7 @@ async fn keys() {
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
 	let mut tx = ds.transaction(Read, Optimistic).await.unwrap().inner();
-	let val = tx.keys("test1".."test9", u32::MAX).await.unwrap();
+	let val = tx.keys("test1".."test9", u32::MAX, None).await.unwrap();
 	assert_eq!(val.len(), 5);
 	assert_eq!(val[0], b"test1");
 	assert_eq!(val[1], b"test2");
@@ -216,14 +216,14 @@ async fn keys() {
 	tx.cancel().await.unwrap();
 	// Create a readonly transaction
 	let mut tx = ds.transaction(Read, Optimistic).await.unwrap().inner();
-	let val = tx.keys("test2".."test4", u32::MAX).await.unwrap();
+	let val = tx.keys("test2".."test4", u32::MAX, None).await.unwrap();
 	assert_eq!(val.len(), 2);
 	assert_eq!(val[0], b"test2");
 	assert_eq!(val[1], b"test3");
 	tx.cancel().await.unwrap();
 	// Create a readonly transaction
 	let mut tx = ds.transaction(Read, Optimistic).await.unwrap().inner();
-	let val = tx.keys("test1".."test9", 2).await.unwrap();
+	let val = tx.keys("test1".."test9", 2, None).await.unwrap();
 	assert_eq!(val.len(), 2);
 	assert_eq!(val[0], b"test1");
 	assert_eq!(val[1], b"test2");

--- a/core/src/kvs/tikv/mod.rs
+++ b/core/src/kvs/tikv/mod.rs
@@ -176,7 +176,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Check if a key exists
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn exists<K>(&mut self, key: K) -> Result<bool, Error>
+	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
@@ -448,7 +448,12 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a range of keys from the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keys<K>(&mut self, rng: Range<K>, limit: u32) -> Result<Vec<Key>, Error>
+	async fn keys<K>(
+		&mut self,
+		rng: Range<K>,
+		limit: u32,
+		version: Option<u64>,
+	) -> Result<Vec<Key>, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{

--- a/core/src/kvs/tikv/mod.rs
+++ b/core/src/kvs/tikv/mod.rs
@@ -180,6 +180,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// TiKV does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -200,7 +204,6 @@ impl super::api::Transaction for Transaction {
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -222,7 +225,6 @@ impl super::api::Transaction for Transaction {
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -260,7 +262,6 @@ impl super::api::Transaction for Transaction {
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -451,6 +452,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// TiKV does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -481,7 +486,6 @@ impl super::api::Transaction for Transaction {
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
 		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -102,11 +102,11 @@ impl Transaction {
 
 	/// Check if a key exists in the datastore.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
-	pub async fn exists<K>(&self, key: K) -> Result<bool, Error>
+	pub async fn exists<K>(&self, key: K, version: Option<u64>) -> Result<bool, Error>
 	where
 		K: Into<Key> + Debug,
 	{
-		self.lock().await.exists(key).await
+		self.lock().await.exists(key, version).await
 	}
 
 	/// Fetch a key from the datastore.
@@ -228,11 +228,16 @@ impl Transaction {
 	///
 	/// This function fetches the full range of keys, in a single request to the underlying datastore.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
-	pub async fn keys<K>(&self, rng: Range<K>, limit: u32) -> Result<Vec<Key>, Error>
+	pub async fn keys<K>(
+		&self,
+		rng: Range<K>,
+		limit: u32,
+		version: Option<u64>,
+	) -> Result<Vec<Key>, Error>
 	where
 		K: Into<Key> + Debug,
 	{
-		self.lock().await.keys(rng, limit).await
+		self.lock().await.keys(rng, limit, version).await
 	}
 
 	/// Retrieve a specific range of keys from the datastore.

--- a/core/src/kvs/version/fixes/v1_to_2_id_uuid/mod.rs
+++ b/core/src/kvs/version/fixes/v1_to_2_id_uuid/mod.rs
@@ -34,7 +34,7 @@ async fn migrate_tb_records(
 	let mut queue: Vec<Vec<u8>> = Vec::new();
 
 	'scan: loop {
-		let keys = tx.keys(beg.clone()..end.clone(), 1000).await?;
+		let keys = tx.keys(beg.clone()..end.clone(), 1000, None).await?;
 		if keys.is_empty() {
 			break 'scan;
 		}
@@ -80,7 +80,7 @@ async fn migrate_tb_edges(tx: Arc<Transaction>, ns: &str, db: &str, tb: &str) ->
 	let mut queue: Vec<Vec<u8>> = Vec::new();
 
 	'scan: loop {
-		let keys = tx.keys(beg.clone()..end.clone(), 1000).await?;
+		let keys = tx.keys(beg.clone()..end.clone(), 1000, None).await?;
 		if keys.is_empty() {
 			break 'scan;
 		}

--- a/core/src/kvs/version/fixes/v1_to_2_migrate_to_access.rs
+++ b/core/src/kvs/version/fixes/v1_to_2_migrate_to_access.rs
@@ -44,7 +44,7 @@ async fn migrate_ns_tokens(tx: Arc<Transaction>, ns: &str) -> Result<(), Error> 
 
 	// Scan the token definitions
 	'scan: loop {
-		let mut keys = tx.keys(beg.clone()..end.clone(), 1000).await?;
+		let mut keys = tx.keys(beg.clone()..end.clone(), 1000, None).await?;
 		if keys.is_empty() {
 			break 'scan;
 		}
@@ -90,7 +90,7 @@ async fn migrate_db_tokens(tx: Arc<Transaction>, ns: &str, db: &str) -> Result<(
 
 	// Scan the token definitions
 	'scan: loop {
-		let mut keys = tx.keys(beg.clone()..end.clone(), 1000).await?;
+		let mut keys = tx.keys(beg.clone()..end.clone(), 1000, None).await?;
 		if keys.is_empty() {
 			break 'scan;
 		}
@@ -140,7 +140,7 @@ async fn collect_db_scope_keys(
 
 	// Scan the token definitions
 	'scan: loop {
-		let mut keys = tx.keys(beg.clone()..end.clone(), 1000).await?;
+		let mut keys = tx.keys(beg.clone()..end.clone(), 1000, None).await?;
 		if keys.is_empty() {
 			break 'scan;
 		}
@@ -205,7 +205,7 @@ async fn migrate_sc_tokens(
 
 	// Scan the token definitions
 	'scan: loop {
-		let mut keys = tx.keys(beg.clone()..end.clone(), 1000).await?;
+		let mut keys = tx.keys(beg.clone()..end.clone(), 1000, None).await?;
 		if keys.is_empty() {
 			break 'scan;
 		}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Some queries would use the wrong key processing in certain situations. For instance the following query (now optimised to scan keys only) will only scan current records, and will not take the `VERSION` into account:

```sql
SELECT count() FROM person GROUP ALL VERSION d"2024-01-01T00:00:00Z"
```

## What does this change do?

Ensures that the necessary key processing uses versions in all situations.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
