### PR TITLE
Add `stdout` and `stderr` log splitting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,6 +1315,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5468,6 +5477,7 @@ dependencies = [
  "tower-http",
  "tower-service",
  "tracing",
+ "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ulid",
@@ -6343,6 +6353,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ tower = "0.4.13"
 tower-http = { version = "0.5.2", features = ["trace", "sensitive-headers", "auth", "request-id", "util", "catch-panic", "cors", "set-header", "limit", "add-extension", "compression-full"] }
 tower-service = "0.3.3"
 tracing = "0.1"
+tracing-appender = "0.2.3"
 tracing-opentelemetry = "0.25.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 urlencoding = "2.1.3"

--- a/cackle.toml
+++ b/cackle.toml
@@ -641,7 +641,6 @@ from.test.allow_apis = ["net"]
 [pkg.deranged]
 allow_unsafe = true
 
-
 [pkg.same-file]
 allow_unsafe = true
 allow_apis = ["fs"]
@@ -695,7 +694,6 @@ allow_unsafe = true
 
 [pkg.miette]
 allow_unsafe = true
-
 
 [pkg.glob]
 allow_apis = ["fs"]
@@ -830,6 +828,9 @@ allow_unsafe = true
 allow_unsafe = true
 
 [pkg.crossbeam-deque]
+allow_unsafe = true
+
+[pkg.crossbeam-channel]
 allow_unsafe = true
 
 [pkg.anstream]
@@ -1296,4 +1297,3 @@ allow_unsafe = true
 
 [pkg.idna]
 allow_unsafe = true
-

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -41,8 +41,7 @@ pub async fn init(
 	}: ExportCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_log_level("info").init()?;
-
+	let (outg, errg) = crate::telemetry::builder().with_log_level("info").init()?;
 	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
 	// If we are connecting directly to a datastore (i.e. surrealkv://local.skv or tikv://...), then we don't need to authenticate because we use an embedded (local) SurrealDB instance with auth disabled.
 	let client = if username.is_some()
@@ -93,6 +92,9 @@ pub async fn init(
 		client.export(file).await?;
 	}
 	info!("The SurrealQL file was exported successfully");
+	// Drop the log guards
+	drop(outg);
+	drop(errg);
 	// Everything OK
 	Ok(())
 }

--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -40,8 +40,6 @@ pub async fn init(
 		},
 	}: ExportCommandArguments,
 ) -> Result<(), Error> {
-	// Initialize opentelemetry and logging
-	let (outg, errg) = crate::telemetry::builder().with_log_level("info").init()?;
 	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
 	// If we are connecting directly to a datastore (i.e. surrealkv://local.skv or tikv://...), then we don't need to authenticate because we use an embedded (local) SurrealDB instance with auth disabled.
 	let client = if username.is_some()
@@ -92,9 +90,6 @@ pub async fn init(
 		client.export(file).await?;
 	}
 	info!("The SurrealQL file was exported successfully");
-	// Drop the log guards
-	drop(outg);
-	drop(errg);
 	// Everything OK
 	Ok(())
 }

--- a/src/cli/fix.rs
+++ b/src/cli/fix.rs
@@ -1,5 +1,3 @@
-use crate::cli::validator::parser::env_filter::CustomEnvFilter;
-use crate::cli::validator::parser::env_filter::CustomEnvFilterParser;
 use crate::dbs;
 use crate::err::Error;
 use clap::Args;
@@ -12,21 +10,13 @@ pub struct FixCommandArguments {
 	#[arg(default_value = "memory")]
 	#[arg(value_parser = super::validator::path_valid)]
 	path: String,
-	#[arg(help = "The logging level for the database server")]
-	#[arg(env = "SURREAL_LOG", short = 'l', long = "log")]
-	#[arg(default_value = "info")]
-	#[arg(value_parser = CustomEnvFilterParser::new())]
-	log: CustomEnvFilter,
 }
 
 pub async fn init(
 	FixCommandArguments {
 		path,
-		log,
 	}: FixCommandArguments,
 ) -> Result<(), Error> {
-	// Initialize opentelemetry and logging
-	let (outg, errg) = crate::telemetry::builder().with_filter(log).init()?;
 	// Clean the path
 	let endpoint = path.into_endpoint()?;
 	let path = if endpoint.path.is_empty() {
@@ -36,9 +26,6 @@ pub async fn init(
 	};
 	// Fix the datastore, if applicable
 	dbs::fix(path).await?;
-	// Drop the log guards
-	drop(outg);
-	drop(errg);
 	// All ok
 	Ok(())
 }

--- a/src/cli/fix.rs
+++ b/src/cli/fix.rs
@@ -26,7 +26,7 @@ pub async fn init(
 	}: FixCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_filter(log).init()?;
+	let (outg, errg) = crate::telemetry::builder().with_filter(log).init()?;
 	// Clean the path
 	let endpoint = path.into_endpoint()?;
 	let path = if endpoint.path.is_empty() {
@@ -36,6 +36,9 @@ pub async fn init(
 	};
 	// Fix the datastore, if applicable
 	dbs::fix(path).await?;
+	// Drop the log guards
+	drop(outg);
+	drop(errg);
 	// All ok
 	Ok(())
 }

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -38,8 +38,6 @@ pub async fn init(
 		},
 	}: ImportCommandArguments,
 ) -> Result<(), Error> {
-	// Initialize opentelemetry and logging
-	let (outg, errg) = crate::telemetry::builder().with_log_level("info").init()?;
 	// Default datastore configuration for local engines
 	let config = Config::new().capabilities(Capabilities::all());
 	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
@@ -80,9 +78,6 @@ pub async fn init(
 	// Import the data into the database
 	client.import(file).await?;
 	info!("The SurrealQL file was imported successfully");
-	// Drop the log guards
-	drop(outg);
-	drop(errg);
-	// Everything OK
+	// All ok
 	Ok(())
 }

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -39,7 +39,7 @@ pub async fn init(
 	}: ImportCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_log_level("info").init()?;
+	let (outg, errg) = crate::telemetry::builder().with_log_level("info").init()?;
 	// Default datastore configuration for local engines
 	let config = Config::new().capabilities(Capabilities::all());
 	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
@@ -80,6 +80,9 @@ pub async fn init(
 	// Import the data into the database
 	client.import(file).await?;
 	info!("The SurrealQL file was imported successfully");
+	// Drop the log guards
+	drop(outg);
+	drop(errg);
 	// Everything OK
 	Ok(())
 }

--- a/src/cli/isready.rs
+++ b/src/cli/isready.rs
@@ -17,9 +17,14 @@ pub async fn init(
 	}: IsReadyCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_log_level("error").init()?;
+	let (outg, errg) = crate::telemetry::builder().with_log_level("error").init()?;
 	// Connect to the database engine
 	connect(endpoint).await?;
+	// Log output ok
 	println!("OK");
+	// Drop the log guards
+	drop(outg);
+	drop(errg);
+	// All ok
 	Ok(())
 }

--- a/src/cli/isready.rs
+++ b/src/cli/isready.rs
@@ -16,15 +16,10 @@ pub async fn init(
 		},
 	}: IsReadyCommandArguments,
 ) -> Result<(), Error> {
-	// Initialize opentelemetry and logging
-	let (outg, errg) = crate::telemetry::builder().with_log_level("error").init()?;
 	// Connect to the database engine
 	connect(endpoint).await?;
 	// Log output ok
 	println!("OK");
-	// Drop the log guards
-	drop(outg);
-	drop(errg);
 	// All ok
 	Ok(())
 }

--- a/src/cli/ml/export.rs
+++ b/src/cli/ml/export.rs
@@ -58,7 +58,7 @@ pub async fn init(
 	}: ExportCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_log_level("info").init()?;
+	let (outg, errg) = crate::telemetry::builder().with_log_level("info").init()?;
 	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
 	// If we are connecting directly to a datastore (i.e. surrealkv://local.skv or tikv://...), then we don't need to authenticate because we use an embedded (local) SurrealDB instance with auth disabled.
 	let client = if username.is_some()
@@ -117,6 +117,9 @@ pub async fn init(
 		client.export(file).ml(&name, version).await?;
 	}
 	info!("The SurrealML file was exported successfully");
+	// Drop the log guards
+	drop(outg);
+	drop(errg);
 	// Everything OK
 	Ok(())
 }

--- a/src/cli/ml/export.rs
+++ b/src/cli/ml/export.rs
@@ -57,8 +57,6 @@ pub async fn init(
 		},
 	}: ExportCommandArguments,
 ) -> Result<(), Error> {
-	// Initialize opentelemetry and logging
-	let (outg, errg) = crate::telemetry::builder().with_log_level("info").init()?;
 	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
 	// If we are connecting directly to a datastore (i.e. surrealkv://local.skv or tikv://...), then we don't need to authenticate because we use an embedded (local) SurrealDB instance with auth disabled.
 	let client = if username.is_some()
@@ -117,9 +115,6 @@ pub async fn init(
 		client.export(file).ml(&name, version).await?;
 	}
 	info!("The SurrealML file was exported successfully");
-	// Drop the log guards
-	drop(outg);
-	drop(errg);
-	// Everything OK
+	// All ok
 	Ok(())
 }

--- a/src/cli/ml/import.rs
+++ b/src/cli/ml/import.rs
@@ -39,7 +39,7 @@ pub async fn init(
 	}: ImportCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_log_level("info").init()?;
+	let (outg, errg) = crate::telemetry::builder().with_log_level("info").init()?;
 	// Default datastore configuration for local engines
 	let config = Config::new().capabilities(Capabilities::all());
 	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
@@ -80,6 +80,9 @@ pub async fn init(
 	// Import the data into the database
 	client.import(file).ml().await?;
 	info!("The SurrealML file was imported successfully");
+	// Drop the log guards
+	drop(outg);
+	drop(errg);
 	// Everything OK
 	Ok(())
 }

--- a/src/cli/ml/import.rs
+++ b/src/cli/ml/import.rs
@@ -38,8 +38,6 @@ pub async fn init(
 		},
 	}: ImportCommandArguments,
 ) -> Result<(), Error> {
-	// Initialize opentelemetry and logging
-	let (outg, errg) = crate::telemetry::builder().with_log_level("info").init()?;
 	// Default datastore configuration for local engines
 	let config = Config::new().capabilities(Capabilities::all());
 	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
@@ -80,9 +78,6 @@ pub async fn init(
 	// Import the data into the database
 	client.import(file).ml().await?;
 	info!("The SurrealML file was imported successfully");
-	// Drop the log guards
-	drop(outg);
-	drop(errg);
-	// Everything OK
+	// All ok
 	Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,6 +15,8 @@ pub(crate) mod validator;
 mod version;
 mod version_client;
 
+use crate::cli::validator::parser::env_filter::CustomEnvFilter;
+use crate::cli::validator::parser::env_filter::CustomEnvFilterParser;
 use crate::cli::version_client::VersionClient;
 #[cfg(debug_assertions)]
 use crate::cnf::DEBUG_BUILD_WARNING;
@@ -57,6 +59,12 @@ We would love it if you could star the repository (https://github.com/surrealdb/
 struct Cli {
 	#[command(subcommand)]
 	command: Commands,
+	#[arg(help = "The logging level for the command-line tool")]
+	#[arg(env = "SURREAL_LOG", short = 'l', long = "log")]
+	#[arg(global = true)]
+	#[arg(default_value = "info")]
+	#[arg(value_parser = CustomEnvFilterParser::new())]
+	log: CustomEnvFilter,
 	#[arg(help = "Whether to allow web check for client version upgrades at start")]
 	#[arg(env = "SURREAL_ONLINE_VERSION_CHECK", long)]
 	#[arg(default_value_t = true)]
@@ -125,6 +133,10 @@ pub async fn init() -> ExitCode {
 			warn!("You can upgrade using the {} command", "surreal upgrade");
 		}
 	}
+	// Initialize opentelemetry and logging
+	let telemetry = crate::telemetry::builder().with_log_level("info").with_filter(args.log);
+	// Extract the telemtry log guards
+	let (outg, errg) = telemetry.init().expect("Unable to configure logs");
 	// After version warning we can run the respective command
 	let output = match args.command {
 		Commands::Start(args) => start::init(args).await,
@@ -156,9 +168,18 @@ pub async fn init() -> ExitCode {
 	};
 	// Error and exit the programme
 	if let Err(e) = output {
+		// Output any error
 		error!("{}", e);
+		// Drop the log guards
+		drop(outg);
+		drop(errg);
+		// Return failure
 		ExitCode::FAILURE
 	} else {
+		// Drop the log guards
+		drop(outg);
+		drop(errg);
+		// Return success
 		ExitCode::SUCCESS
 	}
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -104,6 +104,9 @@ enum Commands {
 }
 
 pub async fn init() -> ExitCode {
+	// Print debug mode warning
+	#[cfg(debug_assertions)]
+	println!("{DEBUG_BUILD_WARNING}");
 	// Start a new CPU profiler
 	#[cfg(feature = "performance-profiler")]
 	let guard = pprof::ProfilerGuardBuilder::default()
@@ -113,10 +116,6 @@ pub async fn init() -> ExitCode {
 		.unwrap();
 	// Parse the CLI arguments
 	let args = Cli::parse();
-
-	#[cfg(debug_assertions)]
-	println!("{DEBUG_BUILD_WARNING}");
-
 	// After parsing arguments, we check the version online
 	if args.online_version_check {
 		let client = version_client::new(Some(Duration::from_millis(500))).unwrap();
@@ -135,7 +134,7 @@ pub async fn init() -> ExitCode {
 	}
 	// Initialize opentelemetry and logging
 	let telemetry = crate::telemetry::builder().with_log_level("info").with_filter(args.log);
-	// Extract the telemtry log guards
+	// Extract the telemetry log guards
 	let (outg, errg) = telemetry.init().expect("Unable to configure logs");
 	// After version warning we can run the respective command
 	let output = match args.command {

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -62,7 +62,7 @@ pub async fn init(
 	}: SqlCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_log_level("warn").init()?;
+	let (outg, errg) = crate::telemetry::builder().with_log_level("warn").init()?;
 	// Default datastore configuration for local engines
 	let config = Config::new().capabilities(Capabilities::all());
 	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
@@ -261,6 +261,9 @@ pub async fn init(
 	}
 	// Save the inputs to the history
 	let _ = rl.save_history("history.txt");
+	// Drop the log guards
+	drop(outg);
+	drop(errg);
 	// Everything OK
 	Ok(())
 }

--- a/src/cli/sql.rs
+++ b/src/cli/sql.rs
@@ -61,8 +61,6 @@ pub async fn init(
 		..
 	}: SqlCommandArguments,
 ) -> Result<(), Error> {
-	// Initialize opentelemetry and logging
-	let (outg, errg) = crate::telemetry::builder().with_log_level("warn").init()?;
 	// Default datastore configuration for local engines
 	let config = Config::new().capabilities(Capabilities::all());
 	// If username and password are specified, and we are connecting to a remote SurrealDB server, then we need to authenticate.
@@ -261,10 +259,7 @@ pub async fn init(
 	}
 	// Save the inputs to the history
 	let _ = rl.save_history("history.txt");
-	// Drop the log guards
-	drop(outg);
-	drop(errg);
-	// Everything OK
+	// All ok
 	Ok(())
 }
 

--- a/src/cli/start.rs
+++ b/src/cli/start.rs
@@ -173,7 +173,7 @@ pub async fn init(
 	}: StartCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_filter(log).init()?;
+	let (outg, errg) = crate::telemetry::builder().with_filter(log).init()?;
 	// Check if we should output a banner
 	if !no_banner {
 		println!("{LOGO}");
@@ -227,6 +227,9 @@ pub async fn init(
 	nodetasks.resolve().await?;
 	// Shutdown the datastore
 	datastore.shutdown().await?;
+	// Drop the log guards
+	drop(outg);
+	drop(errg);
 	// All ok
 	Ok(())
 }

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -88,7 +88,7 @@ pub(crate) fn parse_version(input: &str) -> Result<Version, Error> {
 
 pub async fn init(args: UpgradeCommandArguments) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_log_level("error").init()?;
+	let (outg, errg) = crate::telemetry::builder().with_log_level("error").init()?;
 
 	// Upgrading overwrites the existing executable
 	let exe = std::env::current_exe()?;
@@ -211,6 +211,10 @@ pub async fn init(args: UpgradeCommandArguments) -> Result<(), Error> {
 		println!("SurrealDB successfully upgraded");
 	}
 
+	// Drop the log guards
+	drop(outg);
+	drop(errg);
+	// Everything OK
 	Ok(())
 }
 

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -87,9 +87,6 @@ pub(crate) fn parse_version(input: &str) -> Result<Version, Error> {
 }
 
 pub async fn init(args: UpgradeCommandArguments) -> Result<(), Error> {
-	// Initialize opentelemetry and logging
-	let (outg, errg) = crate::telemetry::builder().with_log_level("error").init()?;
-
 	// Upgrading overwrites the existing executable
 	let exe = std::env::current_exe()?;
 
@@ -211,10 +208,7 @@ pub async fn init(args: UpgradeCommandArguments) -> Result<(), Error> {
 		println!("SurrealDB successfully upgraded");
 	}
 
-	// Drop the log guards
-	drop(outg);
-	drop(errg);
-	// Everything OK
+	// All ok
 	Ok(())
 }
 

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -17,8 +17,6 @@ pub async fn init(
 		},
 	}: VersionCommandArguments,
 ) -> Result<(), Error> {
-	// Initialize opentelemetry and logging
-	let (outg, errg) = crate::telemetry::builder().with_log_level("error").init()?;
 	// Print server version if endpoint supplied else CLI version
 	if let Some(e) = endpoint {
 		// Print remote server version
@@ -27,10 +25,7 @@ pub async fn init(
 		// Print local CLI version
 		println!("{}", *RELEASE);
 	}
-	// Drop the log guards
-	drop(outg);
-	drop(errg);
-	// Everything OK
+	// All ok
 	Ok(())
 }
 

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -18,7 +18,7 @@ pub async fn init(
 	}: VersionCommandArguments,
 ) -> Result<(), Error> {
 	// Initialize opentelemetry and logging
-	crate::telemetry::builder().with_log_level("error").init()?;
+	let (outg, errg) = crate::telemetry::builder().with_log_level("error").init()?;
 	// Print server version if endpoint supplied else CLI version
 	if let Some(e) = endpoint {
 		// Print remote server version
@@ -27,6 +27,10 @@ pub async fn init(
 		// Print local CLI version
 		println!("{}", *RELEASE);
 	}
+	// Drop the log guards
+	drop(outg);
+	drop(errg);
+	// Everything OK
 	Ok(())
 }
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -363,6 +363,10 @@ criteria = "safe-to-deploy"
 version = "0.5.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.crossbeam-channel]]
+version = "0.5.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.crossbeam-deque]]
 version = "0.8.5"
 criteria = "safe-to-deploy"
@@ -1517,6 +1521,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tracing]]
 version = "0.1.40"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-appender]]
+version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tracing-attributes]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -457,15 +457,15 @@ user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb]]
-version = "2.1.2"
-when = "2024-11-26"
+version = "2.1.3"
+when = "2024-12-10"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb-core]]
-version = "2.1.2"
-when = "2024-11-26"
+version = "2.1.3"
+when = "2024-12-10"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -839,6 +839,17 @@ delta = "0.8.4 -> 0.8.6"
 notes = """
 The changes here are all typical bindings updates: new functions, types, and
 constants. I have not audited all the bindings for ABI conformance.
+"""
+
+[[audits.bytecode-alliance.audits.crossbeam-channel]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.4 -> 0.5.8"
+notes = """
+This diff does what it says on the tin for this version range, notably fixing a
+race condition, improving handling of durations, and additionally swapping out a
+spin lock with a lock from the standard library. Minor bits of `unsafe` code
+are modified but that's expected given the nature of this crate.
 """
 
 [[audits.bytecode-alliance.audits.crypto-common]]
@@ -1961,6 +1972,25 @@ delta = "0.9.3 -> 0.9.4"
 notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.crossbeam-channel]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.8 -> 0.5.11"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crossbeam-channel]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.11 -> 0.5.12"
+notes = "Minimal change fixing a memory leak."
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.crossbeam-channel]]
+who = "Glenn Watson <git@intuitionlibrary.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.12 -> 0.5.13"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.crypto-common]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -3011,6 +3041,16 @@ who = "Jack Grigg <jack@z.cash>"
 criteria = "safe-to-deploy"
 delta = "0.1.0 -> 0.1.1"
 notes = "Adds `#![forbid(unsafe_code)]` and license files."
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.tracing-appender]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+delta = "0.2.2 -> 0.2.3"
+notes = """
+- The rolling file appender has new code to automatically delete files; this is
+  restricted to files within the configured log directory.
+"""
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.tracing-core]]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1211,7 +1211,7 @@ mod cli_integration {
 			// Make sure the SLEEP query is being executed
 			tokio::time::timeout(time::Duration::from_secs(10), async {
 				loop {
-					let err = server.stderr();
+					let err = server.stdout_and_stderr();
 					if err.contains("SLEEP 30s") {
 						break;
 					}

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -65,6 +65,13 @@ impl Child {
 		std::fs::read_to_string(&self.stderr_path).expect("Failed to read the stderr file")
 	}
 
+	pub fn stdout_and_stderr(&self) -> String {
+		let mut output: String = String::new();
+		output.push_str(self.stdout().as_str());
+		output.push_str(self.stderr().as_str());
+		output
+	}
+
 	/// Read the child's stdout concatenated with its stderr. Returns Ok if the child
 	/// returns successfully, Err otherwise.
 	pub fn output(&mut self) -> Result<String, String> {
@@ -304,7 +311,7 @@ pub async fn start_server(
 		for _i in 0..10 {
 			interval.tick().await;
 
-			let out = server.stderr();
+			let out = server.stdout_and_stderr();
 			if out.contains("Address already in use") {
 				continue 'retry;
 			}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently, all server logs are output to `stderr`, and there is no differentiation between `stdout` or `stderr` for different log levels. In addition, currently all logs are written in a blocking way, resulting in reduced performance when using `DEBUG` or `TRACE` level logging.

## What does this change do?

This pull-request makes the following changes:

- `stdout` is now used for `INFO`, `DEBUG`, and `TRACE` level logs
- `stderr` is now used for `WARN`, `ERROR`, and `FATAL` level logs
- Two separate non-blocking threads are initiated and used for the `stdout` and `stderr` logging, ensuring that writing to the logs are done in a non-blocking way, using separate threads. Logs are buffered in memory and, if the logs are not able to be written to `stdout` or `stderr` fast enough, are dropped when the buffered limit is reached. As a result logs can now be dropped if too many log entries are generated in a short period of time.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #5261

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
