### PR TITLE
Ensure Windows builds have a default allocator

### DIFF
--- a/crates/core/src/mem/mod.rs
+++ b/crates/core/src/mem/mod.rs
@@ -5,6 +5,20 @@ mod track;
 pub static ALLOC: fake::FakeAlloc = fake::FakeAlloc::new();
 
 #[cfg(feature = "allocator")]
+#[cfg(not(any(
+	target_os = "android",
+	target_os = "freebsd",
+	target_os = "ios",
+	target_os = "linux",
+	target_os = "macos",
+	target_os = "netbsd",
+	target_os = "openbsd"
+)))]
+#[global_allocator]
+pub static ALLOC: track::TrackAlloc<std::alloc::System> =
+	track::TrackAlloc::new(std::alloc::System);
+
+#[cfg(feature = "allocator")]
 #[cfg(target_os = "android")]
 #[global_allocator]
 pub static ALLOC: track::TrackAlloc<jemallocator::Jemalloc> =


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Windows builds are currently broken.

## What does this change do?

Fixes Windows builds.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
