### PR TITLE
Add object::is_empty

### DIFF
--- a/crates/core/src/fnc/mod.rs
+++ b/crates/core/src/fnc/mod.rs
@@ -248,6 +248,7 @@ pub fn synchronous(
 		//
 		"object::entries" => object::entries,
 		"object::from_entries" => object::from_entries,
+		"object::is_empty" => object::is_empty,
 		"object::keys" => object::keys,
 		"object::len" => object::len,
 		"object::values" => object::values,
@@ -685,6 +686,7 @@ pub async fn idiom(
 				"no such method found for the object type",
 				//
 				"entries" => object::entries,
+				"is_empty" => object::is_empty,
 				"keys" => object::keys,
 				"len" => object::len,
 				"values" => object::values,

--- a/crates/core/src/fnc/object.rs
+++ b/crates/core/src/fnc/object.rs
@@ -57,6 +57,10 @@ pub fn from_entries((array,): (Array,)) -> Result<Value, Error> {
 	Ok(Value::Object(Object(obj)))
 }
 
+pub fn is_empty((object,): (Object,)) -> Result<Value, Error> {
+	Ok(Value::Bool(object.0.is_empty()))
+}
+
 pub fn len((object,): (Object,)) -> Result<Value, Error> {
 	Ok(Value::from(object.len()))
 }

--- a/crates/core/src/fnc/script/modules/surrealdb/functions/object.rs
+++ b/crates/core/src/fnc/script/modules/surrealdb/functions/object.rs
@@ -9,6 +9,7 @@ impl_module_def!(
 	"object",
 	"entries" => run,
 	"from_entries" => run,
+	"is_empty" => run,
 	"keys" => run,
 	"len" => run,
 	"values" => run

--- a/crates/core/src/syn/parser/builtin.rs
+++ b/crates/core/src/syn/parser/builtin.rs
@@ -243,6 +243,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		//
 		UniCase::ascii("object::entries") => PathKind::Function,
 		UniCase::ascii("object::from_entries") => PathKind::Function,
+		UniCase::ascii("object::is_empty") => PathKind::Function,
 		UniCase::ascii("object::keys") => PathKind::Function,
 		UniCase::ascii("object::len") => PathKind::Function,
 		UniCase::ascii("object::matches") => PathKind::Function,

--- a/crates/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_executor.dict
@@ -262,6 +262,7 @@
 "meta::tb("
 "object::entries("
 "object::from_entries("
+"object::is_empty("
 "object::keys("
 "object::len("
 "object::values("

--- a/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -261,6 +261,7 @@
 "meta::tb("
 "object::entries("
 "object::from_entries("
+"object::is_empty("
 "object::keys("
 "object::len("
 "object::values("

--- a/crates/sdk/tests/function.rs
+++ b/crates/sdk/tests/function.rs
@@ -2866,6 +2866,25 @@ async fn function_object_len() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn function_object_is_empty() -> Result<(), Error> {
+	let sql = r#"
+		{ a: 1, b: 2 }.is_empty();
+		{}.is_empty();
+	"#;
+	let mut test = Test::new(sql).await?;
+	//
+	let tmp = test.next()?.result?;
+	let val = Value::parse("false");
+	assert_eq!(tmp, val);
+	//
+	let tmp = test.next()?.result?;
+	let val = Value::parse("true");
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}
+
+#[tokio::test]
 async fn function_object_values() -> Result<(), Error> {
 	let sql = r#"
 		RETURN object::values({ a: 1, b: 2 });


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

This function exists for arrays but makes sense to have it for objects too. Currently the other functions can be used such as checking if len() = 0 or if functions like .keys() return an empty array, but nothing beats a simple .is_empty() for ease and readability.

## What does this change do?

It adds object::is_empty().

## What is your testing strategy?

Added a test.

- [X] No related issues

## Does this change need documentation?

Yes, https://github.com/surrealdb/docs.surrealdb.com/issues/1087

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
