### PR TITLE
Implement `FETCH` for live queries

### DIFF
--- a/crates/sdk/tests/api.rs
+++ b/crates/sdk/tests/api.rs
@@ -53,6 +53,12 @@ mod api_integration {
 		id: RecordId,
 	}
 
+	#[derive(Debug, Clone, Deserialize, PartialEq, PartialOrd)]
+	struct ApiRecordIdWithFetchedLink {
+		id: RecordId,
+		link: Option<ApiRecordId>,
+	}
+
 	#[derive(Debug, Deserialize)]
 	struct RecordName {
 		name: String,

--- a/crates/sdk/tests/api.rs
+++ b/crates/sdk/tests/api.rs
@@ -59,6 +59,17 @@ mod api_integration {
 		link: Option<ApiRecordId>,
 	}
 
+	#[derive(Debug, Clone, Deserialize, PartialEq, PartialOrd)]
+	struct ApiRecordIdWithUnfetchedLink {
+		id: RecordId,
+		link: RecordId,
+	}
+
+	#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, PartialOrd)]
+	struct LinkContent {
+		link: RecordId,
+	}
+
 	#[derive(Debug, Deserialize)]
 	struct RecordName {
 		name: String,

--- a/crates/sdk/tests/api/live.rs
+++ b/crates/sdk/tests/api/live.rs
@@ -4,6 +4,7 @@
 use futures::Stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
+use surrealdb::RecordId;
 use std::ops::DerefMut;
 use surrealdb::method::QueryStream;
 use surrealdb::Action;
@@ -417,6 +418,70 @@ async fn live_select_query() {
 		assert!(notification.data.into_inner().is_object());
 		// It should be newly created
 		assert_eq!(notification.action, Action::Create);
+	}
+
+	drop(permit);
+}
+
+#[test_log::test(tokio::test)]
+async fn live_select_with_fetch() {
+	let (permit, db) = new_db().await;
+
+	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+
+	{
+		let table = format!("table_{}", Ulid::new());
+		let linktb = format!("link_{}", Ulid::new());
+		if FFLAGS.change_feed_live_queries.enabled() {
+			db.query(format!("DEFINE TABLE {table} CHANGEFEED 10m INCLUDE ORIGINAL"))
+				.await
+				.unwrap();
+		} else {
+			db.query(format!("DEFINE TABLE {table}")).await.unwrap();
+		}
+
+		// Start listening
+		let mut users = db
+			.query(format!("LIVE SELECT * FROM {table} FETCH link"))
+			.await
+			.unwrap()
+			.stream::<Notification<_>>(())
+			.unwrap();
+
+		let link: Option<ApiRecordId> = db.create(&linktb).await.unwrap();
+		let linkone = link.unwrap().id;
+		let link: Option<ApiRecordId> = db.create(&linktb).await.unwrap();
+		let linktwo = link.unwrap().id;
+
+		// Create a record
+		let created: Option<ApiRecordIdWithFetchedLink> = db.create(table)
+			.content(json!({"link": linkone}))
+			.await.unwrap();
+		// Pull the notification
+		let notification: Notification<ApiRecordIdWithFetchedLink> =
+			tokio::time::timeout(LQ_TIMEOUT, users.next()).await.unwrap().unwrap().unwrap();
+		// The returned record should match the created record
+		assert_eq!(created, Some(notification.data.clone()));
+		// It should be newly created
+		assert_eq!(notification.action, Action::Create);
+
+		// Update the record
+		let _: Option<ApiRecordIdWithFetchedLink> =
+			db.update(&notification.data.id)
+				.content(json!({"link": linktwo}))
+				.await.unwrap();
+		// Pull the notification
+		let notification: Notification<ApiRecordIdWithFetchedLink> =
+			tokio::time::timeout(LQ_TIMEOUT, users.next()).await.unwrap().unwrap().unwrap();
+		// It should be updated
+		assert_eq!(notification.action, Action::Update);
+
+		// Delete the record
+		let _: Option<ApiRecordIdWithFetchedLink> = db.delete(&notification.data.id).await.unwrap();
+		// Pull the notification
+		let notification: Notification<ApiRecordIdWithFetchedLink> = users.next().await.unwrap().unwrap();
+		// It should be deleted
+		assert_eq!(notification.action, Action::Delete);
 	}
 
 	drop(permit);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See #2766

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It implements the `FETCH` clause for `LIVE SELECT` statements. Syntax was already there, just the logic was missing :D

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Closes #2766

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Needs documentation

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
