### PR TITLE
Add cross-transaction caching to database and table statements

### DIFF
--- a/crates/core/src/doc/check.rs
+++ b/crates/core/src/doc/check.rs
@@ -145,7 +145,7 @@ impl Document {
 						Value::Thing(v) if v.eq(&rid) => (),
 						// The id is a match, so don't error
 						v if rid.id.is(&v) => (),
-						// The in field does not match
+						// The id field does not match
 						v => {
 							return Err(Error::IdMismatch {
 								value: v.to_string(),
@@ -216,7 +216,7 @@ impl Document {
 						Value::Thing(v) if v.eq(r) => (),
 						// The out is a match, so don't error
 						v if r.id.is(&v) => (),
-						// The in field does not match
+						// The out field does not match
 						v => {
 							return Err(Error::OutMismatch {
 								value: v.to_string(),
@@ -303,8 +303,9 @@ impl Document {
 		opt: &Options,
 		stm: &Statement<'_>,
 	) -> Result<(), Error> {
-		// Check where condition
+		// Check if we have already processed a condition
 		if !self.is_condition_checked() {
+			// Check if a WHERE condition is specified
 			if let Some(cond) = stm.cond() {
 				// Process the permitted documents
 				let current = match self.reduced(stk, ctx, opt, Current).await? {

--- a/crates/core/src/kvs/cache/ds/entry.rs
+++ b/crates/core/src/kvs/cache/ds/entry.rs
@@ -4,12 +4,15 @@ use crate::sql::statements::DefineFieldStatement;
 use crate::sql::statements::DefineIndexStatement;
 use crate::sql::statements::DefineTableStatement;
 use crate::sql::statements::LiveStatement;
+use std::any::Any;
 use std::sync::Arc;
 use uuid::Uuid;
 
 #[derive(Clone)]
 #[non_exhaustive]
 pub(crate) enum Entry {
+	/// A cached entry of any type
+	Any(Arc<dyn Any + Send + Sync>),
 	/// A slice of DefineEventStatement specified on a table.
 	Evs(Arc<[DefineEventStatement]>),
 	/// A slice of DefineFieldStatement specified on a table.
@@ -25,6 +28,16 @@ pub(crate) enum Entry {
 }
 
 impl Entry {
+	/// Converts this cache entry into a single entry of arbitrary type.
+	/// This panics if called on a cache entry that is not an [`Entry::Any`].
+	pub(crate) fn try_into_type<T: Send + Sync + 'static>(self: Entry) -> Result<Arc<T>, Error> {
+		match self {
+			Entry::Any(v) => {
+				v.downcast::<T>().map_err(|_| fail!("Unable to convert type into Entry::Any"))
+			}
+			_ => Err(fail!("Unable to convert type into Entry::Any")),
+		}
+	}
 	/// Converts this cache entry into a slice of [`DefineEventStatement`].
 	/// This panics if called on a cache entry that is not an [`Entry::Evs`].
 	pub(crate) fn try_into_evs(self) -> Result<Arc<[DefineEventStatement]>, Error> {

--- a/crates/core/src/kvs/cache/ds/key.rs
+++ b/crates/core/src/kvs/cache/ds/key.rs
@@ -3,6 +3,10 @@ use uuid::Uuid;
 
 #[derive(Clone, Hash, Eq, PartialEq)]
 pub(crate) enum Key {
+	/// A cache key for a database
+	Db(String, String),
+	/// A cache key for a table
+	Tb(String, String, String),
 	/// A cache key for events (on a table)
 	Evs(String, String, String, Uuid),
 	/// A cache key for fieds (on a table)
@@ -21,6 +25,8 @@ impl<'a> From<Lookup<'a>> for Key {
 	#[rustfmt::skip]
 	fn from(value: Lookup<'a>) -> Self {
 		match value {
+			Lookup::Db(a, b) => Key::Db(a.to_string(), b.to_string()),
+			Lookup::Tb(a, b, c) => Key::Tb(a.to_string(), b.to_string(), c.to_string()),
 			Lookup::Evs(a, b, c, d) => Key::Evs(a.to_string(), b.to_string(), c.to_string(), d),
 			Lookup::Fds(a, b, c, d) => Key::Fds(a.to_string(), b.to_string(), c.to_string(), d),
 			Lookup::Fts(a, b, c, d) => Key::Fts(a.to_string(), b.to_string(), c.to_string(), d),

--- a/crates/core/src/kvs/cache/ds/lookup.rs
+++ b/crates/core/src/kvs/cache/ds/lookup.rs
@@ -4,6 +4,10 @@ use uuid::Uuid;
 
 #[derive(Hash, Eq, PartialEq)]
 pub(crate) enum Lookup<'a> {
+	/// A cache key for a database
+	Db(&'a str, &'a str),
+	/// A cache key for a table
+	Tb(&'a str, &'a str, &'a str),
 	/// A cache key for events (on a table)
 	Evs(&'a str, &'a str, &'a str, Uuid),
 	/// A cache key for fields (on a table)
@@ -22,6 +26,8 @@ impl Equivalent<Key> for Lookup<'_> {
 	#[rustfmt::skip]
 	fn equivalent(&self, key: &Key) -> bool {
 		match (self, key) {
+			(Self::Db(la, lb), Key::Db(ka, kb)) => la == ka && lb == kb,
+			(Self::Tb(la, lb, lc), Key::Tb(ka, kb, kc)) => la == ka && lb == kb && lc == kc,
 			(Self::Evs(la, lb, lc, ld), Key::Evs(ka, kb, kc, kd)) => la == ka && lb == kb && lc == kc && ld == kd,
 			(Self::Fds(la, lb, lc, ld), Key::Fds(ka, kb, kc, kd)) => la == ka && lb == kb && lc == kc && ld == kd,
 			(Self::Fts(la, lb, lc, ld), Key::Fts(ka, kb, kc, kd)) => la == ka && lb == kb && lc == kc && ld == kd,

--- a/crates/core/src/kvs/cache/ds/mod.rs
+++ b/crates/core/src/kvs/cache/ds/mod.rs
@@ -38,16 +38,15 @@ impl DatastoreCache {
 		self.cache.insert(lookup.into(), entry);
 	}
 
-	/// Clear the cache entry for a database
-	pub(crate) fn clear_db(&self, ns: &str, db: &str) {
-		let key = Lookup::Db(ns, db);
-		self.cache.remove(&key);
-	}
-
 	/// Clear the cache entry for a table
 	pub(crate) fn clear_tb(&self, ns: &str, db: &str, tb: &str) {
 		let key = Lookup::Tb(ns, db, tb);
 		self.cache.remove(&key);
+	}
+
+	/// Clear all items from the datastore cache
+	pub(crate) fn clear(&self) {
+		self.cache.clear();
 	}
 
 	pub fn get_live_queries_version(&self, ns: &str, db: &str, tb: &str) -> Result<Uuid, Error> {

--- a/crates/core/src/kvs/cache/ds/mod.rs
+++ b/crates/core/src/kvs/cache/ds/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use entry::Entry;
 pub(crate) use lookup::Lookup;
 use uuid::Uuid;
 
-pub type Cache = quick_cache::sync::Cache<key::Key, Entry, weight::Weight>;
+pub(crate) type Cache = quick_cache::sync::Cache<key::Key, Entry, weight::Weight>;
 
 pub struct DatastoreCache {
 	/// Store the cache entries
@@ -16,6 +16,7 @@ pub struct DatastoreCache {
 }
 
 impl DatastoreCache {
+	/// Creates a new datastore cache
 	pub(in crate::kvs) fn new() -> Self {
 		let cache = Cache::with_weighter(
 			*crate::cnf::DATASTORE_CACHE_SIZE,
@@ -27,10 +28,12 @@ impl DatastoreCache {
 		}
 	}
 
+	/// Fetches an item from the datastore cache
 	pub(crate) fn get(&self, lookup: &Lookup) -> Option<Entry> {
 		self.cache.get(lookup)
 	}
 
+	/// Inserts an item into the datastore cache
 	pub(crate) fn insert(&self, lookup: Lookup, entry: Entry) {
 		self.cache.insert(lookup.into(), entry);
 	}

--- a/crates/core/src/kvs/cache/ds/mod.rs
+++ b/crates/core/src/kvs/cache/ds/mod.rs
@@ -38,6 +38,18 @@ impl DatastoreCache {
 		self.cache.insert(lookup.into(), entry);
 	}
 
+	/// Clear the cache entry for a database
+	pub(crate) fn clear_db(&self, ns: &str, db: &str) {
+		let key = Lookup::Db(ns, db);
+		self.cache.remove(&key);
+	}
+
+	/// Clear the cache entry for a table
+	pub(crate) fn clear_tb(&self, ns: &str, db: &str, tb: &str) {
+		let key = Lookup::Tb(ns, db, tb);
+		self.cache.remove(&key);
+	}
+
 	pub fn get_live_queries_version(&self, ns: &str, db: &str, tb: &str) -> Result<Uuid, Error> {
 		// Get the live-queries cache version
 		let key = Lookup::Lvv(ns, db, tb);

--- a/crates/core/src/kvs/cache/tx/mod.rs
+++ b/crates/core/src/kvs/cache/tx/mod.rs
@@ -8,10 +8,41 @@ pub(crate) use lookup::Lookup;
 
 pub(crate) type Cache = quick_cache::sync::Cache<key::Key, Entry, weight::Weight>;
 
-pub(crate) fn new() -> Cache {
-	Cache::with_weighter(
-		*crate::cnf::TRANSACTION_CACHE_SIZE,
-		*crate::cnf::TRANSACTION_CACHE_SIZE as u64,
-		weight::Weight,
-	)
+pub struct TransactionCache {
+	/// Store the cache entries
+	cache: Cache,
+}
+
+impl TransactionCache {
+	/// Creates a new transaction cache
+	pub(in crate::kvs) fn new() -> Self {
+		let cache = Cache::with_weighter(
+			*crate::cnf::TRANSACTION_CACHE_SIZE,
+			*crate::cnf::TRANSACTION_CACHE_SIZE as u64,
+			weight::Weight,
+		);
+		Self {
+			cache,
+		}
+	}
+
+	/// Fetch an item from the datastore cache
+	pub(crate) fn get(&self, lookup: &Lookup) -> Option<Entry> {
+		self.cache.get(lookup)
+	}
+
+	/// Insert an item into the datastore cache
+	pub(crate) fn insert(&self, lookup: Lookup, entry: Entry) {
+		self.cache.insert(lookup.into(), entry);
+	}
+
+	/// Remove an item from the datastore cache
+	pub(crate) fn remove(&self, lookup: Lookup) {
+		self.cache.remove(&lookup);
+	}
+
+	/// Clear all items from the datastore cache
+	pub(crate) fn clear(&self) {
+		self.cache.clear();
+	}
 }

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -428,7 +428,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Nds(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -446,7 +446,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Rus(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -464,7 +464,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Ras(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -482,7 +482,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Rag(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -500,7 +500,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Nss(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -518,7 +518,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Nus(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -536,7 +536,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Nas(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -558,7 +558,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Nag(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -576,7 +576,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Dbs(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -598,7 +598,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Dus(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -620,7 +620,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Das(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -643,7 +643,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Dag(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -665,7 +665,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Azs(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -687,7 +687,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Fcs(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -709,7 +709,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Pas(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -731,7 +731,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Mls(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -753,7 +753,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Cgs(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -776,7 +776,7 @@ impl Transaction {
 				let val = self.getr(beg..end, version).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Tbs(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -799,7 +799,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Evs(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -823,7 +823,7 @@ impl Transaction {
 				let val = self.getr(beg..end, version).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Fds(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -846,7 +846,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Ixs(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -869,7 +869,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Fts(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -892,7 +892,7 @@ impl Transaction {
 				let val = self.getr(beg..end, None).await?;
 				let val = util::deserialize_cache(val.iter().map(|x| x.1.as_slice()))?;
 				let entry = cache::tx::Entry::Lvs(val.clone());
-				self.cache.insert(qey.into(), entry);
+				self.cache.insert(qey, entry);
 				Ok(val)
 			}
 		}
@@ -911,7 +911,7 @@ impl Transaction {
 				})?;
 				let val: Node = val.into();
 				let val = cache::tx::Entry::Any(Arc::new(val));
-				self.cache.insert(qey.into(), val.clone());
+				self.cache.insert(qey, val.clone());
 				val
 			}
 		}
@@ -932,7 +932,7 @@ impl Transaction {
 				let val: DefineUserStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -952,7 +952,7 @@ impl Transaction {
 				let val: DefineAccessStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -978,7 +978,7 @@ impl Transaction {
 				let val: AccessGrant = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -998,7 +998,7 @@ impl Transaction {
 				let val: DefineNamespaceStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1019,7 +1019,7 @@ impl Transaction {
 				let val: DefineUserStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1044,7 +1044,7 @@ impl Transaction {
 				let val: DefineAccessStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1072,7 +1072,7 @@ impl Transaction {
 				let val: AccessGrant = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1092,7 +1092,7 @@ impl Transaction {
 				let val: DefineDatabaseStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1119,7 +1119,7 @@ impl Transaction {
 				let val: DefineUserStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1146,7 +1146,7 @@ impl Transaction {
 				let val: DefineAccessStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1176,7 +1176,7 @@ impl Transaction {
 				let val: AccessGrant = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1202,7 +1202,7 @@ impl Transaction {
 				let val: DefineModelStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1227,7 +1227,7 @@ impl Transaction {
 				let val: DefineAnalyzerStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1252,7 +1252,7 @@ impl Transaction {
 				let val: DefineFunctionStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1277,7 +1277,7 @@ impl Transaction {
 				let val: DefineParamStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1302,7 +1302,7 @@ impl Transaction {
 				let val: DefineConfigStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1327,7 +1327,7 @@ impl Transaction {
 				let val: DefineTableStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1353,7 +1353,7 @@ impl Transaction {
 				let val: DefineEventStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1379,7 +1379,7 @@ impl Transaction {
 				let val: DefineFieldStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1405,7 +1405,7 @@ impl Transaction {
 				let val: DefineIndexStatement = val.into();
 				let val = Arc::new(val);
 				let entr = cache::tx::Entry::Any(val.clone());
-				self.cache.insert(qey.into(), entr);
+				self.cache.insert(qey, entr);
 				Ok(val)
 			}
 		}
@@ -1447,7 +1447,7 @@ impl Transaction {
 						// The value exists in the datastore
 						Some(val) => {
 							let val = cache::tx::Entry::Val(Arc::new(val.into()));
-							self.cache.insert(qey.into(), val.clone());
+							self.cache.insert(qey, val.clone());
 							val.try_into_val()
 						}
 						// The value is not in the datastore
@@ -1652,14 +1652,14 @@ impl Transaction {
 							self.put(&key, &val, None).await?;
 							cache::tx::Entry::Any(Arc::new(val))
 						};
-						self.cache.insert(qey.into(), val.clone());
+						self.cache.insert(qey, val.clone());
 						val
 					}
 					// Store the fetched value in the cache
 					Ok(val) => {
 						let val: DefineNamespaceStatement = val.into();
 						let val = cache::tx::Entry::Any(Arc::new(val));
-						self.cache.insert(qey.into(), val.clone());
+						self.cache.insert(qey, val.clone());
 						val
 					}
 					// Throw any received errors
@@ -1709,7 +1709,7 @@ impl Transaction {
 							self.put(&key, &val, None).await?;
 							cache::tx::Entry::Any(Arc::new(val))
 						};
-						self.cache.insert(qey.into(), val.clone());
+						self.cache.insert(qey, val.clone());
 						val
 					}
 					// Check to see that the hierarchy exists
@@ -1725,7 +1725,7 @@ impl Transaction {
 					Ok(val) => {
 						let val: DefineDatabaseStatement = val.into();
 						let val = cache::tx::Entry::Any(Arc::new(val));
-						self.cache.insert(qey.into(), val.clone());
+						self.cache.insert(qey, val.clone());
 						val
 					}
 					// Throw any received errors
@@ -1777,7 +1777,7 @@ impl Transaction {
 							self.put(&key, &val, None).await?;
 							cache::tx::Entry::Any(Arc::new(val))
 						};
-						self.cache.insert(qey.into(), val.clone());
+						self.cache.insert(qey, val.clone());
 						val
 					}
 					// Check to see that the hierarchy exists
@@ -1794,7 +1794,7 @@ impl Transaction {
 					Ok(val) => {
 						let val: DefineTableStatement = val.into();
 						let val = cache::tx::Entry::Any(Arc::new(val));
-						self.cache.insert(qey.into(), val.clone());
+						self.cache.insert(qey, val.clone());
 						val
 					}
 					// Throw any received errors

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -10,7 +10,7 @@ use crate::dbs::node::Node;
 use crate::err::Error;
 use crate::idx::trees::store::cache::IndexTreeCaches;
 use crate::kvs::cache;
-use crate::kvs::cache::tx::Cache;
+use crate::kvs::cache::tx::TransactionCache;
 use crate::kvs::scanner::Scanner;
 use crate::kvs::Transactor;
 use crate::sql::statements::define::DefineConfigStatement;
@@ -44,7 +44,7 @@ pub struct Transaction {
 	/// The underlying transactor
 	tx: Mutex<Transactor>,
 	/// The query cache for this store
-	cache: Cache,
+	cache: TransactionCache,
 	/// Cache the index updates
 	index_caches: IndexTreeCaches,
 }
@@ -54,7 +54,7 @@ impl Transaction {
 	pub fn new(tx: Transactor) -> Transaction {
 		Transaction {
 			tx: Mutex::new(tx),
-			cache: cache::tx::new(),
+			cache: TransactionCache::new(),
 			index_caches: IndexTreeCaches::default(),
 		}
 	}
@@ -1492,7 +1492,7 @@ impl Transaction {
 		self.del(&key).await?;
 		// Set the value in the cache
 		let key = cache::tx::Lookup::Record(ns, db, tb, id);
-		self.cache.remove(&key);
+		self.cache.remove(key);
 		// Return nothing
 		Ok(())
 	}

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -1471,8 +1471,8 @@ impl Transaction {
 		let key = crate::key::thing::new(ns, db, tb, id);
 		self.set(&key, &val, None).await?;
 		// Set the value in the cache
-		let key = cache::tx::Lookup::Record(ns, db, tb, id);
-		self.cache.insert(key.into(), cache::tx::Entry::Val(Arc::new(val)));
+		let qey = cache::tx::Lookup::Record(ns, db, tb, id);
+		self.cache.insert(qey, cache::tx::Entry::Val(Arc::new(val)));
 		// Return nothing
 		Ok(())
 	}
@@ -1487,8 +1487,8 @@ impl Transaction {
 		val: Arc<Value>,
 	) -> Result<(), Error> {
 		// Set the value in the cache
-		let key = cache::tx::Lookup::Record(ns, db, tb, id);
-		self.cache.insert(key.into(), cache::tx::Entry::Val(val));
+		let qey = cache::tx::Lookup::Record(ns, db, tb, id);
+		self.cache.insert(qey, cache::tx::Entry::Val(val));
 		// Return nothing
 		Ok(())
 	}
@@ -1499,8 +1499,8 @@ impl Transaction {
 		let key = crate::key::thing::new(ns, db, tb, id);
 		self.del(&key).await?;
 		// Set the value in the cache
-		let key = cache::tx::Lookup::Record(ns, db, tb, id);
-		self.cache.remove(key);
+		let qey = cache::tx::Lookup::Record(ns, db, tb, id);
+		self.cache.remove(qey);
 		// Return nothing
 		Ok(())
 	}

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -41,6 +41,8 @@ use uuid::Uuid;
 
 #[non_exhaustive]
 pub struct Transaction {
+	/// Is this is a local datastore transaction
+	local: bool,
 	/// The underlying transactor
 	tx: Mutex<Transactor>,
 	/// The query cache for this store
@@ -51,8 +53,9 @@ pub struct Transaction {
 
 impl Transaction {
 	/// Create a new query store
-	pub fn new(tx: Transactor) -> Transaction {
+	pub fn new(local: bool, tx: Transactor) -> Transaction {
 		Transaction {
+			local,
 			tx: Mutex::new(tx),
 			cache: TransactionCache::new(),
 			index_caches: IndexTreeCaches::default(),
@@ -72,6 +75,11 @@ impl Transaction {
 	/// Retrieve the underlying transaction
 	pub async fn lock(&self) -> MutexGuard<'_, Transactor> {
 		self.tx.lock().await
+	}
+
+	/// Check if the transaction is local or distributed
+	pub fn local(&self) -> bool {
+		self.local
 	}
 
 	/// Check if the transaction is finished.

--- a/crates/core/src/sql/statements/define/database.rs
+++ b/crates/core/src/sql/statements/define/database.rs
@@ -70,7 +70,7 @@ impl DefineDatabaseStatement {
 		.await?;
 		// Clear the cache
 		if let Some(cache) = ctx.get_cache() {
-			cache.clear_db(ns, &self.name);
+			cache.clear();
 		}
 		// Clear the cache
 		txn.clear();

--- a/crates/core/src/sql/statements/define/database.rs
+++ b/crates/core/src/sql/statements/define/database.rs
@@ -35,10 +35,12 @@ impl DefineDatabaseStatement {
 	) -> Result<Value, Error> {
 		// Allowed to run?
 		opt.is_allowed(Action::Edit, ResourceKind::Database, &Base::Ns)?;
+		// Get the NS
+		let ns = opt.ns()?;
 		// Fetch the transaction
 		let txn = ctx.tx();
 		// Check if the definition exists
-		if txn.get_db(opt.ns()?, &self.name).await.is_ok() {
+		if txn.get_db(ns, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
 			} else if !self.overwrite {
@@ -48,13 +50,13 @@ impl DefineDatabaseStatement {
 			}
 		}
 		// Process the statement
-		let key = crate::key::namespace::db::new(opt.ns()?, &self.name);
-		let ns = txn.get_or_add_ns(opt.ns()?, opt.strict).await?;
+		let key = crate::key::namespace::db::new(ns, &self.name);
+		let nsv = txn.get_or_add_ns(ns, opt.strict).await?;
 		txn.set(
 			key,
 			DefineDatabaseStatement {
-				id: if self.id.is_none() && ns.id.is_some() {
-					Some(txn.lock().await.get_next_db_id(ns.id.unwrap()).await?)
+				id: if self.id.is_none() && nsv.id.is_some() {
+					Some(txn.lock().await.get_next_db_id(nsv.id.unwrap()).await?)
 				} else {
 					None
 				},
@@ -66,6 +68,10 @@ impl DefineDatabaseStatement {
 			None,
 		)
 		.await?;
+		// Clear the cache
+		if let Some(cache) = ctx.get_cache() {
+			cache.clear_db(ns, &self.name);
+		}
 		// Clear the cache
 		txn.clear();
 		// Ok all good

--- a/crates/core/src/sql/statements/define/event.rs
+++ b/crates/core/src/sql/statements/define/event.rs
@@ -38,10 +38,13 @@ impl DefineEventStatement {
 	) -> Result<Value, Error> {
 		// Allowed to run?
 		opt.is_allowed(Action::Edit, ResourceKind::Event, &Base::Db)?;
+		// Get the NS and DB
+		let ns = opt.ns()?;
+		let db = opt.db()?;
 		// Fetch the transaction
 		let txn = ctx.tx();
 		// Check if the definition exists
-		if txn.get_tb_event(opt.ns()?, opt.db()?, &self.what, &self.name).await.is_ok() {
+		if txn.get_tb_event(ns, db, &self.what, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
 			} else if !self.overwrite {
@@ -51,10 +54,10 @@ impl DefineEventStatement {
 			}
 		}
 		// Process the statement
-		let key = crate::key::table::ev::new(opt.ns()?, opt.db()?, &self.what, &self.name);
-		txn.get_or_add_ns(opt.ns()?, opt.strict).await?;
-		txn.get_or_add_db(opt.ns()?, opt.db()?, opt.strict).await?;
-		txn.get_or_add_tb(opt.ns()?, opt.db()?, &self.what, opt.strict).await?;
+		let key = crate::key::table::ev::new(ns, db, &self.what, &self.name);
+		txn.get_or_add_ns(ns, opt.strict).await?;
+		txn.get_or_add_db(ns, db, opt.strict).await?;
+		txn.get_or_add_tb(ns, db, &self.what, opt.strict).await?;
 		txn.set(
 			key,
 			DefineEventStatement {
@@ -67,8 +70,8 @@ impl DefineEventStatement {
 		)
 		.await?;
 		// Refresh the table cache
-		let key = crate::key::database::tb::new(opt.ns()?, opt.db()?, &self.what);
-		let tb = txn.get_tb(opt.ns()?, opt.db()?, &self.what).await?;
+		let key = crate::key::database::tb::new(ns, db, &self.what);
+		let tb = txn.get_tb(ns, db, &self.what).await?;
 		txn.set(
 			key,
 			DefineTableStatement {
@@ -78,6 +81,10 @@ impl DefineEventStatement {
 			None,
 		)
 		.await?;
+		// Clear the cache
+		if let Some(cache) = ctx.get_cache() {
+			cache.clear_tb(ns, db, &self.what);
+		}
 		// Clear the cache
 		txn.clear();
 		// Ok all good

--- a/crates/core/src/sql/statements/define/field.rs
+++ b/crates/core/src/sql/statements/define/field.rs
@@ -106,6 +106,10 @@ impl DefineFieldStatement {
 		)
 		.await?;
 		// Clear the cache
+		if let Some(cache) = ctx.get_cache() {
+			cache.clear_tb(ns, db, &self.what);
+		}
+		// Clear the cache
 		txn.clear();
 		// Find all existing field definitions
 		let fields = txn.all_tb_fields(ns, db, &self.what, None).await.ok();
@@ -190,6 +194,10 @@ impl DefineFieldStatement {
 						};
 						txn.set(key, val, None).await?;
 						// Clear the cache
+						if let Some(cache) = ctx.get_cache() {
+							cache.clear_tb(ns, db, &self.what);
+						}
+						// Clear the cache
 						txn.clear();
 					}
 				}
@@ -221,6 +229,10 @@ impl DefineFieldStatement {
 							..tb.as_ref().to_owned()
 						};
 						txn.set(key, val, None).await?;
+						// Clear the cache
+						if let Some(cache) = ctx.get_cache() {
+							cache.clear_tb(ns, db, &self.what);
+						}
 						// Clear the cache
 						txn.clear();
 					}

--- a/crates/core/src/sql/statements/define/index.rs
+++ b/crates/core/src/sql/statements/define/index.rs
@@ -44,10 +44,13 @@ impl DefineIndexStatement {
 	) -> Result<Value, Error> {
 		// Allowed to run?
 		opt.is_allowed(Action::Edit, ResourceKind::Index, &Base::Db)?;
+		// Get the NS and DB
+		let ns = opt.ns()?;
+		let db = opt.db()?;
 		// Fetch the transaction
 		let txn = ctx.tx();
 		// Check if the definition exists
-		if txn.get_tb_index(opt.ns()?, opt.db()?, &self.what, &self.name).await.is_ok() {
+		if txn.get_tb_index(ns, db, &self.what, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
 			} else if !self.overwrite {
@@ -57,17 +60,16 @@ impl DefineIndexStatement {
 			}
 		}
 		// Does the table exists?
-		match txn.get_tb(opt.ns()?, opt.db()?, &self.what).await {
-			Ok(db) => {
+		match txn.get_tb(ns, db, &self.what).await {
+			Ok(tb) => {
 				// Are we SchemaFull?
-				if db.full {
+				if tb.full {
 					// Check that the fields exists
 					for idiom in self.cols.iter() {
 						let Some(Part::Field(first)) = idiom.0.first() else {
 							continue;
 						};
-						txn.get_tb_field(opt.ns()?, opt.db()?, &self.what, &first.to_string())
-							.await?;
+						txn.get_tb_field(ns, db, &self.what, &first.to_string()).await?;
 					}
 				}
 			}
@@ -79,10 +81,10 @@ impl DefineIndexStatement {
 			Err(e) => return Err(e),
 		}
 		// Process the statement
-		let key = crate::key::table::ix::new(opt.ns()?, opt.db()?, &self.what, &self.name);
+		let key = crate::key::table::ix::new(ns, db, &self.what, &self.name);
 		txn.get_or_add_ns(opt.ns()?, opt.strict).await?;
-		txn.get_or_add_db(opt.ns()?, opt.db()?, opt.strict).await?;
-		txn.get_or_add_tb(opt.ns()?, opt.db()?, &self.what, opt.strict).await?;
+		txn.get_or_add_db(ns, db, opt.strict).await?;
+		txn.get_or_add_tb(ns, db, &self.what, opt.strict).await?;
 		txn.set(
 			key,
 			DefineIndexStatement {
@@ -95,8 +97,8 @@ impl DefineIndexStatement {
 		)
 		.await?;
 		// Refresh the table cache
-		let key = crate::key::database::tb::new(opt.ns()?, opt.db()?, &self.what);
-		let tb = txn.get_tb(opt.ns()?, opt.db()?, &self.what).await?;
+		let key = crate::key::database::tb::new(ns, db, &self.what);
+		let tb = txn.get_tb(ns, db, &self.what).await?;
 		txn.set(
 			key,
 			DefineTableStatement {
@@ -107,7 +109,12 @@ impl DefineIndexStatement {
 		)
 		.await?;
 		// Clear the cache
+		if let Some(cache) = ctx.get_cache() {
+			cache.clear_tb(ns, db, &self.what);
+		}
+		// Clear the cache
 		txn.clear();
+		// Process the index
 		#[cfg(not(target_family = "wasm"))]
 		if self.concurrently {
 			self.async_index(ctx, opt)?;

--- a/crates/core/src/sql/statements/define/table.rs
+++ b/crates/core/src/sql/statements/define/table.rs
@@ -153,6 +153,10 @@ impl DefineTableStatement {
 			}
 		}
 		// Clear the cache
+		if let Some(cache) = ctx.get_cache() {
+			cache.clear_tb(ns, db, &self.name);
+		}
+		// Clear the cache
 		txn.clear();
 		// Ok all good
 		Ok(Value::None)

--- a/crates/core/src/sql/statements/define/table.rs
+++ b/crates/core/src/sql/statements/define/table.rs
@@ -138,6 +138,10 @@ impl DefineTableStatement {
 				)
 				.await?;
 				// Clear the cache
+				if let Some(cache) = ctx.get_cache() {
+					cache.clear_tb(ns, db, ft);
+				}
+				// Clear the cache
 				txn.clear();
 				// Process the view data
 				let stm = UpdateStatement {

--- a/crates/core/src/sql/statements/define/table.rs
+++ b/crates/core/src/sql/statements/define/table.rs
@@ -69,10 +69,13 @@ impl DefineTableStatement {
 	) -> Result<Value, Error> {
 		// Allowed to run?
 		opt.is_allowed(Action::Edit, ResourceKind::Table, &Base::Db)?;
+		// Get the NS and DB
+		let ns = opt.ns()?;
+		let db = opt.db()?;
 		// Fetch the transaction
 		let txn = ctx.tx();
 		// Check if the definition exists
-		if txn.get_tb(opt.ns()?, opt.db()?, &self.name).await.is_ok() {
+		if txn.get_tb(ns, db, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
 			} else if !self.overwrite {
@@ -82,12 +85,12 @@ impl DefineTableStatement {
 			}
 		}
 		// Process the statement
-		let key = crate::key::database::tb::new(opt.ns()?, opt.db()?, &self.name);
-		let ns = txn.get_or_add_ns(opt.ns()?, opt.strict).await?;
-		let db = txn.get_or_add_db(opt.ns()?, opt.db()?, opt.strict).await?;
+		let key = crate::key::database::tb::new(ns, db, &self.name);
+		let nsv = txn.get_or_add_ns(ns, opt.strict).await?;
+		let dbv = txn.get_or_add_db(ns, db, opt.strict).await?;
 		let mut dt = DefineTableStatement {
-			id: if self.id.is_none() && ns.id.is_some() && db.id.is_some() {
-				Some(txn.lock().await.get_next_tb_id(ns.id.unwrap(), db.id.unwrap()).await?)
+			id: if self.id.is_none() && nsv.id.is_some() && dbv.id.is_some() {
+				Some(txn.lock().await.get_next_tb_id(nsv.id.unwrap(), dbv.id.unwrap()).await?)
 			} else {
 				None
 			},
@@ -97,30 +100,34 @@ impl DefineTableStatement {
 			..self.clone()
 		};
 		// Add table relational fields
-		Self::add_in_out_fields(&txn, &mut dt, opt).await?;
+		Self::add_in_out_fields(&txn, ns, db, &mut dt).await?;
 		// Set the table definition
 		txn.set(key, &dt, None).await?;
+		// Clear the cache
+		if let Some(cache) = ctx.get_cache() {
+			cache.clear_tb(ns, db, &self.name);
+		}
 		// Clear the cache
 		txn.clear();
 		// Record definition change
 		if dt.changefeed.is_some() {
-			txn.lock().await.record_table_change(opt.ns()?, opt.db()?, &self.name, &dt);
+			txn.lock().await.record_table_change(ns, db, &self.name, &dt);
 		}
 		// Check if table is a view
 		if let Some(view) = &self.view {
 			// Force queries to run
 			let opt = &opt.new_with_force(Force::Table(Arc::new([dt])));
 			// Remove the table data
-			let key = crate::key::table::all::new(opt.ns()?, opt.db()?, &self.name);
+			let key = crate::key::table::all::new(ns, db, &self.name);
 			txn.delp(key).await?;
 			// Process each foreign table
 			for ft in view.what.0.iter() {
 				// Save the view config
-				let key = crate::key::table::ft::new(opt.ns()?, opt.db()?, ft, &self.name);
+				let key = crate::key::table::ft::new(ns, db, ft, &self.name);
 				txn.set(key, self, None).await?;
 				// Refresh the table cache
-				let key = crate::key::database::tb::new(opt.ns()?, opt.db()?, ft);
-				let tb = txn.get_tb(opt.ns()?, opt.db()?, ft).await?;
+				let key = crate::key::database::tb::new(ns, db, ft);
+				let tb = txn.get_tb(ns, db, ft).await?;
 				txn.set(
 					key,
 					DefineTableStatement {
@@ -168,14 +175,15 @@ impl DefineTableStatement {
 	/// Used to add relational fields to existing table records
 	pub async fn add_in_out_fields(
 		txn: &Transaction,
+		ns: &str,
+		db: &str,
 		tb: &mut DefineTableStatement,
-		opt: &Options,
 	) -> Result<(), Error> {
 		// Add table relational fields
 		if let TableType::Relation(rel) = &tb.kind {
 			// Set the `in` field as a DEFINE FIELD definition
 			{
-				let key = crate::key::table::fd::new(opt.ns()?, opt.db()?, &tb.name, "in");
+				let key = crate::key::table::fd::new(ns, db, &tb.name, "in");
 				let val = rel.from.clone().unwrap_or(Kind::Record(vec![]));
 				txn.set(
 					key,
@@ -191,7 +199,7 @@ impl DefineTableStatement {
 			}
 			// Set the `out` field as a DEFINE FIELD definition
 			{
-				let key = crate::key::table::fd::new(opt.ns()?, opt.db()?, &tb.name, "out");
+				let key = crate::key::table::fd::new(ns, db, &tb.name, "out");
 				let val = rel.to.clone().unwrap_or(Kind::Record(vec![]));
 				txn.set(
 					key,

--- a/crates/core/src/sql/statements/remove/database.rs
+++ b/crates/core/src/sql/statements/remove/database.rs
@@ -45,6 +45,10 @@ impl RemoveDatabaseStatement {
 				false => txn.delp(key).await?,
 			};
 			// Clear the cache
+			if let Some(cache) = ctx.get_cache() {
+				cache.clear();
+			}
+			// Clear the cache
 			txn.clear();
 			// Ok all good
 			Ok(Value::None)

--- a/crates/core/src/sql/statements/remove/namespace.rs
+++ b/crates/core/src/sql/statements/remove/namespace.rs
@@ -45,6 +45,10 @@ impl RemoveNamespaceStatement {
 				false => txn.delp(key).await?,
 			};
 			// Clear the cache
+			if let Some(cache) = ctx.get_cache() {
+				cache.clear();
+			}
+			// Clear the cache
 			txn.clear();
 			// Ok all good
 			Ok(Value::None)

--- a/crates/core/src/sql/statements/remove/table.rs
+++ b/crates/core/src/sql/statements/remove/table.rs
@@ -28,22 +28,25 @@ impl RemoveTableStatement {
 		let future = async {
 			// Allowed to run?
 			opt.is_allowed(Action::Edit, ResourceKind::Table, &Base::Db)?;
+			// Get the NS and DB
+			let ns = opt.ns()?;
+			let db = opt.db()?;
 			// Get the transaction
 			let txn = ctx.tx();
 			// Remove the index stores
-			ctx.get_index_stores().table_removed(&txn, opt.ns()?, opt.db()?, &self.name).await?;
+			ctx.get_index_stores().table_removed(&txn, ns, db, &self.name).await?;
 			// Get the defined table
-			let tb = txn.get_tb(opt.ns()?, opt.db()?, &self.name).await?;
+			let tb = txn.get_tb(ns, db, &self.name).await?;
 			// Get the foreign tables
-			let fts = txn.all_tb_views(opt.ns()?, opt.db()?, &self.name).await?;
+			let fts = txn.all_tb_views(ns, db, &self.name).await?;
 			// Delete the definition
-			let key = crate::key::database::tb::new(opt.ns()?, opt.db()?, &self.name);
+			let key = crate::key::database::tb::new(ns, db, &self.name);
 			match self.expunge {
 				true => txn.clr(key).await?,
 				false => txn.del(key).await?,
 			};
 			// Remove the resource data
-			let key = crate::key::table::all::new(opt.ns()?, opt.db()?, &self.name);
+			let key = crate::key::table::all::new(ns, db, &self.name);
 			match self.expunge {
 				true => txn.clrp(key).await?,
 				false => txn.delp(key).await?,
@@ -51,8 +54,8 @@ impl RemoveTableStatement {
 			// Process each attached foreign table
 			for ft in fts.iter() {
 				// Refresh the table cache
-				let key = crate::key::database::tb::new(opt.ns()?, opt.db()?, &ft.name);
-				let tb = txn.get_tb(opt.ns()?, opt.db()?, &ft.name).await?;
+				let key = crate::key::database::tb::new(ns, db, &ft.name);
+				let tb = txn.get_tb(ns, db, &ft.name).await?;
 				txn.set(
 					key,
 					DefineTableStatement {
@@ -62,26 +65,33 @@ impl RemoveTableStatement {
 					None,
 				)
 				.await?;
+				// Clear the cache
+				if let Some(cache) = ctx.get_cache() {
+					cache.clear_tb(ns, db, &ft.name);
+				}
 			}
 			// Check if this is a foreign table
 			if let Some(view) = &tb.view {
 				// Process each foreign table
 				for ft in view.what.0.iter() {
 					// Save the view config
-					let key = crate::key::table::ft::new(opt.ns()?, opt.db()?, ft, &self.name);
+					let key = crate::key::table::ft::new(ns, db, ft, &self.name);
 					txn.del(key).await?;
 					// Refresh the table cache for foreign tables
-					let key = crate::key::database::tb::new(opt.ns()?, opt.db()?, ft);
-					if let Ok(tb) = txn.get_tb(opt.ns()?, opt.db()?, ft).await {
-						txn.set(
-							key,
-							DefineTableStatement {
-								cache_tables_ts: Uuid::now_v7(),
-								..tb.as_ref().clone()
-							},
-							None,
-						)
-						.await?;
+					let key = crate::key::database::tb::new(ns, db, ft);
+					let tb = txn.get_tb(ns, db, ft).await?;
+					txn.set(
+						key,
+						DefineTableStatement {
+							cache_tables_ts: Uuid::now_v7(),
+							..tb.as_ref().clone()
+						},
+						None,
+					)
+					.await?;
+					// Clear the cache
+					if let Some(cache) = ctx.get_cache() {
+						cache.clear_tb(ns, db, &self.name);
 					}
 				}
 			}

--- a/crates/core/src/sql/statements/remove/table.rs
+++ b/crates/core/src/sql/statements/remove/table.rs
@@ -89,11 +89,11 @@ impl RemoveTableStatement {
 						None,
 					)
 					.await?;
-					// Clear the cache
-					if let Some(cache) = ctx.get_cache() {
-						cache.clear_tb(ns, db, &self.name);
-					}
 				}
+			}
+			// Clear the cache
+			if let Some(cache) = ctx.get_cache() {
+				cache.clear_tb(ns, db, &self.name);
 			}
 			// Clear the cache
 			txn.clear();

--- a/crates/sdk/tests/group.rs
+++ b/crates/sdk/tests/group.rs
@@ -681,13 +681,8 @@ async fn select_array_count_subquery_group_by() -> Result<(), Error> {
 async fn select_aggregate_mean_update() -> Result<(), Error> {
 	let sql = "
 		CREATE test:a SET a = 3;
-		DEFINE TABLE foo AS SELECT
-			math::mean(a) AS avg
-		FROM test
-		GROUP ALL;
-
+		DEFINE TABLE foo AS SELECT math::mean(a) AS avg FROM test GROUP ALL;
 		UPDATE test:a SET a = 2;
-
 		SELECT avg FROM foo;
 	";
 	let dbs = new_ds().await?;
@@ -698,20 +693,18 @@ async fn select_aggregate_mean_update() -> Result<(), Error> {
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
-		{
-			id: test:a,
-			a: 3
-		}
-	]",
+			{
+				id: test:a,
+				a: 3
+			}
+		]",
 	);
-
 	assert_eq!(tmp, val);
 	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse("None");
-
 	assert_eq!(tmp, val);
-
+	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
@@ -721,9 +714,8 @@ async fn select_aggregate_mean_update() -> Result<(), Error> {
 			}
 		]",
 	);
-
 	assert_eq!(tmp, val);
-
+	//
 	let tmp = res.remove(0).result?;
 	let val = Value::parse(
 		"[
@@ -733,7 +725,7 @@ async fn select_aggregate_mean_update() -> Result<(), Error> {
 		]",
 	);
 	assert_eq!(tmp, val);
-
+	//
 	Ok(())
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

This pull-request improves local datastore, cross-transaction caching. It adds caching of the following definitions:
- Database definitions (`DefineDatabaseStatement`)
- Table definitions (`DefineTableStatement`).

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
