### PR TITLE
fix thing parsing function

### DIFF
--- a/core/src/sql/thing.rs
+++ b/core/src/sql/thing.rs
@@ -204,7 +204,7 @@ impl TryFrom<Strand> for Thing {
 impl TryFrom<&str> for Thing {
 	type Error = ();
 	fn try_from(v: &str) -> Result<Self, Self::Error> {
-		match syn::thing(v) {
+		match syn::thing_with_range(v) {
 			Ok(v) => Ok(v),
 			_ => Err(()),
 		}

--- a/core/src/sql/thing.rs
+++ b/core/src/sql/thing.rs
@@ -247,3 +247,62 @@ impl Thing {
 		}))
 	}
 }
+
+#[cfg(test)]
+mod test {
+	use std::{ops::Bound, str::FromStr};
+
+	use crate::sql::{Array, Id, IdRange, Object, Value};
+
+	use super::Thing;
+
+	#[test]
+	fn from() {
+		{
+			let string = "foo:bar";
+			let thing = Thing {
+				tb: "foo".into(),
+				id: Id::String("bar".into()),
+			};
+			assert_eq!(thing, Thing::from_str(string).unwrap());
+		}
+		{
+			let string = "foo:1";
+			let thing = Thing {
+				tb: "foo".into(),
+				id: Id::Number(1),
+			};
+			assert_eq!(thing, Thing::from_str(string).unwrap());
+		}
+		{
+			let string = "foo:[1, 'bar']";
+			let thing = Thing {
+				tb: "foo".into(),
+				id: Id::Array(Array(vec![1i64.into(), "bar".into()])),
+			};
+			assert_eq!(thing, Thing::from_str(string).unwrap());
+		}
+		{
+			let string = "foo:{bar: 1}";
+			let thing = Thing {
+				tb: "foo".into(),
+				id: Id::Object(Object([("bar".to_string(), Value::from(1))].into_iter().collect())),
+			};
+			assert_eq!(thing, Thing::from_str(string).unwrap());
+		}
+		{
+			let string = "foo:1..=2";
+			let thing = Thing {
+				tb: "foo".into(),
+				id: Id::Range(Box::new(
+					IdRange::try_from((
+						Bound::Included(Id::Number(1)),
+						Bound::Included(Id::Number(2)),
+					))
+					.unwrap(),
+				)),
+			};
+			assert_eq!(thing, Thing::from_str(string).unwrap());
+		}
+	}
+}

--- a/core/src/syn/parser/prime.rs
+++ b/core/src/syn/parser/prime.rs
@@ -107,7 +107,7 @@ impl Parser<'_> {
 					}
 					t!(":") => {
 						let str = self.next_token_value::<Ident>()?.0;
-						self.parse_thing_or_range(ctx, str).await
+						self.parse_thing_or_range(ctx, str).await.map(Value::Thing)
 					}
 					_ => Ok(Value::Table(self.next_token_value()?)),
 				}
@@ -315,7 +315,7 @@ impl Parser<'_> {
 					}
 					t!(":") => {
 						let str = self.next_token_value::<Ident>()?.0;
-						self.parse_thing_or_range(ctx, str).await?
+						self.parse_thing_or_range(ctx, str).await?.into()
 					}
 					_ => {
 						if self.table_as_field {

--- a/core/src/syn/parser/thing.rs
+++ b/core/src/syn/parser/thing.rs
@@ -158,9 +158,14 @@ impl Parser<'_> {
 		})
 	}
 
-	pub(crate) async fn parse_thing(&mut self, ctx: &mut Stk) -> ParseResult<Thing> {
+	pub(crate) async fn parse_thing_with_range(&mut self, ctx: &mut Stk) -> ParseResult<Thing> {
 		let ident = self.next_token_value::<Ident>()?.0;
 		self.parse_thing_or_range(ctx, ident).await
+	}
+
+	pub(crate) async fn parse_thing(&mut self, ctx: &mut Stk) -> ParseResult<Thing> {
+		let ident = self.next_token_value::<Ident>()?.0;
+		self.parse_thing_from_ident(ctx, ident).await
 	}
 
 	pub(crate) async fn parse_thing_from_ident(


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

the syn::thing function no longer parses things properly given the range change

## What does this change do?

changes the implementation to allow ranges

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added unit tests for all Id variants

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
