### PR TITLE
Add `Tx::count()`, `Tr::count()`, and `kvs::count()` methods

### DIFF
--- a/crates/core/src/cnf/mod.rs
+++ b/crates/core/src/cnf/mod.rs
@@ -42,15 +42,12 @@ pub static DATASTORE_CACHE_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_DATASTORE_CACHE_SIZE", usize, 1_000);
 
 /// The maximum number of keys that should be scanned at once in general queries.
-pub static NORMAL_FETCH_SIZE: LazyLock<u32> = lazy_env_parse!("SURREAL_NORMAL_FETCH_SIZE", u32, 50);
+pub static NORMAL_FETCH_SIZE: LazyLock<u32> =
+	lazy_env_parse!("SURREAL_NORMAL_FETCH_SIZE", u32, 500);
 
 /// The maximum number of keys that should be scanned at once for export queries.
 pub static EXPORT_BATCH_SIZE: LazyLock<u32> =
 	lazy_env_parse!("SURREAL_EXPORT_BATCH_SIZE", u32, 1000);
-
-/// The maximum number of keys that should be fetched when streaming range scans in a Scanner.
-pub static MAX_STREAM_BATCH_SIZE: LazyLock<u32> =
-	lazy_env_parse!("SURREAL_MAX_STREAM_BATCH_SIZE", u32, 1000);
 
 /// The maximum number of keys that should be scanned at once per concurrent indexing batch.
 pub static INDEXING_BATCH_SIZE: LazyLock<u32> =

--- a/crates/core/src/kvs/batch.rs
+++ b/crates/core/src/kvs/batch.rs
@@ -1,35 +1,19 @@
 use super::Key;
-use super::Val;
-use super::Version;
 use std::ops::Range;
 
 /// A batch scan result returned from the [`Transaction::batch`] or [`Transactor::batch`] functions.
 #[derive(Debug)]
-pub struct Batch {
+pub struct Batch<T> {
 	pub next: Option<Range<Key>>,
-	pub values: Vec<(Key, Val)>,
-	pub versioned_values: Vec<(Key, Val, Version, bool)>,
+	pub result: Vec<T>,
 }
 
-impl Batch {
+impl<T> Batch<T> {
 	/// Create a new batch scan result.
-	pub fn new(next: Option<Range<Key>>, values: Vec<(Key, Val)>) -> Self {
+	pub fn new(next: Option<Range<Key>>, result: Vec<T>) -> Self {
 		Self {
 			next,
-			values,
-			versioned_values: vec![],
-		}
-	}
-
-	/// Create a new batch scan result with versioned values.
-	pub fn new_versioned(
-		next: Option<Range<Key>>,
-		versioned_values: Vec<(Key, Val, Version, bool)>,
-	) -> Self {
-		Self {
-			next,
-			values: vec![],
-			versioned_values,
+			result,
 		}
 	}
 }

--- a/crates/core/src/kvs/export.rs
+++ b/crates/core/src/kvs/export.rs
@@ -334,23 +334,21 @@ impl Transaction {
 
 		while let Some(rng) = next {
 			if cfg.versions {
-				let batch = self.batch_versions(rng, *EXPORT_BATCH_SIZE).await?;
+				let batch = self.batch_keys_vals_versions(rng, *EXPORT_BATCH_SIZE).await?;
 				next = batch.next;
-				let values = batch.versioned_values;
 				// If there are no versioned values, return early.
-				if values.is_empty() {
+				if batch.result.is_empty() {
 					break;
 				}
-				self.export_versioned_data(values, chn).await?;
+				self.export_versioned_data(batch.result, chn).await?;
 			} else {
-				let batch = self.batch(rng, *EXPORT_BATCH_SIZE, true, None).await?;
+				let batch = self.batch_keys_vals(rng, *EXPORT_BATCH_SIZE, None).await?;
 				next = batch.next;
 				// If there are no values, return early.
-				let values = batch.values;
-				if values.is_empty() {
+				if batch.result.is_empty() {
 					break;
 				}
-				self.export_regular_data(values, chn).await?;
+				self.export_regular_data(batch.result, chn).await?;
 			}
 			// Fetch more records
 			continue;

--- a/crates/core/src/kvs/node.rs
+++ b/crates/core/src/kvs/node.rs
@@ -161,9 +161,10 @@ impl Datastore {
 					// Pause and yield execution
 					yield_now!();
 					// Fetch the next batch of keys and values
-					let res = catch!(txn, txn.batch(rng, *NORMAL_FETCH_SIZE, true, None).await);
+					let max = *NORMAL_FETCH_SIZE;
+					let res = catch!(txn, txn.batch_keys_vals(rng, max, None).await);
 					next = res.next;
-					for (k, v) in res.values.iter() {
+					for (k, v) in res.result.iter() {
 						// Decode the data for this live query
 						let val: Live = v.into();
 						// Get the key for this node live query
@@ -249,9 +250,13 @@ impl Datastore {
 					let end = crate::key::table::lq::suffix(&ns.name, &db.name, &tb.name);
 					let mut next = Some(beg..end);
 					while let Some(rng) = next {
-						let res = catch!(txn, txn.batch(rng, *NORMAL_FETCH_SIZE, true, None).await);
+						// Pause and yield execution
+						yield_now!();
+						// Fetch the next batch of keys and values
+						let max = *NORMAL_FETCH_SIZE;
+						let res = catch!(txn, txn.batch_keys_vals(rng, max, None).await);
 						next = res.next;
-						for (k, v) in res.values.iter() {
+						for (k, v) in res.result.iter() {
 							// Decode the LIVE query statement
 							let stm: LiveStatement = v.into();
 							// Get the node id and the live query id

--- a/crates/core/src/kvs/scanner.rs
+++ b/crates/core/src/kvs/scanner.rs
@@ -1,7 +1,6 @@
 use super::tx::Transaction;
 use super::Key;
 use super::Val;
-use crate::cnf::MAX_STREAM_BATCH_SIZE;
 use crate::err::Error;
 use futures::stream::Stream;
 use futures::Future;
@@ -67,12 +66,10 @@ impl Stream for Scanner<'_, (Key, Val)> {
 		}
 		// Check if there is no pending future task
 		if self.future.is_none() {
-			// Set the max number of results to fetch
-			let num = std::cmp::min(*MAX_STREAM_BATCH_SIZE, self.batch);
 			// Clone the range to use when scanning
 			let range = self.range.clone();
 			// Prepare a future to scan for results
-			self.future = Some(Box::pin(self.store.scan(range, num, self.version)));
+			self.future = Some(Box::pin(self.store.scan(range, self.batch, self.version)));
 		}
 		// Try to resolve the future
 		match self.future.as_mut().unwrap().poll_unpin(cx) {
@@ -134,12 +131,10 @@ impl Stream for Scanner<'_, Key> {
 		}
 		// Check if there is no pending future task
 		if self.future.is_none() {
-			// Set the max number of results to fetch
-			let num = std::cmp::min(*MAX_STREAM_BATCH_SIZE, self.batch);
 			// Clone the range to use when scanning
 			let range = self.range.clone();
 			// Prepare a future to scan for results
-			self.future = Some(Box::pin(self.store.keys(range, num, self.version)));
+			self.future = Some(Box::pin(self.store.keys(range, self.batch, self.version)));
 		}
 		// Try to resolve the future
 		match self.future.as_mut().unwrap().poll_unpin(cx) {

--- a/crates/core/src/kvs/tests/raw.rs
+++ b/crates/core/src/kvs/tests/raw.rs
@@ -297,8 +297,9 @@ async fn batch() {
 	tx.commit().await.unwrap();
 	// Create a readonly transaction
 	let mut tx = ds.transaction(Read, Optimistic).await.unwrap().inner();
-	let res = tx.batch("test1".as_bytes().."test9".as_bytes(), u32::MAX, true, None).await.unwrap();
-	let val = res.values;
+	let rng = "test1".as_bytes().."test9".as_bytes();
+	let res = tx.batch_keys_vals(rng, u32::MAX, None).await.unwrap();
+	let val = res.result;
 	assert_eq!(val.len(), 5);
 	assert_eq!(val[0].0, b"test1");
 	assert_eq!(val[0].1, b"1");
@@ -313,8 +314,9 @@ async fn batch() {
 	tx.cancel().await.unwrap();
 	// Create a readonly transaction
 	let mut tx = ds.transaction(Read, Optimistic).await.unwrap().inner();
-	let res = tx.batch("test2".as_bytes().."test4".as_bytes(), u32::MAX, true, None).await.unwrap();
-	let val = res.values;
+	let rng = "test2".as_bytes().."test4".as_bytes();
+	let res = tx.batch_keys_vals(rng, u32::MAX, None).await.unwrap();
+	let val = res.result;
 	assert_eq!(val.len(), 2);
 	assert_eq!(val[0].0, b"test2");
 	assert_eq!(val[0].1, b"2");
@@ -323,8 +325,9 @@ async fn batch() {
 	tx.cancel().await.unwrap();
 	// Create a readonly transaction
 	let mut tx = ds.transaction(Read, Optimistic).await.unwrap().inner();
-	let res = tx.batch("test2".as_bytes().."test4".as_bytes(), u32::MAX, true, None).await.unwrap();
-	let val = res.values;
+	let rng = "test2".as_bytes().."test4".as_bytes();
+	let res = tx.batch_keys_vals(rng, u32::MAX, None).await.unwrap();
+	let val = res.result;
 	assert_eq!(val.len(), 2);
 	assert_eq!(val[0].0, b"test2");
 	assert_eq!(val[0].1, b"2");

--- a/crates/core/src/kvs/tr.rs
+++ b/crates/core/src/kvs/tr.rs
@@ -487,6 +487,21 @@ impl Transactor {
 		expand_inner!(&mut self.inner, v => { v.batch_keys(beg..end, batch, version).await })
 	}
 
+	/// Count the total number of keys within a range in the datastore.
+	///
+	/// This function fetches the total count, in batches, with multiple requests to the underlying datastore.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tr", skip_all)]
+	pub async fn count<K>(&mut self, rng: Range<K>) -> Result<usize, Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		let beg: Key = rng.start.into();
+		let end: Key = rng.end.into();
+		let rng = beg.as_slice()..end.as_slice();
+		trace!(target: TARGET, rng = rng.sprint(), "Count");
+		expand_inner!(&mut self.inner, v => { v.count(beg..end).await })
+	}
+
 	/// Retrieve a batched scan over a specific range of keys in the datastore.
 	///
 	/// This function fetches key-value pairs, in batches, with multiple requests to the underlying datastore.

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -3,6 +3,7 @@ use super::tr::Check;
 use super::Convert;
 use super::Key;
 use super::Val;
+use super::Version;
 use crate::cnf::NORMAL_FETCH_SIZE;
 use crate::dbs::node::Node;
 use crate::err::Error;
@@ -307,30 +308,49 @@ impl Transaction {
 
 	/// Retrieve a batched scan over a specific range of keys in the datastore.
 	///
-	/// This function fetches the key-value pairs in batches, with multiple requests to the underlying datastore.
+	/// This function fetches the keys in batches, with multiple requests to the underlying datastore.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
-	pub async fn batch<K>(
+	pub async fn batch_keys<K>(
 		&self,
 		rng: Range<K>,
 		batch: u32,
-		values: bool,
 		version: Option<u64>,
-	) -> Result<Batch, Error>
+	) -> Result<Batch<Key>, Error>
 	where
 		K: Into<Key> + Debug,
 	{
-		self.lock().await.batch(rng, batch, values, version).await
+		self.lock().await.batch_keys(rng, batch, version).await
 	}
 
-	/// Retrieve a batched scan to scan all versions over a specific range of keys in the datastore.
+	/// Retrieve a batched scan over a specific range of keys in the datastore.
 	///
 	/// This function fetches the key-value pairs in batches, with multiple requests to the underlying datastore.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
-	pub async fn batch_versions<K>(&self, rng: Range<K>, batch: u32) -> Result<Batch, Error>
+	pub async fn batch_keys_vals<K>(
+		&self,
+		rng: Range<K>,
+		batch: u32,
+		version: Option<u64>,
+	) -> Result<Batch<(Key, Val)>, Error>
 	where
 		K: Into<Key> + Debug,
 	{
-		self.lock().await.batch_versions(rng, batch).await
+		self.lock().await.batch_keys_vals(rng, batch, version).await
+	}
+
+	/// Retrieve a batched scan over a specific range of keys in the datastore.
+	///
+	/// This function fetches the key-value-version pairs in batches, with multiple requests to the underlying datastore.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
+	pub async fn batch_keys_vals_versions<K>(
+		&self,
+		rng: Range<K>,
+		batch: u32,
+	) -> Result<Batch<(Key, Val, Version, bool)>, Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		self.lock().await.batch_keys_vals_versions(rng, batch).await
 	}
 
 	/// Retrieve a stream over a specific range of keys in the datastore.

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -306,6 +306,17 @@ impl Transaction {
 		self.lock().await.scan(rng, limit, version).await
 	}
 
+	/// Count the total number of keys within a range in the datastore.
+	///
+	/// This function fetches the total count, in batches, with multiple requests to the underlying datastore.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
+	pub async fn count<K>(&self, rng: Range<K>) -> Result<usize, Error>
+	where
+		K: Into<Key> + Debug,
+	{
+		self.lock().await.count(rng).await
+	}
+
 	/// Retrieve a batched scan over a specific range of keys in the datastore.
 	///
 	/// This function fetches the keys in batches, with multiple requests to the underlying datastore.


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

Add a count method to the internal `Transaction`, `Transactor` and storage engine APIs.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
