### PR TITLE
Drop id selection behaviour

### DIFF
--- a/crates/core/src/sql/ident.rs
+++ b/crates/core/src/sql/ident.rs
@@ -40,10 +40,6 @@ impl Ident {
 	pub(crate) fn is_dash(&self) -> bool {
 		self.0.as_str() == "-"
 	}
-	/// Checks if this field is the `id` field
-	pub(crate) fn is_id(&self) -> bool {
-		self.0.as_str() == "id"
-	}
 	/// Checks if this field is the `type` field
 	pub(crate) fn is_type(&self) -> bool {
 		self.0.as_str() == "type"

--- a/crates/core/src/sql/value/get.rs
+++ b/crates/core/src/sql/value/get.rs
@@ -10,12 +10,10 @@ use crate::exe::try_join_all_buffered;
 use crate::fnc::idiom;
 use crate::sql::edges::Edges;
 use crate::sql::field::{Field, Fields};
-use crate::sql::id::Id;
 use crate::sql::part::{FindRecursionPlan, Next, NextMethod, SplitByRepeatRecurse};
 use crate::sql::part::{Part, Skip};
 use crate::sql::paths::ID;
 use crate::sql::statements::select::SelectStatement;
-use crate::sql::thing::Thing;
 use crate::sql::value::{Value, Values};
 use crate::sql::Function;
 use futures::future::try_join_all;
@@ -166,27 +164,6 @@ impl Value {
 				}
 				// Current value at path is an object
 				Value::Object(v) => match p {
-					// If requesting an `id` field, check if it is a complex Record ID
-					Part::Field(f) if f.is_id() && path.len() > 1 => match v.get(f.as_str()) {
-						Some(Value::Thing(Thing {
-							id: Id::Object(v),
-							..
-						})) => {
-							let v = Value::Object(v.clone());
-							stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
-						}
-						Some(Value::Thing(Thing {
-							id: Id::Array(v),
-							..
-						})) => {
-							let v = Value::Array(v.clone());
-							stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
-						}
-						Some(v) => stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await,
-						None => {
-							stk.run(|stk| Value::None.get(stk, ctx, opt, doc, path.next())).await
-						}
-					},
 					Part::Graph(_) => match v.rid() {
 						Some(v) => {
 							let v = Value::Thing(v);
@@ -551,6 +528,7 @@ mod tests {
 	use super::*;
 	use crate::dbs::test::mock;
 	use crate::sql::idiom::Idiom;
+	use crate::sql::{Id, Thing};
 	use crate::syn::Parse;
 
 	#[tokio::test]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

This behaviour is ambiguous and a leftover from pre-1.0.0, no longer intended, which should have been removed ages ago.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR introduces a minor breaking change. It drops the behaviour where you select `id` from an object, that it will return the value part of a record id stored in the `id` property only when it is a complex record id.

Instead, the `record::id()` or idiom `.id()` methods should be used for this.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
