### PR TITLE
SDK export config

### DIFF
--- a/core/src/kvs/export.rs
+++ b/core/src/kvs/export.rs
@@ -124,6 +124,12 @@ impl From<Vec<String>> for TableConfig {
 	}
 }
 
+impl From<Vec<&str>> for TableConfig {
+	fn from(value: Vec<&str>) -> Self {
+		TableConfig::Some(value.into_iter().map(ToOwned::to_owned).collect())
+	}
+}
+
 impl TryFrom<&Value> for TableConfig {
 	type Error = Error;
 	fn try_from(value: &Value) -> Result<Self, Self::Error> {

--- a/core/src/kvs/export.rs
+++ b/core/src/kvs/export.rs
@@ -36,6 +36,26 @@ impl Default for Config {
 	}
 }
 
+impl Into<Value> for Config {
+	fn into(self) -> Value {
+		let obj = map!(
+			"users" => self.users.into(),
+			"accesses" => self.accesses.into(),
+			"params" => self.params.into(),
+			"functions" => self.functions.into(),
+			"analyzers" => self.analyzers.into(),
+			"versions" => self.versions.into(),
+			"tables" => match self.tables {
+				TableConfig::All => true.into(),
+				TableConfig::None => false.into(),
+				TableConfig::Some(v) => v.into()
+			}
+		);
+
+		obj.into()
+	}
+}
+
 impl TryFrom<&Value> for Config {
 	type Error = Error;
 	fn try_from(value: &Value) -> Result<Self, Self::Error> {
@@ -84,6 +104,21 @@ pub enum TableConfig {
 	All,
 	None,
 	Some(Vec<String>),
+}
+
+impl From<bool> for TableConfig {
+	fn from(value: bool) -> Self {
+		match value {
+			true => TableConfig::All,
+			false => TableConfig::None,
+		}
+	}
+}
+
+impl From<Vec<String>> for TableConfig {
+	fn from(value: Vec<String>) -> Self {
+		TableConfig::Some(value)
+	}
 }
 
 impl TryFrom<&Value> for TableConfig {

--- a/core/src/kvs/export.rs
+++ b/core/src/kvs/export.rs
@@ -36,16 +36,16 @@ impl Default for Config {
 	}
 }
 
-impl Into<Value> for Config {
-	fn into(self) -> Value {
+impl From<Config> for Value {
+	fn from(config: Config) -> Value {
 		let obj = map!(
-			"users" => self.users.into(),
-			"accesses" => self.accesses.into(),
-			"params" => self.params.into(),
-			"functions" => self.functions.into(),
-			"analyzers" => self.analyzers.into(),
-			"versions" => self.versions.into(),
-			"tables" => match self.tables {
+			"users" => config.users.into(),
+			"accesses" => config.accesses.into(),
+			"params" => config.params.into(),
+			"functions" => config.functions.into(),
+			"analyzers" => config.analyzers.into(),
+			"versions" => config.versions.into(),
+			"tables" => match config.tables {
 				TableConfig::All => true.into(),
 				TableConfig::None => false.into(),
 				TableConfig::Some(v) => v.into()

--- a/sdk/src/api/conn/cmd.rs
+++ b/sdk/src/api/conn/cmd.rs
@@ -6,9 +6,9 @@ use revision::Revisioned;
 use serde::{ser::SerializeMap as _, Serialize};
 use std::io::Read;
 use std::path::PathBuf;
+use surrealdb_core::kvs::export::Config as DbExportConfig;
 use surrealdb_core::sql::{Array as CoreArray, Object as CoreObject, Query, Value as CoreValue};
 use uuid::Uuid;
-use surrealdb_core::kvs::export::Config as DbExportConfig;
 
 #[cfg(any(feature = "protocol-ws", feature = "protocol-http"))]
 use surrealdb_core::sql::Table as CoreTable;

--- a/sdk/src/api/conn/cmd.rs
+++ b/sdk/src/api/conn/cmd.rs
@@ -8,6 +8,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use surrealdb_core::sql::{Array as CoreArray, Object as CoreObject, Query, Value as CoreValue};
 use uuid::Uuid;
+use surrealdb_core::kvs::export::Config as DbExportConfig;
 
 #[cfg(any(feature = "protocol-ws", feature = "protocol-http"))]
 use surrealdb_core::sql::Table as CoreTable;
@@ -70,6 +71,7 @@ pub(crate) enum Command {
 	},
 	ExportFile {
 		path: PathBuf,
+		config: Option<DbExportConfig>,
 	},
 	ExportMl {
 		path: PathBuf,
@@ -77,6 +79,7 @@ pub(crate) enum Command {
 	},
 	ExportBytes {
 		bytes: Sender<Result<Vec<u8>>>,
+		config: Option<DbExportConfig>,
 	},
 	ExportBytesMl {
 		bytes: Sender<Result<Vec<u8>>>,

--- a/sdk/src/api/engine/local/mod.rs
+++ b/sdk/src/api/engine/local/mod.rs
@@ -44,6 +44,7 @@ use std::{
 	mem,
 	sync::Arc,
 };
+use surrealdb_core::kvs::export::Config as DbExportConfig;
 use surrealdb_core::sql::Function;
 use surrealdb_core::{
 	dbs::{Response, Session},
@@ -60,7 +61,6 @@ use surrealdb_core::{
 #[cfg(not(target_arch = "wasm32"))]
 use tokio_util::bytes::BytesMut;
 use uuid::Uuid;
-use surrealdb_core::kvs::export::Config as DbExportConfig;
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::{future::Future, path::PathBuf};
@@ -474,7 +474,12 @@ async fn take(one: bool, responses: Vec<Response>) -> Result<CoreValue> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn export_file(kvs: &Datastore, sess: &Session, chn: channel::Sender<Vec<u8>>, config: Option<DbExportConfig>) -> Result<()> {
+async fn export_file(
+	kvs: &Datastore,
+	sess: &Session,
+	chn: channel::Sender<Vec<u8>>,
+	config: Option<DbExportConfig>,
+) -> Result<()> {
 	let res = match config {
 		Some(config) => kvs.export_with_config(sess, chn, config).await?.await,
 		None => kvs.export(sess, chn).await?.await,

--- a/sdk/src/api/engine/local/mod.rs
+++ b/sdk/src/api/engine/local/mod.rs
@@ -60,6 +60,7 @@ use surrealdb_core::{
 #[cfg(not(target_arch = "wasm32"))]
 use tokio_util::bytes::BytesMut;
 use uuid::Uuid;
+use surrealdb_core::kvs::export::Config as DbExportConfig;
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::{future::Future, path::PathBuf};
@@ -473,8 +474,13 @@ async fn take(one: bool, responses: Vec<Response>) -> Result<CoreValue> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-async fn export_file(kvs: &Datastore, sess: &Session, chn: channel::Sender<Vec<u8>>) -> Result<()> {
-	if let Err(error) = kvs.export(sess, chn).await?.await {
+async fn export_file(kvs: &Datastore, sess: &Session, chn: channel::Sender<Vec<u8>>, config: Option<DbExportConfig>) -> Result<()> {
+	let res = match config {
+		Some(config) => kvs.export_with_config(sess, chn, config).await?.await,
+		None => kvs.export(sess, chn).await?.await,
+	};
+
+	if let Err(error) = res {
 		if let crate::error::Db::Channel(message) = error {
 			// This is not really an error. Just logging it for improved visibility.
 			trace!("{message}");
@@ -792,12 +798,13 @@ async fn router(
 		#[cfg(not(target_arch = "wasm32"))]
 		Command::ExportFile {
 			path: file,
+			config,
 		} => {
 			let (tx, rx) = crate::channel::bounded(1);
 			let (mut writer, mut reader) = io::duplex(10_240);
 
 			// Write to channel.
-			let export = export_file(kvs, session, tx);
+			let export = export_file(kvs, session, tx, config);
 
 			// Read from channel and write to pipe.
 			let bridge = async move {
@@ -885,6 +892,7 @@ async fn router(
 		#[cfg(not(target_arch = "wasm32"))]
 		Command::ExportBytes {
 			bytes,
+			config,
 		} => {
 			let (tx, rx) = crate::channel::bounded(1);
 
@@ -892,7 +900,7 @@ async fn router(
 			let session = session.clone();
 			tokio::spawn(async move {
 				let export = async {
-					if let Err(error) = export_file(&kvs, &session, tx).await {
+					if let Err(error) = export_file(&kvs, &session, tx, config).await {
 						let _ = bytes.send(Err(error)).await;
 					}
 				};

--- a/sdk/src/api/engine/remote/http/mod.rs
+++ b/sdk/src/api/engine/remote/http/mod.rs
@@ -443,24 +443,34 @@ async fn router(
 		#[cfg(not(target_arch = "wasm32"))]
 		Command::ExportFile {
 			path,
+			config,
 		} => {
 			let req_path = base_url.join("export")?;
+			let config = config.unwrap_or_default();
+			let config_value: CoreValue = config.into();
 			let request = client
-				.get(req_path)
+				.post(req_path)
+				.body(config_value.into_json().to_string())
 				.headers(headers.clone())
 				.auth(auth)
+				.header(CONTENT_TYPE, "application/json")
 				.header(ACCEPT, "application/octet-stream");
 			export_file(request, path).await?;
 			Ok(DbResponse::Other(CoreValue::None))
 		}
 		Command::ExportBytes {
 			bytes,
+			config,
 		} => {
 			let req_path = base_url.join("export")?;
+			let config = config.unwrap_or_default();
+			let config_value: CoreValue = config.into();
 			let request = client
-				.get(req_path)
+				.post(req_path)
+				.body(config_value.into_json().to_string())
 				.headers(headers.clone())
 				.auth(auth)
+				.header(CONTENT_TYPE, "application/json")
 				.header(ACCEPT, "application/octet-stream");
 			export_bytes(request, bytes).await?;
 			Ok(DbResponse::Other(CoreValue::None))

--- a/sdk/src/api/method/export.rs
+++ b/sdk/src/api/method/export.rs
@@ -53,7 +53,7 @@ where
 	}
 
 	/// Whether to export users from the database
-	pub fn with_users(self, users: bool) -> Export<'r, C, R, Model> {
+	pub fn with_users(self, users: bool) -> Export<'r, C, R> {
 		let mut db_config = self.db_config.unwrap_or_default();
 		db_config.users = users;
 
@@ -68,7 +68,7 @@ where
 	}
 
 	/// Whether to export accesses from the database
-	pub fn with_accesses(self, accesses: bool) -> Export<'r, C, R, Model> {
+	pub fn with_accesses(self, accesses: bool) -> Export<'r, C, R> {
 		let mut db_config = self.db_config.unwrap_or_default();
 		db_config.accesses = accesses;
 
@@ -83,7 +83,7 @@ where
 	}
 
 	/// Whether to export params from the database
-	pub fn with_params(self, params: bool) -> Export<'r, C, R, Model> {
+	pub fn with_params(self, params: bool) -> Export<'r, C, R> {
 		let mut db_config = self.db_config.unwrap_or_default();
 		db_config.params = params;
 
@@ -98,7 +98,7 @@ where
 	}
 
 	/// Whether to export functions from the database
-	pub fn with_functions(self, functions: bool) -> Export<'r, C, R, Model> {
+	pub fn with_functions(self, functions: bool) -> Export<'r, C, R> {
 		let mut db_config = self.db_config.unwrap_or_default();
 		db_config.functions = functions;
 
@@ -113,7 +113,7 @@ where
 	}
 
 	/// Whether to export analyzers from the database
-	pub fn with_analyzers(self, analyzers: bool) -> Export<'r, C, R, Model> {
+	pub fn with_analyzers(self, analyzers: bool) -> Export<'r, C, R> {
 		let mut db_config = self.db_config.unwrap_or_default();
 		db_config.analyzers = analyzers;
 
@@ -128,7 +128,7 @@ where
 	}
 
 	/// Whether to export all versions of data from the database
-	pub fn versioned(self, versioned: bool) -> Export<'r, C, R, Model> {
+	pub fn versioned(self, versioned: bool) -> Export<'r, C, R> {
 		let mut db_config = self.db_config.unwrap_or_default();
 		db_config.versions = versioned;
 

--- a/sdk/src/api/method/export.rs
+++ b/sdk/src/api/method/export.rs
@@ -137,6 +137,14 @@ where
 		}
 		self
 	}
+
+	/// Whether to export records from the database
+	pub fn records(mut self, records: bool) -> Self {
+		if let Some(cfg) = self.db_config.as_mut() {
+			cfg.records = records;
+		}
+		self
+	}
 }
 
 impl<C, R, T> Export<'_, C, R, T>

--- a/sdk/src/api/method/export.rs
+++ b/sdk/src/api/method/export.rs
@@ -128,7 +128,7 @@ where
 	}
 
 	/// Whether to export all versions of data from the database
-	pub fn versioned(self, versioned: bool) -> Export<'r, C, R> {
+	pub fn with_versions(self, versioned: bool) -> Export<'r, C, R> {
 		let mut db_config = self.db_config.unwrap_or_default();
 		db_config.versions = versioned;
 
@@ -143,6 +143,17 @@ where
 	}
 
 	/// Whether to export tables or which ones from the database
+	///
+	/// We can pass a `bool` to export all tables or none at all:
+	/// ```
+	/// db.export().with_tables(true);
+	/// db.export().with_tables(false);
+	/// ```
+	///
+	/// Or we can pass a `Vec<String>` to specify a list of tables to export:
+	/// ```
+	/// db.export().with_tables(vec!["users".into()]);
+	/// ```
 	pub fn with_tables(self, tables: impl Into<TableConfig>) -> Export<'r, C, R> {
 		let mut db_config = self.db_config.unwrap_or_default();
 		db_config.tables = tables.into();

--- a/sdk/src/api/method/export.rs
+++ b/sdk/src/api/method/export.rs
@@ -143,7 +143,7 @@ where
 	}
 
 	/// Whether to export tables or which ones from the database
-	pub fn with_tables(self, tables: impl Into<TableConfig>) -> Export<'r, C, R, Model> {
+	pub fn with_tables(self, tables: impl Into<TableConfig>) -> Export<'r, C, R> {
 		let mut db_config = self.db_config.unwrap_or_default();
 		db_config.tables = tables.into();
 

--- a/sdk/src/api/method/export.rs
+++ b/sdk/src/api/method/export.rs
@@ -129,7 +129,7 @@ where
 	///
 	/// Or we can pass a `Vec<String>` to specify a list of tables to export:
 	/// ```
-	/// db.export().with_config().tables(vec!["users".into()]);
+	/// db.export().with_config().tables(vec!["users"]);
 	/// ```
 	pub fn tables(mut self, tables: impl Into<TableConfig>) -> Self {
 		if let Some(cfg) = self.db_config.as_mut() {

--- a/sdk/src/api/method/export.rs
+++ b/sdk/src/api/method/export.rs
@@ -5,6 +5,7 @@ use crate::api::Connection;
 use crate::api::Error;
 use crate::api::ExtraFeatures;
 use crate::api::Result;
+use crate::method::ExportConfig as Config;
 use crate::method::Model;
 use crate::method::OnceLockExt;
 use crate::Surreal;
@@ -52,120 +53,89 @@ where
 		}
 	}
 
-	/// Whether to export users from the database
-	pub fn with_users(self, users: bool) -> Export<'r, C, R> {
-		let mut db_config = self.db_config.unwrap_or_default();
-		db_config.users = users;
-
+	/// Configure the export options
+	pub fn with_config(self) -> Export<'r, C, R, Config> {
 		Export {
 			client: self.client,
 			target: self.target,
 			ml_config: self.ml_config,
-			db_config: Some(db_config),
+			// Use default configuration options
+			db_config: Some(Default::default()),
 			response: self.response,
 			export_type: PhantomData,
 		}
+	}
+}
+
+impl<'r, C, R> Export<'r, C, R, Config>
+where
+	C: Connection,
+{
+	/// Whether to export users from the database
+	pub fn users(mut self, users: bool) -> Self {
+		if let Some(cfg) = self.db_config.as_mut() {
+			cfg.users = users;
+		}
+		self
 	}
 
 	/// Whether to export accesses from the database
-	pub fn with_accesses(self, accesses: bool) -> Export<'r, C, R> {
-		let mut db_config = self.db_config.unwrap_or_default();
-		db_config.accesses = accesses;
-
-		Export {
-			client: self.client,
-			target: self.target,
-			ml_config: self.ml_config,
-			db_config: Some(db_config),
-			response: self.response,
-			export_type: PhantomData,
+	pub fn accesses(mut self, accesses: bool) -> Self {
+		if let Some(cfg) = self.db_config.as_mut() {
+			cfg.accesses = accesses;
 		}
+		self
 	}
 
 	/// Whether to export params from the database
-	pub fn with_params(self, params: bool) -> Export<'r, C, R> {
-		let mut db_config = self.db_config.unwrap_or_default();
-		db_config.params = params;
-
-		Export {
-			client: self.client,
-			target: self.target,
-			ml_config: self.ml_config,
-			db_config: Some(db_config),
-			response: self.response,
-			export_type: PhantomData,
+	pub fn params(mut self, params: bool) -> Self {
+		if let Some(cfg) = self.db_config.as_mut() {
+			cfg.params = params;
 		}
+		self
 	}
 
 	/// Whether to export functions from the database
-	pub fn with_functions(self, functions: bool) -> Export<'r, C, R> {
-		let mut db_config = self.db_config.unwrap_or_default();
-		db_config.functions = functions;
-
-		Export {
-			client: self.client,
-			target: self.target,
-			ml_config: self.ml_config,
-			db_config: Some(db_config),
-			response: self.response,
-			export_type: PhantomData,
+	pub fn functions(mut self, functions: bool) -> Self {
+		if let Some(cfg) = self.db_config.as_mut() {
+			cfg.functions = functions;
 		}
+		self
 	}
 
 	/// Whether to export analyzers from the database
-	pub fn with_analyzers(self, analyzers: bool) -> Export<'r, C, R> {
-		let mut db_config = self.db_config.unwrap_or_default();
-		db_config.analyzers = analyzers;
-
-		Export {
-			client: self.client,
-			target: self.target,
-			ml_config: self.ml_config,
-			db_config: Some(db_config),
-			response: self.response,
-			export_type: PhantomData,
+	pub fn analyzers(mut self, analyzers: bool) -> Self {
+		if let Some(cfg) = self.db_config.as_mut() {
+			cfg.analyzers = analyzers;
 		}
+		self
 	}
 
 	/// Whether to export all versions of data from the database
-	pub fn with_versions(self, versioned: bool) -> Export<'r, C, R> {
-		let mut db_config = self.db_config.unwrap_or_default();
-		db_config.versions = versioned;
-
-		Export {
-			client: self.client,
-			target: self.target,
-			ml_config: self.ml_config,
-			db_config: Some(db_config),
-			response: self.response,
-			export_type: PhantomData,
+	pub fn versions(mut self, versions: bool) -> Self {
+		if let Some(cfg) = self.db_config.as_mut() {
+			cfg.versions = versions;
 		}
+		self
 	}
 
 	/// Whether to export tables or which ones from the database
 	///
 	/// We can pass a `bool` to export all tables or none at all:
 	/// ```
-	/// db.export().with_tables(true);
-	/// db.export().with_tables(false);
+	/// db.export().with_config().tables(true);
+	/// db.export().with_config().tables(false);
 	/// ```
 	///
 	/// Or we can pass a `Vec<String>` to specify a list of tables to export:
 	/// ```
-	/// db.export().with_tables(vec!["users".into()]);
+	/// db.export().with_config().tables(vec!["users".into()]);
 	/// ```
-	pub fn with_tables(self, tables: impl Into<TableConfig>) -> Export<'r, C, R> {
-		let mut db_config = self.db_config.unwrap_or_default();
-		db_config.tables = tables.into();
-
-		Export {
-			client: self.client,
-			target: self.target,
-			ml_config: self.ml_config,
-			db_config: Some(db_config),
-			response: self.response,
-			export_type: PhantomData,
+	pub fn tables(mut self, tables: impl Into<TableConfig>) -> Self {
+		if let Some(cfg) = self.db_config.as_mut() {
+			cfg.tables = tables.into();
 		}
+		self
 	}
 }
 

--- a/sdk/src/api/method/mod.rs
+++ b/sdk/src/api/method/mod.rs
@@ -109,6 +109,9 @@ pub struct Stats {
 /// Machine learning model marker type for import and export types
 pub struct Model;
 
+/// Marker type for configured exports
+pub struct ExportConfig;
+
 /// Live query marker type
 pub struct Live;
 

--- a/sdk/src/api/method/mod.rs
+++ b/sdk/src/api/method/mod.rs
@@ -1366,6 +1366,7 @@ where
 			client: Cow::Borrowed(self),
 			target: target.into_export_destination(),
 			ml_config: None,
+			db_config: None,
 			response: PhantomData,
 			export_type: PhantomData,
 		}

--- a/sdk/tests/api/backup.rs
+++ b/sdk/tests/api/backup.rs
@@ -1,6 +1,7 @@
 // Tests for exporting and importing data
 // Supported by the storage engines and the HTTP protocol
 
+use surrealdb::sql::Array;
 use surrealdb_core::sql::Table;
 use tokio::fs::remove_file;
 
@@ -104,11 +105,9 @@ async fn export_with_config() {
     res.unwrap();
 
     // Verify that no group records were imported
-    let mut response = db.query(&format!("SELECT count() AS count FROM group GROUP all")).await.unwrap();
-    let Some(count): Option<i64> = response.take("count").unwrap() else {
-        panic!("Failed to count group records");
-    };
-    assert_eq!(count, 0);
+    let mut response = db.query(&format!("SELECT id FROM group")).await.unwrap();
+    let tmp: Option<Value> = response.take(0).unwrap();
+    assert_eq!(tmp, None);
 
     // Verify that all user records exist post-import
     for i in 0..10 {

--- a/sdk/tests/api/backup.rs
+++ b/sdk/tests/api/backup.rs
@@ -89,7 +89,7 @@ async fn export_with_config() {
 
 	// Export, remove table, and import
 	let res = async {
-		db.export(&file).with_config().tables(vec!["user".to_string()]).await?;
+		db.export(&file).with_config().tables(vec!["user"]).await?;
 		db.query("REMOVE TABLE user; REMOVE TABLE group;").await?;
 		db.import(&file).await?;
 		Result::<(), Error>::Ok(())

--- a/sdk/tests/api/backup.rs
+++ b/sdk/tests/api/backup.rs
@@ -7,119 +7,115 @@ use tokio::fs::remove_file;
 
 #[tokio::test]
 async fn export_import() {
-    let (permit, db) = new_db().await;
-    let db_name = Ulid::new().to_string();
-    db.use_ns(NS).use_db(&db_name).await.unwrap();
+	let (permit, db) = new_db().await;
+	let db_name = Ulid::new().to_string();
+	db.use_ns(NS).use_db(&db_name).await.unwrap();
 
-    // Insert records
-    for i in 0..10 {
-        let _: Option<ApiRecordId> = db
-            .create("user")
-            .content(Record {
-                name: format!("User {i}"),
-            })
-            .await
-            .unwrap();
-    }
+	// Insert records
+	for i in 0..10 {
+		let _: Option<ApiRecordId> = db
+			.create("user")
+			.content(Record {
+				name: format!("User {i}"),
+			})
+			.await
+			.unwrap();
+	}
 
-    // Drop the permit to release the database lock
-    drop(permit);
+	// Drop the permit to release the database lock
+	drop(permit);
 
-    // Define the export file name
-    let file = format!("{db_name}.sql");
+	// Define the export file name
+	let file = format!("{db_name}.sql");
 
-    // Export, remove table, and import
-    let res = async {
-        db.export(&file).await?;
-        db.query("REMOVE TABLE user").await?;
-        db.import(&file).await?;
-        Result::<(), Error>::Ok(())
-    }
-    .await;
+	// Export, remove table, and import
+	let res = async {
+		db.export(&file).await?;
+		db.query("REMOVE TABLE user").await?;
+		db.import(&file).await?;
+		Result::<(), Error>::Ok(())
+	}
+	.await;
 
-    // Remove the export file
-    remove_file(&file).await.unwrap();
+	// Remove the export file
+	remove_file(&file).await.unwrap();
 
-    // Check the result of the export/import operations
-    res.unwrap();
+	// Check the result of the export/import operations
+	res.unwrap();
 
-    // Verify that all records exist post-import
-    for i in 0..10 {
-        let mut response = db
-            .query(&format!("SELECT name FROM user WHERE name = 'User {i}'"))
-            .await
-            .unwrap();
-        let Some(name): Option<String> = response.take("name").unwrap() else {
-            panic!("query returned no record");
-        };
-        assert_eq!(name, format!("User {i}"));
-    }
+	// Verify that all records exist post-import
+	for i in 0..10 {
+		let mut response =
+			db.query(&format!("SELECT name FROM user WHERE name = 'User {i}'")).await.unwrap();
+		let Some(name): Option<String> = response.take("name").unwrap() else {
+			panic!("query returned no record");
+		};
+		assert_eq!(name, format!("User {i}"));
+	}
 }
 
 #[tokio::test]
 async fn export_with_config() {
-    let (permit, db) = new_db().await;
-    let db_name = Ulid::new().to_string();
-    db.use_ns(NS).use_db(&db_name).await.unwrap();
+	let (permit, db) = new_db().await;
+	let db_name = Ulid::new().to_string();
+	db.use_ns(NS).use_db(&db_name).await.unwrap();
 
-    // Insert records
-    for i in 0..10 {
-        // Record on "user" table
-        let _: Option<ApiRecordId> = db
-            .create("user")
-            .content(Record {
-                name: format!("User {i}"),
-            })
-            .await
-            .unwrap();
+	// Insert records
+	for i in 0..10 {
+		// Record on "user" table
+		let _: Option<ApiRecordId> = db
+			.create("user")
+			.content(Record {
+				name: format!("User {i}"),
+			})
+			.await
+			.unwrap();
 
-        // Record on "group" table
-        let _: Option<ApiRecordId> = db
-            .create("group")
-            .content(Record {
-                name: format!("Group {i}"),
-            })
-            .await
-            .unwrap();
-    }
+		// Record on "group" table
+		let _: Option<ApiRecordId> = db
+			.create("group")
+			.content(Record {
+				name: format!("Group {i}"),
+			})
+			.await
+			.unwrap();
+	}
 
-    // Drop the permit to release the database lock
-    drop(permit);
+	// Drop the permit to release the database lock
+	drop(permit);
 
-    // Define the export file name
-    let file = format!("{db_name}.sql");
+	// Define the export file name
+	let file = format!("{db_name}.sql");
 
-    // Export, remove table, and import
-    let res = async {
-        db.export(&file).with_tables(vec!["user".to_string()]).await?;
-        db.query("REMOVE TABLE user; REMOVE TABLE group;").await?;
-        db.import(&file).await?;
-        Result::<(), Error>::Ok(())
-    }
-    .await;
+	// Export, remove table, and import
+	let res = async {
+		db.export(&file).with_config().tables(vec!["user".to_string()]).await?;
+		db.query("REMOVE TABLE user; REMOVE TABLE group;").await?;
+		db.import(&file).await?;
+		Result::<(), Error>::Ok(())
+	}
+	.await;
 
-    // Remove the export file
-    remove_file(&file).await.unwrap();
+	// Remove the export file
+	remove_file(&file).await.unwrap();
 
-    // Check the result of the export/import operations
-    res.unwrap();
+	// Check the result of the export/import operations
+	res.unwrap();
 
-    // Verify that no group records were imported
-    let mut response = db.query(&format!("SELECT id FROM group")).await.unwrap();
-    let tmp: Option<Value> = response.take(0).unwrap();
-    assert_eq!(tmp, None);
+	// Verify that no group records were imported
+	let mut response = db.query(&format!("SELECT id FROM group")).await.unwrap();
+	let tmp: Option<Value> = response.take(0).unwrap();
+	assert_eq!(tmp, None);
 
-    // Verify that all user records exist post-import
-    for i in 0..10 {
-        let mut response = db
-            .query(&format!("SELECT name FROM user WHERE name = 'User {i}'"))
-            .await
-            .unwrap();
-        let Some(name): Option<String> = response.take("name").unwrap() else {
-            panic!("query returned no record");
-        };
-        assert_eq!(name, format!("User {i}"));
-    }
+	// Verify that all user records exist post-import
+	for i in 0..10 {
+		let mut response =
+			db.query(&format!("SELECT name FROM user WHERE name = 'User {i}'")).await.unwrap();
+		let Some(name): Option<String> = response.take("name").unwrap() else {
+			panic!("query returned no record");
+		};
+		assert_eq!(name, format!("User {i}"));
+	}
 }
 
 #[test_log::test(tokio::test)]

--- a/sdk/tests/api/backup.rs
+++ b/sdk/tests/api/backup.rs
@@ -55,6 +55,67 @@ async fn export_import() {
     }
 }
 
+#[tokio::test]
+async fn export_with_config() {
+    let (permit, db) = new_db().await;
+    let db_name = Ulid::new().to_string();
+    db.use_ns(NS).use_db(&db_name).await.unwrap();
+
+    // Insert records
+    for i in 0..10 {
+        // Record on "user" table
+        let _: Option<ApiRecordId> = db
+            .create("user")
+            .content(Record {
+                name: format!("User {i}"),
+            })
+            .await
+            .unwrap();
+
+        // Record on "group" table
+        let _: Option<ApiRecordId> = db
+            .create("group")
+            .content(Record {
+                name: format!("Group {i}"),
+            })
+            .await
+            .unwrap();
+    }
+
+    // Drop the permit to release the database lock
+    drop(permit);
+
+    // Define the export file name
+    let file = format!("{db_name}.sql");
+
+    // Export, remove table, and import
+    let res = async {
+        db.export(&file).with_tables(vec!["user".to_string()]).await?;
+        db.query("REMOVE TABLE user, group").await?;
+        db.import(&file).await?;
+        Result::<(), Error>::Ok(())
+    }
+    .await;
+
+    // Remove the export file
+    remove_file(&file).await.unwrap();
+
+    // Check the result of the export/import operations
+    res.unwrap();
+
+    // Verify that all records exist post-import
+    for i in 0..10 {
+        let mut response = db
+            .query(&format!("SELECT name FROM user WHERE name = 'User {i}'"))
+            .await
+            .unwrap();
+        let Some(name): Option<String> = response.take("name").unwrap() else {
+            panic!("query returned no record");
+        };
+        assert_eq!(name, format!("User {i}"));
+    }
+}
+
 #[test_log::test(tokio::test)]
 #[cfg(feature = "ml")]
 async fn ml_export_import() {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Followup of #5108, now also allowing to pass export options in the Rust SDK.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Implements chainable `.with_users()`, `.with_accesses()`, `.with_params()`, `.with_functions()`, `.with_analyzers()`, `.with_tables()` and `.versioned()` methods on the SDK's `.export()` method, allowing you to configure all export options.
All methods accept a boolean, and `.with_tables()` also accepts a `Vec<String>` in addition with a list of tables to export.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Needs documentation

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
