### PR TITLE
Backport fix for object key export

### DIFF
--- a/core/src/sql/escape.rs
+++ b/core/src/sql/escape.rs
@@ -104,15 +104,13 @@ pub fn escape_ident(s: &str) -> Cow<'_, str> {
 
 #[inline]
 pub fn escape_normal<'a>(s: &'a str, l: char, r: char, e: &str) -> Cow<'a, str> {
-	// Loop over each character
-	for x in s.bytes() {
-		// Check if character is allowed
-		if !(x.is_ascii_alphanumeric() || x == b'_') {
-			return Cow::Owned(format!("{l}{}{r}", s.replace(r, e)));
-		}
+	if s.bytes().next().map(|x| !x.is_ascii_digit()).unwrap_or(true)
+		&& s.bytes().all(|x| x.is_ascii_alphanumeric() || x == b'_')
+	{
+		return Cow::Borrowed(s);
 	}
-	// Output the value
-	Cow::Borrowed(s)
+
+	Cow::Owned(format!("{l}{}{r}", s.replace(r, e)))
 }
 
 #[cfg(not(feature = "experimental-parser"))]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Back-ports the fix for object key escaping

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Back-ports the fix for object key escaping

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

N/A

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
