### PR TITLE
Change bearer key storage and verification to only use hashes

### DIFF
--- a/crates/core/src/iam/signin.rs
+++ b/crates/core/src/iam/signin.rs
@@ -786,6 +786,7 @@ mod tests {
 	use crate::iam::Role;
 	use chrono::Duration;
 	use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+	use regex::Regex;
 	use std::collections::HashMap;
 
 	struct TestLevel {
@@ -1178,6 +1179,79 @@ mod tests {
 				Err(Error::InvalidAuth) => {} // ok
 				Err(e) => panic!("Expected InvalidAuth, but got: {e}"),
 			}
+		}
+		// Test that only the hash of the refresh token is stored
+		{
+			let ds = Datastore::new("memory").await.unwrap();
+			let sess = Session::owner().with_ns("test").with_db("test");
+			ds.execute(
+				r#"
+				DEFINE ACCESS user ON DATABASE TYPE RECORD
+					SIGNIN (
+						SELECT * FROM user WHERE name = $user AND crypto::argon2::compare(pass, $pass)
+					)
+					WITH REFRESH
+					DURATION FOR GRANT 1w, FOR SESSION 2h
+				;
+
+				CREATE user:test CONTENT {
+					name: 'user',
+					pass: crypto::argon2::generate('pass')
+				}
+				"#,
+				&sess,
+				None,
+			)
+			.await
+			.unwrap();
+
+			// Signin with the user
+			let mut sess = Session {
+				ns: Some("test".to_string()),
+				db: Some("test".to_string()),
+				..Default::default()
+			};
+			let mut vars: HashMap<&str, Value> = HashMap::new();
+			vars.insert("user", "user".into());
+			vars.insert("pass", "pass".into());
+			let res = db_access(
+				&ds,
+				&mut sess,
+				"test".to_string(),
+				"test".to_string(),
+				"user".to_string(),
+				vars.into(),
+			)
+			.await;
+
+			assert!(res.is_ok(), "Failed to signin with credentials: {:?}", res);
+			let refresh = match res {
+				Ok(data) => match data.refresh {
+					Some(refresh) => refresh,
+					None => panic!("Refresh token was not returned"),
+				},
+				Err(e) => panic!("Failed to signin with credentials: {e}"),
+			};
+
+			// Extract grant identifier from refresh token
+			let id = refresh.split("-").collect::<Vec<&str>>()[2];
+
+			// Test that returned refresh token is in plain text
+			let ok = Regex::new(r"surreal-refresh-[a-zA-Z0-9]{12}-[a-zA-Z0-9]{24}").unwrap();
+			assert!(ok.is_match(&refresh), "Output '{}' doesn't match regex '{}'", refresh, ok);
+
+			// Get the stored bearer key representing the refresh token
+			let tx = ds.transaction(Read, Optimistic).await.unwrap().enclose();
+			let grant = tx.get_db_access_grant("test", "test", "user".into(), id).await.unwrap();
+			let key = match &grant.grant {
+				access::Grant::Bearer(grant) => grant.key.clone(),
+				_ => panic!("Incorrect grant type returned, expected a bearer grant"),
+			};
+			tx.cancel().await.unwrap();
+
+			// Test that the returned key is a SHA-256 hash
+			let ok = Regex::new(r"[0-9a-f]{64}").unwrap();
+			assert!(ok.is_match(&key), "Output '{}' doesn't match regex '{}'", key, ok);
 		}
 	}
 
@@ -3009,6 +3083,78 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 					),
 				}
 			}
+
+			// Test that only the key hash is stored
+			{
+				let ds = Datastore::new("memory").await.unwrap();
+				let sess = Session::owner().with_ns("test").with_db("test");
+				let res = ds
+					.execute(
+						&format!(
+							r#"
+						DEFINE ACCESS api ON {} TYPE BEARER FOR USER
+							DURATION FOR SESSION 2h
+						;
+						DEFINE USER tobie ON {} ROLES EDITOR;
+						ACCESS api ON {} GRANT FOR USER tobie;
+						"#,
+							level.level, level.level, level.level
+						),
+						&sess,
+						None,
+					)
+					.await
+					.unwrap();
+
+				// Get the bearer key from grant
+				let result = if let Ok(res) = &res.last().unwrap().result {
+					res.clone()
+				} else {
+					panic!("Unable to retrieve bearer key grant");
+				};
+				let grant = result
+					.coerce_to_object()
+					.unwrap()
+					.get("grant")
+					.unwrap()
+					.clone()
+					.coerce_to_object()
+					.unwrap();
+				let id = grant.get("id").unwrap().clone().as_string();
+				let key = grant.get("key").unwrap().clone().as_string();
+
+				// Test that returned key is in plain text
+				let ok = Regex::new(r"surreal-bearer-[a-zA-Z0-9]{12}-[a-zA-Z0-9]{24}").unwrap();
+				assert!(ok.is_match(&key), "Output '{}' doesn't match regex '{}'", key, ok);
+
+				// Get the stored bearer grant
+				let tx = ds.transaction(Read, Optimistic).await.unwrap().enclose();
+				let grant = match level.level {
+					"DB" => tx
+						.get_db_access_grant(
+							level.ns.unwrap(),
+							level.db.unwrap(),
+							"api".into(),
+							&id,
+						)
+						.await
+						.unwrap(),
+					"NS" => {
+						tx.get_ns_access_grant(level.ns.unwrap(), "api".into(), &id).await.unwrap()
+					}
+					"ROOT" => tx.get_root_access_grant("api".into(), &id).await.unwrap(),
+					_ => panic!("Unsupported level"),
+				};
+				let key = match &grant.grant {
+					access::Grant::Bearer(grant) => grant.key.clone(),
+					_ => panic!("Incorrect grant type returned, expected a bearer grant"),
+				};
+				tx.cancel().await.unwrap();
+
+				// Test that the returned key is a SHA-256 hash
+				let ok = Regex::new(r"[0-9a-f]{64}").unwrap();
+				assert!(ok.is_match(&key), "Output '{}' doesn't match regex '{}'", key, ok);
+			}
 		}
 	}
 
@@ -3827,6 +3973,59 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 					res
 				),
 			}
+		}
+
+		// Test that only the key hash is stored
+		{
+			let ds = Datastore::new("memory").await.unwrap();
+			let sess = Session::owner().with_ns("test").with_db("test");
+			let res = ds
+				.execute(
+					r#"
+					DEFINE ACCESS api ON DATABASE TYPE BEARER FOR RECORD
+						DURATION FOR SESSION 2h
+					;
+					ACCESS api ON DATABASE GRANT FOR RECORD user:test;
+					"#,
+					&sess,
+					None,
+				)
+				.await
+				.unwrap();
+
+			// Get the bearer key from grant
+			let result = if let Ok(res) = &res.last().unwrap().result {
+				res.clone()
+			} else {
+				panic!("Unable to retrieve bearer key grant");
+			};
+			let grant = result
+				.coerce_to_object()
+				.unwrap()
+				.get("grant")
+				.unwrap()
+				.clone()
+				.coerce_to_object()
+				.unwrap();
+			let id = grant.get("id").unwrap().clone().as_string();
+			let key = grant.get("key").unwrap().clone().as_string();
+
+			// Test that returned key is in plain text
+			let ok = Regex::new(r"surreal-bearer-[a-zA-Z0-9]{12}-[a-zA-Z0-9]{24}").unwrap();
+			assert!(ok.is_match(&key), "Output '{}' doesn't match regex '{}'", key, ok);
+
+			// Get the stored bearer grant
+			let tx = ds.transaction(Read, Optimistic).await.unwrap().enclose();
+			let grant = tx.get_db_access_grant("test", "test", "api".into(), &id).await.unwrap();
+			let key = match &grant.grant {
+				access::Grant::Bearer(grant) => grant.key.clone(),
+				_ => panic!("Incorrect grant type returned, expected a bearer grant"),
+			};
+			tx.cancel().await.unwrap();
+
+			// Test that the returned key is a SHA-256 hash
+			let ok = Regex::new(r"[0-9a-f]{64}").unwrap();
+			assert!(ok.is_match(&key), "Output '{}' doesn't match regex '{}'", key, ok);
 		}
 	}
 

--- a/crates/core/src/sql/statements/access.rs
+++ b/crates/core/src/sql/statements/access.rs
@@ -8,10 +8,12 @@ use crate::sql::{
 	AccessType, Array, Base, Cond, Datetime, Duration, Ident, Object, Strand, Thing, Uuid, Value,
 };
 use derive::Store;
+use md5::Digest;
 use rand::Rng;
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
@@ -246,8 +248,11 @@ pub struct GrantRecord {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct GrantBearer {
-	pub id: Ident,   // Key ID
-	pub key: Strand, // Key. Will be stored but afterwards returned redacted.
+	pub id: Ident, // Key ID
+	// Key. Will not be stored and be returned as redacted.
+	// Immediately after generation, it will contain the plaintext key.
+	// Will be hashed before storage so that the plaintext key is not stored.
+	pub key: Strand,
 }
 
 impl GrantBearer {
@@ -263,6 +268,22 @@ impl GrantBearer {
 		Self {
 			id: id.clone().into(),
 			key: format!("{prefix}-{id}-{secret}").into(),
+		}
+	}
+
+	pub fn hashed(self) -> Self {
+		// The hash of the bearer key is stored to mitigate the impact of a read-only compromise.
+		// We use SHA-256 as the key needs to be verified performantly for every operation.
+		// Unlike with passwords, brute force and rainbow tables are infeasable due to the key length.
+		// When hashing the bearer keys, the prefix and key identifier are kept as salt.
+		let mut hasher = Sha256::new();
+		hasher.update(self.key.as_string());
+		let hash = hasher.finalize();
+		let hash_hex = format!("{hash:x}").into();
+
+		Self {
+			key: hash_hex,
+			..self
 		}
 	}
 }
@@ -343,18 +364,21 @@ pub async fn create_grant(
 				// Subject associated with the grant.
 				subject: stmt.subject.to_owned(),
 				// The contents of the grant.
-				grant: Grant::Bearer(grant),
+				grant: Grant::Bearer(grant.clone()),
 			};
 
 			// Create the grant.
 			// On the very unlikely event of a collision, "put" will return an error.
 			let res = match base {
 				Base::Db => {
+					// Create a hashed version of the grant for storage.
+					let mut gr_store = gr.clone();
+					gr_store.grant = Grant::Bearer(grant.hashed());
 					let key =
 						crate::key::database::access::gr::new(opt.ns()?, opt.db()?, &gr.ac, &gr.id);
 					txn.get_or_add_ns(opt.ns()?, opt.strict).await?;
 					txn.get_or_add_db(opt.ns()?, opt.db()?, opt.strict).await?;
-					txn.put(key, &gr, None).await
+					txn.put(key, &gr_store, None).await
 				}
 				_ => return Err(Error::AccessLevelMismatch),
 			};
@@ -375,6 +399,8 @@ pub async fn create_grant(
 				opt.auth.id()
 			);
 
+			// Return the original version of the grant.
+			// This is the only time the the plaintext key is returned.
 			Ok(gr)
 		}
 		AccessType::Bearer(at) => {
@@ -422,27 +448,30 @@ pub async fn create_grant(
 				// Subject associated with the grant.
 				subject: stmt.subject.to_owned(),
 				// The contents of the grant.
-				grant: Grant::Bearer(grant),
+				grant: Grant::Bearer(grant.clone()),
 			};
 
 			// Create the grant.
 			// On the very unlikely event of a collision, "put" will return an error.
+			// Create a hashed version of the grant for storage.
+			let mut gr_store = gr.clone();
+			gr_store.grant = Grant::Bearer(grant.hashed());
 			let res = match base {
 				Base::Root => {
 					let key = crate::key::root::access::gr::new(&gr.ac, &gr.id);
-					txn.put(key, &gr, None).await
+					txn.put(key, &gr_store, None).await
 				}
 				Base::Ns => {
 					let key = crate::key::namespace::access::gr::new(opt.ns()?, &gr.ac, &gr.id);
 					txn.get_or_add_ns(opt.ns()?, opt.strict).await?;
-					txn.put(key, &gr, None).await
+					txn.put(key, &gr_store, None).await
 				}
 				Base::Db => {
 					let key =
 						crate::key::database::access::gr::new(opt.ns()?, opt.db()?, &gr.ac, &gr.id);
 					txn.get_or_add_ns(opt.ns()?, opt.strict).await?;
 					txn.get_or_add_db(opt.ns()?, opt.db()?, opt.strict).await?;
-					txn.put(key, &gr, None).await
+					txn.put(key, &gr_store, None).await
 				}
 				_ => {
 					return Err(Error::Unimplemented(
@@ -468,6 +497,8 @@ pub async fn create_grant(
 				opt.auth.id()
 			);
 
+			// Return the original version of the grant.
+			// This is the only time the the plaintext key is returned.
 			Ok(gr)
 		}
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

To ensure that an hypothetical read-only compromise of the datastore cannot leverage any stored bearer keys in order to gain write access to data. Since SurrealDB already does not allow accessing the contents of the bearer key again after its creation, it can be stored hashed without affecting the user experience in any way.

## What does this change do?

Replaces the key value of the bearer grants for its SHA-256 (i.e. SHA-2) before storage. The value used for the hash also includes the key prefix and identifier as a sort of salt. When verifying a bearer key, the hash of the provided key and the stored key will be compared with a time constant comparison function to ensure that the value of the hash is not leaked via a timing side channel.

The decision to use SHA-2 over specific password hashing algorithms was made to avoid introducing significant latency in the key verification process. SHA-2 is designed to be fast, whereas password hashing algorithms are slow by design, potentially introducing around 200ms of latency for each request using a bearer key, which is unacceptable in the case of SurrealDB. For bearer keys, SHA-256 provides sufficient security and collision resistance. Unlike passwords, in the event that an attacker were able to somehow obtain bearer key hashes, cracking through brute force or rainbow tables would be infeasible due to the key length.

**Note:** This is a breaking change to the storage of experimental bearer keys. If you were trialing the feature, updating to a version with this change will cause existing bearer keys to fail verification, as the key value will be treated as a hash instead of a plaintext key. You will need to remove (i.e. revoke and purge) any existing bearer grants and create them again or just remove the access method that was used to created, which will also completely remove all existing bearer grants created with it.

## What is your testing strategy?

- Ensure that existing tests using bearer keys keep working.
- Add new tests to verify that hashes for bearer keys are actually stored instead of the plaintext key.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
