### PR TITLE
Require credentials when specifying auth level

### DIFF
--- a/src/cli/abstraction/mod.rs
+++ b/src/cli/abstraction/mod.rs
@@ -31,8 +31,8 @@ pub(crate) struct AuthArguments {
 		conflicts_with_all = ["username", "password", "auth_level"],
 	)]
 	pub(crate) token: Option<String>,
-	#[arg(help = "Authentication level to use when connecting")]
-	#[arg(env = "SURREAL_AUTH_LEVEL", long = "auth-level", default_value = "root")]
+	#[arg(help = "Level on which the authenticating user is defined")]
+	#[arg(env = "SURREAL_AUTH_LEVEL", long = "auth-level", default_value = "root", requires_all = ["username", "password"])]
 	#[arg(value_parser = super::validator::parser::creds_level::CredentialsLevelParser::new())]
 	pub(crate) auth_level: CredentialsLevel,
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -482,6 +482,21 @@ mod cli_integration {
 				"auth level database requires providing a namespace and database: {output:?}"
 			);
 		}
+
+		info!("* Pass auth level without providing credentials");
+		{
+			let args = format!("sql --conn http://{addr} --ns {ns} --auth-level database");
+			let output = common::run(&args)
+				.input(format!("USE NS `{ns}` DB `{db}`; INFO FOR DB;\n").as_str())
+				.output();
+			assert!(
+				output
+					.clone()
+					.unwrap_err()
+					.contains("error: the following required arguments were not provided:\n  --password <PASSWORD>\n  --username <USERNAME>"),
+				"auth level database requires credentials: {output:?}"
+			);
+		}
 		server.finish().unwrap();
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To avoid misleading users into thinking that the `--auth-level` argument in the CLI does anything unless user credentials are provided, as well as to clarify the purpose of the argument via a clearer help message.

## What does this change do?

Requires the `--username` and `--password` arguments to be provided on `surreal sql` if the `--auth-level` argument is provided.
Changes the help message for the `--auth-level` argument to one that is clearer.

## What is your testing strategy?

Add a test to ensure that `--auth-level` is not accepted without user credentials.

## Is this related to any issues?

No.

## Does this change need documentation?

The CLI documentation should probably be updated with the new help message.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
