### PR TITLE
Simplify unnecessary versioned puts

### DIFF
--- a/crates/core/src/key/mod.rs
+++ b/crates/core/src/key/mod.rs
@@ -4,7 +4,6 @@
 ///
 /// crate::key::root::all                /
 /// crate::key::root::ac                 /!ac{ac}
-/// crate::key::root::hb                 /!hb{ts}/{nd}
 /// crate::key::root::nd                 /!nd{nd}
 /// crate::key::root::ni                 /!ni
 /// crate::key::root::ns                 /!ns{ns}

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -555,14 +555,14 @@ impl Datastore {
 					// There was en error getting the version
 					Err(err) => {
 						// We didn't write anything, so just rollback
-						txn.cancel().await?;
+						catch!(txn, txn.cancel().await);
 						// Return the error
 						return Err(err);
 					}
 					// We could decode the version correctly
 					Ok(val) => {
 						// We didn't write anything, so just rollback
-						txn.cancel().await?;
+						catch!(txn, txn.cancel().await);
 						// Return the current version
 						val
 					}

--- a/crates/core/src/kvs/node.rs
+++ b/crates/core/src/kvs/node.rs
@@ -166,9 +166,9 @@ impl Datastore {
 							// Get the key for this table live query
 							let tlq = crate::key::table::lq::new(&val.ns, &val.db, &val.tb, nlq.lq);
 							// Delete the table live query
-							catch!(txn, txn.del(tlq).await);
+							catch!(txn, txn.clr(tlq).await);
 							// Delete the node live query
-							catch!(txn, txn.del(nlq).await);
+							catch!(txn, txn.clr(nlq).await);
 						}
 					}
 				}
@@ -179,7 +179,7 @@ impl Datastore {
 				// Get the key for the node entry
 				let key = crate::key::root::nd::new(*id);
 				// Delete the cluster node entry
-				catch!(txn, txn.del(key).await);
+				catch!(txn, txn.clr(key).await);
 			}
 			// Commit the changes
 			catch!(txn, txn.commit().await);
@@ -256,9 +256,9 @@ impl Datastore {
 								// Get the key for this table live query
 								let nlq = crate::key::node::lq::new(nid, lid);
 								// Delete the node live query
-								catch!(txn, txn.del(nlq).await);
+								catch!(txn, txn.clr(nlq).await);
 								// Delete the table live query
-								catch!(txn, txn.del(tlq).await);
+								catch!(txn, txn.clr(tlq).await);
 							}
 						}
 					}
@@ -298,9 +298,9 @@ impl Datastore {
 				// Get the key for this table live query
 				let tlq = crate::key::table::lq::new(&lq.ns, &lq.db, &lq.tb, id);
 				// Delete the table live query
-				catch!(txn, txn.del(tlq).await);
+				catch!(txn, txn.clr(tlq).await);
 				// Delete the node live query
-				catch!(txn, txn.del(nlq).await);
+				catch!(txn, txn.clr(nlq).await);
 			}
 		}
 		// Commit the changes

--- a/crates/core/src/kvs/tr.rs
+++ b/crates/core/src/kvs/tr.rs
@@ -597,7 +597,7 @@ impl Transactor {
 		let nid = seq.get_next_id();
 		self.stash.set(key, seq.clone());
 		let (k, v) = seq.finish().unwrap();
-		self.set(k, v, None).await?;
+		self.replace(k, v).await?;
 		Ok(nid)
 	}
 
@@ -608,7 +608,7 @@ impl Transactor {
 		let nid = seq.get_next_id();
 		self.stash.set(key, seq.clone());
 		let (k, v) = seq.finish().unwrap();
-		self.set(k, v, None).await?;
+		self.replace(k, v).await?;
 		Ok(nid)
 	}
 
@@ -619,7 +619,7 @@ impl Transactor {
 		let nid = seq.get_next_id();
 		self.stash.set(key, seq.clone());
 		let (k, v) = seq.finish().unwrap();
-		self.set(k, v, None).await?;
+		self.replace(k, v).await?;
 		Ok(nid)
 	}
 
@@ -631,7 +631,7 @@ impl Transactor {
 		seq.remove_id(ns);
 		self.stash.set(key, seq.clone());
 		let (k, v) = seq.finish().unwrap();
-		self.set(k, v, None).await?;
+		self.replace(k, v).await?;
 		Ok(())
 	}
 
@@ -643,7 +643,7 @@ impl Transactor {
 		seq.remove_id(db);
 		self.stash.set(key, seq.clone());
 		let (k, v) = seq.finish().unwrap();
-		self.set(k, v, None).await?;
+		self.replace(k, v).await?;
 		Ok(())
 	}
 
@@ -655,7 +655,7 @@ impl Transactor {
 		seq.remove_id(tb);
 		self.stash.set(key, seq.clone());
 		let (k, v) = seq.finish().unwrap();
-		self.set(k, v, None).await?;
+		self.replace(k, v).await?;
 		Ok(())
 	}
 

--- a/crates/core/src/sql/statements/kill.rs
+++ b/crates/core/src/sql/statements/kill.rs
@@ -58,10 +58,10 @@ impl KillStatement {
 				let val: Live = val.into();
 				// Delete the node live query
 				let key = crate::key::node::lq::new(nid, lid);
-				txn.del(key).await?;
+				txn.clr(key).await?;
 				// Delete the table live query
 				let key = crate::key::table::lq::new(&val.ns, &val.db, &val.tb, lid);
-				txn.del(key).await?;
+				txn.clr(key).await?;
 				// Refresh the table cache for lives
 				let key = crate::key::database::tb::new(&val.ns, &val.db, &val.tb);
 				let tb = txn.get_tb(&val.ns, &val.db, &val.tb).await?;

--- a/crates/core/src/sql/statements/live.rs
+++ b/crates/core/src/sql/statements/live.rs
@@ -125,10 +125,10 @@ impl LiveStatement {
 				txn.ensure_ns_db_tb(ns, db, &tb, opt.strict).await?;
 				// Insert the node live query
 				let key = crate::key::node::lq::new(nid, id);
-				txn.put(key, lq, None).await?;
+				txn.replace(key, lq).await?;
 				// Insert the table live query
 				let key = crate::key::table::lq::new(ns, db, &tb, id);
-				txn.put(key, stm, None).await?;
+				txn.replace(key, stm).await?;
 				// Refresh the table cache for lives
 				let key = crate::key::database::tb::new(ns, db, &tb);
 				let tb = txn.get_tb(ns, db, &tb).await?;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently, certain internal keys used for configuration and database operations are versioned alongside data. This is unnecessary as this versioned data is not accessible at any time, and is not beneficial in any way.

## What does this change do?

Ensures that keys and values are not versioned for:
- `DEFINE CONFIG` statements
- `LIVE SELECT` statements
- Namespace, database, and table incrementing ID keys

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
