### PR TITLE
Add `SURREAL_COUNT_BATCH_SIZE` environment variable

### DIFF
--- a/crates/core/src/cnf/mod.rs
+++ b/crates/core/src/cnf/mod.rs
@@ -49,6 +49,10 @@ pub static NORMAL_FETCH_SIZE: LazyLock<u32> =
 pub static EXPORT_BATCH_SIZE: LazyLock<u32> =
 	lazy_env_parse!("SURREAL_EXPORT_BATCH_SIZE", u32, 1000);
 
+/// The maximum number of keys that should be scanned at once for count queries.
+pub static COUNT_BATCH_SIZE: LazyLock<u32> =
+	lazy_env_parse!("SURREAL_COUNT_BATCH_SIZE", u32, 10_000);
+
 /// The maximum size of the priority queue triggering usage of the priority queue for the result collector.
 pub static MAX_ORDER_LIMIT_PRIORITY_QUEUE_SIZE: LazyLock<u32> =
 	lazy_env_parse!("SURREAL_MAX_ORDER_LIMIT_PRIORITY_QUEUE_SIZE", u32, 1000);

--- a/crates/core/src/kvs/api.rs
+++ b/crates/core/src/kvs/api.rs
@@ -1,5 +1,6 @@
 use super::kv::Add;
 use super::tr::Check;
+use crate::cnf::COUNT_BATCH_SIZE;
 use crate::cnf::NORMAL_FETCH_SIZE;
 use crate::err::Error;
 use crate::key::debug::Sprintable;
@@ -334,7 +335,7 @@ pub trait Transaction {
 		let end: Key = rng.end.into();
 		let mut next = Some(beg..end);
 		while let Some(rng) = next {
-			let res = self.batch_keys(rng, 10_000, None).await?;
+			let res = self.batch_keys(rng, *COUNT_BATCH_SIZE, None).await?;
 			next = res.next;
 			len += res.result.len();
 		}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The internal `Tx::count()`, `Tr::count()` and `kvs::count()` methods use batching to count the total number of key-value entries within a range. The batch processing for this was initially set to `10,000`.

## What does this change do?

This pull-request adds a `SURREAL_COUNT_BATCH_SIZE` environment variable so that the number of records fetched at once when counting key-value entries can be customised.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [ ] Documentation to be added.

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
