### PR TITLE
Fix panic when calling Thing::try_from("") - with empty value

### DIFF
--- a/core/src/syn/error/render.rs
+++ b/core/src/syn/error/render.rs
@@ -77,15 +77,16 @@ impl Snippet {
 		explain: Option<&'static str>,
 		kind: MessageKind,
 	) -> Self {
-		let line = source.split('\n').nth(location.line - 1).unwrap();
-		let (line, truncation, offset) = Self::truncate_line(line, location.column - 1);
+		let n_len = if source.len() > 0 { 1 } else { 0 };
+		let line = source.split('\n').nth(location.line - n_len).unwrap();
+		let (line, truncation, offset) = Self::truncate_line(line, location.column - n_len);
 
 		Snippet {
 			source: line.to_owned(),
 			truncation,
 			location,
 			offset,
-			length: 1,
+			length: n_len,
 			label: explain.map(|x| x.into()),
 			kind,
 		}
@@ -97,12 +98,13 @@ impl Snippet {
 		explain: Option<&str>,
 		kind: MessageKind,
 	) -> Self {
-		let line = source.split('\n').nth(location.start.line - 1).unwrap();
-		let (line, truncation, offset) = Self::truncate_line(line, location.start.column - 1);
+		let n_len = if source.len() > 0 { 1 } else { 0 };
+		let line = source.split('\n').nth(location.start.line - n_len).unwrap();
+		let (line, truncation, offset) = Self::truncate_line(line, location.start.column - n_len);
 		let length = if location.start.line == location.end.line {
 			location.end.column - location.start.column
 		} else {
-			1
+			n_len
 		};
 		Snippet {
 			source: line.to_owned(),


### PR DESCRIPTION
Currently it panics in from_source_location_range() when source is empty &str - "". Fix is checking source.len() before substracting.

Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Encountered call to Thing::try_from() with empty &str value and application paniked.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Checks if there is length available to subtract from in from_source_location_range().

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Running Thing::try_from("") returned error and not paniking.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
