### PR TITLE
Object improvements

### DIFF
--- a/core/src/sql/value/cut.rs
+++ b/core/src/sql/value/cut.rs
@@ -30,6 +30,15 @@ impl Value {
 							}
 						}
 					},
+					Part::All => match path.len() {
+						1 => {
+							v.clear();
+						}
+						_ => {
+							let path = path.next();
+							v.iter_mut().for_each(|(_, v)| v.cut(path));
+						}
+					},
 					_ => {}
 				},
 				// Current value at path is an array

--- a/core/src/sql/value/each.rs
+++ b/core/src/sql/value/each.rs
@@ -17,7 +17,10 @@ impl Value {
 						Some(v) => v._each(path.next(), prev.push(p.clone())),
 						None => vec![],
 					},
-					Part::All => self._each(path.next(), prev.push(p.clone())),
+					Part::All => v
+						.iter()
+						.flat_map(|(field, v)| v._each(path.next(), prev.clone().push(Part::Field(field.to_owned().into()))))
+						.collect::<Vec<_>>(),
 					_ => vec![],
 				},
 				// Current path part is an array

--- a/core/src/sql/value/each.rs
+++ b/core/src/sql/value/each.rs
@@ -19,7 +19,12 @@ impl Value {
 					},
 					Part::All => v
 						.iter()
-						.flat_map(|(field, v)| v._each(path.next(), prev.clone().push(Part::Field(field.to_owned().into()))))
+						.flat_map(|(field, v)| {
+							v._each(
+								path.next(),
+								prev.clone().push(Part::Field(field.to_owned().into())),
+							)
+						})
 						.collect::<Vec<_>>(),
 					_ => vec![],
 				},

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -213,9 +213,10 @@ impl Value {
 						_ => stk.run(|stk| Value::None.get(stk, ctx, opt, doc, path.next())).await,
 					},
 					Part::All => {
-						let v: Value = v.values().map(|v| v.to_owned()).collect::<Vec<Value>>().into();
+						let v: Value =
+							v.values().map(|v| v.to_owned()).collect::<Vec<Value>>().into();
 						stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
-					},
+					}
 					Part::Destructure(p) => {
 						let mut obj = BTreeMap::<String, Value>::new();
 						for p in p.iter() {

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -126,6 +126,10 @@ impl Value {
 						let obj = Value::Object(v.as_object());
 						stk.run(|stk| obj.get(stk, ctx, opt, doc, path)).await
 					}
+					Part::All => {
+						let obj = Value::Object(v.as_object());
+						stk.run(|stk| obj.get(stk, ctx, opt, doc, path)).await
+					}
 					Part::Method(name, args) => {
 						let v = stk
 							.run(|stk| {

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -476,10 +476,18 @@ impl Value {
 								};
 								let v =
 									stk.run(|stk| stm.compute(stk, ctx, opt, None)).await?.first();
+
+								// .* on a record id means fetch the record's contents
+								// The above select statement results in an object, if
+								// we apply `.*` on that, we can an array with the record's
+								// values instead of just the content. Therefore, if we
+								// encounter the first part to be `.*`, we simply skip it here
 								let next = match path.first() {
 									Some(Part::All) => path.next(),
-									_ => path
+									_ => path,
 								};
+
+								// Continue processing the path on the now fetched record
 								stk.run(|stk| v.get(stk, ctx, opt, None, next)).await
 							}
 						},

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -126,10 +126,6 @@ impl Value {
 						let obj = Value::Object(v.as_object());
 						stk.run(|stk| obj.get(stk, ctx, opt, doc, path)).await
 					}
-					Part::All => {
-						let obj = Value::Object(v.as_object());
-						stk.run(|stk| obj.get(stk, ctx, opt, doc, path)).await
-					}
 					Part::Method(name, args) => {
 						let v = stk
 							.run(|stk| {

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -212,7 +212,10 @@ impl Value {
 						},
 						_ => stk.run(|stk| Value::None.get(stk, ctx, opt, doc, path.next())).await,
 					},
-					Part::All => stk.run(|stk| self.get(stk, ctx, opt, doc, path.next())).await,
+					Part::All => {
+						let v: Value = v.values().map(|v| v.to_owned()).collect::<Vec<Value>>().into();
+						stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
+					},
 					Part::Destructure(p) => {
 						let mut obj = BTreeMap::<String, Value>::new();
 						for p in p.iter() {

--- a/core/src/sql/value/get.rs
+++ b/core/src/sql/value/get.rs
@@ -476,7 +476,11 @@ impl Value {
 								};
 								let v =
 									stk.run(|stk| stm.compute(stk, ctx, opt, None)).await?.first();
-								stk.run(|stk| v.get(stk, ctx, opt, None, path)).await
+								let next = match path.first() {
+									Some(Part::All) => path.next(),
+									_ => path
+								};
+								stk.run(|stk| v.get(stk, ctx, opt, None, next)).await
 							}
 						},
 					}

--- a/core/src/sql/value/pick.rs
+++ b/core/src/sql/value/pick.rs
@@ -18,10 +18,9 @@ impl Value {
 						Some(v) => v.pick(path.next()),
 						None => Value::None,
 					},
-					Part::All => v.iter()
-						.map(|(_, v)| v.pick(path.next()))
-						.collect::<Vec<_>>()
-						.into(),
+					Part::All => {
+						v.iter().map(|(_, v)| v.pick(path.next())).collect::<Vec<_>>().into()
+					}
 					_ => Value::None,
 				},
 				// Current value at path is an array

--- a/core/src/sql/value/pick.rs
+++ b/core/src/sql/value/pick.rs
@@ -18,7 +18,10 @@ impl Value {
 						Some(v) => v.pick(path.next()),
 						None => Value::None,
 					},
-					Part::All => self.pick(path.next()),
+					Part::All => v.iter()
+						.map(|(_, v)| v.pick(path.next()))
+						.collect::<Vec<_>>()
+						.into(),
 					_ => Value::None,
 				},
 				// Current value at path is an array

--- a/core/src/sql/value/put.rs
+++ b/core/src/sql/value/put.rs
@@ -34,6 +34,10 @@ impl Value {
 							v.insert(i.to_string(), obj);
 						}
 					},
+					Part::All => {
+						let path = path.next();
+						v.iter_mut().for_each(|(_, v)| v.put(path, val.clone()));
+					}
 					_ => (),
 				},
 				// Current value at path is an array

--- a/core/src/sql/value/set.rs
+++ b/core/src/sql/value/set.rs
@@ -185,21 +185,23 @@ impl Value {
 					match place {
 						Value::Array(v) => {
 							stk.scope(|scope| {
-								let futs = v.iter_mut()
-									.map(|v| scope.run(|stk| v.set(stk, ctx, opt, path, val.clone())));
+								let futs = v.iter_mut().map(|v| {
+									scope.run(|stk| v.set(stk, ctx, opt, path, val.clone()))
+								});
 								try_join_all_buffered(futs)
 							})
 							.await?;
-						},
+						}
 						Value::Object(v) => {
 							stk.scope(|scope| {
-								let futs = v.iter_mut()
-									.map(|(_, v)| scope.run(|stk| v.set(stk, ctx, opt, path, val.clone())));
+								let futs = v.iter_mut().map(|(_, v)| {
+									scope.run(|stk| v.set(stk, ctx, opt, path, val.clone()))
+								});
 								try_join_all_buffered(futs)
 							})
 							.await?;
-						},
-						_ => ()
+						}
+						_ => (),
 					};
 
 					return Ok(());

--- a/core/src/sql/value/set.rs
+++ b/core/src/sql/value/set.rs
@@ -181,18 +181,27 @@ impl Value {
 					place = x
 				}
 				Part::All => {
-					let Value::Array(arr) = place else {
-						return Ok(());
+					let path = iter.as_slice();
+					match place {
+						Value::Array(v) => {
+							stk.scope(|scope| {
+								let futs = v.iter_mut()
+									.map(|v| scope.run(|stk| v.set(stk, ctx, opt, path, val.clone())));
+								try_join_all_buffered(futs)
+							})
+							.await?;
+						},
+						Value::Object(v) => {
+							stk.scope(|scope| {
+								let futs = v.iter_mut()
+									.map(|(_, v)| scope.run(|stk| v.set(stk, ctx, opt, path, val.clone())));
+								try_join_all_buffered(futs)
+							})
+							.await?;
+						},
+						_ => ()
 					};
 
-					let path = iter.as_slice();
-					stk.scope(|scope| {
-						let futs = arr
-							.iter_mut()
-							.map(|v| scope.run(|stk| v.set(stk, ctx, opt, path, val.clone())));
-						try_join_all_buffered(futs)
-					})
-					.await?;
 					return Ok(());
 				}
 				Part::Where(w) => {

--- a/core/src/sql/value/value.rs
+++ b/core/src/sql/value/value.rs
@@ -2746,6 +2746,10 @@ impl Value {
 				Value::Geometry(w) => v.contains(w),
 				_ => false,
 			},
+			Value::Object(v) => match other {
+				Value::Strand(w) => v.0.contains_key(&w.0),
+				_ => false,
+			},
 			Value::Range(r) => {
 				let beg = match &r.beg {
 					Bound::Unbounded => true,

--- a/core/src/sql/value/walk.rs
+++ b/core/src/sql/value/walk.rs
@@ -23,7 +23,12 @@ impl Value {
 					},
 					Part::All => v
 						.iter()
-						.flat_map(|(field, v)| v._walk(path.next(), prev.clone().push(Part::Field(field.to_owned().into()))))
+						.flat_map(|(field, v)| {
+							v._walk(
+								path.next(),
+								prev.clone().push(Part::Field(field.to_owned().into())),
+							)
+						})
 						.collect::<Vec<_>>(),
 					_ => vec![],
 				},

--- a/core/src/sql/value/walk.rs
+++ b/core/src/sql/value/walk.rs
@@ -21,7 +21,10 @@ impl Value {
 						Some(v) => v._walk(path.next(), prev.push(p.clone())),
 						None => Value::None._walk(path.next(), prev.push(p.clone())),
 					},
-					Part::All => self._walk(path.next(), prev.push(p.clone())),
+					Part::All => v
+						.iter()
+						.flat_map(|(field, v)| v._walk(path.next(), prev.clone().push(Part::Field(field.to_owned().into()))))
+						.collect::<Vec<_>>(),
 					_ => vec![],
 				},
 				// Current path part is an array

--- a/sdk/tests/expression.rs
+++ b/sdk/tests/expression.rs
@@ -26,11 +26,14 @@ async fn expr_value_in_range() -> Result<(), Error> {
 
 #[tokio::test]
 async fn expr_object_contains_key() -> Result<(), Error> {
-	Test::new("
+	Test::new(
+		"
 		'a' IN { a: 1 };
 		'b' IN { a: 1 };
-	").await?
-		.expect_val("true")?
-		.expect_val("false")?;
+	",
+	)
+	.await?
+	.expect_val("true")?
+	.expect_val("false")?;
 	Ok(())
 }

--- a/sdk/tests/expression.rs
+++ b/sdk/tests/expression.rs
@@ -23,3 +23,14 @@ async fn expr_value_in_range() -> Result<(), Error> {
 	.expect_val("false")?;
 	Ok(())
 }
+
+#[tokio::test]
+async fn expr_object_contains_key() -> Result<(), Error> {
+	Test::new("
+		'a' IN { a: 1 };
+		'b' IN { a: 1 };
+	").await?
+		.expect_val("true")?
+		.expect_val("false")?;
+	Ok(())
+}

--- a/sdk/tests/idiom.rs
+++ b/sdk/tests/idiom.rs
@@ -932,3 +932,24 @@ async fn idiom_recursion_limits() -> Result<(), Error> {
 		)?;
 	Ok(())
 }
+
+#[tokio::test]
+async fn idiom_object_dot_star() -> Result<(), Error> {
+	let sql = r#"
+		{ a: 1, b: 2 }.*;
+
+		DEFINE FIELD obj ON test TYPE object;
+		DEFINE FIELD obj.* ON test TYPE number;
+		CREATE test:1 SET obj.a = 'a';
+
+		(1, 2).*;
+	"#;
+	Test::new(sql)
+		.await?
+		.expect_val("[1, 2]")?
+		.expect_val("NONE")?
+		.expect_val("NONE")?
+		.expect_error("Found 'a' for field `obj[*]`, with record `test:1`, but expected a number")?
+		.expect_val("[[1f, 2f], 'Point']")?;
+	Ok(())
+}

--- a/sdk/tests/idiom.rs
+++ b/sdk/tests/idiom.rs
@@ -947,6 +947,8 @@ async fn idiom_object_dot_star() -> Result<(), Error> {
 		.expect_val("[1, 2]")?
 		.expect_val("NONE")?
 		.expect_val("NONE")?
-		.expect_error("Found 'a' for field `obj[*]`, with record `test:1`, but expected a number")?;
+		.expect_error(
+			"Found 'a' for field `obj[*]`, with record `test:1`, but expected a number",
+		)?;
 	Ok(())
 }

--- a/sdk/tests/idiom.rs
+++ b/sdk/tests/idiom.rs
@@ -941,15 +941,12 @@ async fn idiom_object_dot_star() -> Result<(), Error> {
 		DEFINE FIELD obj ON test TYPE object;
 		DEFINE FIELD obj.* ON test TYPE number;
 		CREATE test:1 SET obj.a = 'a';
-
-		(1, 2).*;
 	"#;
 	Test::new(sql)
 		.await?
 		.expect_val("[1, 2]")?
 		.expect_val("NONE")?
 		.expect_val("NONE")?
-		.expect_error("Found 'a' for field `obj[*]`, with record `test:1`, but expected a number")?
-		.expect_val("[[1f, 2f], 'Point']")?;
+		.expect_error("Found 'a' for field `obj[*]`, with record `test:1`, but expected a number")?;
 	Ok(())
 }

--- a/sdk/tests/idiom.rs
+++ b/sdk/tests/idiom.rs
@@ -950,9 +950,9 @@ async fn idiom_object_dot_star() -> Result<(), Error> {
 		DEFINE FIELD emails.*.address ON TABLE user TYPE option<number>;
 		DEFINE FIELD tags.*.value ON TABLE user TYPE option<string>;
 
-		CREATE user SET emails.address = 9;
-		CREATE user SET emails.address = "me@me.com";
-		create user set tags = [{ value: 'bla' }], emails.address = "me@me.com"
+		CREATE user:1 SET emails.address = 9;
+		CREATE user:2 SET emails.address = "me@me.com";
+		create user:3 set tags = [{ value: 'bla' }], emails.address = "me@me.com"
 	"#;
 	Test::new(sql)
 		.await?
@@ -965,14 +965,13 @@ async fn idiom_object_dot_star() -> Result<(), Error> {
 		.expect_val("NONE")?
 		.expect_val("NONE")?
 		.expect_val("NONE")?
-		.expect_val("NONE")?
-		.expect_error("Found 9 for field `emails.address`, with record `user:j29qttc4fady01dw0met`, but expected a string")?
+		.expect_error("Found 9 for field `emails.address`, with record `user:1`, but expected a string")?
 		.expect_val("[
 			{
 				emails: {
 					address: 'me@me.com'
 				},
-				id: user:taczy40pn197dv2wg7ao
+				id: user:2
 			}
 		]")?
 		.expect_val("[
@@ -980,7 +979,7 @@ async fn idiom_object_dot_star() -> Result<(), Error> {
 				emails: {
 					address: 'me@me.com'
 				},
-				id: user:imek7ar10kberisp62hv,
+				id: user:3,
 				tags: [
 					{
 						value: 'bla'

--- a/sdk/tests/idiom.rs
+++ b/sdk/tests/idiom.rs
@@ -959,22 +959,25 @@ async fn idiom_object_dot_star() -> Result<(), Error> {
 		.expect_val("[1, 2]")?
 		.expect_val("NONE")?
 		.expect_val("NONE")?
+		.expect_error("Found 'a' for field `obj[*]`, with record `test:1`, but expected a number")?
+		.expect_val("NONE")?
+		.expect_val("NONE")?
+		.expect_val("NONE")?
 		.expect_error(
-			"Found 'a' for field `obj[*]`, with record `test:1`, but expected a number",
+			"Found 9 for field `emails.address`, with record `user:1`, but expected a string",
 		)?
-		.expect_val("NONE")?
-		.expect_val("NONE")?
-		.expect_val("NONE")?
-		.expect_error("Found 9 for field `emails.address`, with record `user:1`, but expected a string")?
-		.expect_val("[
+		.expect_val(
+			"[
 			{
 				emails: {
 					address: 'me@me.com'
 				},
 				id: user:2
 			}
-		]")?
-		.expect_val("[
+		]",
+		)?
+		.expect_val(
+			"[
 			{
 				emails: {
 					address: 'me@me.com'
@@ -986,6 +989,7 @@ async fn idiom_object_dot_star() -> Result<(), Error> {
 					}
 				]
 			}
-		]")?;
+		]",
+		)?;
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Applying `.*` on an object is currently quite useless as the part is essentially skipped.
Additionally, you currently need to collect object keys first before you can check if it contains a key, which is cumbersome.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Implements `.*` on object values to apply to it's values instead of itself, and implements `contains` on object value to allow checking for key existence.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added tests

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Closes https://github.com/surrealdb/surrealdb/issues/4291
- [x] Closes https://github.com/surrealdb/surrealdb/issues/4060
- [x] Closes https://github.com/surrealdb/surrealdb/issues/4693

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Needs documentation

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
