### PR TITLE
Ensure `LIMIT` and `PARALLEL` can be used together

### DIFF
--- a/core/src/doc/compute.rs
+++ b/core/src/doc/compute.rs
@@ -26,7 +26,8 @@ impl Document {
 		for _ in 0..2 {
 			// Check current context
 			if ctx.is_done() {
-				break;
+				// Don't process the document
+				return Ok(());
 			}
 			// Setup a new workable
 			let ins = match pro.val {

--- a/core/src/doc/process.rs
+++ b/core/src/doc/process.rs
@@ -22,6 +22,11 @@ impl Document {
 		let mut retry = false;
 		// Loop over maximum two times
 		for _ in 0..2 {
+			// Check current context
+			if ctx.is_done() {
+				// Don't process the document
+				return Err(Error::Ignore);
+			}
 			// Setup a new workable
 			let ins = match pro.val {
 				Operable::Value(v) => (v, Workable::Normal),

--- a/sdk/tests/planner.rs
+++ b/sdk/tests/planner.rs
@@ -2825,7 +2825,6 @@ async fn select_from_standard_index_descending() -> Result<(), Error> {
 		CREATE session:6 SET time = d'2024-06-30T23:30:00Z';
 		SELECT * FROM session ORDER BY time DESC LIMIT 4 EXPLAIN;
 		SELECT * FROM session ORDER BY time DESC LIMIT 4;
-		SELECT * FROM session ORDER BY time DESC LIMIT 4 PARALLEL;
 		SELECT * FROM session ORDER BY time DESC EXPLAIN;
 		SELECT * FROM session ORDER BY time DESC;
 	";
@@ -2845,24 +2844,6 @@ async fn select_from_standard_index_descending() -> Result<(), Error> {
 					type: 'MemoryOrdered'
 				},
 				operation: 'Collector'
-			}
-		]",
-		"[
-			{
-				id: session:5,
-				time: d'2024-07-01T02:00:00Z'
-			},
-			{
-				id: session:1,
-				time: d'2024-07-01T01:00:00Z'
-			},
-			{
-				id: session:6,
-				time: d'2024-06-30T23:30:00Z'
-			},
-			{
-				id: session:2,
-				time: d'2024-06-30T23:00:00Z'
 			}
 		]",
 		"[
@@ -3244,5 +3225,22 @@ async fn select_memory_ordered_collector() -> Result<(), Error> {
 	// At a rate of one test per minute, we're SURE that approximately 10^4,104.8 years from now a test WILL fail.
 	// For perspective, this time frame is far longer than the age of the universe,
 	// but well, my apologies if that even happen ¯\_(ツ)_/¯
+	Ok(())
+}
+
+#[tokio::test]
+async fn select_limit_start_parallel() -> Result<(), Error> {
+	let sql = r"
+		CREATE |item:1000|;
+		SELECT * FROM item LIMIT 10 START 0 PARALLEL;";
+	let mut t = Test::new(sql).await?;
+	t.expect_size(2)?;
+	t.skip_ok(1)?;
+	let r = t.next()?.result?;
+	if let Value::Array(a) = r {
+		assert_eq!(a.len(), 10);
+	} else {
+		panic!("Unexpected value: {r:#}");
+	}
 	Ok(())
 }

--- a/sdk/tests/planner.rs
+++ b/sdk/tests/planner.rs
@@ -2825,6 +2825,7 @@ async fn select_from_standard_index_descending() -> Result<(), Error> {
 		CREATE session:6 SET time = d'2024-06-30T23:30:00Z';
 		SELECT * FROM session ORDER BY time DESC LIMIT 4 EXPLAIN;
 		SELECT * FROM session ORDER BY time DESC LIMIT 4;
+		SELECT * FROM session ORDER BY time DESC LIMIT 4 PARALLEL;
 		SELECT * FROM session ORDER BY time DESC EXPLAIN;
 		SELECT * FROM session ORDER BY time DESC;
 	";
@@ -2844,6 +2845,24 @@ async fn select_from_standard_index_descending() -> Result<(), Error> {
 					type: 'MemoryOrdered'
 				},
 				operation: 'Collector'
+			}
+		]",
+		"[
+			{
+				id: session:5,
+				time: d'2024-07-01T02:00:00Z'
+			},
+			{
+				id: session:1,
+				time: d'2024-07-01T01:00:00Z'
+			},
+			{
+				id: session:6,
+				time: d'2024-06-30T23:30:00Z'
+			},
+			{
+				id: session:2,
+				time: d'2024-06-30T23:00:00Z'
 			}
 		]",
 		"[


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently specifying `LIMIT` and `PARALLEL` on a `SELECT` statement caused an internal server error.

## What does this change do?

This ensures that the concurrent document processing function exits, instead of breaking from the current loop, resulting in an internal error.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #5085.

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
