### PR TITLE
Fix the `cargo-acl` job

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -109,6 +109,8 @@ jobs:
           cargo install --debug --locked cargo-acl
           sudo apt-get -y update
           sudo apt-get install -y bubblewrap
+          sudo ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/
+          sudo apparmor_parser /etc/apparmor.d/bwrap-userns-restrict
 
       - name: Check dependencies for unauthorized access
         env:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -106,10 +106,24 @@ jobs:
 
       - name: Install cargo-acl
         run: |
-          sudo apt-get -y update
-          sudo apt-get install -y bubblewrap
-          which bwrap
           cargo install --debug --locked cargo-acl
+          sudo apt-get install -y bubblewrap
+      
+      # See https://etbe.coker.com.au/2024/04/24/ubuntu-24-04-bubblewrap/
+      - name: Configure bubblewrap
+        run: |
+          sudo cat << EOF > /etc/apparmor.d/bwrap
+          abi <abi/4.0>,
+          include <tunables/global>
+
+          profile bwrap /usr/bin/bwrap flags=(unconfined) {
+            userns,
+
+            # Site-specific additions and overrides. See local/README for details.
+            include if exists <local/bwrap>
+          }
+          EOF
+          sudo systemctl reload apparmor
 
       - name: Check dependencies for unauthorized access
         env:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -106,11 +106,10 @@ jobs:
 
       - name: Install cargo-acl
         run: |
-          cargo install --debug --locked cargo-acl
           sudo apt-get -y update
           sudo apt-get install -y bubblewrap
-          sudo ln -s /usr/share/apparmor/extra-profiles/bwrap-userns-restrict /etc/apparmor.d/
-          sudo apparmor_parser /etc/apparmor.d/bwrap-userns-restrict
+          which bwrap
+          cargo install --debug --locked cargo-acl
 
       - name: Check dependencies for unauthorized access
         env:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -112,7 +112,7 @@ jobs:
       # See https://etbe.coker.com.au/2024/04/24/ubuntu-24-04-bubblewrap/
       - name: Configure bubblewrap
         run: |
-          cat << EOF
+          cat << EOF > bwrap
           abi <abi/4.0>,
           include <tunables/global>
 
@@ -122,7 +122,8 @@ jobs:
             # Site-specific additions and overrides. See local/README for details.
             include if exists <local/bwrap>
           }
-          EOF | sudo tee -a /etc/apparmor.d/bwrap
+          EOF
+          sudo mv bwrap /etc/apparmor.d/
           sudo systemctl reload apparmor
 
       - name: Check dependencies for unauthorized access

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -112,7 +112,7 @@ jobs:
       # See https://etbe.coker.com.au/2024/04/24/ubuntu-24-04-bubblewrap/
       - name: Configure bubblewrap
         run: |
-          sudo cat << EOF > /etc/apparmor.d/bwrap
+          cat << EOF
           abi <abi/4.0>,
           include <tunables/global>
 
@@ -122,7 +122,7 @@ jobs:
             # Site-specific additions and overrides. See local/README for details.
             include if exists <local/bwrap>
           }
-          EOF
+          EOF | sudo tee -a /etc/apparmor.d/bwrap
           sudo systemctl reload apparmor
 
       - name: Check dependencies for unauthorized access

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Install cargo-acl
         run: |
           cargo install --debug --locked cargo-acl
+          sudo apt-get -y update
           sudo apt-get install -y bubblewrap
 
       - name: Check dependencies for unauthorized access


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

`ubuntu-latest` has now moved to Ubuntu 24.04. This breaks the `cargo-acl` job.

> bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It configures bubblewrap to fix the permission issue.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
