### PR TITLE
rv truthiness check on Datetime that requires after epoch dates

### DIFF
--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -959,12 +959,12 @@ impl Value {
 			Value::Uuid(_) => true,
 			Value::Thing(_) => true,
 			Value::Geometry(_) => true,
+			Value::Datetime(_) => true,
 			Value::Array(v) => !v.is_empty(),
 			Value::Object(v) => !v.is_empty(),
 			Value::Strand(v) => !v.is_empty(),
 			Value::Number(v) => v.is_truthy(),
 			Value::Duration(v) => v.as_nanos() > 0,
-			Value::Datetime(v) => v.timestamp() > 0,
 			_ => false,
 		}
 	}
@@ -3116,6 +3116,8 @@ impl TryNeg for Value {
 #[cfg(test)]
 mod tests {
 
+	use chrono::TimeZone;
+
 	use super::*;
 	use crate::syn::Parse;
 
@@ -3167,6 +3169,7 @@ mod tests {
 		assert!(Value::from("falsey").is_truthy());
 		assert!(Value::from("something").is_truthy());
 		assert!(Value::from(Uuid::new()).is_truthy());
+		assert!(Value::from(Utc.with_ymd_and_hms(1948, 12, 3, 0, 0, 0).unwrap()).is_truthy());
 	}
 
 	#[test]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The `.is_truthy()` method currently checks the number of non-leap seconds inside a Datetime: https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.timestamp

But this check only returns `true` for datetimes after 1970, leading to the following oddity where pre-1970 dates are filtered out:

```
[d"2020-09-09", d"1969-12-31"][WHERE $this];
-- Returns [d'2020-09-09T00:00:00Z']
```

## What does this change do?

Removes the check. IMO anything that is already a datetime should be truthy.

## What is your testing strategy?

Added a line to one of the tests asserting that a datetime formed before 1970 is truthy.

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
