### PR TITLE
Increase default message interleaving size on WebSockets

### DIFF
--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -67,10 +67,10 @@ pub static WEBSOCKET_MAX_FRAME_SIZE: LazyLock<usize> =
 pub static WEBSOCKET_MAX_MESSAGE_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE", usize, 128 << 20);
 
-/// How many concurrent tasks can be handled on each WebSocket (defaults to the number of CPU cores, minimum 12)
+/// How many concurrent tasks can be handled on each WebSocket (defaults to 4 times the number of CPU cores, minimum 12)
 pub static WEBSOCKET_MAX_CONCURRENT_REQUESTS: LazyLock<usize> =
 	lazy_env_parse_or_else!("SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS", usize, |_| {
-		std::cmp::max(12, num_cpus::get())
+		std::cmp::max(12, num_cpus::get().saturating_mul(4))
 	});
 
 /// The number of runtime worker threads to start (defaults to the number of CPU cores, minimum 4)


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

Increases the default number of messages which can be interleaved and executed concurrently down a single WebSocket connection. The default was previously limited to the number of CPU cores. Now the default is a minimum of 12, or 4 times the number of CPU cores.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
