### PR TITLE
feat: allow for negative durations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,9 +1078,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ axum-extra = { version = "0.9.3", features = ["query", "typed-routing", "typed-h
 axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
 base64 = "0.21.5"
 bytes = "1.5.0"
-chrono = "0.4.38"
+chrono = "0.4.39"
 ciborium = "0.2.1"
 clap = { version = "4.4.11", features = ["env", "derive", "wrap_help", "unicode"] }
 futures = "0.3.30"
@@ -117,7 +117,7 @@ nix = { version = "0.27.1", features = ["signal", "user"] }
 
 [dev-dependencies]
 assert_fs = "1.0.13"
-chrono = "0.4.38"
+chrono = "0.4.39"
 env_logger = "0.10.1"
 jsonwebtoken = "9.3.0"
 opentelemetry-proto = { version = "0.7.0", features = ["gen-tonic", "metrics", "logs"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -64,7 +64,7 @@ blake3 = "1.5.3"
 bytes = "1.5.0"
 castaway = "0.2.3"
 cedar-policy = "2.4.2"
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.39", features = ["serde"] }
 ciborium = "0.2.1"
 dashmap = "5.5.3"
 derive = { version = "0.12.0", package = "surrealdb-derive" }

--- a/crates/core/src/cf/gc.rs
+++ b/crates/core/src/cf/gc.rs
@@ -39,7 +39,7 @@ pub async fn gc_ns(tx: &Transaction, ts: u64, ns: &str) -> Result<(), Error> {
 		// Fetch all tables
 		let tbs = tx.all_tb(ns, &db.name, None).await?;
 		// Get the database changefeed expiration
-		let db_cf_expiry = db.changefeed.map(|v| v.expiry.as_secs()).unwrap_or_default();
+		let db_cf_expiry = db.changefeed.map(|v| v.expiry.num_seconds().max(0) as u64).unwrap_or_default();
 		// Get the maximum table changefeed expiration
 		let tb_cf_expiry = tbs.as_ref().iter().fold(0, |acc, tb| match &tb.changefeed {
 			None => acc,
@@ -47,7 +47,7 @@ pub async fn gc_ns(tx: &Transaction, ts: u64, ns: &str) -> Result<(), Error> {
 				if cf.expiry.is_zero() {
 					acc
 				} else {
-					acc.max(cf.expiry.as_secs())
+					acc.max(cf.expiry.num_seconds().max(0) as u64)
 				}
 			}
 		});

--- a/crates/core/src/err/mod.rs
+++ b/crates/core/src/err/mod.rs
@@ -277,7 +277,7 @@ pub enum Error {
 
 	/// Invalid timeout
 	#[error("Invalid timeout: {0:?} seconds")]
-	InvalidTimeout(u64),
+	InvalidTimeout(String),
 
 	/// The query timedout
 	#[error("The query was not executed because it exceeded the timeout")]

--- a/crates/core/src/fnc/duration.rs
+++ b/crates/core/src/fnc/duration.rs
@@ -44,35 +44,35 @@ pub mod from {
 	use crate::sql::duration::Duration;
 	use crate::sql::value::Value;
 
-	pub fn days((val,): (u64,)) -> Result<Value, Error> {
+	pub fn days((val,): (i64,)) -> Result<Value, Error> {
 		Ok(Duration::from_days(val).into())
 	}
 
-	pub fn hours((val,): (u64,)) -> Result<Value, Error> {
+	pub fn hours((val,): (i64,)) -> Result<Value, Error> {
 		Ok(Duration::from_hours(val).into())
 	}
 
-	pub fn micros((val,): (u64,)) -> Result<Value, Error> {
+	pub fn micros((val,): (i64,)) -> Result<Value, Error> {
 		Ok(Duration::from_micros(val).into())
 	}
 
-	pub fn millis((val,): (u64,)) -> Result<Value, Error> {
+	pub fn millis((val,): (i64,)) -> Result<Value, Error> {
 		Ok(Duration::from_millis(val).into())
 	}
 
-	pub fn mins((val,): (u64,)) -> Result<Value, Error> {
+	pub fn mins((val,): (i64,)) -> Result<Value, Error> {
 		Ok(Duration::from_mins(val).into())
 	}
 
-	pub fn nanos((val,): (u64,)) -> Result<Value, Error> {
+	pub fn nanos((val,): (i64,)) -> Result<Value, Error> {
 		Ok(Duration::from_nanos(val).into())
 	}
 
-	pub fn secs((val,): (u64,)) -> Result<Value, Error> {
+	pub fn secs((val,): (i64,)) -> Result<Value, Error> {
 		Ok(Duration::from_secs(val).into())
 	}
 
-	pub fn weeks((val,): (u64,)) -> Result<Value, Error> {
+	pub fn weeks((val,): (i64,)) -> Result<Value, Error> {
 		Ok(Duration::from_weeks(val).into())
 	}
 }

--- a/crates/core/src/fnc/sleep.rs
+++ b/crates/core/src/fnc/sleep.rs
@@ -6,7 +6,8 @@ use crate::sql::Value;
 /// Sleep during the provided duration parameter.
 pub async fn sleep(ctx: &Context, (dur,): (Duration,)) -> Result<Value, Error> {
 	// Calculate the sleep duration
-	let dur = match (ctx.timeout(), dur.0) {
+	let dur = dur.to_std().map_err(|_| Error::InvalidTimeout(dur.to_string()))?;
+	let dur = match (ctx.timeout(), dur) {
 		(Some(t), d) if t < d => t,
 		(_, d) => d,
 	};

--- a/crates/core/src/fnc/time.rs
+++ b/crates/core/src/fnc/time.rs
@@ -6,32 +6,24 @@ use chrono::offset::TimeZone;
 use chrono::{DateTime, Datelike, DurationRound, Local, Timelike, Utc};
 
 pub fn ceil((val, duration): (Datetime, Duration)) -> Result<Value, Error> {
-	match chrono::Duration::from_std(*duration) {
-		Ok(d) => {
-			let floor_to_ceil = |floor: DateTime<Utc>| -> Option<DateTime<Utc>> {
-				if floor == *val {
-					Some(floor)
-				} else {
-					floor.checked_add_signed(d)
-				}
-			};
-			// Check for zero duration.
-			if d.is_zero() {
-				return Ok(Value::Datetime(val));
-			}
-			let result = val
-				.duration_trunc(d)
-				.ok()
-				.and_then(floor_to_ceil);
+	let floor_to_ceil = |floor: DateTime<Utc>| -> Option<DateTime<Utc>> {
+		if floor == *val {
+			Some(floor)
+		} else {
+			floor.checked_add_signed(*duration)
+		}
+	};
+	// Check for zero duration.
+	if duration.is_zero() {
+		return Ok(Value::Datetime(val));
+	}
+	let result = val
+		.duration_trunc(*duration)
+		.ok()
+		.and_then(floor_to_ceil);
 
-			match result {
-				Some(v) => Ok(v.into()),
-				_ => Err(Error::InvalidArguments {
-					name: String::from("time::ceil"),
-					message: String::from("The second argument must be a duration, and must be able to be represented as nanoseconds."),
-				}),
-			}
-		},
+	match result {
+		Some(v) => Ok(v.into()),
 		_ => Err(Error::InvalidArguments {
 			name: String::from("time::ceil"),
 			message: String::from("The second argument must be a duration, and must be able to be represented as nanoseconds."),
@@ -47,20 +39,12 @@ pub fn day((val,): (Option<Datetime>,)) -> Result<Value, Error> {
 }
 
 pub fn floor((val, duration): (Datetime, Duration)) -> Result<Value, Error> {
-	match chrono::Duration::from_std(*duration) {
-		Ok(d) => {
-			// Check for zero duration
-			if d.is_zero() {
-				return Ok(Value::Datetime(val));
-			}
-			match val.duration_trunc(d){
-				Ok(v) => Ok(v.into()),
-				_ => Err(Error::InvalidArguments {
-					name: String::from("time::floor"),
-					message: String::from("The second argument must be a duration, and must be able to be represented as nanoseconds."),
-				}),
-			}
-		},
+	// Check for zero duration
+	if duration.is_zero() {
+		return Ok(Value::Datetime(val));
+	}
+	match val.duration_trunc(*duration){
+		Ok(v) => Ok(v.into()),
 		_ => Err(Error::InvalidArguments {
 			name: String::from("time::floor"),
 			message: String::from("The second argument must be a duration, and must be able to be represented as nanoseconds."),
@@ -172,20 +156,12 @@ pub fn now(_: ()) -> Result<Value, Error> {
 }
 
 pub fn round((val, duration): (Datetime, Duration)) -> Result<Value, Error> {
-	match chrono::Duration::from_std(*duration) {
-		Ok(d) => {
-			// Check for zero duration
-			if d.is_zero() {
-				return Ok(Value::Datetime(val));
-			}
-			match val.duration_round(d) {
-				Ok(v) => Ok(v.into()),
-				_ => Err(Error::InvalidArguments {
-					name: String::from("time::round"),
-					message: String::from("The second argument must be a duration, and must be able to be represented as nanoseconds."),
-				}),
-			}
-		},
+	// Check for zero duration
+	if duration.is_zero() {
+		return Ok(Value::Datetime(val));
+	}
+	match val.duration_round(*duration) {
+		Ok(v) => Ok(v.into()),
 		_ => Err(Error::InvalidArguments {
 			name: String::from("time::round"),
 			message: String::from("The second argument must be a duration, and must be able to be represented as nanoseconds."),

--- a/crates/core/src/iam/issue.rs
+++ b/crates/core/src/iam/issue.rs
@@ -1,7 +1,6 @@
 use crate::err::Error;
 use crate::sql::duration::Duration;
 use crate::sql::Algorithm;
-use chrono::Duration as ChronoDuration;
 use chrono::Utc;
 use jsonwebtoken::EncodingKey;
 
@@ -26,14 +25,10 @@ pub(crate) fn config(alg: Algorithm, key: &str) -> Result<EncodingKey, Error> {
 pub(crate) fn expiration(d: Option<Duration>) -> Result<Option<i64>, Error> {
 	let exp = match d {
 		Some(v) => {
-			// The defined duration must be valid
-			match ChronoDuration::from_std(v.0) {
-				// The resulting expiration must be valid
-				Ok(d) => match Utc::now().checked_add_signed(d) {
-					Some(exp) => Some(exp.timestamp()),
-					None => return Err(Error::AccessInvalidExpiration),
-				},
-				Err(_) => return Err(Error::AccessInvalidDuration),
+			// The resulting expiration must be valid
+			match Utc::now().checked_add_signed(v.0) {
+				Some(exp) => Some(exp.timestamp()),
+				None => return Err(Error::AccessInvalidExpiration),
 			}
 		}
 		_ => None,

--- a/crates/core/src/kvs/clock.rs
+++ b/crates/core/src/kvs/clock.rs
@@ -101,7 +101,7 @@ impl IncFakeClock {
 	}
 
 	pub async fn now(&self) -> Timestamp {
-		self.now.fetch_add(self.increment.as_millis() as u64, Ordering::SeqCst);
+		self.now.fetch_add(self.increment.millis() as u64, Ordering::SeqCst);
 		Timestamp {
 			value: self.now.load(Ordering::SeqCst),
 		}

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -991,7 +991,7 @@ impl Datastore {
 		ctx.add_capabilities(self.capabilities.clone());
 		// Set the global query timeout
 		if let Some(timeout) = self.query_timeout {
-			ctx.add_timeout(timeout)?;
+			ctx.add_std_timeout(timeout)?;
 		}
 		// Setup the notification channel
 		if let Some(channel) = &self.notification_channel {
@@ -1063,7 +1063,7 @@ impl Datastore {
 		ctx.add_capabilities(self.capabilities.clone());
 		// Set the global query timeout
 		if let Some(timeout) = self.query_timeout {
-			ctx.add_timeout(timeout)?;
+			ctx.add_std_timeout(timeout)?;
 		}
 		// Setup the notification channel
 		if let Some(channel) = &self.notification_channel {

--- a/crates/core/src/rpc/format/cbor/convert.rs
+++ b/crates/core/src/rpc/format/cbor/convert.rs
@@ -133,13 +133,13 @@ impl TryFrom<Cbor> for Value {
 						},
 						_ => Err("Expected a CBOR text data type"),
 					},
-					// A custom [seconds: Option<u64>, nanos: Option<u32>] duration
+					// A custom [seconds: Option<i64>, nanos: Option<u32>] duration
 					TAG_CUSTOM_DURATION => match *v {
 						Data::Array(v) if v.len() <= 2 => {
 							let mut iter = v.into_iter();
 
 							let seconds = match iter.next() {
-								Some(Data::Integer(v)) => match u64::try_from(v) {
+								Some(Data::Integer(v)) => match i64::try_from(v) {
 									Ok(v) => v,
 									_ => return Err("Expected a CBOR integer data type"),
 								},
@@ -154,7 +154,10 @@ impl TryFrom<Cbor> for Value {
 								_ => 0,
 							};
 
-							Ok(Duration::new(seconds, nanos).into())
+							match Duration::new(seconds, nanos) {
+								Ok(v) => Ok(v.into()),
+								_ => Err("Expected a valid Duration value"),
+							}
 						}
 						_ => Err("Expected a CBOR array with at most 2 elements"),
 					},

--- a/crates/core/src/sql/changefeed.rs
+++ b/crates/core/src/sql/changefeed.rs
@@ -5,13 +5,12 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 use std::str;
-use std::time;
 
 #[revisioned(revision = 2)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[non_exhaustive]
 pub struct ChangeFeed {
-	pub expiry: time::Duration,
+	pub expiry: chrono::Duration,
 	#[revision(start = 2)]
 	pub store_diff: bool,
 }
@@ -28,7 +27,7 @@ impl Display for ChangeFeed {
 impl Default for ChangeFeed {
 	fn default() -> Self {
 		Self {
-			expiry: time::Duration::from_secs(0),
+			expiry: chrono::Duration::seconds(0),
 			store_diff: false,
 		}
 	}

--- a/crates/core/src/sql/datetime.rs
+++ b/crates/core/src/sql/datetime.rs
@@ -1,4 +1,3 @@
-use crate::err::Error;
 use crate::sql::duration::Duration;
 use crate::sql::strand::Strand;
 use crate::syn;
@@ -12,7 +11,6 @@ use std::str;
 use std::str::FromStr;
 
 use super::escape::quote_str;
-use super::value::TrySub;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Datetime";
 
@@ -119,19 +117,6 @@ impl Display for Datetime {
 impl ops::Sub<Self> for Datetime {
 	type Output = Duration;
 	fn sub(self, other: Self) -> Duration {
-		match (self.0 - other.0).to_std() {
-			Ok(d) => Duration::from(d),
-			Err(_) => Duration::default(),
-		}
-	}
-}
-
-impl TrySub for Datetime {
-	type Output = Duration;
-	fn try_sub(self, other: Self) -> Result<Duration, Error> {
-		(self.0 - other.0)
-			.to_std()
-			.map_err(|_| Error::ArithmeticNegativeOverflow(format!("{self} - {other}")))
-			.map(Duration::from)
+		(self.0 - other.0).into()
 	}
 }

--- a/crates/core/src/sql/statements/access.rs
+++ b/crates/core/src/sql/statements/access.rs
@@ -822,12 +822,12 @@ async fn compute_purge(
 		let purge_expired = stmt.expired
 			&& gr.expiration.as_ref().map_or(false, |exp| {
 				now.timestamp() >= exp.timestamp() // Prevent saturating when not expired yet.
-					&& (now.timestamp().saturating_sub(exp.timestamp()) as u64) > stmt.grace.secs()
+					&& now.timestamp().saturating_sub(exp.timestamp()) > stmt.grace.secs()
 			});
 		let purge_revoked = stmt.revoked
 			&& gr.revocation.as_ref().map_or(false, |rev| {
 				now.timestamp() >= rev.timestamp() // Prevent saturating when not revoked yet.
-					&& (now.timestamp().saturating_sub(rev.timestamp()) as u64) > stmt.grace.secs()
+					&& now.timestamp().saturating_sub(rev.timestamp()) > stmt.grace.secs()
 			});
 		// If it should, delete the grant and append the redacted version to the result.
 		if purge_expired || purge_revoked {

--- a/crates/core/src/sql/value/serde/ser/mod.rs
+++ b/crates/core/src/sql/value/serde/ser/mod.rs
@@ -27,7 +27,7 @@ where
 		rust_decimal::Decimal as v => Ok(v.into()),
 		sql::Strand as v => Ok(v.into()),
 		sql::Duration as v => Ok(v.into()),
-		core::time::Duration as v => Ok(v.into()),
+		chrono::Duration as v => Ok(v.into()),
 		sql::Datetime as v => Ok(v.into()),
 		chrono::DateTime<chrono::Utc> as v => Ok(v.into()),
 		sql::Uuid as v => Ok(v.into()),

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -440,6 +440,12 @@ impl From<&str> for Value {
 	}
 }
 
+impl From<chrono::Duration> for Value {
+	fn from(v: chrono::Duration) -> Self {
+		Value::Duration(Duration::from(v))
+	}
+}
+
 impl From<DateTime<Utc>> for Value {
 	fn from(v: DateTime<Utc>) -> Self {
 		Value::Datetime(Datetime::from(v))
@@ -800,12 +806,12 @@ impl TryFrom<Value> for bool {
 	}
 }
 
-impl TryFrom<Value> for std::time::Duration {
+impl TryFrom<Value> for chrono::Duration {
 	type Error = Error;
 	fn try_from(value: Value) -> Result<Self, Self::Error> {
 		match value {
 			Value::Duration(x) => Ok(x.into()),
-			_ => Err(Error::TryFrom(value.to_string(), "time::Duration")),
+			_ => Err(Error::TryFrom(value.to_string(), "chrono::Duration")),
 		}
 	}
 }
@@ -970,7 +976,7 @@ impl Value {
 			Value::Object(v) => !v.is_empty(),
 			Value::Strand(v) => !v.is_empty(),
 			Value::Number(v) => v.is_truthy(),
-			Value::Duration(v) => v.as_nanos() > 0,
+			Value::Duration(v) => v.is_zero(),
 			_ => false,
 		}
 	}
@@ -3012,7 +3018,7 @@ impl TrySub for Value {
 	fn try_sub(self, other: Self) -> Result<Self, Error> {
 		Ok(match (self, other) {
 			(Self::Number(v), Self::Number(w)) => Self::Number(v.try_sub(w)?),
-			(Self::Datetime(v), Self::Datetime(w)) => Self::Duration(v.try_sub(w)?),
+			(Self::Datetime(v), Self::Datetime(w)) => Self::Duration(v - w),
 			(Self::Datetime(v), Self::Duration(w)) => Self::Datetime(w.try_sub(v)?),
 			(Self::Duration(v), Self::Datetime(w)) => Self::Datetime(v.try_sub(w)?),
 			(Self::Duration(v), Self::Duration(w)) => Self::Duration(v.try_sub(w)?),

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -72,7 +72,7 @@ targets = []
 arrayvec = "0.7.6"
 bincode = "1.3.3"
 channel = { version = "2.3.1", package = "async-channel" }
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.39", features = ["serde"] }
 dmp = "0.2.0"
 futures = "0.3.30"
 geo = { version = "0.28.0", features = ["use-serde"] }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Allow for negative durations.

## What does this change do?

* [x] Change inner Duration type, from `std::time::Duration` to `chrono::Duration`
* [x] Update RPC conversion
* [x] Update functions
* [x] Update `display` function
* [ ] Update parser (allow for the minus symbol "-" at the start)
* [ ] Update & add more tests

**BREAKING CHANGE 1**

The storage data is currently `std::time::Duration`. Moving to `chrono::Duration` would require data migration.

**BREAKING CHANGE 2**

Seconds component will move from `u64` to `i64`. Previously stored Duration may not be compatible due to overflow.

## What is your testing strategy?

Unit tests

## Is this related to any issues?

Closes #3428 

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
