### PR TITLE
Derive more traits for SDK-related value types

### DIFF
--- a/sdk/src/api/value/mod.rs
+++ b/sdk/src/api/value/mod.rs
@@ -77,7 +77,7 @@ impl From<Vec<u8>> for Bytes {
 }
 
 transparent_wrapper!(
-	#[derive( Clone, Eq, Default, PartialEq, Ord, PartialOrd)]
+	#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 	pub struct Datetime(CoreDatetime)
 );
 impl_serialize_wrapper!(Datetime);
@@ -90,7 +90,7 @@ impl From<DateTime<Utc>> for Datetime {
 
 transparent_wrapper!(
 	/// The key of a [`RecordId`].
-	#[derive( Clone, PartialEq, PartialOrd)]
+	#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 	#[non_exhaustive]
 	pub struct RecordIdKey(CoreId)
 );
@@ -196,7 +196,7 @@ transparent_wrapper!(
 	///
 	/// Record id's consist of a table name and a key.
 	/// For example the record id `user:tkwse1j5o0anqjxonvzx` has the table `user` and the key `tkwse1j5o0anqjxonvzx`.
-	#[derive( Clone, PartialEq, PartialOrd)]
+	#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 	pub struct RecordId(CoreThing)
 );
 impl_serialize_wrapper!(RecordId);
@@ -260,7 +260,7 @@ impl Number {
 }
 
 transparent_wrapper!(
-	#[derive( Clone, Default, PartialEq, PartialOrd)]
+	#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 	pub struct Value(pub(crate) CoreValue)
 );
 impl_serialize_wrapper!(Value);

--- a/sdk/src/api/value/obj.rs
+++ b/sdk/src/api/value/obj.rs
@@ -8,7 +8,7 @@ use surrealdb_core::sql::{Object as CoreObject, Value as CoreValue};
 use super::Value;
 
 transparent_wrapper! {
-	#[derive( Clone, Eq, PartialEq, Ord, PartialOrd, Default)]
+	#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 	pub struct Object(CoreObject)
 }
 impl_serialize_wrapper!(Object);


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Types like `RecordId` cannot be used as `HashMap` keys.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It derives additional traits, including `Hash`.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

It fixes #4991.

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
