### PR TITLE
Make `check_size` less sensitive to size changes

### DIFF
--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -3211,11 +3211,6 @@ mod tests {
 		assert_eq!(56, std::mem::size_of::<crate::sql::thing::Thing>());
 		assert_eq!(40, std::mem::size_of::<crate::sql::mock::Mock>());
 		assert_eq!(32, std::mem::size_of::<crate::sql::regex::Regex>());
-		assert_eq!(8, std::mem::size_of::<Box<crate::sql::range::Range>>());
-		assert_eq!(8, std::mem::size_of::<Box<crate::sql::edges::Edges>>());
-		assert_eq!(8, std::mem::size_of::<Box<crate::sql::function::Function>>());
-		assert_eq!(8, std::mem::size_of::<Box<crate::sql::subquery::Subquery>>());
-		assert_eq!(8, std::mem::size_of::<Box<crate::sql::expression::Expression>>());
 	}
 
 	#[test]

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -3196,21 +3196,21 @@ mod tests {
 	#[test]
 	fn check_size() {
 		assert!(64 >= std::mem::size_of::<Value>(), "size of value too big");
-		assert_eq!(104, std::mem::size_of::<Error>());
-		assert_eq!(104, std::mem::size_of::<Result<Value, Error>>());
-		assert_eq!(24, std::mem::size_of::<crate::sql::number::Number>());
-		assert_eq!(24, std::mem::size_of::<crate::sql::strand::Strand>());
-		assert_eq!(16, std::mem::size_of::<crate::sql::duration::Duration>());
-		assert_eq!(12, std::mem::size_of::<crate::sql::datetime::Datetime>());
-		assert_eq!(24, std::mem::size_of::<crate::sql::array::Array>());
-		assert_eq!(24, std::mem::size_of::<crate::sql::object::Object>());
-		assert_eq!(48, std::mem::size_of::<crate::sql::geometry::Geometry>());
-		assert_eq!(24, std::mem::size_of::<crate::sql::param::Param>());
-		assert_eq!(24, std::mem::size_of::<crate::sql::idiom::Idiom>());
-		assert_eq!(24, std::mem::size_of::<crate::sql::table::Table>());
-		assert_eq!(56, std::mem::size_of::<crate::sql::thing::Thing>());
-		assert_eq!(40, std::mem::size_of::<crate::sql::mock::Mock>());
-		assert_eq!(32, std::mem::size_of::<crate::sql::regex::Regex>());
+		assert!(104 >= std::mem::size_of::<Error>());
+		assert!(104 >= std::mem::size_of::<Result<Value, Error>>());
+		assert!(24 >= std::mem::size_of::<crate::sql::number::Number>());
+		assert!(24 >= std::mem::size_of::<crate::sql::strand::Strand>());
+		assert!(16 >= std::mem::size_of::<crate::sql::duration::Duration>());
+		assert!(12 >= std::mem::size_of::<crate::sql::datetime::Datetime>());
+		assert!(24 >= std::mem::size_of::<crate::sql::array::Array>());
+		assert!(24 >= std::mem::size_of::<crate::sql::object::Object>());
+		assert!(48 >= std::mem::size_of::<crate::sql::geometry::Geometry>());
+		assert!(24 >= std::mem::size_of::<crate::sql::param::Param>());
+		assert!(24 >= std::mem::size_of::<crate::sql::idiom::Idiom>());
+		assert!(24 >= std::mem::size_of::<crate::sql::table::Table>());
+		assert!(56 >= std::mem::size_of::<crate::sql::thing::Thing>());
+		assert!(40 >= std::mem::size_of::<crate::sql::mock::Mock>());
+		assert!(32 >= std::mem::size_of::<crate::sql::regex::Regex>());
 	}
 
 	#[test]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

`check_size` currently fails even if the size actually get smaller.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Instead of ensuring a type is a specific size, we now simply check that it's not bigger than the size we want.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
