### PR TITLE
Allow transactions during imports

### DIFF
--- a/core/src/dbs/executor.rs
+++ b/core/src/dbs/executor.rs
@@ -259,17 +259,11 @@ impl<'a> Executor<'a> {
 				}
 				// Begin a new transaction
 				Statement::Begin(_) => {
-					if opt.import {
-						continue;
-					}
 					self.begin(Write).await;
 					continue;
 				}
 				// Cancel a running transaction
 				Statement::Cancel(_) => {
-					if opt.import {
-						continue;
-					}
 					self.cancel(true).await;
 					self.clear(&ctx, recv.clone()).await;
 					buf = buf.into_iter().map(|v| self.buf_cancel(v)).collect();
@@ -280,9 +274,6 @@ impl<'a> Executor<'a> {
 				}
 				// Commit a running transaction
 				Statement::Commit(_) => {
-					if opt.import {
-						continue;
-					}
 					let commit_error = self.commit(true).await.err();
 					buf = buf.into_iter().map(|v| self.buf_commit(v, &commit_error)).collect();
 					self.flush(&ctx, recv.clone()).await;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

In https://github.com/surrealdb/surrealdb/pull/4725, we made the change to ignore transactions during imports. The reasoning behind this was not very solid however, and it causes exports from SurrealDB 1.x to be imported quite slowly.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Reverts the change by not skipping the `BEGIN`, `CANCEL` and `COMMIT` statements anymore.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
