### PR TITLE
Use SurrealKV for in-memory storage engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6122,9 +6122,9 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fd737b47319170abe4b792aa934aaf4f31e5e0407e9aad00ca6fb8d065469b"
+checksum = "4e88295b4810342441d397d63a9df4dbf97fb1dd79a108a067d5ae8e5cb28fac"
 dependencies = [
  "ahash 0.8.11",
  "async-channel 2.2.0",
@@ -7071,9 +7071,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vart"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5333f3d56808a1b86455429ba0c6d2451d6d8b935fcbacb4f7c9a59baaa7a25e"
+checksum = "ea7fc7164de494edba1a18a45374052ed27ca9f35e35a4bc4b68b8284718ff89"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,12 +1031,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
-name = "bitmaps"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
-
-[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,18 +1843,6 @@ checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
 dependencies = [
  "itertools 0.11.0",
  "num-traits",
-]
-
-[[package]]
-name = "echodb"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1eccc44ff21b80ca7e883ff57423a12610965a33637d5d0bef4adebcd81749"
-dependencies = [
- "arc-swap",
- "imbl",
- "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -2866,28 +2848,6 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "imbl"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978d142c8028edf52095703af2fad11d6f611af1246685725d6b850634647085"
-dependencies = [
- "bitmaps",
- "imbl-sized-chunks",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "version_check",
-]
-
-[[package]]
-name = "imbl-sized-chunks"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144006fb58ed787dcae3f54575ff4349755b00ccc99f4b4873860b654be1ed63"
-dependencies = [
- "bitmaps",
 ]
 
 [[package]]
@@ -4582,15 +4542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6052,7 +6003,6 @@ dependencies = [
  "dashmap",
  "deunicode",
  "dmp",
- "echodb",
  "env_logger 0.10.2",
  "ext-sort",
  "flate2",
@@ -6172,9 +6122,9 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58da1e2355c6e5239658e37ed67551871163df626a0d2f69d730718922f704cf"
+checksum = "d1fd737b47319170abe4b792aa934aaf4f31e5e0407e9aad00ca6fb8d065469b"
 dependencies = [
  "ahash 0.8.11",
  "async-channel 2.2.0",
@@ -7121,9 +7071,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vart"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8d5a909a58ae4ed6612e7efef7c70dcca222721c48b20ddbe55bc4ae06e07c"
+checksum = "5333f3d56808a1b86455429ba0c6d2451d6d8b935fcbacb4f7c9a59baaa7a25e"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,13 +477,12 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.2.0",
- "event-listener-strategy 0.5.1",
+ "event-listener-strategy 0.5.2",
  "futures-core",
  "pin-project-lite",
 ]
@@ -1435,9 +1434,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1973,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f51cb23d20b0de8458b86580878211da09bcd4503cb579c225b3d124cabb3"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener 5.2.0",
  "pin-project-lite",
@@ -6122,12 +6121,12 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e88295b4810342441d397d63a9df4dbf97fb1dd79a108a067d5ae8e5cb28fac"
+checksum = "7ac583491e924ebc624ef5693b0132bad077acae759e15f224f2fd4d41dc1581"
 dependencies = [
  "ahash 0.8.11",
- "async-channel 2.2.0",
+ "async-channel 2.3.1",
  "bytes",
  "chrono",
  "crc32fast",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -147,7 +147,7 @@ snap = "1.1.0"
 storekey = "0.5.0"
 subtle = "2.6"
 surrealcs = { version = "0.4.4", optional = true }
-surrealkv = { version = "0.4.1", optional = true }
+surrealkv = { version = "0.4.2", optional = true }
 surrealml = { version = "0.1.1", optional = true, package = "surrealml-core" }
 tempfile = { version = "3.10.1", optional = true }
 thiserror = "1.0.63"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -147,7 +147,7 @@ snap = "1.1.0"
 storekey = "0.5.0"
 subtle = "2.6"
 surrealcs = { version = "0.4.4", optional = true }
-surrealkv = { version = "0.4.2", optional = true }
+surrealkv = { version = "0.4.3", optional = true }
 surrealml = { version = "0.1.1", optional = true, package = "surrealml-core" }
 tempfile = { version = "3.10.1", optional = true }
 thiserror = "1.0.63"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ resolver = "2"
 [features]
 # Public features
 default = ["kv-mem"]
-kv-mem = ["dep:echodb", "tokio/time", "dep:tempfile", "dep:ext-sort"]
+kv-mem = ["dep:surrealkv", "tokio/time", "dep:tempfile", "dep:ext-sort"]
 kv-indxdb = ["dep:indxdb"]
 kv-rocksdb = ["dep:rocksdb", "tokio/time", "dep:tempfile", "dep:ext-sort"]
 kv-tikv = ["dep:tikv", "tokio/time", "dep:tempfile", "dep:ext-sort"]
@@ -75,7 +75,6 @@ dashmap = "5.5.3"
 derive = { version = "0.12.0", package = "surrealdb-derive" }
 deunicode = "1.4.1"
 dmp = "0.2.0"
-echodb = { version = "0.7.0", optional = true }
 executor = { version = "1.8.0", package = "async-executor" }
 ext-sort = { version = "^0.1.4", optional = true }
 foundationdb = { version = "0.9.0", default-features = false, features = [
@@ -148,7 +147,7 @@ snap = "1.1.0"
 storekey = "0.5.0"
 subtle = "2.6"
 surrealcs = { version = "0.4.4", optional = true }
-surrealkv = { version = "0.4.0", optional = true }
+surrealkv = { version = "0.4.1", optional = true }
 surrealml = { version = "0.1.1", optional = true, package = "surrealml-core" }
 tempfile = { version = "3.10.1", optional = true }
 thiserror = "1.0.63"

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1198,14 +1198,17 @@ impl From<regex::Error> for Error {
 	}
 }
 
-#[cfg(feature = "kv-mem")]
-impl From<echodb::err::Error> for Error {
-	fn from(e: echodb::err::Error) -> Error {
-		match e {
-			echodb::err::Error::KeyAlreadyExists => Error::TxKeyAlreadyExists,
-			echodb::err::Error::ValNotExpectedValue => Error::TxConditionNotMet,
-			_ => Error::Tx(e.to_string()),
-		}
+#[cfg(any(feature = "kv-mem", feature = "kv-surrealkv"))]
+impl From<surrealkv::Error> for Error {
+	fn from(e: surrealkv::Error) -> Error {
+		Error::Tx(e.to_string())
+	}
+}
+
+#[cfg(feature = "kv-rocksdb")]
+impl From<rocksdb::Error> for Error {
+	fn from(e: rocksdb::Error) -> Error {
+		Error::Tx(e.to_string())
 	}
 }
 
@@ -1229,20 +1232,6 @@ impl From<tikv::Error> for Error {
 			tikv::Error::RegionError(re) if re.raft_entry_too_large.is_some() => Error::TxTooLarge,
 			_ => Error::Tx(e.to_string()),
 		}
-	}
-}
-
-#[cfg(feature = "kv-rocksdb")]
-impl From<rocksdb::Error> for Error {
-	fn from(e: rocksdb::Error) -> Error {
-		Error::Tx(e.to_string())
-	}
-}
-
-#[cfg(feature = "kv-surrealkv")]
-impl From<surrealkv::Error> for Error {
-	fn from(e: surrealkv::Error) -> Error {
-		Error::Tx(e.to_string())
 	}
 }
 

--- a/core/src/kvs/mem/mod.rs
+++ b/core/src/kvs/mem/mod.rs
@@ -2,16 +2,18 @@
 
 use crate::err::Error;
 use crate::key::debug::Sprintable;
-use crate::kvs::savepoint::{SaveOperation, SavePointImpl, SavePoints};
 use crate::kvs::Check;
 use crate::kvs::Key;
 use crate::kvs::Val;
 use std::fmt::Debug;
 use std::ops::Range;
+use surrealkv::Options;
+use surrealkv::Store;
+use surrealkv::Transaction as Tx;
 
 #[non_exhaustive]
 pub struct Datastore {
-	db: echodb::Db<Key, Val>,
+	db: Store,
 }
 
 #[non_exhaustive]
@@ -23,9 +25,7 @@ pub struct Transaction {
 	/// Should we check unhandled transactions?
 	check: Check,
 	/// The underlying datastore transaction
-	inner: echodb::Tx<Key, Val>,
-	/// The save point implementation
-	save_points: SavePoints,
+	inner: Tx,
 }
 
 impl Drop for Transaction {
@@ -61,9 +61,19 @@ impl Drop for Transaction {
 impl Datastore {
 	/// Open a new database
 	pub(crate) async fn new() -> Result<Datastore, Error> {
-		Ok(Datastore {
-			db: echodb::db::new(),
-		})
+		// Create new configuration options
+		let mut opts = Options::new();
+		// Ensure versions are enabled
+		opts.enable_versions = false;
+		// Ensure persistence is enabled
+		opts.disk_persistence = false;
+		// Create a new datastore
+		match Store::new(opts) {
+			Ok(db) => Ok(Datastore {
+				db,
+			}),
+			Err(e) => Err(Error::Ds(e.to_string())),
+		}
 	}
 	/// Shutdown the database
 	pub(crate) async fn shutdown(&self) -> Result<(), Error> {
@@ -78,13 +88,12 @@ impl Datastore {
 		#[cfg(debug_assertions)]
 		let check = Check::Panic;
 		// Create a new transaction
-		match self.db.begin(write).await {
+		match self.db.begin() {
 			Ok(inner) => Ok(Transaction {
 				done: false,
 				check,
 				write,
 				inner,
-				save_points: Default::default(),
 			}),
 			Err(e) => Err(Error::Tx(e.to_string())),
 		}
@@ -107,22 +116,22 @@ impl super::api::Transaction for Transaction {
 		self.write
 	}
 
-	/// Cancel a transaction
+	/// Cancels the transaction.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self))]
 	async fn cancel(&mut self) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
-		// Mark this transaction as done
+		// Mark the transaction as done.
 		self.done = true;
-		// Cancel this transaction
-		self.inner.cancel()?;
+		// Rollback the transaction.
+		self.inner.rollback();
 		// Continue
 		Ok(())
 	}
 
-	/// Commit a transaction
+	/// Commits the transaction.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self))]
 	async fn commit(&mut self) -> Result<(), Error> {
 		// Check to see if transaction is closed
@@ -133,30 +142,26 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Mark this transaction as done
+		// Mark the transaction as done.
 		self.done = true;
-		// Cancel this transaction
-		self.inner.commit()?;
+		// Commit the transaction.
+		self.inner.commit().await?;
 		// Continue
 		Ok(())
 	}
 
-	/// Check if a key exists
+	/// Checks if a key exists in the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
 	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// EchoDB does not support versioned queries.
-		if version.is_some() {
-			return Err(Error::UnsupportedVersionedQueries);
-		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
 		// Check the key
-		let res = self.inner.exi(key.into())?;
+		let res = self.inner.get(&key.into())?.is_some();
 		// Return result
 		Ok(res)
 	}
@@ -167,16 +172,17 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// EchoDB does not support versioned queries.
-		if version.is_some() {
-			return Err(Error::UnsupportedVersionedQueries);
-		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
-		// Get the key
-		let res = self.inner.get(key.into())?;
+
+		// Fetch the value from the database.
+		let res = match version {
+			Some(ts) => self.inner.get_at_ts(&key.into(), ts)?,
+			None => self.inner.get(&key.into())?,
+		};
+
 		// Return result
 		Ok(res)
 	}
@@ -188,10 +194,6 @@ impl super::api::Transaction for Transaction {
 		K: Into<Key> + Sprintable + Debug,
 		V: Into<Val> + Debug,
 	{
-		// EchoDB does not support versioned queries.
-		if version.is_some() {
-			return Err(Error::UnsupportedVersionedQueries);
-		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -200,19 +202,10 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Extract the key
-		let key = key.into();
-		// Prepare the savepoint if any
-		let prep = if self.save_points.is_some() {
-			self.save_point_prepare(&key, version, SaveOperation::Set).await?
-		} else {
-			None
-		};
 		// Set the key
-		self.inner.set(key, val.into())?;
-		// Confirm the save point
-		if let Some(prep) = prep {
-			self.save_points.save(prep);
+		match version {
+			Some(ts) => self.inner.set_at_ts(&key.into(), &val.into(), ts)?,
+			None => self.inner.set(&key.into(), &val.into())?,
 		}
 		// Return result
 		Ok(())
@@ -225,11 +218,6 @@ impl super::api::Transaction for Transaction {
 		K: Into<Key> + Sprintable + Debug,
 		V: Into<Val> + Debug,
 	{
-		// EchoDB does not support versioned queries.
-		if version.is_some() {
-			return Err(Error::UnsupportedVersionedQueries);
-		}
-
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -238,19 +226,17 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Extract the key
+		// Get the arguments
 		let key = key.into();
-		// Hydrate the savepoint if any
-		let prep = if self.save_points.is_some() {
-			self.save_point_prepare(&key, version, SaveOperation::Put).await?
+		let val = val.into();
+		// Set the key if empty
+		if let Some(ts) = version {
+			self.inner.set_at_ts(&key, &val, ts)?;
 		} else {
-			None
-		};
-		// Set the key
-		self.inner.put(key, val.into())?;
-		// Confirm the save point
-		if let Some(prep) = prep {
-			self.save_points.save(prep);
+			match self.inner.get(&key)? {
+				None => self.inner.set(&key, &val)?,
+				_ => return Err(Error::TxKeyAlreadyExists),
+			}
 		}
 		// Return result
 		Ok(())
@@ -271,25 +257,21 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Extract the key
+		// Get the arguments
 		let key = key.into();
-		// Hydrate the savepoint if any
-		let prep = if self.save_points.is_some() {
-			self.save_point_prepare(&key, None, SaveOperation::Put).await?
-		} else {
-			None
+		let val = val.into();
+		let chk = chk.map(Into::into);
+		// Set the key if valid
+		match (self.inner.get(&key)?, chk) {
+			(Some(v), Some(w)) if v == w => self.inner.set(&key, &val)?,
+			(None, None) => self.inner.set(&key, &val)?,
+			_ => return Err(Error::TxConditionNotMet),
 		};
-		// Set the key
-		self.inner.putc(key, val.into(), chk.map(Into::into))?;
-		// Confirm the save point
-		if let Some(prep) = prep {
-			self.save_points.save(prep);
-		}
 		// Return result
 		Ok(())
 	}
 
-	/// Delete a key
+	/// Deletes a key from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
 	async fn del<K>(&mut self, key: K) -> Result<(), Error>
 	where
@@ -303,20 +285,8 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Extract the key
-		let key = key.into();
-		// Hydrate the savepoint if any
-		let prep = if self.save_points.is_some() {
-			self.save_point_prepare(&key, None, SaveOperation::Del).await?
-		} else {
-			None
-		};
 		// Remove the key
-		self.inner.del(key)?;
-		// Confirm the save point
-		if let Some(prep) = prep {
-			self.save_points.save(prep);
-		}
+		self.inner.delete(&key.into())?;
 		// Return result
 		Ok(())
 	}
@@ -336,25 +306,20 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Extract the key
+		// Get the arguments
 		let key = key.into();
-		// Hydrate the savepoint if any
-		let prep = if self.save_points.is_some() {
-			self.save_point_prepare(&key, None, SaveOperation::Del).await?
-		} else {
-			None
+		let chk = chk.map(Into::into);
+		// Delete the key if valid
+		match (self.inner.get(&key)?, chk) {
+			(Some(v), Some(w)) if v == w => self.inner.delete(&key)?,
+			(None, None) => self.inner.delete(&key)?,
+			_ => return Err(Error::TxConditionNotMet),
 		};
-		// Remove the key
-		self.inner.delc(key, chk.map(Into::into))?;
-		// Confirm the save point
-		if let Some(prep) = prep {
-			self.save_points.save(prep);
-		}
 		// Return result
 		Ok(())
 	}
 
-	/// Retrieve a range of keys from the databases
+	/// Retrieves a range of key-value pairs from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
 	async fn keys<K>(
 		&mut self,
@@ -365,26 +330,22 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// EchoDB does not support versioned queries.
-		if version.is_some() {
-			return Err(Error::UnsupportedVersionedQueries);
-		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
-		// Convert the range to bytes
-		let rng: Range<Key> = Range {
-			start: rng.start.into(),
-			end: rng.end.into(),
-		};
-		// Scan the keys
-		let res = self.inner.keys(rng, limit as usize)?;
+		// Set the key range
+		let beg = rng.start.into();
+		let end = rng.end.into();
+		// Retrieve the scan range
+		let res = self.inner.scan(beg.as_slice()..end.as_slice(), Some(limit as usize))?;
+		// Convert the keys and values
+		let res = res.into_iter().map(|kv| Key::from(kv.0)).collect();
 		// Return result
 		Ok(res)
 	}
 
-	/// Retrieve a range of keys from the databases
+	/// Retrieves a range of key-value pairs from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
 	async fn scan<K>(
 		&mut self,
@@ -395,28 +356,43 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
-		// EchoDB does not support versioned queries.
-		if version.is_some() {
-			return Err(Error::UnsupportedVersionedQueries);
-		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
-		// Convert the range to bytes
-		let rng: Range<Key> = Range {
-			start: rng.start.into(),
-			end: rng.end.into(),
+		// Set the key range
+		let beg = rng.start.into();
+		let end = rng.end.into();
+		let range = beg.as_slice()..end.as_slice();
+
+		// Retrieve the scan range
+		let res = match version {
+			Some(ts) => self.inner.scan_at_ts(range, ts, Some(limit as usize))?,
+			None => self
+				.inner
+				.scan(range, Some(limit as usize))?
+				.into_iter()
+				.map(|kv| (kv.0, kv.1))
+				.collect(),
 		};
-		// Scan the keys
-		let res = self.inner.scan(rng, limit as usize)?;
-		// Return result
+
 		Ok(res)
 	}
 }
 
-impl SavePointImpl for Transaction {
-	fn get_save_points(&mut self) -> &mut SavePoints {
-		&mut self.save_points
+impl Transaction {
+	pub(crate) fn new_save_point(&mut self) {
+		// Set the save point, the errors are ignored.
+		let _ = self.inner.set_savepoint();
+	}
+
+	pub(crate) async fn rollback_to_save_point(&mut self) -> Result<(), Error> {
+		// Rollback
+		self.inner.rollback_to_savepoint()?;
+		Ok(())
+	}
+
+	pub(crate) fn release_last_save_point(&mut self) -> Result<(), Error> {
+		Ok(())
 	}
 }

--- a/core/src/kvs/mem/mod.rs
+++ b/core/src/kvs/mem/mod.rs
@@ -156,6 +156,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// Memory does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -172,17 +176,19 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// Memory does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
-
 		// Fetch the value from the database.
 		let res = match version {
 			Some(ts) => self.inner.get_at_ts(&key.into(), ts)?,
 			None => self.inner.get(&key.into())?,
 		};
-
 		// Return result
 		Ok(res)
 	}
@@ -194,6 +200,10 @@ impl super::api::Transaction for Transaction {
 		K: Into<Key> + Sprintable + Debug,
 		V: Into<Val> + Debug,
 	{
+		// Memory does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -218,6 +228,10 @@ impl super::api::Transaction for Transaction {
 		K: Into<Key> + Sprintable + Debug,
 		V: Into<Val> + Debug,
 	{
+		// Memory does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -330,6 +344,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// Memory does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -356,6 +374,10 @@ impl super::api::Transaction for Transaction {
 	where
 		K: Into<Key> + Sprintable + Debug,
 	{
+		// Memory does not support versioned queries.
+		if version.is_some() {
+			return Err(Error::UnsupportedVersionedQueries);
+		}
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -364,7 +386,6 @@ impl super::api::Transaction for Transaction {
 		let beg = rng.start.into();
 		let end = rng.end.into();
 		let range = beg.as_slice()..end.as_slice();
-
 		// Retrieve the scan range
 		let res = match version {
 			Some(ts) => self.inner.scan_at_ts(range, ts, Some(limit as usize))?,
@@ -375,7 +396,7 @@ impl super::api::Transaction for Transaction {
 				.map(|kv| (kv.0, kv.1))
 				.collect(),
 		};
-
+		// Return result
 		Ok(res)
 	}
 }

--- a/core/src/kvs/mem/mod.rs
+++ b/core/src/kvs/mem/mod.rs
@@ -300,7 +300,7 @@ impl super::api::Transaction for Transaction {
 			return Err(Error::TxReadonly);
 		}
 		// Remove the key
-		self.inner.soft_delete(&key.into())?;
+		self.inner.delete(&key.into())?;
 		// Return result
 		Ok(())
 	}
@@ -325,8 +325,8 @@ impl super::api::Transaction for Transaction {
 		let chk = chk.map(Into::into);
 		// Delete the key if valid
 		match (self.inner.get(&key)?, chk) {
-			(Some(v), Some(w)) if v == w => self.inner.soft_delete(&key)?,
-			(None, None) => self.inner.soft_delete(&key)?,
+			(Some(v), Some(w)) if v == w => self.inner.delete(&key)?,
+			(None, None) => self.inner.delete(&key)?,
 			_ => return Err(Error::TxConditionNotMet),
 		};
 		// Return result

--- a/core/src/kvs/mem/mod.rs
+++ b/core/src/kvs/mem/mod.rs
@@ -63,9 +63,9 @@ impl Datastore {
 	pub(crate) async fn new() -> Result<Datastore, Error> {
 		// Create new configuration options
 		let mut opts = Options::new();
-		// Ensure versions are enabled
+		// Ensure versions are disabled
 		opts.enable_versions = false;
-		// Ensure persistence is enabled
+		// Ensure persistence is disabled
 		opts.disk_persistence = false;
 		// Create a new datastore
 		match Store::new(opts) {

--- a/core/src/kvs/mem/mod.rs
+++ b/core/src/kvs/mem/mod.rs
@@ -300,7 +300,7 @@ impl super::api::Transaction for Transaction {
 			return Err(Error::TxReadonly);
 		}
 		// Remove the key
-		self.inner.delete(&key.into())?;
+		self.inner.soft_delete(&key.into())?;
 		// Return result
 		Ok(())
 	}
@@ -325,8 +325,8 @@ impl super::api::Transaction for Transaction {
 		let chk = chk.map(Into::into);
 		// Delete the key if valid
 		match (self.inner.get(&key)?, chk) {
-			(Some(v), Some(w)) if v == w => self.inner.delete(&key)?,
-			(None, None) => self.inner.delete(&key)?,
+			(Some(v), Some(w)) if v == w => self.inner.soft_delete(&key)?,
+			(None, None) => self.inner.soft_delete(&key)?,
 			_ => return Err(Error::TxConditionNotMet),
 		};
 		// Return result

--- a/core/src/kvs/mod.rs
+++ b/core/src/kvs/mod.rs
@@ -39,7 +39,6 @@ mod tikv;
 #[cfg(not(target_arch = "wasm32"))]
 mod index;
 #[cfg(any(
-	feature = "kv-mem",
 	feature = "kv-tikv",
 	feature = "kv-fdb",
 	feature = "kv-indxdb",

--- a/core/src/kvs/surrealkv/mod.rs
+++ b/core/src/kvs/surrealkv/mod.rs
@@ -178,13 +178,11 @@ impl super::api::Transaction for Transaction {
 		if self.done {
 			return Err(Error::TxFinished);
 		}
-
 		// Fetch the value from the database.
 		let res = match version {
 			Some(ts) => self.inner.get_at_ts(&key.into(), ts)?,
 			None => self.inner.get(&key.into())?,
 		};
-
 		// Return result
 		Ok(res)
 	}
@@ -366,7 +364,6 @@ impl super::api::Transaction for Transaction {
 		let beg = rng.start.into();
 		let end = rng.end.into();
 		let range = beg.as_slice()..end.as_slice();
-
 		// Retrieve the scan range
 		let res = match version {
 			Some(ts) => self.inner.scan_at_ts(range, ts, Some(limit as usize))?,
@@ -377,7 +374,7 @@ impl super::api::Transaction for Transaction {
 				.map(|kv| (kv.0, kv.1))
 				.collect(),
 		};
-
+		// Return result
 		Ok(res)
 	}
 }

--- a/core/src/kvs/surrealkv/mod.rs
+++ b/core/src/kvs/surrealkv/mod.rs
@@ -63,6 +63,10 @@ impl Datastore {
 	pub(crate) async fn new(path: &str) -> Result<Datastore, Error> {
 		// Create new configuration options
 		let mut opts = Options::new();
+		// Ensure versions are enabled
+		opts.enable_versions = true;
+		// Ensure persistence is enabled
+		opts.disk_persistence = true;
 		// Set the data storage directory
 		opts.dir = path.to_string().into();
 		// Create a new datastore

--- a/core/src/kvs/tr.rs
+++ b/core/src/kvs/tr.rs
@@ -11,7 +11,6 @@ use crate::key::debug::Sprintable;
 use crate::kvs::batch::Batch;
 use crate::kvs::clock::SizedClock;
 #[cfg(any(
-	feature = "kv-mem",
 	feature = "kv-tikv",
 	feature = "kv-fdb",
 	feature = "kv-indxdb",


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

EchoDB is an in-memory storage engine implementation which supports multiple-concurrent readers, and a single writer. This can cause slow downs when working with in-memory uses in SurrealDB.

## What does this change do?

Switches out EchoDB for SurrealKV, with in-memory storage only, no on-disk-persistence, and data versioning disabled.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
