### PR TITLE
Add custom storage engine shutdown behaviour

### DIFF
--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -663,7 +663,7 @@ impl Datastore {
 		Ok(())
 	}
 
-	/// Run the background task to perform changeed garbage collection
+	/// Run the background task to perform changefeed garbage collection
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::ds", skip(self))]
 	pub async fn changefeed_process(&self) -> Result<(), Error> {
 		// Output function invocation details to logs
@@ -683,7 +683,7 @@ impl Datastore {
 		Ok(())
 	}
 
-	/// Run the background task to perform changeed garbage collection
+	/// Run the background task to perform changefeed garbage collection
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::ds", skip(self))]
 	pub async fn changefeed_process_at(&self, ts: u64) -> Result<(), Error> {
 		// Output function invocation details to logs
@@ -696,7 +696,7 @@ impl Datastore {
 		Ok(())
 	}
 
-	/// Run the background task to perform changeed garbage collection
+	/// Run the datastore shutdown tasks, perfoming any necessary cleanup
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::ds", skip(self))]
 	pub async fn shutdown(&self) -> Result<(), Error> {
 		// Output function invocation details to logs

--- a/core/src/kvs/fdb/mod.rs
+++ b/core/src/kvs/fdb/mod.rs
@@ -94,10 +94,10 @@ impl Datastore {
 	/// for more information on cluster connection files.
 	pub(crate) async fn new(path: &str) -> Result<Datastore, Error> {
 		// Initialize the FoundationDB Client API
-		static FDBNET: LazyLock<Arc<foundationdb::api::NetworkAutoStop>> =
+		static NETWORK: LazyLock<Arc<foundationdb::api::NetworkAutoStop>> =
 			LazyLock::new(|| Arc::new(unsafe { foundationdb::boot() }));
 		// Store the network cancellation handle
-		let _fdbnet = (*FDBNET).clone();
+		let _fdbnet = (*NETWORK).clone();
 		// Configure and setup the database
 		match foundationdb::Database::from_path(path) {
 			Ok(db) => {
@@ -125,6 +125,11 @@ impl Datastore {
 			}
 			Err(e) => Err(Error::Ds(e.to_string())),
 		}
+	}
+	/// Shutdown the database
+	pub(crate) async fn shutdown(&self) -> Result<(), Error> {
+		// Nothing to do here
+		Ok(())
 	}
 	/// Start a new transaction
 	pub(crate) async fn transaction(&self, write: bool, lock: bool) -> Result<Transaction, Error> {

--- a/core/src/kvs/indxdb/mod.rs
+++ b/core/src/kvs/indxdb/mod.rs
@@ -68,6 +68,11 @@ impl Datastore {
 			Err(e) => Err(Error::Ds(e.to_string())),
 		}
 	}
+	/// Shutdown the database
+	pub(crate) async fn shutdown(&self) -> Result<(), Error> {
+		// Nothing to do here
+		Ok(())
+	}
 	/// Start a new transaction
 	pub async fn transaction(&self, write: bool, _: bool) -> Result<Transaction, Error> {
 		// Specify the check level

--- a/core/src/kvs/mem/mod.rs
+++ b/core/src/kvs/mem/mod.rs
@@ -65,6 +65,11 @@ impl Datastore {
 			db: echodb::db::new(),
 		})
 	}
+	/// Shutdown the database
+	pub(crate) async fn shutdown(&self) -> Result<(), Error> {
+		// Nothing to do here
+		Ok(())
+	}
 	/// Start a new transaction
 	pub(crate) async fn transaction(&self, write: bool, _: bool) -> Result<Transaction, Error> {
 		// Specify the check level

--- a/core/src/kvs/rocksdb/mod.rs
+++ b/core/src/kvs/rocksdb/mod.rs
@@ -143,6 +143,11 @@ impl Datastore {
 			db: Arc::pin(OptimisticTransactionDB::open(&opts, path)?),
 		})
 	}
+	/// Shutdown the database
+	pub(crate) async fn shutdown(&self) -> Result<(), Error> {
+		// Nothing to do here
+		Ok(())
+	}
 	/// Start a new transaction
 	pub(crate) async fn transaction(&self, write: bool, _: bool) -> Result<Transaction, Error> {
 		// Set the transaction options

--- a/core/src/kvs/surrealcs/mod.rs
+++ b/core/src/kvs/surrealcs/mod.rs
@@ -83,7 +83,11 @@ impl Datastore {
 			}
 		}
 	}
-
+	/// Shutdown the database
+	pub(crate) async fn shutdown(&self) -> Result<(), Error> {
+		// Nothing to do here
+		Ok(())
+	}
 	/// Starts a new transaction.
 	///
 	/// # Arguments

--- a/core/src/kvs/surrealkv/mod.rs
+++ b/core/src/kvs/surrealkv/mod.rs
@@ -61,15 +61,22 @@ impl Drop for Transaction {
 impl Datastore {
 	/// Open a new database
 	pub(crate) async fn new(path: &str) -> Result<Datastore, Error> {
+		// Create new configuration options
 		let mut opts = Options::new();
+		// Set the data storage directory
 		opts.dir = path.to_string().into();
-
+		// Create a new datastore
 		match Store::new(opts) {
 			Ok(db) => Ok(Datastore {
 				db,
 			}),
 			Err(e) => Err(Error::Ds(e.to_string())),
 		}
+	}
+	/// Shutdown the database
+	pub(crate) async fn shutdown(&self) -> Result<(), Error> {
+		// Nothing to do here
+		Ok(())
 	}
 	/// Start a new transaction
 	pub(crate) async fn transaction(&self, write: bool, _: bool) -> Result<Transaction, Error> {

--- a/core/src/kvs/tikv/mod.rs
+++ b/core/src/kvs/tikv/mod.rs
@@ -79,6 +79,11 @@ impl Datastore {
 			Err(e) => Err(Error::Ds(e.to_string())),
 		}
 	}
+	/// Shutdown the database
+	pub(crate) async fn shutdown(&self) -> Result<(), Error> {
+		// Nothing to do here
+		Ok(())
+	}
 	/// Start a new transaction
 	pub(crate) async fn transaction(&self, write: bool, lock: bool) -> Result<Transaction, Error> {
 		// Set whether this should be an optimistic or pessimistic transaction

--- a/sdk/src/api/engine/local/native.rs
+++ b/sdk/src/api/engine/local/native.rs
@@ -192,5 +192,5 @@ pub(crate) async fn run_router(
 	// Wait for background tasks to finish
 	let _ = tasks.resolve().await;
 	// Delete this node from the cluster
-	let _ = kvs.delete_node(kvs.id()).await;
+	let _ = kvs.shutdown().await;
 }

--- a/sdk/src/api/engine/local/wasm.rs
+++ b/sdk/src/api/engine/local/wasm.rs
@@ -195,5 +195,5 @@ pub(crate) async fn run_router(
 	// Wait for background tasks to finish
 	let _ = tasks.resolve().await;
 	// Delete this node from the cluster
-	let _ = kvs.delete_node(kvs.id()).await;
+	let _ = kvs.shutdown().await;
 }

--- a/sdk/src/api/engine/tasks.rs
+++ b/sdk/src/api/engine/tasks.rs
@@ -72,8 +72,7 @@ fn spawn_task_node_membership_refresh(
 				// Receive a notification on the channel
 				Some(_) = ticker.next() => {
 					if let Err(e) = dbs.node_membership_update().await {
-						error!("Error running node agent tick: {e}");
-						break;
+						error!("Error updating node registration information: {e}");
 					}
 				}
 			}
@@ -104,8 +103,7 @@ fn spawn_task_node_membership_check(
 				// Receive a notification on the channel
 				Some(_) = ticker.next() => {
 					if let Err(e) = dbs.node_membership_expire().await {
-						error!("Error running node agent tick: {e}");
-						break;
+						error!("Error processing and archiving inactive nodes: {e}");
 					}
 				}
 			}
@@ -136,8 +134,7 @@ fn spawn_task_node_membership_cleanup(
 				// Receive a notification on the channel
 				Some(_) = ticker.next() => {
 					if let Err(e) = dbs.node_membership_remove().await {
-						error!("Error running node agent tick: {e}");
-						break;
+						error!("Error processing and cleaning archived nodes: {e}");
 					}
 				}
 			}
@@ -168,8 +165,7 @@ fn spawn_task_changefeed_cleanup(
 				// Receive a notification on the channel
 				Some(_) = ticker.next() => {
 					if let Err(e) = dbs.changefeed_process().await {
-						error!("Error running node agent tick: {e}");
-						break;
+						error!("Error running changefeed garbage collection: {e}");
 					}
 				}
 			}

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -225,8 +225,8 @@ pub async fn init(
 	canceller.cancel();
 	// Wait for background tasks to finish
 	nodetasks.resolve().await?;
-	// Delete this node from the cluster
-	datastore.delete_node(datastore.id()).await?;
+	// Shutdown the datastore
+	datastore.shutdown().await?;
 	// All ok
 	Ok(())
 }

--- a/src/net/signals.rs
+++ b/src/net/signals.rs
@@ -20,7 +20,7 @@ pub fn graceful_shutdown(
 	// Spawn a new background asynchronous task
 	tokio::spawn(async move {
 		// Listen to the primary OS task signal
-		if let Err(signal) = listen().await {
+		if let Ok(signal) = listen().await {
 			warn!(target: super::LOG, "{signal} received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.");
 		} else {
 			error!(target: super::LOG, "Failed to listen to shutdown signal. Terminating immediately.");

--- a/src/net/signals.rs
+++ b/src/net/signals.rs
@@ -1,14 +1,10 @@
-use std::sync::Arc;
-
+use crate::err::Error;
+use crate::rpc::{self, RpcState};
+use crate::telemetry;
 use axum_server::Handle;
+use std::sync::Arc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-
-use crate::{
-	err::Error,
-	rpc::{self, RpcState},
-	telemetry,
-};
 
 /// Start a graceful shutdown:
 /// * Signal the Axum Handle when a shutdown signal is received.
@@ -18,62 +14,88 @@ use crate::{
 /// A second signal will force an immediate shutdown.
 pub fn graceful_shutdown(
 	state: Arc<RpcState>,
-	ct: CancellationToken,
+	canceller: CancellationToken,
 	http_handle: Handle,
 ) -> JoinHandle<()> {
+	// Spawn a new background asynchronous task
 	tokio::spawn(async move {
-		let result = listen().await.expect("Failed to listen to shutdown signal");
-		info!(target: super::LOG, "{} received. Waiting for graceful shutdown... A second signal will force an immediate shutdown", result);
-
+		// Listen to the primary OS task signal
+		if let Err(signal) = listen().await {
+			warn!(target: super::LOG, "{signal} received. Waiting for a graceful shutdown. A second signal will force an immediate shutdown.");
+		} else {
+			error!(target: super::LOG, "Failed to listen to shutdown signal. Terminating immediately.");
+			canceller.cancel();
+		}
+		// Spawn a task to gracefully shutdown
 		let shutdown = {
+			// Clone the state
 			let http_handle = http_handle.clone();
-			let ct = ct.clone();
-			let state_clone = state.clone();
-
+			let canceller = canceller.clone();
+			let state = state.clone();
+			// Spawn a background task
 			tokio::spawn(async move {
-				// Stop accepting new HTTP requests and wait until all connections are closed
+				// Stop accepting new HTTP connections
 				http_handle.graceful_shutdown(None);
+				// Wait for all connections to close
 				while http_handle.connection_count() > 0 {
 					tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 				}
-
-				rpc::graceful_shutdown(state_clone).await;
-
-				ct.cancel();
-
+				// Stop accepting new WebSocket connections
+				rpc::graceful_shutdown(state).await;
+				// Cancel the cancellation token
+				canceller.cancel();
 				// Flush all telemetry data
 				if let Err(err) = telemetry::shutdown() {
-					error!("Failed to flush telemetry data: {}", err);
+					error!("Failed to flush telemetry data: {err}");
 				}
 			})
 		};
-
+		// Wait for the primary or secondary signals to complete
 		tokio::select! {
+			// Check signals in order
+			biased;
 			// Start a normal graceful shutdown
 			_ = shutdown => (),
-			// Force an immediate shutdown if a second signal is received
-			_ = async {
-				if let Ok(signal) = listen().await {
-					warn!(target: super::LOG, "{} received during graceful shutdown. Terminate immediately...", signal);
-				} else {
-					error!(target: super::LOG, "Failed to listen to shutdown signal. Terminate immediately...");
-				}
-
-				// Force an immediate shutdown
+			// Check if this has shutdown
+			_ = canceller.cancelled() => {
+				// Close all HTTP connections immediately
 				http_handle.shutdown();
-
 				// Close all WebSocket connections immediately
 				rpc::shutdown(state);
-
-				// Cancel cancellation token
-				ct.cancel();
-			} => (),
+				// Cancel the cancellation token
+				canceller.cancel();
+				// Flush all telemetry data
+				if let Err(err) = telemetry::shutdown() {
+					error!("Failed to flush telemetry data: {err}");
+				}
+			}
+			// Listen for a secondary signal
+			res = listen() => {
+				// If we receive a secondary signal, force a shutdown
+				if let Ok(signal) = res {
+					warn!(target: super::LOG, "{signal} received during graceful shutdown. Terminating immediately.");
+				} else {
+					error!(target: super::LOG, "Failed to listen to shutdown signal. Terminating immediately.");
+				}
+				// Close all HTTP connections immediately
+				http_handle.shutdown();
+				// Close all WebSocket connections immediately
+				rpc::shutdown(state);
+				// Cancel the cancellation token
+				canceller.cancel();
+				// Flush all telemetry data
+				if let Err(err) = telemetry::shutdown() {
+					error!("Failed to flush telemetry data: {err}");
+				}
+			},
 		}
 	})
 }
 
 #[cfg(unix)]
 pub async fn listen() -> Result<String, Error> {
+	// Log informational message
+	info!(target: super::LOG, "Listening for a system shutdown signal.");
 	// Import the OS signals
 	use tokio::signal::unix::{signal, SignalKind};
 	// Get the operating system signal types
@@ -104,6 +126,8 @@ pub async fn listen() -> Result<String, Error> {
 
 #[cfg(windows)]
 pub async fn listen() -> Result<String, Error> {
+	// Log informational message
+	info!(target: super::LOG, "Listening for a system shutdown signal.");
 	// Import the OS signals
 	use tokio::signal::windows;
 	// Get the operating system signal types


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The current node shutdown process can be cleaned up a little, and currently no storage engine can have custom shutdown behaviour.

## What does this change do?

Improves the signal handling code, and adds support for custom shutdown behaviour on each storage engine implementation. In addition, failed long-running tasks do not exit prematurely, but continue to execute, logging errors in the event of a failure.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
