### PR TITLE
Better handling of unexpected authentication errors

### DIFF
--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -861,8 +861,16 @@ pub enum Error {
 	InvalidPass,
 
 	/// There was an error with authentication
+	///
+	/// This error hides different kinds of errors directly related to authentication
 	#[error("There was a problem with authentication")]
 	InvalidAuth,
+
+	/// There was an unexpected error while performing authentication
+	///
+	/// This error hides different kinds of unexpected errors that may affect authentication
+	#[error("There was an unexpected error while performing authentication")]
+	UnexpectedAuth,
 
 	/// There was an error with signing up
 	#[error("There was a problem with signing up")]

--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -212,7 +212,10 @@ pub async fn db_access(
 									Error::Thrown(_) => Err(e),
 									// If the SIGNIN clause failed due to an unexpected error, be more specific
 									// This allows clients to handle these errors, which may be retryable
-									Error::Tx(_) | Error::TxFailure => Err(Error::UnexpectedAuth),
+									Error::Tx(_) | Error::TxFailure => {
+										debug!("Unexpected error found while executing a SIGNIN clause: {e}");
+										Err(Error::UnexpectedAuth)
+									}
 									// Otherwise, return a generic error unless it should be forwarded
 									e => {
 										debug!("Record user signin query failed: {e}");

--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -208,7 +208,12 @@ pub async fn db_access(
 									}
 								}
 								Err(e) => match e {
+									// If the SIGNIN clause throws a specific error, authentication fails with that error
 									Error::Thrown(_) => Err(e),
+									// If the SIGNIN clause failed due to an unexpected error, be more specific
+									// This allows clients to handle these errors, which may be retryable
+									Error::Tx(_) | Error::TxFailure => Err(Error::UnexpectedAuth),
+									// Otherwise, return a generic error unless it should be forwarded
 									e => {
 										debug!("Record user signin query failed: {e}");
 										if *INSECURE_FORWARD_ACCESS_ERRORS {

--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -957,6 +957,86 @@ mod tests {
 
 			assert!(res.is_err(), "Unexpected successful signin: {:?}", res);
 		}
+
+		// Test SIGNIN failing due to datastore transaction conflict
+		{
+			let ds = Datastore::new("memory").await.unwrap();
+			let sess = Session::owner().with_ns("test").with_db("test");
+			ds.execute(
+				r#"
+				DEFINE ACCESS user ON DATABASE TYPE RECORD
+					SIGNIN {
+					    UPSERT count:1 SET count += 1; -- Concurrently write to the same document
+					    SLEEP(2s); -- Increase the duration of the transaction
+						RETURN (SELECT * FROM user WHERE name = $user AND crypto::argon2::compare(pass, $pass))
+					}
+					SIGNUP (
+						CREATE user CONTENT {
+							name: $user,
+							pass: crypto::argon2::generate($pass)
+						}
+					)
+					DURATION FOR SESSION 2h
+				;
+
+				CREATE user:test CONTENT {
+					name: 'user',
+					pass: crypto::argon2::generate('pass')
+				}
+				"#,
+				&sess,
+				None,
+			)
+			.await
+			.unwrap();
+
+			// Sign in with the user twice at the same time
+			let mut sess1 = Session {
+				ns: Some("test".to_string()),
+				db: Some("test".to_string()),
+				..Default::default()
+			};
+			let mut sess2 = Session {
+				ns: Some("test".to_string()),
+				db: Some("test".to_string()),
+				..Default::default()
+			};
+			let mut vars: HashMap<&str, Value> = HashMap::new();
+			vars.insert("user", "user".into());
+			vars.insert("pass", "pass".into());
+
+			let (res1, res2) = tokio::join!(
+				db_access(
+					&ds,
+					&mut sess1,
+					"test".to_string(),
+					"test".to_string(),
+					"user".to_string(),
+					vars.clone().into(),
+				),
+				db_access(
+					&ds,
+					&mut sess2,
+					"test".to_string(),
+					"test".to_string(),
+					"user".to_string(),
+					vars.into(),
+				)
+			);
+
+			match (res1, res2) {
+				(Ok(r1), Ok(r2)) => panic!("Expected authentication to fail in one instance, but instead received: {:?} and {:?}", r1, r2),
+				(Err(e1), Err(e2)) => panic!("Expected authentication to fail in one instance, but instead received: {:?} and {:?}", e1, e2),
+				(Err(e1), Ok(_)) => match &e1 {
+						Error::UnexpectedAuth => {} // ok
+						e => panic!("Expected authentication to return an UnexpectedAuth error, but insted got: {e}")
+				}
+				(Ok(_), Err(e2)) => match &e2 {
+						Error::UnexpectedAuth => {} // ok
+						e => panic!("Expected authentication to return an UnexpectedAuth error, but insted got: {e}")
+				}
+			}
+		}
 	}
 
 	#[tokio::test]
@@ -1594,6 +1674,78 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 					"Expected authentication to generally fail, but instead received: {:?}",
 					res
 				),
+			}
+		}
+		// Test AUTHENTICATE failing due to datastore transaction conflict
+		{
+			let ds = Datastore::new("memory").await.unwrap();
+			let sess = Session::owner().with_ns("test").with_db("test");
+			ds.execute(
+				r#"
+				DEFINE ACCESS user ON DATABASE TYPE RECORD
+					SIGNIN (
+					   SELECT * FROM type::thing('user', $id)
+					)
+					AUTHENTICATE {
+					   UPSERT count:1 SET count += 1; -- Concurrently write to the same document
+					   SLEEP(2s); -- Increase the duration of the transaction
+					   $auth.id -- Continue with authentication
+					}
+					DURATION FOR SESSION 2h
+				;
+
+				CREATE user:1;
+				"#,
+				&sess,
+				None,
+			)
+			.await
+			.unwrap();
+
+			// Sign in with the user twice at the same time
+			let mut sess1 = Session {
+				ns: Some("test".to_string()),
+				db: Some("test".to_string()),
+				..Default::default()
+			};
+			let mut sess2 = Session {
+				ns: Some("test".to_string()),
+				db: Some("test".to_string()),
+				..Default::default()
+			};
+			let mut vars: HashMap<&str, Value> = HashMap::new();
+			vars.insert("id", 1.into());
+
+			let (res1, res2) = tokio::join!(
+				db_access(
+					&ds,
+					&mut sess1,
+					"test".to_string(),
+					"test".to_string(),
+					"user".to_string(),
+					vars.clone().into(),
+				),
+				db_access(
+					&ds,
+					&mut sess2,
+					"test".to_string(),
+					"test".to_string(),
+					"user".to_string(),
+					vars.into(),
+				)
+			);
+
+			match (res1, res2) {
+				(Ok(r1), Ok(r2)) => panic!("Expected authentication to fail in one instance, but instead received: {:?} and {:?}", r1, r2),
+				(Err(e1), Err(e2)) => panic!("Expected authentication to fail in one instance, but instead received: {:?} and {:?}", e1, e2),
+				(Err(e1), Ok(_)) => match &e1 {
+						Error::UnexpectedAuth => {} // ok
+						e => panic!("Expected authentication to return an UnexpectedAuth error, but insted got: {e}")
+				}
+				(Ok(_), Err(e2)) => match &e2 {
+						Error::UnexpectedAuth => {} // ok
+						e => panic!("Expected authentication to return an UnexpectedAuth error, but insted got: {e}")
+				}
 			}
 		}
 	}

--- a/core/src/iam/signup.rs
+++ b/core/src/iam/signup.rs
@@ -119,7 +119,14 @@ pub async fn db_access(
 														}
 													},
 													Err(e) => return match e {
+														// If the SIGNUP clause throws a specific error, authentication fails with that error
 														Error::Thrown(_) => Err(e),
+														// If the SIGNUP clause failed due to an unexpected error, be more specific
+														// This allows clients to handle these errors, which may be retryable
+														Error::Tx(_) | Error::TxFailure => {
+															Err(Error::UnexpectedAuth)
+														}
+														// Otherwise, return a generic error unless it should be forwarded
 														e if *INSECURE_FORWARD_ACCESS_ERRORS => {
 															Err(e)
 														}

--- a/core/src/iam/verify.rs
+++ b/core/src/iam/verify.rs
@@ -670,6 +670,10 @@ pub async fn authenticate_record(
 		Err(e) => match e {
 			// If the AUTHENTICATE clause throws a specific error, authentication fails with that error
 			Error::Thrown(_) => Err(e),
+			// If the AUTHENTICATE clause failed due to an unexpected error, be more specific
+			// This allows clients to handle these errors, which may be retryable
+			Error::Tx(_) | Error::TxFailure => Err(Error::UnexpectedAuth),
+			// Otherwise, return a generic error unless it should be forwarded
 			e if *INSECURE_FORWARD_ACCESS_ERRORS => Err(e),
 			_ => Err(Error::InvalidAuth),
 		},
@@ -697,6 +701,10 @@ pub async fn authenticate_generic(
 		Err(e) => match e {
 			// If the AUTHENTICATE clause throws a specific error, authentication fails with that error
 			Error::Thrown(_) => Err(e),
+			// If the AUTHENTICATE clause failed due to an unexpected error, be more specific
+			// This allows clients to handle these errors, which may be retryable
+			Error::Tx(_) | Error::TxFailure => Err(Error::UnexpectedAuth),
+			// Otherwise, return a generic error unless it should be forwarded
 			e if *INSECURE_FORWARD_ACCESS_ERRORS => Err(e),
 			_ => Err(Error::InvalidAuth),
 		},


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To better handle scenarios where authentication fails due to an error that is not directly related with authentication, but rather with a failure with some of the components necessary for authentication. A specific example is the `AUTHENTICATE`, `SIGNIN` or `SIGNUP` clauses failing due to a datastore error, such as those arising from a write conflict during the transaction. These failures can potentially be retried, and we want to distinguish them for other generic authentication failures which are actually related with the authentication process (e.g. incorrect credentials) and would fail again if they were retried.

## What does this change do?

- Implements the new `UnexpectedAuth` error that represents an unexpected error during authentication.
- Improves debug and trace logs related to authentication clauses in order to identify the specific error on the server.

## What is your testing strategy?

Added specific tests for `signin` and `signup` for testing the `SIGNIN`, `SIGNUP` and `AUTHENTICATE` clauses.

## Is this related to any issues?

Resolves #5114 and #5042, which failed due to the use of `UPSERT` against the exact same document within the `AUTHENTICATE` clause. When several users would authenticate concurrently, the `UPSERT` statement would fail with a `There was a problem with a datastore transaction: Transaction read conflict` error due to the record being updated during the execution of the transaction. This error would be hidden by `InvalidAuth`, which is the generic error returned to authenticating users in order to avoid leaking internal database information. With the changes from this PR, clients can handle the more specific `UnexpectedAuth` error in order to retry the operation, given that the failure is unrelated with the authentication logic.

## Does this change need documentation?

Yes, we will write specific troubleshooting information for authentication, including this specific error.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
