### PR TITLE
Fix changefeed test

### DIFF
--- a/crates/sdk/tests/api/mod.rs
+++ b/crates/sdk/tests/api/mod.rs
@@ -1228,14 +1228,10 @@ async fn changefeed() {
 	let response = db.query(sql).await.unwrap();
 	response.check().unwrap();
 	// Create and update users
-	let sql = "
-        CREATE user:amos SET name = 'Amos';
-        CREATE user:jane SET name = 'Jane';
-        UPDATE user:amos SET name = 'AMOS';
-    ";
+	db.query("CREATE user:amos SET name = 'Amos';").await.unwrap().check().unwrap();
+	db.query("CREATE user:jane SET name = 'Jane';").await.unwrap().check().unwrap();
+	db.query("UPDATE user:amos SET name = 'AMOS';").await.unwrap().check().unwrap();
 	let table = "user";
-	let response = db.query(sql).await.unwrap();
-	response.check().unwrap();
 	let users: Vec<RecordBuf> = db
 		.update(table)
 		.content(Record {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The changefeed test has been failing sporadically for quite some time now, e.g. https://github.com/surrealdb/surrealdb/actions/runs/12748917383/job/35530183633 and https://github.com/surrealdb/surrealdb/actions/runs/12749585886/job/35532365377

The backtrace has indicated that the source of the write-write conflict is the test's initial CREATE and UPDATE part:
```
        CREATE user:amos SET name = 'Amos';
        CREATE user:jane SET name = 'Jane';
        UPDATE user:amos SET name = 'AMOS';
```

## What does this change do?

This fix takes the simplest approach by serialising the transactions. This has no effect on the actual changefeed logic.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
