### PR TITLE
Implement `Ord` for `Duration` and `Table`

### DIFF
--- a/core/src/sql/duration.rs
+++ b/core/src/sql/duration.rs
@@ -26,7 +26,7 @@ pub(crate) static NANOSECONDS_PER_MICROSECOND: u32 = 1000;
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Duration";
 
 #[revisioned(revision = 1)]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord)]
 #[serde(rename = "$surrealdb::private::sql::Duration")]
 #[non_exhaustive]
 pub struct Duration(pub time::Duration);

--- a/core/src/sql/duration.rs
+++ b/core/src/sql/duration.rs
@@ -26,7 +26,9 @@ pub(crate) static NANOSECONDS_PER_MICROSECOND: u32 = 1000;
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Duration";
 
 #[revisioned(revision = 1)]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord)]
+#[derive(
+    Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord,
+)]
 #[serde(rename = "$surrealdb::private::sql::Duration")]
 #[non_exhaustive]
 pub struct Duration(pub time::Duration);

--- a/core/src/sql/duration.rs
+++ b/core/src/sql/duration.rs
@@ -27,7 +27,7 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Duration";
 
 #[revisioned(revision = 1)]
 #[derive(
-    Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord,
+	Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord,
 )]
 #[serde(rename = "$surrealdb::private::sql::Duration")]
 #[non_exhaustive]

--- a/core/src/sql/table.rs
+++ b/core/src/sql/table.rs
@@ -8,9 +8,7 @@ use std::str;
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Table";
 
 #[revisioned(revision = 1)]
-#[derive(
-    Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord,
-)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Tables(pub Vec<Table>);
@@ -35,9 +33,7 @@ impl Display for Tables {
 }
 
 #[revisioned(revision = 1)]
-#[derive(
-    Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord,
-)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord)]
 #[serde(rename = "$surrealdb::private::sql::Table")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]

--- a/core/src/sql/table.rs
+++ b/core/src/sql/table.rs
@@ -8,7 +8,7 @@ use std::str;
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Table";
 
 #[revisioned(revision = 1)]
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Tables(pub Vec<Table>);

--- a/core/src/sql/table.rs
+++ b/core/src/sql/table.rs
@@ -8,7 +8,9 @@ use std::str;
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Table";
 
 #[revisioned(revision = 1)]
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord)]
+#[derive(
+    Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct Tables(pub Vec<Table>);
@@ -33,7 +35,9 @@ impl Display for Tables {
 }
 
 #[revisioned(revision = 1)]
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord)]
+#[derive(
+    Clone, Copy, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord,
+)]
 #[serde(rename = "$surrealdb::private::sql::Table")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]

--- a/core/src/sql/table.rs
+++ b/core/src/sql/table.rs
@@ -33,7 +33,7 @@ impl Display for Tables {
 }
 
 #[revisioned(revision = 1)]
-#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash, Ord)]
 #[serde(rename = "$surrealdb::private::sql::Table")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

These types are order-able, therefore they should be able to be ordered for downstream crates for usages within things such as `BTreeSet`s

## What does this change do?

Implements Ord

## What is your testing strategy?

> [!WARNING]
> No tests **should** be required

## Is this related to any issues?

- [ ] No related issues

## Does this change need documentation?

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
