### PR TITLE
Add env vars to disable tracing and metrics

### DIFF
--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -97,12 +97,12 @@ pub static TELEMETRY_PROVIDER: LazyLock<String> =
 	lazy_env_parse!("SURREAL_TELEMETRY_PROVIDER", String);
 
 /// If set to "true" then no traces are sent to the GRPC OTEL collector
-pub static TELEMETRY_DISABLE_TRACING: LazyLock<String> =
-	lazy_env_parse!("SURREAL_TELEMETRY_DISABLE_TRACING", String);
+pub static TELEMETRY_DISABLE_TRACING: LazyLock<bool> =
+	lazy_env_parse!("SURREAL_TELEMETRY_DISABLE_TRACING", bool);
 
 /// If set to "true" then no metrics are sent to the GRPC OTEL collector
-pub static TELEMETRY_DISABLE_METRICS: LazyLock<String> =
-	lazy_env_parse!("SURREAL_TELEMETRY_DISABLE_METRICS", String);
+pub static TELEMETRY_DISABLE_METRICS: LazyLock<bool> =
+	lazy_env_parse!("SURREAL_TELEMETRY_DISABLE_METRICS", bool);
 
 /// If set then use this as value for the namespace label when sending telemetry
 pub static TELEMETRY_NAMESPACE: LazyLock<String> =

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -96,6 +96,14 @@ pub static RUNTIME_MAX_BLOCKING_THREADS: LazyLock<usize> =
 pub static TELEMETRY_PROVIDER: LazyLock<String> =
 	lazy_env_parse!("SURREAL_TELEMETRY_PROVIDER", String);
 
+/// If set to "true" then no traces are sent to the GRPC OTEL collector
+pub static TELEMETRY_DISABLE_TRACING: LazyLock<String> =
+	lazy_env_parse!("SURREAL_TELEMETRY_DISABLE_TRACING", String);
+
+/// If set to "true" then no metrics are sent to the GRPC OTEL collector
+pub static TELEMETRY_DISABLE_METRICS: LazyLock<String> =
+	lazy_env_parse!("SURREAL_TELEMETRY_DISABLE_METRICS", String);
+
 /// If set then use this as value for the namespace label when sending telemetry
 pub static TELEMETRY_NAMESPACE: LazyLock<String> =
 	lazy_env_parse!("SURREAL_TELEMETRY_NAMESPACE", String);

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -1,7 +1,7 @@
 pub mod http;
 pub mod ws;
 
-use crate::cnf::TELEMETRY_PROVIDER;
+use crate::cnf::{TELEMETRY_PROVIDER, TELEMETRY_DISABLE_METRICS};
 use opentelemetry::metrics::MetricsError;
 use opentelemetry_otlp::MetricsExporterBuilder;
 use opentelemetry_sdk::metrics::reader::{DefaultAggregationSelector, DefaultTemporalitySelector};
@@ -41,9 +41,14 @@ const HISTOGRAM_BUCKETS_BYTES: &[f64] = &[
 
 // Returns a metrics configuration based on the SURREAL_TELEMETRY_PROVIDER environment variable
 pub fn init() -> Result<Option<SdkMeterProvider>, MetricsError> {
+	let metrics_disabled = match TELEMETRY_DISABLE_METRICS.trim() {
+		"true" => true,
+		_ => false,
+	};
+
 	match TELEMETRY_PROVIDER.trim() {
 		// The OTLP telemetry provider has been specified
-		s if s.eq_ignore_ascii_case("otlp") => {
+		s if s.eq_ignore_ascii_case("otlp") && metrics_disabled => {
 			// Create a new metrics exporter using tonic
 			let exporter = MetricsExporterBuilder::from(opentelemetry_otlp::new_exporter().tonic())
 				.build_metrics_exporter(

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -1,7 +1,7 @@
 pub mod http;
 pub mod ws;
 
-use crate::cnf::{TELEMETRY_PROVIDER, TELEMETRY_DISABLE_METRICS};
+use crate::cnf::{TELEMETRY_DISABLE_METRICS, TELEMETRY_PROVIDER};
 use opentelemetry::metrics::MetricsError;
 use opentelemetry_otlp::MetricsExporterBuilder;
 use opentelemetry_sdk::metrics::reader::{DefaultAggregationSelector, DefaultTemporalitySelector};
@@ -41,14 +41,9 @@ const HISTOGRAM_BUCKETS_BYTES: &[f64] = &[
 
 // Returns a metrics configuration based on the SURREAL_TELEMETRY_PROVIDER environment variable
 pub fn init() -> Result<Option<SdkMeterProvider>, MetricsError> {
-	let metrics_disabled = match TELEMETRY_DISABLE_METRICS.trim() {
-		"true" => true,
-		_ => false,
-	};
-
 	match TELEMETRY_PROVIDER.trim() {
 		// The OTLP telemetry provider has been specified
-		s if s.eq_ignore_ascii_case("otlp") && metrics_disabled => {
+		s if s.eq_ignore_ascii_case("otlp") && !*TELEMETRY_DISABLE_METRICS => {
 			// Create a new metrics exporter using tonic
 			let exporter = MetricsExporterBuilder::from(opentelemetry_otlp::new_exporter().tonic())
 				.build_metrics_exporter(

--- a/src/telemetry/traces/mod.rs
+++ b/src/telemetry/traces/mod.rs
@@ -1,7 +1,7 @@
 pub mod rpc;
 
 use crate::cli::validator::parser::env_filter::CustomEnvFilter;
-use crate::cnf::TELEMETRY_PROVIDER;
+use crate::cnf::{TELEMETRY_PROVIDER, TELEMETRY_DISABLE_TRACING};
 use crate::err::Error;
 use crate::telemetry::OTEL_DEFAULT_RESOURCE;
 use opentelemetry::trace::TracerProvider as _;
@@ -15,9 +15,14 @@ pub fn new<S>(filter: CustomEnvFilter) -> Result<Option<Box<dyn Layer<S> + Send 
 where
 	S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a> + Send + Sync,
 {
+	let tracing_disabled = match TELEMETRY_DISABLE_TRACING.trim() {
+		"true" => true,
+		_ => false,
+	};
+
 	match TELEMETRY_PROVIDER.trim() {
 		// The OTLP telemetry provider has been specified
-		s if s.eq_ignore_ascii_case("otlp") => {
+		s if s.eq_ignore_ascii_case("otlp") && tracing_disabled => {
 			// Create a new OTLP exporter using gRPC
 			let exporter = opentelemetry_otlp::new_exporter().tonic();
 			// Build a new span exporter which uses gRPC

--- a/src/telemetry/traces/mod.rs
+++ b/src/telemetry/traces/mod.rs
@@ -1,7 +1,7 @@
 pub mod rpc;
 
 use crate::cli::validator::parser::env_filter::CustomEnvFilter;
-use crate::cnf::{TELEMETRY_PROVIDER, TELEMETRY_DISABLE_TRACING};
+use crate::cnf::{TELEMETRY_DISABLE_TRACING, TELEMETRY_PROVIDER};
 use crate::err::Error;
 use crate::telemetry::OTEL_DEFAULT_RESOURCE;
 use opentelemetry::trace::TracerProvider as _;
@@ -15,14 +15,9 @@ pub fn new<S>(filter: CustomEnvFilter) -> Result<Option<Box<dyn Layer<S> + Send 
 where
 	S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a> + Send + Sync,
 {
-	let tracing_disabled = match TELEMETRY_DISABLE_TRACING.trim() {
-		"true" => true,
-		_ => false,
-	};
-
 	match TELEMETRY_PROVIDER.trim() {
 		// The OTLP telemetry provider has been specified
-		s if s.eq_ignore_ascii_case("otlp") && tracing_disabled => {
+		s if s.eq_ignore_ascii_case("otlp") && !*TELEMETRY_DISABLE_TRACING => {
 			// Create a new OTLP exporter using gRPC
 			let exporter = opentelemetry_otlp::new_exporter().tonic();
 			// Build a new span exporter which uses gRPC


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

This pull request adds two environment variables for configuring Open Telemetry monitoring:
- `SURREAL_TELEMETRY_DISABLE_TRACING` for disabling sending traces
- `SURREAL_TELEMETRY_DISABLE_METRICS` for disabling sending metrics

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] Yes documentation to be added.

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
