### PR TITLE
Improve logs on permission error during bind

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -211,7 +211,7 @@ pub async fn init(ds: Arc<Datastore>, ct: CancellationToken) -> Result<(), Error
 		// Setup the Axum server with TLS
 		let server = axum_server::bind_rustls(opt.bind, tls);
 		// Log the server startup to the CLI
-		info!(target: LOG, "Started web server on {}", opt.bind);
+		info!(target: LOG, "Started web server on {}", &opt.bind);
 		// Start the server and listen for connections
 		server
 			.handle(handle)
@@ -232,7 +232,7 @@ pub async fn init(ds: Arc<Datastore>, ct: CancellationToken) -> Result<(), Error
 	if let Err(e) = res {
 		if opt.bind.port() < 1024 {
 			if let io::ErrorKind::PermissionDenied = e.kind() {
-				error!(target: LOG, "Binding to ports below 1024 requires root privileges.");
+				error!(target: LOG, "Binding to ports below 1024 requires privileged access or special permissions.");
 			}
 		}
 		return Err(e.into());

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -32,6 +32,7 @@ use axum::{middleware, Router};
 use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
 use http::header;
+use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -203,19 +204,19 @@ pub async fn init(ds: Arc<Datastore>, ct: CancellationToken) -> Result<(), Error
 
 	// Spawn a task to handle notifications
 	tokio::spawn(async move { notifications(ds, rpc_state, ct.clone()).await });
-	// If a certificate and key are specified then setup TLS
-	if let (Some(cert), Some(key)) = (&opt.crt, &opt.key) {
+	// If a certificate and key are specified, then setup TLS
+	let res = if let (Some(cert), Some(key)) = (&opt.crt, &opt.key) {
 		// Configure certificate and private key used by https
-		let tls = RustlsConfig::from_pem_file(cert, key).await.unwrap();
+		let tls = RustlsConfig::from_pem_file(cert, key).await?;
 		// Setup the Axum server with TLS
 		let server = axum_server::bind_rustls(opt.bind, tls);
 		// Log the server startup to the CLI
-		info!(target: LOG, "Started web server on {}", &opt.bind);
+		info!(target: LOG, "Started web server on {}", opt.bind);
 		// Start the server and listen for connections
 		server
 			.handle(handle)
 			.serve(axum_app.into_make_service_with_connect_info::<SocketAddr>())
-			.await?;
+			.await
 	} else {
 		// Setup the Axum server
 		let server = axum_server::bind(opt.bind);
@@ -225,8 +226,17 @@ pub async fn init(ds: Arc<Datastore>, ct: CancellationToken) -> Result<(), Error
 		server
 			.handle(handle)
 			.serve(axum_app.into_make_service_with_connect_info::<SocketAddr>())
-			.await?;
+			.await
 	};
+	// Catch the error and try to provide some guidance
+	if let Err(e) = res {
+		if opt.bind.port() < 1024 {
+			if let io::ErrorKind::PermissionDenied = e.kind() {
+				error!(target: LOG, "Binding to ports below 1024 requires root privileges.");
+			}
+		}
+		return Err(e.into());
+	}
 	// Wait for the shutdown to finish
 	let _ = shutdown_handler.await;
 	// Log the server shutdown to the CLI


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When running SurrealDB on a privileged port without sufficient permissions, the error message is somewhat cryptic:

    Couldn't open the specified file: Permission denied (os error 13)


## What does this change do?

When a permission error is caught during server startup, an additional message is displayed:

    Binding to ports below 1024 requires root privileges

```
ekeller@EK-SUR-MBP16 surrealdb % cargo run start --bind 127.0.0.1:80                                           
   Compiling surreal v2.0.4 (/Users/ekeller/github/surrealdb/surrealdb)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.05s
     Running `target/debug/surreal start --bind '127.0.0.1:80'`
┌─────────────────────────────────────────────────────────────────────────────┐
│                     !!! THIS IS A DEVELOPMENT BUILD !!!                     │
│     Development builds are not intended for production use and include      │
│    tooling and features that may affect the performance of the database.    │
└─────────────────────────────────────────────────────────────────────────────┘

 .d8888b.                                             888 8888888b.  888888b.
d88P  Y88b                                            888 888  'Y88b 888  '88b
Y88b.                                                 888 888    888 888  .88P
 'Y888b.   888  888 888d888 888d888  .d88b.   8888b.  888 888    888 8888888K.
    'Y88b. 888  888 888P'   888P'   d8P  Y8b     '88b 888 888    888 888  'Y88b
      '888 888  888 888     888     88888888 .d888888 888 888    888 888    888
Y88b  d88P Y88b 888 888     888     Y8b.     888  888 888 888  .d88P 888   d88P
 'Y8888P'   'Y88888 888     888      'Y8888  'Y888888 888 8888888P'  8888888P'


2024-11-07T18:30:04.245235Z  INFO surreal::env: src/env/mod.rs:12: Running 2.0.4+20241107.5223f81f for macos on aarch64
2024-11-07T18:30:04.245598Z  INFO surrealdb::core::kvs::ds: core/src/kvs/ds.rs:283: Starting kvs store in memory
2024-11-07T18:30:04.246577Z  INFO surrealdb::core::kvs::ds: core/src/kvs/ds.rs:286: Started kvs store in memory
2024-11-07T18:30:04.254755Z  INFO surrealdb::net: src/net/mod.rs:224: Started web server on 127.0.0.1:80
2024-11-07T18:30:04.254801Z  INFO surrealdb::net: src/net/signals.rs:98: Listening for a system shutdown signal.
2024-11-07T18:30:04.254952Z ERROR surrealdb::net: src/net/mod.rs:235: Binding to ports below 1024 requires privileged access or special permissions.
2024-11-07T18:30:04.255015Z ERROR surreal::cli: src/cli/mod.rs:159: Couldn't open the specified file: Permission denied (os error 13)
```


## What is your testing strategy?

Github action

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?


- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
