### PR TITLE
Improve live query stability over WebSockets

### DIFF
--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -51,7 +51,7 @@ use wasmtimer::std::{SystemTime, UNIX_EPOCH};
 const TARGET: &str = "surrealdb::core::kvs::ds";
 
 // If there are an infinite number of heartbeats, then we want to go batch-by-batch spread over several checks
-const LQ_CHANNEL_SIZE: usize = 100;
+const LQ_CHANNEL_SIZE: usize = 15_000;
 
 // The role assigned to the initial user created when starting the server with credentials for the first time
 const INITIAL_USER_ROLE: &str = "owner";

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -116,6 +116,10 @@ async fn get_handler(
 		.max_frame_size(*cnf::WEBSOCKET_MAX_FRAME_SIZE)
 		// Set the maximum WebSocket message size
 		.max_message_size(*cnf::WEBSOCKET_MAX_MESSAGE_SIZE)
+		// Set an error
+		.on_failed_upgrade(|err| {
+			warn!("Failed to upgrade WebSocket connection: {err}");
+		})
 		// Handle the WebSocket upgrade and process messages
 		.on_upgrade(move |socket| {
 			handle_socket(state.datastore.clone(), rpc_state, socket, sess, id)

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -162,7 +162,11 @@ impl Connection {
 					// Create a new ping message
 					let msg = Message::Ping(vec![]);
 					// Close the connection if the message fails
-					if internal_sender.send(msg).await.is_err() {
+					if let Err(err) = internal_sender.send(msg).await {
+						// Output any errors if not a close error
+						if err.to_string() != CONN_CLOSED_ERR {
+							trace!("WebSocket error: {err}");
+						}
 						// Cancel the WebSocket tasks
 						rpc.read().await.canceller.cancel();
 						// Exit out of the loop
@@ -196,7 +200,7 @@ impl Connection {
 					if let Err(err) = sender.send(res).await {
 						// Output any errors if not a close error
 						if err.to_string() != CONN_CLOSED_ERR {
-							debug!("WebSocket error: {err:?}");
+							trace!("WebSocket error: {err}");
 						}
 						// Cancel the WebSocket tasks
 						rpc.read().await.canceller.cancel();
@@ -241,7 +245,7 @@ impl Connection {
 					// There was an uncaught panic in the task
 					Err(err) if err.is_panic() => {
 						// There was an error with the task
-						warn!("WebSocket request error: {err:?}");
+						error!("WebSocket request error: {err}");
 						// Cancel the WebSocket tasks
 						rpc.read().await.canceller.cancel();
 						// Exit out of the loop
@@ -287,7 +291,7 @@ impl Connection {
 						Message::Close(_) => {
 							// Respond with a close message
 							if let Err(err) = internal_sender.send(Message::Close(None)).await {
-								trace!("WebSocket error when replying to the close message: {err:?}");
+								trace!("WebSocket error when replying to the close message: {err}");
 							};
 							// Cancel the WebSocket tasks
 							rpc.read().await.canceller.cancel();
@@ -303,7 +307,7 @@ impl Connection {
 					},
 					Err(err) => {
 						// There was an error with the WebSocket
-						trace!("WebSocket error: {err:?}");
+						trace!("WebSocket error: {err}");
 						// Cancel the WebSocket tasks
 						rpc.read().await.canceller.cancel();
 						// Exit out of the loop
@@ -318,7 +322,7 @@ impl Connection {
 			if let Err(err) = res {
 				// There was an uncaught panic in the task
 				if err.is_panic() {
-					warn!("WebSocket request error: {err:?}");
+					error!("WebSocket request error: {err}");
 				}
 			}
 		}
@@ -491,7 +495,7 @@ impl Connection {
 		};
 		// Respond with a close message
 		if let Err(err) = chn.send(Message::Close(Some(frame))).await {
-			trace!("WebSocket error when sending close message: {err:?}");
+			debug!("WebSocket error when sending close message: {err}");
 		};
 		// Cancel the WebSocket tasks
 		rpc.read().await.canceller.cancel();
@@ -534,13 +538,13 @@ impl RpcContext for Connection {
 	/// Handles the execution of a LIVE statement
 	async fn handle_live(&self, lqid: &Uuid) {
 		self.state.live_queries.write().await.insert(*lqid, self.id);
-		trace!("Registered live query {} on websocket {}", lqid, self.id);
+		trace!("Registered live query {lqid} on websocket {}", self.id);
 	}
 
 	/// Handles the execution of a KILL statement
 	async fn handle_kill(&self, lqid: &Uuid) {
 		if let Some(id) = self.state.live_queries.write().await.remove(lqid) {
-			trace!("Unregistered live query {} on websocket {}", lqid, id);
+			trace!("Unregistered live query {lqid} on websocket {id}");
 		}
 	}
 
@@ -550,7 +554,7 @@ impl RpcContext for Connection {
 		// Find all live queries for to this connection
 		self.state.live_queries.write().await.retain(|key, value| {
 			if value == &self.id {
-				trace!("Removing live query: {}", key);
+				trace!("Removing live query: {key}");
 				gc.push(*key);
 				return false;
 			}
@@ -558,7 +562,7 @@ impl RpcContext for Connection {
 		});
 		// Garbage collect the live queries on this connection
 		if let Err(err) = self.kvs().delete_queries(gc).await {
-			error!("Error handling RPC connection: {}", err);
+			error!("Error handling RPC connection: {err}");
 		}
 	}
 

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -9,6 +9,7 @@ use crate::telemetry;
 use crate::telemetry::metrics::ws::RequestContext;
 use crate::telemetry::traces::rpc::span_for_request;
 use axum::extract::ws::{close_code::AGAIN, CloseFrame, Message, WebSocket};
+use futures_util::sink::Buffer;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use opentelemetry::trace::FutureExt;
@@ -107,7 +108,7 @@ impl Connection {
 		// Log the succesful WebSocket connection
 		trace!("WebSocket {} connected", id);
 		// Split the socket into sending and receiving streams
-		let (sender, receiver) = ws.split();
+		let (sender, receiver) = ws.buffer(100).split();
 		// Create an internal channel for sending and receiving
 		let internal_sender = rpc_lock.channel.0.clone();
 		let internal_receiver = rpc_lock.channel.1.clone();
@@ -180,7 +181,7 @@ impl Connection {
 	/// Write messages to the client
 	async fn write(
 		rpc: Arc<RwLock<Connection>>,
-		mut sender: SplitSink<WebSocket, Message>,
+		mut sender: SplitSink<Buffer<WebSocket, Message>, Message>,
 		internal_receiver: Receiver<Message>,
 	) {
 		// Pin the internal receiving channel
@@ -215,7 +216,7 @@ impl Connection {
 	/// Read messages sent from the client
 	async fn read(
 		rpc: Arc<RwLock<Connection>>,
-		mut receiver: SplitStream<WebSocket>,
+		mut receiver: SplitStream<Buffer<WebSocket, Message>>,
 		internal_sender: Sender<Message>,
 	) {
 		// Get all required values

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -90,7 +90,7 @@ impl Connection {
 			shutdown: CancellationToken::new(),
 			canceller: CancellationToken::new(),
 			semaphore: Arc::new(Semaphore::new(*WEBSOCKET_MAX_CONCURRENT_REQUESTS)),
-			channel: channel::bounded(*WEBSOCKET_MAX_CONCURRENT_REQUESTS),
+			channel: channel::bounded(100),
 			#[cfg(surrealdb_unstable)]
 			gql_schema: SchemaCache::new(datastore.clone()),
 			datastore,

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -406,7 +406,7 @@ impl Connection {
 								let res = Self::process_message(rpc.clone(), method, req.params).await;
 								// Process the response
 								res.into_response(req.id)
-									.send(otel_cx.clone(), fmt, &chn)
+									.send(otel_cx.clone(), fmt, chn)
 									.with_context(otel_cx.as_ref().clone())
 									.await;
 							}
@@ -416,7 +416,7 @@ impl Connection {
 								if shutdown.is_cancelled() {
 									// Process the response
 									failure(req.id, Failure::custom(SERVER_SHUTTING_DOWN))
-										.send(otel_cx.clone(), fmt, &chn)
+										.send(otel_cx.clone(), fmt, chn)
 										.with_context(otel_cx.as_ref().clone())
 										.await;
 								}
@@ -424,7 +424,7 @@ impl Connection {
 								else if ALLOC.is_beyond_threshold() {
 									// Process the response
 									failure(req.id, Failure::custom(SERVER_OVERLOADED))
-										.send(otel_cx.clone(), fmt, &chn)
+										.send(otel_cx.clone(), fmt, chn)
 										.with_context(otel_cx.as_ref().clone())
 										.await;
 								}
@@ -436,14 +436,14 @@ impl Connection {
 									if ALLOC.is_beyond_threshold() {
 										// Process the response
 										failure(req.id, Failure::custom(SERVER_OVERLOADED))
-											.send(otel_cx.clone(), fmt, &chn)
+											.send(otel_cx.clone(), fmt, chn)
 											.with_context(otel_cx.as_ref().clone())
 											.await;
 									} else {
 										// Process the message when the semaphore is acquired
 										Self::process_message(rpc.clone(), method, req.params).await
 											.into_response(req.id)
-											.send(otel_cx.clone(), fmt, &chn)
+											.send(otel_cx.clone(), fmt, chn)
 											.with_context(otel_cx.as_ref().clone())
 											.await;
 									}
@@ -457,7 +457,7 @@ impl Connection {
 				Err(err) => {
 					// Process the response
 					failure(None, err)
-						.send(otel_cx.clone(), fmt, &chn)
+						.send(otel_cx.clone(), fmt, chn)
 						.with_context(otel_cx.as_ref().clone())
 						.await
 				}

--- a/src/rpc/response.rs
+++ b/src/rpc/response.rs
@@ -37,7 +37,7 @@ impl Response {
 	}
 
 	/// Send the response to the WebSocket channel
-	pub async fn send(self, cx: Arc<TelemetryContext>, fmt: Format, chn: &Sender<Message>) {
+	pub async fn send(self, cx: Arc<TelemetryContext>, fmt: Format, chn: Sender<Message>) {
 		// Create a new tracing span
 		let span = Span::current();
 		// Log the rpc response call


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Live queries can currently slow down and fail when a socket disconnects in certain abnormal ways, or when the socket can not keep up with the number of messages being submitted and attempted for delivery.

## What does this change do?

This pull-request makes a number of changes:

- Implements a buffer of `100` messages for each WebSocket connection. This allows messages to be fed to the WebSocket without needing to fully flush the WebSocket message through the TCP connection. This ensures that if there is an issue with the WebSocket, then messages can be buffered a small amount, allowing for the server to process other messages.
- Increases the live query buffered notification channel from `100` to `15,000` allowing for more notifications to be buffered in memory before needing to be processed by the notification worker. This increase will increase the amount of memory use which could potentially be used by pending notifications, but realistically this will be between `10MiB` to `150MiB`.
- Ensures that notifications are sent to WebSockets concurrently instead of serially. Previously messages would send to each WebSocket serially, meaning that if one WebSocket had issues with buffering, flushing, or receiving, then other notifications would be delayed. Now message futures which are sent to WebSockets are processed concurrently, and those messages which fail are ignored without delaying other WebSocket notifications. This change along with the other change allows for better performance, better scalability, and reduced contention and bottlenecks in the notification stream.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #5068

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
