### PR TITLE
Fix nightly version prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5425,7 +5425,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surreal"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "argon2",
  "assert_fs",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "arrayvec",
  "async-channel",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "addr",
  "ahash 0.8.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surreal"
 publish = false
 edition = "2021"
-version = "2.1.3"
+version = "2.1.4"
 license-file = "LICENSE"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surrealdb-core"
 publish = true
 edition = "2021"
-version = "2.1.3"
+version = "2.1.4"
 rust-version = "1.80.1"
 readme = "README.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "surrealdb"
 publish = true
 edition = "2021"
-version = "2.1.3"
+version = "2.1.4"
 rust-version = "1.80.1"
 readme = "CARGO.md"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
@@ -105,7 +105,7 @@ semver = { version = "1.0.20", features = ["serde"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 serde-content = "0.1.0"
-surrealdb-core = { version = "=2.1.3", default-features = false, path = "../core", package = "surrealdb-core" }
+surrealdb-core = { version = "=2.1.4", default-features = false, path = "../core", package = "surrealdb-core" }
 thiserror = "1.0.63"
 tokio-util = { version = "0.7.11", features = ["compat"] }
 tracing = "0.1.40"


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Nightly version still shows 2.1.3 as the version prefix.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Updates the version on main.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
