### PR TITLE
`DEFAULT ALWAYS` clause

### DIFF
--- a/crates/core/src/doc/field.rs
+++ b/crates/core/src/doc/field.rs
@@ -216,10 +216,13 @@ impl Document {
 					if !skipped {
 						// Process any DEFAULT clause
 						val = field.process_default_clause(val).await?;
-						// Process any TYPE clause
-						val = field.process_type_clause(val).await?;
-						// Process any VALUE clause
-						val = field.process_value_clause(val).await?;
+						// Check for the existance of a VALUE clause
+						if field.def.value.is_some() {
+							// Process any TYPE clause
+							val = field.process_type_clause(val).await?;
+							// Process any VALUE clause
+							val = field.process_value_clause(val).await?;
+						}
 						// Process any TYPE clause
 						val = field.process_type_clause(val).await?;
 						// Process any ASSERT clause
@@ -348,7 +351,7 @@ impl FieldEditContext<'_> {
 			return Ok(val);
 		}
 		// The document is not being created
-		if !self.doc.is_new() {
+		if !self.doc.is_new() && !self.def.default_always {
 			return Ok(val);
 		}
 		// Get the default value

--- a/crates/core/src/sql/statements/define/field.rs
+++ b/crates/core/src/sql/statements/define/field.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Write};
 use uuid::Uuid;
 
-#[revisioned(revision = 5)]
+#[revisioned(revision = 6)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Store, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
@@ -39,6 +39,8 @@ pub struct DefineFieldStatement {
 	pub overwrite: bool,
 	#[revision(start = 5)]
 	pub reference: Option<Reference>,
+	#[revision(start = 6)]
+	pub default_always: bool,
 }
 
 impl DefineFieldStatement {
@@ -366,7 +368,12 @@ impl Display for DefineFieldStatement {
 			write!(f, " TYPE {v}")?
 		}
 		if let Some(ref v) = self.default {
-			write!(f, " DEFAULT {v}")?
+			write!(f, " DEFAULT")?;
+			if self.default_always {
+				write!(f, " ALWAYS")?
+			}
+
+			write!(f, " {v}")?
 		}
 		if self.readonly {
 			write!(f, " READONLY")?

--- a/crates/core/src/syn/lexer/keywords.rs
+++ b/crates/core/src/syn/lexer/keywords.rs
@@ -62,6 +62,7 @@ pub(crate) static KEYWORDS: phf::Map<UniCase<&'static str>, TokenKind> = phf_map
 	UniCase::ascii("ALGORITHM") => TokenKind::Keyword(Keyword::Algorithm),
 	UniCase::ascii("ALL") => TokenKind::Keyword(Keyword::All),
 	UniCase::ascii("Alter") => TokenKind::Keyword(Keyword::Alter),
+	UniCase::ascii("ALWAYS") => TokenKind::Keyword(Keyword::Always),
 	UniCase::ascii("ANALYZE") => TokenKind::Keyword(Keyword::Analyze),
 	UniCase::ascii("ANALYZER") => TokenKind::Keyword(Keyword::Analyzer),
 	UniCase::ascii("AS") => TokenKind::Keyword(Keyword::As),

--- a/crates/core/src/syn/parser/stmt/define.rs
+++ b/crates/core/src/syn/parser/stmt/define.rs
@@ -889,6 +889,10 @@ impl Parser<'_> {
 				}
 				t!("DEFAULT") => {
 					self.pop_peek();
+					if self.eat(t!("ALWAYS")) {
+						res.default_always = true;
+					}
+
 					res.default = Some(ctx.run(|ctx| self.parse_value_field(ctx)).await?);
 				}
 				t!("PERMISSIONS") => {

--- a/crates/core/src/syn/parser/test/stmt.rs
+++ b/crates/core/src/syn/parser/test/stmt.rs
@@ -1924,6 +1924,7 @@ fn parse_define_field() {
 				if_not_exists: false,
 				overwrite: false,
 				reference: None,
+				default_always: false,
 			}))
 		)
 	}
@@ -1957,6 +1958,7 @@ fn parse_define_field() {
 				if_not_exists: false,
 				overwrite: false,
 				reference: None,
+				default_always: false,
 			}))
 		)
 	}

--- a/crates/core/src/syn/parser/test/streaming.rs
+++ b/crates/core/src/syn/parser/test/streaming.rs
@@ -333,6 +333,7 @@ fn statements() -> Vec<Statement> {
 			if_not_exists: false,
 			overwrite: false,
 			reference: None,
+			default_always: false,
 		})),
 		Statement::Define(DefineStatement::Index(DefineIndexStatement {
 			name: Ident("index".to_owned()),

--- a/crates/core/src/syn/token/keyword.rs
+++ b/crates/core/src/syn/token/keyword.rs
@@ -29,6 +29,7 @@ keyword! {
 	Algorithm => "ALGORITHM",
 	All => "ALL",
 	Alter => "ALTER",
+	Always => "ALWAYS",
 	Analyze => "ANALYZE",
 	Analyzer => "ANALYZER",
 	As => "AS",

--- a/crates/language-tests/tests/language/statements/define/field/default_always.surql
+++ b/crates/language-tests/tests/language/statements/define/field/default_always.surql
@@ -18,6 +18,22 @@ value = "[{ id: product:test, primary: 123.456f }]"
 [[test.results]]
 value = "[{ id: product:test, primary: 123.456f }]"
 
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: post:test, tags: [] }]"
+[[test.results]]
+value = "[{ id: post:test, tags: [{ color: 'red', name: 'test' }] }]"
+[[test.results]]
+value = "[{ id: post:test, tags: [{ color: 'red', name: 'test' }, { color: 'blue', name: 'test' }] }]"
+
 */
 
 DEFINE TABLE product SCHEMAFULL;
@@ -29,3 +45,12 @@ CREATE product:test;
 UPSERT product:test SET primary = 654.321;
 UPSERT product:test SET primary = NONE;
 UPSERT product:test CONTENT {};
+--
+DEFINE TABLE post SCHEMAFULL;
+DEFINE FIELD tags ON post TYPE array<object> DEFAULT ALWAYS [];
+DEFINE FIELD tags.*.color ON post TYPE string DEFAULT ALWAYS 'red';
+DEFINE FIELD tags.*.name ON post TYPE string;
+--
+CREATE post:test;
+UPSERT post:test SET tags += { name: 'test' };
+UPSERT post:test SET tags += { name: 'test', color: 'blue' };

--- a/crates/language-tests/tests/language/statements/define/field/default_always.surql
+++ b/crates/language-tests/tests/language/statements/define/field/default_always.surql
@@ -1,0 +1,31 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+error = "Found NULL for field `primary`, with record `product:test`, but expected a number"
+
+[[test.results]]
+value = "[{ id: product:test, primary: 123.456f }]"
+[[test.results]]
+value = "[{ id: product:test, primary: 654.321f }]"
+[[test.results]]
+value = "[{ id: product:test, primary: 123.456f }]"
+[[test.results]]
+value = "[{ id: product:test, primary: 123.456f }]"
+
+*/
+
+DEFINE TABLE product SCHEMAFULL;
+DEFINE FIELD primary ON product TYPE number DEFAULT ALWAYS 123.456;
+--
+CREATE product:test SET primary = NULL;
+--
+CREATE product:test;
+UPSERT product:test SET primary = 654.321;
+UPSERT product:test SET primary = NONE;
+UPSERT product:test CONTENT {};

--- a/revision.lock
+++ b/revision.lock
@@ -53,7 +53,7 @@ DefineAnalyzerStatement:4(crates/core/src/sql/statements/define/analyzer.rs)(324
 DefineConfigStatement:1(crates/core/src/sql/statements/define/config/mod.rs)(344983375)
 DefineDatabaseStatement:3(crates/core/src/sql/statements/define/database.rs)(3862762822)
 DefineEventStatement:3(crates/core/src/sql/statements/define/event.rs)(3245497894)
-DefineFieldStatement:5(crates/core/src/sql/statements/define/field.rs)(3361903720)
+DefineFieldStatement:6(crates/core/src/sql/statements/define/field.rs)(4245386341)
 DefineFunctionStatement:4(crates/core/src/sql/statements/define/function.rs)(2511533132)
 DefineIndexStatement:4(crates/core/src/sql/statements/define/index.rs)(2028612622)
 DefineModelStatement:3(crates/core/src/sql/statements/define/model.rs)(2141629244)


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

There are certain scenario's where you want the `DEFAULT` clause to be applied also when the field is completely reset.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR introduces an `ALWAYS` keyword to the `DEFAULT` keyword, indicating that the `DEFAULT` clause is used not only on `CREATE`, but also on `UPDATE` if the value is empty (`NONE`).

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Closes #5029 
- [x] Closes #5422
- [x] Closes #5346
- [x] Closes #5013
- [x] Closes #2581
- [x] Related to #3662

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Needs documentation

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
