### PR TITLE
Fix like operator bug

### DIFF
--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -2521,3 +2521,8 @@ fn parse_access_list() {
 		}))
 	);
 }
+
+#[test]
+fn parse_like_operator() {
+	test_parse!(parse_stmt, r#"SELECT * FROM "a" ~ "b"; "#).unwrap();
+}

--- a/core/src/syn/token/mac.rs
+++ b/core/src/syn/token/mac.rs
@@ -176,7 +176,7 @@ macro_rules! t {
 	};
 
 	("?") => {
-		$crate::syn::token::TokenKind::Operator($crate::syn::token::Operator::Like)
+		$crate::syn::token::TokenKind::Question
 	};
 	("?:") => {
 		$crate::syn::token::TokenKind::Operator($crate::syn::token::Operator::Tco)


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

There is a bug in the parsing of the like operator.

## What does this change do?

Fixes the bug where a like operator will cause a parsing error where it shouldn't.

## What is your testing strategy?

Added a test to ensure this PR properly fixes the issue.

## Is this related to any issues?

- Fixes #4942

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
