### PR TITLE
Add support for data expunge

### DIFF
--- a/core/src/kvs/surrealkv/mod.rs
+++ b/core/src/kvs/surrealkv/mod.rs
@@ -345,6 +345,54 @@ impl super::api::Transaction for Transaction {
 		Ok(())
 	}
 
+	/// Deletes all versions of a key from the database.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
+	async fn clr<K>(&mut self, key: K) -> Result<(), Error>
+	where
+		K: Into<Key> + Sprintable + Debug,
+	{
+		// Check to see if transaction is closed
+		if self.done {
+			return Err(Error::TxFinished);
+		}
+		// Check to see if transaction is writable
+		if !self.write {
+			return Err(Error::TxReadonly);
+		}
+		// Remove the key
+		self.inner.delete(&key.into())?;
+		// Return result
+		Ok(())
+	}
+
+	/// Delete all versions of a key if the current value matches a condition
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
+	async fn clrc<K, V>(&mut self, key: K, chk: Option<V>) -> Result<(), Error>
+	where
+		K: Into<Key> + Sprintable + Debug,
+		V: Into<Val> + Debug,
+	{
+		// Check to see if transaction is closed
+		if self.done {
+			return Err(Error::TxFinished);
+		}
+		// Check to see if transaction is writable
+		if !self.write {
+			return Err(Error::TxReadonly);
+		}
+		// Get the arguments
+		let key = key.into();
+		let chk = chk.map(Into::into);
+		// Delete the key if valid
+		match (self.inner.get(&key)?, chk) {
+			(Some(v), Some(w)) if v == w => self.inner.delete(&key)?,
+			(None, None) => self.inner.delete(&key)?,
+			_ => return Err(Error::TxConditionNotMet),
+		};
+		// Return result
+		Ok(())
+	}
+
 	/// Retrieves a range of key-value pairs from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
 	async fn keys<K>(

--- a/core/src/kvs/tr.rs
+++ b/core/src/kvs/tr.rs
@@ -369,6 +369,57 @@ impl Transactor {
 		expand_inner!(&mut self.inner, v => { v.delp(key).await })
 	}
 
+	/// Delete all versions of a key from the datastore.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tr", skip_all)]
+	pub async fn clr<K>(&mut self, key: K) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		let key = key.into();
+		trace!(target: TARGET, key = key.sprint(), "Clr");
+		expand_inner!(&mut self.inner, v => { v.clr(key).await })
+	}
+
+	/// Delete all versions of a key from the datastore if the current value matches a condition.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tr", skip_all)]
+	pub async fn clrc<K, V>(&mut self, key: K, chk: Option<V>) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+		V: Into<Val> + Debug,
+	{
+		let key = key.into();
+		trace!(target: TARGET, key = key.sprint(), "ClrC");
+		expand_inner!(&mut self.inner, v => { v.clrc(key, chk).await })
+	}
+
+	/// Delete all versions of a range of keys from the datastore.
+	///
+	/// This function deletes all matching key-value pairs from the underlying datastore in grouped batches.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tr", skip_all)]
+	pub async fn clrr<K>(&mut self, rng: Range<K>) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		let beg: Key = rng.start.into();
+		let end: Key = rng.end.into();
+		let rng = beg.as_slice()..end.as_slice();
+		trace!(target: TARGET, rng = rng.sprint(), "ClrR");
+		expand_inner!(&mut self.inner, v => { v.clrr(beg..end).await })
+	}
+
+	/// Delete all versions of a prefixed range of keys from the datastore.
+	///
+	/// This function deletes all matching key-value pairs from the underlying datastore in grouped batches.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tr", skip_all)]
+	pub async fn clrp<K>(&mut self, key: K) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		let key: Key = key.into();
+		trace!(target: TARGET, key = key.sprint(), "ClrP");
+		expand_inner!(&mut self.inner, v => { v.clrp(key).await })
+	}
+
 	/// Retrieve a specific range of keys from the datastore.
 	///
 	/// This function fetches the full range of keys without values, in a single request to the underlying datastore.

--- a/core/src/kvs/tx.rs
+++ b/core/src/kvs/tx.rs
@@ -188,6 +188,47 @@ impl Transaction {
 		self.lock().await.delp(key).await
 	}
 
+	/// Delete all versions of a key from the datastore.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
+	pub async fn clr<K>(&self, key: K) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		self.lock().await.clr(key).await
+	}
+
+	/// Delete all versions of a key from the datastore if the current value matches a condition.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
+	pub async fn clrc<K, V>(&self, key: K, chk: Option<V>) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+		V: Into<Val> + Debug,
+	{
+		self.lock().await.clrc(key, chk).await
+	}
+
+	/// Delete all versions of a range of keys from the datastore.
+	///
+	/// This function deletes entries from the underlying datastore in grouped batches.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
+	pub async fn clrr<K>(&self, rng: Range<K>) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		self.lock().await.clrr(rng).await
+	}
+
+	/// Delete all versions of a prefix of keys from the datastore.
+	///
+	/// This function deletes entries from the underlying datastore in grouped batches.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
+	pub async fn clrp<K>(&self, key: K) -> Result<(), Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		self.lock().await.clrp(key).await
+	}
+
 	/// Insert or update a key in the datastore.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
 	pub async fn set<K, V>(&self, key: K, val: V, version: Option<u64>) -> Result<(), Error>

--- a/core/src/sql/statements/remove/database.rs
+++ b/core/src/sql/statements/remove/database.rs
@@ -34,10 +34,16 @@ impl RemoveDatabaseStatement {
 			let db = txn.get_db(opt.ns()?, &self.name).await?;
 			// Delete the definition
 			let key = crate::key::namespace::db::new(opt.ns()?, &db.name);
-			txn.del(key).await?;
+			match self.expunge {
+				true => txn.clr(key).await?,
+				false => txn.del(key).await?,
+			};
 			// Delete the resource data
 			let key = crate::key::database::all::new(opt.ns()?, &db.name);
-			txn.delp(key).await?;
+			match self.expunge {
+				true => txn.clrp(key).await?,
+				false => txn.delp(key).await?,
+			};
 			// Clear the cache
 			txn.clear();
 			// Ok all good

--- a/core/src/sql/statements/remove/namespace.rs
+++ b/core/src/sql/statements/remove/namespace.rs
@@ -34,10 +34,16 @@ impl RemoveNamespaceStatement {
 			let ns = txn.get_ns(&self.name).await?;
 			// Delete the definition
 			let key = crate::key::root::ns::new(&ns.name);
-			txn.del(key).await?;
+			match self.expunge {
+				true => txn.clr(key).await?,
+				false => txn.del(key).await?,
+			};
 			// Delete the resource data
 			let key = crate::key::namespace::all::new(&ns.name);
-			txn.delp(key).await?;
+			match self.expunge {
+				true => txn.clrp(key).await?,
+				false => txn.delp(key).await?,
+			};
 			// Clear the cache
 			txn.clear();
 			// Ok all good


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When performing `REMOVE NAMESPACE`, `REMOVE DATABASE` or `REMOVE TABLE` statements when using SurrealKV, historical data would not actually be deleted. Instead the data would be soft deleted, allowing queries to time-travel over old data.

## What does this change do?

This change allows the namespaces, databases, and tables to be removed completely, and expunging historical data at the same time. To clear out all data including historical data it is now possible to do the following:

```sql
REMOVE NAMESPACE AND EXPUNGE test;
REMOVE DATABASE AND EXPUNGE test;
REMOVE TABLE AND EXPUNGE test;
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
