### PR TITLE
Allow importing data when the SurrealDB server starts

### DIFF
--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -426,6 +426,7 @@ pub async fn init(
 	dbs.check_version().await?;
 	// Import file at start, if provided
 	if let Some(file) = import_file {
+		info!("Importing data from file: {:?}", file);
 		let sql = fs::read_to_string(file)?;
 		dbs.import(&sql, &Session::owner()).await?;
 	}

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -15,6 +15,7 @@ mod cli_integration {
 	#[cfg(unix)]
 	use serde_json::json;
 	use std::fs::File;
+	use std::io::Write;
 	#[cfg(unix)]
 	use std::time;
 	use std::time::Duration;
@@ -884,6 +885,92 @@ mod cli_integration {
 			);
 		}
 		server.finish().unwrap();
+	}
+
+	#[test(tokio::test)]
+	async fn with_import_file() {
+		let ns = Ulid::new();
+		let db = Ulid::new();
+
+		info!("* Import and re-import root-level file");
+		{
+			// Start the server with an import file containing the following query:
+			let query = r#"DEFINE ACCESS OVERWRITE admin ON ROOT TYPE JWT URL "https://www.surrealdb.com/jwks.json";"#;
+			let import_file = common::tmp_file("import.surql");
+			let mut file = File::create(&import_file).unwrap();
+			file.write_all(query.as_bytes()).unwrap();
+			let (addr, mut server) =
+				common::start_server_with_import_file(&import_file).await.unwrap();
+			// Define connection arguments.
+			let args = format!("sql --conn http://{addr} --user {USER} --pass {PASS}");
+			// Verify that the file has been imported correctly.
+			let output = common::run(&args).input("INFO FOR ROOT").output().expect("success");
+			assert!(output.contains(
+				r#"DEFINE ACCESS admin ON ROOT TYPE JWT URL 'https://www.surrealdb.com/jwks.json'"#
+			));
+			// Modify the resource that was imported.
+			common::run(&args)
+				.input("DEFINE ACCESS OVERWRITE admin ON ROOT TYPE JWT URL 'https://www.example.com/jwks.json'")
+				.output()
+				.expect("success");
+			// Verify that the resource has been modified correctly.
+			let output = common::run(&args).input("INFO FOR ROOT").output().expect("success");
+			assert!(output.contains(
+				r#"DEFINE ACCESS admin ON ROOT TYPE JWT URL 'https://www.example.com/jwks.json'"#
+			));
+			// Restart the server.
+			server.finish().unwrap();
+			let (addr, mut server) =
+				common::start_server_with_import_file(&import_file).await.unwrap();
+			// Verify that the resource has been recreated correctly.
+			let args = format!("sql --conn http://{addr} --user {USER} --pass {PASS}");
+			let output = common::run(&args).input("INFO FOR ROOT").output().expect("success");
+			assert!(output.contains(
+				r#"DEFINE ACCESS admin ON ROOT TYPE JWT URL 'https://www.surrealdb.com/jwks.json'"#
+			));
+			server.finish().unwrap();
+		}
+
+		info!("* Multi-level import file");
+		{
+			// Start the server with an import file containing the following query:
+			let query = format!(
+				r#"
+				USE NS `{ns}`;
+				DEFINE USER test ON NAMESPACE PASSWORD "secret";
+				USE NS `{ns}` DB `{db}`;
+				CREATE user:1;
+			"#
+			);
+			let import_file = common::tmp_file("import.surql");
+			let mut file = File::create(&import_file).unwrap();
+			file.write_all(query.as_bytes()).unwrap();
+			let (addr, mut server) =
+				common::start_server_with_import_file(&import_file).await.unwrap();
+			// Verify that the file has been imported correctly.
+			let args =
+				format!("sql --conn http://{addr} --user {USER} --pass {PASS} --namespace {ns}");
+			let output = common::run(&args).input("INFO FOR NAMESPACE").output().expect("success");
+			assert!(output.contains(r#"DEFINE USER test ON NAMESPACE PASSHASH"#));
+			let args =
+				format!("sql --conn http://{addr} --user {USER} --pass {PASS} --namespace {ns} --database {db}");
+			let output = common::run(&args).input("SELECT * FROM user").output().expect("success");
+			assert!(output.contains(r#"{ id: user:1 }"#));
+			server.finish().unwrap();
+		}
+
+		info!("* Nonexistent import file");
+		{
+			// Start the server with an import file which does not exist.
+			let import_file = common::tmp_file("import.surql");
+			let res = common::start_server_with_import_file(&import_file).await;
+			match res {
+				Ok(_) => panic!("import file should require an existent file"),
+				Err(e) => {
+					assert!(e.to_string().contains("server failed to start"))
+				}
+			}
+		}
 	}
 
 	#[test(tokio::test)]

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -161,6 +161,7 @@ pub struct StartServerArguments {
 	pub tls: bool,
 	pub wait_is_ready: bool,
 	pub temporary_directory: Option<String>,
+	pub import_file: Option<String>,
 	pub args: String,
 	pub vars: Option<HashMap<String, String>>,
 }
@@ -173,6 +174,7 @@ impl Default for StartServerArguments {
 			tls: false,
 			wait_is_ready: true,
 			temporary_directory: None,
+			import_file: None,
 			args: "".to_string(),
 			vars: None,
 		}
@@ -209,6 +211,14 @@ pub async fn start_server_with_temporary_directory(
 	.await
 }
 
+pub async fn start_server_with_import_file(path: &str) -> Result<(String, Child), Box<dyn Error>> {
+	start_server(StartServerArguments {
+		import_file: Some(path.to_string()),
+		..Default::default()
+	})
+	.await
+}
+
 pub async fn start_server_gql() -> Result<(String, Child), Box<dyn Error>> {
 	start_server(StartServerArguments {
 		vars: Some(HashMap::from([(
@@ -239,6 +249,7 @@ pub async fn start_server(
 		tls,
 		wait_is_ready,
 		temporary_directory,
+		import_file,
 		args,
 		vars,
 	}: StartServerArguments,
@@ -266,6 +277,10 @@ pub async fn start_server(
 
 	if let Some(path) = temporary_directory {
 		extra_args.push_str(format!(" --temporary-directory {path}").as_str());
+	}
+
+	if let Some(path) = import_file {
+		extra_args.push_str(format!(" --import-file {path}").as_str());
 	}
 
 	'retry: for _ in 0..3 {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To address uses cases that require that certain resources exist in the datastore when the server is started.

## What does this change do?

This feature will import a file containing SurrealQL queries to the datastore with `owner` permissions on `ROOT` before the server is started.  This feature functions similarly to the `import` sub-command. While the flag is present, the file will be imported every time that the server is started; this allows creating users, access methods and any other resources or data that clients may need to rely on. An informational message is logged on the server whenever data is imported from a file on start.

From a security perspective, this feature is used when starting the server and hence already requires complete access to the datastore, which is extended to the import file. On the other hand, this feature provides an alternative to the `-u` and `-p` flags that would create a root-level owner user when starting the server for the first time, allowing users to instead rely on more secure paswordless access methods, which can also be kept updated when restarting the server.

## What is your testing strategy?

Implement integration tests for the basic import functionality, the effect on a restart in any imported resources, the creation of resources at different levels and the requirement of providing an existent file.

## Is this related to any issues?

No.

## Does this change need documentation?

Yes, this requires updating the CLI documentation for the `start` command.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
