### PR TITLE
Enable allocation tracking as a separate feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
@@ -2505,7 +2505,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -2897,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libloading"
@@ -3332,6 +3332,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -5665,6 +5674,7 @@ dependencies = [
  "surrealdb-tikv-client",
  "surrealkv",
  "surrealml-core",
+ "sysinfo",
  "temp-dir",
  "tempfile",
  "test-log",
@@ -5845,6 +5855,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "948512566b1895f93b1592c7574baeb2de842f224f2aab158799ecadb8ebbb46"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
 ]
 
 [[package]]
@@ -6902,6 +6926,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6911,13 +6945,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -6936,7 +7013,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ http = ["surrealdb/http"]
 http-compression = []
 ml = ["surrealdb/ml"]
 jwks = ["surrealdb/jwks"]
+allocation-tracking = ["surrealdb/allocation-tracking"]
 performance-profiler = ["dep:pprof"]
 # Special features
 storage-fdb-7_1 = ["surrealdb/kv-fdb-7_1"]

--- a/cackle.toml
+++ b/cackle.toml
@@ -1303,3 +1303,6 @@ allow_proc_macro = true
 
 [pkg.windows-interface]
 allow_proc_macro = true
+
+[pkg.sysinfo]
+allow_unsafe = true

--- a/cackle.toml
+++ b/cackle.toml
@@ -1297,3 +1297,9 @@ allow_unsafe = true
 
 [pkg.idna]
 allow_unsafe = true
+
+[pkg.windows-implement]
+allow_proc_macro = true
+
+[pkg.windows-interface]
+allow_proc_macro = true

--- a/cackle.toml
+++ b/cackle.toml
@@ -978,7 +978,7 @@ build.allow_build_instructions = ["cargo::rustc-check-cfg=*"]
 
 [pkg.surrealdb-core]
 allow_unsafe = true
-allow_apis = ["net", "fs"]
+allow_apis = ["net", "fs", "process"]
 build.allow_build_instructions = [
     "cargo:rustc-cfg=*",
     "cargo::rustc-check-cfg=*",
@@ -1306,3 +1306,4 @@ allow_proc_macro = true
 
 [pkg.sysinfo]
 allow_unsafe = true
+allow_apis = ["fs"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -36,13 +36,8 @@ http = ["dep:reqwest"]
 ml = ["dep:surrealml"]
 jwks = ["dep:reqwest"]
 allocator = ["dep:jemallocator", "dep:mimalloc"]
-arbitrary = [
-    "dep:arbitrary",
-    "dep:regex-syntax",
-    "rust_decimal/rust-fuzz",
-    "geo-types/arbitrary",
-    "uuid/arbitrary",
-]
+arbitrary = ["dep:arbitrary", "dep:regex-syntax", "rust_decimal/rust-fuzz", "geo-types/arbitrary", "uuid/arbitrary"]
+allocation-tracking = []
 # Special features
 kv-fdb-7_1 = ["foundationdb/fdb-7_1"]
 kv-fdb-7_3 = ["foundationdb/fdb-7_3"]
@@ -61,9 +56,7 @@ argon2 = "0.5.2"
 ascii = { version = "0.3.2", package = "any_ascii" }
 async-channel = "2.3.1"
 async-executor = "1.13.1"
-async-graphql = { version = "7.0.9", default-features = false, features = [
-    "dynamic-schema",
-] }
+async-graphql = { version = "7.0.9", default-features = false, features = ["dynamic-schema"] }
 base64 = "0.21.5"
 bcrypt = "0.15.0"
 bincode = "1.3.3"
@@ -78,9 +71,7 @@ derive = { version = "0.12.0", package = "surrealdb-derive" }
 deunicode = "1.4.1"
 dmp = "0.2.0"
 ext-sort = { version = "^0.1.4", optional = true }
-foundationdb = { version = "0.9.0", default-features = false, features = [
-    "embedded-fdb-include",
-], optional = true }
+foundationdb = { version = "0.9.0", default-features = false, features = ["embedded-fdb-include"], optional = true }
 fst = "0.4.7"
 futures = "0.3.29"
 fuzzy-matcher = "0.3.7"
@@ -89,17 +80,7 @@ geo-types = { version = "0.7.13", features = ["arbitrary"] }
 hex = { version = "0.4.3" }
 indxdb = { version = "0.5.0", optional = true }
 ipnet = "2.9.0"
-js = { version = "0.8.1", package = "rquickjs", features = [
-    "array-buffer",
-    "bindgen",
-    "classes",
-    "futures",
-    "loader",
-    "macro",
-    "parallel",
-    "properties",
-    "rust-alloc",
-], optional = true }
+js = { version = "0.8.1", package = "rquickjs", features = ["array-buffer", "bindgen", "classes", "futures", "loader", "macro", "parallel", "properties", "rust-alloc"], optional = true }
 jsonwebtoken = "9.3.0"
 lexicmp = "0.1.0"
 linfa-linalg = "=0.1.0"
@@ -120,19 +101,8 @@ rayon = "1.10.0"
 reblessive = { version = "0.4.2", features = ["tree"] }
 regex = "1.10.6"
 regex-syntax = { version = "0.8.4", optional = true, features = ["arbitrary"] }
-reqwest = { version = "0.12.7", default-features = false, features = [
-    "json",
-    "stream",
-    "multipart",
-], optional = true }
-revision = { version = "0.10.0", features = [
-    "chrono",
-    "geo",
-    "roaring",
-    "regex",
-    "rust_decimal",
-    "uuid",
-] }
+reqwest = { version = "0.12.7", default-features = false, features = ["json", "stream", "multipart"], optional = true }
+revision = { version = "0.10.0", features = ["chrono", "geo", "roaring", "regex", "rust_decimal", "uuid"] }
 rmpv = "1.0.1"
 roaring = { version = "0.10.6", features = ["serde"] }
 rocksdb = { version = "0.22.0", features = ["lz4", "snappy"], optional = true }
@@ -152,6 +122,7 @@ subtle = "2.6"
 surrealcs = { version = "0.4.4", optional = true }
 surrealkv = { version = "0.6.1", optional = true }
 surrealml = { version = "0.1.1", optional = true, package = "surrealml-core" }
+sysinfo = "0.33.0"
 tempfile = { version = "3.10.1", optional = true }
 thiserror = "1.0.63"
 tikv = { version = "0.3.0-surreal.1", default-features = false, package = "surrealdb-tikv-client", optional = true }
@@ -178,27 +149,14 @@ wiremock = "0.6.0"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pharos = "0.5.3"
 ring = { version = "0.17.7", features = ["wasm32_unknown_unknown_js"] }
-tokio = { version = "1.41.1", default-features = false, features = [
-    "rt",
-    "sync",
-] }
+tokio = { version = "1.41.1", default-features = false, features = ["rt", "sync"] }
 uuid = { version = "1.10.0", features = ["serde", "js", "v4", "v7"] }
 wasm-bindgen-futures = "0.4.39"
-wasmtimer = { version = "0.2.0", default-features = false, features = [
-    "tokio",
-] }
+wasmtimer = { version = "0.2.0", default-features = false, features = ["tokio"] }
 ws_stream_wasm = "0.7.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.41.1", default-features = false, features = [
-    "macros",
-    "io-util",
-    "io-std",
-    "fs",
-    "rt-multi-thread",
-    "time",
-    "sync",
-] }
+tokio = { version = "1.41.1", default-features = false, features = ["macros", "io-util", "io-std", "fs", "rt-multi-thread", "time", "sync"] }
 tokio-tungstenite = { version = "0.21.0", optional = true }
 uuid = { version = "1.10.0", features = ["serde", "v4", "v7"] }
 

--- a/crates/core/src/kvs/node.rs
+++ b/crates/core/src/kvs/node.rs
@@ -22,6 +22,8 @@ impl Datastore {
 	pub async fn insert_node(&self, id: uuid::Uuid) -> Result<(), Error> {
 		// Log when this method is run
 		trace!(target: TARGET, "Inserting node in the cluster");
+		// Refresh system usage metrics
+		crate::sys::refresh().await;
 		// Open transaction and set node data
 		let txn = self.transaction(Write, Optimistic).await?;
 		let key = crate::key::root::nd::Nd::new(id);
@@ -46,6 +48,8 @@ impl Datastore {
 	pub async fn update_node(&self, id: uuid::Uuid) -> Result<(), Error> {
 		// Log when this method is run
 		trace!(target: TARGET, "Updating node in the cluster");
+		// Refresh system usage metrics
+		crate::sys::refresh().await;
 		// Open transaction and set node data
 		let txn = self.transaction(Write, Optimistic).await?;
 		let key = crate::key::root::nd::new(id);

--- a/crates/core/src/mem/fake.rs
+++ b/crates/core/src/mem/fake.rs
@@ -1,0 +1,28 @@
+#![cfg(not(feature = "allocator"))]
+
+/// This structure implements a wrapper around the
+/// system allocator, or around a user-specified
+/// allocator. It tracks the current memory which
+/// is allocated, and the total memory allocated
+/// across the duration of the programme. This
+/// memory use can then be checked at runtime.
+#[derive(Debug)]
+pub struct FakeAlloc;
+
+impl FakeAlloc {
+	#[inline]
+	pub const fn new() -> Self {
+		Self {}
+	}
+}
+
+impl FakeAlloc {
+	/// Returns the number of bytes that are allocated to the process
+	pub fn current_usage(&self) -> usize {
+		0
+	}
+	/// Checks whether the allocator is above the memory limit threshold
+	pub fn is_beyond_threshold(&self) -> bool {
+		false
+	}
+}

--- a/crates/core/src/mem/mod.rs
+++ b/crates/core/src/mem/mod.rs
@@ -1,3 +1,9 @@
+mod fake;
+mod track;
+
+#[cfg(not(feature = "allocator"))]
+pub static ALLOC: fake::FakeAlloc = fake::FakeAlloc::new();
+
 #[cfg(feature = "allocator")]
 #[cfg(not(any(
 	target_os = "android",
@@ -14,34 +20,41 @@ pub static ALLOC: std::alloc::System = std::alloc::System;
 #[cfg(feature = "allocator")]
 #[cfg(target_os = "android")]
 #[global_allocator]
-pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+pub static ALLOC: track::TrackAlloc<jemallocator::Jemalloc> =
+	track::TrackAlloc::new(jemallocator::Jemalloc);
 
 #[cfg(feature = "allocator")]
 #[cfg(target_os = "freebsd")]
 #[global_allocator]
-pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+pub static ALLOC: track::TrackAlloc<jemallocator::Jemalloc> =
+	track::TrackAlloc::new(jemallocator::Jemalloc);
 
 #[cfg(feature = "allocator")]
 #[cfg(target_os = "ios")]
 #[global_allocator]
-pub static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+pub static ALLOC: track::TrackAlloc<mimalloc::MiMalloc> =
+	track::TrackAlloc::new(mimalloc::MiMalloc);
 
 #[cfg(feature = "allocator")]
 #[cfg(target_os = "linux")]
 #[global_allocator]
-pub static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+pub static ALLOC: track::TrackAlloc<mimalloc::MiMalloc> =
+	track::TrackAlloc::new(mimalloc::MiMalloc);
 
 #[cfg(feature = "allocator")]
 #[cfg(target_os = "macos")]
 #[global_allocator]
-pub static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+pub static ALLOC: track::TrackAlloc<mimalloc::MiMalloc> =
+	track::TrackAlloc::new(mimalloc::MiMalloc);
 
 #[cfg(feature = "allocator")]
 #[cfg(target_os = "netbsd")]
 #[global_allocator]
-pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+pub static ALLOC: track::TrackAlloc<jemallocator::Jemalloc> =
+	track::TrackAlloc::new(jemallocator::Jemalloc);
 
 #[cfg(feature = "allocator")]
 #[cfg(target_os = "openbsd")]
 #[global_allocator]
-pub static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+pub static ALLOC: track::TrackAlloc<jemallocator::Jemalloc> =
+	track::TrackAlloc::new(jemallocator::Jemalloc);

--- a/crates/core/src/sql/statements/info.rs
+++ b/crates/core/src/sql/statements/info.rs
@@ -5,13 +5,13 @@ use crate::err::Error;
 use crate::iam::Action;
 use crate::iam::ResourceKind;
 use crate::sql::{Base, Ident, Object, Value, Version};
+use crate::sys::INFORMATION;
 use derive::Store;
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::sync::Arc;
-use std::thread::available_parallelism;
 
 #[revisioned(revision = 5)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
@@ -61,7 +61,7 @@ impl InfoStatement {
 						"accesses".to_string() => process(txn.all_root_accesses().await?.iter().map(|v| v.redacted()).collect()),
 						"namespaces".to_string() => process(txn.all_ns().await?),
 						"nodes".to_string() => process(txn.all_nodes().await?),
-						"system".to_string() => process(Arc::new([System::new()])),
+						"system".to_string() => system().await,
 						"users".to_string() => process(txn.all_root_users().await?),
 					}),
 					false => Value::from(map! {
@@ -86,9 +86,7 @@ impl InfoStatement {
 							}
 							out.into()
 						},
-						"system".to_string() => {
-							System::new().into()
-						},
+						"system".to_string() => system().await,
 						"users".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_root_users().await?.iter() {
@@ -397,32 +395,14 @@ where
 	Value::Array(a.iter().cloned().map(InfoStructure::structure).collect())
 }
 
-#[derive(Clone)]
-struct System {
-	memory_allocated: usize,
-	parallelism: usize,
-}
-
-impl System {
-	fn new() -> Self {
-		Self {
-			memory_allocated: 0,
-			parallelism: available_parallelism().map_or_else(|_| num_cpus::get(), |m| m.get()),
-		}
-	}
-}
-
-impl From<System> for Value {
-	fn from(s: System) -> Self {
-		Self::from(map! {
-			"parallelism".to_string() => s.parallelism.into(),
-			"memory_allocated".to_string() => s.memory_allocated.into()
-		})
-	}
-}
-
-impl InfoStructure for System {
-	fn structure(self) -> Value {
-		self.into()
-	}
+async fn system() -> Value {
+	let info = INFORMATION.lock().await;
+	Value::from(map! {
+		"available_parallelism".to_string() => info.available_parallelism.into(),
+		"cpu_usage".to_string() => info.cpu_usage.into(),
+		"load_average".to_string() => info.load_average.to_vec().into(),
+		"memory_usage".to_string() => info.memory_usage.into(),
+		"physical_cores".to_string() => info.physical_cores.into(),
+		"memory_allocated".to_string() => info.memory_allocated.into(),
+	})
 }

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -500,6 +500,12 @@ impl From<Vec<f32>> for Value {
 	}
 }
 
+impl From<Vec<f64>> for Value {
+	fn from(v: Vec<f64>) -> Self {
+		Value::Array(Array::from(v))
+	}
+}
+
 impl From<Vec<usize>> for Value {
 	fn from(v: Vec<usize>) -> Self {
 		Value::Array(Array::from(v))

--- a/crates/core/src/sys/mod.rs
+++ b/crates/core/src/sys/mod.rs
@@ -6,7 +6,7 @@ use sysinfo::System;
 /// The current system environment which is used to
 /// periodically fetch and compute the system metrics.
 pub static ENVIRONMENT: LazyLock<Mutex<Environment>> =
-	LazyLock::new(|| Mutex::new(Environment::new()));
+	LazyLock::new(|| Mutex::new(Environment::default()));
 
 /// The current system information which was acquired
 /// from the periodic environment process computation.
@@ -45,15 +45,16 @@ pub struct Environment {
 	pid: Pid,
 }
 
-impl Environment {
-	/// Create a new system environment
-	pub fn new() -> Self {
+impl Default for Environment {
+	fn default() -> Self {
 		Self {
 			sys: System::new_all(),
 			pid: Pid::from(std::process::id() as usize),
 		}
 	}
+}
 
+impl Environment {
 	/// Returns the system load average value.
 	/// This function returns three numbers,
 	/// representing the last 1 minute, 5

--- a/crates/core/src/sys/mod.rs
+++ b/crates/core/src/sys/mod.rs
@@ -1,4 +1,116 @@
-#[inline]
-pub async fn is_beyond_threshold() -> bool {
-	false
+use futures::lock::Mutex;
+use std::sync::LazyLock;
+use sysinfo::Pid;
+use sysinfo::System;
+
+/// The current system environment which is used to
+/// periodically fetch and compute the system metrics.
+pub static ENVIRONMENT: LazyLock<Mutex<Environment>> =
+	LazyLock::new(|| Mutex::new(Environment::new()));
+
+/// The current system information which was acquired
+/// from the periodic environment process computation.
+pub static INFORMATION: LazyLock<Mutex<Information>> =
+	LazyLock::new(|| Mutex::new(Information::default()));
+
+pub async fn refresh() {
+	// Get the environment
+	let mut environment = ENVIRONMENT.lock().await;
+	environment.refresh();
+	// Get the system information cache
+	let mut information = INFORMATION.lock().await;
+	// Update the cached information metrics
+	information.cpu_usage = environment.cpu_usage();
+	information.memory_allocated = crate::mem::ALLOC.current_usage();
+	information.memory_usage = environment.memory_usage();
+	information.load_average = environment.load_average();
+	information.physical_cores = environment.physical_cores();
+	information.available_parallelism = environment.available_parallelism();
+}
+
+/// Cached system utilisation metrics information
+#[derive(Default)]
+pub struct Information {
+	pub available_parallelism: usize,
+	pub cpu_usage: f32,
+	pub load_average: [f64; 3],
+	pub memory_allocated: usize,
+	pub memory_usage: u64,
+	pub physical_cores: usize,
+}
+
+/// An environment for fetching system utilisation
+pub struct Environment {
+	sys: System,
+	pid: Pid,
+}
+
+impl Environment {
+	/// Create a new system environment
+	pub fn new() -> Self {
+		Self {
+			sys: System::new_all(),
+			pid: Pid::from(std::process::id() as usize),
+		}
+	}
+
+	/// Returns the system load average value.
+	/// This function returns three numbers,
+	/// representing the last 1 minute, 5
+	/// minute, and 15 minute periods.
+	pub fn load_average(&self) -> [f64; 3] {
+		let load = System::load_average();
+		[load.one, load.five, load.fifteen]
+	}
+
+	/// Fetches the estimate of the available
+	/// parallelism of the hardware on which the
+	/// database is running. This number often
+	/// corresponds to the amount of CPUs, but
+	/// it may diverge in various cases.
+	pub fn physical_cores(&self) -> usize {
+		self.sys.physical_core_count().unwrap_or_default()
+	}
+
+	/// Fetches the estimate of the available
+	/// parallelism of the hardware on which the
+	/// database is running. This number often
+	/// corresponds to the amount of CPUs, but
+	/// it may diverge in various cases.
+	pub fn available_parallelism(&self) -> usize {
+		std::thread::available_parallelism().map_or_else(|_| num_cpus::get(), |m| m.get())
+	}
+
+	/// Returns the total CPU usage of the system
+	/// as a percentage. This may be greater than
+	/// 100% if running on a mult-core machine.
+	pub fn cpu_usage(&self) -> f32 {
+		if let Some(process) = self.sys.process(self.pid) {
+			process.cpu_usage()
+		} else {
+			0.0
+		}
+	}
+
+	/// Returns the total memory usage (in bytes)
+	/// of the system. This is the size of the
+	/// memory allocated, not including swap.
+	pub fn memory_usage(&self) -> u64 {
+		if let Some(process) = self.sys.process(self.pid) {
+			process.memory()
+		} else {
+			0
+		}
+	}
+
+	/// Refreshes the current process information
+	/// with memory and cpu usage details. This
+	/// ensures that we only fetch data we need.
+	pub fn refresh(&mut self) {
+		self.sys.refresh_processes_specifics(
+			sysinfo::ProcessesToUpdate::Some(&[self.pid]),
+			true,
+			sysinfo::ProcessRefreshKind::nothing().with_memory().with_cpu(),
+		);
+	}
 }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -49,6 +49,7 @@ rustls = [
 ml = ["surrealdb-core/ml"]
 jwks = ["surrealdb-core/jwks"]
 arbitrary = ["surrealdb-core/arbitrary"]
+allocation-tracking = ["surrealdb-core/allocation-tracking"]
 # Special features
 kv-fdb-7_1 = ["surrealdb-core/kv-fdb-7_1"]
 kv-fdb-7_3 = ["surrealdb-core/kv-fdb-7_3"]

--- a/crates/sdk/tests/define.rs
+++ b/crates/sdk/tests/define.rs
@@ -6,7 +6,6 @@ mod helpers;
 use helpers::*;
 
 use std::collections::HashMap;
-use std::thread::available_parallelism;
 use std::time::{Duration, SystemTime};
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
@@ -33,13 +32,23 @@ async fn define_statement_namespace() -> Result<(), Error> {
 	assert!(tmp.is_ok(), "{:?}", tmp);
 	//
 	let tmp = res.remove(0).result?;
-	let parallelism = available_parallelism()?;
 	let val = Value::parse(&format!(
 		"{{
 			accesses: {{}},
 			namespaces: {{ test: 'DEFINE NAMESPACE test' }},
 			nodes: {{}},
-			system: {{ memory_allocated: 0, parallelism: {parallelism} }},
+			system: {{
+				available_parallelism: 0,
+				cpu_usage: 0.0f,
+				load_average: [
+					0.0f,
+					0.0f,
+					0.0f
+				],
+				memory_allocated: 0,
+				memory_usage: 0,
+				physical_cores: 0
+			}},
 			users: {{}},
 		}}"
 	));
@@ -2039,9 +2048,8 @@ async fn permissions_checks_define_ns() {
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
-	let parallelism = available_parallelism().unwrap();
-	let access1 = format!("{{ accesses: {{  }}, namespaces: {{ NS: 'DEFINE NAMESPACE NS' }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{  }} }}");
-	let access2 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{  }} }}");
+	let access1 = format!("{{ accesses: {{  }}, namespaces: {{ NS: 'DEFINE NAMESPACE NS' }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
+	let access2 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
 	let check_results = [vec![access1.as_str()], vec![access2.as_str()]];
 
 	let test_cases = [
@@ -2204,9 +2212,8 @@ async fn permissions_checks_define_access_root() {
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
-	let parallelism = available_parallelism().unwrap();
-	let access1 = format!("{{ accesses: {{ access: \"DEFINE ACCESS access ON ROOT TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION FOR TOKEN 1h, FOR SESSION NONE\" }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{  }} }}");
-	let access2 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{  }} }}");
+	let access1 = format!("{{ accesses: {{ access: \"DEFINE ACCESS access ON ROOT TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION FOR TOKEN 1h, FOR SESSION NONE\" }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
+	let access2 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
 	let check_results = [vec![access1.as_str()], vec![access2.as_str()]];
 
 	let test_cases = [
@@ -2330,9 +2337,8 @@ async fn permissions_checks_define_user_root() {
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
-	let parallelism = available_parallelism().unwrap();
-	let check1 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{ user: \"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER DURATION FOR TOKEN 15m, FOR SESSION 6h\" }} }}");
-	let check2 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{  }} }}");
+	let check1 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{ user: \"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER DURATION FOR TOKEN 15m, FOR SESSION 6h\" }} }}");
+	let check2 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
 	let check_results = [vec![check1.as_str()], vec![check2.as_str()]];
 
 	let test_cases = [

--- a/crates/sdk/tests/info.rs
+++ b/crates/sdk/tests/info.rs
@@ -3,7 +3,6 @@ use helpers::*;
 
 use regex::Regex;
 use std::collections::HashMap;
-use std::thread::available_parallelism;
 use surrealdb::dbs::Session;
 use surrealdb::iam::Role;
 
@@ -19,7 +18,7 @@ async fn info_for_root() {
 	let mut t = Test::new(sql).await.unwrap();
 	t.skip_ok(3).unwrap();
 	t.expect_regex(r"\{ accesses: \{ access: .* \}, namespaces: \{ NS: .* \}, nodes: \{ .* \}, system: \{ .* \}, users: \{ user: .* \} \}").unwrap();
-	t.expect_regex(r"\{ accesses: \[\{.* \}\], namespaces: \[\{ .* \}\], nodes: \[.*\], system: \[\{ .* \}\], users: \[\{ .* \}\] \}").unwrap();
+	t.expect_regex(r"\{ accesses: \[\{.* \}\], namespaces: \[\{ .* \}\], nodes: \[.*\], system: \{ .* \}, users: \[\{ .* \}\] \}").unwrap();
 }
 
 #[tokio::test]
@@ -158,8 +157,7 @@ async fn permissions_checks_info_root() {
 		HashMap::from([("prepare", ""), ("test", "INFO FOR ROOT"), ("check", "INFO FOR ROOT")]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
-	let parallelism = available_parallelism().unwrap();
-	let check = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0,  parallelism: {parallelism}}}, users: {{  }} }}");
+	let check = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
 	let check_results = [vec![check.as_str()], vec![check.as_str()]];
 
 	let test_cases = [

--- a/crates/sdk/tests/remove.rs
+++ b/crates/sdk/tests/remove.rs
@@ -8,7 +8,6 @@ use helpers::*;
 mod util;
 
 use std::collections::HashMap;
-use std::thread::available_parallelism;
 use surrealdb::dbs::Session;
 use surrealdb::err::Error;
 use surrealdb::iam::Role;
@@ -583,9 +582,8 @@ async fn permissions_checks_remove_ns() {
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
-	let parallelism = available_parallelism().unwrap();
-	let check1 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0,  memory_allocated: 0, parallelism: {parallelism}}}, users: {{  }} }}");
-	let check2 = format!("{{ accesses: {{  }}, namespaces: {{ NS: 'DEFINE NAMESPACE NS' }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{  }} }}");
+	let check1 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
+	let check2 = format!("{{ accesses: {{  }}, namespaces: {{ NS: 'DEFINE NAMESPACE NS' }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
 	let check_results = [vec![check1.as_str()], vec![check2.as_str()]];
 
 	let test_cases = [
@@ -751,9 +749,8 @@ async fn permissions_checks_remove_root_access() {
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
-	let parallelism = available_parallelism().unwrap();
-	let check1 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{  }} }}");
-	let check2 = format!("{{ accesses: {{ access: \"DEFINE ACCESS access ON ROOT TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION FOR TOKEN 1h, FOR SESSION NONE\" }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{  }} }}");
+	let check1 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
+	let check2 = format!("{{ accesses: {{ access: \"DEFINE ACCESS access ON ROOT TYPE JWT ALGORITHM HS512 KEY '[REDACTED]' WITH ISSUER KEY '[REDACTED]' DURATION FOR TOKEN 1h, FOR SESSION NONE\" }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
 	let check_results = [vec![check1.as_str()], vec![check2.as_str()]];
 
 	let test_cases = [
@@ -877,9 +874,8 @@ async fn permissions_checks_remove_root_user() {
 	]);
 
 	// Define the expected results for the check statement when the test statement succeeded and when it failed
-	let parallelism = available_parallelism().unwrap();
-	let check1 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{  }} }}");
-	let check2 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ memory_allocated: 0, parallelism: {parallelism}}}, users: {{ user: \"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER DURATION FOR TOKEN 1h, FOR SESSION NONE\" }} }}");
+	let check1 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{  }} }}");
+	let check2 = format!("{{ accesses: {{  }}, namespaces: {{  }}, nodes: {{  }}, system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }}, users: {{ user: \"DEFINE USER user ON ROOT PASSHASH 'secret' ROLES VIEWER DURATION FOR TOKEN 1h, FOR SESSION NONE\" }} }}");
 	let check_results = [vec![check1.as_str()], vec![check2.as_str()]];
 
 	let test_cases = [

--- a/crates/sdk/tests/strict.rs
+++ b/crates/sdk/tests/strict.rs
@@ -1,7 +1,6 @@
 mod parse;
 
 use parse::Parse;
-use std::thread::available_parallelism;
 mod helpers;
 use helpers::new_ds;
 use surrealdb::dbs::Session;
@@ -232,15 +231,13 @@ async fn loose_mode_all_ok() -> Result<(), Error> {
 	let val = Value::parse("[{ id: test:tester, extra: true }]");
 	assert_eq!(tmp, val);
 	//
-	let parallelism = available_parallelism()?;
-	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(&format!(
 		"{{
 			accesses: {{ }},
 			namespaces: {{ test: 'DEFINE NAMESPACE test' }},
 			nodes: {{ }},
-			system: {{ memory_allocated: 0, parallelism: {parallelism} }},
+			system: {{ available_parallelism: 0, cpu_usage: 0.0f, load_average: [0.0f, 0.0f, 0.0f], memory_allocated: 0, memory_usage: 0, physical_cores: 0 }},
 			users: {{ }},
 		}}"
 	));

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -26,10 +26,10 @@ use http::header::SEC_WEBSOCKET_PROTOCOL;
 use http::HeaderMap;
 use surrealdb::dbs::Session;
 use surrealdb::kvs::Datastore;
+use surrealdb::mem::ALLOC;
 use surrealdb::rpc::format::Format;
 use surrealdb::rpc::format::PROTOCOLS;
 use surrealdb::rpc::method::Method;
-use surrealdb::sys;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::request_id::RequestId;
 use uuid::Uuid;
@@ -175,7 +175,7 @@ async fn post_handler(
 	// Create a new HTTP instance
 	let mut rpc = PostRpcContext::new(&state.datastore, session, BTreeMap::new());
 	// Check to see available memory
-	if sys::is_beyond_threshold().await {
+	if ALLOC.is_beyond_threshold() {
 		return Err(Error::ServerOverloaded);
 	}
 	// Parse the HTTP request body

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -20,13 +20,13 @@ use surrealdb::dbs::Session;
 #[cfg(surrealdb_unstable)]
 use surrealdb::gql::{Pessimistic, SchemaCache};
 use surrealdb::kvs::Datastore;
+use surrealdb::mem::ALLOC;
 use surrealdb::rpc::format::Format;
 use surrealdb::rpc::method::Method;
 use surrealdb::rpc::Data;
 use surrealdb::rpc::RpcContext;
 use surrealdb::sql::Array;
 use surrealdb::sql::Value;
-use surrealdb::sys;
 use tokio::sync::{RwLock, Semaphore};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -258,7 +258,7 @@ impl Connection {
 							// Clone the response sending channel
 							let chn = internal_sender.clone();
 							// Check to see whether we have available memory
-							if sys::is_beyond_threshold().await {
+							if ALLOC.is_beyond_threshold() {
 								// Reject the message
 								Self::close_socket(rpc.clone(), chn).await;
 								// Abort all tasks
@@ -273,7 +273,7 @@ impl Connection {
 							// Clone the response sending channel
 							let chn = internal_sender.clone();
 							// Check to see whether we have available memory
-							if sys::is_beyond_threshold().await {
+							if ALLOC.is_beyond_threshold() {
 								// Reject the message
 								Self::close_socket(rpc.clone(), chn).await;
 								// Abort all tasks
@@ -416,7 +416,7 @@ impl Connection {
 										.await;
 								}
 								// Check to see whether we have available memory
-								else if sys::is_beyond_threshold().await {
+								else if ALLOC.is_beyond_threshold() {
 									// Process the response
 									failure(req.id, Failure::custom(SERVER_OVERLOADED))
 										.send(otel_cx.clone(), fmt, &chn)
@@ -428,7 +428,7 @@ impl Connection {
 									// Acquire concurrent request rate limiter
 									let permit = semaphore.acquire_owned().await.unwrap();
 									// Check to see whether we have available memory
-									if sys::is_beyond_threshold().await {
+									if ALLOC.is_beyond_threshold() {
 										// Process the response
 										failure(req.id, Failure::custom(SERVER_OVERLOADED))
 											.send(otel_cx.clone(), fmt, &chn)

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -21,6 +21,11 @@ who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
 criteria = "safe-to-deploy"
 delta = "4.7.0 -> 4.7.1"
 
+[[audits.core-foundation-sys]]
+who = "Tobie Morgan Hitchcock <tobie@surrealdb.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.6 -> 0.8.7"
+
 [[audits.easy-parallel]]
 who = "Emmanuel Keller <emmanuel.keller@surrealdb.com>"
 criteria = "safe-to-deploy"
@@ -36,6 +41,11 @@ delta = "2.3.0 -> 2.5.0"
 who = "arriqaaq <farhan.khan@surrealdb.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.161 -> 0.2.162"
+
+[[audits.libc]]
+who = "Tobie Morgan Hitchcock <tobie@surrealdb.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.162 -> 0.2.168"
 
 [[trusted.addr]]
 criteria = "safe-to-deploy"
@@ -529,11 +539,29 @@ user-id = 189 # Andrew Gallant (BurntSushi)
 start = "2020-01-11"
 end = "2025-08-31"
 
+[[trusted.windows]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2021-01-15"
+end = "2025-12-16"
+
 [[trusted.windows-core]]
 criteria = "safe-to-deploy"
 user-id = 64539 # Kenny Kerr (kennykerr)
 start = "2021-11-15"
 end = "2025-09-03"
+
+[[trusted.windows-implement]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-01-27"
+end = "2025-12-16"
+
+[[trusted.windows-interface]]
+criteria = "safe-to-deploy"
+user-id = 64539 # Kenny Kerr (kennykerr)
+start = "2022-02-18"
+end = "2025-12-16"
 
 [[trusted.windows-registry]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -851,6 +851,10 @@ criteria = "safe-to-deploy"
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.ntapi]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.num-complex]]
 version = "0.4.5"
 criteria = "safe-to-deploy"
@@ -1409,6 +1413,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.sync_wrapper]]
 version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.sysinfo]]
+version = "0.33.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tar]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -603,6 +603,13 @@ user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
+[[publisher.windows]]
+version = "0.57.0"
+when = "2024-06-07"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
 [[publisher.windows-core]]
 version = "0.52.0"
 when = "2023-11-15"
@@ -610,9 +617,37 @@ user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
+[[publisher.windows-core]]
+version = "0.57.0"
+when = "2024-06-07"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-implement]]
+version = "0.57.0"
+when = "2024-06-07"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-interface]]
+version = "0.57.0"
+when = "2024-06-07"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
 [[publisher.windows-registry]]
 version = "0.2.0"
 when = "2024-07-03"
+user-id = 64539
+user-login = "kennykerr"
+user-name = "Kenny Kerr"
+
+[[publisher.windows-result]]
+version = "0.1.2"
+when = "2024-06-07"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

This pull-request adds a new feature `allocation-tracking` which (when enabled with the `allocator` feature) enables tracking memory allocation from within the Rust memory allocator.

In addition, this pull-request adds system utilisation information to the `INFO FOR ROOT` command. This is currently undocumented and may be subject to change. The `INFO FOR ROOT` statement now includes a `system` key with the following structure:

```js
{
    available_parallelism: 12, // the available parallelism of the instance
    cpu_usage: 0.8106060028076172f,  // the current CPU usage as a %
    load_average: [
        4.0673828125f,  // the 1-minute load average of the instance
        5.7294921875f,  // the 5-minute load average of the instance
        5.75439453125f  // the 15-minute load average of the instance
    ],
    memory_allocated: 14178884, // the current Rust allocation memory (if `allocation-tracking` is enabled)
    memory_usage: 157450240, // the current memory usage as tracked by the system
    physical_cores: 12 // the total number of physical CPU core of the instance
}
```

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
