### PR TITLE
Improve `type::field()` and `type::fields()` projection functionality

### DIFF
--- a/core/src/dbs/options.rs
+++ b/core/src/dbs/options.rs
@@ -234,12 +234,6 @@ impl Options {
 		self.futures = Futures::Never;
 	}
 
-	/// Specify if we should process field projections
-	pub fn with_projections(mut self, projections: bool) -> Self {
-		self.projections = projections;
-		self
-	}
-
 	/// Create a new Options object with auth enabled
 	pub fn with_auth_enabled(mut self, auth_enabled: bool) -> Self {
 		self.auth_enabled = auth_enabled;
@@ -324,20 +318,6 @@ impl Options {
 					false => Futures::Disabled,
 				},
 			},
-			..*self
-		}
-	}
-
-	/// Create a new Options object for a subquery
-	pub fn new_with_projections(&self, projections: bool) -> Self {
-		Self {
-			sender: self.sender.clone(),
-			auth: self.auth.clone(),
-			ns: self.ns.clone(),
-			db: self.db.clone(),
-			force: self.force.clone(),
-			futures: self.futures.clone(),
-			projections,
 			..*self
 		}
 	}

--- a/core/src/fnc/type.rs
+++ b/core/src/fnc/type.rs
@@ -44,10 +44,7 @@ pub async fn field(
 			// Parse the string as an Idiom
 			let idi = syn::idiom(&val)?;
 			// Return the Idiom or fetch the field
-			match opt.projections {
-				true => Ok(idi.compute(stk, ctx, opt, doc).await?),
-				false => Ok(idi.into()),
-			}
+			Ok(idi.compute(stk, ctx, opt, doc).await?)
 		}
 		_ => Ok(Value::None),
 	}
@@ -64,10 +61,7 @@ pub async fn fields(
 				// Parse the string as an Idiom
 				let idi = syn::idiom(&v)?;
 				// Return the Idiom or fetch the field
-				match opt.projections {
-					true => args.push(idi.compute(stk, ctx, opt, doc).await?),
-					false => args.push(idi.into()),
-				}
+				args.push(idi.compute(stk, ctx, opt, doc).await?);
 			}
 			Ok(args.into())
 		}

--- a/core/src/sql/statements/delete.rs
+++ b/core/src/sql/statements/delete.rs
@@ -43,7 +43,7 @@ impl DeleteStatement {
 		// Assign the statement
 		let stm = Statement::from(self);
 		// Ensure futures are stored
-		let opt = &opt.new_with_futures(false).with_projections(false);
+		let opt = &opt.new_with_futures(false);
 		// Check if there is a timeout
 		let ctx = match self.timeout.as_ref() {
 			Some(timeout) => {

--- a/core/src/sql/statements/insert.rs
+++ b/core/src/sql/statements/insert.rs
@@ -49,7 +49,7 @@ impl InsertStatement {
 		// Propagate the version to the underlying datastore
 		let version = self.version.as_ref().map(|v| v.to_u64());
 		// Ensure futures are stored
-		let opt = &opt.new_with_futures(false).with_projections(false).with_version(version);
+		let opt = &opt.new_with_futures(false).with_version(version);
 		// Check if there is a timeout
 		let ctx = match self.timeout.as_ref() {
 			Some(timeout) => {

--- a/core/src/sql/statements/relate.rs
+++ b/core/src/sql/statements/relate.rs
@@ -44,7 +44,7 @@ impl RelateStatement {
 		// Create a new iterator
 		let mut i = Iterator::new();
 		// Ensure futures are stored
-		let opt = &opt.new_with_futures(false).with_projections(false);
+		let opt = &opt.new_with_futures(false);
 		// Check if there is a timeout
 		let ctx = match self.timeout.as_ref() {
 			Some(timeout) => {

--- a/core/src/sql/statements/select.rs
+++ b/core/src/sql/statements/select.rs
@@ -110,8 +110,7 @@ impl SelectStatement {
 		let mut i = Iterator::new();
 		// Ensure futures are stored and the version is set if specified
 		let version = self.version.as_ref().map(|v| v.to_u64());
-		let opt =
-			Arc::new(opt.new_with_futures(false).with_projections(true).with_version(version));
+		let opt = Arc::new(opt.new_with_futures(false).with_version(version));
 		// Extract the limit
 		let limit = i.setup_limit(stk, ctx, &opt, &stm).await?;
 		// Used for ONLY: is the limit 1?

--- a/core/src/sql/statements/update.rs
+++ b/core/src/sql/statements/update.rs
@@ -44,7 +44,7 @@ impl UpdateStatement {
 		// Assign the statement
 		let stm = Statement::from(self);
 		// Ensure futures are stored
-		let opt = &opt.new_with_futures(false).with_projections(false);
+		let opt = &opt.new_with_futures(false);
 		// Check if there is a timeout
 		let ctx = match self.timeout.as_ref() {
 			Some(timeout) => {

--- a/core/src/sql/statements/upsert.rs
+++ b/core/src/sql/statements/upsert.rs
@@ -43,7 +43,7 @@ impl UpsertStatement {
 		// Assign the statement
 		let stm = Statement::from(self);
 		// Ensure futures are stored
-		let opt = &opt.new_with_futures(false).with_projections(false);
+		let opt = &opt.new_with_futures(false);
 		// Check if there is a timeout
 		let ctx = match self.timeout.as_ref() {
 			Some(timeout) => {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently fields specified in the projection function `type::field()` and `type::fields()` are only able to be used in `SELECT` statements:

```sql
SELECT type::field('name') FROM person;
```

## What does this change do?

This enables users to use `type::field()` and `type::fields()` function expressions in more places, including `SELECT` statement expressions, and in `WHERE` clause expressions, and in `RETURN` clause expressions on all statement types:

```sql
SELECT type::field('name') FROM person;
UPDATE person SET modified = true WHERE type::field('name') = 'Tobie';
UPDATE person SET updated_at = time::now() RETURN type::field('name');
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #2913.

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
