### PR TITLE
Improve UPSERT behaviour

### DIFF
--- a/core/src/dbs/result.rs
+++ b/core/src/dbs/result.rs
@@ -89,6 +89,16 @@ impl Results {
 		}
 	}
 
+	pub(super) fn is_empty(&self) -> bool {
+		match self {
+			Self::None => true,
+			Self::Memory(s) => s.len() == 0,
+			#[cfg(storage)]
+			Self::File(e) => e.len() == 0,
+			Self::Groups(g) => g.len() == 0,
+		}
+	}
+
 	pub(super) fn take(&mut self) -> Result<Vec<Value>, Error> {
 		Ok(match self {
 			Self::Memory(m) => m.take_vec(),

--- a/core/src/dbs/result.rs
+++ b/core/src/dbs/result.rs
@@ -79,16 +79,6 @@ impl Results {
 		}
 	}
 
-	pub(super) fn len(&self) -> usize {
-		match self {
-			Self::None => 0,
-			Self::Memory(s) => s.len(),
-			#[cfg(storage)]
-			Self::File(e) => e.len(),
-			Self::Groups(g) => g.len(),
-		}
-	}
-
 	pub(super) fn is_empty(&self) -> bool {
 		match self {
 			Self::None => true,
@@ -96,6 +86,16 @@ impl Results {
 			#[cfg(storage)]
 			Self::File(e) => e.len() == 0,
 			Self::Groups(g) => g.len() == 0,
+		}
+	}
+
+	pub(super) fn len(&self) -> usize {
+		match self {
+			Self::None => 0,
+			Self::Memory(s) => s.len(),
+			#[cfg(storage)]
+			Self::File(e) => e.len(),
+			Self::Groups(g) => g.len(),
 		}
 	}
 

--- a/core/src/dbs/statement.rs
+++ b/core/src/dbs/statement.rs
@@ -165,7 +165,7 @@ impl<'a> Statement<'a> {
 	/// UPSERT { id: some:thing } WHERE test = true;
 	pub(crate) fn is_deferable(&self) -> bool {
 		match self {
-			Statement::Upsert(ref v) if v.cond.is_none() => true,
+			Statement::Upsert(v) if v.cond.is_none() => true,
 			Statement::Create(_) => true,
 			_ => false,
 		}
@@ -180,10 +180,7 @@ impl<'a> Statement<'a> {
 	///
 	/// UPSERT some WHERE test = true;
 	pub(crate) fn is_guaranteed(&self) -> bool {
-		match self {
-			Statement::Upsert(ref v) if v.cond.is_some() => true,
-			_ => false,
-		}
+		matches!(self, Statement::Upsert(v) if v.cond.is_some())
 	}
 
 	/// Returns whether the document processing for

--- a/core/src/doc/alter.rs
+++ b/core/src/doc/alter.rs
@@ -15,7 +15,11 @@ use reblessive::tree::Stk;
 use std::sync::Arc;
 
 impl Document {
-	///
+	/// Generates a new record id for this document.
+	/// This only happens when a document does not
+	/// have a record id, because we are attempting
+	/// to create a new record, and are leaving the
+	/// id generation up to the pdocument processor.
 	pub(crate) async fn generate_record_id(
 		&mut self,
 		stk: &mut Stk,
@@ -45,7 +49,7 @@ impl Document {
 						value: id.to_string(),
 					});
 				}
-				//
+				// Set the document id
 				self.id = Some(Arc::new(id));
 			}
 			// This is a INSERT statement

--- a/core/src/doc/alter.rs
+++ b/core/src/doc/alter.rs
@@ -19,7 +19,7 @@ impl Document {
 	/// This only happens when a document does not
 	/// have a record id, because we are attempting
 	/// to create a new record, and are leaving the
-	/// id generation up to the pdocument processor.
+	/// id generation up to the document processor.
 	pub(crate) async fn generate_record_id(
 		&mut self,
 		stk: &mut Stk,

--- a/core/src/doc/alter.rs
+++ b/core/src/doc/alter.rs
@@ -39,6 +39,12 @@ impl Document {
 					// There is no data clause so create a record id
 					None => tb.generate(),
 				};
+				// The id field can not be a record range
+				if id.is_range() {
+					return Err(Error::IdInvalid {
+						value: id.to_string(),
+					});
+				}
 				//
 				self.id = Some(Arc::new(id));
 			}

--- a/core/src/doc/alter.rs
+++ b/core/src/doc/alter.rs
@@ -32,7 +32,7 @@ impl Document {
 					// There is a data clause so fetch a record id
 					Some(data) => match data.rid(stk, ctx, opt).await? {
 						// Generate a new id from the id field
-						Some(id) => id.generate(&tb, false)?,
+						Some(id) => id.generate(tb, false)?,
 						// Generate a new random table id
 						None => tb.generate(),
 					},

--- a/core/src/doc/alter.rs
+++ b/core/src/doc/alter.rs
@@ -12,8 +12,48 @@ use crate::sql::paths::IN;
 use crate::sql::paths::OUT;
 use crate::sql::value::Value;
 use reblessive::tree::Stk;
+use std::sync::Arc;
 
 impl Document {
+	///
+	pub(crate) async fn generate_record_id(
+		&mut self,
+		stk: &mut Stk,
+		ctx: &Context,
+		opt: &Options,
+		stm: &Statement<'_>,
+	) -> Result<(), Error> {
+		// Check if we need to generate a record id
+		if let Some(tb) = &self.gen {
+			// This is a CREATE, UPSERT, UPDATE statement
+			if let Workable::Normal = &self.extras {
+				// Fetch the record id if specified
+				let id = match stm.data() {
+					// There is a data clause so fetch a record id
+					Some(data) => match data.rid(stk, ctx, opt).await? {
+						// Generate a new id from the id field
+						Some(id) => id.generate(&tb, false)?,
+						// Generate a new random table id
+						None => tb.generate(),
+					},
+					// There is no data clause so create a record id
+					None => tb.generate(),
+				};
+				//
+				self.id = Some(Arc::new(id));
+			}
+			// This is a INSERT statement
+			else if let Workable::Insert(_) = &self.extras {
+				// TODO(tobiemh): implement last-step id generation for INSERT statements
+			}
+			// This is a RELATE statement
+			else if let Workable::Relate(_, _, _) = &self.extras {
+				// TODO(tobiemh): implement last-step id generation for RELATE statements
+			}
+		}
+		//
+		Ok(())
+	}
 	/// Clears all of the content of this document.
 	/// This is used to empty the current content
 	/// of the document within a `DELETE` statement.
@@ -45,7 +85,7 @@ impl Document {
 		// Set default field values
 		self.current.doc.to_mut().def(&rid);
 		// This is a RELATE statement, so reset fields
-		if let Workable::Relate(l, r, _, _) = &self.extras {
+		if let Workable::Relate(l, r, _) = &self.extras {
 			// Mark that this is an edge node
 			self.current.doc.to_mut().put(&*EDGE, Value::Bool(true));
 			// If this document existed before, check the `in` field
@@ -114,24 +154,24 @@ impl Document {
 		match self.reduced(stk, ctx, opt, Current).await? {
 			true => {
 				// This is an INSERT statement
-				if let Workable::Insert(v, _) = &self.extras {
+				if let Workable::Insert(v) = &self.extras {
 					let v = v.compute(stk, ctx, opt, Some(&self.current_reduced)).await?;
 					self.current.doc.to_mut().merge(v)?;
 				}
 				// This is an INSERT RELATION statement
-				if let Workable::Relate(_, _, Some(v), _) = &self.extras {
+				if let Workable::Relate(_, _, Some(v)) = &self.extras {
 					let v = v.compute(stk, ctx, opt, Some(&self.current_reduced)).await?;
 					self.current.doc.to_mut().merge(v)?;
 				}
 			}
 			false => {
 				// This is an INSERT statement
-				if let Workable::Insert(v, _) = &self.extras {
+				if let Workable::Insert(v) = &self.extras {
 					let v = v.compute(stk, ctx, opt, Some(&self.current)).await?;
 					self.current.doc.to_mut().merge(v)?;
 				}
 				// This is an INSERT RELATION statement
-				if let Workable::Relate(_, _, Some(v), _) = &self.extras {
+				if let Workable::Relate(_, _, Some(v)) = &self.extras {
 					let v = v.compute(stk, ctx, opt, Some(&self.current)).await?;
 					self.current.doc.to_mut().merge(v)?;
 				}
@@ -271,10 +311,10 @@ impl Document {
 					// Duplicate context
 					let mut ctx = MutableContext::new(ctx);
 					// Add insertable value
-					if let Workable::Insert(value, _) = &self.extras {
+					if let Workable::Insert(value) = &self.extras {
 						ctx.add_value("input", value.clone());
 					}
-					if let Workable::Relate(_, _, Some(value), _) = &self.extras {
+					if let Workable::Relate(_, _, Some(value)) = &self.extras {
 						ctx.add_value("input", value.clone());
 					}
 					// Freeze the context

--- a/core/src/doc/changefeeds.rs
+++ b/core/src/doc/changefeeds.rs
@@ -25,8 +25,12 @@ impl Document {
 		let txn = ctx.tx();
 		// Get the database and the table for the record
 		let cf = txn.get_or_add_db(ns, db, opt.strict).await?;
+		// Get the changefeed definition on the database
+		let dbcf = cf.as_ref().changefeed.as_ref();
+		// Get the changefeed definition on the table
+		let tbcf = tb.as_ref().changefeed.as_ref();
 		// Check if changefeeds are enabled
-		if let Some(cf) = cf.as_ref().changefeed.as_ref().or(tb.as_ref().changefeed.as_ref()) {
+		if let Some(cf) = dbcf.or(tbcf) {
 			// Create the changefeed entry
 			if let Some(id) = &self.id {
 				txn.lock().await.record_change(

--- a/core/src/doc/compute.rs
+++ b/core/src/doc/compute.rs
@@ -20,6 +20,8 @@ impl Document {
 		chn: Sender<Result<Value, Error>>,
 		mut pro: Processed,
 	) -> Result<(), Error> {
+		// Whether we are retrying
+		let mut retry = false;
 		// Loop over maximum two times
 		for _ in 0..2 {
 			// Check current context
@@ -29,11 +31,13 @@ impl Document {
 			// Setup a new workable
 			let ins = match pro.val {
 				Operable::Value(v) => (v, Workable::Normal),
-				Operable::Mergeable(v, o, u) => (v, Workable::Insert(o, u)),
-				Operable::Relatable(f, v, w, o, u) => (v, Workable::Relate(f, w, o, u)),
+				Operable::Insert(v, o) => (v, Workable::Insert(o)),
+				Operable::Relate(f, v, w, o) => (v, Workable::Relate(f, w, o)),
 			};
 			// Setup a new document
-			let mut doc = Document::new(pro.rid, pro.ir, ins.0, ins.1);
+			let mut doc = Document::new(pro.rid, pro.ir, pro.generate, ins.0, ins.1, retry);
+			// Generate a new document id if necessary
+			doc.generate_record_id(stk, ctx, opt, stm).await?;
 			// Optionally create a save point so we can roll back any upcoming changes
 			let is_save_point = if stm.is_retryable() {
 				ctx.tx().lock().await.new_save_point().await;
@@ -71,14 +75,17 @@ impl Document {
 						None => Value::None,
 					});
 					pro = Processed {
+						generate: None,
 						rid: Some(Arc::new(v)),
 						ir: None,
 						val: match doc.extras {
 							Workable::Normal => Operable::Value(val),
-							Workable::Insert(o, _) => Operable::Mergeable(val, o, true),
-							Workable::Relate(f, w, o, _) => Operable::Relatable(f, val, w, o, true),
+							Workable::Insert(o) => Operable::Insert(val, o),
+							Workable::Relate(f, w, o) => Operable::Relate(f, val, w, o),
 						},
 					};
+					// Mark this as retrying
+					retry = true;
 					// Go to top of loop
 					continue;
 				}

--- a/core/src/doc/document.rs
+++ b/core/src/doc/document.rs
@@ -12,6 +12,7 @@ use crate::sql::statements::define::DefineFieldStatement;
 use crate::sql::statements::define::DefineIndexStatement;
 use crate::sql::statements::define::DefineTableStatement;
 use crate::sql::statements::live::LiveStatement;
+use crate::sql::table::Table;
 use crate::sql::thing::Thing;
 use crate::sql::value::Value;
 use crate::sql::Base;
@@ -22,7 +23,12 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 pub(crate) struct Document {
+	/// The record id of this document
 	pub(super) id: Option<Arc<Thing>>,
+	/// The table that we should generate a record id from
+	pub(super) gen: Option<Table>,
+	/// Whether this is the second iteration of the processing
+	pub(super) retry: bool,
 	pub(super) extras: Workable,
 	pub(super) initial: CursorDoc,
 	pub(super) current: CursorDoc,
@@ -169,11 +175,15 @@ impl Document {
 	pub fn new(
 		id: Option<Arc<Thing>>,
 		ir: Option<Arc<IteratorRecord>>,
+		gen: Option<Table>,
 		val: Arc<Value>,
 		extras: Workable,
+		retry: bool,
 	) -> Self {
 		Document {
 			id: id.clone(),
+			gen,
+			retry,
 			extras,
 			current: CursorDoc::new(id.clone(), ir.clone(), val.clone()),
 			initial: CursorDoc::new(id.clone(), ir.clone(), val.clone()),
@@ -181,6 +191,7 @@ impl Document {
 			initial_reduced: CursorDoc::new(id.clone(), ir.clone(), val.clone()),
 		}
 	}
+
 	/// Check if document has changed
 	pub fn changed(&self) -> bool {
 		self.initial.doc.as_ref() != self.current.doc.as_ref()
@@ -189,6 +200,54 @@ impl Document {
 	/// Check if document is being created
 	pub fn is_new(&self) -> bool {
 		self.initial.doc.as_ref().is_none()
+	}
+
+	/// Check if this is the first iteration. When
+	/// running an UPSERT or INSERT statement we don't
+	/// first fetch the value from the storage engine.
+	/// If there is an error when attempting to set the
+	/// value in the storage engine, then we retry the
+	/// document processing, and this will return false.
+	pub(crate) fn is_iteration_initial(&self) -> bool {
+		!self.retry && self.initial.doc.as_ref().is_none()
+	}
+
+	/// Check if the the record id for this document
+	/// has been specifically set upfront. This is true
+	/// in the following instances:
+	///
+	/// CREATE some:thing;
+	/// CREATE some SET id = some:thing;
+	/// CREATE some CONTENT { id: some:thing };
+	/// UPSERT some:thing;
+	/// UPSERT some SET id = some:thing;
+	/// UPSERT some CONTENT { id: some:thing };
+	/// INSERT some (id) VALUES (some:thing);
+	/// INSERT { id: some:thing };
+	/// INSERT [{ id: some:thing }];
+	/// RELATE from->some:thing->to;
+	/// RELATE from->some->to SET id = some:thing;
+	/// RELATE from->some->to CONTENT { id: some:thing };
+	///
+	/// In addition, when iterating over tables or ranges
+	/// the record id will also be specified before we
+	/// process the document in this module. So therefore
+	/// although this function is not used or checked in
+	/// these scenarios, this function will also be true
+	/// in the following instances:
+	///
+	/// UPDATE some;
+	/// UPDATE some:thing;
+	/// UPDATE some:from..to;
+	/// DELETE some;
+	/// DELETE some:thing;
+	/// DELETE some:from..to;
+	pub(crate) fn is_specific_record_id(&self) -> bool {
+		match self.extras {
+			Workable::Insert(ref v) if v.rid().is_some() => true,
+			Workable::Normal if self.gen.is_none() => true,
+			_ => false,
+		}
 	}
 
 	/// Checks if permissions are required to be run
@@ -319,6 +378,7 @@ impl Document {
 			Ok(tb) => Ok(tb),
 		}
 	}
+
 	/// Get the foreign tables for this document
 	pub async fn ft(
 		&self,
@@ -330,6 +390,7 @@ impl Document {
 		// Get the table definitions
 		ctx.tx().all_tb_views(opt.ns()?, opt.db()?, &id.tb).await
 	}
+
 	/// Get the events for this document
 	pub async fn ev(
 		&self,
@@ -341,6 +402,7 @@ impl Document {
 		// Get the event definitions
 		ctx.tx().all_tb_events(opt.ns()?, opt.db()?, &id.tb).await
 	}
+
 	/// Get the fields for this document
 	pub async fn fd(
 		&self,
@@ -352,6 +414,7 @@ impl Document {
 		// Get the field definitions
 		ctx.tx().all_tb_fields(opt.ns()?, opt.db()?, &id.tb, None).await
 	}
+
 	/// Get the indexes for this document
 	pub async fn ix(
 		&self,
@@ -363,6 +426,7 @@ impl Document {
 		// Get the index definitions
 		ctx.tx().all_tb_indexes(opt.ns()?, opt.db()?, &id.tb).await
 	}
+
 	// Get the lives for this document
 	pub async fn lv(&self, ctx: &Context, opt: &Options) -> Result<Arc<[LiveStatement]>, Error> {
 		// Get the record id

--- a/core/src/doc/document.rs
+++ b/core/src/doc/document.rs
@@ -343,8 +343,16 @@ impl Document {
 
 	/// Retrieve the record id for this document
 	pub fn id(&self) -> Result<Arc<Thing>, Error> {
-		match self.id.as_ref() {
-			Some(id) => Ok(id.clone()),
+		match self.id.clone() {
+			Some(id) => Ok(id),
+			_ => Err(fail!("Expected a document id to be present")),
+		}
+	}
+
+	/// Retrieve the record id for this document
+	pub fn inner_id(&self) -> Result<Thing, Error> {
+		match self.id.clone() {
+			Some(id) => Ok(Arc::unwrap_or_clone(id)),
 			_ => Err(fail!("Expected a document id to be present")),
 		}
 	}

--- a/core/src/doc/edges.rs
+++ b/core/src/doc/edges.rs
@@ -26,7 +26,7 @@ impl Document {
 			return Ok(());
 		}
 		// Store the record edges
-		if let Workable::Relate(l, r, _, _) = &self.extras {
+		if let Workable::Relate(l, r, _) = &self.extras {
 			// Get the namespace
 			let ns = opt.ns()?;
 			// Get the database

--- a/core/src/doc/field.rs
+++ b/core/src/doc/field.rs
@@ -4,6 +4,7 @@ use crate::dbs::Statement;
 use crate::doc::Document;
 use crate::err::Error;
 use crate::iam::Action;
+use crate::sql::data::Data;
 use crate::sql::idiom::Idiom;
 use crate::sql::kind::Kind;
 use crate::sql::permission::Permission;
@@ -82,7 +83,7 @@ impl Document {
 		stk: &mut Stk,
 		ctx: &Context,
 		opt: &Options,
-		_stm: &Statement<'_>,
+		stm: &Statement<'_>,
 	) -> Result<(), Error> {
 		// Check import
 		if opt.import {
@@ -119,13 +120,36 @@ impl Document {
 				let old = Arc::new(self.initial.doc.as_ref().pick(&k));
 				// Get the input value
 				let inp = Arc::new(inp.pick(&k));
-				// Check for READONLY clause
-				if fd.readonly || fd.name.is_id() {
+				// Check for the `id` field
+				if fd.name.is_id() {
 					if !self.is_new() && val.ne(&old) {
 						return Err(Error::FieldReadonly {
 							field: fd.name.clone(),
 							thing: rid.to_string(),
 						});
+					} else if !self.is_new() {
+						continue;
+					}
+				}
+				// Check for READONLY clause
+				if fd.readonly {
+					if !self.is_new() && val.ne(&old) {
+						match stm.data() {
+							Some(Data::ContentExpression(_)) => {
+								self.current
+									.doc
+									.to_mut()
+									.set(stk, ctx, opt, &k, old.as_ref().clone())
+									.await?;
+								continue;
+							}
+							_ => {
+								return Err(Error::FieldReadonly {
+									field: fd.name.clone(),
+									thing: rid.to_string(),
+								});
+							}
+						}
 					} else if !self.is_new() {
 						continue;
 					}

--- a/core/src/doc/insert.rs
+++ b/core/src/doc/insert.rs
@@ -20,7 +20,7 @@ impl Document {
 		// to create the record, if the record already exists
 		// then we will fetch the record from the storage
 		// engine, and will update the record subsequently
-		match self.extras.is_insert_initial() {
+		match self.is_iteration_initial() {
 			// We haven't yet checked if the record exists
 			// so let's assume that the record does not exist
 			// and attempt to create the record in the database
@@ -35,7 +35,7 @@ impl Document {
 					value,
 				}) => match stm.is_retryable() {
 					// There is an ON DUPLICATE KEY UPDATE clause
-					true => match self.extras.is_insert_with_specific_id() {
+					true => match self.is_specific_record_id() {
 						// No specific Record ID has been specified, so retry
 						false => Err(Error::RetryWithId(thing)),
 						// A specific Record ID was specified, so error
@@ -79,7 +79,8 @@ impl Document {
 			false => self.insert_update(stk, ctx, opt, stm).await,
 		}
 	}
-	/// Attempt to run an INSERT clause
+	/// Attempt to run an INSERT statement to
+	/// create a record which does not exist
 	async fn insert_create(
 		&mut self,
 		stk: &mut Stk,
@@ -104,7 +105,8 @@ impl Document {
 		self.process_changefeeds(ctx, opt, stm).await?;
 		self.pluck(stk, ctx, opt, stm).await
 	}
-	/// Attempt to run an UPDATE clause
+	/// Attempt to run an INSERT statement to
+	/// update a record which already exists
 	async fn insert_update(
 		&mut self,
 		stk: &mut Stk,

--- a/core/src/doc/insert.rs
+++ b/core/src/doc/insert.rs
@@ -62,9 +62,12 @@ impl Document {
 					// There is an ON DUPLICATE KEY UPDATE clause
 					true => Err(Error::RetryWithId(thing)),
 					// There is no ON DUPLICATE KEY UPDATE clause
-					false => Err(Error::RecordExists {
-						thing,
-					}),
+					false => match stm.is_ignore() {
+						false => Err(Error::RecordExists {
+							thing,
+						}),
+						true => Err(Error::Ignore),
+					},
 				},
 				// If any other error was received, then let's
 				// pass that error through and return an error

--- a/core/src/doc/process.rs
+++ b/core/src/doc/process.rs
@@ -87,15 +87,11 @@ impl Document {
 				Err(Error::Ignore) => Err(Error::Ignore),
 				// Pass other errors through and return the error
 				Err(e) => {
-					if stm.is_ignore() && matches!(e, Error::RecordExists { .. }) {
-						Err(Error::Ignore)
-					} else {
-						// We roll back any change following the save point
-						if is_save_point {
-							ctx.tx().lock().await.rollback_to_save_point().await?;
-						}
-						Err(e)
+					// We roll back any change following the save point
+					if is_save_point {
+						ctx.tx().lock().await.rollback_to_save_point().await?;
 					}
+					Err(e)
 				}
 				// Otherwise the record creation succeeded
 				Ok(v) => {

--- a/core/src/doc/store.rs
+++ b/core/src/doc/store.rs
@@ -34,7 +34,7 @@ impl Document {
 			// at this point the current document is not empty so we
 			// set and update the key, without checking if the key
 			// already exists in the storage engine.
-			Statement::Insert(_) if self.extras.is_insert_initial() => {
+			Statement::Insert(_) if self.is_iteration_initial() => {
 				match ctx.tx().put(key, self, opt.version).await {
 					// The key already exists, so return an error
 					Err(Error::TxKeyAlreadyExists) => Err(Error::RecordExists {

--- a/core/src/doc/store.rs
+++ b/core/src/doc/store.rs
@@ -52,7 +52,7 @@ impl Document {
 			// to store the record value, we must ensure that the
 			// key does not exist.  If the record value exists then we
 			// retry and attempt to update the record which exists.
-			Statement::Upsert(_) if self.is_new() => {
+			Statement::Upsert(_) if self.is_iteration_initial() => {
 				match ctx.tx().put(key, self, opt.version).await {
 					// The key already exists, so return an error
 					Err(Error::TxKeyAlreadyExists) => Err(Error::RecordExists {

--- a/core/src/doc/upsert.rs
+++ b/core/src/doc/upsert.rs
@@ -14,22 +14,81 @@ impl Document {
 		opt: &Options,
 		stm: &Statement<'_>,
 	) -> Result<Value, Error> {
-		match self.upsert_process(stk, ctx, opt, stm).await {
-			// We attempted to INSERT a document with an ID,
-			// and this ID already exists in the database,
-			// so we need to UPDATE the record instead.
-			Err(Error::RecordExists {
-				thing,
-			}) => Err(Error::RetryWithId(thing)),
-			// If any other error was received, then let's
-			// pass that error through and return an error
-			Err(e) => Err(e),
-			// Otherwise the record creation succeeded
-			Ok(v) => Ok(v),
+		// On the first iteration, we do not first attempt
+		// to fetch the record from the storage engine. After
+		// trying to create the record, if the record already
+		// exists then we will fetch the record from storage,
+		// and will update the record subsequently
+		match self.is_iteration_initial() {
+			// We haven't yet checked if the record exists
+			// so let's assume that the record does not exist
+			// and attempt to create the record in the database
+			true => match self.upsert_create(stk, ctx, opt, stm).await {
+				// We received an index exists error, so we
+				// ignore the error, and attempt to update the
+				// record using the ON DUPLICATE KEY UPDATE
+				// clause with the ID received in the error
+				Err(Error::IndexExists {
+					thing,
+					index,
+					value,
+				}) => match self.is_specific_record_id() {
+					// No specific Record ID has been specified, so retry
+					false => Err(Error::RetryWithId(thing)),
+					// A specific Record ID was specified, so error
+					true => Err(Error::IndexExists {
+						thing,
+						index,
+						value,
+					}),
+				},
+				// We attempted to INSERT a document with an ID,
+				// and this ID already exists in the database,
+				// so we need to UPDATE the record instead.
+				Err(Error::RecordExists {
+					thing,
+				}) => Err(Error::RetryWithId(thing)),
+				// If any other error was received, then let's
+				// pass that error through and return an error
+				Err(e) => Err(e),
+				// Otherwise the record creation succeeded
+				Ok(v) => Ok(v),
+			},
+			// If we first attempted to create the record,
+			// but the record existed already, then we will
+			// fetch the record from the storage engine,
+			// and will update the record subsequently
+			false => self.upsert_update(stk, ctx, opt, stm).await,
 		}
 	}
-	/// Attempt to run an UPSERT clause
-	async fn upsert_process(
+	/// Attempt to run an UPSERT statement to
+	/// create a record which does not exist
+	async fn upsert_create(
+		&mut self,
+		stk: &mut Stk,
+		ctx: &Context,
+		opt: &Options,
+		stm: &Statement<'_>,
+	) -> Result<Value, Error> {
+		self.check_permissions_quick(stk, ctx, opt, stm).await?;
+		self.check_table_type(ctx, opt, stm).await?;
+		self.check_data_fields(stk, ctx, opt, stm).await?;
+		self.process_record_data(stk, ctx, opt, stm).await?;
+		self.process_table_fields(stk, ctx, opt, stm).await?;
+		self.cleanup_table_fields(stk, ctx, opt, stm).await?;
+		self.default_record_data(ctx, opt, stm).await?;
+		self.check_permissions_table(stk, ctx, opt, stm).await?;
+		self.store_record_data(ctx, opt, stm).await?;
+		self.store_index_data(stk, ctx, opt, stm).await?;
+		self.process_table_views(stk, ctx, opt, stm).await?;
+		self.process_table_lives(stk, ctx, opt, stm).await?;
+		self.process_table_events(stk, ctx, opt, stm).await?;
+		self.process_changefeeds(ctx, opt, stm).await?;
+		self.pluck(stk, ctx, opt, stm).await
+	}
+	/// Attempt to run an UPSERT statement to
+	/// update a record which already exists
+	async fn upsert_update(
 		&mut self,
 		stk: &mut Stk,
 		ctx: &Context,

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1300,6 +1300,16 @@ impl Serialize for Error {
 	}
 }
 impl Error {
+	pub fn is_schema_related(&self) -> bool {
+		matches!(
+			self,
+			Error::FieldCheck { .. }
+				| Error::FieldValue { .. }
+				| Error::FieldReadonly { .. }
+				| Error::FieldUndefined { .. }
+		)
+	}
+
 	pub fn set_check_from_coerce(self, name: String) -> Error {
 		match self {
 			Error::CoerceTo {

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1300,6 +1300,7 @@ impl Serialize for Error {
 	}
 }
 impl Error {
+	/// Check if this error is related to schema checks
 	pub fn is_schema_related(&self) -> bool {
 		matches!(
 			self,
@@ -1310,6 +1311,7 @@ impl Error {
 		)
 	}
 
+	/// Convert CoerceTo errors in LET statements
 	pub fn set_check_from_coerce(self, name: String) -> Error {
 		match self {
 			Error::CoerceTo {
@@ -1324,6 +1326,7 @@ impl Error {
 		}
 	}
 
+	/// Convert CoerceTo errors in functions and closures
 	pub fn function_check_from_coerce(self, name: impl Into<String>) -> Error {
 		match self {
 			Error::CoerceTo {

--- a/sdk/tests/upsert.rs
+++ b/sdk/tests/upsert.rs
@@ -504,7 +504,7 @@ async fn upsert_new_and_update_records_with_content_and_merge_with_readonly_fiel
 	let sql = "
 		-- Setup the schemaful table
 		DEFINE TABLE person SCHEMALESS;
-		DEFINE FIELD created ON tester TYPE datetime READONLY DEFAULT d'2024-01-01';
+		DEFINE FIELD created ON person TYPE datetime READONLY DEFAULT d'2024-01-01';
 		DEFINE FIELD age ON person TYPE number;
 		DEFINE FIELD data ON person FLEXIBLE TYPE object;
 		-- This record will be created successfully

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -183,7 +183,7 @@ async fn update_all(
 	match surrealdb::sql::value(data) {
 		Ok(data) => {
 			// Specify the request statement
-			let sql = "UPSERT type::table($table) CONTENT $data";
+			let sql = "UPDATE type::table($table) CONTENT $data";
 			// Specify the request variables
 			let vars = map! {
 				String::from("table") => Value::from(table),
@@ -233,7 +233,7 @@ async fn modify_all(
 	match surrealdb::sql::value(data) {
 		Ok(data) => {
 			// Specify the request statement
-			let sql = "UPSERT type::table($table) MERGE $data";
+			let sql = "UPDATE type::table($table) MERGE $data";
 			// Specify the request variables
 			let vars = map! {
 				String::from("table") => Value::from(table),


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

`UPSERT` behaviour is currently not correct when dealing with existing index entries, where conditions, and when generating new records without specifically setting the Record ID.

## What does this change do?

This pull request makes the following changes:

1. When creating records with `UPSERT` and not specifying a specific Record ID, the record will be created with a randomly generated Record ID:

```sql
UPSERT person SET one = "something", two = "something", three = "something";
```

2. When running an `UPSERT` statement with a `WHERE` clause, when *no* Record ID has been specifically set, then the iterator will first fetch records from storage. If records already exist which match the `WHERE` clause, then these will be updated. Otherwise a new record will be created, if no records are found:

```sql
-- This will return the created record as no matching records exist
UPSERT person SET name = 'Jaime' WHERE name = 'Jaime';
-- This will return the updated record, because a matching record exists, and the WHERE clause matches
UPSERT person SET name = 'Tobie' WHERE name = 'Jaime';
-- This will return a newly created record, because the WHERE clause does not match
UPSERT person SET name = 'Tobie' WHERE name = 'Jaime';
```

3. When running an `UPSERT` statement with a `WHERE` clause, when a Record ID has been specifically set, then the record will first be fetched from storage. If the record does not exist, then the record will be created. If the record exists, then the record will be updated, if the `WHERE` clause matches, and will not be updated if the `WHERE` clause does not match:

```sql
-- This will return the created record as the record does not yet exist
UPSERT person:test SET name = 'Jaime' WHERE name = 'Jaime';
-- This will return the updated record, because the record exists, and the WHERE clause matches
UPSERT person:test SET name = 'Tobie' WHERE name = 'Jaime';
-- This will not return any record, because the record exists, but the WHERE clause no longer matches
UPSERT person:test SET name = 'Tobie' WHERE name = 'Jaime';
```

4. When using `UNIQUE` indexes combined with the `UPSERT` statement, SurrealDB will now fetch the record from the index if it already exists. If a specific Record ID has been specified for the statement, then an error will be returned in the event that the index is already populated with a matching unique value for a different record.

```sql
-- This will define a unique index on the table
DEFINE INDEX OVERWRITE testing ON person FIELDS one, two, three UNIQUE;
-- This will create a record, and populate the unique index with this record id
UPSERT person SET one = "something", two = "something", three = "something";
-- This will update the record, returning the same record id created in the statement above
UPSERT person SET one = "something", two = "something", three = "something";
-- This will throw an error, because the unique index already has a record with a different record id
UPSERT person:test SET one = "something", two = "something", three = "something";
```

5. When specifying Record IDs using dynamic functions, an error will no longer be returned:

```sql
CREATE person SET id = rand:string(12);
```

6. When updating a record with a `CONTENT` clause, fields which are defined as `READONLY` are not modified. This ensures that any flexible fields in a record are able to be cleared or reset, without throwing errors for overwriting readonly fields. If overwriting fields is not desired, then the `REPLACE` clause will continue to throw an error when a `READONLY` field is modified:

```sql
-- Setup the schemaful table
DEFINE TABLE person SCHEMALESS;
DEFINE FIELD created ON tester TYPE datetime READONLY DEFAULT d'2024-01-01';
DEFINE FIELD age ON person TYPE number;
DEFINE FIELD data ON person FLEXIBLE TYPE object;
-- This record will be created successfully
UPSERT tester:something CONTENT { age: 1, data: { some: true, other: false } };
-- This record will be updated successfully, with the readonly field untouched
UPSERT tester:something CONTENT { age: 2, data: { nothing: true } };
-- This record will be updated successfully, with the readonly and flexible fields untouched
UPSERT tester:something MERGE { age: 3 };
-- This record will be updated successfully, with the readonly and flexible fields untouched
UPSERT tester:something SET age = 4, data.nothing = false;
-- This will error, because the readonly field `created` was modified
UPSERT tester:something REPLACE { age: 5, data: { other: true } };
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #4893.
- [x] Closes #4883.
- [x] Closes #4952.
- [x] Closes #4501.

## Does this change need documentation?

- [ ] Yes documentation to be added.

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
