### PR TITLE
Fix Clippy for Rust 1.82

### DIFF
--- a/core/src/idx/trees/store/mod.rs
+++ b/core/src/idx/trees/store/mod.rs
@@ -29,7 +29,7 @@ where
 	N: TreeNode + Debug + Clone,
 {
 	/// caches every read nodes, and keeps track of updated and created nodes
-	Write(TreeWrite<N>),
+	Write(Box<TreeWrite<N>>),
 	/// caches read nodes in an LRU cache
 	Read(TreeRead<N>),
 }
@@ -41,7 +41,7 @@ where
 	pub async fn new(np: TreeNodeProvider, cache: Arc<TreeCache<N>>, tt: TransactionType) -> Self {
 		match tt {
 			TransactionType::Read => Self::Read(TreeRead::new(cache)),
-			TransactionType::Write => Self::Write(TreeWrite::new(np, cache)),
+			TransactionType::Write => Self::Write(Box::new(TreeWrite::new(np, cache))),
 		}
 	}
 

--- a/core/src/idx/trees/store/mod.rs
+++ b/core/src/idx/trees/store/mod.rs
@@ -24,12 +24,13 @@ pub type NodeId = u64;
 pub type StoreGeneration = u64;
 
 #[non_exhaustive]
+#[allow(clippy::large_enum_variant)]
 pub enum TreeStore<N>
 where
 	N: TreeNode + Debug + Clone,
 {
 	/// caches every read nodes, and keeps track of updated and created nodes
-	Write(Box<TreeWrite<N>>),
+	Write(TreeWrite<N>),
 	/// caches read nodes in an LRU cache
 	Read(TreeRead<N>),
 }
@@ -41,7 +42,7 @@ where
 	pub async fn new(np: TreeNodeProvider, cache: Arc<TreeCache<N>>, tt: TransactionType) -> Self {
 		match tt {
 			TransactionType::Read => Self::Read(TreeRead::new(cache)),
-			TransactionType::Write => Self::Write(Box::new(TreeWrite::new(np, cache))),
+			TransactionType::Write => Self::Write(TreeWrite::new(np, cache)),
 		}
 	}
 

--- a/core/src/sql/order.rs
+++ b/core/src/sql/order.rs
@@ -93,9 +93,8 @@ impl fmt::Display for Order {
 		if self.numeric {
 			write!(f, " NUMERIC")?;
 		}
-		match self.direction {
-			false => write!(f, " DESC")?,
-			true => (),
+		if !self.direction {
+			write!(f, " DESC")?
 		};
 		Ok(())
 	}

--- a/core/src/sql/order.rs
+++ b/core/src/sql/order.rs
@@ -94,8 +94,8 @@ impl fmt::Display for Order {
 			write!(f, " NUMERIC")?;
 		}
 		if !self.direction {
-			write!(f, " DESC")?
-		};
+			write!(f, " DESC")?;
+		}
 		Ok(())
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Clippy is generating errors with Rust 1.82 that are failing all builds.

## What does this change do?

Implements suggestions provided by Clippy. Exempts the `TreeStore` enum from the `large_enum_variant` check.

For context on the exemption:
The `Write` variant of the `TreeStore` struct is much larger than the `Read` variant, causing the size of the enum to be bounded by the larger variant. Doing so may have performance implications due to the inner value being allocated in the heap instead of the stack. We can exempt `TreeStore` from the check until we can be sure of what those implications are.

## What is your testing strategy?

Ensure that existing tests continue passing.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
