### PR TITLE
Allow escape characters inside mathematical angle bracket escaped idents

### DIFF
--- a/crates/core/src/syn/lexer/test.rs
+++ b/crates/core/src/syn/lexer/test.rs
@@ -120,3 +120,12 @@ fn keyword() {
 		]
 	}
 }
+
+#[test]
+fn ident_angle_with_escape_char() {
+	test_case! {
+		r#"⟨⟨something\⟩⟩"# => [
+			TokenKind::Identifier,
+		]
+	}
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

When SurrealDB prints an ident (which is always printed enclosed in mathematical angle brackets) with a closing mathematical angle bracket, it puts an escape character before it. However, escape characters inside idents surrounded by mathematical angle brackets is not currently supported, causing a conflict.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR enables the parser to support escape sequences inside idents escaped by mathematical angle brackets, like the following:
```sql
⟨⟨something\⟩⟩
```

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a lexer test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
