### PR TITLE
Make it possible to construct `surrealdb::Datetime` and add better support for UUIDs in record IDs

### DIFF
--- a/sdk/src/api/value/mod.rs
+++ b/sdk/src/api/value/mod.rs
@@ -1,4 +1,5 @@
 use crate::Error;
+use chrono::{DateTime, Utc};
 use revision::revisioned;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
@@ -79,6 +80,12 @@ transparent_wrapper!(
 	#[derive( Clone, Eq, PartialEq, Ord, PartialOrd)]
 	pub struct Datetime(CoreDatetime)
 );
+
+impl From<DateTime<Utc>> for Datetime {
+	fn from(v: DateTime<Utc>) -> Self {
+		Self(v.into())
+	}
+}
 
 transparent_wrapper!(
 	/// The key of a [`RecordId`].

--- a/sdk/src/api/value/mod.rs
+++ b/sdk/src/api/value/mod.rs
@@ -124,6 +124,12 @@ impl From<i64> for RecordIdKey {
 	}
 }
 
+impl From<Uuid> for RecordIdKey {
+	fn from(value: Uuid) -> Self {
+		Self(CoreId::Uuid(value.into()))
+	}
+}
+
 impl From<Vec<Value>> for RecordIdKey {
 	fn from(value: Vec<Value>) -> Self {
 		let res = Value::array_to_core(value);


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

`Datetime` cannot be constructed and UUIDs need to be converted to strings first when passing them in as record IDs.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Instead of something like

```rust
db.create(("foo", Uuid::new_v4().to_string()))
```

it should now be possible to do

```rust
db.create(("foo", Uuid::new_v4()))
```

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
