### PR TITLE
Fix incorrect index in array::reduce

### DIFF
--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -583,14 +583,16 @@ pub async fn reduce(
 			}
 			_ => {
 				// Get the first item
-				let mut iter = array.into_iter().enumerate();
-				let Some((_, mut accum)) = iter.next() else {
+				let mut iter = array.into_iter();
+				let Some(mut accum) = iter.next() else {
 					return Ok(Value::None);
 				};
-				for (i, val) in iter {
+				let mut idx = 0;
+				for val in iter {
 					let fnc =
-						Function::Anonymous(mapper.clone().into(), vec![accum, val, i.into()]);
+						Function::Anonymous(mapper.clone().into(), vec![accum, val, idx.into()]);
 					accum = fnc.compute(stk, ctx, opt, doc).await?;
+					idx += 1;
 				}
 				Ok(accum)
 			}

--- a/core/src/fnc/array.rs
+++ b/core/src/fnc/array.rs
@@ -587,12 +587,10 @@ pub async fn reduce(
 				let Some(mut accum) = iter.next() else {
 					return Ok(Value::None);
 				};
-				let mut idx = 0;
-				for val in iter {
+				for (idx, val) in iter.enumerate() {
 					let fnc =
 						Function::Anonymous(mapper.clone().into(), vec![accum, val, idx.into()]);
 					accum = fnc.compute(stk, ctx, opt, doc).await?;
-					idx += 1;
 				}
 				Ok(accum)
 			}

--- a/sdk/tests/function.rs
+++ b/sdk/tests/function.rs
@@ -695,7 +695,7 @@ async fn function_array_reduce() -> Result<(), Error> {
 
 	// The index can also be accessed in the same way as array::map
 	let sql = r#"
-	[10, 9, 8, 7, 6, 5, 4, 3, 2, 1].reduce(|$one, $two, $three| $one + $two + $three);
+	[10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].reduce(|$one, $two, $three| $one + $two + $three);
 	"#;
 	Test::new(sql).await?.expect_val("100")?;
 
@@ -710,6 +710,14 @@ async fn function_array_reduce() -> Result<(), Error> {
 	[9].reduce(|$x, $y, $z| $x + $y + $z);
 	"#;
 	Test::new(sql).await?.expect_val("9")?;
+
+	let sql = r#"
+	[1,2].reduce(|$x, $y, $idx| $idx)"#;
+	Test::new(sql).await?.expect_val("0")?;
+
+	let sql = r#"
+	[1,2,3].reduce(|$x, $y, $idx| $idx)"#;
+	Test::new(sql).await?.expect_val("1")?;
 
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

array::reduce as I implemented it starts with an index of 1 instead of 0.

## What does this change do?

Pulls the first item out of the iterator and only then calls .enumerate() for the remainder.

## What is your testing strategy?

Added two tests to assert that the final index is 0 in case of two items (one operation) and 1 in case of three items (two operations).

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
