### PR TITLE
Make local engines more concurrent

### DIFF
--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -53,7 +53,7 @@ View the [features](https://surrealdb.com/features), the latest [releases](https
 - [x] Clonable connections with auto-reconnect capabilities, no need for a connection pool
 - [x] Range queries
 - [x] Consistent API across all supported protocols and storage engines
-- [x] Asynchronous, lock-free connections
+- [x] Asynchronous connections
 - [x] TLS support via either [`rustls`](https://crates.io/crates/rustls) or [`native-tls`](https://crates.io/crates/native-tls)
 
 <h2><img height="20" src="https://github.com/surrealdb/surrealdb/blob/main/img/documentation.svg?raw=true">&nbsp;&nbsp;Documentation</h2>

--- a/crates/sdk/src/api/engine/local/mod.rs
+++ b/crates/sdk/src/api/engine/local/mod.rs
@@ -565,9 +565,9 @@ async fn router(
 		..
 	}: RequestData,
 	kvs: &Arc<Datastore>,
-	session: &RwLock<Session>,
-	vars: &RwLock<BTreeMap<String, CoreValue>>,
-	live_queries: &RwLock<HashMap<Uuid, Sender<Notification<CoreValue>>>>,
+	session: &Arc<RwLock<Session>>,
+	vars: &Arc<RwLock<BTreeMap<String, CoreValue>>>,
+	live_queries: &Arc<RwLock<HashMap<Uuid, Sender<Notification<CoreValue>>>>>,
 ) -> Result<DbResponse> {
 	match command {
 		Command::Use {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

To improve performance.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Processes all requests and responses in the background to avoid blocking the main Tokio task. Here are the before after results from crud-bench:

Before:

```
Create 100% - Create took 2s 265ms
Read 100% - Read took 1s 90ms
Update 100% - Update took 2s 39ms
Scan::count_all 100% - Scan::count_all took 965ms 543µs
Scan::limit_keys 100% - Scan::limit_keys took 29ms 88µs
Scan::limit_full 100% - Scan::limit_full took 22ms 491µs
Scan::limit_count 100% - Scan::limit_count took 32ms 86µs
Delete 100% - Delete took 2s 470ms
--------------------------------------------------
Benchmark result for Surrealdb; endpoint => rocksdb:/var/folders/ct/ll8y0pfs4k13cjcb9gljq26c0000gp/T/tmp.zTOxh5Ie5t
CPUs: 16 - Blocking threads: 16 - Workers: 16 - Clients: 128 - Threads: 24 - Samples: 100000 - Key: Integer - Random: true
--------------------------------------------------
╭───────────────────────────┬─────────────┬───────────┬───────────┬───────────┬───────────┬───────────┬───────────┬───────────┬──────────┬──────────┬───────────┬──────────┬────────┬──────────┬────────┬────────┬────────────────╮
│ Test                      ┆ Total time  ┆ Mean      ┆ Max       ┆ 99th      ┆ 95th      ┆ 75th      ┆ 50th      ┆ 25th      ┆ 1st      ┆ Min      ┆ IQR       ┆ OPS      ┆    CPU ┆   Memory ┆  Reads ┆ Writes ┆ System load    │
╞═══════════════════════════╪═════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪══════════╪══════════╪═══════════╪══════════╪════════╪══════════╪════════╪════════╪════════════════╡
│ [C]reate                  ┆ 2s 265ms    ┆ 68.23 ms  ┆ 77.38 ms  ┆ 76.29 ms  ┆ 75.01 ms  ┆ 71.87 ms  ┆ 68.73 ms  ┆ 66.30 ms  ┆ 21.66 ms ┆ 2.71 ms  ┆ 5.57 ms   ┆ 44143.16 ┆ 10.19% ┆ 517.1 MB ┆ 8.4 MB ┆    0 B ┆ 3.55/5.34/5.05 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [R]ead                    ┆ 1s 90ms     ┆ 32.73 ms  ┆ 37.53 ms  ┆ 36.90 ms  ┆ 35.62 ms  ┆ 34.34 ms  ┆ 33.12 ms  ┆ 32.03 ms  ┆ 10.27 ms ┆ 2.28 ms  ┆ 2.30 ms   ┆ 91668.09 ┆ 10.94% ┆ 673.4 MB ┆    0 B ┆    0 B ┆ 5.82/5.78/5.21 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [U]pdate                  ┆ 2s 39ms     ┆ 61.47 ms  ┆ 73.22 ms  ┆ 71.04 ms  ┆ 69.50 ms  ┆ 66.05 ms  ┆ 61.79 ms  ┆ 58.11 ms  ┆ 19.68 ms ┆ 2.65 ms  ┆ 7.94 ms   ┆ 49029.04 ┆ 10.38% ┆ 719.8 MB ┆ 8.4 MB ┆    0 B ┆ 5.82/5.78/5.21 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::count_all (100)   ┆ 965ms 543µs ┆ 500.45 ms ┆ 963.07 ms ┆ 963.07 ms ┆ 925.18 ms ┆ 734.72 ms ┆ 496.64 ms ┆ 258.05 ms ┆ 23.25 ms ┆ 23.23 ms ┆ 476.67 ms ┆ 103.57   ┆  6.77% ┆ 731.6 MB ┆    0 B ┆    0 B ┆ 5.82/5.78/5.21 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_keys (100)  ┆ 29ms 88µs   ┆ 14.52 ms  ┆ 24.72 ms  ┆ 24.57 ms  ┆ 23.73 ms  ┆ 19.42 ms  ┆ 14.17 ms  ┆ 9.55 ms   ┆ 3.82 ms  ┆ 3.82 ms  ┆ 9.87 ms   ┆ 3437.77  ┆  0.08% ┆ 738.3 MB ┆    0 B ┆    0 B ┆ 5.82/5.78/5.21 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_full (100)  ┆ 22ms 491µs  ┆ 12.43 ms  ┆ 21.42 ms  ┆ 21.41 ms  ┆ 20.67 ms  ┆ 17.04 ms  ┆ 12.18 ms  ┆ 7.85 ms   ┆ 0.84 ms  ┆ 0.84 ms  ┆ 9.19 ms   ┆ 4446.15  ┆  0.03% ┆ 740.0 MB ┆    0 B ┆    0 B ┆ 5.82/5.78/5.21 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_count (100) ┆ 32ms 86µs   ┆ 15.82 ms  ┆ 28.43 ms  ┆ 28.34 ms  ┆ 27.31 ms  ┆ 22.06 ms  ┆ 15.41 ms  ┆ 9.10 ms   ┆ 2.36 ms  ┆ 2.36 ms  ┆ 12.96 ms  ┆ 3116.57  ┆  0.06% ┆ 741.5 MB ┆    0 B ┆    0 B ┆ 5.82/5.78/5.21 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [D]elete                  ┆ 2s 470ms    ┆ 74.45 ms  ┆ 96.38 ms  ┆ 93.06 ms  ┆ 85.12 ms  ┆ 78.33 ms  ┆ 74.69 ms  ┆ 71.49 ms  ┆ 24.09 ms ┆ 2.36 ms  ┆ 6.85 ms   ┆ 40481.52 ┆  9.47% ┆ 791.3 MB ┆    0 B ┆    0 B ┆ 6.00/5.82/5.22 │
╰───────────────────────────┴─────────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴──────────┴──────────┴───────────┴──────────┴────────┴──────────┴────────┴────────┴────────────────╯
```

After:

```
Create 100% - Create took 894ms 949µs
Read 100% - Read took 544ms 212µs
Update 100% - Update took 893ms 150µs
Scan::count_all 100% - Scan::count_all took 160ms 62µs
Scan::limit_keys 100% - Scan::limit_keys took 19ms 615µs
Scan::limit_full 100% - Scan::limit_full took 15ms 107µs
Scan::limit_count 100% - Scan::limit_count took 19ms 590µs
Delete 100% - Delete took 901ms 455µs
--------------------------------------------------
Benchmark result for Surrealdb; endpoint => rocksdb:/var/folders/ct/ll8y0pfs4k13cjcb9gljq26c0000gp/T/tmp.MDIuTLhIq6
CPUs: 16 - Blocking threads: 16 - Workers: 16 - Clients: 128 - Threads: 24 - Samples: 100000 - Key: Integer - Random: true
--------------------------------------------------
╭───────────────────────────┬─────────────┬──────────┬───────────┬───────────┬───────────┬───────────┬──────────┬──────────┬──────────┬──────────┬──────────┬───────────┬────────┬────────┬─────────┬────────┬────────────────╮
│ Test                      ┆ Total time  ┆ Mean     ┆ Max       ┆ 99th      ┆ 95th      ┆ 75th      ┆ 50th     ┆ 25th     ┆ 1st      ┆ Min      ┆ IQR      ┆ OPS       ┆    CPU ┆ Memory ┆   Reads ┆ Writes ┆ System load    │
╞═══════════════════════════╪═════════════╪══════════╪═══════════╪═══════════╪═══════════╪═══════════╪══════════╪══════════╪══════════╪══════════╪══════════╪═══════════╪════════╪════════╪═════════╪════════╪════════════════╡
│ [C]reate                  ┆ 894ms 949µs ┆ 26.78 ms ┆ 78.59 ms  ┆ 51.26 ms  ┆ 41.38 ms  ┆ 30.19 ms  ┆ 26.54 ms ┆ 24.09 ms ┆ 2.70 ms  ┆ 0.04 ms  ┆ 6.10 ms  ┆ 111738.10 ┆ 63.27% ┆ 1.1 GB ┆  8.4 MB ┆    0 B ┆ 6.12/9.29/7.63 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [R]ead                    ┆ 544ms 212µs ┆ 16.15 ms ┆ 50.53 ms  ┆ 35.62 ms  ┆ 28.00 ms  ┆ 20.41 ms  ┆ 16.30 ms ┆ 11.66 ms ┆ 1.11 ms  ┆ 0.02 ms  ┆ 8.75 ms  ┆ 183751.61 ┆ 74.71% ┆ 1.2 GB ┆     0 B ┆    0 B ┆ 6.12/9.29/7.63 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [U]pdate                  ┆ 893ms 150µs ┆ 26.68 ms ┆ 96.13 ms  ┆ 52.19 ms  ┆ 42.27 ms  ┆ 30.77 ms  ┆ 26.59 ms ┆ 23.25 ms ┆ 2.35 ms  ┆ 0.03 ms  ┆ 7.52 ms  ┆ 111963.18 ┆ 63.51% ┆ 1.3 GB ┆ 16.8 MB ┆    0 B ┆ 6.12/9.29/7.63 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::count_all (100)   ┆ 160ms 62µs  ┆ 83.64 ms ┆ 152.57 ms ┆ 142.72 ms ┆ 134.14 ms ┆ 115.26 ms ┆ 85.76 ms ┆ 51.97 ms ┆ 21.74 ms ┆ 21.73 ms ┆ 63.30 ms ┆ 624.76    ┆  1.61% ┆ 1.3 GB ┆     0 B ┆    0 B ┆ 6.12/9.29/7.63 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_keys (100)  ┆ 19ms 615µs  ┆ 10.28 ms ┆ 19.12 ms  ┆ 19.12 ms  ┆ 18.66 ms  ┆ 13.91 ms  ┆ 10.18 ms ┆ 5.67 ms  ┆ 2.58 ms  ┆ 2.58 ms  ┆ 8.24 ms  ┆ 5097.99   ┆  0.18% ┆ 1.3 GB ┆     0 B ┆    0 B ┆ 6.12/9.29/7.63 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_full (100)  ┆ 15ms 107µs  ┆ 8.15 ms  ┆ 14.38 ms  ┆ 14.37 ms  ┆ 13.95 ms  ┆ 11.34 ms  ┆ 8.45 ms  ┆ 4.68 ms  ┆ 2.23 ms  ┆ 2.23 ms  ┆ 6.66 ms  ┆ 6619.34   ┆  0.15% ┆ 1.3 GB ┆     0 B ┆    0 B ┆ 6.12/9.29/7.63 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_count (100) ┆ 19ms 590µs  ┆ 14.22 ms ┆ 19.02 ms  ┆ 19.01 ms  ┆ 18.78 ms  ┆ 17.04 ms  ┆ 14.61 ms ┆ 12.29 ms ┆ 3.39 ms  ┆ 3.39 ms  ┆ 4.75 ms  ┆ 5104.45   ┆  0.18% ┆ 1.3 GB ┆     0 B ┆    0 B ┆ 6.12/9.29/7.63 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [D]elete                  ┆ 901ms 455µs ┆ 27.02 ms ┆ 98.24 ms  ┆ 52.48 ms  ┆ 42.98 ms  ┆ 30.70 ms  ┆ 26.67 ms ┆ 23.34 ms ┆ 2.57 ms  ┆ 0.04 ms  ┆ 7.36 ms  ┆ 110931.69 ┆ 62.14% ┆ 1.4 GB ┆     0 B ┆    0 B ┆ 6.12/9.29/7.63 │
╰───────────────────────────┴─────────────┴──────────┴───────────┴───────────┴───────────┴───────────┴──────────┴──────────┴──────────┴──────────┴──────────┴───────────┴────────┴────────┴─────────┴────────┴────────────────╯
```

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
