### PR TITLE
Fix #5409 - meaningful `rand::time()` retries.

### DIFF
--- a/crates/core/src/fnc/rand.rs
+++ b/crates/core/src/fnc/rand.rs
@@ -153,11 +153,11 @@ pub fn time((range,): (Option<(Value, Value)>,)) -> Result<Value, Error> {
 	// Set the maximum valid seconds
 	const LIMIT: i64 = 8210298412799;
 	// Check the function input arguments
-	let val = if let Some((min, max)) = range {
+	let (min, max) = if let Some((min, max)) = range {
 		match min {
 			min if (1..=LIMIT).contains(&min) => match max {
-				max if min <= max && max <= LIMIT => rand::thread_rng().gen_range(min..=max),
-				max if max >= 1 && max <= min => rand::thread_rng().gen_range(max..=min),
+				max if min <= max && max <= LIMIT => (min, max),
+				max if max >= 1 && max <= min => (max, min),
 				_ => return Err(Error::InvalidArguments {
 					name: String::from("rand::time"),
 					message: format!("To generate a time between X and Y seconds, the 2 arguments must be positive numbers and no higher than {LIMIT}."),
@@ -169,10 +169,11 @@ pub fn time((range,): (Option<(Value, Value)>,)) -> Result<Value, Error> {
 			}),
 		}
 	} else {
-		rand::thread_rng().gen_range(0..=LIMIT)
+		(0, LIMIT)
 	};
 	// Generate the random time, try up to 5 times
 	for _ in 0..5 {
+		let val = rand::thread_rng().gen_range(min..=max);
 		if let Some(v) = Utc.timestamp_opt(val, 0).earliest() {
 			return Ok(v.into());
 		}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

See #5409

## What does this change do?

Generates a new random time for each retry.

## What is your testing strategy?

N/A

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Fixes #5409

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
