### PR TITLE
Remove development panic backtrace on transaction drop

### DIFF
--- a/crates/core/src/kvs/mem/mod.rs
+++ b/crates/core/src/kvs/mem/mod.rs
@@ -9,12 +9,10 @@ use surrealkv::Options;
 use surrealkv::Store;
 use surrealkv::Transaction as Tx;
 
-#[non_exhaustive]
 pub struct Datastore {
 	db: Store,
 }
 
-#[non_exhaustive]
 pub struct Transaction {
 	/// Is the transaction complete?
 	done: bool,
@@ -29,11 +27,6 @@ pub struct Transaction {
 impl Drop for Transaction {
 	fn drop(&mut self) {
 		if !self.done && self.write {
-			// Check if already panicking
-			if std::thread::panicking() {
-				return;
-			}
-			// Handle the behaviour
 			match self.check {
 				Check::None => {
 					trace!("A transaction was dropped without being committed or cancelled");
@@ -41,15 +34,8 @@ impl Drop for Transaction {
 				Check::Warn => {
 					warn!("A transaction was dropped without being committed or cancelled");
 				}
-				Check::Panic => {
-					#[cfg(debug_assertions)]
-					{
-						let backtrace = std::backtrace::Backtrace::force_capture();
-						if let std::backtrace::BacktraceStatus::Captured = backtrace.status() {
-							println!("{}", backtrace);
-						}
-					}
-					panic!("A transaction was dropped without being committed or cancelled");
+				Check::Error => {
+					error!("A transaction was dropped without being committed or cancelled");
 				}
 			}
 		}
@@ -84,7 +70,7 @@ impl Datastore {
 		#[cfg(not(debug_assertions))]
 		let check = Check::Warn;
 		#[cfg(debug_assertions)]
-		let check = Check::Panic;
+		let check = Check::Error;
 		// Create a new transaction
 		match self.db.begin() {
 			Ok(inner) => Ok(Transaction {

--- a/crates/core/src/kvs/surrealkv/mod.rs
+++ b/crates/core/src/kvs/surrealkv/mod.rs
@@ -10,12 +10,10 @@ use surrealkv::Options;
 use surrealkv::Store;
 use surrealkv::Transaction as Tx;
 
-#[non_exhaustive]
 pub struct Datastore {
 	db: Store,
 }
 
-#[non_exhaustive]
 pub struct Transaction {
 	/// Is the transaction complete?
 	done: bool,
@@ -30,11 +28,6 @@ pub struct Transaction {
 impl Drop for Transaction {
 	fn drop(&mut self) {
 		if !self.done && self.write {
-			// Check if already panicking
-			if std::thread::panicking() {
-				return;
-			}
-			// Handle the behaviour
 			match self.check {
 				Check::None => {
 					trace!("A transaction was dropped without being committed or cancelled");
@@ -42,15 +35,8 @@ impl Drop for Transaction {
 				Check::Warn => {
 					warn!("A transaction was dropped without being committed or cancelled");
 				}
-				Check::Panic => {
-					#[cfg(debug_assertions)]
-					{
-						let backtrace = std::backtrace::Backtrace::force_capture();
-						if let std::backtrace::BacktraceStatus::Captured = backtrace.status() {
-							println!("{}", backtrace);
-						}
-					}
-					panic!("A transaction was dropped without being committed or cancelled");
+				Check::Error => {
+					error!("A transaction was dropped without being committed or cancelled");
 				}
 			}
 		}
@@ -98,7 +84,7 @@ impl Datastore {
 		#[cfg(not(debug_assertions))]
 		let check = Check::Warn;
 		#[cfg(debug_assertions)]
-		let check = Check::Panic;
+		let check = Check::Error;
 		// Create a new transaction
 		let txn = match write {
 			true => self.db.begin_with_mode(Mode::ReadWrite),

--- a/crates/core/src/kvs/tr.rs
+++ b/crates/core/src/kvs/tr.rs
@@ -35,7 +35,7 @@ pub enum Check {
 	#[default]
 	None,
 	Warn,
-	Panic,
+	Error,
 }
 
 /// Specifies whether the transaction is read-only or writeable.

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -378,9 +378,9 @@ impl Transaction {
 		self
 	}
 
-	/// Panic if this transaction is dropped without proper handling.
-	pub async fn rollback_with_panic(self) -> Self {
-		self.tx.lock().await.check_level(Check::Panic);
+	/// Error if this transaction is dropped without proper handling.
+	pub async fn rollback_with_error(self) -> Self {
+		self.tx.lock().await.check_level(Check::Error);
 		self
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When a transaction was dropped without being rolled back, when running with `#[cfg(debug_assertions)]`, then a panic would be raised, and a default backtrace would be printed to the console. This resulted in some changes to the memory usage of the application from that point onwards.

## What does this change do?

Now, when a transaction is dropped and  `#[cfg(debug_assertions)]` is enabled, then an error is logged.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
