### PR TITLE
Add more static value types for `DEFAULT` clause

### DIFF
--- a/core/src/sql/array.rs
+++ b/core/src/sql/array.rs
@@ -165,6 +165,7 @@ impl Array {
 		self.0.iter().all(|v| v.is_none_or_null())
 	}
 
+	/// Checks whether all array values are static values
 	pub(crate) fn is_static(&self) -> bool {
 		self.iter().all(Value::is_static)
 	}

--- a/core/src/sql/cast.rs
+++ b/core/src/sql/cast.rs
@@ -37,6 +37,10 @@ impl Cast {
 	pub(crate) fn writeable(&self) -> bool {
 		self.1.writeable()
 	}
+	/// Checks whether all array values are static values
+	pub(crate) fn is_static(&self) -> bool {
+		self.1.is_static()
+	}
 	/// Was marked recursively
 	pub(crate) async fn compute(
 		&self,

--- a/core/src/sql/expression.rs
+++ b/core/src/sql/expression.rs
@@ -68,6 +68,7 @@ impl Expression {
 		}
 	}
 
+	/// Checks whether all expression parts are static values
 	pub(crate) fn is_static(&self) -> bool {
 		match self {
 			Self::Unary {

--- a/core/src/sql/function.rs
+++ b/core/src/sql/function.rs
@@ -105,7 +105,7 @@ impl Function {
 		matches!(self, Self::Script(_, _))
 	}
 
-	/// Check if this function has static arguments
+	/// Check if all arguments are static values
 	pub fn is_static(&self) -> bool {
 		match self {
 			Self::Normal(_, a) => a.iter().all(Value::is_static),

--- a/core/src/sql/object.rs
+++ b/core/src/sql/object.rs
@@ -232,6 +232,7 @@ impl Object {
 		Ok(Value::Object(Object(x)))
 	}
 
+	/// Checks whether all object values are static values
 	pub(crate) fn is_static(&self) -> bool {
 		self.values().all(Value::is_static)
 	}

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -2604,6 +2604,7 @@ impl Value {
 			Value::Bool(_) => true,
 			Value::Bytes(_) => true,
 			Value::Uuid(_) => true,
+			Value::Thing(_) => true,
 			Value::Number(_) => true,
 			Value::Strand(_) => true,
 			Value::Duration(_) => true,
@@ -2613,6 +2614,7 @@ impl Value {
 			Value::Object(v) => v.is_static(),
 			Value::Expression(v) => v.is_static(),
 			Value::Function(v) => v.is_static(),
+			Value::Cast(v) => v.is_static(),
 			Value::Constant(_) => true,
 			_ => false,
 		}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

Allows Record IDs and static values cast to another type to be specified in `VALUE` clauses and used within `DEFAULT` clauses when not defined.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
