### PR TITLE
Local live queries cross-transaction cache

### DIFF
--- a/crates/core/src/ctx/context.rs
+++ b/crates/core/src/ctx/context.rs
@@ -8,7 +8,7 @@ use crate::err::Error;
 use crate::idx::planner::executor::QueryExecutor;
 use crate::idx::planner::{IterationStage, QueryPlanner};
 use crate::idx::trees::store::IndexStores;
-use crate::kvs::cache::ds::Cache;
+use crate::kvs::cache::ds::DatastoreCache;
 #[cfg(not(target_family = "wasm"))]
 use crate::kvs::IndexBuilder;
 use crate::kvs::Transaction;
@@ -47,7 +47,7 @@ pub struct MutableContext {
 	// An optional iteration stage
 	iteration_stage: Option<IterationStage>,
 	// An optional datastore cache
-	cache: Option<Arc<Cache>>,
+	cache: Option<Arc<DatastoreCache>>,
 	// The index store
 	index_stores: IndexStores,
 	// The index concurrent builders
@@ -191,7 +191,7 @@ impl MutableContext {
 		time_out: Option<Duration>,
 		capabilities: Capabilities,
 		index_stores: IndexStores,
-		cache: Arc<Cache>,
+		cache: Arc<DatastoreCache>,
 		#[cfg(not(target_family = "wasm"))] index_builder: IndexBuilder,
 		#[cfg(storage)] temporary_directory: Option<Arc<PathBuf>>,
 	) -> Result<MutableContext, Error> {
@@ -335,7 +335,7 @@ impl MutableContext {
 	}
 
 	// Get the current datastore cache
-	pub(crate) fn get_cache(&self) -> Option<Arc<Cache>> {
+	pub(crate) fn get_cache(&self) -> Option<Arc<DatastoreCache>> {
 		self.cache.clone()
 	}
 

--- a/crates/core/src/kvs/cache/ds/entry.rs
+++ b/crates/core/src/kvs/cache/ds/entry.rs
@@ -5,6 +5,7 @@ use crate::sql::statements::DefineIndexStatement;
 use crate::sql::statements::DefineTableStatement;
 use crate::sql::statements::LiveStatement;
 use std::sync::Arc;
+use uuid::Uuid;
 
 #[derive(Clone)]
 #[non_exhaustive]
@@ -19,6 +20,8 @@ pub(crate) enum Entry {
 	Ixs(Arc<[DefineIndexStatement]>),
 	/// A slice of LiveStatement specified on a table.
 	Lvs(Arc<[LiveStatement]>),
+	/// An Uuid.
+	Lvv(Uuid),
 }
 
 impl Entry {
@@ -60,6 +63,15 @@ impl Entry {
 		match self {
 			Entry::Lvs(v) => Ok(v),
 			_ => Err(fail!("Unable to convert type into Entry::Lvs")),
+		}
+	}
+
+	/// Converts this cache entry into a slice of [`LiveStatement`].
+	/// This panics if called on a cache entry that is not an [`Entry::Lvs`].
+	pub(crate) fn try_info_lvv(self) -> Result<Uuid, Error> {
+		match self {
+			Entry::Lvv(v) => Ok(v),
+			_ => Err(fail!("Unable to convert type into Entry::Lvv")),
 		}
 	}
 }

--- a/crates/core/src/kvs/cache/ds/key.rs
+++ b/crates/core/src/kvs/cache/ds/key.rs
@@ -13,6 +13,8 @@ pub(crate) enum Key {
 	Ixs(String, String, String, Uuid),
 	/// A cache key for live queries (on a table)
 	Lvs(String, String, String, Uuid),
+	/// A cache key for live queries version (on a table)
+	Lvv(String, String, String),
 }
 
 impl<'a> From<Lookup<'a>> for Key {
@@ -24,6 +26,7 @@ impl<'a> From<Lookup<'a>> for Key {
 			Lookup::Fts(a, b, c, d) => Key::Fts(a.to_string(), b.to_string(), c.to_string(), d),
 			Lookup::Ixs(a, b, c, d) => Key::Ixs(a.to_string(), b.to_string(), c.to_string(), d),
 			Lookup::Lvs(a, b, c, d) => Key::Lvs(a.to_string(), b.to_string(), c.to_string(), d),
+			Lookup::Lvv(a, b, c) => Key::Lvv(a.to_string(), b.to_string(), c.to_string()),
 		}
 	}
 }

--- a/crates/core/src/kvs/cache/ds/lookup.rs
+++ b/crates/core/src/kvs/cache/ds/lookup.rs
@@ -14,6 +14,8 @@ pub(crate) enum Lookup<'a> {
 	Ixs(&'a str, &'a str, &'a str, Uuid),
 	/// A cache key for live queries (on a table)
 	Lvs(&'a str, &'a str, &'a str, Uuid),
+	/// A cache key for live queries version (on a table)
+	Lvv(&'a str, &'a str, &'a str),
 }
 
 impl Equivalent<Key> for Lookup<'_> {
@@ -25,6 +27,7 @@ impl Equivalent<Key> for Lookup<'_> {
 			(Self::Fts(la, lb, lc, ld), Key::Fts(ka, kb, kc, kd)) => la == ka && lb == kb && lc == kc && ld == kd,
 			(Self::Ixs(la, lb, lc, ld), Key::Ixs(ka, kb, kc, kd)) => la == ka && lb == kb && lc == kc && ld == kd,
 			(Self::Lvs(la, lb, lc, ld), Key::Lvs(ka, kb, kc, kd)) => la == ka && lb == kb && lc == kc && ld == kd,
+			(Self::Lvv(la, lb, lc), Key::Lvv(ka, kb, kc)) => la == ka && lb == kb && lc == kc,
 			_ => false,
 		}
 	}

--- a/crates/core/src/kvs/cache/ds/mod.rs
+++ b/crates/core/src/kvs/cache/ds/mod.rs
@@ -3,15 +3,55 @@ mod key;
 mod lookup;
 mod weight;
 
+use crate::err::Error;
 pub(crate) use entry::Entry;
 pub(crate) use lookup::Lookup;
+use uuid::Uuid;
 
-pub(crate) type Cache = quick_cache::sync::Cache<key::Key, entry::Entry, weight::Weight>;
+pub type Cache = quick_cache::sync::Cache<key::Key, Entry, weight::Weight>;
 
-pub(crate) fn new() -> Cache {
-	quick_cache::sync::Cache::with_weighter(
-		*crate::cnf::DATASTORE_CACHE_SIZE,
-		*crate::cnf::DATASTORE_CACHE_SIZE as u64,
-		weight::Weight,
-	)
+pub struct DatastoreCache {
+	/// Store the cache entries
+	cache: Cache,
+}
+
+impl DatastoreCache {
+	pub(in crate::kvs) fn new() -> Self {
+		let cache = Cache::with_weighter(
+			*crate::cnf::DATASTORE_CACHE_SIZE,
+			*crate::cnf::DATASTORE_CACHE_SIZE as u64,
+			weight::Weight,
+		);
+		Self {
+			cache,
+		}
+	}
+
+	pub(crate) fn get(&self, lookup: &Lookup) -> Option<Entry> {
+		self.cache.get(lookup)
+	}
+
+	pub(crate) fn insert(&self, lookup: Lookup, entry: Entry) {
+		self.cache.insert(lookup.into(), entry);
+	}
+
+	pub fn get_live_queries_version(&self, ns: &str, db: &str, tb: &str) -> Result<Uuid, Error> {
+		// Get the live-queries cache version
+		let key = Lookup::Lvv(ns, db, tb);
+		let version = match self.get(&key) {
+			Some(val) => val.try_info_lvv()?,
+			None => {
+				let version = Uuid::now_v7();
+				let val = Entry::Lvv(version);
+				self.insert(key, val);
+				version
+			}
+		};
+		Ok(version)
+	}
+
+	pub(crate) fn new_live_queries_version(&self, ns: &str, db: &str, tb: &str) {
+		let key = Lookup::Lvv(ns, db, tb);
+		self.insert(key, Entry::Lvv(Uuid::now_v7()));
+	}
 }

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -16,8 +16,7 @@ use crate::err::Error;
 use crate::iam::jwks::JwksCache;
 use crate::iam::{Action, Auth, Error as IamError, Resource, Role};
 use crate::idx::trees::store::IndexStores;
-use crate::kvs::cache;
-use crate::kvs::cache::ds::Cache;
+use crate::kvs::cache::ds::DatastoreCache;
 use crate::kvs::clock::SizedClock;
 #[allow(unused_imports)]
 use crate::kvs::clock::SystemClock;
@@ -78,7 +77,7 @@ pub struct Datastore {
 	// The index store cache
 	index_stores: IndexStores,
 	// The cross transaction cache
-	cache: Arc<Cache>,
+	cache: Arc<DatastoreCache>,
 	// The index asynchronous builder
 	#[cfg(not(target_family = "wasm"))]
 	index_builder: IndexBuilder,
@@ -408,7 +407,7 @@ impl Datastore {
 				jwks_cache: Arc::new(RwLock::new(JwksCache::new())),
 				#[cfg(storage)]
 				temporary_directory: None,
-				cache: Arc::new(cache::ds::new()),
+				cache: Arc::new(DatastoreCache::new()),
 			}
 		})
 	}
@@ -433,7 +432,7 @@ impl Datastore {
 			#[cfg(storage)]
 			temporary_directory: self.temporary_directory,
 			transaction_factory: self.transaction_factory,
-			cache: Arc::new(cache::ds::new()),
+			cache: Arc::new(DatastoreCache::new()),
 		}
 	}
 
@@ -528,6 +527,12 @@ impl Datastore {
 
 	pub(super) async fn clock_now(&self) -> Timestamp {
 		self.transaction_factory.clock.now().await
+	}
+
+	// Used for testing live queries
+	#[allow(dead_code)]
+	pub fn get_cache(&self) -> Arc<DatastoreCache> {
+		self.cache.clone()
 	}
 
 	// Initialise the cluster and run bootstrap utilities

--- a/crates/core/src/sql/statements/define/table.rs
+++ b/crates/core/src/sql/statements/define/table.rs
@@ -16,12 +16,13 @@ use crate::sql::{Idiom, Kind, TableType};
 use derive::Store;
 use reblessive::tree::Stk;
 use revision::revisioned;
+use revision::Error as RevisionError;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Write};
 use std::sync::Arc;
 use uuid::Uuid;
 
-#[revisioned(revision = 5)]
+#[revisioned(revision = 6)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
@@ -54,7 +55,7 @@ pub struct DefineTableStatement {
 	#[revision(start = 5)]
 	pub cache_indexes_ts: Uuid,
 	/// The last time that a LIVE query was added to this table
-	#[revision(start = 5)]
+	#[revision(start = 5, end = 6, convert_fn = "convert_cache_ts")]
 	pub cache_lives_ts: Uuid,
 }
 
@@ -144,6 +145,10 @@ impl DefineTableStatement {
 		txn.clear();
 		// Ok all good
 		Ok(Value::None)
+	}
+
+	fn convert_cache_ts(&self, _revision: u16, _value: Uuid) -> Result<(), RevisionError> {
+		Ok(())
 	}
 }
 

--- a/crates/core/src/sql/statements/live.rs
+++ b/crates/core/src/sql/statements/live.rs
@@ -4,7 +4,6 @@ use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::iam::Auth;
 use crate::kvs::Live;
-use crate::sql::statements::define::DefineTableStatement;
 use crate::sql::statements::info::InfoStructure;
 use crate::sql::{Cond, Fetchs, Fields, Uuid, Value};
 use derive::Store;
@@ -129,17 +128,9 @@ impl LiveStatement {
 				let key = crate::key::table::lq::new(ns, db, &tb, id);
 				txn.replace(key, stm).await?;
 				// Refresh the table cache for lives
-				let key = crate::key::database::tb::new(ns, db, &tb);
-				let tb = txn.get_tb(ns, db, &tb).await?;
-				txn.set(
-					key,
-					DefineTableStatement {
-						cache_lives_ts: uuid::Uuid::now_v7(),
-						..tb.as_ref().clone()
-					},
-					None,
-				)
-				.await?;
+				if let Some(cache) = ctx.get_cache() {
+					cache.new_live_queries_version(ns, db, &tb);
+				}
 				// Clear the cache
 				txn.clear();
 			}

--- a/crates/core/src/syn/parser/test/stmt.rs
+++ b/crates/core/src/syn/parser/test/stmt.rs
@@ -1862,7 +1862,6 @@ fn parse_define_table() {
 			cache_events_ts: uuid::Uuid::default(),
 			cache_tables_ts: uuid::Uuid::default(),
 			cache_indexes_ts: uuid::Uuid::default(),
-			cache_lives_ts: uuid::Uuid::default(),
 		}))
 	);
 }

--- a/crates/core/src/syn/parser/test/streaming.rs
+++ b/crates/core/src/syn/parser/test/streaming.rs
@@ -296,7 +296,6 @@ fn statements() -> Vec<Statement> {
 			cache_events_ts: uuid::Uuid::default(),
 			cache_tables_ts: uuid::Uuid::default(),
 			cache_indexes_ts: uuid::Uuid::default(),
-			cache_lives_ts: uuid::Uuid::default(),
 		})),
 		Statement::Define(DefineStatement::Event(DefineEventStatement {
 			name: Ident("event".to_owned()),

--- a/revision.lock
+++ b/revision.lock
@@ -61,7 +61,7 @@ DefineNamespaceStatement:3(crates/core/src/sql/statements/define/namespace.rs)(3
 DefineParamStatement:3(crates/core/src/sql/statements/define/param.rs)(1839637619)
 DefineScopeStatement:2(crates/core/src/sql/statements/define/deprecated/scope.rs)(3489132686)
 DefineStatement:2(crates/core/src/sql/statements/define/mod.rs)(235139927)
-DefineTableStatement:5(crates/core/src/sql/statements/define/table.rs)(388381631)
+DefineTableStatement:6(crates/core/src/sql/statements/define/table.rs)(4283293969)
 DefineTokenStatement:2(crates/core/src/sql/statements/define/deprecated/token.rs)(2218883889)
 DefineUserStatement:4(crates/core/src/sql/statements/define/user.rs)(3981483186)
 DeleteStatement:2(crates/core/src/sql/statements/delete.rs)(1697946887)


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

 Follows up #5423 and #5390.

As live queries exist only while the client is connected, the cache key does not need to be stored on disk.

## What does this change do?

The live queries cache version is stored in the cross-transaction cache.

## What is your testing strategy?

GitHub Action.
An existing test has been updated.


## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Follows up #5390

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
