### PR TITLE
Fix bytes serialisation

### DIFF
--- a/core/src/sql/value/serde/ser/mod.rs
+++ b/core/src/sql/value/serde/ser/mod.rs
@@ -4,6 +4,7 @@ mod r#struct;
 use crate::err::Error;
 use crate::sql;
 use crate::sql::value::Value;
+use crate::sql::Bytes;
 use castaway::match_type;
 use serde::ser::Serialize;
 use serde_content::Number;
@@ -92,8 +93,8 @@ impl TryFrom<Content> for Value {
 				Cow::Owned(v) => Ok(v.into()),
 			},
 			Content::Bytes(v) => match v {
-				Cow::Borrowed(v) => Ok(v.to_vec().into()),
-				Cow::Owned(v) => Ok(v.into()),
+				Cow::Borrowed(v) => Ok(Value::Bytes(Bytes(v.to_vec()))),
+				Cow::Owned(v) => Ok(Value::Bytes(Bytes(v))),
 			},
 			Content::Seq(v) => v.try_into(),
 			Content::Map(v) => v.try_into(),

--- a/sdk/tests/api.rs
+++ b/sdk/tests/api.rs
@@ -40,7 +40,8 @@ mod api_integration {
 	const NS: &str = "test-ns";
 	const ROOT_USER: &str = "root";
 	const ROOT_PASS: &str = "root";
-	const TEMP_DIR: LazyLock<PathBuf> = LazyLock::new(|| TempDir::new().unwrap().child("sdb-test"));
+	static TEMP_DIR: LazyLock<PathBuf> =
+		LazyLock::new(|| TempDir::new().unwrap().child("sdb-test"));
 
 	#[derive(Debug, Serialize)]
 	struct Record {

--- a/sdk/tests/api.rs
+++ b/sdk/tests/api.rs
@@ -143,6 +143,7 @@ mod api_integration {
 		}
 
 		include!("api/mod.rs");
+		include!("api/serialisation.rs");
 		include!("api/live.rs");
 	}
 
@@ -172,6 +173,7 @@ mod api_integration {
 		}
 
 		include!("api/mod.rs");
+		include!("api/serialisation.rs");
 		include!("api/backup.rs");
 	}
 
@@ -266,6 +268,7 @@ mod api_integration {
 		}
 
 		include!("api/mod.rs");
+		include!("api/serialisation.rs");
 		include!("api/live.rs");
 		include!("api/backup.rs");
 	}
@@ -308,6 +311,7 @@ mod api_integration {
 		}
 
 		include!("api/mod.rs");
+		include!("api/serialisation.rs");
 		include!("api/live.rs");
 		include!("api/backup.rs");
 	}
@@ -351,6 +355,7 @@ mod api_integration {
 		}
 
 		include!("api/mod.rs");
+		include!("api/serialisation.rs");
 		include!("api/live.rs");
 		include!("api/backup.rs");
 	}
@@ -381,6 +386,7 @@ mod api_integration {
 		}
 
 		include!("api/mod.rs");
+		include!("api/serialisation.rs");
 		include!("api/live.rs");
 		include!("api/backup.rs");
 	}
@@ -408,6 +414,7 @@ mod api_integration {
 		}
 
 		include!("api/mod.rs");
+		include!("api/serialisation.rs");
 		include!("api/live.rs");
 		include!("api/backup.rs");
 	}
@@ -451,6 +458,7 @@ mod api_integration {
 		}
 
 		include!("api/mod.rs");
+		include!("api/serialisation.rs");
 		include!("api/live.rs");
 		include!("api/version.rs");
 		include!("api/backup.rs");
@@ -474,6 +482,7 @@ mod api_integration {
 		}
 
 		include!("api/mod.rs");
+		include!("api/serialisation.rs");
 		include!("api/backup.rs");
 	}
 }

--- a/sdk/tests/api/mod.rs
+++ b/sdk/tests/api/mod.rs
@@ -571,6 +571,22 @@ async fn create_record_with_id_in_content() {
 }
 
 #[test_log::test(tokio::test)]
+async fn create_uuid() {
+	use uuid::Uuid;
+	#[derive(Debug, Serialize, Deserialize)]
+	struct Record {
+		uuid: Uuid,
+	}
+	let (permit, db) = new_db().await;
+	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+	drop(permit);
+	let record = Record {
+		uuid: Uuid::now_v7(),
+	};
+	let _: Option<Record> = db.create("user").content(record).await.unwrap();
+}
+
+#[test_log::test(tokio::test)]
 async fn insert_table() {
 	let (permit, db) = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();

--- a/sdk/tests/api/mod.rs
+++ b/sdk/tests/api/mod.rs
@@ -571,22 +571,6 @@ async fn create_record_with_id_in_content() {
 }
 
 #[test_log::test(tokio::test)]
-async fn create_uuid() {
-	use uuid::Uuid;
-	#[derive(Debug, Serialize, Deserialize)]
-	struct Record {
-		uuid: Uuid,
-	}
-	let (permit, db) = new_db().await;
-	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
-	drop(permit);
-	let record = Record {
-		uuid: Uuid::now_v7(),
-	};
-	let _: Option<Record> = db.create("user").content(record).await.unwrap();
-}
-
-#[test_log::test(tokio::test)]
 async fn insert_table() {
 	let (permit, db) = new_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();

--- a/sdk/tests/api/serialisation.rs
+++ b/sdk/tests/api/serialisation.rs
@@ -1,0 +1,15 @@
+#[test_log::test(tokio::test)]
+async fn serialise_uuid() {
+	use uuid::Uuid;
+	#[derive(Debug, Serialize, Deserialize)]
+	struct Record {
+		uuid: Uuid,
+	}
+	let (permit, db) = new_db().await;
+	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+	drop(permit);
+	let record = Record {
+		uuid: Uuid::new_v4(),
+	};
+	let _: Option<Record> = db.create("user").content(record).await.unwrap();
+}


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Trying to serialise bytes or anything that serialises to bytes invokes the `From<Vec<u8>> for Value` implementation which incorrectly tries to decode the bytes as a core `Value` instead of just wrapping the bytes in `Value::Bytes`.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Bypasses the conversion and just embeds the bytes directly.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a new test.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Fixes #4940.

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
