### PR TITLE
Bug: table not being overwritten when there is a relation in the definition

### DIFF
--- a/crates/core/src/sql/statements/define/table.rs
+++ b/crates/core/src/sql/statements/define/table.rs
@@ -95,6 +95,7 @@ impl DefineTableStatement {
 			overwrite: false,
 			..self.clone()
 		};
+		println!("{dt:#}");
 		txn.set(key, &dt, None).await?;
 		// Add table relational fields
 		self.add_in_out_fields(&txn, opt).await?;

--- a/crates/sdk/tests/define.rs
+++ b/crates/sdk/tests/define.rs
@@ -2969,6 +2969,11 @@ async fn define_overwrite_tables() -> Result<(), Error> {
 		INFO FOR DB;
 		DEFINE TABLE OVERWRITE whatever SCHEMALESS TYPE RELATION FROM user TO test PERMISSIONS FULL;
 		INFO FOR DB;
+		CREATE person:one;
+		CREATE library:one;
+		RELATE person:one->works_at->library:one;
+		DEFINE TABLE OVERWRITE works_at TYPE RELATION IN person OUT library;
+		INFO FOR DB;
 	";
 	let mut t = Test::new(sql).await?;
 	t.skip_ok(1)?;
@@ -2997,6 +3002,24 @@ async fn define_overwrite_tables() -> Result<(), Error> {
 				params: {},
 				tables: {
 					whatever: 'DEFINE TABLE whatever TYPE RELATION IN user OUT test SCHEMALESS PERMISSIONS FULL'
+				},
+				users: {}
+			}",
+	)?;
+	t.skip_ok(4)?;
+	t.expect_val(
+		r"{
+				accesses: {},
+				analyzers: {},
+				configs: {},
+				functions: {},
+				models: {},
+				params: {},
+				tables: {
+					library: 'DEFINE TABLE library TYPE ANY SCHEMALESS PERMISSIONS NONE',
+					person: 'DEFINE TABLE person TYPE ANY SCHEMALESS PERMISSIONS NONE',
+					whatever: 'DEFINE TABLE whatever TYPE RELATION IN user OUT test SCHEMALESS PERMISSIONS FULL',
+					works_at: 'DEFINE TABLE works_at TYPE RELATION IN person OUT library SCHEMALESS PERMISSIONS NONE'
 				},
 				users: {}
 			}",

--- a/crates/sdk/tests/define.rs
+++ b/crates/sdk/tests/define.rs
@@ -2963,6 +2963,48 @@ async fn define_remove_tables() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn define_overwrite_tables() -> Result<(), Error> {
+	let sql = "
+		DEFINE TABLE OVERWRITE whatever SCHEMALESS TYPE RELATION FROM user TO test PERMISSIONS NONE;
+		INFO FOR DB;
+		DEFINE TABLE OVERWRITE whatever SCHEMALESS TYPE RELATION FROM user TO test PERMISSIONS FULL;
+		INFO FOR DB;
+	";
+	let mut t = Test::new(sql).await?;
+	t.skip_ok(1)?;
+	t.expect_val(
+		r"{
+				accesses: {},
+				analyzers: {},
+				configs: {},
+				functions: {},
+				models: {},
+				params: {},
+				tables: {
+					whatever: 'DEFINE TABLE whatever TYPE RELATION IN user OUT test SCHEMALESS PERMISSIONS NONE'
+				},
+				users: {}
+			}",
+	)?;
+	t.skip_ok(1)?;
+	t.expect_val(
+		r"{
+				accesses: {},
+				analyzers: {},
+				configs: {},
+				functions: {},
+				models: {},
+				params: {},
+				tables: {
+					whatever: 'DEFINE TABLE whatever TYPE RELATION IN user OUT test SCHEMALESS PERMISSIONS FULL'
+				},
+				users: {}
+			}",
+	)?;
+	Ok(())
+}
+
+#[tokio::test]
 async fn define_remove_users() -> Result<(), Error> {
 	let sql = "
 		DEFINE USER example ON ROOT PASSWORD \"example\" ROLES OWNER DURATION FOR TOKEN 15m, FOR SESSION 6h;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Redefining a TABLE failed it there is a RELATION defined: the table is not updated.

```sql
DEFINE TABLE OVERWRITE whatever SCHEMALESS TYPE RELATION FROM user TO test PERMISSIONS NONE;
DEFINE TABLE OVERWRITE whatever SCHEMALESS TYPE RELATION FROM user TO test PERMISSIONS FULL;
INFO FOR DB;
```
Returns:

```js
{
 ...,
  tables: {
	  whatever: 'DEFINE TABLE whatever TYPE RELATION IN user OUT test SCHEMALESS PERMISSIONS NONE'
  },
 ...
			}
```

It should be:

```js
{
 ...,
  tables: {
	  whatever: 'DEFINE TABLE whatever TYPE RELATION IN user OUT test SCHEMALESS PERMISSIONS FULL'
  },
  ...
			}
```

## What does this change do?

Fixes it.

## What is your testing strategy?

Github action.
A test has been added.

## Is this related to any issues?

https://github.com/surrealdb/surrealdb/security/advisories/GHSA-27vq-hv74-7cqp

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
