### PR TITLE
Improve storage engine shutdown logic

### DIFF
--- a/crates/core/src/kvs/surrealkv/mod.rs
+++ b/crates/core/src/kvs/surrealkv/mod.rs
@@ -86,6 +86,10 @@ impl Datastore {
 	}
 	/// Shutdown the database
 	pub(crate) async fn shutdown(&self) -> Result<(), Error> {
+		// Shutdown the database
+		if let Err(e) = self.db.close().await {
+			error!("An error occured closing the database: {e}");
+		}
 		// Nothing to do here
 		Ok(())
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

Ensures certain shutdown logic is asynchronously called before shutdown.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
