### PR TITLE
Enforce successful conversion from Ident to Role

### DIFF
--- a/core/src/iam/auth.rs
+++ b/core/src/iam/auth.rs
@@ -89,9 +89,10 @@ impl Auth {
 	}
 }
 
-impl std::convert::From<(&DefineUserStatement, Level)> for Auth {
-	fn from(val: (&DefineUserStatement, Level)) -> Self {
-		Self::new((val.0, val.1).into())
+impl std::convert::TryFrom<(&DefineUserStatement, Level)> for Auth {
+	type Error = Error;
+	fn try_from(val: (&DefineUserStatement, Level)) -> Result<Self, Self::Error> {
+		Ok(Self::new((val.0, val.1).try_into()?))
 	}
 }
 

--- a/core/src/iam/entities/resources/actor.rs
+++ b/core/src/iam/entities/resources/actor.rs
@@ -7,7 +7,7 @@ use cedar_policy::{Entity, EntityId, EntityTypeName, EntityUid, RestrictedExpres
 use serde::{Deserialize, Serialize};
 
 use super::{Level, Resource, ResourceKind};
-use crate::iam::Role;
+use crate::iam::{Error, Role};
 use crate::sql::statements::{DefineAccessStatement, DefineUserStatement};
 
 //
@@ -118,9 +118,11 @@ impl std::convert::From<&Actor> for Entity {
 	}
 }
 
-impl std::convert::From<(&DefineUserStatement, Level)> for Actor {
-	fn from(val: (&DefineUserStatement, Level)) -> Self {
-		Self::new(val.0.name.to_string(), val.0.roles.iter().map(Role::from).collect(), val.1)
+impl std::convert::TryFrom<(&DefineUserStatement, Level)> for Actor {
+	type Error = Error;
+	fn try_from(val: (&DefineUserStatement, Level)) -> Result<Self, Self::Error> {
+		let roles = val.0.roles.iter().map(Role::try_from).collect::<Result<_, _>>()?;
+		Ok(Self::new(val.0.name.to_string(), roles, val.1))
 	}
 }
 

--- a/core/src/iam/entities/roles.rs
+++ b/core/src/iam/entities/roles.rs
@@ -39,9 +39,10 @@ impl FromStr for Role {
 	}
 }
 
-impl std::convert::From<&Ident> for Role {
-	fn from(id: &Ident) -> Self {
-		Role::from_str(id).unwrap()
+impl std::convert::TryFrom<&Ident> for Role {
+	type Error = Error;
+	fn try_from(id: &Ident) -> Result<Self, Self::Error> {
+		Role::from_str(id)
 	}
 }
 

--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -3436,4 +3436,102 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			}
 		}
 	}
+
+	#[tokio::test]
+	async fn test_signin_nonexistent_role() {
+		use crate::iam::Error as IamError;
+		use crate::sql::{
+			statements::{define::DefineStatement, DefineUserStatement},
+			user::UserDuration,
+			Base, Statement,
+		};
+		let test_levels = vec![
+			TestLevel {
+				level: "ROOT",
+				ns: None,
+				db: None,
+			},
+			TestLevel {
+				level: "NS",
+				ns: Some("test"),
+				db: None,
+			},
+			TestLevel {
+				level: "DB",
+				ns: Some("test"),
+				db: Some("test"),
+			},
+		];
+
+		for level in &test_levels {
+			let ds = Datastore::new("memory").await.unwrap();
+			let sess = Session::owner().with_ns("test").with_db("test");
+
+			let base = match level.level {
+				"ROOT" => Base::Root,
+				"NS" => Base::Ns,
+				"DB" => Base::Db,
+				_ => panic!("Unsupported level"),
+			};
+
+			let user = DefineUserStatement {
+				base,
+				name: "user".into(),
+				// This is the Argon2id hash for "pass" with a random salt.
+				hash: "$argon2id$v=19$m=16,t=2,p=1$VUlHTHVOYjc5d0I1dGE3OQ$sVtmRNH+Xtiijk0uXL2+4w"
+					.to_string(),
+				code: "dummy".to_string(),
+				roles: vec!["nonexistent".into()],
+				duration: UserDuration::default(),
+				comment: None,
+				if_not_exists: false,
+				overwrite: false,
+			};
+
+			// Use pre-parsed definition, which bypasses the existent role check during parsing.
+			ds.process(Statement::Define(DefineStatement::User(user)).into(), &sess, None)
+				.await
+				.unwrap();
+
+			let mut sess = Session {
+				ns: level.ns.map(String::from),
+				db: level.db.map(String::from),
+				..Default::default()
+			};
+
+			// Sign in using the newly defined user.
+			let res = match level.level {
+				"ROOT" => root_user(&ds, &mut sess, "user".to_string(), "pass".to_string()).await,
+				"NS" => {
+					ns_user(
+						&ds,
+						&mut sess,
+						level.ns.unwrap().to_string(),
+						"user".to_string(),
+						"pass".to_string(),
+					)
+					.await
+				}
+				"DB" => {
+					db_user(
+						&ds,
+						&mut sess,
+						level.ns.unwrap().to_string(),
+						level.db.unwrap().to_string(),
+						"user".to_string(),
+						"pass".to_string(),
+					)
+					.await
+				}
+				_ => panic!("Unsupported level"),
+			};
+
+			match res {
+				Err(Error::IamError(IamError::InvalidRole(_))) => {} // ok
+				res => {
+					panic!("Expected an invalid role IAM error, but instead received: {:?}", res)
+				}
+			}
+		}
+	}
 }

--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -317,7 +317,7 @@ pub async fn db_access(
 						access::Subject::User(user) => {
 							session.au = Arc::new(Auth::new(Actor::new(
 								user.to_string(),
-								roles.iter().map(Role::from).collect(),
+								roles.iter().map(Role::try_from).collect::<Result<_, _>>()?,
 								Level::Database(ns, db),
 							)));
 						}
@@ -377,7 +377,7 @@ pub async fn db_user(
 			session.ns = Some(ns.to_owned());
 			session.db = Some(db.to_owned());
 			session.exp = expiration(u.duration.session)?;
-			session.au = Arc::new((&u, Level::Database(ns.to_owned(), db.to_owned())).into());
+			session.au = Arc::new((&u, Level::Database(ns.to_owned(), db.to_owned())).try_into()?);
 			// Check the authentication token
 			match enc {
 				// The auth token was created successfully
@@ -506,7 +506,7 @@ pub async fn ns_access(
 						access::Subject::User(user) => {
 							session.au = Arc::new(Auth::new(Actor::new(
 								user.to_string(),
-								roles.iter().map(Role::from).collect(),
+								roles.iter().map(Role::try_from).collect::<Result<_, _>>()?,
 								Level::Namespace(ns),
 							)));
 						}
@@ -557,7 +557,7 @@ pub async fn ns_user(
 			session.tk = Some((&val).into());
 			session.ns = Some(ns.to_owned());
 			session.exp = expiration(u.duration.session)?;
-			session.au = Arc::new((&u, Level::Namespace(ns.to_owned())).into());
+			session.au = Arc::new((&u, Level::Namespace(ns.to_owned())).try_into()?);
 			// Check the authentication token
 			match enc {
 				// The auth token was created successfully
@@ -602,7 +602,7 @@ pub async fn root_user(
 			// Set the authentication on the session
 			session.tk = Some(val.into());
 			session.exp = expiration(u.duration.session)?;
-			session.au = Arc::new((&u, Level::Root).into());
+			session.au = Arc::new((&u, Level::Root).try_into()?);
 			// Check the authentication token
 			match enc {
 				// The auth token was created successfully
@@ -727,7 +727,7 @@ pub async fn root_access(
 						access::Subject::User(user) => {
 							session.au = Arc::new(Auth::new(Actor::new(
 								user.to_string(),
-								roles.iter().map(Role::from).collect(),
+								roles.iter().map(Role::try_from).collect::<Result<_, _>>()?,
 								Level::Root,
 							)));
 						}

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -95,7 +95,8 @@ pub async fn basic(
 			Ok(u) => {
 				debug!("Authenticated as database user '{}'", user);
 				session.exp = expiration(u.duration.session)?;
-				session.au = Arc::new((&u, Level::Database(ns.to_owned(), db.to_owned())).into());
+				session.au =
+					Arc::new((&u, Level::Database(ns.to_owned(), db.to_owned())).try_into()?);
 				Ok(())
 			}
 			Err(err) => Err(err),
@@ -105,7 +106,7 @@ pub async fn basic(
 			Ok(u) => {
 				debug!("Authenticated as namespace user '{}'", user);
 				session.exp = expiration(u.duration.session)?;
-				session.au = Arc::new((&u, Level::Namespace(ns.to_owned())).into());
+				session.au = Arc::new((&u, Level::Namespace(ns.to_owned())).try_into()?);
 				Ok(())
 			}
 			Err(err) => Err(err),
@@ -115,7 +116,7 @@ pub async fn basic(
 			Ok(u) => {
 				debug!("Authenticated as root user '{}'", user);
 				session.exp = expiration(u.duration.session)?;
-				session.au = Arc::new((&u, Level::Root).into());
+				session.au = Arc::new((&u, Level::Root).try_into()?);
 				Ok(())
 			}
 			Err(err) => Err(err),
@@ -365,7 +366,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			session.exp = expiration(de.duration.session)?;
 			session.au = Arc::new(Auth::new(Actor::new(
 				id.to_string(),
-				de.roles.iter().map(|r| r.into()).collect(),
+				de.roles.iter().map(Role::try_from).collect::<Result<_, _>>()?,
 				Level::Database(ns.to_string(), db.to_string()),
 			)));
 			Ok(())
@@ -467,7 +468,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			session.exp = expiration(de.duration.session)?;
 			session.au = Arc::new(Auth::new(Actor::new(
 				id.to_string(),
-				de.roles.iter().map(|r| r.into()).collect(),
+				de.roles.iter().map(Role::try_from).collect::<Result<_, _>>()?,
 				Level::Namespace(ns.to_string()),
 			)));
 			Ok(())
@@ -561,7 +562,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			session.exp = expiration(de.duration.session)?;
 			session.au = Arc::new(Auth::new(Actor::new(
 				id.to_string(),
-				de.roles.iter().map(|r| r.into()).collect(),
+				de.roles.iter().map(Role::try_from).collect::<Result<_, _>>()?,
 				Level::Root,
 			)));
 			Ok(())

--- a/core/src/syn/parser/stmt/define.rs
+++ b/core/src/syn/parser/stmt/define.rs
@@ -238,6 +238,7 @@ impl Parser<'_> {
 				}
 				t!("ROLES") => {
 					self.pop_peek();
+					let mut roles = Vec::new();
 					loop {
 						let token = self.peek();
 						let role = self.next_token_value::<Ident>()?;
@@ -248,9 +249,10 @@ impl Parser<'_> {
 						if !matches!(role.to_lowercase().as_str(), "viewer" | "editor" | "owner") {
 							unexpected!(self, token, "an existent role");
 						}
-						res.roles.push(role);
+						roles.push(role);
 
 						if !self.eat(t!(",")) {
+							res.roles = roles;
 							break;
 						}
 					}

--- a/core/src/syn/parser/stmt/define.rs
+++ b/core/src/syn/parser/stmt/define.rs
@@ -238,9 +238,21 @@ impl Parser<'_> {
 				}
 				t!("ROLES") => {
 					self.pop_peek();
-					res.roles = vec![self.next_token_value()?];
-					while self.eat(t!(",")) {
-						res.roles.push(self.next_token_value()?);
+					loop {
+						let token = self.peek();
+						let role = self.next_token_value::<Ident>()?;
+						// NOTE(gguillemas): This hardcoded list is a temporary fix in order
+						// to avoid making breaking changes to the DefineUserStatement structure
+						// while still providing parsing feedback to users referencing unexistent roles.
+						// This list should be removed once arbitrary roles can be defined by users.
+						if !matches!(role.to_lowercase().as_str(), "viewer" | "editor" | "owner") {
+							unexpected!(self, token, "an existent role");
+						}
+						res.roles.push(role);
+
+						if !self.eat(t!(",")) {
+							break;
+						}
 					}
 				}
 				t!("DURATION") => {

--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -291,14 +291,7 @@ fn parse_define_user() {
 		assert_eq!(stmt.name, Ident("user".to_string()));
 		assert_eq!(stmt.base, Base::Root);
 		assert_eq!(stmt.hash, "hunter2".to_owned());
-		assert_eq!(
-			stmt.roles,
-			vec![
-				Ident("Viewer".to_string()),
-				Ident("editor".to_string()),
-				Ident("OWNER".to_string())
-			]
-		);
+		assert_eq!(stmt.roles, vec![Ident("editor".to_string()), Ident("OWNER".to_string())]);
 		assert_eq!(
 			stmt.duration,
 			UserDuration {

--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -280,7 +280,7 @@ fn parse_define_user() {
 	{
 		let res = test_parse!(
 			parse_stmt,
-			r#"DEFINE USER user ON ROOT COMMENT 'test' PASSHASH 'hunter2' ROLES foo, bar"#
+			r#"DEFINE USER user ON ROOT COMMENT 'test' PASSHASH 'hunter2' ROLES editor, OWNER"#
 		)
 		.unwrap();
 
@@ -291,7 +291,14 @@ fn parse_define_user() {
 		assert_eq!(stmt.name, Ident("user".to_string()));
 		assert_eq!(stmt.base, Base::Root);
 		assert_eq!(stmt.hash, "hunter2".to_owned());
-		assert_eq!(stmt.roles, vec![Ident("foo".to_string()), Ident("bar".to_string())]);
+		assert_eq!(
+			stmt.roles,
+			vec![
+				Ident("Viewer".to_string()),
+				Ident("editor".to_string()),
+				Ident("OWNER".to_string())
+			]
+		);
 		assert_eq!(
 			stmt.duration,
 			UserDuration {
@@ -357,6 +364,30 @@ fn parse_define_user() {
 		assert!(
 			res.is_err(),
 			"Unexpected successful parsing of user with none token duration: {:?}",
+			res
+		);
+	}
+	// With nonexistent role.
+	{
+		let res = test_parse!(
+			parse_stmt,
+			r#"DEFINE USER user ON ROOT COMMENT 'test' PASSHASH 'hunter2' ROLES foo"#
+		);
+		assert!(
+			res.is_err(),
+			"Unexpected successful parsing of user with nonexistent role: {:?}",
+			res
+		);
+	}
+	// With existent and nonexistent roles.
+	{
+		let res = test_parse!(
+			parse_stmt,
+			r#"DEFINE USER user ON ROOT COMMENT 'test' PASSHASH 'hunter2' ROLES Viewer, foo"#
+		);
+		assert!(
+			res.is_err(),
+			"Unexpected successful parsing of user with nonexistent role: {:?}",
 			res
 		);
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To provide an alternative resolution to #5072 which, unlike #5079, does not introduce any potentially breaking changes other than the fact that nonexistent roles (which would result in a panic) will no longer be accepted when defining a user.

## What does this change do?

Implements `TryFrom` instead of `From` for converting from `Ident` to `Role`. Replaces all calls to `into()` for `try_into()` and propagates the potentially resulting `InvalidRole` error to the caller. Since this error can be triggered only after user authentication has been successful, it is safe to return it to the client instead of the generic `InvalidAuth`. This error will also be extremely helpful to users who may have defined a user with nonexistent roles in an older version of SurrealDB.

## What is your testing strategy?

- Implement tests to ensure nonexistent roles are no longer accepted when defining a user.
- Implement tests to ensure that signing in with a user with nonexistent roles fails without a panic.
- Implement tests to ensure that authenticating with a token with nonexistent roles fails without a panic.

## Is this related to any issues?

Resolves #5072.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
