### PR TITLE
Transpose add none when item not found

### DIFF
--- a/crates/core/src/sql/array.rs
+++ b/crates/core/src/sql/array.rs
@@ -474,8 +474,13 @@ impl Transpose<Array> for Array {
 		// This is safe.
 		let longest_length = iters.iter().map(|i| i.len()).max().unwrap();
 		for _ in 0..longest_length {
-			transposed_vec
-				.push(iters.iter_mut().filter_map(|i| i.next()).collect::<Vec<_>>().into());
+			transposed_vec.push(
+				iters
+					.iter_mut()
+					.map(|i| i.next().unwrap_or(Value::None))
+					.collect::<Vec<_>>()
+					.into(),
+			);
 		}
 		transposed_vec.into()
 	}

--- a/crates/sdk/tests/function.rs
+++ b/crates/sdk/tests/function.rs
@@ -1209,7 +1209,7 @@ async fn function_array_transpose() -> Result<(), Error> {
 		"[[0, 2, 4], [1, 3, 5]]",
 		"[[0, \"oops\", NULL], [1, NONE, \"sorry\"], [2, NONE, NONE]]",
 		"[[1, 1, 1], [NONE, 2, 2], [NONE, NONE, 3]]",
-		"[[1, NONE, NONE], [1, 2, NONE], [1, 2, 3]]"
+		"[[1, NONE, NONE], [1, 2, NONE], [1, 2, 3]]",
 	];
 	test_queries(sql, &desired_responses).await?;
 	Ok(())

--- a/crates/sdk/tests/function.rs
+++ b/crates/sdk/tests/function.rs
@@ -1199,13 +1199,17 @@ async fn function_array_transpose() -> Result<(), Error> {
 		RETURN array::transpose([[0, 1], [2, 3, 4]]);
 		RETURN array::transpose([[0, 1], [2, 3], [4, 5]]);
 		RETURN array::transpose([[0, 1, 2], "oops", [null, "sorry"]]);
+		RETURN [[1],[1,2],[1,2,3]].transpose();
+		RETURN [[1],[1,2],[1,2,3]].transpose().transpose();
 	"#;
 	let desired_responses = [
 		"[[0, 2], [1, 3]]",
-		"[[0, 3], [1, 4], [2]]",
-		"[[0, 2], [1, 3], [4]]",
+		"[[0, 3], [1, 4], [2, NONE]]",
+		"[[0, 2], [1, 3], [NONE, 4]]",
 		"[[0, 2, 4], [1, 3, 5]]",
-		"[[0, \"oops\", null], [1, \"sorry\"], [2]]",
+		"[[0, \"oops\", NULL], [1, NONE, \"sorry\"], [2, NONE, NONE]]",
+		"[[1, 1, 1], [NONE, 2, 2], [NONE, NONE, 3]]",
+		"[[1, NONE, NONE], [1, 2, NONE], [1, 2, 3]]"
 	];
 	test_queries(sql, &desired_responses).await?;
 	Ok(())


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

array::transpose() would be more useful if non-matching items showed up as NONE instead of not being inserted in the first place. This would show where no items at the matching index were found, and would also allow .transpose() to be called again to restore the original input (with the exception of the NONEs added).

## What does this change do?

Calling `[["Name", "age"], ["Alice"], ["Bobby", 25]].transpose()` currently outputs this, making it look like Bobby is the one without a second item when it's actually Alice.

```
[
	[
		'Name',
		'Alice',
		'Bobby'
	],
	[
		'age',
		25
	]
]
```

But with the change you can now see that it is Alice with a NONE for age, while Bobby has 25.

```
[
	[
		'Name',
		'Alice',
		'Bobby'
	],
	[
		'age',
		NONE,
		25
	]
]
```

You can then call .transpose() a second time and get the same output. Calling .transpose() twice will also become a convenient way to insert NONEs in arrays that lack these items and you want to make it more obvious.

```
[
	[
		'Name',
		'age'
	],
	[
		'Alice',
		NONE
	],
	[
		'Bobby',
		25
	]
]
```

## What is your testing strategy?

Modified existing tests and added two new ones.

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

That would depend on if we consider this a breaking change or a fix that gives .transpose() its intended behaviour. If the latter, then no documentation is needed.

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
