### PR TITLE
Hide and warn against using client side transaction API

### DIFF
--- a/crates/sdk/src/api/method/mod.rs
+++ b/crates/sdk/src/api/method/mod.rs
@@ -55,13 +55,17 @@ mod version;
 mod tests;
 
 pub use authenticate::Authenticate;
-#[doc(hidden)] // Not supported yet
+/// Not supported yet
+#[doc(hidden)]
 pub use begin::Begin;
-#[doc(hidden)] // Not supported yet
+/// Not supported yet
+#[doc(hidden)]
 pub use begin::Transaction;
-#[doc(hidden)] // Not supported yet
+/// Not supported yet
+#[doc(hidden)]
 pub use cancel::Cancel;
-#[doc(hidden)] // Not supported yet
+/// Not supported yet
+#[doc(hidden)]
 pub use commit::Commit;
 pub use content::Content;
 pub use create::Create;
@@ -253,8 +257,11 @@ where
 		}
 	}
 
-	#[doc(hidden)] // Not supported yet
+	/// Not supported yet
+	#[doc(hidden)]
+	#[cfg(surrealdb_unstable)] // Mark this API as unstable
 	pub fn transaction(self) -> Begin<C> {
+		warn!("Client side transactions are not yet supported. This API doesn't do anything yet.");
 		Begin {
 			client: self,
 		}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Client side transactions are not supported yet. Some users seem to be accidentally using this API.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

The API has always been hidden but the "not supported yet" comment may not be visible when using code completion. This PR upgrades the comment to a doc comment. It also marks the API as unstable so it's not available unless when using `surrealdb_unstable` and we now also log a warning when one actually invokes the method.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Action.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
