### PR TITLE
Fix parallel query calls in script functions causing a panic.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4563,9 +4563,9 @@ dependencies = [
 
 [[package]]
 name = "reblessive"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4f118ca848dfd632a8c0883f9aacd6b58da548eb0629a78cafee3d330938da"
+checksum = "ffead9d0a0b45f3e0bc063a244b1779fd53a09d2c2f7282c186a016b1f10a778"
 
 [[package]]
 name = "redox_syscall"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -116,7 +116,7 @@ quick_cache = "0.5.1"
 radix_trie = { version = "0.2.1", features = ["serde"] }
 rand = "0.8.5"
 rayon = "1.10.0"
-reblessive = { version = "0.4.1", features = ["tree"] }
+reblessive = { version = "0.4.2", features = ["tree"] }
 regex = "1.10.6"
 regex-syntax = { version = "0.8.4", optional = true, features = ["arbitrary"] }
 reqwest = { version = "0.12.7", default-features = false, features = [

--- a/core/src/fnc/script/modules/surrealdb/functions/mod.rs
+++ b/core/src/fnc/script/modules/surrealdb/functions/mod.rs
@@ -75,9 +75,10 @@ fn run(js_ctx: js::Ctx<'_>, name: &str, args: Vec<Value>) -> Result<Value> {
 async fn fut(js_ctx: js::Ctx<'_>, name: &str, args: Vec<Value>) -> Result<Value> {
 	let this = js_ctx.globals().get::<_, OwnedBorrow<QueryContext>>(QUERY_DATA_PROP_NAME)?;
 	// Process the called function
-	let res =
-		Stk::enter_run(|stk| fnc::asynchronous(stk, this.context, this.opt, this.doc, name, args))
-			.await;
+	let res = Stk::enter_scope(|stk| {
+		stk.run(|stk| fnc::asynchronous(stk, this.context, this.opt, this.doc, name, args))
+	})
+	.await;
 	// Convert any response error
 	res.map_err(|err| {
 		js::Exception::from_message(js_ctx, &err.to_string())

--- a/core/src/fnc/script/modules/surrealdb/query/mod.rs
+++ b/core/src/fnc/script/modules/surrealdb/query/mod.rs
@@ -79,8 +79,10 @@ pub async fn query<'js>(
 		.map_err(|e| Exception::throw_message(&ctx, &e.to_string()))?;
 	let context = context.freeze();
 
-	let value = Stk::enter_run(|stk| query.query.compute(stk, &context, this.opt, this.doc))
-		.await
-		.map_err(|e| Exception::throw_message(&ctx, &e.to_string()))?;
+	let value = Stk::enter_scope(|stk| {
+		stk.run(|stk| query.query.compute(stk, &context, this.opt, this.doc))
+	})
+	.await
+	.map_err(|e| Exception::throw_message(&ctx, &e.to_string()))?;
 	Ok(value)
 }

--- a/sdk/tests/script.rs
+++ b/sdk/tests/script.rs
@@ -715,3 +715,19 @@ async fn script_geometry_into() -> Result<(), Error> {
 	dbs.execute(sql, &ses, None).await?;
 	Ok(())
 }
+
+#[tokio::test]
+async fn script_parallel_query() -> Result<(), Error> {
+	let sql = r#"
+		RETURN function() {
+			await Promise.all([
+				surrealdb.query("1")
+				surrealdb.query("1")
+			])
+		}
+	"#;
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	dbs.execute(sql, &ses, None).await?;
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Calling `surrealdb.query` or `surrealdb.value` in parallel in a scripting functions causes a panic.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Fixes the panic.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test which previously caused the panic.

## Is this related to any issues?

Fixes #5098

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
