### PR TITLE
feat: implement parameters for ORDER BY

### DIFF
--- a/crates/core/src/dbs/result.rs
+++ b/crates/core/src/dbs/result.rs
@@ -46,9 +46,7 @@ impl Results {
 			}
 			return match ordering {
 				Ordering::Random => Ok(Self::MemoryRandom(MemoryRandom::new(None))),
-				Ordering::Order(orders) => {
-					Ok(Self::MemoryOrdered(MemoryOrdered::new(orders.clone(), None)))
-				}
+				Ordering::Order(_orders) => Ok(Self::MemoryOrdered(MemoryOrdered::new(None))),
 			};
 		}
 		Ok(Self::Memory(Default::default()))
@@ -93,7 +91,7 @@ impl Results {
 		match self {
 			#[cfg(storage)]
 			Self::File(f) => f.sort(orders),
-			Self::MemoryOrdered(c) => c.sort().await?,
+			Self::MemoryOrdered(c) => c.sort(orders).await?,
 			Self::AsyncMemoryOrdered(c) => {
 				c.finalize().await?;
 			}

--- a/crates/core/src/sql/graph.rs
+++ b/crates/core/src/sql/graph.rs
@@ -8,6 +8,7 @@ use crate::sql::order::{OldOrders, Order, OrderList, Ordering};
 use crate::sql::split::Splits;
 use crate::sql::start::Start;
 use crate::sql::table::Tables;
+use crate::sql::Value;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter, Write};
@@ -51,10 +52,10 @@ impl Graph {
 		let new_ord =
 			x.0.into_iter()
 				.map(|x| Order {
-					value: x.order,
+					value: Value::Idiom(x.order),
 					collate: x.collate,
 					numeric: x.numeric,
-					direction: x.direction,
+					direction: Value::Bool(x.direction),
 				})
 				.collect();
 

--- a/crates/core/src/sql/order.rs
+++ b/crates/core/src/sql/order.rs
@@ -1,6 +1,10 @@
+use crate::ctx::Context;
+use crate::dbs::Options;
+use crate::err::Error;
 use crate::sql::fmt::Fmt;
 use crate::sql::idiom::Idiom;
 use crate::sql::Value;
+use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
@@ -44,12 +48,55 @@ impl fmt::Display for OrderList {
 }
 
 impl OrderList {
+	pub(crate) async fn process(
+		&self,
+		stk: &mut Stk,
+		ctx: &Context,
+		opt: &Options,
+	) -> Result<OrderList, Error> {
+		let mut processed = OrderList(Vec::with_capacity(self.0.len()));
+		for order in &self.0 {
+			let value = order.value.compute(stk, ctx, opt, None).await?;
+			let direction = match &order.direction {
+				Value::Param(_p) => {
+					let computed = order.direction.compute(stk, ctx, opt, None).await?;
+					match computed {
+						Value::Strand(s) => {
+							let dir = s.0.to_uppercase();
+							match dir.as_str() {
+								"ASC" | "ASCENDING" => Value::Bool(true),
+								"DESC" | "DESCENDING" => Value::Bool(false),
+								_ => Value::Bool(true), // Default to ASC for unknown values
+							}
+						}
+						_ => Value::Bool(true), // Default to ASC for other types
+					}
+				}
+				_ => {
+					Value::Bool(true) // Default to ASC
+				}
+			};
+			processed.0.push(Order {
+				value,
+				direction,
+				collate: order.collate,
+				numeric: order.numeric,
+			});
+		}
+		Ok(processed)
+	}
+
 	pub(crate) fn compare(&self, a: &Value, b: &Value) -> cmp::Ordering {
 		for order in &self.0 {
 			// Reverse the ordering if DESC
 			let o = match order.direction {
-				true => a.compare(b, &order.value.0, order.collate, order.numeric),
-				false => b.compare(a, &order.value.0, order.collate, order.numeric),
+				Value::Bool(true) => {
+					a.compare(b, &order.value.to_idiom(), order.collate, order.numeric)
+				}
+				Value::Bool(false) => {
+					b.compare(a, &order.value.to_idiom(), order.collate, order.numeric)
+				}
+				_ => a.compare(b, &order.value.to_idiom(), order.collate, order.numeric),
 			};
 			//
 			match o {
@@ -69,11 +116,11 @@ impl OrderList {
 #[non_exhaustive]
 pub struct Order {
 	/// The value to order by
-	pub value: Idiom,
+	pub value: Value,
 	pub collate: bool,
 	pub numeric: bool,
 	/// true if the direction is ascending
-	pub direction: bool,
+	pub direction: Value,
 }
 
 impl fmt::Display for Order {
@@ -85,8 +132,10 @@ impl fmt::Display for Order {
 		if self.numeric {
 			write!(f, " NUMERIC")?;
 		}
-		if !self.direction {
-			write!(f, " DESC")?;
+		match &self.direction {
+			Value::Bool(false) => write!(f, " DESC")?,
+			Value::Param(p) => write!(f, " ${}", p.0)?,
+			_ => {} // ASC is default, no need to write it
 		}
 		Ok(())
 	}

--- a/crates/core/src/sql/statements/select.rs
+++ b/crates/core/src/sql/statements/select.rs
@@ -65,10 +65,10 @@ impl SelectStatement {
 		let new_ord =
 			x.0.into_iter()
 				.map(|x| Order {
-					value: x.order,
+					value: Value::Idiom(x.order),
 					collate: x.collate,
 					numeric: x.numeric,
-					direction: x.direction,
+					direction: Value::Bool(x.direction),
 				})
 				.collect();
 

--- a/crates/core/src/sql/value/compare.rs
+++ b/crates/core/src/sql/value/compare.rs
@@ -11,7 +11,7 @@ impl Value {
 		collate: bool,
 		numeric: bool,
 	) -> Option<Ordering> {
-		match path.first() {
+		let res = match path.first() {
 			// Get the current path part
 			Some(p) => match (self, other) {
 				// Current path part is an object
@@ -83,7 +83,8 @@ impl Value {
 				(false, true) => self.natural_cmp(other),
 				_ => self.partial_cmp(other),
 			},
-		}
+		};
+		res
 	}
 }
 

--- a/crates/core/src/syn/parser/test/streaming.rs
+++ b/crates/core/src/syn/parser/test/streaming.rs
@@ -509,10 +509,10 @@ fn statements() -> Vec<Statement> {
 				Group(Idiom(vec![Part::Field(Ident("bar".to_owned()))])),
 			])),
 			order: Some(Ordering::Order(OrderList(vec![Order {
-				value: Idiom(vec![Part::Field(Ident("foo".to_owned()))]),
+				value: Value::Idiom(Idiom(vec![Part::Field(Ident("foo".to_owned()))])),
 				collate: true,
 				numeric: true,
-				direction: true,
+				direction: Value::Bool(true),
 			}]))),
 			limit: Some(Limit(Value::Thing(Thing {
 				tb: "a".to_owned(),


### PR DESCRIPTION
## What is the motivation?

To be able to dynamically change the sort column and direction.

## What does this change do?

Currently, parameters are not allowed in the `ORDER BY` clause and throw an error. This allows for queries like the following:

```
LET $order_by = "name";
LET $order_direction = "desc";
LET $start = 0;
LET $limit = 10;

SELECT * FROM user ORDER BY $order_by $order_direction START $start LIMIT $limit;
```
## What is your testing strategy?

None as of yet. Would like reviewer feedback.

## Is this related to any issues?

 - Fixes #3007 

## Does this change need documentation?

- [ ] TODO

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
