### PR TITLE
Don't enable the `allocator` feature on Windows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,6 @@ jobs:
     with:
       environment: nightly
       extra-features: storage-surrealkv,ml
-      git-ref: main
+      git-ref: rushmore/allocator-feature
       publish: ${{ inputs.publish || github.event_name == 'schedule' }}
     secrets: inherit

--- a/.github/workflows/reusable_publish_version.yml
+++ b/.github/workflows/reusable_publish_version.yml
@@ -395,7 +395,7 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}
+              features=storage-tikv,http-compression,jwks,allocator,${{ inputs.extra-features }}
 
               # Download libonnxruntime's static library and tell ORT crate to use it
               mkdir /tmp/onnxruntime
@@ -422,7 +422,7 @@ jobs:
               brew install protobuf
 
               # Build
-              features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}
+              features=storage-tikv,http-compression,jwks,allocator,${{ inputs.extra-features }}
 
               # Download libonnxruntime's static library and tell ORT crate to use it
               mkdir /tmp/onnxruntime
@@ -444,7 +444,7 @@ jobs:
             file: surreal-${{ needs.prepare-vars.outputs.name }}.linux-amd64
             build-step: |
               # Build
-              features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}
+              features=storage-tikv,http-compression,jwks,allocator,${{ inputs.extra-features }}
 
               # Download libonnxruntime's static library and tell ORT crate to use it
               tmpdir=$(mktemp -d)
@@ -482,7 +482,7 @@ jobs:
               set -x
 
               # Build
-              features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}
+              features=storage-tikv,http-compression,jwks,allocator,${{ inputs.extra-features }}
 
               # Download libonnxruntime's static library and tell ORT crate to use it
               tmpdir=$(mktemp -d)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ members = [
 [features]
 # Public features
 default = [
-    "allocator",
     "storage-mem",
     "storage-surrealkv",
     "storage-surrealcs",


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

It currently breaks Windows builds.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It removes it from default features and manually adds it to all other platforms except Windows.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
