### PR TITLE
Improve HTTP database function error messages

### DIFF
--- a/crates/sdk/tests/function.rs
+++ b/crates/sdk/tests/function.rs
@@ -7037,7 +7037,7 @@ pub async fn function_http_error() -> Result<(), Error> {
 	);
 
 	Test::new(&query).await?.expect_error(
-		"There was an error processing a remote HTTP request: Internal Server Error",
+		"There was an error processing a remote HTTP request: 500 Internal Server Error",
 	)?;
 
 	server.verify().await;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

This pull-request makes 3 changes:

- When calling `http::get()`, `http:post()`, `http::put()`, `http::patch()`, and `http::delete()`, the error messages can be a little obscure, returning only the HTTP status code, and no other information about the error.

- In addition, when the HTTP body is a string, the HTTP request body is automatically encoded as JSON, which is probably not the desired behaviour.

- Finally, when the HTTP body is a SurrealQL bytes value the  `Content-Type: application/octet-stream` header is added automatically, which might not be desired.

## What does this change do?

This pull-request makes 3 changes:

- Improves HTTP error messages, giving the status code, and some additional information if available.

- SurrealQL byte values are now sent as raw bytes, SurrealQL strings are sent as raw strings, and other SurrealQL values are encoded as JSON automatically.

- Finally, the automatic addition of the `Content-Type: application/octet-stream` header when the HTTP body was a SurrealQL bytes value has been removed.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #2384.

## Does this change need documentation?

- [ ] Documentation to be added

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
