### PR TITLE
Graph with filter should also be flattened after Record ID

### DIFF
--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -352,14 +352,14 @@ impl Value {
 											.run(|stk| v.get(stk, ctx, opt, None, path.next()))
 											.await?;
 										// We only want to flatten the results if the next part
-										// is a graph or where part. Reason being that if we flatten 
-										// fields, the results of those fields (which could be arrays) 
+										// is a graph or where part. Reason being that if we flatten
+										// fields, the results of those fields (which could be arrays)
 										// will be merged into each other. So [1, 2, 3], [4, 5, 6] would
 										// become [1, 2, 3, 4, 5, 6]. This slice access won't panic
 										// as we have already checked the length of the path.
 										Ok(match path[1] {
 											Part::Graph(_) | Part::Where(_) => res.flatten(),
-											_ => res
+											_ => res,
 										})
 									}
 								}

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -352,15 +352,14 @@ impl Value {
 											.run(|stk| v.get(stk, ctx, opt, None, path.next()))
 											.await?;
 										// We only want to flatten the results if the next part
-										// is a graph part. Reason being that if we flatten fields,
-										// the results of those fields (which could be arrays) will
-										// be merged into each other. So [1, 2, 3], [4, 5, 6] would
+										// is a graph or where part. Reason being that if we flatten 
+										// fields, the results of those fields (which could be arrays) 
+										// will be merged into each other. So [1, 2, 3], [4, 5, 6] would
 										// become [1, 2, 3, 4, 5, 6]. This slice access won't panic
 										// as we have already checked the length of the path.
-										Ok(if let Part::Graph(_) = path[1] {
-											res.flatten()
-										} else {
-											res
+										Ok(match path[1] {
+											Part::Graph(_) | Part::Where(_) => res.flatten(),
+											_ => res
 										})
 									}
 								}

--- a/sdk/tests/idiom.rs
+++ b/sdk/tests/idiom.rs
@@ -95,6 +95,7 @@ async fn idiom_graph_with_filter_should_be_flattened() -> Result<(), Error> {
 		person:1->likes->person[?true];
 		[person:1][?true]->likes->person;
 		[person:1]->likes->person[?true]->likes->person;
+		SELECT ->likes[?true]->person as likes FROM person;
 	"#;
 	Test::new(sql)
 		.await?
@@ -105,6 +106,11 @@ async fn idiom_graph_with_filter_should_be_flattened() -> Result<(), Error> {
 		.expect_val("[person:3]")?
 		.expect_val("[person:2]")?
 		.expect_val("[[person:2]]")?
-		.expect_val("[[person:3]]")?;
+		.expect_val("[[person:3]]")?
+		.expect_val("[
+			{likes: [person:2]},
+			{likes: [person:3]},
+			{likes: []},
+		]")?;
 	Ok(())
 }

--- a/sdk/tests/idiom.rs
+++ b/sdk/tests/idiom.rs
@@ -107,10 +107,12 @@ async fn idiom_graph_with_filter_should_be_flattened() -> Result<(), Error> {
 		.expect_val("[person:2]")?
 		.expect_val("[[person:2]]")?
 		.expect_val("[[person:3]]")?
-		.expect_val("[
+		.expect_val(
+			"[
 			{likes: [person:2]},
 			{likes: [person:3]},
 			{likes: []},
-		]")?;
+		]",
+		)?;
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

As pointed out in discord, #5056 did not actually fix the originally reported issue, as the implemented test unknowningly covered a different part of the `.get()` method than originally reported. Both cases should be fixed.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR now also ensures that a graph part with a filter will be flattened when placed directly after a Record ID.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Updated the test and verified that the original test case is covered (the example in the original issue used random ids, hence not ideal for testing). Removed the patch to validate that the updated test now actually catches the original issue too.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] #5055

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
