### PR TITLE
Add support for unicode escape sequences

### DIFF
--- a/core/src/syn/error/mac.rs
+++ b/core/src/syn/error/mac.rs
@@ -16,13 +16,13 @@
 ///     //   |                       ^ your wrong here!
 /// }
 /// ```
-macro_rules! error {
+macro_rules! syntax_error {
 	($format:literal $(, $expr:expr)*
 		$(, @ $span:expr $(=> $label_format:literal $(, $label_expr:expr)* $(,)? )? )*
 	) => {{
 		let __error: $crate::syn::error::SyntaxError = $crate::syn::error::SyntaxError::new(format_args!($format $(, $expr)*));
 		$(
-			$crate::syn::error::error!(#label __error, $span $(=> $label_format$(, $label_expr)*  )?);
+			$crate::syn::error::syntax_error!(#label __error, $span $(=> $label_format$(, $label_expr)*  )?);
 		)*
 		__error
 	}};
@@ -39,10 +39,10 @@ macro_rules! error {
 /// Similar to [`error`] but immediately returns the error.
 macro_rules! bail {
 	($($t:tt)*) => {{
-		let __error = $crate::syn::error::error!($($t)*);
+		let __error = $crate::syn::error::syntax_error!($($t)*);
 		return Err(__error)
 	}};
 }
 
 pub(crate) use bail;
-pub(crate) use error;
+pub(crate) use syntax_error;

--- a/core/src/syn/error/mod.rs
+++ b/core/src/syn/error/mod.rs
@@ -5,7 +5,7 @@ mod location;
 mod mac;
 mod render;
 pub use location::Location;
-pub(crate) use mac::{bail, error};
+pub(crate) use mac::{bail, syntax_error};
 pub use render::{RenderedError, Snippet};
 
 #[derive(Debug, Clone, Copy)]

--- a/core/src/syn/lexer/byte.rs
+++ b/core/src/syn/lexer/byte.rs
@@ -1,5 +1,5 @@
 use crate::syn::{
-	error::{bail, error, SyntaxError},
+	error::{bail, syntax_error, SyntaxError},
 	lexer::{
 		unicode::{byte, chars},
 		Lexer,
@@ -143,7 +143,7 @@ impl<'a> Lexer<'a> {
 					t!("&&")
 				}
 				_ => {
-					let error = error!("Invalid token `&`, single `&` are not a valid token, did you mean `&&`?",@self.current_span());
+					let error = syntax_error!("Invalid token `&`, single `&` are not a valid token, did you mean `&&`?",@self.current_span());
 					return self.invalid_token(error);
 				}
 			},
@@ -237,7 +237,7 @@ impl<'a> Lexer<'a> {
 							t!("+?=")
 						}
 						_ => {
-							let error = error!("Invalid token `+?` did you maybe mean `+?=` ?", @self.current_span());
+							let error = syntax_error!("Invalid token `+?` did you maybe mean `+?=` ?", @self.current_span());
 							return self.invalid_token(error);
 						}
 					}
@@ -376,7 +376,7 @@ impl<'a> Lexer<'a> {
 			}
 			//b'0'..=b'9' => return self.lex_number(byte),
 			x => {
-				let err = error!("Invalid token `{}`", x as char, @self.current_span());
+				let err = syntax_error!("Invalid token `{}`", x as char, @self.current_span());
 				return self.invalid_token(err);
 			}
 		};

--- a/core/src/syn/lexer/char.rs
+++ b/core/src/syn/lexer/char.rs
@@ -1,5 +1,5 @@
 use crate::syn::{
-	error::error,
+	error::syntax_error,
 	lexer::Lexer,
 	token::{t, Token},
 };
@@ -29,7 +29,7 @@ impl<'a> Lexer<'a> {
 			'×' => t!("×"),
 			'÷' => t!("÷"),
 			x => {
-				let err = error!("Invalid token `{x}`", @self.current_span());
+				let err = syntax_error!("Invalid token `{x}`", @self.current_span());
 				return self.invalid_token(err);
 			}
 		};

--- a/core/src/syn/lexer/compound/datetime.rs
+++ b/core/src/syn/lexer/compound/datetime.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Utc};
 
 use crate::syn::{
-	error::{bail, error, SyntaxError},
+	error::{bail, syntax_error, SyntaxError},
 	lexer::Lexer,
 	token::{t, Token},
 };
@@ -45,7 +45,7 @@ pub fn datetime_inner(lexer: &mut Lexer) -> Result<DateTime<Utc>, SyntaxError> {
 	};
 
 	let date = NaiveDate::from_ymd_opt(year, month as u32, day as u32).ok_or_else(
-		|| error!("Invalid DateTime date: date outside of valid range", @lexer.span_since(date_start)),
+		|| syntax_error!("Invalid DateTime date: date outside of valid range", @lexer.span_since(date_start)),
 	)?;
 
 	if !lexer.eat_when(|x| x == b'T') {
@@ -105,7 +105,7 @@ pub fn datetime_inner(lexer: &mut Lexer) -> Result<DateTime<Utc>, SyntaxError> {
 
 	let time = NaiveTime::from_hms_nano_opt(hour as u32, minute as u32, second as u32, nanos)
 		.ok_or_else(
-			|| error!("Invalid DateTime time: time outside of valid range", @lexer.span_since(time_start)),
+			|| syntax_error!("Invalid DateTime time: time outside of valid range", @lexer.span_since(time_start)),
 		)?;
 
 	let timezone_start = lexer.reader.offset();

--- a/core/src/syn/lexer/compound/regex.rs
+++ b/core/src/syn/lexer/compound/regex.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 
 use crate::syn::{
-	error::{bail, error, SyntaxError},
+	error::{bail, syntax_error, SyntaxError},
 	lexer::Lexer,
 	token::{t, Token},
 };
@@ -44,7 +44,7 @@ pub fn regex(lexer: &mut Lexer, start: Token) -> Result<Regex, SyntaxError> {
 	}
 
 	let span = lexer.current_span();
-	let regex = lexer.scratch.parse().map_err(|e| error!("Invalid regex: {e}", @span))?;
+	let regex = lexer.scratch.parse().map_err(|e| syntax_error!("Invalid regex: {e}", @span))?;
 	lexer.scratch.clear();
 	Ok(regex)
 }

--- a/core/src/syn/lexer/compound/strand.rs
+++ b/core/src/syn/lexer/compound/strand.rs
@@ -1,7 +1,8 @@
-use std::mem;
+use std::ops::RangeInclusive;
+use std::{char, mem};
 
 use crate::syn::{
-	error::{bail, error, SyntaxError},
+	error::{bail, syntax_error, SyntaxError},
 	lexer::{unicode::chars, Lexer},
 	token::{t, Token},
 };
@@ -16,8 +17,7 @@ pub fn strand(lexer: &mut Lexer, start: Token) -> Result<String, SyntaxError> {
 	loop {
 		let Some(x) = lexer.reader.next() else {
 			lexer.scratch.clear();
-			let err =
-				error!("Unexpected end of file, expected strand to end",@lexer.current_span());
+			let err = syntax_error!("Unexpected end of file, expected strand to end",@lexer.current_span());
 			return Err(err.with_data_pending());
 		};
 
@@ -38,7 +38,7 @@ pub fn strand(lexer: &mut Lexer, start: Token) -> Result<String, SyntaxError> {
 					// Handle escape sequences.
 					let Some(next) = lexer.reader.next() else {
 						lexer.scratch.clear();
-						let err = error!("Unexpected end of file, expected strand to end",@lexer.current_span());
+						let err = syntax_error!("Unexpected end of file, expected strand to end",@lexer.current_span());
 						return Err(err.with_data_pending());
 					};
 					match next {
@@ -69,6 +69,10 @@ pub fn strand(lexer: &mut Lexer, start: Token) -> Result<String, SyntaxError> {
 						b't' => {
 							lexer.scratch.push(chars::TAB);
 						}
+						b'u' => {
+							let c = lex_unicode_sequence(lexer)?;
+							lexer.scratch.push(c);
+						}
 						x => match lexer.reader.convert_to_char(x) {
 							Ok(char) => {
 								let valid_escape = if is_double {
@@ -76,7 +80,7 @@ pub fn strand(lexer: &mut Lexer, start: Token) -> Result<String, SyntaxError> {
 								} else {
 									'\''
 								};
-								bail!("Invalid escape character `{char}`, valid characters are `\\`, `{valid_escape}`, `/`, `b`, `f`, `n`, `r`, or `t`", @lexer.current_span());
+								bail!("Invalid escape character `{char}`, valid characters are `\\`, `{valid_escape}`, `/`, `b`, `f`, `n`, `r`, `t`, or `u` ", @lexer.current_span());
 							}
 							Err(e) => {
 								lexer.scratch.clear();
@@ -97,4 +101,94 @@ pub fn strand(lexer: &mut Lexer, start: Token) -> Result<String, SyntaxError> {
 			}
 		}
 	}
+}
+
+const LEADING_SURROGATES: RangeInclusive<u16> = 0xD800..=0xDBFF;
+const TRAILING_SURROGATES: RangeInclusive<u16> = 0xDC00..=0xDFFF;
+
+fn lex_unicode_sequence(lexer: &mut Lexer) -> Result<char, SyntaxError> {
+	if let Some(b'{') = lexer.reader.peek() {
+		lexer.reader.next();
+		return lex_bracket_unicode_sequence(lexer);
+	}
+
+	let leading = lex_bare_unicode_sequence(lexer)?;
+	if LEADING_SURROGATES.contains(&leading) {
+		if !(lexer.reader.next() == Some(b'\\') && lexer.reader.next() == Some(b'u')) {
+			bail!("Unicode escape sequence encoding a leading surrogate needs to be followed by a trailing surrogate", @lexer.current_span());
+		}
+		let trailing = lex_bare_unicode_sequence(lexer)?;
+		// Compute the codepoint.
+		// https://datacadamia.com/data/type/text/surrogate#from_surrogate_to_character_code
+		let codepoint = 0x10000
+			+ ((leading as u32 - *LEADING_SURROGATES.start() as u32) << 10)
+			+ trailing as u32
+			- *TRAILING_SURROGATES.start() as u32;
+
+		return char::from_u32(codepoint).ok_or_else(|| {
+			syntax_error!("Unicode escape sequences encode invalid character codepoint", @lexer.current_span())
+		});
+	}
+
+	char::from_u32(leading as u32)
+		.ok_or_else(|| syntax_error!("Unicode escape sequences encode invalid character codepoint", @lexer.current_span()))
+}
+
+fn lex_bracket_unicode_sequence(lexer: &mut Lexer) -> Result<char, SyntaxError> {
+	let mut accum = 0u32;
+	for _ in 0..6 {
+		let c = lexer.reader.peek().ok_or_else(
+			|| syntax_error!("Unexpected end of file, expected strand to end", @lexer.current_span()),
+		)?;
+
+		match c {
+			b'a'..=b'f' => {
+				accum <<= 4;
+				accum += (c - b'a') as u32 + 10;
+			}
+			b'A'..=b'F' => {
+				accum <<= 4;
+				accum += (c - b'A') as u32 + 10;
+			}
+			b'0'..=b'9' => {
+				accum <<= 4;
+				accum += (c - b'0') as u32;
+			}
+			_ => break,
+		}
+		lexer.reader.next();
+	}
+
+	let Some(b'}') = lexer.reader.next() else {
+		bail!("Missing end brace `}}` of unicode escape sequence", @lexer.current_span())
+	};
+
+	char::from_u32(accum)
+		.ok_or_else(|| syntax_error!("Unicode escape sequences encode invalid character codepoint", @lexer.current_span()))
+}
+
+fn lex_bare_unicode_sequence(lexer: &mut Lexer) -> Result<u16, SyntaxError> {
+	let mut accum: u16 = 0;
+	for _ in 0..4 {
+		let Some(c) = lexer.reader.next() else {
+			bail!("Missing characters after unicode escape sequence", @lexer.current_span());
+		};
+
+		accum <<= 4;
+		match c {
+			b'a'..=b'f' => {
+				accum += (c - b'a') as u16 + 10;
+			}
+			b'A'..=b'F' => {
+				accum += (c - b'A') as u16 + 10;
+			}
+			b'0'..=b'9' => {
+				accum += (c - b'0') as u16;
+			}
+			_ => {
+				bail!("Invalid character `{}` in unicode escape sequence, must be a hex digit.",c as char, @lexer.current_span());
+			}
+		}
+	}
+	Ok(accum)
 }

--- a/core/src/syn/lexer/ident.rs
+++ b/core/src/syn/lexer/ident.rs
@@ -3,7 +3,7 @@ use std::mem;
 use unicase::UniCase;
 
 use crate::syn::{
-	error::{error, SyntaxError},
+	error::{syntax_error, SyntaxError},
 	lexer::{keywords::KEYWORDS, Lexer},
 	token::{Token, TokenKind},
 };
@@ -108,7 +108,7 @@ impl<'a> Lexer<'a> {
 				} else {
 					'⟩'
 				};
-				let error = error!("Unexpected end of file, expected identifier to end with `{end_char}`", @self.current_span());
+				let error = syntax_error!("Unexpected end of file, expected identifier to end with `{end_char}`", @self.current_span());
 				return Err(error.with_data_pending());
 			};
 			if x.is_ascii() {
@@ -119,7 +119,7 @@ impl<'a> Lexer<'a> {
 					}
 					b'\0' => {
 						// null bytes not allowed
-						let err = error!("Invalid null byte in source, null bytes are not valid SurrealQL characters",@self.current_span());
+						let err = syntax_error!("Invalid null byte in source, null bytes are not valid SurrealQL characters",@self.current_span());
 						return Err(err);
 					}
 					b'\\' if is_backtick => {
@@ -132,7 +132,7 @@ impl<'a> Lexer<'a> {
 							} else {
 								'⟩'
 							};
-							let error = error!("Unexpected end of file, expected identifier to end with `{end_char}`", @self.current_span());
+							let error = syntax_error!("Unexpected end of file, expected identifier to end with `{end_char}`", @self.current_span());
 							return Err(error.with_data_pending());
 						};
 						match next {
@@ -166,9 +166,9 @@ impl<'a> Lexer<'a> {
 									if char == '⟩' {
 										self.scratch.push(char);
 									}
-									error!("Invalid escape character `{x}` for identifier, valid characters are `⟩`, `\\`, ```, `/`, `b`, `f`, `n`, `r`, or `t`", @self.current_span())
+									syntax_error!("Invalid escape character `{x}` for identifier, valid characters are `⟩`, `\\`, ```, `/`, `b`, `f`, `n`, `r`, or `t`", @self.current_span())
 								} else {
-									error!("Invalid escape character `{x}` for identifier, valid characters are `\\`, ```, `/`, `b`, `f`, `n`, `r`, or `t`", @self.current_span())
+									syntax_error!("Invalid escape character `{x}` for identifier, valid characters are `\\`, ```, `/`, `b`, `f`, `n`, `r`, or `t`", @self.current_span())
 								};
 								return Err(error);
 							}

--- a/core/src/syn/lexer/reader.rs
+++ b/core/src/syn/lexer/reader.rs
@@ -1,9 +1,6 @@
 use thiserror::Error;
 
-use crate::syn::{
-	error::{error, SyntaxError},
-	token::Span,
-};
+use crate::syn::{error::SyntaxError, token::Span};
 
 #[derive(Error, Debug)]
 #[non_exhaustive]

--- a/core/src/syn/parser/basic/number.rs
+++ b/core/src/syn/parser/basic/number.rs
@@ -5,7 +5,7 @@ use rust_decimal::Decimal;
 use crate::{
 	sql::Number,
 	syn::{
-		error::{bail, error},
+		error::{bail, syntax_error},
 		lexer::compound::{self, NumberKind},
 		parser::{mac::unexpected, GluedValue, ParseResult, Parser},
 		token::{self, t, TokenKind},
@@ -97,18 +97,20 @@ impl TokenValue for Number {
 					NumberKind::Integer => number_str
 						.parse()
 						.map(Number::Int)
-						.map_err(|e| error!("Failed to parse number: {e}", @token.span)),
+						.map_err(|e| syntax_error!("Failed to parse number: {e}", @token.span)),
 					NumberKind::Float => number_str
 						.parse()
 						.map(Number::Float)
-						.map_err(|e| error!("Failed to parse number: {e}", @token.span)),
+						.map_err(|e| syntax_error!("Failed to parse number: {e}", @token.span)),
 					NumberKind::Decimal => {
 						let decimal = if number_str.contains(['e', 'E']) {
-							Decimal::from_scientific(number_str)
-								.map_err(|e| error!("Failed to parser decimal: {e}", @token.span))?
+							Decimal::from_scientific(number_str).map_err(
+								|e| syntax_error!("Failed to parser decimal: {e}", @token.span),
+							)?
 						} else {
-							Decimal::from_str(number_str)
-								.map_err(|e| error!("Failed to parser decimal: {e}", @token.span))?
+							Decimal::from_str(number_str).map_err(
+								|e| syntax_error!("Failed to parser decimal: {e}", @token.span),
+							)?
 						};
 						Ok(Number::Decimal(decimal))
 					}

--- a/core/src/syn/parser/function.rs
+++ b/core/src/syn/parser/function.rs
@@ -3,7 +3,7 @@ use reblessive::Stk;
 use crate::{
 	sql::{Function, Ident, Model, Value},
 	syn::{
-		error::error,
+		error::syntax_error,
 		parser::mac::{expected, expected_whitespace, unexpected},
 		token::{t, TokenKind},
 	},
@@ -59,38 +59,35 @@ impl Parser<'_> {
 		let start = expected!(self, t!("<")).span;
 
 		let token = self.next();
-		let major: u32 = match token.kind {
-			TokenKind::Digits => self
-				.lexer
-				.span_str(token.span)
-				.parse()
-				.map_err(|e| error!("Failed to parse model version: {e}", @token.span))?,
-			_ => unexpected!(self, token, "an integer"),
-		};
+		let major: u32 =
+			match token.kind {
+				TokenKind::Digits => self.lexer.span_str(token.span).parse().map_err(
+					|e| syntax_error!("Failed to parse model version: {e}", @token.span),
+				)?,
+				_ => unexpected!(self, token, "an integer"),
+			};
 
 		expected_whitespace!(self, t!("."));
 
 		let token = self.next_whitespace();
-		let minor: u32 = match token.kind {
-			TokenKind::Digits => self
-				.lexer
-				.span_str(token.span)
-				.parse()
-				.map_err(|e| error!("Failed to parse model version: {e}", @token.span))?,
-			_ => unexpected!(self, token, "an integer"),
-		};
+		let minor: u32 =
+			match token.kind {
+				TokenKind::Digits => self.lexer.span_str(token.span).parse().map_err(
+					|e| syntax_error!("Failed to parse model version: {e}", @token.span),
+				)?,
+				_ => unexpected!(self, token, "an integer"),
+			};
 
 		expected_whitespace!(self, t!("."));
 
 		let token = self.next_whitespace();
-		let patch: u32 = match token.kind {
-			TokenKind::Digits => self
-				.lexer
-				.span_str(token.span)
-				.parse()
-				.map_err(|e| error!("Failed to parse model version: {e}", @token.span))?,
-			_ => unexpected!(self, token, "an integer"),
-		};
+		let patch: u32 =
+			match token.kind {
+				TokenKind::Digits => self.lexer.span_str(token.span).parse().map_err(
+					|e| syntax_error!("Failed to parse model version: {e}", @token.span),
+				)?,
+				_ => unexpected!(self, token, "an integer"),
+			};
 
 		self.expect_closing_delimiter(t!(">"), start)?;
 

--- a/core/src/syn/parser/mac.rs
+++ b/core/src/syn/parser/mac.rs
@@ -15,7 +15,7 @@ macro_rules! unexpected {
 				return Err($parser.lexer.error.take().unwrap());
 			}
 			$crate::syn::token::TokenKind::Eof => {
-				let error = $crate::syn::error::error!("Unexpected end of file, expected {}",$expected, @__found.span $( $($t)* )?);
+				let error = $crate::syn::error::syntax_error!("Unexpected end of file, expected {}",$expected, @__found.span $( $($t)* )?);
 				return Err(error.with_data_pending())
 			}
 			$crate::syn::token::TokenKind::WhiteSpace => {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The parser didn't properly implement unicode escape sequences for strings.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->
Implements the escape sequences.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Test implemented in to-be-merged language testing suite.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- Fixes #5036
- Fixes #5026

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
