### PR TITLE
Log storage engine configuration as `info` not `debug`

### DIFF
--- a/crates/core/src/kvs/fdb/mod.rs
+++ b/crates/core/src/kvs/fdb/mod.rs
@@ -18,6 +18,8 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::sync::LazyLock;
 
+const TARGET: &str = "surrealdb::core::kvs::fdb";
+
 const TIMESTAMP: [u8; 10] = [0x00; 10];
 
 pub struct Datastore {
@@ -86,16 +88,19 @@ impl Datastore {
 		match foundationdb::Database::from_path(path) {
 			Ok(db) => {
 				// Set the transaction timeout
+				info!(target: TARGET, "Setting transaction timeout: {}", *cnf::FOUNDATIONDB_TRANSACTION_TIMEOUT);
 				db.set_option(DatabaseOption::TransactionTimeout(
 					*cnf::FOUNDATIONDB_TRANSACTION_TIMEOUT,
 				))
 				.map_err(|e| Error::Ds(format!("Unable to set transaction timeout: {e}")))?;
 				// Set the transaction retry liimt
+				info!(target: TARGET, "Setting transaction retry limit: {}", *cnf::FOUNDATIONDB_TRANSACTION_RETRY_LIMIT);
 				db.set_option(DatabaseOption::TransactionRetryLimit(
 					*cnf::FOUNDATIONDB_TRANSACTION_RETRY_LIMIT,
 				))
 				.map_err(|e| Error::Ds(format!("Unable to set transaction retry limit: {e}")))?;
 				// Set the transaction max retry delay
+				info!(target: TARGET, "Setting maximum transaction retry delay: {}", *cnf::FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY);
 				db.set_option(DatabaseOption::TransactionMaxRetryDelay(
 					*cnf::FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY,
 				))

--- a/crates/core/src/kvs/rocksdb/cnf.rs
+++ b/crates/core/src/kvs/rocksdb/cnf.rs
@@ -53,7 +53,7 @@ pub static ROCKSDB_STORAGE_LOG_LEVEL: LazyLock<String> =
 	lazy_env_parse!("SURREAL_ROCKSDB_STORAGE_LOG_LEVEL", String, "warn".to_string());
 
 pub static ROCKSDB_COMPACTION_STYLE: LazyLock<String> =
-	lazy_env_parse!("SURREAL_ROCKSDB_COMPACTION_STYLE", String);
+	lazy_env_parse!("SURREAL_ROCKSDB_COMPACTION_STYLE", String, "level".to_string());
 
 pub static ROCKSDB_DELETION_FACTORY_WINDOW_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_ROCKSDB_DELETION_FACTORY_WINDOW_SIZE", usize, 1000);

--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -68,52 +68,51 @@ impl Datastore {
 		// Create column families if missing
 		opts.create_missing_column_families(true);
 		// Increase the background thread count
-		debug!(target: TARGET, "Background thread count: {}", *cnf::ROCKSDB_THREAD_COUNT);
+		info!(target: TARGET, "Background thread count: {}", *cnf::ROCKSDB_THREAD_COUNT);
 		opts.increase_parallelism(*cnf::ROCKSDB_THREAD_COUNT);
 		// Specify the max concurrent background jobs
-		debug!(target: TARGET, "Maximum background jobs count: {}", *cnf::ROCKSDB_JOBS_COUNT);
+		info!(target: TARGET, "Maximum background jobs count: {}", *cnf::ROCKSDB_JOBS_COUNT);
 		opts.set_max_background_jobs(*cnf::ROCKSDB_JOBS_COUNT);
 		// Set the maximum number of open files that can be used by the database
-		debug!(target: TARGET, "Maximum number of open files: {}", *cnf::ROCKSDB_MAX_OPEN_FILES);
+		info!(target: TARGET, "Maximum number of open files: {}", *cnf::ROCKSDB_MAX_OPEN_FILES);
 		opts.set_max_open_files(*cnf::ROCKSDB_MAX_OPEN_FILES);
 		// Set the maximum number of write buffers
-		debug!(target: TARGET, "Maximum write buffers: {}", *cnf::ROCKSDB_MAX_WRITE_BUFFER_NUMBER);
+		info!(target: TARGET, "Maximum write buffers: {}", *cnf::ROCKSDB_MAX_WRITE_BUFFER_NUMBER);
 		opts.set_max_write_buffer_number(*cnf::ROCKSDB_MAX_WRITE_BUFFER_NUMBER);
 		// Set the number of log files to keep
-		debug!(target: TARGET, "Number of log files to keep: {}", *cnf::ROCKSDB_KEEP_LOG_FILE_NUM);
+		info!(target: TARGET, "Number of log files to keep: {}", *cnf::ROCKSDB_KEEP_LOG_FILE_NUM);
 		opts.set_keep_log_file_num(*cnf::ROCKSDB_KEEP_LOG_FILE_NUM);
 		// Set the amount of data to build up in memory
-		debug!(target: TARGET, "Write buffer size: {}", *cnf::ROCKSDB_WRITE_BUFFER_SIZE);
+		info!(target: TARGET, "Write buffer size: {}", *cnf::ROCKSDB_WRITE_BUFFER_SIZE);
 		opts.set_write_buffer_size(*cnf::ROCKSDB_WRITE_BUFFER_SIZE);
 		// Set the target file size for compaction
-		debug!(target: TARGET, "Target file size for compaction: {}", *cnf::ROCKSDB_TARGET_FILE_SIZE_BASE);
+		info!(target: TARGET, "Target file size for compaction: {}", *cnf::ROCKSDB_TARGET_FILE_SIZE_BASE);
 		opts.set_target_file_size_base(*cnf::ROCKSDB_TARGET_FILE_SIZE_BASE);
 		// Set minimum number of write buffers to merge
-		debug!(target: TARGET, "Minimum write buffers to merge: {}", *cnf::ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE);
+		info!(target: TARGET, "Minimum write buffers to merge: {}", *cnf::ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE);
 		opts.set_min_write_buffer_number_to_merge(*cnf::ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE);
 		// Use separate write thread queues
-		debug!(target: TARGET, "Use separate thread queues: {}", *cnf::ROCKSDB_ENABLE_PIPELINED_WRITES);
+		info!(target: TARGET, "Use separate thread queues: {}", *cnf::ROCKSDB_ENABLE_PIPELINED_WRITES);
 		opts.set_enable_pipelined_write(*cnf::ROCKSDB_ENABLE_PIPELINED_WRITES);
 		// Enable separation of keys and values
-		debug!(target: TARGET, "Enable separation of keys and values: {}", *cnf::ROCKSDB_ENABLE_BLOB_FILES);
+		info!(target: TARGET, "Enable separation of keys and values: {}", *cnf::ROCKSDB_ENABLE_BLOB_FILES);
 		opts.set_enable_blob_files(*cnf::ROCKSDB_ENABLE_BLOB_FILES);
 		// Store 4KB values separate from keys
-		debug!(target: TARGET, "Minimum blob value size: {}", *cnf::ROCKSDB_MIN_BLOB_SIZE);
+		info!(target: TARGET, "Minimum blob value size: {}", *cnf::ROCKSDB_MIN_BLOB_SIZE);
 		opts.set_min_blob_size(*cnf::ROCKSDB_MIN_BLOB_SIZE);
 		// Allow multiple writers to update memtables in parallel
-		debug!(target: TARGET, "Allow concurrent memtable writes: true");
+		info!(target: TARGET, "Allow concurrent memtable writes: true");
 		opts.set_allow_concurrent_memtable_write(true);
 		// Avoid unnecessary blocking io, preferring background threads
-		debug!(target: TARGET, "Avoid unnecessary blocking IO: true");
+		info!(target: TARGET, "Avoid unnecessary blocking IO: true");
 		opts.set_avoid_unnecessary_blocking_io(true);
 		// Improve concurrency from write batch mutex
-		debug!(target: TARGET, "Allow adaptive write thread yielding: true");
+		info!(target: TARGET, "Allow adaptive write thread yielding: true");
 		opts.set_enable_write_thread_adaptive_yield(true);
 		// Set the block cache size in bytes
-		debug!(target: TARGET, "Block cache size: {}", *cnf::ROCKSDB_BLOCK_CACHE_SIZE);
+		info!(target: TARGET, "Block cache size: {}", *cnf::ROCKSDB_BLOCK_CACHE_SIZE);
 		// Configure the in-memory cache options
 		let cache = Cache::new_lru_cache(*cnf::ROCKSDB_BLOCK_CACHE_SIZE);
-		// Create the in-memory LRU cache
 		// Configure the block based file options
 		let mut block_opts = BlockBasedOptions::default();
 		block_opts.set_hybrid_ribbon_filter(10.0, 2);
@@ -123,7 +122,7 @@ impl Datastore {
 		opts.set_blob_cache(&cache);
 		opts.set_row_cache(&cache);
 		// Set the delete compaction factory
-		debug!(target: TARGET, "Setting delete compaction factory: {} / {} ({})",
+		info!(target: TARGET, "Setting delete compaction factory: {} / {} ({})",
 			*cnf::ROCKSDB_DELETION_FACTORY_WINDOW_SIZE,
 			*cnf::ROCKSDB_DELETION_FACTORY_DELETE_COUNT,
 			*cnf::ROCKSDB_DELETION_FACTORY_RATIO,
@@ -134,7 +133,7 @@ impl Datastore {
 			*cnf::ROCKSDB_DELETION_FACTORY_RATIO,
 		);
 		// Set the datastore compaction style
-		debug!(target: TARGET, "Setting compaction style: {}", *cnf::ROCKSDB_COMPACTION_STYLE);
+		info!(target: TARGET, "Setting compaction style: {}", *cnf::ROCKSDB_COMPACTION_STYLE);
 		opts.set_compaction_style(
 			match cnf::ROCKSDB_COMPACTION_STYLE.to_ascii_lowercase().as_str() {
 				"universal" => DBCompactionStyle::Universal,
@@ -142,7 +141,7 @@ impl Datastore {
 			},
 		);
 		// Set specific compression levels
-		debug!(target: TARGET, "Setting compression level");
+		info!(target: TARGET, "Setting compression level");
 		opts.set_compression_per_level(&[
 			DBCompressionType::None,
 			DBCompressionType::None,
@@ -151,7 +150,7 @@ impl Datastore {
 			DBCompressionType::Snappy,
 		]);
 		// Set specific storage log level
-		debug!(target: TARGET, "Setting storage engine log level: {}", *cnf::ROCKSDB_STORAGE_LOG_LEVEL);
+		info!(target: TARGET, "Setting storage engine log level: {}", *cnf::ROCKSDB_STORAGE_LOG_LEVEL);
 		opts.set_log_level(match cnf::ROCKSDB_STORAGE_LOG_LEVEL.to_ascii_lowercase().as_str() {
 			"debug" => LogLevel::Debug,
 			"info" => LogLevel::Info,

--- a/crates/core/src/kvs/surrealkv/mod.rs
+++ b/crates/core/src/kvs/surrealkv/mod.rs
@@ -12,6 +12,8 @@ use surrealkv::Options;
 use surrealkv::Store;
 use surrealkv::Transaction as Tx;
 
+const TARGET: &str = "surrealdb::core::kvs::surrealkv";
+
 pub struct Datastore {
 	db: Store,
 }
@@ -56,11 +58,14 @@ impl Datastore {
 		opts.disk_persistence = true;
 		// Set the data storage directory
 		opts.dir = path.to_string().into();
-		// Set the maximum value threshold
-		opts.max_value_threshold = *cnf::SURREALKV_MAX_VALUE_THRESHOLD;
 		// Set the maximum segment size
+		info!(target: TARGET, "Setting maximum segment size: {}", *cnf::SURREALKV_MAX_SEGMENT_SIZE);
 		opts.max_segment_size = *cnf::SURREALKV_MAX_SEGMENT_SIZE;
+		// Set the maximum value threshold
+		info!(target: TARGET, "Setting maximum value threshold: {}", *cnf::SURREALKV_MAX_VALUE_THRESHOLD);
+		opts.max_value_threshold = *cnf::SURREALKV_MAX_VALUE_THRESHOLD;
 		// Set the maximum value cache size
+		info!(target: TARGET, "Setting maximum value cache size: {}", *cnf::SURREALKV_MAX_VALUE_CACHE_SIZE);
 		opts.max_value_cache_size = *cnf::SURREALKV_MAX_VALUE_CACHE_SIZE;
 		// Create a new datastore
 		match Store::new(opts) {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Storage engine configuration options are currently available when running as `--log debug`.

## What does this change do?

Ensures that configuration options are logged when using `--log info`.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
