### PR TITLE
Implements in-memory parallel sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6083,6 +6083,7 @@ dependencies = [
  "quick_cache 0.5.1",
  "radix_trie",
  "rand 0.8.5",
+ "rayon",
  "reblessive",
  "regex",
  "regex-syntax 0.8.4",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -116,6 +116,7 @@ pin-project-lite = "0.2.13"
 quick_cache = "0.5.1"
 radix_trie = { version = "0.2.1", features = ["serde"] }
 rand = "0.8.5"
+rayon = "1.10.0"
 reblessive = { version = "0.4.1", features = ["tree"] }
 regex = "1.10.6"
 regex-syntax = { version = "0.8.4", optional = true, features = ["arbitrary"] }

--- a/core/src/dbs/iterator.rs
+++ b/core/src/dbs/iterator.rs
@@ -339,6 +339,9 @@ impl Iterator {
 
 			// Process any ORDER clause
 			if let Some(orders) = stm.order() {
+				#[cfg(not(target_arch = "wasm32"))]
+				self.results.async_sort(orders).await;
+				#[cfg(target_arch = "wasm32")]
 				self.results.sort(orders);
 			}
 

--- a/core/src/dbs/iterator.rs
+++ b/core/src/dbs/iterator.rs
@@ -340,7 +340,7 @@ impl Iterator {
 			// Process any ORDER clause
 			if let Some(orders) = stm.order() {
 				#[cfg(not(target_arch = "wasm32"))]
-				self.results.async_sort(orders).await;
+				self.results.async_sort(orders).await?;
 				#[cfg(target_arch = "wasm32")]
 				self.results.sort(orders);
 			}

--- a/core/src/dbs/result.rs
+++ b/core/src/dbs/result.rs
@@ -60,9 +60,20 @@ impl Results {
 		Ok(())
 	}
 
+	#[cfg(not(target_arch = "wasm32"))]
+	pub(super) async fn async_sort(&mut self, orders: &Ordering) {
+		match self {
+			Self::Memory(m) => m.sort(orders).await,
+			#[cfg(storage)]
+			Self::File(f) => f.sort(orders),
+			_ => {}
+		}
+	}
+
+	#[cfg(target_arch = "wasm32")]
 	pub(super) fn sort(&mut self, orders: &Ordering) {
 		match self {
-			Self::Memory(m) => m.sort(orders),
+			Self::Memory(m) => m.small_sort(orders),
 			#[cfg(storage)]
 			Self::File(f) => f.sort(orders),
 			_ => {}

--- a/core/src/dbs/result.rs
+++ b/core/src/dbs/result.rs
@@ -61,13 +61,14 @@ impl Results {
 	}
 
 	#[cfg(not(target_arch = "wasm32"))]
-	pub(super) async fn async_sort(&mut self, orders: &Ordering) {
+	pub(super) async fn async_sort(&mut self, orders: &Ordering) -> Result<(), Error> {
 		match self {
-			Self::Memory(m) => m.sort(orders).await,
+			Self::Memory(m) => m.sort(orders).await?,
 			#[cfg(storage)]
 			Self::File(f) => f.sort(orders),
 			_ => {}
 		}
+		Ok(())
 	}
 
 	#[cfg(target_arch = "wasm32")]

--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1170,8 +1170,11 @@ pub enum Error {
 	#[error("Failed to compute: \"{0}\", as the operation results in an overflow.")]
 	ArithmeticOverflow(String),
 
-	#[error("Recieved error while streaming query: {0}.")]
+	#[error("Received error while streaming query: {0}.")]
 	QueryStream(String),
+
+	#[error("Error while ordering a result: {0}.")]
+	OrderingError(String),
 }
 
 impl From<Error> for String {

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -209,3 +209,7 @@ harness = false
 [[bench]]
 name = "with_or_without_index"
 harness = false
+
+[[bench]]
+name = "sort"
+harness = false

--- a/sdk/benches/sort.rs
+++ b/sdk/benches/sort.rs
@@ -1,0 +1,72 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use std::time::Duration;
+use surrealdb::dbs::Session;
+use surrealdb::kvs::Datastore;
+use surrealdb_core::sql::Value;
+use tokio::runtime::Runtime;
+
+fn bench_sort(c: &mut Criterion) {
+	let rt = Runtime::new().unwrap();
+
+	let mut group = c.benchmark_group("sort");
+	group.throughput(Throughput::Elements(1));
+	group.sample_size(10);
+	group.measurement_time(Duration::from_secs(15));
+
+	let i = rt.block_on(prepare_data(9999));
+
+	group.bench_function("sort", |b| {
+		b.to_async(Runtime::new().unwrap()).iter(|| run(&i, "SELECT * FROM i ORDER BY v", 9999))
+	});
+
+	group.bench_function("sort-parallel", |b| {
+		b.to_async(Runtime::new().unwrap())
+			.iter(|| run(&i, "SELECT * FROM i ORDER BY v PARALLEL", 9999))
+	});
+
+	let i = rt.block_on(prepare_data(10000));
+
+	group.bench_function("sort-rayon", |b| {
+		b.to_async(Runtime::new().unwrap()).iter(|| run(&i, "SELECT * FROM i ORDER BY v", 10000))
+	});
+
+	group.bench_function("sort-rayon-parallel", |b| {
+		b.to_async(Runtime::new().unwrap())
+			.iter(|| run(&i, "SELECT * FROM i ORDER BY v PARALLEL", 10000))
+	});
+
+	group.finish();
+}
+
+struct Input {
+	dbs: Datastore,
+	ses: Session,
+}
+
+async fn prepare_data(n: usize) -> Input {
+	let dbs = Datastore::new("memory").await.unwrap();
+	let ses = Session::owner().with_ns("bench").with_db("bench");
+	let sql = format!(" CREATE |i:{n}| SET v = rand::guid() RETURN NONE");
+	let res = &mut dbs.execute(&sql, &ses, None).await.unwrap();
+	let _ = res.remove(0).result.is_ok();
+	Input {
+		dbs,
+		ses,
+	}
+}
+
+async fn run(i: &Input, q: &str, expected: usize) {
+	let mut r = i.dbs.execute(black_box(q), &i.ses, None).await.unwrap();
+	if cfg!(debug_assertions) {
+		assert_eq!(r.len(), 1);
+		if let Value::Array(a) = r.remove(0).result.unwrap() {
+			assert_eq!(a.len(), expected);
+		} else {
+			panic!("Fail");
+		}
+	}
+	black_box(r);
+}
+
+criterion_group!(benches, bench_sort);
+criterion_main!(benches);

--- a/sdk/benches/sort.rs
+++ b/sdk/benches/sort.rs
@@ -5,6 +5,12 @@ use surrealdb::kvs::Datastore;
 use surrealdb_core::sql::Value;
 use tokio::runtime::Runtime;
 
+/// When ordering a query, the sort method can choose between
+/// single-threaded sorting or parallel sorting (Rayon::par_sort_unstable_by).
+/// Following several tests, a value of 10000 has been selected to decide when we use the parallel sort.
+/// This benchmark ensures that we start seeing a performance improvement.
+/// 9999 = sort_unstable_by
+/// >=10000 = par_sort_unstable_by
 fn bench_sort(c: &mut Criterion) {
 	let rt = Runtime::new().unwrap();
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

In-memory sorting is a single-threaded process.
For large result sets, we can achieve better performance by using parallel sorting.

## What does this change do?

- Result sets larger than or equal to 10,000 records are now sorted concurrently (parallel quicksort).
- Sorting is now unstable, leveraging quicksort, which performs faster and uses less memory.
- A benchmark showing a performance improvement when using Rayon's parallel sorting.

```
sort/sort               time:   [52.442 ms 52.805 ms 53.205 ms]
                        thrpt:  [18.795  elem/s 18.938  elem/s 19.069  elem/s]

sort/sort-parallel      time:   [46.127 ms 47.122 ms 48.322 ms]
                        thrpt:  [20.695  elem/s 21.222  elem/s 21.679  elem/s]

sort/sort-rayon         time:   [49.255 ms 49.993 ms 50.748 ms]
                        thrpt:  [19.705  elem/s 20.003  elem/s 20.303  elem/s]

sort/sort-rayon-parallel
                        time:   [44.051 ms 44.285 ms 44.441 ms]
                        thrpt:  [22.502  elem/s 22.581  elem/s 22.701  elem/s]
```


## What is your testing strategy?

A benchmark has been written.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
