### PR TITLE
Support variables in shortest path

### DIFF
--- a/crates/core/src/sql/part.rs
+++ b/crates/core/src/sql/part.rs
@@ -684,7 +684,10 @@ impl RecurseInstruction {
 			Self::Shortest {
 				expects,
 				inclusive,
-			} => walk_paths!(stk, ctx, opt, doc, rec, finished, inclusive, Some(expects)),
+			} => {
+				let expects = expects.compute(stk, ctx, opt, doc).await?.coerce_to_record()?;
+				walk_paths!(stk, ctx, opt, doc, rec, finished, inclusive, Some(&expects))
+			}
 			Self::Collect {
 				inclusive,
 			} => {

--- a/crates/core/src/sql/part.rs
+++ b/crates/core/src/sql/part.rs
@@ -685,7 +685,8 @@ impl RecurseInstruction {
 				expects,
 				inclusive,
 			} => {
-				let expects = expects.compute(stk, ctx, opt, doc).await?.coerce_to_record()?;
+				let expects =
+					Value::from(expects.compute(stk, ctx, opt, doc).await?.coerce_to_record()?);
 				walk_paths!(stk, ctx, opt, doc, rec, finished, inclusive, Some(&expects))
 			}
 			Self::Collect {

--- a/crates/core/src/syn/parser/idiom.rs
+++ b/crates/core/src/syn/parser/idiom.rs
@@ -3,7 +3,7 @@ use reblessive::Stk;
 use crate::{
 	sql::{
 		part::{DestructurePart, Recurse, RecurseInstruction},
-		Dir, Edges, Field, Fields, Graph, Ident, Idiom, Part, Table, Tables, Value,
+		Dir, Edges, Field, Fields, Graph, Ident, Idiom, Param, Part, Table, Tables, Value,
 	},
 	syn::{
 		error::bail,
@@ -445,7 +445,18 @@ impl Parser<'_> {
 			},
 			"shortest" => {
 				expected!(self, t!("="));
-				let expects = Value::from(self.parse_thing(ctx).await?);
+				let token = self.peek();
+				let expects = match token.kind {
+					TokenKind::Parameter => {
+						Value::from(self.next_token_value::<Param>()?)
+					},
+					x if Parser::kind_is_identifier(x) => {
+						Value::from(self.parse_thing(ctx).await?)
+					}
+					_ => {
+						unexpected!(self, token, "a param or thing");
+					}
+				};
 				let mut inclusive = false;
 				loop {
 					parse_option!(

--- a/crates/sdk/tests/idiom.rs
+++ b/crates/sdk/tests/idiom.rs
@@ -1164,7 +1164,8 @@ async fn idiom_recursion_shortest_path() -> Result<(), Error> {
 			{ id: a:5 },
 		];
 
-		a:1.{..+shortest=a:5}.links;
+		LET $rid = a:5;
+		a:1.{..+shortest=$rid}.links;
 		a:1.{..+shortest=a:5+inclusive}.links;
 	"#;
 
@@ -1179,6 +1180,7 @@ async fn idiom_recursion_shortest_path() -> Result<(), Error> {
 			{ id: a:5 },
 		]",
 		)?
+		.expect_val("NONE")?
 		.expect_val(
 			"[
 			a:4,

--- a/crates/sdk/tests/idiom.rs
+++ b/crates/sdk/tests/idiom.rs
@@ -1226,7 +1226,7 @@ async fn idiom_recursion_invalid_instruction() -> Result<(), Error> {
 	expect_parse_error!("a:1.{..+shortest}", "Unexpected token `}`, expected =");
 	expect_parse_error!(
 		"a:1.{..+shortest=123}",
-		"Unexpected token `a number`, expected an identifier"
+		"Unexpected token `a number`, expected a param or thing"
 	);
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Internal suggestion to support variables in shortest path syntax

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Adds support for variables in shortest path

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Adjusted a test to test this new behaviour

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Can have an example in docs, only variables containing a record id are supported!

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
