### PR TITLE
RID caching on TX level

### DIFF
--- a/crates/core/src/dbs/processor.rs
+++ b/crates/core/src/dbs/processor.rs
@@ -190,7 +190,7 @@ impl Collected {
 		// Fetch the data from the store
 		let val = txn.get_record(opt.ns()?, opt.db()?, &v.tb, &v.id, None).await?;
 		// Create a new operable value
-		let val = Operable::Relate(f, val.into(), w, o.map(|v| v.into()));
+		let val = Operable::Relate(f, val, w, o.map(|v| v.into()));
 		// Process the document record
 		let pro = Processed {
 			generate: None,
@@ -301,7 +301,7 @@ impl Collected {
 			v
 		} else {
 			// Otherwise we have to fetch the record
-			Iterable::fetch_thing(txn, opt, &r.0).await?.into()
+			Iterable::fetch_thing(txn, opt, &r.0).await?
 		};
 		let pro = Processed {
 			generate: None,

--- a/crates/core/src/doc/compute.rs
+++ b/crates/core/src/doc/compute.rs
@@ -68,13 +68,10 @@ impl Document {
 						ctx.tx().lock().await.rollback_to_save_point().await?;
 					}
 					// Fetch the data from the store
-					let key = crate::key::thing::new(opt.ns()?, opt.db()?, &v.tb, &v.id);
-					let val = ctx.tx().get(key, None).await?;
-					// Parse the data from the store
-					let val = Arc::new(match val {
-						Some(v) => Value::from(v),
-						None => Value::None,
-					});
+					let val = ctx
+						.tx()
+						.get_record(opt.ns()?, opt.db()?, &v.tb, &v.id, opt.version)
+						.await?;
 					pro = Processed {
 						generate: None,
 						rid: Some(Arc::new(v)),

--- a/crates/core/src/doc/process.rs
+++ b/crates/core/src/doc/process.rs
@@ -66,13 +66,10 @@ impl Document {
 						ctx.tx().lock().await.rollback_to_save_point().await?;
 					}
 					// Fetch the data from the store
-					let key = crate::key::thing::new(opt.ns()?, opt.db()?, &v.tb, &v.id);
-					let val = ctx.tx().get(key, None).await?;
-					// Parse the data from the store
-					let val = Arc::new(match val {
-						Some(v) => Value::from(v),
-						None => Value::None,
-					});
+					let val = ctx
+						.tx()
+						.get_record(opt.ns()?, opt.db()?, &v.tb, &v.id, opt.version)
+						.await?;
 					pro = Processed {
 						generate: None,
 						rid: Some(Arc::new(v)),

--- a/crates/core/src/doc/store.rs
+++ b/crates/core/src/doc/store.rs
@@ -6,7 +6,7 @@ use crate::err::Error;
 
 impl Document {
 	pub(super) async fn store_record_data(
-		&self,
+		&mut self,
 		ctx: &Context,
 		opt: &Options,
 		stm: &Statement<'_>,
@@ -21,8 +21,11 @@ impl Document {
 		}
 		// Get the record id
 		let rid = self.id()?;
+		// Get NS & DB
+		let ns = opt.ns()?;
+		let db = opt.db()?;
 		// Store the record data
-		let key = crate::key::thing::new(opt.ns()?, opt.db()?, &rid.tb, &rid.id);
+		let key = crate::key::thing::new(ns, db, &rid.tb, &rid.id);
 		// Match the statement type
 		match stm {
 			// This is a INSERT statement so try to insert the key.
@@ -35,7 +38,7 @@ impl Document {
 			// set and update the key, without checking if the key
 			// already exists in the storage engine.
 			Statement::Insert(_) if self.is_iteration_initial() => {
-				match ctx.tx().put(key, self, opt.version).await {
+				match ctx.tx().put(key, &*self, opt.version).await {
 					// The key already exists, so return an error
 					Err(Error::TxKeyAlreadyExists) => Err(Error::RecordExists {
 						thing: rid.as_ref().to_owned(),
@@ -53,7 +56,7 @@ impl Document {
 			// key does not exist.  If the record value exists then we
 			// retry and attempt to update the record which exists.
 			Statement::Upsert(_) if self.is_iteration_initial() => {
-				match ctx.tx().put(key, self, opt.version).await {
+				match ctx.tx().put(key, &*self, opt.version).await {
 					// The key already exists, so return an error
 					Err(Error::TxKeyAlreadyExists) => Err(Error::RecordExists {
 						thing: rid.as_ref().to_owned(),
@@ -71,7 +74,7 @@ impl Document {
 			// key does not exist. If it already exists, then we
 			// return an error, and the statement fails.
 			Statement::Create(_) => {
-				match ctx.tx().put(key, self, opt.version).await {
+				match ctx.tx().put(key, &*self, opt.version).await {
 					// The key already exists, so return an error
 					Err(Error::TxKeyAlreadyExists) => Err(Error::RecordExists {
 						thing: rid.as_ref().to_owned(),
@@ -83,8 +86,10 @@ impl Document {
 				}
 			}
 			// Let's update the stored value for the specified key
-			_ => ctx.tx().set(key, self, opt.version).await,
+			_ => ctx.tx().set(key, &*self, opt.version).await,
 		}?;
+		// Update the cache
+		ctx.tx().set_record_cache(ns, db, &rid.tb, &rid.id, self.current.doc.as_arc())?;
 		// Carry on
 		Ok(())
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

There is no caching for picking out record ids on the TX level right now.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Adds caching for picking out record ids on the TX level.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
