### PR TITLE
Fix incorrect future decoding

### DIFF
--- a/core/src/rpc/format/cbor/convert.rs
+++ b/core/src/rpc/format/cbor/convert.rs
@@ -191,7 +191,7 @@ impl TryFrom<Cbor> for Value {
 					TAG_RANGE => Ok(Value::Range(Box::new(Range::try_from(*v)?))),
 					TAG_FUTURE => match *v {
 						Data::Text(v) => {
-							let block = crate::syn::block(format!("{{{v}}}").as_str())
+							let block = crate::syn::block(v.as_str())
 								.map_err(|_| "Failed to parse block")?;
 							Ok(Value::Future(Box::new(Future(block))))
 						}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently, the CBOR decoding for futures wraps blocks with another set of braces

## What does this change do?

Pass the string directly to the block parser

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Locally tested

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
