### PR TITLE
chore: make max_value_size configurable in surrealkv

### DIFF
--- a/core/src/kvs/surrealkv/cnf.rs
+++ b/core/src/kvs/surrealkv/cnf.rs
@@ -1,0 +1,4 @@
+use std::sync::LazyLock;
+
+pub static SURREALKV_MAX_VALUE_SIZE: LazyLock<u64> =
+	lazy_env_parse!("SURREAL_SURREALKV_MAX_VALUE_SIZE", u64, 1024 * 1024);

--- a/core/src/kvs/surrealkv/mod.rs
+++ b/core/src/kvs/surrealkv/mod.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "kv-surrealkv")]
 
+mod cnf;
+
 use crate::err::Error;
 use crate::key::debug::Sprintable;
 use crate::kvs::Check;
@@ -64,6 +66,7 @@ impl Datastore {
 		let mut opts = Options::new();
 		opts.dir = path.to_string().into();
 		opts.max_key_size = 10000;
+		opts.max_value_size = *cnf::SURREALKV_MAX_VALUE_SIZE;
 
 		match Store::new(opts) {
 			Ok(db) => Ok(Datastore {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Make maximum value size configurable inside surrealkv

## What does this change do?

Makes maximum value size configurable inside surrealkv

## What is your testing strategy?

CI

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
