### PR TITLE
Add logging for RocksDB config options

### DIFF
--- a/core/src/kvs/rocksdb/cnf.rs
+++ b/core/src/kvs/rocksdb/cnf.rs
@@ -30,6 +30,9 @@ pub static ROCKSDB_MIN_BLOB_SIZE: LazyLock<u64> =
 pub static ROCKSDB_KEEP_LOG_FILE_NUM: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_ROCKSDB_KEEP_LOG_FILE_NUM", usize, 20);
 
+pub static ROCKSDB_STORAGE_LOG_LEVEL: LazyLock<String> =
+	lazy_env_parse!("SURREAL_ROCKSDB_STORAGE_LOG_LEVEL", String, "warn".to_string());
+
 pub static ROCKSDB_COMPACTION_STYLE: LazyLock<String> =
 	lazy_env_parse!("SURREAL_ROCKSDB_COMPACTION_STYLE", String);
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Showing specified RocksDB config options on startup.

## What does this change do?

Outputs RocksDB config options on startup to the logs. It also introduces the new environment variable `SURREAL_ROCKSDB_STORAGE_LOG_LEVEL` which can be one of: `debug`, `info`, `warn` (default), `error`, `fatal`.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [ ] Yes documentation to be added.

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
