### PR TITLE
Remove execution-time parsing from RPC protocol

### DIFF
--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -843,7 +843,7 @@ impl Transaction {
 		.try_into_lvs()
 	}
 
-	/// Retrieve a specific namespace definition.
+	/// Retrieve a specific node in the cluster.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip(self))]
 	pub async fn get_node(&self, id: Uuid) -> Result<Arc<Node>, Error> {
 		let key = crate::key::root::nd::new(id).encode()?;

--- a/core/src/rpc/method.rs
+++ b/core/src/rpc/method.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum Method {
 	Unknown,

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -853,7 +853,6 @@ pub trait RpcContext {
 			.into(),
 			_ => Function::Normal(name, args).into(),
 		};
-		//
 		// Specify the query variables
 		let vars = Some(self.vars().clone());
 		// Execute the function on the database

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -343,7 +343,6 @@ pub trait RpcContext {
 		};
 		// Specify the SQL query string
 		let sql = InsertStatement {
-			into: Some(what.could_be_table()),
 			into: match what.is_none_or_null() {
 				false => Some(what.could_be_table()),
 				true => None,
@@ -677,7 +676,7 @@ pub trait RpcContext {
 		}
 		// Specify the query variables
 		let vars = match vars {
-			Value::Object(v) => Some(mrg! {v.0, &self.vars()}),
+			Value::Object(mut v) => Some(mrg! {v.0, &self.vars()}),
 			Value::None | Value::Null => Some(self.vars().clone()),
 			_ => return Err(RpcError::InvalidParams),
 		};

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -292,7 +292,7 @@ pub trait RpcContext {
 			// LIVE SELECT DIFF FROM $what
 			LiveStatement {
 				expr: Fields::default(),
-				what: vec![what.could_be_table()].into(),
+				what: what.could_be_table(),
 				..Default::default()
 			}
 			.into()
@@ -300,7 +300,7 @@ pub trait RpcContext {
 			// LIVE SELECT * FROM $what
 			LiveStatement {
 				expr: Fields::all(),
-				what: vec![what.could_be_table()].into(),
+				what: what.could_be_table(),
 				..Default::default()
 			}
 			.into()

--- a/core/src/rpc/rpc_context.rs
+++ b/core/src/rpc/rpc_context.rs
@@ -272,17 +272,14 @@ pub trait RpcContext {
 		let sql = {
 			// KILL $id
 			KillStatement {
-				id: Value::Param("id".into()),
+				id,
 			}
 			.into()
 		};
 		// Specify the query parameters
-		let var = map! {
-			String::from("id") => id,
-			=> &self.vars()
-		};
+		let var = Some(self.vars().clone());
 		// Execute the query on the database
-		let mut res = self.query_inner(Value::Query(sql), Some(var)).await?;
+		let mut res = self.query_inner(Value::Query(sql), var).await?;
 		// Extract the first query result
 		Ok(res.remove(0).result?.into())
 	}
@@ -295,7 +292,7 @@ pub trait RpcContext {
 			// LIVE SELECT DIFF FROM $what
 			LiveStatement {
 				expr: Fields::default(),
-				what: vec![Value::Param("what".into())].into(),
+				what: vec![what.could_be_table()].into(),
 				..Default::default()
 			}
 			.into()
@@ -303,18 +300,15 @@ pub trait RpcContext {
 			// LIVE SELECT * FROM $what
 			LiveStatement {
 				expr: Fields::all(),
-				what: vec![Value::Param("what".into())].into(),
+				what: vec![what.could_be_table()].into(),
 				..Default::default()
 			}
 			.into()
 		};
 		// Specify the query parameters
-		let var = map! {
-			String::from("what") => what.could_be_table(),
-			=> &self.vars()
-		};
+		let var = Some(self.vars().clone());
 		// Execute the query on the database
-		let mut res = self.query_inner(Value::Query(sql), Some(var)).await?;
+		let mut res = self.query_inner(Value::Query(sql), var).await?;
 		// Extract the first query result
 		Ok(res.remove(0).result?.into())
 	}
@@ -328,30 +322,23 @@ pub trait RpcContext {
 		let Ok(what) = params.needs_one() else {
 			return Err(RpcError::InvalidParams);
 		};
-		// Return a single result?
-		let one = what.is_thing_single();
 		// Specify the SQL query string
 		let sql = {
 			// SELECT * FROM $what
 			SelectStatement {
+				only: what.is_thing_single(),
 				expr: Fields::all(),
-				what: vec![Value::Param("what".into())].into(),
+				what: vec![what.could_be_table()].into(),
 				..Default::default()
 			}
 			.into()
 		};
 		// Specify the query parameters
-		let var = Some(map! {
-			String::from("what") => what.could_be_table(),
-			=> &self.vars()
-		});
+		let var = Some(self.vars().clone());
 		// Execute the query on the database
 		let mut res = self.kvs().process(sql, self.session(), var).await?;
 		// Extract the first query result
-		Ok(match one {
-			true => res.remove(0).result?.first().into(),
-			false => res.remove(0).result?.into(),
-		})
+		Ok(res.remove(0).result?.into())
 	}
 
 	// ------------------------------
@@ -363,49 +350,32 @@ pub trait RpcContext {
 		let Ok((what, data)) = params.needs_two() else {
 			return Err(RpcError::InvalidParams);
 		};
-		// Process the insert request
-		let mut res = match what {
+		// Specify the SQL query string
+		let sql = match what {
 			Value::None | Value::Null => {
-				// Specify the SQL query string
-				let sql = {
-					// INSERT $data RETURN AFTER
-					InsertStatement {
-						data: crate::sql::Data::SingleExpression(Value::Param("data".into())),
-						output: Some(Output::After),
-						..Default::default()
-					}
-					.into()
-				};
-				// Specify the query parameters
-				let var = Some(map! {
-					String::from("data") => data,
-					=> &self.vars()
-				});
-				// Execute the query on the database
-				self.kvs().process(sql, self.session(), var).await?
+				// INSERT $data RETURN AFTER
+				InsertStatement {
+					data: crate::sql::Data::SingleExpression(data),
+					output: Some(Output::After),
+					..Default::default()
+				}
+				.into()
 			}
 			what => {
-				// Specify the SQL query string
-				let sql = {
-					// INSERT INTO $what $data RETURN AFTER
-					InsertStatement {
-						into: Some(Value::Param("what".into())),
-						data: crate::sql::Data::SingleExpression(Value::Param("data".into())),
-						output: Some(Output::After),
-						..Default::default()
-					}
-					.into()
-				};
-				// Specify the query parameters
-				let var = Some(map! {
-					String::from("what") => what.could_be_table(),
-					String::from("data") => data,
-					=> &self.vars()
-				});
-				// Execute the query on the database
-				self.kvs().process(sql, self.session(), var).await?
+				// INSERT INTO $what $data RETURN AFTER
+				InsertStatement {
+					into: Some(what.could_be_table()),
+					data: crate::sql::Data::SingleExpression(data),
+					output: Some(Output::After),
+					..Default::default()
+				}
+				.into()
 			}
 		};
+		// Specify the query parameters
+		let var = Some(self.vars().clone());
+		// Execute the query on the database
+		let mut res = self.kvs().process(sql, self.session(), var).await?;
 		// Extract the first query result
 		Ok(res.remove(0).result?.into())
 	}
@@ -415,52 +385,35 @@ pub trait RpcContext {
 		let Ok((what, data)) = params.needs_two() else {
 			return Err(RpcError::InvalidParams);
 		};
-		// Process the insert request
-		let mut res = match what {
+		// Specify the SQL query string
+		let sql = match what {
 			Value::None | Value::Null => {
-				// Specify the SQL query string
-				let sql = {
-					// INSERT RELATION $data RETURN AFTER
-					InsertStatement {
-						relation: true,
-						data: crate::sql::Data::SingleExpression(Value::Param("data".into())),
-						output: Some(Output::After),
-						..Default::default()
-					}
-					.into()
-				};
-				// Specify the query parameters
-				let vars = Some(map! {
-					String::from("data") => data,
-					=> &self.vars()
-				});
-				// Execute the query on the database
-				self.kvs().process(sql, self.session(), vars).await?
+				// INSERT RELATION $data RETURN AFTER
+				InsertStatement {
+					relation: true,
+					data: crate::sql::Data::SingleExpression(data),
+					output: Some(Output::After),
+					..Default::default()
+				}
+				.into()
 			}
 			Value::Table(_) | Value::Strand(_) => {
-				// Specify the SQL query string
-				let sql = {
-					// INSERT RELATION INTO $what $data RETURN AFTER
-					InsertStatement {
-						relation: true,
-						into: Some(Value::Param("what".into())),
-						data: crate::sql::Data::SingleExpression(Value::Param("data".into())),
-						output: Some(Output::After),
-						..Default::default()
-					}
-					.into()
-				};
-				// Specify the query parameters
-				let vars = Some(map! {
-					String::from("data") => data,
-					String::from("what") => what.could_be_table(),
-					=> &self.vars()
-				});
-				// Execute the query on the database
-				self.kvs().process(sql, self.session(), vars).await?
+				// INSERT RELATION INTO $what $data RETURN AFTER
+				InsertStatement {
+					relation: true,
+					into: Some(what.could_be_table()),
+					data: crate::sql::Data::SingleExpression(data),
+					output: Some(Output::After),
+					..Default::default()
+				}
+				.into()
 			}
 			_ => return Err(RpcError::InvalidParams),
 		};
+		// Specify the query parameters
+		let var = Some(self.vars().clone());
+		// Execute the query on the database
+		let mut res = self.kvs().process(sql, self.session(), var).await?;
 		// Extract the first query result
 		Ok(res.remove(0).result?.into())
 	}
@@ -475,13 +428,12 @@ pub trait RpcContext {
 			return Err(RpcError::InvalidParams);
 		};
 		let what = what.could_be_table();
-		// Return a single result?
-		let one = what.is_thing_single() || what.is_table();
 		// Specify the SQL query string
 		let sql = if data.is_none_or_null() {
 			// CREATE $what RETURN AFTER
 			CreateStatement {
-				what: vec![Value::Param("what".into())].into(),
+				only: what.is_thing_single() || what.is_table(),
+				what: vec![what.could_be_table()].into(),
 				output: Some(Output::After),
 				..Default::default()
 			}
@@ -489,26 +441,20 @@ pub trait RpcContext {
 		} else {
 			// CREATE $what CONTENT $data RETURN AFTER
 			CreateStatement {
-				what: vec![Value::Param("what".into())].into(),
-				data: Some(crate::sql::Data::MergeExpression(Value::Param("data".into()))),
+				only: what.is_thing_single() || what.is_table(),
+				what: vec![what.could_be_table()].into(),
+				data: Some(crate::sql::Data::MergeExpression(data)),
 				output: Some(Output::After),
 				..Default::default()
 			}
 			.into()
 		};
 		// Specify the query parameters
-		let var = Some(map! {
-			String::from("what") => what,
-			String::from("data") => data,
-			=> &self.vars()
-		});
+		let var = Some(self.vars().clone());
 		// Execute the query on the database
 		let mut res = self.kvs().process(sql, self.session(), var).await?;
 		// Extract the first query result
-		Ok(match one {
-			true => res.remove(0).result?.first().into(),
-			false => res.remove(0).result?.into(),
-		})
+		Ok(res.remove(0).result?.into())
 	}
 
 	// ------------------------------
@@ -520,13 +466,12 @@ pub trait RpcContext {
 		let Ok((what, data)) = params.needs_one_or_two() else {
 			return Err(RpcError::InvalidParams);
 		};
-		// Return a single result?
-		let one = what.is_thing_single();
 		// Specify the SQL query string
 		let sql = if data.is_none_or_null() {
 			// UPSERT $what RETURN AFTER
 			UpsertStatement {
-				what: vec![Value::Param("what".into())].into(),
+				only: what.is_thing_single(),
+				what: vec![what.could_be_table()].into(),
 				output: Some(Output::After),
 				..Default::default()
 			}
@@ -534,26 +479,20 @@ pub trait RpcContext {
 		} else {
 			// UPSERT $what CONTENT $data RETURN AFTER
 			UpsertStatement {
-				what: vec![Value::Param("what".into())].into(),
-				data: Some(crate::sql::Data::ContentExpression(Value::Param("data".into()))),
+				only: what.is_thing_single(),
+				what: vec![what.could_be_table()].into(),
+				data: Some(crate::sql::Data::ContentExpression(data)),
 				output: Some(Output::After),
 				..Default::default()
 			}
 			.into()
 		};
 		// Specify the query parameters
-		let var = Some(map! {
-			String::from("what") => what.could_be_table(),
-			String::from("data") => data,
-			=> &self.vars()
-		});
+		let var = Some(self.vars().clone());
 		// Execute the query on the database
 		let mut res = self.kvs().process(sql, self.session(), var).await?;
 		// Extract the first query result
-		Ok(match one {
-			true => res.remove(0).result?.first().into(),
-			false => res.remove(0).result?.into(),
-		})
+		Ok(res.remove(0).result?.into())
 	}
 
 	// ------------------------------
@@ -565,13 +504,12 @@ pub trait RpcContext {
 		let Ok((what, data)) = params.needs_one_or_two() else {
 			return Err(RpcError::InvalidParams);
 		};
-		// Return a single result?
-		let one = what.is_thing_single();
 		// Specify the SQL query string
 		let sql = if data.is_none_or_null() {
 			// UPDATE $what RETURN AFTER
 			UpdateStatement {
-				what: vec![Value::Param("what".into())].into(),
+				only: what.is_thing_single(),
+				what: vec![what.could_be_table()].into(),
 				output: Some(Output::After),
 				..Default::default()
 			}
@@ -579,26 +517,20 @@ pub trait RpcContext {
 		} else {
 			// UPDATE $what CONTENT $data RETURN AFTER
 			UpdateStatement {
-				what: vec![Value::Param("what".into())].into(),
-				data: Some(crate::sql::Data::ContentExpression(Value::Param("data".into()))),
+				only: what.is_thing_single(),
+				what: vec![what.could_be_table()].into(),
+				data: Some(crate::sql::Data::ContentExpression(data)),
 				output: Some(Output::After),
 				..Default::default()
 			}
 			.into()
 		};
 		// Specify the query parameters
-		let var = Some(map! {
-			String::from("what") => what.could_be_table(),
-			String::from("data") => data,
-			=> &self.vars()
-		});
+		let var = Some(self.vars().clone());
 		// Execute the query on the database
 		let mut res = self.kvs().process(sql, self.session(), var).await?;
 		// Extract the first query result
-		Ok(match one {
-			true => res.remove(0).result?.first().into(),
-			false => res.remove(0).result?.into(),
-		})
+		Ok(res.remove(0).result?.into())
 	}
 
 	// ------------------------------
@@ -610,13 +542,12 @@ pub trait RpcContext {
 		let Ok((what, data)) = params.needs_one_or_two() else {
 			return Err(RpcError::InvalidParams);
 		};
-		// Return a single result?
-		let one = what.is_thing_single();
 		// Specify the SQL query string
 		let sql = if data.is_none_or_null() {
 			// UPDATE $what RETURN AFTER
 			UpdateStatement {
-				what: vec![Value::Param("what".into())].into(),
+				only: what.is_thing_single(),
+				what: vec![what.could_be_table()].into(),
 				output: Some(Output::After),
 				..Default::default()
 			}
@@ -624,26 +555,20 @@ pub trait RpcContext {
 		} else {
 			// UPDATE $what MERGE $data RETURN AFTER
 			UpdateStatement {
-				what: vec![Value::Param("what".into())].into(),
-				data: Some(crate::sql::Data::MergeExpression(Value::Param("data".into()))),
+				only: what.is_thing_single(),
+				what: vec![what.could_be_table()].into(),
+				data: Some(crate::sql::Data::MergeExpression(data)),
 				output: Some(Output::After),
 				..Default::default()
 			}
 			.into()
 		};
 		// Specify the query parameters
-		let var = Some(map! {
-			String::from("what") => what.could_be_table(),
-			String::from("data") => data,
-			=> &self.vars()
-		});
+		let var = Some(self.vars().clone());
 		// Execute the query on the database
 		let mut res = self.kvs().process(sql, self.session(), var).await?;
 		// Extract the first query result
-		Ok(match one {
-			true => res.remove(0).result?.first().into(),
-			false => res.remove(0).result?.into(),
-		})
+		Ok(res.remove(0).result?.into())
 	}
 
 	// ------------------------------
@@ -655,14 +580,13 @@ pub trait RpcContext {
 		let Ok((what, data, diff)) = params.needs_one_two_or_three() else {
 			return Err(RpcError::InvalidParams);
 		};
-		// Return a single result?
-		let one = what.is_thing_single();
 		// Specify the SQL query string
 		let sql = if diff.is_true() {
 			// UPDATE $what PATCH $data RETURN DIFF
 			UpdateStatement {
-				what: vec![Value::Param("what".into())].into(),
-				data: Some(crate::sql::Data::PatchExpression(Value::Param("data".into()))),
+				only: what.is_thing_single(),
+				what: vec![what.could_be_table()].into(),
+				data: Some(crate::sql::Data::PatchExpression(data)),
 				output: Some(Output::Diff),
 				..Default::default()
 			}
@@ -670,26 +594,20 @@ pub trait RpcContext {
 		} else {
 			// UPDATE $what PATCH $data RETURN AFTER
 			UpdateStatement {
-				what: vec![Value::Param("what".into())].into(),
-				data: Some(crate::sql::Data::PatchExpression(Value::Param("data".into()))),
+				only: what.is_thing_single(),
+				what: vec![what.could_be_table()].into(),
+				data: Some(crate::sql::Data::PatchExpression(data)),
 				output: Some(Output::After),
 				..Default::default()
 			}
 			.into()
 		};
 		// Specify the query parameters
-		let var = Some(map! {
-			String::from("what") => what.could_be_table(),
-			String::from("data") => data,
-			=> &self.vars()
-		});
+		let var = Some(self.vars().clone());
 		// Execute the query on the database
 		let mut res = self.kvs().process(sql, self.session(), var).await?;
 		// Extract the first query result
-		Ok(match one {
-			true => res.remove(0).result?.first().into(),
-			false => res.remove(0).result?.into(),
-		})
+		Ok(res.remove(0).result?.into())
 	}
 
 	// ------------------------------
@@ -698,49 +616,40 @@ pub trait RpcContext {
 
 	async fn relate(&self, params: Array) -> Result<Data, RpcError> {
 		// Process the method arguments
-		let Ok((from, kind, to, data)) = params.needs_three_or_four() else {
+		let Ok((from, kind, with, data)) = params.needs_three_or_four() else {
 			return Err(RpcError::InvalidParams);
 		};
-		// Return a single result?
-		let one = from.is_single() && to.is_single();
 		// Specify the SQL query string
 		let sql = if data.is_none_or_null() {
-			// RELATE $from->$kind->$to RETURN AFTER
+			// RELATE $from->$kind->$with RETURN AFTER
 			RelateStatement {
-				from: Value::Param("from".into()),
-				kind: Value::Param("kind".into()),
-				with: Value::Param("to".into()),
+				only: from.is_single() && with.is_single(),
+				from,
+				kind: kind.could_be_table(),
+				with,
 				output: Some(Output::After),
 				..Default::default()
 			}
 			.into()
 		} else {
-			// RELATE $from->$kind->$to CONTENT $data RETURN AFTER
+			// RELATE $from->$kind->$with CONTENT $data RETURN AFTER
 			RelateStatement {
-				from: Value::Param("from".into()),
-				kind: Value::Param("kind".into()),
-				with: Value::Param("to".into()),
-				data: Some(crate::sql::Data::ContentExpression(Value::Param("data".into()))),
+				only: from.is_single() && with.is_single(),
+				from,
+				kind: kind.could_be_table(),
+				with,
+				data: Some(crate::sql::Data::ContentExpression(data)),
 				output: Some(Output::After),
 				..Default::default()
 			}
 			.into()
 		};
 		// Specify the query parameters
-		let var = Some(map! {
-			String::from("from") => from,
-			String::from("kind") => kind.could_be_table(),
-			String::from("to") => to,
-			String::from("data") => data,
-			=> &self.vars()
-		});
+		let var = Some(self.vars().clone());
 		// Execute the query on the database
 		let mut res = self.kvs().process(sql, self.session(), var).await?;
 		// Extract the first query result
-		Ok(match one {
-			true => res.remove(0).result?.first().into(),
-			false => res.remove(0).result?.into(),
-		})
+		Ok(res.remove(0).result?.into())
 	}
 
 	// ------------------------------
@@ -752,30 +661,23 @@ pub trait RpcContext {
 		let Ok(what) = params.needs_one() else {
 			return Err(RpcError::InvalidParams);
 		};
-		// Return a single result?
-		let one = what.is_thing_single();
 		// Specify the SQL query string
 		let sql = {
 			// DELETE $what RETURN BEFORE
 			DeleteStatement {
-				what: vec![Value::Param("what".into())].into(),
+				only: what.is_thing_single(),
+				what: vec![what.could_be_table()].into(),
 				output: Some(Output::Before),
 				..Default::default()
 			}
 			.into()
 		};
 		// Specify the query parameters
-		let var = Some(map! {
-			String::from("what") => what.could_be_table(),
-			=> &self.vars()
-		});
+		let var = Some(self.vars().clone());
 		// Execute the query on the database
 		let mut res = self.kvs().process(sql, self.session(), var).await?;
 		// Extract the first query result
-		Ok(match one {
-			true => res.remove(0).result?.first().into(),
-			false => res.remove(0).result?.into(),
-		})
+		Ok(res.remove(0).result?.into())
 	}
 
 	// ------------------------------
@@ -866,12 +768,12 @@ pub trait RpcContext {
 	// ------------------------------
 
 	#[cfg(any(target_arch = "wasm32", not(surrealdb_unstable)))]
-	async fn graphql(&self, _params: Array) -> Result<Data, RpcError> {
+	async fn graphql(&self, _: Array) -> Result<Data, RpcError> {
 		Err(RpcError::MethodNotFound)
 	}
 
 	#[cfg(all(not(target_arch = "wasm32"), surrealdb_unstable))]
-	async fn graphql(&self, params: Array) -> Result<impl Into<Data>, RpcError> {
+	async fn graphql(&self, params: Array) -> Result<Data, RpcError> {
 		if !*GRAPHQL_ENABLE {
 			return Err(RpcError::BadGQLConfig);
 		}
@@ -890,45 +792,50 @@ pub trait RpcContext {
 
 		enum GraphQLFormat {
 			Json,
-			Cbor,
 		}
 
+		// Default to compressed output
 		let mut pretty = false;
+		// Default to graphql json format
 		let mut format = GraphQLFormat::Json;
+		// Process any secondary config options
 		match options {
+			// A config object was passed
 			Value::Object(o) => {
 				for (k, v) in o {
 					match (k.as_str(), v) {
 						("pretty", Value::Bool(b)) => pretty = b,
 						("format", Value::Strand(s)) => match s.as_str() {
 							"json" => format = GraphQLFormat::Json,
-							"cbor" => format = GraphQLFormat::Cbor,
 							_ => return Err(RpcError::InvalidParams),
 						},
 						_ => return Err(RpcError::InvalidParams),
 					}
 				}
 			}
+			// The config argument was not supplied
+			Value::None => (),
+			// An invalid config argument was received
 			_ => return Err(RpcError::InvalidParams),
 		}
-
+		// Process the graphql query argument
 		let req = match query {
+			// It is a string, so parse the query
 			Value::Strand(s) => match format {
 				GraphQLFormat::Json => {
 					let tmp: BatchRequest =
 						serde_json::from_str(s.as_str()).map_err(|_| RpcError::ParseError)?;
 					tmp.into_single().map_err(|_| RpcError::ParseError)?
 				}
-				GraphQLFormat::Cbor => {
-					return Err(RpcError::Thrown("Cbor is not yet supported".to_string()))
-				}
 			},
+			// It is an object, so build the query
 			Value::Object(mut o) => {
+				// We expect a `query` key with the graphql query
 				let mut tmp = match o.remove("query") {
 					Some(Value::Strand(s)) => async_graphql::Request::new(s),
 					_ => return Err(RpcError::InvalidParams),
 				};
-
+				// We can accept a `variables` key with graphql variables
 				match o.remove("variables").or(o.remove("vars")) {
 					Some(obj @ Value::Object(_)) => {
 						let gql_vars = gql::schema::sql_value_to_gql_value(obj)
@@ -939,39 +846,39 @@ pub trait RpcContext {
 					Some(_) => return Err(RpcError::InvalidParams),
 					None => {}
 				}
-
+				// We can accept an `operation` key with a graphql operation name
 				match o.remove("operationName").or(o.remove("operation")) {
 					Some(Value::Strand(s)) => tmp = tmp.operation_name(s),
 					Some(_) => return Err(RpcError::InvalidParams),
 					None => {}
 				}
-
+				// Return the graphql query object
 				tmp
 			}
+			// We received an invalid graphql query
 			_ => return Err(RpcError::InvalidParams),
 		};
-
+		// Process and cache the graphql schema
 		let schema = self
 			.graphql_schema_cache()
 			.get_schema(self.session())
 			.await
 			.map_err(|e| RpcError::Thrown(e.to_string()))?;
-
+		// Execute the request against the schema
 		let res = schema.execute(req).await;
-
+		// Serialize the graphql response
 		let out = match pretty {
 			true => {
 				let mut buf = Vec::new();
 				let formatter = serde_json::ser::PrettyFormatter::with_indent(b"    ");
 				let mut ser = serde_json::Serializer::with_formatter(&mut buf, formatter);
-
 				res.serialize(&mut ser).ok().and_then(|_| String::from_utf8(buf).ok())
 			}
 			false => serde_json::to_string(&res).ok(),
 		}
 		.ok_or(RpcError::Thrown("Serialization Error".to_string()))?;
-
-		Ok(Value::Strand(out.into()))
+		// Output the graphql response
+		Ok(Value::Strand(out.into()).into())
 	}
 
 	// ------------------------------

--- a/core/src/sql/query.rs
+++ b/core/src/sql/query.rs
@@ -1,4 +1,15 @@
 use crate::sql::fmt::Pretty;
+use crate::sql::function::Function;
+use crate::sql::model::Model;
+use crate::sql::statements::CreateStatement;
+use crate::sql::statements::DeleteStatement;
+use crate::sql::statements::InsertStatement;
+use crate::sql::statements::KillStatement;
+use crate::sql::statements::LiveStatement;
+use crate::sql::statements::RelateStatement;
+use crate::sql::statements::SelectStatement;
+use crate::sql::statements::UpdateStatement;
+use crate::sql::statements::UpsertStatement;
 use crate::sql::statements::{DefineStatement, RemoveStatement};
 use crate::sql::{Statement, Statements};
 use derive::Store;
@@ -27,6 +38,72 @@ impl From<DefineStatement> for Query {
 impl From<RemoveStatement> for Query {
 	fn from(s: RemoveStatement) -> Self {
 		Query(Statements(vec![Statement::Remove(s)]))
+	}
+}
+
+impl From<SelectStatement> for Query {
+	fn from(s: SelectStatement) -> Self {
+		Query(Statements(vec![Statement::Select(s)]))
+	}
+}
+
+impl From<CreateStatement> for Query {
+	fn from(s: CreateStatement) -> Self {
+		Query(Statements(vec![Statement::Create(s)]))
+	}
+}
+
+impl From<UpsertStatement> for Query {
+	fn from(s: UpsertStatement) -> Self {
+		Query(Statements(vec![Statement::Upsert(s)]))
+	}
+}
+
+impl From<UpdateStatement> for Query {
+	fn from(s: UpdateStatement) -> Self {
+		Query(Statements(vec![Statement::Update(s)]))
+	}
+}
+
+impl From<RelateStatement> for Query {
+	fn from(s: RelateStatement) -> Self {
+		Query(Statements(vec![Statement::Relate(s)]))
+	}
+}
+
+impl From<DeleteStatement> for Query {
+	fn from(s: DeleteStatement) -> Self {
+		Query(Statements(vec![Statement::Delete(s)]))
+	}
+}
+
+impl From<InsertStatement> for Query {
+	fn from(s: InsertStatement) -> Self {
+		Query(Statements(vec![Statement::Insert(s)]))
+	}
+}
+
+impl From<LiveStatement> for Query {
+	fn from(s: LiveStatement) -> Self {
+		Query(Statements(vec![Statement::Live(s)]))
+	}
+}
+
+impl From<KillStatement> for Query {
+	fn from(s: KillStatement) -> Self {
+		Query(Statements(vec![Statement::Kill(s)]))
+	}
+}
+
+impl From<Function> for Query {
+	fn from(f: Function) -> Self {
+		Query(Statements(vec![Statement::Value(f.into())]))
+	}
+}
+
+impl From<Model> for Query {
+	fn from(m: Model) -> Self {
+		Query(Statements(vec![Statement::Value(m.into())]))
 	}
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently we use string-based queries internally within the RPC protocol, resulting in the query for every RPC method to be re-parsed on every request.

## What does this change do?

This change uses the AST internally within the RPC protocol, ensuring that we bypass any unnecessary parsing for RPC requests.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
