### PR TITLE
Fix benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -38,7 +38,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@97834a484a5ab3c40fa9e2eb40fcf8041105a573
         with:
           aws-region: us-east-1
 
@@ -127,7 +127,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@97834a484a5ab3c40fa9e2eb40fcf8041105a573
         with:
           aws-region: us-east-1
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Benchmark workflow jobs are not currently run correctly, due to an issue with the latest release of `aws-actions/configure-aws-credentials` GitHub Action, which does not support authentication using EKS Pod identities.

## What does this change do?

A fix to `aws-actions/configure-aws-credentials` GitHub Action has been made since the latest release `v4`, but no official release has been made. This pull-request updates the GitHub Workflow to use a specific commit which has support for authentication using EKS Pod identities which was added in https://github.com/aws-actions/configure-aws-credentials/issues/942.

## What is your testing strategy?

Not applicable.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
