### PR TITLE
fix: increase max key size for surrealkv store

### DIFF
--- a/core/src/kvs/surrealkv/mod.rs
+++ b/core/src/kvs/surrealkv/mod.rs
@@ -63,6 +63,7 @@ impl Datastore {
 	pub(crate) async fn new(path: &str) -> Result<Datastore, Error> {
 		let mut opts = Options::new();
 		opts.dir = path.to_string().into();
+		opts.max_key_size = 10000;
 
 		match Store::new(opts) {
 			Ok(db) => Ok(Datastore {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The max key length in surrealkv is 1024. This is creating an issue for [vectors](https://github.com/surrealdb/surrealdb/issues/4755) and needs to be increased.

## What does this change do?

Increase surrealkv max key length to 10000

## What is your testing strategy?

CI tests, and using steps listed on the issue to reproduce the issue.

## Is this related to any issues?

Fixes https://github.com/surrealdb/surrealdb/issues/4755

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
