### PR TITLE
Add `AND EXPUNGE` clause to certain `REMOVE` statements

### DIFF
--- a/core/src/sql/statements/remove/database.rs
+++ b/core/src/sql/statements/remove/database.rs
@@ -8,7 +8,7 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
-#[revisioned(revision = 2)]
+#[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
@@ -16,6 +16,8 @@ pub struct RemoveDatabaseStatement {
 	pub name: Ident,
 	#[revision(start = 2)]
 	pub if_exists: bool,
+	#[revision(start = 3)]
+	pub expunge: bool,
 }
 
 impl RemoveDatabaseStatement {

--- a/core/src/sql/statements/remove/namespace.rs
+++ b/core/src/sql/statements/remove/namespace.rs
@@ -8,7 +8,7 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
-#[revisioned(revision = 2)]
+#[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
@@ -16,6 +16,8 @@ pub struct RemoveNamespaceStatement {
 	pub name: Ident,
 	#[revision(start = 2)]
 	pub if_exists: bool,
+	#[revision(start = 3)]
+	pub expunge: bool,
 }
 
 impl RemoveNamespaceStatement {

--- a/core/src/sql/statements/remove/table.rs
+++ b/core/src/sql/statements/remove/table.rs
@@ -8,7 +8,7 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
-#[revisioned(revision = 2)]
+#[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
@@ -16,6 +16,8 @@ pub struct RemoveTableStatement {
 	pub name: Ident,
 	#[revision(start = 2)]
 	pub if_exists: bool,
+	#[revision(start = 3)]
+	pub expunge: bool,
 }
 
 impl RemoveTableStatement {

--- a/core/src/syn/lexer/keywords.rs
+++ b/core/src/syn/lexer/keywords.rs
@@ -119,6 +119,7 @@ pub(crate) static KEYWORDS: phf::Map<UniCase<&'static str>, TokenKind> = phf_map
 	UniCase::ascii("EXISTS") => TokenKind::Keyword(Keyword::Exists),
 	UniCase::ascii("EXPIRED") => TokenKind::Keyword(Keyword::Expired),
 	UniCase::ascii("EXPLAIN") => TokenKind::Keyword(Keyword::Explain),
+	UniCase::ascii("EXPUNGE") => TokenKind::Keyword(Keyword::Expunge),
 	UniCase::ascii("EXTEND_CANDIDATES") => TokenKind::Keyword(Keyword::ExtendCandidates),
 	UniCase::ascii("false") => TokenKind::Keyword(Keyword::False),
 	UniCase::ascii("FETCH") => TokenKind::Keyword(Keyword::Fetch),

--- a/core/src/syn/parser/stmt/remove.rs
+++ b/core/src/syn/parser/stmt/remove.rs
@@ -24,31 +24,49 @@ impl Parser<'_> {
 		let next = self.next();
 		let res = match next.kind {
 			t!("NAMESPACE") => {
+				let expunge = if self.eat(t!("AND")) {
+					expected!(self, t!("EXPUNGE"));
+					true
+				} else {
+					false
+				};
+
 				let if_exists = if self.eat(t!("IF")) {
 					expected!(self, t!("EXISTS"));
 					true
 				} else {
 					false
 				};
+
 				let name = self.next_token_value()?;
 
 				RemoveStatement::Namespace(RemoveNamespaceStatement {
 					name,
 					if_exists,
+					expunge,
 				})
 			}
 			t!("DATABASE") => {
+				let expunge = if self.eat(t!("AND")) {
+					expected!(self, t!("EXPUNGE"));
+					true
+				} else {
+					false
+				};
+
 				let if_exists = if self.eat(t!("IF")) {
 					expected!(self, t!("EXISTS"));
 					true
 				} else {
 					false
 				};
+
 				let name = self.next_token_value()?;
 
 				RemoveStatement::Database(RemoveDatabaseStatement {
 					name,
 					if_exists,
+					expunge,
 				})
 			}
 			t!("FUNCTION") => {
@@ -101,17 +119,26 @@ impl Parser<'_> {
 				})
 			}
 			t!("TABLE") => {
+				let expunge = if self.eat(t!("AND")) {
+					expected!(self, t!("EXPUNGE"));
+					true
+				} else {
+					false
+				};
+
 				let if_exists = if self.eat(t!("IF")) {
 					expected!(self, t!("EXISTS"));
 					true
 				} else {
 					false
 				};
+
 				let name = self.next_token_value()?;
 
 				RemoveStatement::Table(crate::sql::statements::RemoveTableStatement {
 					name,
 					if_exists,
+					expunge,
 				})
 			}
 			t!("EVENT") => {

--- a/core/src/syn/parser/test/stmt.rs
+++ b/core/src/syn/parser/test/stmt.rs
@@ -2546,6 +2546,7 @@ fn parse_remove() {
 		Statement::Remove(RemoveStatement::Namespace(RemoveNamespaceStatement {
 			name: Ident("ns".to_owned()),
 			if_exists: false,
+			expunge: false,
 		}))
 	);
 
@@ -2555,6 +2556,7 @@ fn parse_remove() {
 		Statement::Remove(RemoveStatement::Database(RemoveDatabaseStatement {
 			name: Ident("database".to_owned()),
 			if_exists: false,
+			expunge: false,
 		}))
 	);
 
@@ -2600,6 +2602,7 @@ fn parse_remove() {
 		Statement::Remove(RemoveStatement::Table(RemoveTableStatement {
 			name: Ident("foo".to_owned()),
 			if_exists: false,
+			expunge: false,
 		}))
 	);
 

--- a/core/src/syn/token/keyword.rs
+++ b/core/src/syn/token/keyword.rs
@@ -82,6 +82,7 @@ keyword! {
 	Exists => "EXISTS",
 	Expired => "EXPIRED",
 	Explain => "EXPLAIN",
+	Expunge => "EXPUNGE",
 	ExtendCandidates => "EXTEND_CANDIDATES",
 	False => "false",
 	Fetch => "FETCH",


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

It's not possible currently to historically delete certain resources

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Introduces an `AND EXPUNGE` clause to the `REMOVE` statement.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Needs documentation

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
