### PR TITLE
Fix the docker compose file

### DIFF
--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -1,0 +1,19 @@
+# Instructions
+
+1. Create a directory called `tempo-data`
+
+   ```
+   mkdir tempo-data
+   ```
+
+2. Run docker compose
+
+   ```
+   docker compose up -d
+   ```
+
+3. Stop docker compose
+
+   ```
+   docker compose down -v
+   ```

--- a/dev/docker/compose.yaml
+++ b/dev/docker/compose.yaml
@@ -1,5 +1,4 @@
 ---
-version: "3"
 services:
   grafana:
     image: "grafana/grafana-oss:main"
@@ -38,12 +37,24 @@ services:
       - "prometheus:/prometheus"
       - "./prometheus.yaml:/etc/prometheus/prometheus.yaml"
 
+  # Tempo runs as user 10001, and docker compose creates the volume as root.
+  # As such, we need to chown the volume in order for Tempo to start correctly.
+  init:
+    image: &tempoImage grafana/tempo:latest
+    user: root
+    entrypoint:
+      - "chown"
+      - "10001:10001"
+      - "/var/tempo"
+    volumes:
+      - ./tempo-data:/var/tempo
+
   tempo:
-    image: grafana/tempo:latest
+    image: *tempoImage
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
-      - tempo:/tmp/tempo
+      - ./tempo-data:/var/tempo
     ports:
       - "3200"   # tempo
       - "4317"  # otlp grpc

--- a/dev/docker/otel-collector.yaml
+++ b/dev/docker/otel-collector.yaml
@@ -16,8 +16,8 @@ exporters:
     resource_to_telemetry_conversion:
       enabled: true
 
-  logging: # add to a pipeline for debugging
-    loglevel: debug
+  debug: # add to a pipeline for debugging
+    verbosity: detailed
 
 # processors:
 #   batch:
@@ -30,7 +30,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlp, logging]
+      exporters: [otlp, debug]
     metrics:
       receivers: [otlp]
       exporters: [prometheus]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The docker compose file in `dev/docker` doesn't work anymore.

## What does this change do?

- Add a README.md file in the `dev/docker` directory with steps on how to run and stop it
- Fix the Tempo setup: it needs a temporary directory with specific permissions
- Fix the otel-collector config: the `logging` config setting was removed and replaced with a `debug` section 

## What is your testing strategy?

Followed the instructions and checked that all components keep on running. Previously both Tempo and the otel-collector would fail. 

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [X] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [X] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
