### PR TITLE
Move the auth check for db and ns use.

### DIFF
--- a/crates/core/src/dbs/executor.rs
+++ b/crates/core/src/dbs/executor.rs
@@ -557,7 +557,7 @@ impl Executor {
 	{
 		// Ensure that the initial namespace and database, if it exists, is valid for authentication
 		if opt.auth.is_record() {
-			if let Some(ns) = opt.ns().ok() {
+			if let Ok(ns) = opt.ns() {
 				if opt.auth.level().ns() != Some(ns) {
 					return Err(Error::NsNotAllowed {
 						ns: ns.into(),
@@ -566,7 +566,7 @@ impl Executor {
 			}
 		}
 		if opt.auth.is_record() {
-			if let Some(db) = opt.db().ok() {
+			if let Ok(db) = opt.db() {
 				if opt.auth.level().db() != Some(db) {
 					return Err(Error::DbNotAllowed {
 						db: db.into(),

--- a/crates/core/src/dbs/executor.rs
+++ b/crates/core/src/dbs/executor.rs
@@ -53,12 +53,32 @@ impl Executor {
 			.ok_or_else(|| fail!("Tried to unfreeze a Context with multiple references"))?;
 
 		if let Some(ns) = stmt.ns {
+			// Check that record authentication matches session
+			if self.opt.auth.is_record() {
+				let ns = self.opt.ns()?;
+				if self.opt.auth.level().ns() != Some(ns) {
+					return Err(Error::NsNotAllowed {
+						ns: ns.into(),
+					});
+				}
+			}
+
 			let mut session = ctx_ref.value("session").unwrap_or(&Value::None).clone();
 			self.opt.set_ns(Some(ns.as_str().into()));
 			session.put(NS.as_ref(), ns.into());
 			ctx_ref.add_value("session", session.into());
 		}
 		if let Some(db) = stmt.db {
+			// Check that record authentication matches session
+			if self.opt.auth.is_record() {
+				let db = self.opt.db()?;
+				if self.opt.auth.level().db() != Some(db) {
+					return Err(Error::DbNotAllowed {
+						db: db.into(),
+					});
+				}
+			}
+
 			let mut session = ctx_ref.value("session").unwrap_or(&Value::None).clone();
 			self.opt.set_db(Some(db.as_str().into()));
 			session.put(DB.as_ref(), db.into());

--- a/crates/core/src/dbs/options.rs
+++ b/crates/core/src/dbs/options.rs
@@ -112,24 +112,6 @@ impl Options {
 
 	// --------------------------------------------------
 
-	/// Set all the required options from a single point.
-	/// The system expects these values to always be set,
-	/// so this should be called for all instances when
-	/// there is doubt.
-	pub fn with_required(
-		mut self,
-		node_id: Uuid,
-		ns: Option<Arc<str>>,
-		db: Option<Arc<str>>,
-		auth: Arc<Auth>,
-	) -> Self {
-		self.id = Some(node_id);
-		self.ns = ns;
-		self.db = db;
-		self.auth = auth;
-		self
-	}
-
 	/// Set the maximum depth a computation can reach.
 	pub fn with_max_computation_depth(mut self, depth: u32) -> Self {
 		self.dive = depth;

--- a/crates/core/src/dbs/processor.rs
+++ b/crates/core/src/dbs/processor.rs
@@ -338,7 +338,7 @@ pub(super) struct ConcurrentCollector<'a> {
 	ite: &'a mut Iterator,
 }
 
-impl<'a> Collector for ConcurrentCollector<'a> {
+impl Collector for ConcurrentCollector<'_> {
 	async fn collect(&mut self, collected: Collected) -> Result<(), Error> {
 		let pro = collected.process(self.opt, self.txn).await?;
 		self.ite.process(self.stk, self.ctx, self.opt, self.stm, pro).await;
@@ -351,7 +351,7 @@ pub(super) struct ConcurrentDistinctCollector<'a> {
 	dis: &'a mut SyncDistinct,
 }
 
-impl<'a> Collector for ConcurrentDistinctCollector<'a> {
+impl Collector for ConcurrentDistinctCollector<'_> {
 	async fn collect(&mut self, collected: Collected) -> Result<(), Error> {
 		let pro = collected.process(self.coll.opt, self.coll.txn).await?;
 		if !self.dis.check_already_processed(&pro) {

--- a/crates/core/src/dbs/statement.rs
+++ b/crates/core/src/dbs/statement.rs
@@ -98,7 +98,7 @@ impl<'a> From<&'a AccessStatement> for Statement<'a> {
 	}
 }
 
-impl<'a> fmt::Display for Statement<'a> {
+impl fmt::Display for Statement<'_> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Statement::Live(v) => write!(f, "{v}"),
@@ -115,7 +115,7 @@ impl<'a> fmt::Display for Statement<'a> {
 	}
 }
 
-impl<'a> Statement<'a> {
+impl Statement<'_> {
 	/// Check if this is a SELECT statement
 	pub(crate) fn is_select(&self) -> bool {
 		matches!(self, Statement::Select(_))

--- a/crates/core/src/doc/check.rs
+++ b/crates/core/src/doc/check.rs
@@ -416,21 +416,6 @@ impl Document {
 		if self.id.is_some() {
 			// Should we run permissions checks?
 			if opt.check_perms(stm.into())? {
-				// Check that record authentication matches session
-				if opt.auth.is_record() {
-					let ns = opt.ns()?;
-					if opt.auth.level().ns() != Some(ns) {
-						return Err(Error::NsNotAllowed {
-							ns: ns.into(),
-						});
-					}
-					let db = opt.db()?;
-					if opt.auth.level().db() != Some(db) {
-						return Err(Error::DbNotAllowed {
-							db: db.into(),
-						});
-					}
-				}
 				// Get the table
 				let table = self.tb(ctx, opt).await?;
 				// Get the permission clause

--- a/crates/core/src/fnc/script/from.rs
+++ b/crates/core/src/fnc/script/from.rs
@@ -53,7 +53,7 @@ fn try_object_to_geom(object: &Object) -> Option<Geometry> {
 			.and_then(Geometry::array_to_multiline)
 			.map(Geometry::MultiLine),
 		"MultiPolygon" => {
-			return object
+			object
 				.get("coordinates")
 				.and_then(Geometry::array_to_multipolygon)
 				.map(Geometry::MultiPolygon)

--- a/crates/core/src/fnc/script/from.rs
+++ b/crates/core/src/fnc/script/from.rs
@@ -52,12 +52,10 @@ fn try_object_to_geom(object: &Object) -> Option<Geometry> {
 			.get("coordinates")
 			.and_then(Geometry::array_to_multiline)
 			.map(Geometry::MultiLine),
-		"MultiPolygon" => {
-			object
-				.get("coordinates")
-				.and_then(Geometry::array_to_multipolygon)
-				.map(Geometry::MultiPolygon)
-		}
+		"MultiPolygon" => object
+			.get("coordinates")
+			.and_then(Geometry::array_to_multipolygon)
+			.map(Geometry::MultiPolygon),
 		"GeometryCollection" => {
 			let Some(Value::Array(x)) = object.get("geometries") else {
 				return None;

--- a/crates/core/src/idx/planner/checker.rs
+++ b/crates/core/src/idx/planner/checker.rs
@@ -130,7 +130,7 @@ pub struct MTreeChecker<'a> {
 	ctx: &'a Context,
 }
 
-impl<'a> MTreeChecker<'a> {
+impl MTreeChecker<'_> {
 	async fn convert_result(
 		&self,
 		doc_ids: &DocIds,
@@ -215,7 +215,7 @@ pub struct MTreeCondChecker<'a> {
 	cache: HashMap<DocId, CheckerCacheEntry>,
 }
 
-impl<'a> MTreeCondChecker<'a> {
+impl MTreeCondChecker<'_> {
 	async fn check_truthy(
 		&mut self,
 		stk: &mut Stk,
@@ -281,7 +281,7 @@ pub struct HnswCondChecker<'a> {
 	cache: HashMap<DocId, CheckerCacheEntry>,
 }
 
-impl<'a> HnswCondChecker<'a> {
+impl HnswCondChecker<'_> {
 	fn convert_result(&mut self, res: VecDeque<(DocId, f64)>) -> VecDeque<KnnIteratorResult> {
 		CheckerCacheEntry::convert_result(res, &mut self.cache)
 	}

--- a/crates/core/src/idx/planner/mod.rs
+++ b/crates/core/src/idx/planner/mod.rs
@@ -29,7 +29,7 @@ pub(crate) struct QueryPlannerParams<'a> {
 	group: Option<&'a Groups>,
 }
 
-impl<'a> QueryPlannerParams<'a> {
+impl QueryPlannerParams<'_> {
 	pub(crate) fn is_keys_only(&self) -> bool {
 		if !self.fields.is_count_all_only() {
 			return false;

--- a/crates/core/src/kvs/cache/ds/lookup.rs
+++ b/crates/core/src/kvs/cache/ds/lookup.rs
@@ -16,7 +16,7 @@ pub(crate) enum Lookup<'a> {
 	Lvs(&'a str, &'a str, &'a str, Uuid),
 }
 
-impl<'a> Equivalent<Key> for Lookup<'a> {
+impl Equivalent<Key> for Lookup<'_> {
 	#[rustfmt::skip]
 	fn equivalent(&self, key: &Key) -> bool {
 		match (self, key) {

--- a/crates/core/src/kvs/cache/tx/lookup.rs
+++ b/crates/core/src/kvs/cache/tx/lookup.rs
@@ -97,7 +97,7 @@ pub(crate) enum Lookup<'a> {
 	Record(&'a str, &'a str, &'a str, &'a Id),
 }
 
-impl<'a> Equivalent<Key> for Lookup<'a> {
+impl Equivalent<Key> for Lookup<'_> {
 	#[rustfmt::skip]
 	fn equivalent(&self, key: &Key) -> bool {
 		match (self, key) {

--- a/crates/core/src/kvs/scanner.rs
+++ b/crates/core/src/kvs/scanner.rs
@@ -51,7 +51,7 @@ impl<'a, I> Scanner<'a, I> {
 	}
 }
 
-impl<'a> Stream for Scanner<'a, (Key, Val)> {
+impl Stream for Scanner<'_, (Key, Val)> {
 	type Item = Result<(Key, Val), Error>;
 	fn poll_next(
 		mut self: Pin<&mut Self>,
@@ -121,7 +121,7 @@ impl<'a> Stream for Scanner<'a, (Key, Val)> {
 	}
 }
 
-impl<'a> Stream for Scanner<'a, Key> {
+impl Stream for Scanner<'_, Key> {
 	type Item = Result<Key, Error>;
 	fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Result<Key, Error>>> {
 		// If we have results, return the first one

--- a/crates/core/src/sql/bytes.rs
+++ b/crates/core/src/sql/bytes.rs
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for Bytes {
 	{
 		struct RawBytesVisitor;
 
-		impl<'de> Visitor<'de> for RawBytesVisitor {
+		impl Visitor<'_> for RawBytesVisitor {
 			type Value = Bytes;
 
 			fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/core/src/sql/duration.rs
+++ b/crates/core/src/sql/duration.rs
@@ -250,7 +250,7 @@ impl TryAdd for Duration {
 	}
 }
 
-impl<'a, 'b> ops::Add<&'b Duration> for &'a Duration {
+impl<'b> ops::Add<&'b Duration> for &Duration {
 	type Output = Duration;
 	fn add(self, other: &'b Duration) -> Duration {
 		match self.0.checked_add(other.0) {
@@ -260,7 +260,7 @@ impl<'a, 'b> ops::Add<&'b Duration> for &'a Duration {
 	}
 }
 
-impl<'a, 'b> TryAdd<&'b Duration> for &'a Duration {
+impl<'b> TryAdd<&'b Duration> for &Duration {
 	type Output = Duration;
 	fn try_add(self, other: &'b Duration) -> Result<Duration, Error> {
 		self.0
@@ -290,7 +290,7 @@ impl TrySub for Duration {
 	}
 }
 
-impl<'a, 'b> ops::Sub<&'b Duration> for &'a Duration {
+impl<'b> ops::Sub<&'b Duration> for &Duration {
 	type Output = Duration;
 	fn sub(self, other: &'b Duration) -> Duration {
 		match self.0.checked_sub(other.0) {
@@ -300,7 +300,7 @@ impl<'a, 'b> ops::Sub<&'b Duration> for &'a Duration {
 	}
 }
 
-impl<'a, 'b> TrySub<&'b Duration> for &'a Duration {
+impl<'b> TrySub<&'b Duration> for &Duration {
 	type Output = Duration;
 	fn try_sub(self, other: &'b Duration) -> Result<Duration, Error> {
 		self.0

--- a/crates/core/src/sql/number.rs
+++ b/crates/core/src/sql/number.rs
@@ -888,7 +888,7 @@ impl ops::Add for Number {
 	}
 }
 
-impl<'a, 'b> ops::Add<&'b Number> for &'a Number {
+impl<'b> ops::Add<&'b Number> for &Number {
 	type Output = Number;
 	fn add(self, other: &'b Number) -> Number {
 		match (self, other) {
@@ -916,7 +916,7 @@ impl ops::Sub for Number {
 	}
 }
 
-impl<'a, 'b> ops::Sub<&'b Number> for &'a Number {
+impl<'b> ops::Sub<&'b Number> for &Number {
 	type Output = Number;
 	fn sub(self, other: &'b Number) -> Number {
 		match (self, other) {
@@ -944,7 +944,7 @@ impl ops::Mul for Number {
 	}
 }
 
-impl<'a, 'b> ops::Mul<&'b Number> for &'a Number {
+impl<'b> ops::Mul<&'b Number> for &Number {
 	type Output = Number;
 	fn mul(self, other: &'b Number) -> Number {
 		match (self, other) {
@@ -972,7 +972,7 @@ impl ops::Div for Number {
 	}
 }
 
-impl<'a, 'b> ops::Div<&'b Number> for &'a Number {
+impl<'b> ops::Div<&'b Number> for &Number {
 	type Output = Number;
 	fn div(self, other: &'b Number) -> Number {
 		match (self, other) {

--- a/crates/core/src/sql/regex.rs
+++ b/crates/core/src/sql/regex.rs
@@ -126,7 +126,7 @@ impl<'de> Deserialize<'de> for Regex {
 			{
 				struct RegexVisitor;
 
-				impl<'de> Visitor<'de> for RegexVisitor {
+				impl Visitor<'_> for RegexVisitor {
 					type Value = Regex;
 
 					fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/core/src/sql/strand.rs
+++ b/crates/core/src/sql/strand.rs
@@ -112,7 +112,7 @@ pub(crate) mod no_nul_bytes {
 	{
 		struct NoNulBytesVisitor;
 
-		impl<'de> Visitor<'de> for NoNulBytesVisitor {
+		impl Visitor<'_> for NoNulBytesVisitor {
 			type Value = String;
 
 			fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/core/src/syn/lexer/byte.rs
+++ b/crates/core/src/syn/lexer/byte.rs
@@ -7,7 +7,7 @@ use crate::syn::{
 	token::{t, Token, TokenKind},
 };
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
 	/// Eats a single line comment.
 	pub(super) fn eat_single_line_comment(&mut self) {
 		loop {

--- a/crates/core/src/syn/lexer/char.rs
+++ b/crates/core/src/syn/lexer/char.rs
@@ -4,7 +4,7 @@ use crate::syn::{
 	token::{t, Token},
 };
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
 	/// lex non-ascii characters.
 	///
 	/// Should only be called after determining that the byte is not a valid ascii character.

--- a/crates/core/src/syn/lexer/compound/mod.rs
+++ b/crates/core/src/syn/lexer/compound/mod.rs
@@ -28,7 +28,7 @@ pub struct CompoundToken<T> {
 	pub span: Span,
 }
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
 	/// Lex a more complex token from the start token.
 	/// The start token should already be consumed.
 	pub fn lex_compound<F, R>(

--- a/crates/core/src/syn/lexer/ident.rs
+++ b/crates/core/src/syn/lexer/ident.rs
@@ -10,7 +10,7 @@ use crate::syn::{
 
 use super::unicode::{chars, is_identifier_continue};
 
-impl<'a> Lexer<'a> {
+impl Lexer<'_> {
 	/// Lex a parameter in the form of `$[a-zA-Z0-9_]*`
 	///
 	/// # Lexer State

--- a/crates/core/src/syn/lexer/reader.rs
+++ b/crates/core/src/syn/lexer/reader.rs
@@ -135,7 +135,7 @@ impl<'a> BytesReader<'a> {
 	}
 }
 
-impl<'a> Iterator for BytesReader<'a> {
+impl Iterator for BytesReader<'_> {
 	type Item = u8;
 
 	#[inline]
@@ -150,7 +150,7 @@ impl<'a> Iterator for BytesReader<'a> {
 	}
 }
 
-impl<'a> ExactSizeIterator for BytesReader<'a> {
+impl ExactSizeIterator for BytesReader<'_> {
 	fn len(&self) -> usize {
 		self.len()
 	}

--- a/crates/sdk/src/api/method/export.rs
+++ b/crates/sdk/src/api/method/export.rs
@@ -67,7 +67,7 @@ where
 	}
 }
 
-impl<'r, C, R> Export<'r, C, R, Config>
+impl<C, R> Export<'_, C, R, Config>
 where
 	C: Connection,
 {

--- a/crates/sdk/src/api/method/import.rs
+++ b/crates/sdk/src/api/method/import.rs
@@ -37,7 +37,7 @@ where
 	}
 }
 
-impl<'r, C, T> Import<'r, C, T>
+impl<C, T> Import<'_, C, T>
 where
 	C: Connection,
 {

--- a/crates/sdk/src/api/method/query.rs
+++ b/crates/sdk/src/api/method/query.rs
@@ -212,7 +212,7 @@ where
 	}
 }
 
-impl<'r, C> Query<'r, C>
+impl<C> Query<'_, C>
 where
 	C: Connection,
 {

--- a/crates/sdk/src/api/method/run.rs
+++ b/crates/sdk/src/api/method/run.rs
@@ -76,7 +76,7 @@ where
 	}
 }
 
-impl<'r, Client, R> Run<'r, Client, R>
+impl<Client, R> Run<'_, Client, R>
 where
 	Client: Connection,
 {

--- a/crates/sdk/src/api/method/select.rs
+++ b/crates/sdk/src/api/method/select.rs
@@ -88,7 +88,7 @@ where
 	into_future! {execute_vec}
 }
 
-impl<'r, C> Select<'r, C, Value>
+impl<C> Select<'_, C, Value>
 where
 	C: Connection,
 {
@@ -99,7 +99,7 @@ where
 	}
 }
 
-impl<'r, C, R> Select<'r, C, Vec<R>>
+impl<C, R> Select<'_, C, Vec<R>>
 where
 	C: Connection,
 {

--- a/crates/sdk/src/api/value/obj.rs
+++ b/crates/sdk/src/api/value/obj.rs
@@ -176,13 +176,13 @@ impl<'a> Iterator for Iter<'a> {
 
 impl FusedIterator for Iter<'_> {}
 
-impl<'a> DoubleEndedIterator for Iter<'a> {
+impl DoubleEndedIterator for Iter<'_> {
 	fn next_back(&mut self) -> Option<Self::Item> {
 		self.iter.next_back().map(|(a, b)| (a, Value::from_inner_ref(b)))
 	}
 }
 
-impl<'a> ExactSizeIterator for Iter<'a> {
+impl ExactSizeIterator for Iter<'_> {
 	fn len(&self) -> usize {
 		self.iter.len()
 	}
@@ -231,13 +231,13 @@ impl<'a> Iterator for IterMut<'a> {
 
 impl FusedIterator for IterMut<'_> {}
 
-impl<'a> DoubleEndedIterator for IterMut<'a> {
+impl DoubleEndedIterator for IterMut<'_> {
 	fn next_back(&mut self) -> Option<Self::Item> {
 		self.iter.next_back().map(|(a, b)| (a, Value::from_inner_mut(b)))
 	}
 }
 
-impl<'a> ExactSizeIterator for IterMut<'a> {
+impl ExactSizeIterator for IterMut<'_> {
 	fn len(&self) -> usize {
 		self.iter.len()
 	}

--- a/crates/sdk/tests/access.rs
+++ b/crates/sdk/tests/access.rs
@@ -733,7 +733,8 @@ async fn access_bearer_purge() {
 		// Wait for a second
 		std::thread::sleep(Duration::from_secs(1));
 		// Purge revoked bearer grants
-		let res = &mut dbs.execute(&"ACCESS srv PURGE REVOKED".to_string(), &ses, None).await.unwrap();
+		let res =
+			&mut dbs.execute(&"ACCESS srv PURGE REVOKED".to_string(), &ses, None).await.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
 		let ok = Regex::new(&format!(
 			r"\[\{{ ac: 'srv', .*?, id: '{kid}', revocation: d'.*?', .*? \}}\]"

--- a/crates/sdk/tests/access.rs
+++ b/crates/sdk/tests/access.rs
@@ -418,7 +418,7 @@ async fn access_bearer_revoke() {
 		assert_eq!(tmp.to_string(), "This access grant has been revoked");
 		// Ensure that only that bearer grant is revoked
 		let res = &mut dbs
-			.execute(&format!("ACCESS srv SHOW WHERE revocation IS NOT NONE"), &ses, None)
+			.execute(&"ACCESS srv SHOW WHERE revocation IS NOT NONE".to_string(), &ses, None)
 			.await
 			.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
@@ -429,7 +429,7 @@ async fn access_bearer_revoke() {
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Revoke all bearer grants for a specific user
 		let res = &mut dbs
-			.execute(&format!("ACCESS srv REVOKE WHERE subject.user = 'jaime'"), &ses, None)
+			.execute(&"ACCESS srv REVOKE WHERE subject.user = 'jaime'".to_string(), &ses, None)
 			.await
 			.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
@@ -439,7 +439,7 @@ async fn access_bearer_revoke() {
 		.unwrap();
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Revoke the rest of the bearer grants
-		let res = &mut dbs.execute(&format!("ACCESS srv REVOKE ALL"), &ses, None).await.unwrap();
+		let res = &mut dbs.execute(&"ACCESS srv REVOKE ALL".to_string(), &ses, None).await.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
 		let ok = Regex::new(
 			r"\[\{ ac: 'srv', .*?, revocation: d'.*?', .*? \}, \{ ac: 'srv', .*?, revocation: d'.*?', .*? \}\]",
@@ -448,7 +448,7 @@ async fn access_bearer_revoke() {
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Ensure that all bearer grants are now revoked
 		let res = &mut dbs
-			.execute(&format!("ACCESS srv SHOW WHERE revocation IS NONE"), &ses, None)
+			.execute(&"ACCESS srv SHOW WHERE revocation IS NONE".to_string(), &ses, None)
 			.await
 			.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
@@ -569,7 +569,7 @@ async fn access_bearer_show() {
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Show all bearer grants for a specific user
 		let res = &mut dbs
-			.execute(&format!("ACCESS srv SHOW WHERE subject.user = 'jaime'"), &ses, None)
+			.execute(&"ACCESS srv SHOW WHERE subject.user = 'jaime'".to_string(), &ses, None)
 			.await
 			.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
@@ -581,7 +581,7 @@ async fn access_bearer_show() {
 		// Show all non-revoked bearer grants for a specific user
 		let res = &mut dbs
 			.execute(
-				&format!("ACCESS srv SHOW WHERE subject.user = 'tobie' AND revocation IS NONE"),
+				&"ACCESS srv SHOW WHERE subject.user = 'tobie' AND revocation IS NONE".to_string(),
 				&ses,
 				None,
 			)
@@ -595,7 +595,7 @@ async fn access_bearer_show() {
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Show all revoked bearer grants
 		let res = &mut dbs
-			.execute(&format!("ACCESS srv SHOW WHERE revocation IS NOT NONE"), &ses, None)
+			.execute(&"ACCESS srv SHOW WHERE revocation IS NOT NONE".to_string(), &ses, None)
 			.await
 			.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
@@ -606,7 +606,7 @@ async fn access_bearer_show() {
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Show all active bearer grants
 		let res = &mut dbs
-			.execute(&format!("ACCESS srv SHOW WHERE revocation IS NONE AND (expiration IS NONE OR expiration < time::now())"), &ses, None)
+			.execute(&"ACCESS srv SHOW WHERE revocation IS NONE AND (expiration IS NONE OR expiration < time::now())".to_string(), &ses, None)
 			.await
 			.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
@@ -733,7 +733,7 @@ async fn access_bearer_purge() {
 		// Wait for a second
 		std::thread::sleep(Duration::from_secs(1));
 		// Purge revoked bearer grants
-		let res = &mut dbs.execute(&format!("ACCESS srv PURGE REVOKED"), &ses, None).await.unwrap();
+		let res = &mut dbs.execute(&"ACCESS srv PURGE REVOKED".to_string(), &ses, None).await.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
 		let ok = Regex::new(&format!(
 			r"\[\{{ ac: 'srv', .*?, id: '{kid}', revocation: d'.*?', .*? \}}\]"
@@ -741,48 +741,42 @@ async fn access_bearer_purge() {
 		.unwrap();
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Ensure that only that bearer grant is purged
-		let res = &mut dbs.execute(&format!("ACCESS srv SHOW ALL"), &ses, None).await.unwrap();
+		let res = &mut dbs.execute(&"ACCESS srv SHOW ALL".to_string(), &ses, None).await.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
-		let ok = Regex::new(&format!(
-			r"\[\{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}\]"
-		))
+		let ok = Regex::new(&r"\[\{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}\]".to_string())
 		.unwrap();
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Wait for all grants to expire
 		std::thread::sleep(Duration::from_secs(2));
 		// Purge grants expired for 2 seconds
 		let res = &mut dbs
-			.execute(&format!("ACCESS srv PURGE EXPIRED FOR 2s"), &ses, None)
+			.execute(&"ACCESS srv PURGE EXPIRED FOR 2s".to_string(), &ses, None)
 			.await
 			.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
-		let ok = Regex::new(&format!(r"\[\]")).unwrap();
+		let ok = Regex::new(&r"\[\]".to_string()).unwrap();
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Ensure that no grants have been purged
-		let res = &mut dbs.execute(&format!("ACCESS srv SHOW ALL"), &ses, None).await.unwrap();
+		let res = &mut dbs.execute(&"ACCESS srv SHOW ALL".to_string(), &ses, None).await.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
-		let ok = Regex::new(&format!(
-			r"\[\{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}\]"
-		))
+		let ok = Regex::new(&r"\[\{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}\]".to_string())
 		.unwrap();
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Wait for grants to be expired for 2 seconds
 		std::thread::sleep(Duration::from_secs(2));
 		// Purge grants expired for 2 seconds
 		let res = &mut dbs
-			.execute(&format!("ACCESS srv PURGE EXPIRED FOR 2s"), &ses, None)
+			.execute(&"ACCESS srv PURGE EXPIRED FOR 2s".to_string(), &ses, None)
 			.await
 			.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
-		let ok = Regex::new(&format!(
-			r"\[\{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}, \{{ ac: 'srv', .*? \}}\]"
-		))
+		let ok = Regex::new(&r"\[\{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}, \{ ac: 'srv', .*? \}\]".to_string())
 		.unwrap();
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 		// Ensure that all grants have been purged
-		let res = &mut dbs.execute(&format!("ACCESS srv SHOW ALL"), &ses, None).await.unwrap();
+		let res = &mut dbs.execute(&"ACCESS srv SHOW ALL".to_string(), &ses, None).await.unwrap();
 		let tmp = res.remove(0).result.unwrap().to_string();
-		let ok = Regex::new(&format!(r"\[\]")).unwrap();
+		let ok = Regex::new(&r"\[\]".to_string()).unwrap();
 		assert!(ok.is_match(&tmp), "Output '{}' doesn't match regex '{}'", tmp, ok);
 	}
 }

--- a/crates/sdk/tests/api/backup.rs
+++ b/crates/sdk/tests/api/backup.rs
@@ -46,7 +46,7 @@ async fn export_import() {
 	// Verify that all records exist post-import
 	for i in 0..10 {
 		let mut response =
-			db.query(&format!("SELECT name FROM user WHERE name = 'User {i}'")).await.unwrap();
+			db.query(format!("SELECT name FROM user WHERE name = 'User {i}'")).await.unwrap();
 		let Some(name): Option<String> = response.take("name").unwrap() else {
 			panic!("query returned no record");
 		};
@@ -103,14 +103,14 @@ async fn export_with_config() {
 	res.unwrap();
 
 	// Verify that no group records were imported
-	let mut response = db.query(&format!("SELECT id FROM group")).await.unwrap();
+	let mut response = db.query("SELECT id FROM group".to_string()).await.unwrap();
 	let tmp: Option<Value> = response.take(0).unwrap();
 	assert_eq!(tmp, None);
 
 	// Verify that all user records exist post-import
 	for i in 0..10 {
 		let mut response =
-			db.query(&format!("SELECT name FROM user WHERE name = 'User {i}'")).await.unwrap();
+			db.query(format!("SELECT name FROM user WHERE name = 'User {i}'")).await.unwrap();
 		let Some(name): Option<String> = response.take("name").unwrap() else {
 			panic!("query returned no record");
 		};

--- a/crates/sdk/tests/api/backup_version.rs
+++ b/crates/sdk/tests/api/backup_version.rs
@@ -406,7 +406,7 @@ async fn export_import_retrieve_specific_versions() {
     // Verify that specific versions can be retrieved
     for (i, version) in versions.iter().enumerate() {
         let mut response = db
-            .query(&format!(
+            .query(format!(
                 "
                 SELECT name FROM user:user1 VERSION d'{version}'
                 "

--- a/crates/sdk/tests/define.rs
+++ b/crates/sdk/tests/define.rs
@@ -3256,7 +3256,7 @@ async fn cross_transaction_caching_uuids_updated() -> Result<(), Error> {
 	assert!(res.remove(0).result.is_ok());
 	// Obtain the initial uuids
 	let txn = ds.transaction(TransactionType::Read, LockType::Pessimistic).await?;
-	let initial = txn.get_tb(&"test", &"test", &"test").await?;
+	let initial = txn.get_tb("test", "test", "test").await?;
 	drop(txn);
 
 	// Define some resources to refresh the UUIDs
@@ -3278,7 +3278,7 @@ async fn cross_transaction_caching_uuids_updated() -> Result<(), Error> {
 	assert!(matches!(lqid, Value::Uuid(_)));
 	// Obtain the uuids after definitions
 	let txn = ds.transaction(TransactionType::Read, LockType::Pessimistic).await?;
-	let after_define = txn.get_tb(&"test", &"test", &"test").await?;
+	let after_define = txn.get_tb("test", "test", "test").await?;
 	drop(txn);
 	// Compare uuids after definitions
 	assert_ne!(initial.cache_fields_ts, after_define.cache_fields_ts);
@@ -3306,7 +3306,7 @@ async fn cross_transaction_caching_uuids_updated() -> Result<(), Error> {
 	assert!(res.remove(0).result.is_ok());
 	// Obtain the uuids after definitions
 	let txn = ds.transaction(TransactionType::Read, LockType::Pessimistic).await?;
-	let after_remove = txn.get_tb(&"test", &"test", &"test").await?;
+	let after_remove = txn.get_tb("test", "test", "test").await?;
 	drop(txn);
 	// Compare uuids after definitions
 	assert_ne!(after_define.cache_fields_ts, after_remove.cache_fields_ts);

--- a/crates/sdk/tests/idiom.rs
+++ b/crates/sdk/tests/idiom.rs
@@ -154,7 +154,7 @@ async fn idiom_optional_after_value_should_pass_through() -> Result<(), Error> {
 		.expect_val("[]")?
 		.expect_val("{}")?
 		.expect_val("(89.0, 90.0)")?
-		.expect_bytes(&[104, 104, 101, 104, 101, 104, 101])?
+		.expect_bytes([104, 104, 101, 104, 101, 104, 101])?
 		.expect_val("person:aeon")?
 		.expect_val(
 			"{

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -1042,9 +1042,9 @@ mod http_integration {
 		Ok(())
 	}
 
-	///
-	/// Key endpoint tests
-	///
+	//
+	// Key endpoint tests
+	//
 
 	async fn seed_table(
 		client: &Client,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Authentication checks for access to databases and namespaces where done on every access to a table.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This moves the check to take place once when the database and namespace are first used.
Also fixes some new clippy lints in nightly.
 
## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
