### PR TITLE
Deprecate DELETE on field permissions

### DIFF
--- a/core/src/sql/permission.rs
+++ b/core/src/sql/permission.rs
@@ -75,7 +75,8 @@ impl Display for Permissions {
 		{
 			// Alternate permissions display implementation ignores delete permission
 			// This display is used to show field permissions, where delete has no effect
-			// Displaying the permission would cause parsing errors during import
+			// Displaying the permission could mislead users into thinking it has an effect
+			// Additionally, including the permission will cause a parsing error in 3.0.0
 			if f.alternate() && matches!(c, PermissionKind::Delete) {
 				continue;
 			}
@@ -126,6 +127,7 @@ impl InfoStructure for Permissions {
 			"select".to_string() => self.select.structure(),
 			"create".to_string() => self.create.structure(),
 			"update".to_string() => self.update.structure(),
+			// TODO(gguillemas): Do not show this value for fields in 3.0.0.
 			"delete".to_string() => self.delete.structure(),
 		})
 	}

--- a/core/src/sql/permission.rs
+++ b/core/src/sql/permission.rs
@@ -73,6 +73,13 @@ impl Display for Permissions {
 		.into_iter()
 		.zip([&self.select, &self.create, &self.update, &self.delete])
 		{
+			// Alternate permissions display implementation ignores delete permission
+			// This display is used to show field permissions, where delete has no effect
+			// Displaying the permission would cause parsing errors during import
+			if f.alternate() && matches!(c, PermissionKind::Delete) {
+				continue;
+			}
+
 			if let Some((existing, _)) = lines.iter_mut().find(|(_, p)| *p == permission) {
 				existing.push(c);
 			} else {

--- a/core/src/sql/statements/define/field.rs
+++ b/core/src/sql/statements/define/field.rs
@@ -225,7 +225,7 @@ impl Display for DefineFieldStatement {
 			f.write_char(' ')?;
 			None
 		};
-		write!(f, "{}", self.permissions)?;
+		write!(f, "{:#}", self.permissions)?;
 		Ok(())
 	}
 }

--- a/core/src/sql/statements/define/field.rs
+++ b/core/src/sql/statements/define/field.rs
@@ -225,6 +225,10 @@ impl Display for DefineFieldStatement {
 			f.write_char(' ')?;
 			None
 		};
+		// Alternate permissions display implementation ignores delete permission
+		// This display is used to show field permissions, where delete has no effect
+		// Displaying the permission could mislead users into thinking it has an effect
+		// Additionally, including the permission will cause a parsing error in 3.0.0
 		write!(f, "{:#}", self.permissions)?;
 		Ok(())
 	}

--- a/core/src/syn/parser/stmt/parts.rs
+++ b/core/src/syn/parser/stmt/parts.rs
@@ -328,8 +328,13 @@ impl Parser<'_> {
 				t!("UPDATE") => {
 					update = true;
 				}
-				t!("DELETE") if !field => {
-					delete = true;
+				t!("DELETE") => {
+					// TODO(gguillemas): Return a parse error instead of logging a warning in 3.0.0.
+					if field {
+						warn!("The DELETE permission has no effect on fields and is deprecated, but was found in a DEFINE FIELD statement.");
+					} else {
+						delete = true;
+					}
 				}
 				_ if field => unexpected!(self, next, "'SELECT', 'CREATE' or 'UPDATE'"),
 				_ => unexpected!(self, next, "'SELECT', 'CREATE', 'UPDATE' or 'DELETE'"),

--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -1471,13 +1471,34 @@ fn parse_define_field() {
 
 	// Invalid DELETE permission
 	{
+		// TODO(gguillemas): Providing the DELETE permission should return a parse error in 3.0.0.
+		// Currently, the DELETE permission is just ignored to maintain backward compatibility.
 		let res =
-			test_parse!(parse_stmt, r#"DEFINE FIELD foo ON TABLE bar PERMISSIONS FOR DELETE NONE"#);
-		assert!(
-			res.is_err(),
-			"Unexpected successful parsing of `DELETE` permission for a field: {:?}",
-			res
-		);
+			test_parse!(parse_stmt, r#"DEFINE FIELD foo ON TABLE bar PERMISSIONS FOR DELETE NONE"#)
+				.unwrap();
+
+		assert_eq!(
+			res,
+			Statement::Define(DefineStatement::Field(DefineFieldStatement {
+				name: Idiom(vec![Part::Field(Ident("foo".to_owned())),]),
+				what: Ident("bar".to_owned()),
+				flex: false,
+				kind: None,
+				readonly: false,
+				value: None,
+				assert: None,
+				default: None,
+				permissions: Permissions {
+					delete: Permission::Full,
+					update: Permission::Full,
+					create: Permission::Full,
+					select: Permission::Full,
+				},
+				comment: None,
+				if_not_exists: false,
+				overwrite: false,
+			}))
+		)
 	}
 }
 

--- a/core/src/syn/parser/test/streaming.rs
+++ b/core/src/syn/parser/test/streaming.rs
@@ -57,7 +57,7 @@ static SOURCE: &str = r#"
 	DEFINE PARAM $a VALUE { a: 1, "b": 3 } PERMISSIONS WHERE null;
 	DEFINE TABLE name DROP SCHEMAFUL CHANGEFEED 1s PERMISSIONS FOR SELECT WHERE a = 1 AS SELECT foo FROM bar GROUP BY foo;
 	DEFINE EVENT event ON TABLE table WHEN null THEN null,none;
-	DEFINE FIELD foo.*[*]... ON TABLE bar FLEX TYPE option<number | array<record<foo>,10>> VALUE null ASSERT true DEFAULT false PERMISSIONS FOR DELETE, UPDATE NONE, FOR create WHERE true;
+	DEFINE FIELD foo.*[*]... ON TABLE bar FLEX TYPE option<number | array<record<foo>,10>> VALUE null ASSERT true DEFAULT false PERMISSIONS FOR UPDATE NONE, FOR CREATE WHERE true;
 	DEFINE INDEX index ON TABLE table FIELDS a,b[*] SEARCH ANALYZER ana BM25 (0.1,0.2)
 			DOC_IDS_ORDER 1
 			DOC_LENGTHS_ORDER 2
@@ -310,7 +310,7 @@ fn statements() -> Vec<Statement> {
 			assert: Some(Value::Bool(true)),
 			default: Some(Value::Bool(false)),
 			permissions: Permissions {
-				delete: Permission::None,
+				delete: Permission::Full,
 				update: Permission::None,
 				create: Permission::Specific(Value::Bool(true)),
 				select: Permission::Full,

--- a/sdk/tests/define.rs
+++ b/sdk/tests/define.rs
@@ -656,7 +656,7 @@ async fn define_field_with_recursive_types() -> Result<(), Error> {
 			fields: {
 				"foo": "DEFINE FIELD foo ON bar TYPE array<float | array<bool>> | set<number> PERMISSIONS FULL",
 				"foo[*]": "DEFINE FIELD foo[*] ON bar TYPE float | array<bool> | number PERMISSIONS FULL",
-				"foo[*][*]": "DEFINE FIELD foo[*][*] ON bar TYPE bool PERMISSIONS FOR select, create, delete FULL, FOR update NONE"
+				"foo[*][*]": "DEFINE FIELD foo[*][*] ON bar TYPE bool PERMISSIONS FOR select, create FULL, FOR update NONE"
 			},
 			indexes: {},
 			lives: {},


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The `DELETE` permission currently has no effect in fields. This is due to it being an operation that only applies to records and, as such, needs to be defined at the table level. There is no difference between "deleting" a field and setting its value to `NONE`, an operation which is governed by the `UPDATE` permission. The fact that the `DELETE` permission is silently parsed and displayed for fields despite having no effect could lead users to have some unmet security expectations.

## What does this change do?

Prints a warning when a `DELETE` permission is specified in `DEFINE FIELD`. Adds comments to prepare a breaking change in 3.0.0, where it will return a parsing error. When a parsing error is found in `DEFINE FIELD` permissions, the list of suitable permissions no longer includes `DELETE`. An alternate display implementation for `Permissions` is used in fields to avoid printing `DELETE` permissions to prevent confusion and ensure that exports from 2.0.3 or later can be imported to 3.0.0.

## What is your testing strategy?

Update existing tests. Test that the the `DELETE` permission is now ignored for fields in definition and display.

## Is this related to any issues?

Resolves #2797.

## Does this change need documentation?

Yes. This requires updating the `DEFINE FIELD` documentation to remove the `DELETE` permission from the syntax.

PR: https://github.com/surrealdb/docs.surrealdb.com/pull/892

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
