### PR TITLE
Allow customising record exporting

### DIFF
--- a/core/src/kvs/export.rs
+++ b/core/src/kvs/export.rs
@@ -20,6 +20,7 @@ pub struct Config {
 	pub analyzers: bool,
 	pub tables: TableConfig,
 	pub versions: bool,
+	pub records: bool,
 }
 
 impl Default for Config {
@@ -32,6 +33,7 @@ impl Default for Config {
 			analyzers: true,
 			tables: TableConfig::default(),
 			versions: false,
+			records: true,
 		}
 	}
 }
@@ -66,6 +68,7 @@ impl TryFrom<&Value> for Config {
 				bool_prop!(functions);
 				bool_prop!(analyzers);
 				bool_prop!(versions);
+				bool_prop!(records);
 
 				if let Some(v) = obj.get("tables") {
 					config.tables = v.try_into()?;
@@ -227,7 +230,10 @@ impl Transaction {
 			}
 
 			self.export_table_structure(ns, db, table, chn).await?;
-			self.export_table_data(ns, db, table, cfg, chn).await?;
+
+			if cfg.records {
+				self.export_table_data(ns, db, table, cfg, chn).await?;
+			}
 		}
 
 		Ok(())


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Table definitions cannot be exported without including records, preventing the easy exporting of a schema without data

## What does this change do?

Adds "records" as a new export config option, defaulting to true

## What is your testing strategy?

CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Needs documentation

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
