### PR TITLE
Improve error messages for negative arithmetic + try_reserve

### DIFF
--- a/core/src/err/mod.rs
+++ b/core/src/err/mod.rs
@@ -1174,9 +1174,17 @@ pub enum Error {
 
 	#[error("Size of query script exceeded maximum supported size of 4,294,967,295 bytes.")]
 	QueryTooLarge,
+
 	/// Represents a failure in timestamp arithmetic related to database internals
-	#[error("Failed to compute: \"{0}\", as the operation results in an overflow.")]
+	#[error("Failed to compute: \"{0}\", as the operation results in an arithmetic overflow.")]
 	ArithmeticOverflow(String),
+
+	/// Represents a negative value for a type that must be zero or positive
+	#[error("Failed to compute: \"{0}\", as the operation results in a negative value.")]
+	ArithmeticNegativeOverflow(String),
+
+	#[error("Failed to allocate space for \"{0}\"")]
+	InsufficientReserve(String),
 
 	#[error("Received error while streaming query: {0}.")]
 	QueryStream(String),

--- a/core/src/sql/datetime.rs
+++ b/core/src/sql/datetime.rs
@@ -126,7 +126,7 @@ impl TrySub for Datetime {
 	fn try_sub(self, other: Self) -> Result<Duration, Error> {
 		(self.0 - other.0)
 			.to_std()
-			.map_err(|_| Error::ArithmeticOverflow(format!("{self} - {other}")))
+			.map_err(|_| Error::ArithmeticNegativeOverflow(format!("{self} - {other}")))
 			.map(Duration::from)
 	}
 }

--- a/core/src/sql/duration.rs
+++ b/core/src/sql/duration.rs
@@ -285,7 +285,7 @@ impl TrySub for Duration {
 	fn try_sub(self, other: Self) -> Result<Self, Error> {
 		self.0
 			.checked_sub(other.0)
-			.ok_or_else(|| Error::ArithmeticOverflow(format!("{self} - {other}")))
+			.ok_or_else(|| Error::ArithmeticNegativeOverflow(format!("{self} - {other}")))
 			.map(Duration::from)
 	}
 }
@@ -305,7 +305,7 @@ impl<'a, 'b> TrySub<&'b Duration> for &'a Duration {
 	fn try_sub(self, other: &'b Duration) -> Result<Duration, Error> {
 		self.0
 			.checked_sub(other.0)
-			.ok_or_else(|| Error::ArithmeticOverflow(format!("{self} - {other}")))
+			.ok_or_else(|| Error::ArithmeticNegativeOverflow(format!("{self} - {other}")))
 			.map(Duration::from)
 	}
 }
@@ -355,9 +355,9 @@ impl TrySub<Datetime> for Duration {
 		match chrono::Duration::from_std(self.0) {
 			Ok(d) => match other.0.checked_sub_signed(d) {
 				Some(v) => Ok(Datetime::from(v)),
-				None => Err(Error::ArithmeticOverflow(format!("{self} - {other}"))),
+				None => Err(Error::ArithmeticNegativeOverflow(format!("{self} - {other}"))),
 			},
-			Err(_) => Err(Error::ArithmeticOverflow(format!("{self} - {other}"))),
+			Err(_) => Err(Error::ArithmeticNegativeOverflow(format!("{self} - {other}"))),
 		}
 	}
 }

--- a/core/src/sql/strand.rs
+++ b/core/src/sql/strand.rs
@@ -82,7 +82,10 @@ impl TryAdd for Strand {
 			self.0.push_str(other.as_str());
 			Ok(self)
 		} else {
-			Err(Error::ArithmeticOverflow(format!("{self} + {other}")))
+			Err(Error::InsufficientReserve(format!(
+				"additional string of length {} bytes",
+				other.0.len()
+			)))
 		}
 	}
 }

--- a/core/src/syn/lexer/compound/number.rs
+++ b/core/src/syn/lexer/compound/number.rs
@@ -291,31 +291,31 @@ pub fn duration(lexer: &mut Lexer, start: Token) -> Result<Duration, SyntaxError
 			DurationSuffix::Second => Duration::from_secs(numeric_value),
 			DurationSuffix::Minute => {
 				let minutes = numeric_value.checked_mul(SECONDS_PER_MINUTE).ok_or_else(
-					|| syntax_error!("Invalid duartion, value overflowed maximum allowed value", @lexer.current_span()),
+					|| syntax_error!("Invalid duration, value overflowed maximum allowed value", @lexer.current_span()),
 				)?;
 				Duration::from_secs(minutes)
 			}
 			DurationSuffix::Hour => {
 				let hours = numeric_value.checked_mul(SECONDS_PER_HOUR).ok_or_else(
-					|| syntax_error!("Invalid duartion, value overflowed maximum allowed value", @lexer.current_span()),
+					|| syntax_error!("Invalid duration, value overflowed maximum allowed value", @lexer.current_span()),
 				)?;
 				Duration::from_secs(hours)
 			}
 			DurationSuffix::Day => {
 				let day = numeric_value.checked_mul(SECONDS_PER_DAY).ok_or_else(
-					|| syntax_error!("Invalid duartion, value overflowed maximum allowed value", @lexer.current_span()),
+					|| syntax_error!("Invalid duration, value overflowed maximum allowed value", @lexer.current_span()),
 				)?;
 				Duration::from_secs(day)
 			}
 			DurationSuffix::Week => {
 				let week = numeric_value.checked_mul(SECONDS_PER_WEEK).ok_or_else(
-					|| syntax_error!("Invalid duartion, value overflowed maximum allowed value", @lexer.current_span()),
+					|| syntax_error!("Invalid duration, value overflowed maximum allowed value", @lexer.current_span()),
 				)?;
 				Duration::from_secs(week)
 			}
 			DurationSuffix::Year => {
 				let year = numeric_value.checked_mul(SECONDS_PER_YEAR).ok_or_else(
-					|| syntax_error!("Invalid duartion, value overflowed maximum allowed value", @lexer.current_span()),
+					|| syntax_error!("Invalid duration, value overflowed maximum allowed value", @lexer.current_span()),
 				)?;
 				Duration::from_secs(year)
 			}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Error messages for negative datetimes and durations are a bit hard to understand. For example:

```
d'2024-11-20T01:56:19.420Z' - d'2024-11-21T01:56:19.420Z';

"Failed to compute: \"d'2024-11-20T01:56:19.420Z' - d'2024-11-21T01:56:19.420Z'\",
as the operation results in an overflow."
```

1) For something as wordy as a datetime, it's not always clear that the problem is that this would result in a negative datetime (not possible to quickly eyeball one and know that the second one is a later datetime compared to the other)
2) The word overflow might be misread as a stack overflow

Also, the ArithmeticOverflow error is being returned for TryAdd for Strand, when the only error possible is a lack of memory for the extra str to be pushed. Since a lack of memory probably implies an absolutely massive string, formatting the entire string for the error message will likely flood the terminal at the same time that the device is already short on memory.

## What does this change do?

Adds a new error variant for disallowed negative operations, and another one for insufficient reserve (for strings). The error for insufficient reserve now tells the user the length of bytes of the string that was attempted to be added instead of displaying the whole string. Also adds 'arithmetic' to the existing overflow message to make it clear that this is an arithmetic overflow so that the user doesn't misread it as a stack overflow.

```
"Failed to compute: \"d'2024-11-20T01:10:03.437101Z' - d'2025-11-19T01:10:03.540142Z'\",
as the operation results in a negative value."
```

## What is your testing strategy?

Probably not needed, as the internal behaviour is the same. Only error messages are changed.

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

- [X] No documentation needed

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
