### PR TITLE
remove File engine ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,35 +504,6 @@ jobs:
           df -h
           ps auxf
 
-  file-engine:
-    name: File engine
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: Install cargo-make
-        run: cargo install --debug --locked cargo-make
-
-      - name: Test file engine
-        run: cargo make ci-api-integration-file
-
-      - name: Debug info
-        if: always()
-        run: |
-          set -x
-          free -m
-          df -h
-          ps auxf
-
   rocksdb-engine:
     name: RocksDB engine
     runs-on: ubuntu-latest

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -151,11 +151,6 @@ category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "mem", _TEST_FEATURES = "kv-mem" }
 run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
 
-[tasks.ci-api-integration-file]
-category = "CI - INTEGRATION TESTS"
-env = { _TEST_API_ENGINE = "file", _TEST_FEATURES = "kv-rocksdb" }
-run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
-
 [tasks.ci-api-integration-rocksdb]
 category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "rocksdb", _TEST_FEATURES = "kv-rocksdb" }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

File has been deprecated so it makes sense to remove the CI tests, at least when it gets removed

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

remove File tests, which doesn't actually reduce the coverage, as File is just an alias for RocksDB

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->


## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
