### PR TITLE
Fix a panic which can be caused by non-valid utf-8

### DIFF
--- a/core/src/syn/lexer/reader.rs
+++ b/core/src/syn/lexer/reader.rs
@@ -130,7 +130,7 @@ impl<'a> BytesReader<'a> {
 				val |= next as u32;
 				char::from_u32(val).ok_or(CharError::Unicode)
 			}
-			_ => return Err(CharError::Unicode),
+			_ => Err(CharError::Unicode),
 		}
 	}
 }

--- a/core/src/syn/lexer/reader.rs
+++ b/core/src/syn/lexer/reader.rs
@@ -130,7 +130,7 @@ impl<'a> BytesReader<'a> {
 				val |= next as u32;
 				char::from_u32(val).ok_or(CharError::Unicode)
 			}
-			x => panic!("start byte did not start multi byte character: {:b}", x),
+			_ => return Err(CharError::Unicode),
 		}
 	}
 }

--- a/core/src/syn/parser/test/mod.rs
+++ b/core/src/syn/parser/test/mod.rs
@@ -3,6 +3,8 @@ use crate::{
 	syn::parser::mac::test_parse,
 };
 
+use super::Parser;
+
 mod json;
 mod limit;
 mod stmt;
@@ -138,4 +140,14 @@ fn micro_second_duration() {
 		4us
 	"#;
 	test_parse!(parse_query, src).unwrap();
+}
+
+#[test]
+fn test_non_valid_utf8() {
+	let mut src = "SELECT * FROM foo;".as_bytes().to_vec();
+	src.push(0xff);
+
+	let mut parser = Parser::new(&src);
+	let mut stack = reblessive::Stack::new();
+	stack.enter(|ctx| parser.parse_query(ctx)).finish().unwrap_err();
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The parser relies on being able to handle non valid utf-8.
However there was a function which panics in some case when non-valid utf-8 is handed to the parser.

## What does this change do?

Returns an error instead of panic.

## What is your testing strategy?

Added a test for the path I could find which could cause the panic.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- Might fix #5065

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
