### PR TITLE
Optimise `Options` and `Auth` core engine internals

### DIFF
--- a/crates/core/src/dbs/options.rs
+++ b/crates/core/src/dbs/options.rs
@@ -17,38 +17,35 @@ use uuid::Uuid;
 /// whether field/event/table queries should be processed (useful
 /// when importing data, where these queries might fail).
 #[derive(Clone, Debug)]
-#[non_exhaustive]
 pub struct Options {
-	/// Current Node ID
+	/// The current Node ID of the datastore instance
 	id: Option<Uuid>,
-	/// Currently selected NS
+	/// The currently selected Namespace
 	ns: Option<Arc<str>>,
-	/// Currently selected DB
+	/// The currently selected Database
 	db: Option<Arc<str>>,
 	/// Approximately how large is the current call stack?
 	dive: u32,
 	/// Connection authentication data
-	pub auth: Arc<Auth>,
-	/// Is authentication enabled?
-	pub auth_enabled: bool,
-	/// Whether live queries are allowed?
-	pub live: bool,
+	pub(crate) auth: Arc<Auth>,
+	/// Is authentication enabled on this datastore?
+	pub(crate) auth_enabled: bool,
+	/// Whether live queries can be used?
+	pub(crate) live: bool,
 	/// Should we force tables/events to re-run?
-	pub force: Force,
+	pub(crate) force: Force,
 	/// Should we run permissions checks?
-	pub perms: bool,
+	pub(crate) perms: bool,
 	/// Should we error if tables don't exist?
-	pub strict: bool,
+	pub(crate) strict: bool,
 	/// Should we process field queries?
-	pub import: bool,
+	pub(crate) import: bool,
 	/// Should we process function futures?
-	pub futures: Futures,
-	/// Should we process variable field projections?
-	pub projections: bool,
+	pub(crate) futures: Futures,
+	/// The data version as nanosecond timestamp
+	pub(crate) version: Option<u64>,
 	/// The channel over which we send notifications
-	pub sender: Option<Sender<Notification>>,
-	/// Version as nanosecond timestamp passed down to Datastore
-	pub version: Option<u64>,
+	pub(crate) sender: Option<Sender<Notification>>,
 }
 
 #[derive(Clone, Debug)]
@@ -87,7 +84,6 @@ impl Options {
 			strict: false,
 			import: false,
 			futures: Futures::Disabled,
-			projections: false,
 			auth_enabled: true,
 			sender: None,
 			auth: Arc::new(Auth::default()),

--- a/crates/core/src/dbs/options.rs
+++ b/crates/core/src/dbs/options.rs
@@ -419,7 +419,7 @@ impl Options {
 			return Ok(false);
 		}
 		// Check if server auth is disabled
-		if !self.auth_enabled {
+		if !self.auth_enabled && self.auth.is_anon() {
 			return Ok(false);
 		}
 		// Check the action to determine if we need to check permissions

--- a/crates/core/src/dbs/options.rs
+++ b/crates/core/src/dbs/options.rs
@@ -1,10 +1,9 @@
 use crate::cnf::MAX_COMPUTATION_DEPTH;
 use crate::dbs::Notification;
 use crate::err::Error;
-use crate::iam::{Action, Auth, ResourceKind, Role};
-use crate::sql::{
-	statements::define::DefineIndexStatement, statements::define::DefineTableStatement, Base,
-};
+use crate::iam::{Action, Auth, ResourceKind};
+use crate::sql::statements::define::{DefineIndexStatement, DefineTableStatement};
+use crate::sql::Base;
 use async_channel::Sender;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -61,7 +60,7 @@ pub enum Force {
 	Index(Arc<[DefineIndexStatement]>),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Futures {
 	Disabled,
 	Enabled,
@@ -111,24 +110,6 @@ impl Options {
 	}
 
 	// --------------------------------------------------
-
-	/// Set all the required options from a single point.
-	/// The system expects these values to always be set,
-	/// so this should be called for all instances when
-	/// there is doubt.
-	pub fn with_required(
-		mut self,
-		node_id: Uuid,
-		ns: Option<Arc<str>>,
-		db: Option<Arc<str>>,
-		auth: Arc<Auth>,
-	) -> Self {
-		self.id = Some(node_id);
-		self.ns = ns;
-		self.db = db;
-		self.auth = auth;
-		self
-	}
 
 	/// Set the maximum depth a computation can reach.
 	pub fn with_max_computation_depth(mut self, depth: u32) -> Self {
@@ -180,13 +161,8 @@ impl Options {
 
 	/// Specify wether tables/events should re-run
 	pub fn with_force(mut self, force: Force) -> Self {
-		self.set_force(force);
-		self
-	}
-
-	/// Specify wether tables/events should re-run
-	pub fn set_force(&mut self, force: Force) {
 		self.force = force;
+		self
 	}
 
 	/// Sepecify if we should error when a table does not exist
@@ -213,13 +189,12 @@ impl Options {
 	}
 
 	pub fn set_futures(&mut self, futures: bool) {
-		if matches!(self.futures, Futures::Never) {
-			return;
-		}
-
-		self.futures = match futures {
-			true => Futures::Enabled,
-			false => Futures::Disabled,
+		self.futures = match self.futures {
+			Futures::Never => Futures::Never,
+			_ => match futures {
+				true => Futures::Enabled,
+				false => Futures::Disabled,
+			},
 		};
 	}
 
@@ -256,7 +231,6 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
-			futures: self.futures.clone(),
 			perms,
 			..*self
 		}
@@ -269,7 +243,6 @@ impl Options {
 			auth: self.auth.clone(),
 			ns: self.ns.clone(),
 			db: self.db.clone(),
-			futures: self.futures.clone(),
 			force,
 			..*self
 		}
@@ -283,7 +256,6 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
-			futures: self.futures.clone(),
 			strict,
 			..*self
 		}
@@ -297,7 +269,6 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
-			futures: self.futures.clone(),
 			import,
 			..*self
 		}
@@ -329,7 +300,6 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
-			futures: self.futures.clone(),
 			sender: Some(sender),
 			..*self
 		}
@@ -359,7 +329,6 @@ impl Options {
 			ns: self.ns.clone(),
 			db: self.db.clone(),
 			force: self.force.clone(),
-			futures: self.futures.clone(),
 			dive: self.dive - cost as u32,
 			..*self
 		})
@@ -437,53 +406,67 @@ impl Options {
 		self.auth.is_allowed(action, &res).map_err(Error::IamError)
 	}
 
-	/// Whether or not to check table permissions
+	/// Checks the current server configuration, and
+	/// user authentication information to determine
+	/// whether we need to process table permissions
+	/// on each document.
 	///
-	/// TODO: This method is called a lot during data operations, so we decided to bypass the system's authorization mechanism.
-	/// This is a temporary solution, until we optimize the new authorization system.
+	/// This method is repeatedly called during the
+	/// document processing operations, and so the
+	/// performance of this function is important.
+	/// We decided to bypass the system cedar auth
+	/// system as a temporary solution until the
+	/// new authorization system is optimised.
 	pub fn check_perms(&self, action: Action) -> Result<bool, Error> {
-		// If permissions are disabled, don't check permissions
+		// Check if permissions are enabled for this sub-process
 		if !self.perms {
 			return Ok(false);
 		}
-
-		// If auth is disabled and actor is anonymous, don't check permissions
-		if !self.auth_enabled && self.auth.is_anon() {
+		// Check if server auth is disabled
+		if !self.auth_enabled {
 			return Ok(false);
 		}
-
-		// Is the actor allowed to view?
-		let can_view =
-			[Role::Viewer, Role::Editor, Role::Owner].iter().any(|r| self.auth.has_role(r));
-		// Is the actor allowed to edit?
-		let can_edit = [Role::Editor, Role::Owner].iter().any(|r| self.auth.has_role(r));
-		// Is the target database in the actor's level?
-		let db_in_actor_level = self.auth.is_root()
-			|| self.auth.is_ns() && self.auth.level().ns().unwrap() == self.ns()?
-			|| self.auth.is_db()
-				&& self.auth.level().ns().unwrap() == self.ns()?
-				&& self.auth.level().db().unwrap() == self.db()?;
-
-		// Is the actor allowed to do the action on the selected database?
-		let is_allowed = match action {
-			Action::View => {
-				// Today all users have at least View permissions, so if the target database belongs to the user's level, don't check permissions
-				can_view && db_in_actor_level
-			}
+		// Check the action to determine if we need to check permissions
+		match action {
+			// This is a request to edit a resource
 			Action::Edit => {
-				// Editor and Owner roles are allowed to edit, but only if the target database belongs to the user's level
-				can_edit && db_in_actor_level
+				// Check if the actor is allowed to edit
+				let allowed = self.auth.has_editor_role();
+				// Today all users have at least View
+				// permissions, so if the target database
+				// belongs to the user's level, we don't
+				// need to check any table permissions.
+				let db_in_actor_level = self.auth.is_root()
+					|| self.auth.is_ns_check(self.ns()?)
+					|| self.auth.is_db_check(self.ns()?, self.db()?);
+				// If either of the above checks are false
+				// then we need to check table permissions
+				Ok(!allowed || !db_in_actor_level)
 			}
-		};
-
-		// Check permissions if the author is not already allowed to do the action
-		Ok(!is_allowed)
+			// This is a request to view a resource
+			Action::View => {
+				// Check if the actor is allowed to view
+				let allowed = self.auth.has_viewer_role();
+				// Today, Owner and Editor roles have
+				// Edit permissions, so if the target
+				// database belongs to the user's level
+				// we don't need to check table permissions.
+				let db_in_actor_level = self.auth.is_root()
+					|| self.auth.is_ns_check(self.ns()?)
+					|| self.auth.is_db_check(self.ns()?, self.db()?);
+				// If either of the above checks are false
+				// then we need to check table permissions
+				Ok(!allowed || !db_in_actor_level)
+			}
+		}
 	}
 }
 
 #[cfg(test)]
 mod tests {
+
 	use super::*;
+	use crate::iam::Role;
 
 	#[test]
 	fn is_allowed() {

--- a/crates/core/src/dbs/statement.rs
+++ b/crates/core/src/dbs/statement.rs
@@ -34,7 +34,6 @@ pub(crate) enum Statement<'a> {
 	Relate(&'a RelateStatement),
 	Delete(&'a DeleteStatement),
 	Insert(&'a InsertStatement),
-	// TODO(gguillemas): Document once bearer access is no longer experimental.
 	Access(&'a AccessStatement),
 }
 

--- a/crates/core/src/iam/auth.rs
+++ b/crates/core/src/iam/auth.rs
@@ -54,6 +54,16 @@ impl Auth {
 		matches!(self.level(), Level::Record(_, _, _))
 	}
 
+	/// Check if the current level is Namespace, and the namespace matches
+	pub fn is_ns_check(&self, ns: &str) -> bool {
+		matches!(self.level(), Level::Namespace(n) if n.eq(ns))
+	}
+
+	/// Check if the current level is Database, and the namespace and database match
+	pub fn is_db_check(&self, ns: &str, db: &str) -> bool {
+		matches!(self.level(), Level::Database(n, d) if n.eq(ns) && d.eq(db))
+	}
+
 	/// System Auth helpers
 	///
 	/// These are not stored in the database and are used for internal operations
@@ -84,8 +94,18 @@ impl Auth {
 	}
 
 	/// Checks if the current actor has a given role
-	pub fn has_role(&self, role: &Role) -> bool {
+	pub fn has_role(&self, role: Role) -> bool {
 		self.actor.has_role(role)
+	}
+
+	/// Checks if the current actor has a Editor role
+	pub fn has_editor_role(&self) -> bool {
+		self.actor.has_editor_role()
+	}
+
+	/// Checks if the current actor has a Viewer role
+	pub fn has_viewer_role(&self) -> bool {
+		self.actor.has_viewer_role()
 	}
 }
 

--- a/crates/core/src/iam/entities/resources/actor.rs
+++ b/crates/core/src/iam/entities/resources/actor.rs
@@ -57,8 +57,18 @@ impl Actor {
 	}
 
 	/// Checks if the actor has the given role.
-	pub fn has_role(&self, role: &Role) -> bool {
-		self.roles.contains(role)
+	pub fn has_role(&self, role: Role) -> bool {
+		self.roles.contains(&role)
+	}
+
+	/// Checks if the actor has the Editor role.
+	pub fn has_editor_role(&self) -> bool {
+		self.roles.iter().any(|r| r.eq(&Role::Owner) || r.eq(&Role::Editor))
+	}
+
+	/// Checks if the actor has the Viewer role.
+	pub fn has_viewer_role(&self) -> bool {
+		self.roles.iter().any(|r| r.eq(&Role::Owner) || r.eq(&Role::Editor) || r.eq(&Role::Viewer))
 	}
 
 	// Cedar policy helpers

--- a/crates/core/src/iam/entities/roles.rs
+++ b/crates/core/src/iam/entities/roles.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 
 // In the future, we will allow for custom roles. For now, provide predefined roles.
 #[revisioned(revision = 1)]
-#[derive(Hash, Clone, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Hash, Copy, Clone, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Role {

--- a/crates/core/src/iam/signin.rs
+++ b/crates/core/src/iam/signin.rs
@@ -892,9 +892,9 @@ mod tests {
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert_eq!(sess.au.level().id(), Some("user:test"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -1059,9 +1059,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert_eq!(sess.au.level().id(), Some("user:test"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Session expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -1262,9 +1262,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 					}
 
 					// Check roles
-					for role in &AVAILABLE_ROLES {
+					for role in AVAILABLE_ROLES {
 						let has_role = sess.au.has_role(role);
-						let should_have_role = case.roles.contains(role);
+						let should_have_role = case.roles.contains(&role);
 						assert_eq!(has_role, should_have_role, "Role {:?} check failed", role);
 					}
 
@@ -1382,9 +1382,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert_eq!(sess.au.level().id(), Some("user:2"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -1477,9 +1477,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert_eq!(sess.au.level().id(), Some("employee:2"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -1872,16 +1872,16 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 
 				// Check roles
 				assert!(
-					!sess.au.has_role(&Role::Viewer),
+					!sess.au.has_role(Role::Viewer),
 					"Auth user expected to not have Viewer role"
 				);
 				assert!(
 					// User is defined with this role only
-					sess.au.has_role(&Role::Editor),
+					sess.au.has_role(Role::Editor),
 					"Auth user expected to have Editor role"
 				);
 				assert!(
-					!sess.au.has_role(&Role::Owner),
+					!sess.au.has_role(Role::Owner),
 					"Auth user expected to not have Owner role"
 				);
 
@@ -1986,16 +1986,16 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 
 				// Check roles
 				assert!(
-					!sess.au.has_role(&Role::Viewer),
+					!sess.au.has_role(Role::Viewer),
 					"Auth user expected to not have Viewer role"
 				);
 				assert!(
 					// User is defined with this role only
-					sess.au.has_role(&Role::Editor),
+					sess.au.has_role(Role::Editor),
 					"Auth user expected to have Editor role"
 				);
 				assert!(
-					!sess.au.has_role(&Role::Owner),
+					!sess.au.has_role(Role::Owner),
 					"Auth user expected to not have Owner role"
 				);
 
@@ -2798,7 +2798,7 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			let res = ds
 				.execute(
 					r#"
-				DEFINE ACCESS api ON DATABASE TYPE BEARER FOR RECORD 
+				DEFINE ACCESS api ON DATABASE TYPE BEARER FOR RECORD
 					DURATION FOR SESSION 2h
 				;
 				CREATE user:test;
@@ -2852,9 +2852,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert_eq!(sess.au.level().id(), Some("user:test"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -2872,7 +2872,7 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			let res = ds
 				.execute(
 					r#"
-				DEFINE ACCESS api ON DATABASE TYPE BEARER FOR RECORD 
+				DEFINE ACCESS api ON DATABASE TYPE BEARER FOR RECORD
 					DURATION FOR SESSION 2h
 				;
 				ACCESS api ON DATABASE GRANT FOR RECORD user:test;
@@ -2926,9 +2926,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert_eq!(sess.au.level().id(), Some("user:test"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -3003,9 +3003,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert_eq!(sess.au.level().id(), Some("user:test"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -3090,7 +3090,7 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			let res = ds
 				.execute(
 					r#"
-					DEFINE ACCESS api ON DATABASE TYPE BEARER FOR RECORD 
+					DEFINE ACCESS api ON DATABASE TYPE BEARER FOR RECORD
 						DURATION FOR GRANT 1s FOR SESSION 2h
 					;
 					ACCESS api ON DATABASE GRANT FOR RECORD user:test;
@@ -3547,7 +3547,7 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			let res = ds
 				.execute(
 					r#"
-					DEFINE ACCESS api ON DATABASE TYPE BEARER FOR RECORD 
+					DEFINE ACCESS api ON DATABASE TYPE BEARER FOR RECORD
 						DURATION FOR SESSION 2h
 					;
 					ACCESS api ON DATABASE GRANT FOR RECORD user:test;

--- a/crates/core/src/iam/signup.rs
+++ b/crates/core/src/iam/signup.rs
@@ -228,9 +228,9 @@ mod tests {
 			assert_eq!(sess.au.level().ns(), Some("test"));
 			assert_eq!(sess.au.level().db(), Some("test"));
 			// Record users should not have roles.
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Session expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -391,9 +391,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			assert_eq!(sess.au.level().ns(), Some("test"));
 			assert_eq!(sess.au.level().db(), Some("test"));
 			// Record users should not have roles.
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Session expiration should always be set for tokens issued by SurrealDB
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -499,9 +499,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert_eq!(sess.au.level().id(), Some("user:2"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -594,9 +594,9 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert!(sess.au.level().id().unwrap().starts_with("employee:"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin

--- a/crates/core/src/iam/verify.rs
+++ b/crates/core/src/iam/verify.rs
@@ -875,9 +875,9 @@ mod tests {
 					}
 
 					// Check roles
-					for role in &AVAILABLE_ROLES {
+					for role in AVAILABLE_ROLES {
 						let has_role = sess.au.has_role(role);
-						let should_have_role = case.roles.contains(role);
+						let should_have_role = case.roles.contains(&role);
 						assert_eq!(has_role, should_have_role, "Role {:?} check failed", role);
 					}
 
@@ -1092,9 +1092,9 @@ mod tests {
 					assert_eq!(sess.au.id(), "token");
 
 					// Check roles
-					for role in &AVAILABLE_ROLES {
+					for role in AVAILABLE_ROLES {
 						let has_role = sess.au.has_role(role);
-						let should_have_role = case.expect_roles.contains(role);
+						let should_have_role = case.expect_roles.contains(&role);
 						assert_eq!(has_role, should_have_role, "Role {:?} check failed", role);
 					}
 
@@ -1254,7 +1254,7 @@ mod tests {
 					assert_eq!(sess.au.id(), *id);
 
 					// Ensure record users do not have roles
-					for role in &AVAILABLE_ROLES {
+					for role in AVAILABLE_ROLES {
 						assert!(
 							!sess.au.has_role(role),
 							"Auth user expected to not have role {:?} in case: {:?}",
@@ -1359,9 +1359,9 @@ mod tests {
 			assert!(sess.au.is_record());
 			assert_eq!(sess.au.level().ns(), Some("test"));
 			assert_eq!(sess.au.level().db(), Some("test"));
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Session expiration has been set explicitly
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -1518,9 +1518,9 @@ mod tests {
 			assert!(sess.au.is_record());
 			assert_eq!(sess.au.level().ns(), Some("test"));
 			assert_eq!(sess.au.level().db(), Some("test"));
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			assert_eq!(sess.exp, None, "Default session expiration is expected to be None");
 		}
 
@@ -1815,15 +1815,15 @@ mod tests {
 
 					// Check roles
 					assert!(
-						sess.au.has_role(&Role::Viewer),
+						sess.au.has_role(Role::Viewer),
 						"Auth user expected to have Viewer role"
 					);
 					assert!(
-						!sess.au.has_role(&Role::Editor),
+						!sess.au.has_role(Role::Editor),
 						"Auth user expected to not have Editor role"
 					);
 					assert!(
-						!sess.au.has_role(&Role::Owner),
+						!sess.au.has_role(Role::Owner),
 						"Auth user expected to not have Owner role"
 					);
 
@@ -1904,9 +1904,9 @@ mod tests {
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert_eq!(sess.au.level().id(), Some("user:2"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin
@@ -1985,9 +1985,9 @@ mod tests {
 			assert_eq!(sess.au.level().db(), Some("test"));
 			assert_eq!(sess.au.level().id(), Some("user:1"));
 			// Record users should not have roles
-			assert!(!sess.au.has_role(&Role::Viewer), "Auth user expected to not have Viewer role");
-			assert!(!sess.au.has_role(&Role::Editor), "Auth user expected to not have Editor role");
-			assert!(!sess.au.has_role(&Role::Owner), "Auth user expected to not have Owner role");
+			assert!(!sess.au.has_role(Role::Viewer), "Auth user expected to not have Viewer role");
+			assert!(!sess.au.has_role(Role::Editor), "Auth user expected to not have Editor role");
+			assert!(!sess.au.has_role(Role::Owner), "Auth user expected to not have Owner role");
 			// Expiration should match the defined duration
 			let exp = sess.exp.unwrap();
 			// Expiration should match the current time plus session duration with some margin


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Certain functions are called many times in order to check whether permissions should be processed when processing documents. These functions should be as optimised as possible.

## What does this change do?

Ensures that the functions are as optimised as possible, only checking internal functions when absolutely necessary.

In the future this could be improved upon by checking whether we should detect if table permissions should be checked, in advance, setting a value on the `Options` object, and passing this down to documents as they are processed. This would result in us not having to call the function on every document check at all, but only once for the statement. This requires more thought however, to ensure that all authentication edge cases are covered.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
