### PR TITLE
Ensure multiwriter tests are run in memory

### DIFF
--- a/core/src/kvs/tests/mod.rs
+++ b/core/src/kvs/tests/mod.rs
@@ -54,7 +54,6 @@ mod mem {
 	include!("multiwriter_different_keys.rs");
 	include!("multiwriter_same_keys_conflict.rs");
 	include!("timestamp_to_versionstamp.rs");
-	include!("timestamp_to_versionstamp.rs");
 }
 
 #[cfg(feature = "kv-rocksdb")]

--- a/core/src/kvs/tests/mod.rs
+++ b/core/src/kvs/tests/mod.rs
@@ -51,6 +51,9 @@ mod mem {
 	include!("raw.rs");
 	include!("snapshot.rs");
 	include!("multireader.rs");
+	include!("multiwriter_different_keys.rs");
+	include!("multiwriter_same_keys_conflict.rs");
+	include!("timestamp_to_versionstamp.rs");
 	include!("timestamp_to_versionstamp.rs");
 }
 

--- a/core/src/kvs/tests/mod.rs
+++ b/core/src/kvs/tests/mod.rs
@@ -52,7 +52,7 @@ mod mem {
 	include!("snapshot.rs");
 	include!("multireader.rs");
 	include!("multiwriter_different_keys.rs");
-	include!("multiwriter_same_keys_conflict.rs");
+	include!("multiwriter_same_keys_allow.rs");
 	include!("timestamp_to_versionstamp.rs");
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

After using SurrealKV as the in-memory storage engine, we didn't enable multi-writer tests on the storage engine.

## What does this change do?

Ensures that multi-writer tests are run against the in-memory storage engine.

## What is your testing strategy?

This pull-request adds tests.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
