### PR TITLE
Graph with filter should be flattened

### DIFF
--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -283,6 +283,8 @@ impl Value {
 						// If we are chaining graph parts, we need to make sure to flatten the result
 						let mapped = match (path.first(), path.get(1)) {
 							(Some(Part::Graph(_)), Some(Part::Graph(_))) => mapped.flatten(),
+							(Some(Part::Graph(_)), Some(Part::Where(_))) => mapped.flatten(),
+							(Some(Part::Where(_)), Some(Part::Graph(_))) => mapped.flatten(),
 							_ => mapped,
 						};
 

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -284,7 +284,6 @@ impl Value {
 						let mapped = match (path.first(), path.get(1)) {
 							(Some(Part::Graph(_)), Some(Part::Graph(_))) => mapped.flatten(),
 							(Some(Part::Graph(_)), Some(Part::Where(_))) => mapped.flatten(),
-							(Some(Part::Where(_)), Some(Part::Graph(_))) => mapped.flatten(),
 							_ => mapped,
 						};
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See https://github.com/surrealdb/surrealdb/issues/5055

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

When we encounter a graph part followed by a filter part, the result should be flattened.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test with a number of cases.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes https://github.com/surrealdb/surrealdb/issues/5055

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
