### PR TITLE
Fix other keys which don’t need to be versioned

### DIFF
--- a/core/src/kvs/ds.rs
+++ b/core/src/kvs/ds.rs
@@ -584,7 +584,7 @@ impl Datastore {
 				// Convert the version to binary
 				let bytes: Vec<u8> = val.into();
 				// Attempt to set the current version in storage
-				catch!(txn, txn.set(key, bytes, None).await);
+				catch!(txn, txn.replace(key, bytes).await);
 				// We set the version, so commit the transaction
 				catch!(txn, txn.commit().await);
 				// Return the current version

--- a/core/src/kvs/node.rs
+++ b/core/src/kvs/node.rs
@@ -70,7 +70,7 @@ impl Datastore {
 		let key = crate::key::root::nd::new(id);
 		let val = catch!(txn, txn.get_node(id).await);
 		let val = val.as_ref().archive();
-		run!(txn, txn.set(key, val, None).await)
+		run!(txn, txn.replace(key, val).await)
 	}
 
 	/// Expires nodes which have timedout from the cluster.
@@ -114,7 +114,7 @@ impl Datastore {
 				// Get the key for the node entry
 				let key = crate::key::root::nd::new(nd.id);
 				// Update the node entry
-				catch!(txn, txn.set(key, val, None).await);
+				catch!(txn, txn.replace(key, val).await);
 			}
 			// Commit the changes
 			catch!(txn, txn.commit().await);

--- a/core/src/kvs/version/mod.rs
+++ b/core/src/kvs/version/mod.rs
@@ -98,7 +98,7 @@ impl Version {
 			let key = crate::key::version::new();
 			let val: Vec<u8> = Version::from(v + 1).into();
 			// Attempt to set the current version in storage
-			tx.set(key, val, None).await?;
+			tx.replace(key, val).await?;
 
 			// Commit the transaction
 			tx.commit().await?;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Not all keys need to be versioned.

## What does this change do?

Uses replace instead of set in certain scenarios.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
