### PR TITLE
Support merging new object values

### DIFF
--- a/crates/core/src/sql/value/merge.rs
+++ b/crates/core/src/sql/value/merge.rs
@@ -10,8 +10,18 @@ impl Value {
 			});
 		}
 		// Otherwise loop through every object field
-		for k in val.every(None, false, false).iter() {
-			match val.pick(k) {
+		for k in val.every(None, true, false).iter() {
+			// Because we iterate every step, we need to this check
+			// If old & new are both objects, we do not want to completely
+			// replace the old object with the new object as that will drop
+			// all the fields in the old object that are not in the new object
+			let old = self.pick(k);
+			let new = val.pick(k);
+			if old.is_object() && new.is_object() {
+				continue;
+			}
+			
+			match new {
 				Value::None => self.cut(k),
 				v => self.put(k, v),
 			}

--- a/crates/core/src/sql/value/merge.rs
+++ b/crates/core/src/sql/value/merge.rs
@@ -119,4 +119,32 @@ mod tests {
 		res.merge(mrg).unwrap();
 		assert_eq!(res, val);
 	}
+
+	#[tokio::test]
+	async fn merge_new_object() {
+		let mut res = Value::parse(
+			"{
+				test: true,
+				name: 'Tobie',
+			}",
+		);
+		let mrg = Value::parse(
+			"{
+				name: {
+					title: 'Mr',
+					initials: NONE,
+				},
+			}",
+		);
+		let val = Value::parse(
+			"{
+				test: true,
+				name: {
+					title: 'Mr',
+				},
+			}",
+		);
+		res.merge(mrg).unwrap();
+		assert_eq!(res, val);
+	}
 }

--- a/crates/core/src/sql/value/merge.rs
+++ b/crates/core/src/sql/value/merge.rs
@@ -20,7 +20,7 @@ impl Value {
 			if old.is_object() && new.is_object() {
 				continue;
 			}
-			
+
 			match new {
 				Value::None => self.cut(k),
 				v => self.put(k, v),

--- a/crates/core/src/sql/value/merge.rs
+++ b/crates/core/src/sql/value/merge.rs
@@ -126,6 +126,10 @@ mod tests {
 			"{
 				test: true,
 				name: 'Tobie',
+				obj: {
+					a: 1,
+					b: 2,
+				}
 			}",
 		);
 		let mrg = Value::parse(
@@ -134,6 +138,10 @@ mod tests {
 					title: 'Mr',
 					initials: NONE,
 				},
+				obj: {
+					a: 2,
+					b: NONE,
+				}
 			}",
 		);
 		let val = Value::parse(
@@ -141,6 +149,9 @@ mod tests {
 				test: true,
 				name: {
 					title: 'Mr',
+				},
+				obj: {
+					a: 2,
 				},
 			}",
 		);

--- a/crates/language-tests/tests/language/statements/update/merge.surql
+++ b/crates/language-tests/tests/language/statements/update/merge.surql
@@ -1,0 +1,32 @@
+/**
+[test]
+
+[[test.results]]
+value = "[{ age: 90, id: person:one, state: 'alive' }]"
+
+[[test.results]]
+value = "[{ age: 91, id: person:one, state: { deceased: '2025-01-07' } }]"
+
+[[test.results]]
+value = "[{ age: 91, id: person:one, state: { deceased: '2025-01-07', other: 'prop' } }]"
+
+*/
+INSERT INTO person {
+    id: person:one,
+    age: 90,
+    state: "alive"
+};
+
+UPDATE person:one MERGE {
+    age: 91,
+    state: {
+        deceased: "2025-01-07"
+    }
+};
+
+UPDATE person:one MERGE {
+    age: 91,
+    state: {
+        other: "prop"
+    }
+};


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See #5339. When you used merge to set a new object value, it would skip it as only the new object's nested fields were being iterated.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

We now iterate every step, only skipping steps when both the old and new values are objects to prevent losing keys only present in the old object.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test which covers both:
- setting a new object
- merging into an existing object, ensuring no old keys are lost

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #5339

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
