### PR TITLE
Add `clippy` to `flake.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
             stable.rustc
             stable.cargo
             targets.${target}.stable.rust-std
+            stable.clippy
           ] ++ extraComponents);
 
         buildPlatform = pkgs.stdenv.buildPlatform.config;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Cargo clippy is currently not available in `nix` environments

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Adds `cargo clippy`

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
