### PR TITLE
Use readonly transactions when possible

### DIFF
--- a/core/src/kvs/surrealkv/mod.rs
+++ b/core/src/kvs/surrealkv/mod.rs
@@ -5,6 +5,7 @@ use crate::key::debug::Sprintable;
 use crate::kvs::{Check, Key, Val, Version};
 use std::fmt::Debug;
 use std::ops::Range;
+use surrealkv::Mode;
 use surrealkv::Options;
 use surrealkv::Store;
 use surrealkv::Transaction as Tx;
@@ -88,7 +89,12 @@ impl Datastore {
 		#[cfg(debug_assertions)]
 		let check = Check::Panic;
 		// Create a new transaction
-		match self.db.begin() {
+		let txn = match write {
+			true => self.db.begin_with_mode(Mode::ReadWrite),
+			false => self.db.begin_with_mode(Mode::ReadOnly),
+		};
+		// Return the new transaction
+		match txn {
 			Ok(inner) => Ok(Transaction {
 				done: false,
 				check,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When we know that we only need a readonly transaction, there is no need to start a readwrite transaction in SurrealKV.

## What does this change do?

Specifies the exact transaction mode when creating a transaction.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
