### PR TITLE
Use new runner types in benchmark jobs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,9 +31,7 @@ defaults:
 jobs:
   common:
     name: Bench common
-    runs-on:
-      - self-hosted
-      - benches
+    runs-on: [runner-arm64-2xlarge]
     timeout-minutes: 60
     steps:
       - name: Install stable toolchain
@@ -92,9 +90,7 @@ jobs:
 
   engines:
     name: Benchmark engines
-    runs-on:
-      - self-hosted
-      - benches
+    runs-on: [runner-arm64-2xlarge]
     timeout-minutes: 60
     permissions:
       id-token: write


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently the benchmark CI tasks are run on the old custom runner infrastructure.

## What does this change do?

Ensures that we are using the new custom runner infrastructure for running the benchmark tasks, in line with the test, build, and release tasks.

## What is your testing strategy?

Not applicable.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
