### PR TITLE
Add lower and upper bounds for RocksDB iterators

### DIFF
--- a/core/src/kvs/rocksdb/mod.rs
+++ b/core/src/kvs/rocksdb/mod.rs
@@ -456,6 +456,8 @@ impl super::api::Transaction for Transaction {
 		// Set the ReadOptions with the snapshot
 		let mut ro = ReadOptions::default();
 		ro.set_snapshot(&inner.snapshot());
+		ro.set_iterate_lower_bound(beg);
+		ro.set_iterate_upper_bound(end);
 		ro.set_async_io(true);
 		ro.fill_cache(true);
 		// Create the iterator
@@ -514,6 +516,8 @@ impl super::api::Transaction for Transaction {
 		// Set the ReadOptions with the snapshot
 		let mut ro = ReadOptions::default();
 		ro.set_snapshot(&inner.snapshot());
+		ro.set_iterate_lower_bound(beg);
+		ro.set_iterate_upper_bound(end);
 		ro.set_async_io(true);
 		ro.fill_cache(true);
 		// Create the iterator


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

RocksDB iterators can sometimes have improved performance when they have a specific lower and upper bound applied to them. Given that we already know the lowest and highest bounds of the iterator, this is a simple addition.

## What does this change do?

Ensures that the start and end of the iterator range are also specified as lower and upper bounds on the RocksDB iterator itself.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
