### PR TITLE
Fix: Allow Record IDs to be used as object keys

### DIFF
--- a/core/src/sql/value/set.rs
+++ b/core/src/sql/value/set.rs
@@ -463,9 +463,15 @@ mod tests {
 		let (ctx, opt) = mock().await;
 		let idi = Idiom::parse("test.other['inner']");
 		let mut val = Value::parse("{ test: { something: [{ age: 34 }, { age: 36 }] } }");
-		let res = Value::parse("{ test: { other: { inner: true }, something: [{ age: 34 }, { age: 36 }] } }");
+		let res = Value::parse(
+			"{ test: { other: { inner: true }, something: [{ age: 34 }, { age: 36 }] } }",
+		);
 		let mut stack = reblessive::TreeStack::new();
-		stack.enter(|stk| val.set(stk, &ctx, &opt, &idi, Value::from(true))).finish().await.unwrap();
+		stack
+			.enter(|stk| val.set(stk, &ctx, &opt, &idi, Value::from(true)))
+			.finish()
+			.await
+			.unwrap();
 		assert_eq!(res, val);
 	}
 
@@ -476,7 +482,11 @@ mod tests {
 		let mut val = Value::parse("{ test: { something: [{ age: 34 }, { age: 36 }] } }");
 		let res = Value::parse("{ test: { something: [{ age: 34, other: { inner: true } }, { age: 36, other: { inner: true } }] } }");
 		let mut stack = reblessive::TreeStack::new();
-		stack.enter(|stk| val.set(stk, &ctx, &opt, &idi, Value::from(true))).finish().await.unwrap();
+		stack
+			.enter(|stk| val.set(stk, &ctx, &opt, &idi, Value::from(true)))
+			.finish()
+			.await
+			.unwrap();
 		assert_eq!(res, val);
 	}
 
@@ -487,7 +497,11 @@ mod tests {
 		let mut val = Value::parse("{ test: { something: [{ age: 34 }, { age: 36 }] } }");
 		let res = Value::parse("{ test: { something: [{ age: 34, other: { 'city:london': true } }, { age: 36, other: { 'city:london': true } }] } }");
 		let mut stack = reblessive::TreeStack::new();
-		stack.enter(|stk| val.set(stk, &ctx, &opt, &idi, Value::from(true))).finish().await.unwrap();
+		stack
+			.enter(|stk| val.set(stk, &ctx, &opt, &idi, Value::from(true)))
+			.finish()
+			.await
+			.unwrap();
 		assert_eq!(res, val);
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently it's not possible to use Record IDs as the keys in objects.

## What does this change do?

This pull request enables the use of Record IDs in objects:

```sql
USE NS test DB test;
-- Convert the Record ID to a string:
LET $id = testing:1.to_string();
UPSERT test:tester SET field[$id] = true;
-- Convert the Record ID to a string:
LET $id = type::string(testing:2);
UPSERT test:tester SET field[$id] = true;
-- Use the Record ID directly without conversion:
LET $id = testing:3;
UPSERT test:tester SET field[$id] = true;
-- Use the Record ID embedded directly without conversion:
UPSERT test:tester SET field[testing:4] = true;
-- See the result
SELECT * FROM ONLY test:tester LIMIT 1;
```

```sql
{
    id: test:tester,
    field: {
        "testing:1": true,
        "testing:2": true,
        "testing:3": true,
        "testing:4": true
    }
}
```
## What is your testing strategy?

Added additional tests.

## Is this related to any issues?

- [x] Closes #4532.

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
