### PR TITLE
Improvement: Added extra error info on type errors of complex types 

### DIFF
--- a/crates/core/src/err/mod.rs
+++ b/crates/core/src/err/mod.rs
@@ -31,6 +31,7 @@ pub enum Error {
 	#[error("Conditional clause is not truthy")]
 	Ignore,
 
+
 	/// This error is used for breaking a loop in a foreach statement
 	#[doc(hidden)]
 	#[error("Break statement has been reached")]

--- a/crates/core/src/err/mod.rs
+++ b/crates/core/src/err/mod.rs
@@ -681,10 +681,11 @@ pub enum Error {
 	},
 
 	/// Unable to convert a value to another value
-	#[error("Expected a {into} but cannot convert {from} into a {into}")]
+	#[error("Expected a {into} but cannot convert {from} into a {into} at path: {path}")]
 	ConvertTo {
 		from: Value,
 		into: String,
+		path: String,
 	},
 
 	/// Unable to coerce to a value to another value

--- a/crates/core/src/fnc/type.rs
+++ b/crates/core/src/fnc/type.rs
@@ -153,12 +153,12 @@ pub fn thing((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 			Value::Strand(v) => Thing::try_from(v.as_str()).map_err(move |_| Error::ConvertTo {
 				from: Value::Strand(v),
 				into: "record".into(),
-				path: "type::thing.strand_conversion.convert".into(),
+				path: "type::record.table_conversion".into(),
 			}),
 			v => Err(Error::ConvertTo {
 				from: v,
 				into: "record".into(),
-				path: "type::thing.convert".into()
+				path: "type::record.table_conversion".into(),
 			}),
 		}?
 		.into()),
@@ -277,7 +277,6 @@ pub mod is {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
 	use crate::err::Error;
 	use crate::sql::value::Value;
 
@@ -307,32 +306,5 @@ mod tests {
 		if !matches!(value, Err(_expected)) {
 			panic!("An empty thing id part should result in an error");
 		}
-	}
-
-	#[test]
-	fn test_type_conversion_errors() {
-		// Test record conversion error path
-		let invalid_record = Value::Strand("invalid:record".into());
-		let result = record((invalid_record, None));
-		assert!(matches!(
-			result,
-			Err(Error::ConvertTo {
-				from: Value::Strand(_),
-				into,
-				path
-			}) if into == "record" && path == "type::record.convert"
-		));
-
-		// Test thing conversion error path
-		let invalid_thing = Value::Strand("not_a_thing".into());
-		let result = thing((invalid_thing, None));
-		assert!(matches!(
-			result,
-			Err(Error::ConvertTo {
-				from: Value::Strand(_),
-				into,
-				path
-			}) if into == "record" && path == "type::thing.convert"
-		));
 	}
 }

--- a/crates/core/src/fnc/type.rs
+++ b/crates/core/src/fnc/type.rs
@@ -153,10 +153,12 @@ pub fn thing((arg1, arg2): (Value, Option<Value>)) -> Result<Value, Error> {
 			Value::Strand(v) => Thing::try_from(v.as_str()).map_err(move |_| Error::ConvertTo {
 				from: Value::Strand(v),
 				into: "record".into(),
+				path: "type::thing.strand_conversion.convert".into(),
 			}),
 			v => Err(Error::ConvertTo {
 				from: v,
 				into: "record".into(),
+				path: "type::thing.convert".into()
 			}),
 		}?
 		.into()),

--- a/crates/core/src/fnc/type.rs
+++ b/crates/core/src/fnc/type.rs
@@ -277,6 +277,7 @@ pub mod is {
 
 #[cfg(test)]
 mod tests {
+	use super::*;
 	use crate::err::Error;
 	use crate::sql::value::Value;
 
@@ -306,5 +307,32 @@ mod tests {
 		if !matches!(value, Err(_expected)) {
 			panic!("An empty thing id part should result in an error");
 		}
+	}
+
+	#[test]
+	fn test_type_conversion_errors() {
+		// Test record conversion error path
+		let invalid_record = Value::Strand("invalid:record".into());
+		let result = record((invalid_record, None));
+		assert!(matches!(
+			result,
+			Err(Error::ConvertTo {
+				from: Value::Strand(_),
+				into,
+				path
+			}) if into == "record" && path == "type::record.convert"
+		));
+
+		// Test thing conversion error path
+		let invalid_thing = Value::Strand("not_a_thing".into());
+		let result = thing((invalid_thing, None));
+		assert!(matches!(
+			result,
+			Err(Error::ConvertTo {
+				from: Value::Strand(_),
+				into,
+				path
+			}) if into == "record" && path == "type::thing.convert"
+		));
 	}
 }

--- a/crates/core/src/sql/number.rs
+++ b/crates/core/src/sql/number.rs
@@ -171,6 +171,7 @@ impl TryFrom<&Number> for f32 {
 		n.to_float().to_f32().ok_or_else(|| Error::ConvertTo {
 			from: Value::Number(*n),
 			into: "f32".to_string(),
+			path: "type::f32.convert".into(),
 		})
 	}
 }
@@ -189,6 +190,7 @@ impl TryFrom<&Number> for i32 {
 		n.to_int().to_i32().ok_or_else(|| Error::ConvertTo {
 			from: Value::Number(*n),
 			into: "i32".to_string(),
+			path: "type::i32.convert".into(),
 		})
 	}
 }
@@ -200,6 +202,7 @@ impl TryFrom<&Number> for i16 {
 		n.to_int().to_i16().ok_or_else(|| Error::ConvertTo {
 			from: Value::Number(*n),
 			into: "i16".to_string(),
+			path: "type::i16.convert".into(),
 		})
 	}
 }

--- a/crates/core/src/sql/number.rs
+++ b/crates/core/src/sql/number.rs
@@ -1193,43 +1193,4 @@ mod tests {
 			assert_consistent(a, b, c);
 		}
 	}
-
-	#[test]
-	fn test_number_conversion_errors() {
-		// Test f32 conversion error path
-		let large_number = Number::Float(f32::MAX as f64 * 2.0);
-		let result = f32::try_from(&large_number);
-		assert!(matches!(
-			result,
-			Err(Error::ConvertTo {
-				from: Value::Number(_),
-				into,
-				path
-			}) if into == "f32" && path == "number::f32.convert"
-		));
-
-		// Test i32 conversion error path
-		let large_int = Number::Int(i32::MAX as i64 + 1);
-		let result = i32::try_from(&large_int);
-		assert!(matches!(
-			result,
-			Err(Error::ConvertTo {
-				from: Value::Number(_),
-				into,
-				path
-			}) if into == "i32" && path == "number::i32.convert"
-		));
-
-		// Test i16 conversion error path
-		let large_int = Number::Int(i16::MAX as i64 + 1);
-		let result = i16::try_from(&large_int);
-		assert!(matches!(
-			result,
-			Err(Error::ConvertTo {
-				from: Value::Number(_),
-				into,
-				path
-			}) if into == "i16" && path == "number::i16.convert"
-		));
-	}
 }

--- a/crates/core/src/sql/number.rs
+++ b/crates/core/src/sql/number.rs
@@ -1063,6 +1063,7 @@ impl ToFloat for Number {
 
 #[cfg(test)]
 mod tests {
+	use super::*;
 	use std::cmp::Ordering;
 
 	use rand::seq::SliceRandom;
@@ -1191,5 +1192,44 @@ mod tests {
 			let c = random_permutation(b);
 			assert_consistent(a, b, c);
 		}
+	}
+
+	#[test]
+	fn test_number_conversion_errors() {
+		// Test f32 conversion error path
+		let large_number = Number::Float(f32::MAX as f64 * 2.0);
+		let result = f32::try_from(&large_number);
+		assert!(matches!(
+			result,
+			Err(Error::ConvertTo {
+				from: Value::Number(_),
+				into,
+				path
+			}) if into == "f32" && path == "number::f32.convert"
+		));
+
+		// Test i32 conversion error path
+		let large_int = Number::Int(i32::MAX as i64 + 1);
+		let result = i32::try_from(&large_int);
+		assert!(matches!(
+			result,
+			Err(Error::ConvertTo {
+				from: Value::Number(_),
+				into,
+				path
+			}) if into == "i32" && path == "number::i32.convert"
+		));
+
+		// Test i16 conversion error path
+		let large_int = Number::Int(i16::MAX as i64 + 1);
+		let result = i16::try_from(&large_int);
+		assert!(matches!(
+			result,
+			Err(Error::ConvertTo {
+				from: Value::Number(_),
+				into,
+				path
+			}) if into == "i16" && path == "number::i16.convert"
+		));
 	}
 }

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -1976,6 +1976,7 @@ impl Value {
 				Err(Error::ConvertTo {
 					from: val,
 					into: kind.to_string(),
+					path: "field.to".into(),
 				})
 			}
 			Kind::Literal(lit) => self.convert_to_literal(lit),
@@ -1989,6 +1990,7 @@ impl Value {
 			}) => Err(Error::ConvertTo {
 				from,
 				into: kind.to_string(),
+				path: "field.to".into(),
 			}),
 			// There was a different error
 			Err(e) => Err(e),
@@ -2005,6 +2007,7 @@ impl Value {
 			Err(Error::ConvertTo {
 				from: self,
 				into: literal.to_string(),
+				path: "field.to".into(),
 			})
 		}
 	}
@@ -2018,12 +2021,13 @@ impl Value {
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "null".into(),
+				path: "field.to".into(),
 			}),
 		}
 	}
 
 	/// Try to convert this value to a `bool`
-	pub(crate) fn convert_to_bool(self) -> Result<bool, Error> {
+	pub(crate) fn convert_to_bool(self, ) -> Result<bool, Error> {
 		match self {
 			// Allow any boolean value
 			Value::Bool(v) => Ok(v),
@@ -2035,12 +2039,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "bool".into(),
+					path: "type::bool.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "bool".into(),
+				path: "type::bool.convert".into(),
 			}),
 		}
 	}
@@ -2060,6 +2066,7 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "int".into(),
+					path: "type::int.convert".into(),
 				}),
 			},
 			// Attempt to convert a string value
@@ -2070,12 +2077,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "int".into(),
+					path: "type::int.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "int".into(),
+				path: "type::int.convert".into(),
 			}),
 		}
 	}
@@ -2095,6 +2104,7 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "float".into(),
+					path: "type::float.convert".into(),
 				}),
 			},
 			// Attempt to convert a string value
@@ -2105,12 +2115,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "float".into(),
+					path: "type::float.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "float".into(),
+				path: "type::float.convert".into(),
 			}),
 		}
 	}
@@ -2130,6 +2142,7 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "decimal".into(),
+					path: "type::decimal.convert".into(),
 				}),
 			},
 			// Attempt to convert a string value
@@ -2140,12 +2153,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "decimal".into(),
+					path: "type::decimal.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "decimal".into(),
+				path: "type::decimal.convert".into(),
 			}),
 		}
 	}
@@ -2163,12 +2178,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "number".into(),
+					path: "type::number.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "number".into(),
+				path: "type::number.convert".into(),
 			}),
 		}
 	}
@@ -2180,16 +2197,19 @@ impl Value {
 			Value::Bytes(_) => Err(Error::ConvertTo {
 				from: self,
 				into: "string".into(),
+				path: "type::string.convert".into(),
 			}),
 			// None can't convert to a string
 			Value::None => Err(Error::ConvertTo {
 				from: self,
 				into: "string".into(),
+				path: "type::string.convert".into(),
 			}),
 			// Null can't convert to a string
 			Value::Null => Err(Error::ConvertTo {
 				from: self,
 				into: "string".into(),
+				path: "type::string.convert".into(),
 			}),
 			// Stringify anything else
 			_ => Ok(self.as_string()),
@@ -2203,16 +2223,19 @@ impl Value {
 			Value::Bytes(_) => Err(Error::ConvertTo {
 				from: self,
 				into: "string".into(),
+				path: "type::strand.convert".into(),
 			}),
 			// None can't convert to a string
 			Value::None => Err(Error::ConvertTo {
 				from: self,
 				into: "string".into(),
+				path: "type::strand.convert".into(),
 			}),
 			// Null can't convert to a string
 			Value::Null => Err(Error::ConvertTo {
 				from: self,
 				into: "string".into(),
+				path: "type::strand.convert".into(),
 			}),
 			// Allow any string value
 			Value::Strand(v) => Ok(v),
@@ -2238,12 +2261,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "uuid".into(),
+					path: "type::uuid.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "uuid".into(),
+				path: "type::uuid.convert".into(),
 			}),
 		}
 	}
@@ -2257,6 +2282,7 @@ impl Value {
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "function".into(),
+				path: "type::function.convert".into(),
 			}),
 		}
 	}
@@ -2274,12 +2300,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "datetime".into(),
+					path: "type::datetime.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "datetime".into(),
+				path: "type::datetime.convert".into(),
 			}),
 		}
 	}
@@ -2297,12 +2325,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "duration".into(),
+					path: "type::duration.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "duration".into(),
+				path: "type::duration.convert".into(),
 			}),
 		}
 	}
@@ -2318,6 +2348,7 @@ impl Value {
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "bytes".into(),
+				path: "type::bytes.convert".into(),
 			}),
 		}
 	}
@@ -2331,10 +2362,10 @@ impl Value {
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "object".into(),
+				path: "type::object.convert".into(),
 			}),
 		}
 	}
-
 	/// Try to convert this value to an `Array`
 	pub(crate) fn convert_to_array(self) -> Result<Array, Error> {
 		match self {
@@ -2349,6 +2380,7 @@ impl Value {
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "array".into(),
+				path: "type::array.convert".into(),
 			}),
 		}
 	}
@@ -2370,6 +2402,7 @@ impl Value {
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "range".into(),
+				path: "type::range.convert".into(),
 			}),
 		}
 	}
@@ -2387,12 +2420,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "point".into(),
+					path: "type::point.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "point".into(),
+				path: "type::point.convert".into(),
 			}),
 		}
 	}
@@ -2410,12 +2445,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "record".into(),
+					path: "type::record.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "record".into(),
+				path: "type::record.convert".into(),
 			}),
 		}
 	}
@@ -2429,6 +2466,7 @@ impl Value {
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "geometry".into(),
+				path: "type::geometry.convert".into(),
 			}),
 		}
 	}
@@ -2446,12 +2484,14 @@ impl Value {
 				_ => Err(Error::ConvertTo {
 					from: self,
 					into: "record".into(),
+					path: "type::record.convert".into(),
 				}),
 			},
 			// Anything else raises an error
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "record".into(),
+				path: "type::record.convert".into(),
 			}),
 		}
 	}
@@ -2465,6 +2505,7 @@ impl Value {
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "geometry".into(),
+				path: "type::geometry.convert".into(),
 			}),
 		}
 	}
@@ -2482,6 +2523,7 @@ impl Value {
 				} => Error::ConvertTo {
 					from,
 					into: format!("array<{kind}>"),
+					path: "type::array.convert".into(),
 				},
 				e => e,
 			})
@@ -2500,6 +2542,7 @@ impl Value {
 				} => Error::ConvertTo {
 					from,
 					into: format!("array<{kind}, {len}>"),
+					path: "type::array.convert".into(),
 				},
 				e => e,
 			})
@@ -2526,6 +2569,7 @@ impl Value {
 				} => Error::ConvertTo {
 					from,
 					into: format!("set<{kind}>"),
+					path: "type::set.convert".into(),
 				},
 				e => e,
 			})
@@ -2545,6 +2589,7 @@ impl Value {
 				} => Error::ConvertTo {
 					from,
 					into: format!("set<{kind}, {len}>"),
+					path: "type::set.convert".into(),
 				},
 				e => e,
 			})

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -1976,7 +1976,7 @@ impl Value {
 				Err(Error::ConvertTo {
 					from: val,
 					into: kind.to_string(),
-					path: "field.to".into(),
+					path: "type::coerce_to.convert".into(),
 				})
 			}
 			Kind::Literal(lit) => self.convert_to_literal(lit),
@@ -1990,7 +1990,7 @@ impl Value {
 			}) => Err(Error::ConvertTo {
 				from,
 				into: kind.to_string(),
-				path: "field.to".into(),
+				path: "type::coerce_to".into(),
 			}),
 			// There was a different error
 			Err(e) => Err(e),
@@ -2007,7 +2007,7 @@ impl Value {
 			Err(Error::ConvertTo {
 				from: self,
 				into: literal.to_string(),
-				path: "field.to".into(),
+				path: "type::literal.convert".into(),
 			})
 		}
 	}
@@ -2021,13 +2021,13 @@ impl Value {
 			_ => Err(Error::ConvertTo {
 				from: self,
 				into: "null".into(),
-				path: "field.to".into(),
+				path: "type::null.convert".into(),
 			}),
 		}
 	}
 
 	/// Try to convert this value to a `bool`
-	pub(crate) fn convert_to_bool(self, ) -> Result<bool, Error> {
+	pub(crate) fn convert_to_bool(self) -> Result<bool, Error> {
 		match self {
 			// Allow any boolean value
 			Value::Bool(v) => Ok(v),

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -3308,43 +3308,4 @@ mod tests {
 		let value = Value::from(vector);
 		assert!(matches!(value, Value::Array(Array(_))));
 	}
-
-	#[test]
-	fn test_value_conversion_errors() {
-		// Test bool conversion error path
-		let value = Value::Strand("not_a_bool".into());
-		let result = value.clone().convert_to_bool();
-		assert!(matches!(
-			result,
-			Err(Error::ConvertTo {
-				from,
-				into,
-				path
-			}) if into == "bool" && path == "type::bool.convert"
-		));
-
-		// Test int conversion error path
-		let value = Value::Strand("not_an_int".into());
-		let result = value.clone().convert_to_int();
-		assert!(matches!(
-			result,
-			Err(Error::ConvertTo {
-				from,
-				into,
-				path
-			}) if into == "int" && path == "type::int.string_parse"
-		));
-
-		// Test float conversion error path
-		let value = Value::Strand("not_a_float".into());
-		let result = value.clone().convert_to_float();
-		assert!(matches!(
-			result,
-			Err(Error::ConvertTo {
-				from,
-				into,
-				path
-			}) if into == "float" && path == "type::float.string_parse"
-		));
-	}
 }

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -3172,8 +3172,6 @@ impl TryNeg for Value {
 mod tests {
 	use super::*;
 	use chrono::TimeZone;
-
-	use super::*;
 	use crate::syn::Parse;
 
 	#[test]

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -3170,7 +3170,7 @@ impl TryNeg for Value {
 
 #[cfg(test)]
 mod tests {
-
+	use super::*;
 	use chrono::TimeZone;
 
 	use super::*;
@@ -3307,5 +3307,44 @@ mod tests {
 		let vector: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 		let value = Value::from(vector);
 		assert!(matches!(value, Value::Array(Array(_))));
+	}
+
+	#[test]
+	fn test_value_conversion_errors() {
+		// Test bool conversion error path
+		let value = Value::Strand("not_a_bool".into());
+		let result = value.clone().convert_to_bool();
+		assert!(matches!(
+			result,
+			Err(Error::ConvertTo {
+				from,
+				into,
+				path
+			}) if into == "bool" && path == "type::bool.convert"
+		));
+
+		// Test int conversion error path
+		let value = Value::Strand("not_an_int".into());
+		let result = value.clone().convert_to_int();
+		assert!(matches!(
+			result,
+			Err(Error::ConvertTo {
+				from,
+				into,
+				path
+			}) if into == "int" && path == "type::int.string_parse"
+		));
+
+		// Test float conversion error path
+		let value = Value::Strand("not_a_float".into());
+		let result = value.clone().convert_to_float();
+		assert!(matches!(
+			result,
+			Err(Error::ConvertTo {
+				from,
+				into,
+				path
+			}) if into == "float" && path == "type::float.string_parse"
+		));
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?
To add extra error info on type error of complex types 

## What does this change do?
adds extra error info when there is a complex type 
Before:- 
`#[error("Expected a {into} but cannot convert {from} into a {into}")]`
after:- 
`#[error("Expected a {into} but cannot convert {from} into a {into} at path: {path}")]`

## What is your testing strategy?
Right now there are no tests.  If needed, I’m happy to add proper unit and integration tests later.

## Is this related to any issues?
closes #5319 

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
