### PR TITLE
Change how record id with string like id's matching random functions parse.

### DIFF
--- a/core/src/syn/parser/thing.rs
+++ b/core/src/syn/parser/thing.rs
@@ -283,23 +283,34 @@ impl Parser<'_> {
 				)
 			}
 			t!("ULID") => {
-				self.pop_peek();
-				// TODO: error message about how to use `ulid` as an identifier.
-				expected!(self, t!("("));
-				expected!(self, t!(")"));
-				Ok(Id::Generate(Gen::Ulid))
+				let token = self.pop_peek();
+				if self.eat(t!("(")) {
+					expected!(self, t!(")"));
+					Ok(Id::Generate(Gen::Ulid))
+				} else {
+					let slice = self.lexer.span_str(token.span);
+					Ok(Id::String(slice.to_string()))
+				}
 			}
 			t!("UUID") => {
-				self.pop_peek();
-				expected!(self, t!("("));
-				expected!(self, t!(")"));
-				Ok(Id::Generate(Gen::Uuid))
+				let token = self.pop_peek();
+				if self.eat(t!("(")) {
+					expected!(self, t!(")"));
+					Ok(Id::Generate(Gen::Uuid))
+				} else {
+					let slice = self.lexer.span_str(token.span);
+					Ok(Id::String(slice.to_string()))
+				}
 			}
 			t!("RAND") => {
-				self.pop_peek();
-				expected!(self, t!("("));
-				expected!(self, t!(")"));
-				Ok(Id::Generate(Gen::Rand))
+				let token = self.pop_peek();
+				if self.eat(t!("(")) {
+					expected!(self, t!(")"));
+					Ok(Id::Generate(Gen::Rand))
+				} else {
+					let slice = self.lexer.span_str(token.span);
+					Ok(Id::String(slice.to_string()))
+				}
 			}
 			_ => {
 				let ident = if self.flexible_record_id {
@@ -569,5 +580,9 @@ mod tests {
 		assert_ident_parses_correctly("dec123");
 		assert_ident_parses_correctly("f123");
 		assert_ident_parses_correctly("e123");
+
+		assert_ident_parses_correctly("ulid");
+		assert_ident_parses_correctly("uuid");
+		assert_ident_parses_correctly("rand");
 	}
 }


### PR DESCRIPTION

Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently `foo:ulid` fails to parse since it expects a random record id like `foo:ULID()`. 


## What does this change do?

This PR changes to except both instead.

## What is your testing strategy?

Added a test for these types of record-ids.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
