### PR TITLE
Use 0.0.0.0:4317 as endpoint

### DIFF
--- a/dev/docker/otel-collector.yaml
+++ b/dev/docker/otel-collector.yaml
@@ -2,6 +2,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
 
 exporters:
   otlp:


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The OTEL collector in the docker file is unable to receive GRPC calls with the default setting. Later versions of the OTEL collector use `localhost:4317` instead of `0.0.0.0:4317`. This GRPC calls from surrealDB are then rejected.

## What does this change do?

 Use `0.0.0.0:4317` instead of the default of `localhost:4317`.

## What is your testing strategy?

I ran the docker compose and surrealdb. Using surrealist a few request were sent. In Grafana the metrics such as `http_server_active_requests` and `http_server_duration` started showing. Previously these were not recorded.

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [X] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
