### PR TITLE
Include request `id` in CBOR encoding failure message; Fix failure being shadowed

### DIFF
--- a/src/rpc/response.rs
+++ b/src/rpc/response.rs
@@ -60,8 +60,7 @@ impl Response {
 		// Process the response for the format
 		let (len, msg) = match fmt.res_ws(self) {
 			Ok((l, m)) => (l, m),
-			Err(_) => {
-				let err: Failure = RpcError::Thrown("Serialisation Error".to_string()).into();
+			Err(err) => {
 				fmt.res_ws(failure(id, err)).expect("Serialising known thrown error should succeed")
 			}
 		};

--- a/src/rpc/response.rs
+++ b/src/rpc/response.rs
@@ -10,7 +10,6 @@ use surrealdb::channel::Sender;
 use surrealdb::rpc::format::Format;
 use surrealdb::rpc::Data;
 use surrealdb::sql::Value;
-use surrealdb_core::rpc::RpcError;
 use tracing::Span;
 
 #[revisioned(revision = 1)]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

https://github.com/surrealdb/surrealdb/issues/4647#event-14380745050

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It ensures that the `id` for the request message is included in the error response, so that client SDKs do not have to close the entire connection.
Additionally, this PR ensures that the serialization error gets forwarded to the client.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #4647 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
