### PR TITLE
Allow Unicode 3.0 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -85,8 +85,8 @@ allow = [
 	"Apache-2.0",
 	"BSD-2-Clause",
 	"BSD-3-Clause",
-	"BSD-2-Clause",
 	"Unlicense",
+    "Unicode-3.0",
 ]
 # The confidence threshold for detecting a license from license text.
 confidence-threshold = 0.95


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To allow [the Unicode 3.0 license](https://www.unicode.org/license.txt) in SurrealDB dependencies. This license is used by some new dependencies.

## What does this change do?

- Adds Unicode 3.0 to the list of allowed licenses for Cargo Deny.
- Removes the duplicated reference to the 2-clause BSD license.

## What is your testing strategy?

Ensure that Cargo Deny passes.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
