### PR TITLE
Add geometry type support to Graphql

### DIFF
--- a/crates/core/src/gql/ext.rs
+++ b/crates/core/src/gql/ext.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use crate::sql::statements::define::config::graphql::TableConfig;
 use crate::sql::statements::DefineTableStatement;
 use crate::sql::{statements::UseStatement, Cond, Ident, Idiom, Limit, Part, Start, Table, Value};
+use async_graphql::{Name, Value as GqlValue};
 
 pub trait IntoExt<T> {
 	fn intox(self) -> T;
@@ -99,6 +100,56 @@ where
 	}
 }
 
+pub trait TryIntoExt<T> {
+	type Error;
+
+	fn try_intox(self) -> Result<T, Self::Error>;
+}
+
+pub trait TryFromExt<T>: Sized {
+	type Error;
+
+	fn try_fromx(value: T) -> Result<Self, Self::Error>;
+}
+
+impl<S, T> TryIntoExt<T> for S
+where
+	T: TryFromExt<S>,
+{
+	type Error = <T as TryFromExt<S>>::Error;
+
+	fn try_intox(self) -> Result<T, <T as TryFromExt<S>>::Error> {
+		T::try_fromx(self)
+	}
+}
+
+impl TryFromExt<f64> for async_graphql::Value {
+	type Error = GqlError;
+
+	fn try_fromx(value: f64) -> Result<Self, GqlError> {
+		Ok(Self::Number(Number::from_f64(value).ok_or_else(|| {
+			resolver_error(format!("non-finite float (not supported in json): {}", value))
+		})?))
+	}
+}
+
+// impl TryFromExt<Coord<f64>> for (GqlValue, GqlValue) {
+// 	type Error = GqlError;
+
+// 	fn try_fromx(value: Coord<f64>) -> Result<Self, Self::Error> {
+// 		// Ok(GqlValue::Object(
+// 		// 	[
+// 		// 		(Name::new("type"), GqlValue::String("Point".to_string())),
+// 		// 		(
+// 		// 			Name::new("coordinates"),
+// 		// 			GqlValue::List(vec![value.x().try_intox()?, value.y().try_intox()?]),
+// 		// 		),
+// 		// 	]
+// 		// 	.into(),
+// 		// ))
+// 	}
+// }
+
 #[cfg(debug_assertions)]
 pub trait ValidatorExt {
 	fn add_validator(
@@ -109,6 +160,8 @@ pub trait ValidatorExt {
 
 #[cfg(debug_assertions)]
 use async_graphql::dynamic::Scalar;
+use geo::{Coord, CoordFloat};
+use serde_json::Number;
 #[cfg(debug_assertions)]
 impl ValidatorExt for Scalar {
 	fn add_validator(
@@ -124,6 +177,9 @@ impl ValidatorExt for Scalar {
 
 use crate::sql::Thing as SqlThing;
 use crate::sql::Value as SqlValue;
+
+use super::error::resolver_error;
+use super::GqlError;
 
 pub trait TryAsExt {
 	fn try_as_thing(self) -> Result<SqlThing, Self>

--- a/crates/core/src/gql/tables.rs
+++ b/crates/core/src/gql/tables.rs
@@ -13,11 +13,11 @@ use crate::sql::{Expression, Value as SqlValue};
 use crate::sql::{Idiom, Kind};
 use crate::sql::{Statement, Thing};
 use async_graphql::dynamic::indexmap::IndexMap;
-use async_graphql::dynamic::FieldFuture;
 use async_graphql::dynamic::InputValue;
 use async_graphql::dynamic::TypeRef;
 use async_graphql::dynamic::{Enum, FieldValue, Type};
 use async_graphql::dynamic::{Field, ResolverContext};
+use async_graphql::dynamic::{FieldFuture, Union};
 use async_graphql::dynamic::{InputObject, Object};
 use async_graphql::Name;
 use async_graphql::Value as GqlValue;
@@ -64,6 +64,10 @@ fn filter_name_from_table(tb_name: impl Display) -> String {
 	format!("_filter_{tb_name}")
 }
 
+fn filter_obj_name_from_table(tb_name: impl Display) -> String {
+	format!("_filter_obj_{tb_name}")
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn process_tbs(
 	tbs: Arc<[DefineTableStatement]>,
@@ -97,9 +101,10 @@ pub async fn process_tbs(
 			.field(InputValue::new("desc", TypeRef::named(&table_orderable_name)))
 			.field(InputValue::new("then", TypeRef::named(&table_order_name)));
 
-		let table_filter_name = filter_name_from_table(tb_name);
-		let mut table_filter = InputObject::new(&table_filter_name);
-		table_filter = table_filter
+		let table_filter_name = filter_name_from_table(&tb_name);
+		let table_filter_obj_name = filter_obj_name_from_table(&tb_name);
+		let mut table_filter_obj = InputObject::new(&table_filter_obj_name);
+		table_filter_obj = table_filter_obj
 			.field(InputValue::new("id", TypeRef::named("_filter_id")))
 			.field(InputValue::new("and", TypeRef::named_nn_list(&table_filter_name)))
 			.field(InputValue::new("or", TypeRef::named_nn_list(&table_filter_name)))
@@ -321,7 +326,7 @@ pub async fn process_tbs(
 			trace!("\n{type_filter:?}\n");
 			types.push(type_filter);
 
-			table_filter = table_filter
+			table_filter_obj = table_filter_obj
 				.field(InputValue::new(fd.name.to_string(), TypeRef::named(type_filter_name)));
 
 			table_ty_obj = table_ty_obj
@@ -337,10 +342,15 @@ pub async fn process_tbs(
 				});
 		}
 
+		let table_filter = Union::new(table_filter_name)
+			.possible_type(TypeRef::STRING)
+			.possible_type(table_filter_obj_name);
+
 		types.push(Type::Object(table_ty_obj));
 		types.push(table_order.into());
 		types.push(Type::Enum(table_orderable));
-		types.push(Type::InputObject(table_filter));
+		types.push(Type::InputObject(table_filter_obj));
+		types.push(Type::Union(table_filter));
 	}
 
 	let sess3 = session.to_owned();


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Geometry types are currently not supported in the grpahql integration

## What does this change do?

adds support for serialising geometry types and returning them through graphql

## What is your testing strategy?

integration tests wip

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- closes #4636 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
