### PR TITLE
Ensure unstable code is also checked in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  RUSTFLAGS: "--cfg surrealdb_unstable"
+
 jobs:
   format:
     name: Check format


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently, code made available behind the `surrealdb_unstable` flag is not checked for code formatting issues in CI tests, but may cause the release build to fail.

## What does this change do?

This pull request ensures that the `surrealdb_unstable` flag is defined when running CI tests.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
