### PR TITLE
Manually install `onnxruntime` in Nix

### DIFF
--- a/pkg/nix/spec/aarch64-apple-darwin.nix
+++ b/pkg/nix/spec/aarch64-apple-darwin.nix
@@ -10,7 +10,7 @@
 
     nativeBuildInputs = [ cmake pkg-config ];
 
-    buildInputs = [ openssl libiconv darwin.apple_sdk.frameworks.Security ];
+    buildInputs = [ openssl libiconv darwin.apple_sdk.frameworks.Security onnxruntime ];
 
     # From https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/rocksdb/default.nix#LL43C7-L52C6
     NIX_CFLAGS_COMPILE = toString ([
@@ -19,5 +19,7 @@
     ]);
 
     CARGO_BUILD_TARGET = target;
+
+    ONNXRUNTIME_LIB_PATH = "${onnxruntime.outPath}/lib/libonnxruntime.dylib";
   };
 }

--- a/pkg/nix/spec/aarch64-unknown-linux-gnu.nix
+++ b/pkg/nix/spec/aarch64-unknown-linux-gnu.nix
@@ -10,7 +10,7 @@
 
     nativeBuildInputs = [ pkg-config ];
 
-    buildInputs = [ openssl binutils ];
+    buildInputs = [ openssl binutils onnxruntime ];
 
     CARGO_BUILD_TARGET = target;
 
@@ -20,5 +20,7 @@
     PROTOC_INCLUDE = "${protobuf}/include";
 
     OPENSSL_NO_VENDOR = "true";
+
+    ONNXRUNTIME_LIB_PATH = "${onnxruntime.outPath}/lib/libonnxruntime.so";
   };
 }

--- a/pkg/nix/spec/wasm32-unknown-unknown.nix
+++ b/pkg/nix/spec/wasm32-unknown-unknown.nix
@@ -8,8 +8,10 @@
   buildSpec = with pkgs; {
       nativeBuildInputs = [ pkg-config ];
 
-      buildInputs = [ openssl ];
+      buildInputs = [ openssl onnxruntime ];
 
       CARGO_BUILD_TARGET = target;
+
+      ONNXRUNTIME_LIB_PATH = "${onnxruntime.outPath}/lib/libonnxruntime.so";
     };
 }

--- a/pkg/nix/spec/x86_64-apple-darwin.nix
+++ b/pkg/nix/spec/x86_64-apple-darwin.nix
@@ -10,7 +10,7 @@
 
     nativeBuildInputs = [ cmake pkg-config ];
 
-    buildInputs = [ openssl libiconv darwin.apple_sdk.frameworks.Security ];
+    buildInputs = [ openssl libiconv darwin.apple_sdk.frameworks.Security onnxruntime ];
 
     # From https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/rocksdb/default.nix#LL43C7-L52C6
     NIX_CFLAGS_COMPILE = toString ([
@@ -19,5 +19,7 @@
     ]);
 
     CARGO_BUILD_TARGET = target;
+
+    ONNXRUNTIME_LIB_PATH = "${onnxruntime.outPath}/lib/libonnxruntime.dylib";
   };
 }

--- a/pkg/nix/spec/x86_64-pc-windows-gnu.nix
+++ b/pkg/nix/spec/x86_64-pc-windows-gnu.nix
@@ -10,8 +10,10 @@
 
     depsBuildBuild = [ pkgsCross.mingwW64.stdenv.cc ];
 
-    buildInputs = [ pkgsCross.mingwW64.windows.pthreads ];
+    buildInputs = [ pkgsCross.mingwW64.windows.pthreads onnxruntime ];
 
     CARGO_BUILD_TARGET = target;
+
+    ONNXRUNTIME_LIB_PATH = "${onnxruntime.outPath}/lib/onnxruntime.dll";
   };
 }

--- a/pkg/nix/spec/x86_64-unknown-linux-gnu.nix
+++ b/pkg/nix/spec/x86_64-unknown-linux-gnu.nix
@@ -16,7 +16,7 @@
 
       nativeBuildInputs = [ pkg-config ];
 
-      buildInputs = [ openssl ]
+      buildInputs = [ openssl onnxruntime ]
         ++ lib.lists.optional (util.fdbSupported fdbPackages)
         (util.fdbPackage fdbPackages);
 
@@ -26,5 +26,7 @@
       PROTOC_INCLUDE = "${protobuf}/include";
 
       CARGO_BUILD_TARGET = target;
+
+      ONNXRUNTIME_LIB_PATH = "${onnxruntime.outPath}/lib/libonnxruntime.so";
     };
 }

--- a/pkg/nix/spec/x86_64-unknown-linux-musl.nix
+++ b/pkg/nix/spec/x86_64-unknown-linux-musl.nix
@@ -6,7 +6,7 @@
   features = with util.features; [ storage-mem ];
 
   buildSpec = with pkgs; {
-    nativeBuildInputs = with pkgsStatic; [ stdenv.cc openssl ];
+    nativeBuildInputs = with pkgsStatic; [ stdenv.cc openssl onnxruntime ];
 
     CARGO_BUILD_TARGET = target;
 
@@ -17,5 +17,7 @@
 
     PROTOC = "${protobuf}/bin/protoc";
     PROTOC_INCLUDE = "${protobuf}/include";
+
+    ONNXRUNTIME_LIB_PATH = "${onnxruntime.outPath}/lib/libonnxruntime.so";
   };
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

I noticed that building SurrealDB with `surrealml` enabled in a Nix environment resulted in a failed build, because the `surrealml-core` build script could not find the required libraries for `libonnxruntime`. 

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

`surrealml-core`'s build script also accepts a `ONNXRUNTIME_LIB_PATH` environment variable, which can be pointed towards the `libonnxruntime` library file manually. That is what this PR does.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
