### PR TITLE
Fixes compilation issue on 32bits platforms (other than wasm32)

### DIFF
--- a/core/src/idx/ft/mod.rs
+++ b/core/src/idx/ft/mod.rs
@@ -504,11 +504,11 @@ impl HitsIterator {
 		}
 	}
 
-	#[cfg(not(target_arch = "wasm32"))]
+	#[cfg(target_pointer_width = "64")]
 	pub(crate) fn len(&self) -> usize {
 		self.iter.len()
 	}
-	#[cfg(target_arch = "wasm32")]
+	#[cfg(not(target_pointer_width = "64"))]
 	pub(crate) fn len(&self) -> usize {
 		self.iter.size_hint().0
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The native JAVA client is built for several 32-bit architectures. The len() API of RoaringTreeMap is not available on non 64-bit architectures.
https://github.com/surrealdb/surrealdb.java/pull/84

## What does this change do?

Use the apprioriate `cfg` template.

## What is your testing strategy?

Successful build.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Related to: https://github.com/surrealdb/surrealdb.java/actions/runs/10998118029/job/30535311237?pr=84

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
