### PR TITLE
Fix being able to set a range id on a document's `id`, `in` and `out` fields

### DIFF
--- a/core/src/doc/check.rs
+++ b/core/src/doc/check.rs
@@ -146,7 +146,7 @@ impl Document {
 			}
 		}
 		// This is a RELATE statement
-		if let Workable::Relate(l, r, v, _) = &self.extras {
+		else if let Workable::Relate(l, r, v, _) = &self.extras {
 			// This is a RELATE statement
 			if let Some(data) = stm.data() {
 				// Check that the 'id' field matches
@@ -162,6 +162,8 @@ impl Document {
 						Value::Thing(v) if v.eq(&rid) => (),
 						// The id is a match, so don't error
 						v if rid.id.is(&v) => (),
+						// There was no id field specified
+						v if v.is_none() => (),
 						// The id field does not match
 						v => {
 							return Err(Error::IdMismatch {
@@ -214,7 +216,7 @@ impl Document {
 				}
 			}
 			// This is a INSERT RELATION statement
-			if let Some(data) = v {
+			else if let Some(data) = v {
 				// Check that the 'id' field matches
 				match data.pick(&*ID).compute(stk, ctx, opt, Some(&self.current)).await? {
 					// You cannot store a range id as the id field on a document
@@ -227,6 +229,8 @@ impl Document {
 					Value::Thing(v) if v.eq(&rid) => (),
 					// The id is a match, so don't error
 					v if rid.id.is(&v) => (),
+					// There was no id field specified
+					v if v.is_none() => (),
 					// The id field does not match
 					v => {
 						return Err(Error::IdMismatch {

--- a/core/src/doc/check.rs
+++ b/core/src/doc/check.rs
@@ -173,6 +173,12 @@ impl Document {
 				// Check that the 'in' field matches
 				if let Some(field) = data.pick(stk, ctx, opt, &*IN).await? {
 					match field {
+						// You cannot store a range id as the in field on a document
+						Value::Thing(v) if v.is_range() => {
+							return Err(Error::InInvalid {
+								value: v.to_string(),
+							})
+						}
 						// The in field is a match, so don't error
 						Value::Thing(v) if v.eq(l) => (),
 						// The in is a match, so don't error
@@ -188,6 +194,12 @@ impl Document {
 				// Check that the 'out' field matches
 				if let Some(field) = data.pick(stk, ctx, opt, &*OUT).await? {
 					match field {
+						// You cannot store a range id as the out field on a document
+						Value::Thing(v) if v.is_range() => {
+							return Err(Error::OutInvalid {
+								value: v.to_string(),
+							})
+						}
 						// The out field is a match, so don't error
 						Value::Thing(v) if v.eq(r) => (),
 						// The out is a match, so don't error
@@ -224,6 +236,12 @@ impl Document {
 				}
 				// Check that the 'in' field matches
 				match data.pick(&*IN).compute(stk, ctx, opt, Some(&self.current)).await? {
+					// You cannot store a range id as the in field on a document
+					Value::Thing(v) if v.is_range() => {
+						return Err(Error::InInvalid {
+							value: v.to_string(),
+						})
+					}
 					// The in field is a match, so don't error
 					Value::Thing(v) if v.eq(l) => (),
 					// The in is a match, so don't error
@@ -237,6 +255,12 @@ impl Document {
 				}
 				// Check that the 'out' field matches
 				match data.pick(&*OUT).compute(stk, ctx, opt, Some(&self.current)).await? {
+					// You cannot store a range id as the out field on a document
+					Value::Thing(v) if v.is_range() => {
+						return Err(Error::OutInvalid {
+							value: v.to_string(),
+						})
+					}
 					// The out field is a match, so don't error
 					Value::Thing(v) if v.eq(r) => (),
 					// The out is a match, so don't error

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -633,6 +633,12 @@ pub enum Error {
 		value: String,
 	},
 
+	/// Found a record id for the record but this is not a valid id
+	#[error("Found {value} for the incoming relation, but this is not a valid Record ID")]
+	InInvalid {
+		value: String,
+	},
+
 	/// Found a record id for the record but we are creating a specific record
 	#[error("Found {value} for the `in` field, but the value does not match the `in` record id")]
 	InMismatch {
@@ -642,6 +648,12 @@ pub enum Error {
 	/// Found a record id for the record but we are creating a specific record
 	#[error("Found {value} for the `in` field, which does not match the existing field value")]
 	InOverride {
+		value: String,
+	},
+
+	/// Found a record id for the record but this is not a valid id
+	#[error("Found {value} for the outgoing relation, but this is not a valid Record ID")]
+	OutInvalid {
 		value: String,
 	},
 

--- a/sdk/tests/create.rs
+++ b/sdk/tests/create.rs
@@ -36,7 +36,7 @@ async fn create_with_id() -> Result<(), Error> {
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
-	assert_eq!(res.len(), 15);
+	assert_eq!(res.len(), 16);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(

--- a/sdk/tests/create.rs
+++ b/sdk/tests/create.rs
@@ -30,6 +30,8 @@ async fn create_with_id() -> Result<(), Error> {
 		-- Should error as id is mismatched
 		CREATE person:other SET id = 'tobie';
 		CREATE person:other CONTENT { id: 'tobie', name: 'Tester' };
+		-- Should error as id is a range
+		CREATE person SET id = person:1..2;
 	";
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
@@ -176,6 +178,12 @@ async fn create_with_id() -> Result<(), Error> {
 	assert!(matches!(
 		tmp.err(),
 		Some(e) if e.to_string() == r#"Found 'tobie' for the `id` field, but a specific record has been specified"#
+	));
+	//
+	let tmp = res.remove(0).result;
+	assert!(matches!(
+		tmp.err(),
+		Some(e) if e.to_string() == r#"Found person:1..2 for the Record ID but this is not a valid id"#
 	));
 	//
 	Ok(())


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Due to an oversight, it was possible to set a range id, as the `id`, `in` and `out` fields for a record.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It disallows setting the `id`, `in` and `out` fields to a range id.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
