### PR TITLE
Fix a bug in random ordering when using files as storage.

### DIFF
--- a/core/src/dbs/store.rs
+++ b/core/src/dbs/store.rs
@@ -122,7 +122,8 @@ pub(super) mod file_store {
 	use crate::sql::order::Ordering;
 	use crate::sql::Value;
 	use ext_sort::{ExternalChunk, ExternalSorter, ExternalSorterBuilder, LimitedBufferBuilder};
-	use rand::seq::SliceRandom as _;
+	use rand::seq::{IteratorRandom as _, SliceRandom as _};
+	use rand::Rng as _;
 	use revision::Revisioned;
 	use std::fs::{File, OpenOptions};
 	use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Take, Write};
@@ -212,11 +213,34 @@ pub(super) mod file_store {
 		) -> Result<Vec<Value>, Error> {
 			match orders {
 				Ordering::Random => {
+					let mut rng = rand::thread_rng();
+					let mut iter = reader.into_iter();
+					// fill initial array
 					let mut res: Vec<Value> = Vec::with_capacity(num as usize);
-					for r in reader.into_iter().skip(start as usize).take(num as usize) {
+					for r in iter.by_ref().take(num as usize) {
 						res.push(r?);
 					}
-					res.shuffle(&mut rand::thread_rng());
+
+					// Then handle the remaining values as they might need to be part of the random
+					// sampling.
+					// This implementation is taken from the IteratorRandom::choose_multiple. It is
+					// emperically tested to produce n values uniformly sampled from the iterator.
+					// TODO (DelSkayn): Figure exactly out why this is guarenteed to produce a uniform
+					// sampling.
+					for (i, v) in iter.enumerate() {
+						let v = v?;
+						// pick an index to insert the value in, swapping existing values if it is
+						// within the range.
+						let idx = rng.gen_range(0..(i + 1 + num as usize));
+						if let Some(slot) = res.get_mut(idx as usize) {
+							*slot = v
+						}
+					}
+
+					// The above code does not create a random ordering.
+					// if for example only the first n values happened to be selected they are
+					// still in the original ordering. So shuffle the final result.
+					res.shuffle(&mut rng);
 					Ok(res)
 				}
 				Ordering::Order(orders) => {
@@ -306,6 +330,7 @@ pub(super) mod file_store {
 	}
 
 	struct FileReader {
+		/// The amount of values present in the file of this reader.
 		len: usize,
 		index: PathBuf,
 		records: PathBuf,
@@ -320,6 +345,10 @@ pub(super) mod file_store {
 				index,
 				records,
 			})
+		}
+
+		fn len(&self) -> usize {
+			self.len
 		}
 
 		fn read_value<R: Read>(reader: &mut R) -> Result<Value, Error> {
@@ -434,6 +463,16 @@ pub(super) mod file_store {
 			} else {
 				None
 			}
+		}
+
+		fn size_hint(&self) -> (usize, Option<usize>) {
+			(self.len - self.pos, Some(self.len - self.pos))
+		}
+	}
+
+	impl ExactSizeIterator for FileRecordsIterator {
+		fn len(&self) -> usize {
+			self.len - self.pos
 		}
 	}
 

--- a/core/src/dbs/store.rs
+++ b/core/src/dbs/store.rs
@@ -122,7 +122,7 @@ pub(super) mod file_store {
 	use crate::sql::order::Ordering;
 	use crate::sql::Value;
 	use ext_sort::{ExternalChunk, ExternalSorter, ExternalSorterBuilder, LimitedBufferBuilder};
-	use rand::seq::{IteratorRandom as _, SliceRandom as _};
+	use rand::seq::SliceRandom as _;
 	use rand::Rng as _;
 	use revision::Revisioned;
 	use std::fs::{File, OpenOptions};
@@ -345,10 +345,6 @@ pub(super) mod file_store {
 				index,
 				records,
 			})
-		}
-
-		fn len(&self) -> usize {
-			self.len
 		}
 
 		fn read_value<R: Read>(reader: &mut R) -> Result<Value, Error> {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

My previous PR changing ordering handling has a bug when using file backed sorting.

## What does this change do?

The previous PR selected a range of N values from the stream and then shuffled those, that is different from having a random ordering.  Take a stream which has M values where M > N then, for example, the first N values are always selected and then shuffled while it should be possible for any of the values in the stream to end up in the final result.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

This seems really hard to test, as it is difficult to ensure that a selection is properly uniform.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
