### PR TITLE
Improve flaky tests

### DIFF
--- a/core/src/iam/signin.rs
+++ b/core/src/iam/signin.rs
@@ -966,8 +966,9 @@ mod tests {
 				r#"
 				DEFINE ACCESS user ON DATABASE TYPE RECORD
 					SIGNIN {
-					    UPSERT count:1 SET count += 1; -- Concurrently write to the same document
-					    SLEEP(2s); -- Increase the duration of the transaction
+					    -- Concurrently write to the same document
+					    -- Artifically increase the duration of the transaction
+					    UPSERT count:1 SET count += sleep(2s) || 1;
 						RETURN (SELECT * FROM user WHERE name = $user AND crypto::argon2::compare(pass, $pass))
 					}
 					SIGNUP (
@@ -1687,8 +1688,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 					   SELECT * FROM type::thing('user', $id)
 					)
 					AUTHENTICATE {
-					   UPSERT count:1 SET count += 1; -- Concurrently write to the same document
-					   SLEEP(2s); -- Increase the duration of the transaction
+					   -- Concurrently write to the same document
+					   -- Artifically increase the duration of the transaction
+					   UPSERT count:1 SET count += sleep(2s) || 1;
 					   $auth.id -- Continue with authentication
 					}
 					DURATION FOR SESSION 2h

--- a/core/src/iam/signup.rs
+++ b/core/src/iam/signup.rs
@@ -300,8 +300,9 @@ mod tests {
 						SELECT * FROM user WHERE name = $user AND crypto::argon2::compare(pass, $pass)
 					)
 					SIGNUP {
-					    UPSERT count:1 SET count += 1; -- Concurrently write to the same document
-					    SLEEP(2s); -- Increase the duration of the transaction
+						-- Concurrently write to the same document
+						-- Artifically increase the duration of the transaction
+						UPSERT count:1 SET count += sleep(2s) || 1;
 						RETURN (CREATE user CONTENT {
 							name: $user,
 							pass: crypto::argon2::generate($pass)
@@ -795,8 +796,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 					   CREATE type::thing('user', $id)
 					)
 					AUTHENTICATE {
-					   UPSERT count:1 SET count += 1; -- Concurrently write to the same document
-					   SLEEP(2s); -- Increase the duration of the transaction
+					   -- Concurrently write to the same document
+					   -- Artifically increase the duration of the transaction
+					   UPSERT count:1 SET count += sleep(2s) || 1;
 					   $auth.id -- Continue with authentication
 					}
 					DURATION FOR SESSION 2h


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To resolve [failing tests](https://github.com/surrealdb/surrealdb/actions/runs/11932878168/job/33258763989) due to tests introduced in #5130 failing to reliably reproduce the race condition that led to the error that is being tested for.

## What does this change do?

Moves the sleep function inside the `UPSERT` statement to ensure that both statements execute during the same time window. Due to differences in hardware, this change is not guaranteed the completely remove the flakiness.

## What is your testing strategy?

I verified the flakiness locally by running the offending tests 100 times:

```bash
for i in $(seq 1 100); do
  cargo test iam::signup::tests::test_record_signup && \
  cargo test iam::signup::tests::test_signup_record_and_authenticate_clause && \
  cargo test iam::signin::tests::test_signin_record && \
  cargo test iam::signin::tests::test_signin_record_and_authenticate_clause
done
```

Then, implemented the changes from this PR and ran the tests 100 times again without issues.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
