### PR TITLE
Bug: Index is corrupted - TreeNode Out of Bound

### DIFF
--- a/crates/core/src/doc/index.rs
+++ b/crates/core/src/doc/index.rs
@@ -414,8 +414,7 @@ impl<'a> IndexOperation<'a> {
 	) -> Result<(), Error> {
 		let txn = ctx.tx();
 		let ikb = IndexKeyBase::new(self.opt.ns()?, self.opt.db()?, self.ix)?;
-		let mut mt =
-			MTreeIndex::new(ctx.get_index_stores(), &txn, ikb, p, TransactionType::Write).await?;
+		let mut mt = MTreeIndex::new(&txn, ikb, p, TransactionType::Write).await?;
 		// Delete the old index data
 		if let Some(o) = self.o.take() {
 			mt.remove_document(stk, &txn, self.rid, &o).await?;

--- a/crates/core/src/idx/ft/mod.rs
+++ b/crates/core/src/idx/ft/mod.rs
@@ -126,12 +126,10 @@ impl FtIndex {
 			State::default()
 		};
 		let doc_ids = Arc::new(RwLock::new(
-			DocIds::new(ixs, txn, tt, index_key_base.clone(), p.doc_ids_order, p.doc_ids_cache)
-				.await?,
+			DocIds::new(txn, tt, index_key_base.clone(), p.doc_ids_order, p.doc_ids_cache).await?,
 		));
 		let doc_lengths = Arc::new(RwLock::new(
 			DocLengths::new(
-				ixs,
 				txn,
 				index_key_base.clone(),
 				p.doc_lengths_order,
@@ -141,11 +139,11 @@ impl FtIndex {
 			.await?,
 		));
 		let postings = Arc::new(RwLock::new(
-			Postings::new(ixs, txn, index_key_base.clone(), p.postings_order, tt, p.postings_cache)
+			Postings::new(txn, index_key_base.clone(), p.postings_order, tt, p.postings_cache)
 				.await?,
 		));
 		let terms = Arc::new(RwLock::new(
-			Terms::new(ixs, txn, index_key_base.clone(), p.terms_order, tt, p.terms_cache).await?,
+			Terms::new(txn, index_key_base.clone(), p.terms_order, tt, p.terms_cache).await?,
 		));
 		let term_docs = TermDocs::new(index_key_base.clone());
 		let offsets = Offsets::new(index_key_base.clone());

--- a/crates/core/src/idx/index.rs
+++ b/crates/core/src/idx/index.rs
@@ -170,9 +170,7 @@ impl<'a> IndexOperation<'a> {
 	async fn index_mtree(&mut self, stk: &mut Stk, p: &MTreeParams) -> Result<(), Error> {
 		let txn = self.ctx.tx();
 		let ikb = IndexKeyBase::new(self.opt.ns()?, self.opt.db()?, self.ix)?;
-		let mut mt =
-			MTreeIndex::new(self.ctx.get_index_stores(), &txn, ikb, p, TransactionType::Write)
-				.await?;
+		let mut mt = MTreeIndex::new(&txn, ikb, p, TransactionType::Write).await?;
 		// Delete the old index data
 		if let Some(o) = self.o.take() {
 			mt.remove_document(stk, &txn, self.rid, &o).await?;

--- a/crates/core/src/idx/planner/executor.rs
+++ b/crates/core/src/idx/planner/executor.rs
@@ -168,14 +168,8 @@ impl InnerQueryExecutor {
 							Entry::Vacant(e) => {
 								let ikb = IndexKeyBase::new(opt.ns()?, opt.db()?, e.key())?;
 								let tx = ctx.tx();
-								let mt = MTreeIndex::new(
-									ctx.get_index_stores(),
-									&tx,
-									ikb,
-									p,
-									TransactionType::Read,
-								)
-								.await?;
+								let mt =
+									MTreeIndex::new(&tx, ikb, p, TransactionType::Read).await?;
 								drop(tx);
 								let entry =
 									MtEntry::new(stk, ctx, opt, &mt, a, *k, knn_condition.clone())

--- a/crates/core/src/idx/trees/btree.rs
+++ b/crates/core/src/idx/trees/btree.rs
@@ -734,7 +734,10 @@ where
 	) -> Result<(bool, bool, Key, NodeId), Error> {
 		// CLRS 3 Determine the root x.ci that must contain k
 		let child_idx = keys.get_child_idx(&key_to_delete);
-		let child_id = children[child_idx];
+		let child_id = match children.get(child_idx) {
+			None => return Err(Error::CorruptedIndex("deleted_traversal:invalid_child_idx")),
+			Some(&child_id) => child_id,
+		};
 		#[cfg(debug_assertions)]
 		debug!(
 			"CLRS: 3 - key_to_delete: {} - child_id: {child_id}",

--- a/crates/core/src/idx/trees/btree.rs
+++ b/crates/core/src/idx/trees/btree.rs
@@ -1085,11 +1085,11 @@ mod tests {
 	where
 		BK: BKeys + Debug + Clone,
 	{
-		let st = ds
-			.index_store()
+		let tx = ds.transaction(tt, Optimistic).await.unwrap();
+		let st = tx
+			.index_caches()
 			.get_store_btree_fst(TreeNodeProvider::Debug, t.state.generation, tt, cache_size)
 			.await;
-		let tx = ds.transaction(tt, Optimistic).await.unwrap();
 		(tx, st)
 	}
 
@@ -1102,11 +1102,11 @@ mod tests {
 	where
 		BK: BKeys + Debug + Clone,
 	{
-		let st = ds
-			.index_store()
+		let tx = ds.transaction(tt, Optimistic).await.unwrap();
+		let st = tx
+			.index_caches()
 			.get_store_btree_trie(TreeNodeProvider::Debug, t.state.generation, tt, cache_size)
 			.await;
-		let tx = ds.transaction(tt, Optimistic).await.unwrap();
 		(tx, st)
 	}
 

--- a/crates/core/src/idx/trees/store/hnsw.rs
+++ b/crates/core/src/idx/trees/store/hnsw.rs
@@ -50,8 +50,4 @@ impl HnswIndexes {
 		let key = ikb.new_vm_key(None);
 		self.0.write().await.remove(&key);
 	}
-
-	pub(super) async fn is_empty(&self) -> bool {
-		self.0.read().await.is_empty()
-	}
 }

--- a/crates/core/src/idx/trees/store/mod.rs
+++ b/crates/core/src/idx/trees/store/mod.rs
@@ -7,10 +7,7 @@ pub(crate) mod tree;
 use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::err::Error;
-use crate::idx::trees::bkeys::{FstKeys, TrieKeys};
-use crate::idx::trees::btree::{BTreeNode, BTreeStore};
-use crate::idx::trees::mtree::{MTreeNode, MTreeStore};
-use crate::idx::trees::store::cache::{TreeCache, TreeCaches};
+use crate::idx::trees::store::cache::TreeCache;
 use crate::idx::trees::store::hnsw::{HnswIndexes, SharedHnswIndex};
 use crate::idx::trees::store::mapper::Mappers;
 use crate::idx::trees::store::tree::{TreeRead, TreeWrite};
@@ -217,18 +214,13 @@ pub trait TreeNode: Debug + Clone + Display {
 pub struct IndexStores(Arc<Inner>);
 
 struct Inner {
-	btree_fst_caches: TreeCaches<BTreeNode<FstKeys>>,
-	btree_trie_caches: TreeCaches<BTreeNode<TrieKeys>>,
-	mtree_caches: TreeCaches<MTreeNode>,
 	hnsw_indexes: HnswIndexes,
 	mappers: Mappers,
 }
+
 impl Default for IndexStores {
 	fn default() -> Self {
 		Self(Arc::new(Inner {
-			btree_fst_caches: TreeCaches::default(),
-			btree_trie_caches: TreeCaches::default(),
-			mtree_caches: TreeCaches::default(),
 			hnsw_indexes: HnswIndexes::default(),
 			mappers: Mappers::default(),
 		}))
@@ -236,51 +228,6 @@ impl Default for IndexStores {
 }
 
 impl IndexStores {
-	pub async fn get_store_btree_fst(
-		&self,
-		keys: TreeNodeProvider,
-		generation: StoreGeneration,
-		tt: TransactionType,
-		cache_size: usize,
-	) -> BTreeStore<FstKeys> {
-		let cache = self.0.btree_fst_caches.get_cache(generation, &keys, cache_size).await;
-		TreeStore::new(keys, cache, tt).await
-	}
-
-	pub fn advance_store_btree_fst(&self, new_cache: TreeCache<BTreeNode<FstKeys>>) {
-		self.0.btree_fst_caches.new_cache(new_cache);
-	}
-
-	pub async fn get_store_btree_trie(
-		&self,
-		keys: TreeNodeProvider,
-		generation: StoreGeneration,
-		tt: TransactionType,
-		cache_size: usize,
-	) -> BTreeStore<TrieKeys> {
-		let cache = self.0.btree_trie_caches.get_cache(generation, &keys, cache_size).await;
-		TreeStore::new(keys, cache, tt).await
-	}
-
-	pub fn advance_cache_btree_trie(&self, new_cache: TreeCache<BTreeNode<TrieKeys>>) {
-		self.0.btree_trie_caches.new_cache(new_cache);
-	}
-
-	pub async fn get_store_mtree(
-		&self,
-		keys: TreeNodeProvider,
-		generation: StoreGeneration,
-		tt: TransactionType,
-		cache_size: usize,
-	) -> MTreeStore {
-		let cache = self.0.mtree_caches.get_cache(generation, &keys, cache_size).await;
-		TreeStore::new(keys, cache, tt).await
-	}
-
-	pub fn advance_store_mtree(&self, new_cache: TreeCache<MTreeNode>) {
-		self.0.mtree_caches.new_cache(new_cache);
-	}
-
 	pub(crate) async fn get_index_hnsw(
 		&self,
 		ctx: &Context,
@@ -341,43 +288,15 @@ impl IndexStores {
 		db: &str,
 		ix: &DefineIndexStatement,
 	) -> Result<(), Error> {
-		let ikb = IndexKeyBase::new(ns, db, ix)?;
-		match ix.index {
-			Index::Search(_) => {
-				self.remove_search_caches(ikb);
-			}
-			Index::MTree(_) => {
-				self.remove_mtree_caches(ikb);
-			}
-			Index::Hnsw(_) => {
-				self.remove_hnsw_index(ikb).await;
-			}
-			_ => {}
+		if matches!(ix.index, Index::Hnsw(_)) {
+			let ikb = IndexKeyBase::new(ns, db, ix)?;
+			self.remove_hnsw_index(ikb).await;
 		}
 		Ok(())
 	}
 
-	fn remove_search_caches(&self, ikb: IndexKeyBase) {
-		self.0.btree_trie_caches.remove_caches(&TreeNodeProvider::DocIds(ikb.clone()));
-		self.0.btree_trie_caches.remove_caches(&TreeNodeProvider::DocLengths(ikb.clone()));
-		self.0.btree_trie_caches.remove_caches(&TreeNodeProvider::Postings(ikb.clone()));
-		self.0.btree_fst_caches.remove_caches(&TreeNodeProvider::Terms(ikb));
-	}
-
-	fn remove_mtree_caches(&self, ikb: IndexKeyBase) {
-		self.0.btree_trie_caches.remove_caches(&TreeNodeProvider::DocIds(ikb.clone()));
-		self.0.mtree_caches.remove_caches(&TreeNodeProvider::Vector(ikb.clone()));
-	}
-
 	async fn remove_hnsw_index(&self, ikb: IndexKeyBase) {
 		self.0.hnsw_indexes.remove(&ikb).await;
-	}
-
-	pub async fn is_empty(&self) -> bool {
-		self.0.mtree_caches.is_empty()
-			&& self.0.btree_fst_caches.is_empty()
-			&& self.0.btree_trie_caches.is_empty()
-			&& self.0.hnsw_indexes.is_empty().await
 	}
 
 	pub(crate) fn mappers(&self) -> &Mappers {

--- a/crates/core/src/kvs/cache/tx/mod.rs
+++ b/crates/core/src/kvs/cache/tx/mod.rs
@@ -6,10 +6,10 @@ mod weight;
 pub(crate) use entry::Entry;
 pub(crate) use lookup::Lookup;
 
-pub(crate) type Cache = quick_cache::sync::Cache<key::Key, entry::Entry, weight::Weight>;
+pub(crate) type Cache = quick_cache::sync::Cache<key::Key, Entry, weight::Weight>;
 
 pub(crate) fn new() -> Cache {
-	quick_cache::sync::Cache::with_weighter(
+	Cache::with_weighter(
 		*crate::cnf::TRANSACTION_CACHE_SIZE,
 		*crate::cnf::TRANSACTION_CACHE_SIZE as u64,
 		weight::Weight,

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -1077,7 +1077,7 @@ impl Datastore {
 		let txn = self.transaction(val.writeable().into(), Optimistic).await?.enclose();
 		// Store the transaction
 		ctx.set_transaction(txn.clone());
-		// Free the context
+		// Freeze the context
 		let ctx = ctx.freeze();
 		// Compute the value
 		let res = stack.enter(|stk| val.compute(stk, &ctx, &opt, None)).finish().await;

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -43,7 +43,7 @@ pub struct Transaction {
 	tx: Mutex<Transactor>,
 	/// The query cache for this store
 	cache: Cache,
-	/// Tracks the index cache updates occurring during this transaction
+	/// Cache the index updates
 	index_caches: IndexTreeCaches,
 }
 

--- a/crates/core/src/sql/statements/analyze.rs
+++ b/crates/core/src/sql/statements/analyze.rs
@@ -50,14 +50,7 @@ impl AnalyzeStatement {
 					}
 					Index::MTree(p) => {
 						let tx = ctx.tx();
-						let mt = MTreeIndex::new(
-							ctx.get_index_stores(),
-							&tx,
-							ikb,
-							p,
-							TransactionType::Read,
-						)
-						.await?;
+						let mt = MTreeIndex::new(&tx, ikb, p, TransactionType::Read).await?;
 						mt.statistics(&tx).await?.into()
 					}
 					_ => {

--- a/crates/sdk/tests/remove.rs
+++ b/crates/sdk/tests/remove.rs
@@ -212,8 +212,6 @@ async fn remove_statement_index() -> Result<(), Error> {
 		}",
 	);
 	assert_eq!(tmp, val);
-	// Every index store cache has been removed
-	assert!(dbs.index_store().is_empty().await);
 	Ok(())
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

We have identified a situation where the full-text index can become corrupted. This may happen when attempting to ingest or update several records within the same transaction, where some of the records are valid, and others are invalid.
When the transaction is canceled, the index is not correctly rolled back, potentially leaving it in a corrupted state.

A typical error will be:
"Index is corrupted: TreeStore::load"

## What does this change do?

This change fixes the condition.

The tree node cache (the underlying structure used by the full-text search index) now persists only during the transaction, preventing race conditions and ensuring the index remains consistent in case of cancellation.

## What is your testing strategy?

Github action.

Additional manual tests meeting the condition have been done.

## Is this related to any issues?

https://discord.com/channels/902568124350599239/902568124350599242/1323144348631826475

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
