### PR TITLE
Add support for `surrealkv+versioned` in the binary

### DIFF
--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -15,6 +15,7 @@ pub(crate) fn path_valid(v: &str) -> Result<String, String> {
 		v if v.starts_with("file:") => Ok(v.to_string()),
 		v if v.starts_with("rocksdb:") => Ok(v.to_string()),
 		v if v.starts_with("surrealkv:") => Ok(v.to_string()),
+		v if v.starts_with("surrealkv+versioned:") => Ok(v.to_string()),
 		v if v.starts_with("surrealcs:") => Ok(v.to_string()),
 		v if v.starts_with("tikv:") => Ok(v.to_string()),
 		v if v.starts_with("fdb:") => Ok(v.to_string()),
@@ -59,8 +60,18 @@ pub(crate) fn endpoint_valid(v: &str) -> Result<String, String> {
 
 	let scheme = split_endpoint(v).0;
 	match scheme {
-		"http" | "https" | "ws" | "wss" | "fdb" | "mem" | "rocksdb" | "surrealkv" | "file"
-		| "surrealcs" | "tikv" => Ok(v.to_string()),
+		"http"
+		| "https"
+		| "ws"
+		| "wss"
+		| "fdb"
+		| "mem"
+		| "rocksdb"
+		| "surrealkv"
+		| "surrealkv+versioned"
+		| "file"
+		| "surrealcs"
+		| "tikv" => Ok(v.to_string()),
 		_ => Err(String::from("Provide a valid database connection string")),
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

`surrealkv+versioned` is not currently supported in the binary.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It adds support for it.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Tested the binary.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
