### PR TITLE
Goodbye!

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -135,6 +135,8 @@ pub async fn init() -> ExitCode {
 			warn!("You can upgrade using the {} command", "surreal upgrade");
 		}
 	}
+	// Check if we are running the server
+	let server = matches!(args.command, Commands::Start(_));
 	// Initialize opentelemetry and logging
 	let telemetry = crate::telemetry::builder().with_log_level("info").with_filter(args.log);
 	// Extract the telemetry log guards
@@ -176,7 +178,9 @@ pub async fn init() -> ExitCode {
 		drop(outg);
 		drop(errg);
 		// Final message
-		println!("Goodbye!");
+		if server {
+			println!("Goodbye!");
+		}
 		// Return failure
 		ExitCode::FAILURE
 	} else {
@@ -184,7 +188,9 @@ pub async fn init() -> ExitCode {
 		drop(outg);
 		drop(errg);
 		// Final message
-		println!("Goodbye!");
+		if server {
+			println!("Goodbye!");
+		}
 		// Return success
 		ExitCode::SUCCESS
 	}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -175,12 +175,16 @@ pub async fn init() -> ExitCode {
 		// Drop the log guards
 		drop(outg);
 		drop(errg);
+		// Final message
+		println!("Goodbye!");
 		// Return failure
 		ExitCode::FAILURE
 	} else {
 		// Drop the log guards
 		drop(outg);
 		drop(errg);
+		// Final message
+		println!("Goodbye!");
 		// Return success
 		ExitCode::SUCCESS
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently once the log buffers have successfully drained, it is hard to know whether the server has shutdown and exited correctly.

## What does this change do?

Prints a `Goodbye!` message to the terminal before successful exit, and after the log buffers have been successfully output to the command-line.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
