### PR TITLE
Fix bug in number parsing after token glueing

### DIFF
--- a/crates/core/src/syn/lexer/compound/number.rs
+++ b/crates/core/src/syn/lexer/compound/number.rs
@@ -28,11 +28,13 @@ pub enum Numeric {
 }
 
 /// Like numeric but holds of parsing the a number into a specific value.
+#[derive(Debug)]
 pub enum NumericKind {
 	Number(NumberKind),
 	Duration(Duration),
 }
 
+#[derive(Debug)]
 pub enum NumberKind {
 	Integer,
 	Float,
@@ -65,7 +67,7 @@ pub fn numeric_kind(lexer: &mut Lexer, start: Token) -> Result<NumericKind, Synt
 	match start.kind {
 		t!("-") | t!("+") => number_kind(lexer, start).map(NumericKind::Number),
 		TokenKind::Digits => match lexer.reader.peek() {
-			Some(b'n' | b'm' | b's' | b'h' | b'y' | b'd' | b'w' | b'u') => {
+			Some(b'n' | b'm' | b's' | b'h' | b'y' | b'w' | b'u') => {
 				duration(lexer, start).map(NumericKind::Duration)
 			}
 			Some(x) if !x.is_ascii() => duration(lexer, start).map(NumericKind::Duration),

--- a/crates/core/src/syn/parser/basic/number.rs
+++ b/crates/core/src/syn/parser/basic/number.rs
@@ -99,10 +99,12 @@ impl TokenValue for Number {
 						.map(Number::Int)
 						.map_err(|e| syntax_error!("Failed to parse number: {e}", @token.span)),
 					NumberKind::Float => number_str
+						.trim_end_matches("f")
 						.parse()
 						.map(Number::Float)
 						.map_err(|e| syntax_error!("Failed to parse number: {e}", @token.span)),
 					NumberKind::Decimal => {
+						let number_str = number_str.trim_end_matches("dec");
 						let decimal = if number_str.contains(['e', 'E']) {
 							Decimal::from_scientific(number_str).map_err(
 								|e| syntax_error!("Failed to parser decimal: {e}", @token.span),

--- a/crates/language-tests/tests/parsing/basic/decimal_literal_suffix.surql
+++ b/crates/language-tests/tests/parsing/basic/decimal_literal_suffix.surql
@@ -1,0 +1,79 @@
+/**
+[test]
+
+[[test.results]]
+value = "1dec"
+
+[[test.results]]
+value = "1dec"
+
+[[test.results]]
+value = "-1dec"
+
+[[test.results]]
+value = "1dec"
+
+[[test.results]]
+value = "1dec"
+
+[[test.results]]
+value = "-1dec"
+
+[[test.results]]
+value = "1.0dec"
+
+[[test.results]]
+value = "1.0dec"
+
+[[test.results]]
+value = "-1.0dec"
+
+[[test.results]]
+value = "1.0dec"
+
+[[test.results]]
+value = "1.0dec"
+
+[[test.results]]
+value = "-1.0dec"
+
+[[test.results]]
+value = "100dec"
+
+[[test.results]]
+value = "100dec"
+
+[[test.results]]
+value = "-100dec"
+
+[[test.results]]
+value = "100dec"
+
+[[test.results]]
+value = "100dec"
+
+[[test.results]]
+value = "-100dec"
+
+*/
+1dec;
++1dec;
+-1dec;
+(1dec);
+(+1dec);
+(-1dec);
+
+1.0dec;
++1.0dec;
+-1.0dec;
+(1.0dec);
+(+1.0dec);
+(-1.0dec);
+
+1.0e2dec;
++1.0e2dec;
+-1.0e2dec;
+(1.0e2dec);
+(+1.0e2dec);
+(-1.0e2dec);
+

--- a/crates/language-tests/tests/parsing/basic/float_literal_suffix.surql
+++ b/crates/language-tests/tests/parsing/basic/float_literal_suffix.surql
@@ -1,0 +1,79 @@
+/**
+[test]
+
+[[test.results]]
+value = "1f"
+
+[[test.results]]
+value = "1f"
+
+[[test.results]]
+value = "-1f"
+
+[[test.results]]
+value = "1f"
+
+[[test.results]]
+value = "1f"
+
+[[test.results]]
+value = "-1f"
+
+[[test.results]]
+value = "1f"
+
+[[test.results]]
+value = "1f"
+
+[[test.results]]
+value = "-1f"
+
+[[test.results]]
+value = "1f"
+
+[[test.results]]
+value = "1f"
+
+[[test.results]]
+value = "-1f"
+
+[[test.results]]
+value = "100f"
+
+[[test.results]]
+value = "100f"
+
+[[test.results]]
+value = "-100f"
+
+[[test.results]]
+value = "100f"
+
+[[test.results]]
+value = "100f"
+
+[[test.results]]
+value = "-100f"
+
+*/
+1f;
++1f;
+-1f;
+(1f);
+(+1f);
+(-1f);
+
+1.0f;
++1.0f;
+-1.0f;
+(1.0f);
+(+1.0f);
+(-1.0f);
+
+1.0e2f;
++1.0e2f;
+-1.0e2f;
+(1.0e2f);
+(+1.0e2f);
+(-1.0e2f);
+


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

There was a bug in token gluing where, in a covered expression numbers would fail to parse if they had a suffix.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->
Fixes the bug.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added two tests to the testing suite.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
