### PR TITLE
Remove naive concurrency rate limiter in WebSocket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ tokio = { version = "1.40.0", features = ["macros", "signal"] }
 tokio-stream = "0.1"
 tokio-tungstenite = "0.23.1"
 tokio-util = { version = "0.7.11", features = ["io"] }
-tower = "0.4.13"
+tower = { version = "0.4.13", features = ["limit", "load-shed"] }
 tower-http = { version = "0.5.2", features = ["trace", "sensitive-headers", "auth", "request-id", "util", "catch-panic", "cors", "set-header", "limit", "add-extension", "compression-full"] }
 tower-service = "0.3.3"
 tracing = "0.1"

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -28,6 +28,10 @@ pub const PKG_NAME: &str = "surrealdb";
 /// The public endpoint for the administration interface
 pub const APP_ENDPOINT: &str = "https://surrealdb.com/surrealist";
 
+/// How many concurrent network requests can be handled at once (defaults to 1,048,576)
+pub static NET_MAX_CONCURRENT_REQUESTS: LazyLock<usize> =
+	lazy_env_parse!("SURREAL_NET_MAX_CONCURRENT_REQUESTS", usize, 1 << 20);
+
 /// The maximum HTTP body size of the HTTP /ml endpoints (defaults to 4 GiB)
 pub static HTTP_MAX_ML_BODY_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_HTTP_MAX_ML_BODY_SIZE", usize, 4 << 30);

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -67,6 +67,14 @@ pub static WEBSOCKET_MAX_FRAME_SIZE: LazyLock<usize> =
 pub static WEBSOCKET_MAX_MESSAGE_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE", usize, 128 << 20);
 
+/// How many messages can be buffered while attempting to deliver to the client.
+pub static WEBSOCKET_RESPONSE_BUFFER_SIZE: LazyLock<usize> =
+	lazy_env_parse!("SURREAL_WEBSOCKET_RESPONSE_BUFFER_SIZE", usize, 100);
+
+/// How many messages can be queued for sending to the buffering WebSocket connection.
+pub static WEBSOCKET_RESPONSE_CHANNEL_SIZE: LazyLock<usize> =
+	lazy_env_parse!("SURREAL_WEBSOCKET_RESPONSE_CHANNEL_SIZE", usize, 100);
+
 /// The number of runtime worker threads to start (defaults to the number of CPU cores, minimum 4)
 pub static RUNTIME_WORKER_THREADS: LazyLock<usize> =
 	lazy_env_parse_or_else!("SURREAL_RUNTIME_WORKER_THREADS", usize, |_| {

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -67,12 +67,6 @@ pub static WEBSOCKET_MAX_FRAME_SIZE: LazyLock<usize> =
 pub static WEBSOCKET_MAX_MESSAGE_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE", usize, 128 << 20);
 
-/// How many concurrent tasks can be handled on each WebSocket (defaults to 4 times the number of CPU cores, minimum 12)
-pub static WEBSOCKET_MAX_CONCURRENT_REQUESTS: LazyLock<usize> =
-	lazy_env_parse_or_else!("SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS", usize, |_| {
-		std::cmp::max(12, num_cpus::get().saturating_mul(4))
-	});
-
 /// The number of runtime worker threads to start (defaults to the number of CPU cores, minimum 4)
 pub static RUNTIME_WORKER_THREADS: LazyLock<usize> =
 	lazy_env_parse_or_else!("SURREAL_RUNTIME_WORKER_THREADS", usize, |_| {

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -90,7 +90,9 @@ pub async fn init(ds: Arc<Datastore>, ct: CancellationToken) -> Result<(), Error
 		// Ensure a X-Request-Id header is specified
 		.set_x_request_id(MakeRequestUuid)
 		// Ensure the Request-Id is sent in the response
-		.propagate_x_request_id();
+		.propagate_x_request_id()
+		// Limit the number of requests handled at once
+		.concurrency_limit(*cnf::NET_MAX_CONCURRENT_REQUESTS);
 
 	#[cfg(feature = "http-compression")]
 	let service = service.layer(
@@ -162,9 +164,7 @@ pub async fn init(ds: Arc<Datastore>, ct: CancellationToken) -> Result<(), Error
 				// allow requests from any origin
 				.allow_origin(Any)
 				.max_age(Duration::from_secs(86400)),
-		)
-		// Limit the number of requests handled at once
-		.concurrency_limit(*cnf::NET_MAX_CONCURRENT_REQUESTS);
+		);
 
 	let axum_app = Router::<Arc<RpcState>>::new()
 		// Redirect until we provide a UI


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The concurrent request limiter on each WebSocket connection, is naive, and does not achieve any supposed goal of limiting load on the server.

## What does this change do?

This pull request makes three changes:

- Removes the naive concurrency rate limiter which was applied on each WebSocket
- Introduces two new environment variables `SURREAL_WEBSOCKET_RESPONSE_BUFFER_SIZE` (defaulting to `100`) and `SURREAL_WEBSOCKET_RESPONSE_CHANNEL_SIZE` (defaulting to `100`) for configuring the WebSocket buffer size and the WebSocket response queue size. 
- Adds a global limit for concurrent server requests, and introduces a new environment variable `SURREAL_NET_MAX_CONCURRENT_REQUESTS` (defaulting to `1,048,576` concurrent requests).

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [ ] Documentation to be added

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
