### PR TITLE
Fix idiom path processing 

### DIFF
--- a/core/src/sql/part.rs
+++ b/core/src/sql/part.rs
@@ -151,6 +151,21 @@ impl<'a> Next<'a> for &'a [Part] {
 
 // ------------------------------
 
+pub trait Skip<'a> {
+	fn skip(&'a self, amount: usize) -> &'a [Part];
+}
+
+impl<'a> Skip<'a> for &'a [Part] {
+	fn skip(&'a self, amount: usize) -> &'a [Part] {
+		match self.len() {
+			0 => &[],
+			_ => &self[amount..],
+		}
+	}
+}
+
+// ------------------------------
+
 pub trait NextMethod<'a> {
 	fn next_method(&'a self) -> &'a [Part];
 }

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -398,12 +398,7 @@ impl Value {
 					match p {
 						Part::Optional => match &self {
 							Value::None => Ok(Value::None),
-							_ => {
-								stk.run(|stk| {
-									Value::None.get(stk, ctx, opt, doc, path.next_method())
-								})
-								.await
-							}
+							v => stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await,
 						},
 						Part::Flatten => {
 							stk.run(|stk| v.get(stk, ctx, opt, None, path.next())).await

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -262,14 +262,32 @@ impl Value {
 							.await?;
 						stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
 					}
-					_ => stk
-						.scope(|scope| {
-							let futs =
-								v.iter().map(|v| scope.run(|stk| v.get(stk, ctx, opt, doc, path)));
-							try_join_all_buffered(futs)
-						})
-						.await
-						.map(Into::into),
+					_ => {
+						let len = match path.get(1) {
+							// Say that we have a path like `[a:1].out.*`, then `.*`
+							// references `out` and not the resulting array of `[a:1].out`
+							Some(Part::All) => 2,
+							_ => 1,
+						};
+
+						let mapped = stk
+							.scope(|scope| {
+								let futs = v.iter().map(|v| {
+									scope.run(|stk| v.get(stk, ctx, opt, doc, &path[0..len]))
+								});
+								try_join_all_buffered(futs)
+							})
+							.await
+							.map(Value::from)?;
+
+						// If we are chaining graph parts, we need to make sure to flatten the result
+						let mapped = match (path.get(0), path.get(1)) {
+							(Some(Part::Graph(_)), Some(Part::Graph(_))) => mapped.flatten(),
+							_ => mapped,
+						};
+
+						stk.run(|stk| mapped.get(stk, ctx, opt, doc, path.next())).await
+					}
 				},
 				// Current value at path is an edges
 				Value::Edges(v) => {

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -10,8 +10,8 @@ use crate::fnc::idiom;
 use crate::sql::edges::Edges;
 use crate::sql::field::{Field, Fields};
 use crate::sql::id::Id;
-use crate::sql::part::Part;
 use crate::sql::part::{Next, NextMethod};
+use crate::sql::part::{Part, Skip};
 use crate::sql::paths::ID;
 use crate::sql::statements::select::SelectStatement;
 use crate::sql::thing::Thing;
@@ -286,7 +286,7 @@ impl Value {
 							_ => mapped,
 						};
 
-						stk.run(|stk| mapped.get(stk, ctx, opt, doc, path.next())).await
+						stk.run(|stk| mapped.get(stk, ctx, opt, doc, path.skip(len))).await
 					}
 				},
 				// Current value at path is an edges

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -281,7 +281,7 @@ impl Value {
 							.map(Value::from)?;
 
 						// If we are chaining graph parts, we need to make sure to flatten the result
-						let mapped = match (path.get(0), path.get(1)) {
+						let mapped = match (path.first(), path.get(1)) {
 							(Some(Part::Graph(_)), Some(Part::Graph(_))) => mapped.flatten(),
 							_ => mapped,
 						};

--- a/core/src/syn/parser/idiom.rs
+++ b/core/src/syn/parser/idiom.rs
@@ -16,7 +16,7 @@ use super::{mac::unexpected, ParseResult, Parser};
 impl Parser<'_> {
 	pub(super) fn peek_continues_idiom(&mut self) -> bool {
 		let peek = self.peek().kind;
-		if matches!(peek, t!("->") | t!("[") | t!(".") | t!("...")) {
+		if matches!(peek, t!("->") | t!("[") | t!(".") | t!("...") | t!("?")) {
 			return true;
 		}
 		peek == t!("<") && matches!(self.peek1().kind, t!("-") | t!("->"))
@@ -88,6 +88,10 @@ impl Parser<'_> {
 		let mut res = start;
 		loop {
 			match self.peek_kind() {
+				t!("?") => {
+					self.pop_peek();
+					res.push(Part::Optional);
+				}
 				t!("...") => {
 					self.pop_peek();
 					res.push(Part::Flatten);

--- a/sdk/tests/idiom.rs
+++ b/sdk/tests/idiom.rs
@@ -56,3 +56,30 @@ async fn idiom_index_range() -> Result<(), Error> {
 		.expect_val("[1,2,3]")?;
 	Ok(())
 }
+
+#[tokio::test]
+async fn idiom_array_nested_prop_continues_as_array() -> Result<(), Error> {
+	let sql = r#"
+    	[{x:2}].x[0];
+    	[{x:2}].x.at(0);
+	"#;
+	Test::new(sql).await?.expect_val("2")?.expect_val("2")?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn idiom_select_all_from_nested_array_prop() -> Result<(), Error> {
+	let sql = r#"
+    	CREATE a:1, a:2;
+        RELATE a:1->edge:1->a:2;
+        a:1->edge.out;
+        a:1->edge.out.*;
+	"#;
+	Test::new(sql)
+		.await?
+		.expect_val("[{id: a:1}, {id: a:2}]")?
+		.expect_val("[{id: edge:1, in: a:1, out: a:2}]")?
+		.expect_val("[a:2]")?
+		.expect_val("[{id: a:2}]")?;
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

- See #2784
- There is a bug in optional parts where it always continues processing only the next method with `Value::None`.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

When processing any unmatched part, we now only iterate over 1 (or 2 for `Part::All`) parts, and then return the resulting array to pick up the rest of the parts.
Additionally, this PR fixes the behaviour of the optional part.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added tests

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #2784

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
