### PR TITLE
Treat TxRetryable as UnexpectedAuth error

### DIFF
--- a/crates/core/src/iam/access.rs
+++ b/crates/core/src/iam/access.rs
@@ -29,7 +29,7 @@ pub async fn authenticate_record(
 				Error::Thrown(_) => Err(e),
 				// If the AUTHENTICATE clause failed due to an unexpected error, be more specific
 				// This allows clients to handle these errors, which may be retryable
-				Error::Tx(_) | Error::TxFailure => {
+				Error::Tx(_) | Error::TxFailure | Error::TxRetryable => {
 					debug!("Unexpected error found while executing AUTHENTICATE clause: {e}");
 					Err(Error::UnexpectedAuth)
 				}
@@ -71,7 +71,7 @@ pub async fn authenticate_generic(
 				Error::Thrown(_) => Err(e),
 				// If the AUTHENTICATE clause failed due to an unexpected error, be more specific
 				// This allows clients to handle these errors, which may be retryable
-				Error::Tx(_) | Error::TxFailure => {
+				Error::Tx(_) | Error::TxFailure | Error::TxRetryable => {
 					debug!("Unexpected error found while executing an AUTHENTICATE clause: {e}");
 					Err(Error::UnexpectedAuth)
 				}

--- a/crates/core/src/iam/signin.rs
+++ b/crates/core/src/iam/signin.rs
@@ -282,7 +282,7 @@ pub async fn db_access(
 									Error::Thrown(_) => Err(e),
 									// If the SIGNIN clause failed due to an unexpected error, be more specific
 									// This allows clients to handle these errors, which may be retryable
-									Error::Tx(_) | Error::TxFailure => {
+									Error::Tx(_) | Error::TxFailure | Error::TxRetryable => {
 										debug!("Unexpected error found while executing a SIGNIN clause: {e}");
 										Err(Error::UnexpectedAuth)
 									}

--- a/crates/core/src/iam/signup.rs
+++ b/crates/core/src/iam/signup.rs
@@ -190,7 +190,7 @@ pub async fn db_access(
 									Error::Thrown(_) => Err(e),
 									// If the SIGNUP clause failed due to an unexpected error, be more specific
 									// This allows clients to handle these errors, which may be retryable
-									Error::Tx(_) | Error::TxFailure => {
+									Error::Tx(_) | Error::TxFailure | Error::TxRetryable => {
 										debug!("Unexpected error found while executing a SIGNUP clause: {e}");
 										Err(Error::UnexpectedAuth)
 									}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

In #5130 we decided to return an `UnexpectedAuth` error whenever an unexpected error would lead to a failed authentication. This was done because these errors could often happen sporadically and the authentication would usually succeed if retried. The original motivation for that change was that a transaction conflict could occur in SurrealDB when the same record was being accessed concurrently. The error returned by the database could be an ambiguous `Tx(_)` or `TxFailed` error. That PR mapped those errors into a new `UnexpectedAuth` error, indicating the client that the authentication operation could be successful if retried.

Afterwards, #5184 and #5418 were merged to introduce support for retryable errors in the database layer, which included replacing some errors which were previously included under `TxFailed` as `TxRetryable`. This led to the error matching condition implemented in #5130 to fail to match those new errors, leading to `InvalidAuth` rather than `UnexpectedAuth` errors.

This change was not caught by the dedicated tests due to them being ignored as flaky in #5162 because of the fact that transaction conflicts could not be reliably reproduced in CI and were resulting in tests failing every so often.

The motivation for this PR is to correctly return `TxRetryable` errors resulting in failed authentication as `UnexpectedAuth` errors to the client so that they can catch them and attempt to retry the authentication without any changes.

## What does this change do?

Returns `TxRetryable` errors raised during authentication as `UnexpectedAuth` instead of `InvalidAuth` errors.

It the future, it should probably be SurrealDB itself who would attempt to retry the failed operation in the authentication layer.

## What is your testing strategy?

Ensure that the transaction conflict tests (which do not run in CI as they can be flaky) pass with the new changes.

## Is this related to any issues?

No.

## Does this change need documentation?

No.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
