### PR TITLE
Fix panic on order by rand

### DIFF
--- a/core/src/dbs/result.rs
+++ b/core/src/dbs/result.rs
@@ -6,7 +6,8 @@ use crate::dbs::store::file_store::FileCollector;
 use crate::dbs::store::MemoryCollector;
 use crate::dbs::{Options, Statement};
 use crate::err::Error;
-use crate::sql::{Orders, Value};
+use crate::sql::order::Ordering;
+use crate::sql::Value;
 use reblessive::tree::Stk;
 
 pub(super) enum Results {
@@ -59,7 +60,7 @@ impl Results {
 		Ok(())
 	}
 
-	pub(super) fn sort(&mut self, orders: &Orders) {
+	pub(super) fn sort(&mut self, orders: &Ordering) {
 		match self {
 			Self::Memory(m) => m.sort(orders),
 			#[cfg(storage)]

--- a/core/src/dbs/statement.rs
+++ b/core/src/dbs/statement.rs
@@ -5,7 +5,7 @@ use crate::sql::field::Fields;
 use crate::sql::group::Groups;
 use crate::sql::idiom::Idioms;
 use crate::sql::limit::Limit;
-use crate::sql::order::Orders;
+use crate::sql::order::Ordering;
 use crate::sql::output::Output;
 use crate::sql::split::Splits;
 use crate::sql::start::Start;
@@ -188,7 +188,7 @@ impl<'a> Statement<'a> {
 		}
 	}
 	/// Returns any ORDER clause if specified
-	pub fn order(&self) -> Option<&Orders> {
+	pub fn order(&self) -> Option<&Ordering> {
 		match self {
 			Statement::Select(v) => v.order.as_ref(),
 			_ => None,

--- a/core/src/gql/ext.rs
+++ b/core/src/gql/ext.rs
@@ -2,9 +2,7 @@ use std::ops::Deref;
 
 use crate::sql::statements::define::config::graphql::TableConfig;
 use crate::sql::statements::DefineTableStatement;
-use crate::sql::{
-	statements::UseStatement, Cond, Ident, Idiom, Limit, Order, Orders, Part, Start, Table, Value,
-};
+use crate::sql::{statements::UseStatement, Cond, Ident, Idiom, Limit, Part, Start, Table, Value};
 
 pub trait IntoExt<T> {
 	fn intox(self) -> T;
@@ -37,21 +35,6 @@ where
 {
 	fn from(value: V) -> Self {
 		Self(value.into())
-	}
-}
-
-impl<I> FromExt<(I, bool, bool, bool, bool)> for Order
-where
-	I: Into<Idiom>,
-{
-	fn from((order, random, collate, numeric, direction): (I, bool, bool, bool, bool)) -> Self {
-		Self {
-			order: order.into(),
-			random,
-			collate,
-			numeric,
-			direction,
-		}
 	}
 }
 
@@ -95,12 +78,6 @@ where
 {
 	fn from(value: S) -> Self {
 		Table(value.into())
-	}
-}
-
-impl FromExt<Vec<Order>> for Orders {
-	fn from(value: Vec<Order>) -> Self {
-		Orders(value)
 	}
 }
 

--- a/core/src/sql/graph.rs
+++ b/core/src/sql/graph.rs
@@ -4,7 +4,7 @@ use crate::sql::field::Fields;
 use crate::sql::group::Groups;
 use crate::sql::idiom::Idiom;
 use crate::sql::limit::Limit;
-use crate::sql::order::Orders;
+use crate::sql::order::{OldOrders, Order, OrderList, Ordering};
 use crate::sql::split::Splits;
 use crate::sql::start::Start;
 use crate::sql::table::Tables;
@@ -12,7 +12,7 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter, Write};
 
-#[revisioned(revision = 1)]
+#[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
@@ -23,13 +23,46 @@ pub struct Graph {
 	pub cond: Option<Cond>,
 	pub split: Option<Splits>,
 	pub group: Option<Groups>,
-	pub order: Option<Orders>,
+	#[revision(end = 2, convert_fn = "convert_old_orders")]
+	pub old_order: Option<OldOrders>,
+	#[revision(start = 2)]
+	pub order: Option<Ordering>,
 	pub limit: Option<Limit>,
 	pub start: Option<Start>,
 	pub alias: Option<Idiom>,
 }
 
 impl Graph {
+	fn convert_old_orders(
+		&mut self,
+		_rev: u16,
+		old_value: Option<OldOrders>,
+	) -> Result<(), revision::Error> {
+		let Some(x) = old_value else {
+			// nothing to do.
+			return Ok(());
+		};
+
+		if x.0.iter().any(|x| x.random) {
+			self.order = Some(Ordering::Random);
+			return Ok(());
+		}
+
+		let new_ord =
+			x.0.into_iter()
+				.map(|x| Order {
+					value: x.order,
+					collate: x.collate,
+					numeric: x.numeric,
+					direction: x.direction,
+				})
+				.collect();
+
+		self.order = Some(Ordering::Order(OrderList(new_ord)));
+
+		Ok(())
+	}
+
 	/// Convert the graph edge to a raw String
 	pub fn to_raw(&self) -> String {
 		self.to_string()

--- a/core/src/sql/mod.rs
+++ b/core/src/sql/mod.rs
@@ -126,7 +126,6 @@ pub use self::object::Object;
 pub use self::operation::Operation;
 pub use self::operator::Operator;
 pub use self::order::Order;
-pub use self::order::Orders;
 pub use self::output::Output;
 pub use self::param::Param;
 pub use self::part::Part;

--- a/core/src/sql/statements/select.rs
+++ b/core/src/sql/statements/select.rs
@@ -4,8 +4,9 @@ use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::idx::planner::{QueryPlanner, QueryPlannerParams};
 use crate::sql::{
-	Cond, Explain, Fetchs, Field, Fields, Groups, Idioms, Limit, Orders, Splits, Start, Timeout,
-	Value, Values, Version, With,
+	order::{OldOrders, Order, OrderList, Ordering},
+	Cond, Explain, Fetchs, Field, Fields, Groups, Idioms, Limit, Splits, Start, Timeout, Value,
+	Values, Version, With,
 };
 use derive::Store;
 use reblessive::tree::Stk;
@@ -14,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::sync::Arc;
 
-#[revisioned(revision = 3)]
+#[revisioned(revision = 4)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
@@ -30,7 +31,10 @@ pub struct SelectStatement {
 	pub cond: Option<Cond>,
 	pub split: Option<Splits>,
 	pub group: Option<Groups>,
-	pub order: Option<Orders>,
+	#[revision(end = 4, convert_fn = "convert_old_orders")]
+	pub old_order: Option<OldOrders>,
+	#[revision(start = 4)]
+	pub order: Option<Ordering>,
 	pub limit: Option<Limit>,
 	pub start: Option<Start>,
 	pub fetch: Option<Fetchs>,
@@ -43,6 +47,36 @@ pub struct SelectStatement {
 }
 
 impl SelectStatement {
+	fn convert_old_orders(
+		&mut self,
+		_rev: u16,
+		old_value: Option<OldOrders>,
+	) -> Result<(), revision::Error> {
+		let Some(x) = old_value else {
+			// nothing to do.
+			return Ok(());
+		};
+
+		if x.0.iter().any(|x| x.random) {
+			self.order = Some(Ordering::Random);
+			return Ok(());
+		}
+
+		let new_ord =
+			x.0.into_iter()
+				.map(|x| Order {
+					value: x.order,
+					collate: x.collate,
+					numeric: x.numeric,
+					direction: x.direction,
+				})
+				.collect();
+
+		self.order = Some(Ordering::Order(OrderList(new_ord)));
+
+		Ok(())
+	}
+
 	/// Check if we require a writeable transaction
 	pub(crate) fn writeable(&self) -> bool {
 		if self.expr.iter().any(|v| match v {

--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -10,9 +10,9 @@ use crate::{
 		filter::Filter,
 		index::{Distance, HnswParams, MTreeParams, SearchParams, VectorType},
 		language::Language,
+		order::{OrderList, Ordering},
 		statements::{
-			access,
-			access::{AccessStatementGrant, AccessStatementList, AccessStatementRevoke},
+			access::{self, AccessStatementGrant, AccessStatementList, AccessStatementRevoke},
 			analyze::AnalyzeStatement,
 			show::{ShowSince, ShowStatement},
 			sleep::SleepStatement,
@@ -33,7 +33,7 @@ use crate::{
 		user::UserDuration,
 		Algorithm, Array, Base, Block, Cond, Data, Datetime, Dir, Duration, Edges, Explain,
 		Expression, Fetch, Fetchs, Field, Fields, Future, Graph, Group, Groups, Id, Ident, Idiom,
-		Idioms, Index, Kind, Limit, Number, Object, Operator, Order, Orders, Output, Param, Part,
+		Idioms, Index, Kind, Limit, Number, Object, Operator, Order, Output, Param, Part,
 		Permission, Permissions, Scoring, Split, Splits, Start, Statement, Strand, Subquery, Table,
 		TableType, Tables, Thing, Timeout, Uuid, Value, Values, Version, With,
 	},
@@ -1873,13 +1873,12 @@ SELECT bar as foo,[1,2],bar OMIT bar FROM ONLY a,1
 				Group(Idiom(vec![Part::Field(Ident("foo".to_owned()))])),
 				Group(Idiom(vec![Part::Field(Ident("bar".to_owned()))])),
 			])),
-			order: Some(Orders(vec![Order {
-				order: Idiom(vec![Part::Field(Ident("foo".to_owned()))]),
-				random: false,
+			order: Some(Ordering::Order(OrderList(vec![Order {
+				value: Idiom(vec![Part::Field(Ident("foo".to_owned()))]),
 				collate: true,
 				numeric: true,
 				direction: true,
-			}])),
+			}]))),
 			limit: Some(Limit(Value::Thing(Thing {
 				tb: "a".to_owned(),
 				id: Id::from("b"),

--- a/core/src/syn/parser/test/streaming.rs
+++ b/core/src/syn/parser/test/streaming.rs
@@ -7,8 +7,11 @@ use crate::{
 		filter::Filter,
 		index::{Distance, MTreeParams, SearchParams, VectorType},
 		language::Language,
+		order::{OrderList, Ordering},
 		statements::{
-			analyze::AnalyzeStatement, show::ShowSince, show::ShowStatement, sleep::SleepStatement,
+			analyze::AnalyzeStatement,
+			show::{ShowSince, ShowStatement},
+			sleep::SleepStatement,
 			BeginStatement, BreakStatement, CancelStatement, CommitStatement, ContinueStatement,
 			CreateStatement, DefineAccessStatement, DefineAnalyzerStatement,
 			DefineDatabaseStatement, DefineEventStatement, DefineFieldStatement,
@@ -22,7 +25,7 @@ use crate::{
 		tokenizer::Tokenizer,
 		Algorithm, Array, Base, Block, Cond, Data, Datetime, Dir, Duration, Edges, Explain,
 		Expression, Fetch, Fetchs, Field, Fields, Future, Graph, Group, Groups, Id, Ident, Idiom,
-		Idioms, Index, Kind, Limit, Number, Object, Operator, Order, Orders, Output, Param, Part,
+		Idioms, Index, Kind, Limit, Number, Object, Operator, Order, Output, Param, Part,
 		Permission, Permissions, Scoring, Split, Splits, Start, Statement, Strand, Subquery, Table,
 		TableType, Tables, Thing, Timeout, Uuid, Value, Values, Version, With,
 	},
@@ -499,13 +502,12 @@ fn statements() -> Vec<Statement> {
 				Group(Idiom(vec![Part::Field(Ident("foo".to_owned()))])),
 				Group(Idiom(vec![Part::Field(Ident("bar".to_owned()))])),
 			])),
-			order: Some(Orders(vec![Order {
-				order: Idiom(vec![Part::Field(Ident("foo".to_owned()))]),
-				random: false,
+			order: Some(Ordering::Order(OrderList(vec![Order {
+				value: Idiom(vec![Part::Field(Ident("foo".to_owned()))]),
 				collate: true,
 				numeric: true,
 				direction: true,
-			}])),
+			}]))),
 			limit: Some(Limit(Value::Thing(Thing {
 				tb: "a".to_owned(),
 				id: Id::from("b"),


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently `ORDER BY RAND()` can panic because of the invalid way of shuffling we currently use.

Currently shuffling is done by changing the comparison function to generate random numbers during each comparison and then compare those two numbers. This causes a panic as this does not guarantee a total ordering, furthermore it can also be a performance issue as sorting could go on forever if the numbers generated keep generating an unsorted layout and finally it doesn't actually guarantee that the results are correctly shuffled as the sorting algorithm might make assumptions about ordering which prevents a full shuffle from occurring. 

## What does this change do?

Fixes the issue by shuffling instead of sorting by randomly generated numbers.
Furthermore also restructures the `Orders` struct to indicate within the type that an ordering is either random or ordered by some fields, you can't have both.


## What is your testing strategy?

Added a test of `ORDER BY RAND()`.

## Is this related to any issues?

- Fixes #4969

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
