### PR TITLE
Fix transaction conflicts in benchmarks

### DIFF
--- a/crates/sdk/benches/sdb_benches/sdk/routines/create.rs
+++ b/crates/sdk/benches/sdb_benches/sdk/routines/create.rs
@@ -26,6 +26,8 @@ impl super::Routine for Create {
 				field: Id::rand(),
 			};
 
+			client.query(format!("DEFINE TABLE {}", self.table_name)).await.unwrap();
+
 			// Spawn one task for each operation
 			let mut tasks = JoinSet::default();
 			for _ in 0..num_ops {

--- a/crates/sdk/benches/sdb_benches/sdk/routines/read.rs
+++ b/crates/sdk/benches/sdb_benches/sdk/routines/read.rs
@@ -20,6 +20,7 @@ impl Read {
 impl super::Routine for Read {
 	fn setup(&self, client: &'static Surreal<Any>, num_ops: usize) {
 		self.runtime.block_on(async {
+			client.query(format!("DEFINE TABLE {}", self.table_name)).await.unwrap();
 			// Spawn one task for each operation
 			let mut tasks = JoinSet::default();
 			for task_id in 0..num_ops {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Benchmarks for embedded engines currently return transaction conflict errors.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It ensures the table name is created before trying to create multiple records concurrently.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
