### PR TITLE
Permission check should not generates an error when the table does not exist

### DIFF
--- a/crates/core/src/idx/planner/mod.rs
+++ b/crates/core/src/idx/planner/mod.rs
@@ -14,13 +14,11 @@ use crate::idx::planner::iterators::IteratorRef;
 use crate::idx::planner::knn::KnnBruteForceResults;
 use crate::idx::planner::plan::{Plan, PlanBuilder};
 use crate::idx::planner::tree::Tree;
-use crate::sql::statements::DefineTableStatement;
 use crate::sql::with::With;
 use crate::sql::{order::Ordering, Cond, Fields, Groups, Table};
 use reblessive::tree::Stk;
 use std::collections::HashMap;
 use std::sync::atomic::{self, AtomicU8};
-use std::sync::Arc;
 
 /// The goal of this structure is to cache parameters so they can be easily passed
 /// from one function to the other, so we don't pass too much arguments.
@@ -92,8 +90,10 @@ impl<'a> StatementContext<'a> {
 						return Ok(false);
 					}
 				}
-				Err(e) if matches!(e, Error::TbNotFound { .. }) => {
-					// We can safely ignore, there are no permissions defined
+				Err(Error::TbNotFound {
+					..
+				}) => {
+					// We can safely ignore this error, as it just means that there are no permissions defined
 				}
 				Err(e) => return Err(e),
 			}

--- a/crates/sdk/tests/group.rs
+++ b/crates/sdk/tests/group.rs
@@ -1007,12 +1007,17 @@ async fn select_count_range_keys_only_permissions(
 	// Define the permissions and create some records
 	let sql = format!(
 		r"
+			SELECT COUNT() FROM table:a..z GROUP ALL;
+			SELECT COUNT() FROM table:a..z;
 			DEFINE TABLE table PERMISSIONS {perms};
 			CREATE table:me CONTENT {{ bar: 'hello', foo: 'world'}};
 			CREATE table:you CONTENT {{ bar: 'don\'t', foo: 'show up'}};
 		"
 	);
 	let mut t = Test::new(&sql).await?;
+	// The first select should be successful (and empty) when the table does not exist
+	t.expect_vals(&["[]", "[]"])?;
+	//
 	t.skip_ok(2)?;
 	// Create and select as a record user
 	let sql = r"


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

https://discord.com/channels/902568124350599239/902568124350599242/1310978712082186242

When permissions are enabled, doing a `SELECT COUNT()` on a non-existing table generates an error (Table not found).

## What does this change do?

Restore the expected behaviour. 

## What is your testing strategy?

GitHub action.
A test has been added.

## Is this related to any issues?

#5005 introduces this bug.

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
