### PR TITLE
Ensure basic values with optional operator pass through

### DIFF
--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -67,6 +67,9 @@ impl Value {
 							.await?;
 						stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
 					}
+					Part::Optional => {
+						stk.run(|stk| self.get(stk, ctx, opt, doc, path.next())).await
+					}
 					// Otherwise return none
 					_ => Ok(Value::None),
 				},
@@ -184,6 +187,9 @@ impl Value {
 
 						stk.run(|stk| res.get(stk, ctx, opt, doc, path.next())).await
 					}
+					Part::Optional => {
+						stk.run(|stk| self.get(stk, ctx, opt, doc, path.next())).await
+					}
 					_ => Ok(Value::None),
 				},
 				// Current value at path is an array
@@ -261,6 +267,9 @@ impl Value {
 							})
 							.await?;
 						stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
+					}
+					Part::Optional => {
+						stk.run(|stk| self.get(stk, ctx, opt, doc, path.next())).await
 					}
 					_ => {
 						let len = match path.get(1) {
@@ -380,6 +389,9 @@ impl Value {
 									})
 									.await?;
 								stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
+							}
+							Part::Optional => {
+								stk.run(|stk| self.get(stk, ctx, opt, doc, path.next())).await
 							}
 							// This is a remote field expression
 							_ => {

--- a/sdk/tests/helpers.rs
+++ b/sdk/tests/helpers.rs
@@ -457,4 +457,21 @@ impl Test {
 		}
 		Ok(self)
 	}
+
+	/// Expects the next value to be bytes
+	#[track_caller]
+	#[allow(dead_code)]
+	pub fn expect_bytes(&mut self, val: impl Into<Vec<u8>>) -> Result<&mut Self, Error> {
+		self.expect_bytes_info(val, "")
+	}
+
+	pub fn expect_bytes_info<I: Display>(
+		&mut self,
+		val: impl Into<Vec<u8>>,
+		info: I,
+	) -> Result<&mut Self, Error> {
+		let val: Vec<u8> = val.into();
+		let val = Value::Bytes(val.into());
+		self.expect_value_info(val, info)
+	}
 }

--- a/sdk/tests/idiom.rs
+++ b/sdk/tests/idiom.rs
@@ -108,3 +108,56 @@ async fn idiom_graph_with_filter_should_be_flattened() -> Result<(), Error> {
 		.expect_val("[[person:3]]")?;
 	Ok(())
 }
+
+#[tokio::test]
+async fn idiom_optional_after_value_should_pass_through() -> Result<(), Error> {
+	let sql = r#"
+		none?;
+		null?;
+		1?;
+		'a'?;
+		1s?;
+		time::EPOCH?;
+		u'0192fb97-e8ee-7683-8198-95710b103bd5'?;
+		[]?;
+		{}?;
+		(89.0, 90.0)?;
+		<bytes>"hhehehe"?;
+		person:aeon?;
+		{
+			type: "Polygon",
+			coordinates: [[
+				[-111.0690, 45.0032],
+				[-104.0838, 44.9893],
+				[-104.0910, 40.9974],
+				[-111.0672, 40.9862]
+			]]
+		}?;
+	"#;
+	Test::new(sql)
+		.await?
+		.expect_val("none")?
+		.expect_val("null")?
+		.expect_val("1")?
+		.expect_val("'a'")?
+		.expect_val("1s")?
+		.expect_val("d'1970-01-01T00:00:00Z'")?
+		.expect_val("u'0192fb97-e8ee-7683-8198-95710b103bd5'")?
+		.expect_val("[]")?
+		.expect_val("{}")?
+		.expect_val("(89.0, 90.0)")?
+		.expect_bytes(&[104, 104, 101, 104, 101, 104, 101])?
+		.expect_val("person:aeon")?
+		.expect_val(
+			"{
+			type: 'Polygon',
+			coordinates: [[
+				[-111.0690, 45.0032],
+				[-104.0838, 44.9893],
+				[-104.0910, 40.9974],
+				[-111.0672, 40.9862]
+			]]
+		}",
+		)?;
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

As reported by a user, when suffixing certain basic values with an optional idiom part, it will return a `NONE` value where it should pass through the original value.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It adds missing `Part::Optional` implementations in the `.get()` method, and adds a `expect_bytes()` helper utility for tests.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
