### PR TITLE
Disallow mismatched field types

### DIFF
--- a/crates/core/src/err/mod.rs
+++ b/crates/core/src/err/mod.rs
@@ -1260,6 +1260,14 @@ pub enum Error {
 	/// Cannot process `Value::Refs` as there is no Record ID in the context for the operation
 	#[error("Cannot obtain a list of references as there is no Record ID in the context for the operation")]
 	InvalidRefsContext,
+
+	#[error("Cannot set field `{name}` with type `{kind}` as it mismatched with field `{existing_name}` with type `{existing_kind}`")]
+	MismatchedFieldTypes {
+		name: String,
+		kind: String,
+		existing_name: String,
+		existing_kind: String,
+	},
 }
 
 impl From<Error> for String {

--- a/crates/core/src/sql/statements/define/field.rs
+++ b/crates/core/src/sql/statements/define/field.rs
@@ -59,6 +59,8 @@ impl DefineFieldStatement {
 		} else {
 			self.kind.clone()
 		};
+		// Disallow mismatched types
+		self.disallow_mismatched_types(ctx, opt).await?;
 		// Get the NS and DB
 		let ns = opt.ns()?;
 		let db = opt.db()?;
@@ -346,6 +348,30 @@ impl DefineFieldStatement {
 		}
 
 		Ok(None)
+	}
+
+	async fn disallow_mismatched_types(&self, ctx: &Context, opt: &Options) -> Result<(), Error> {
+		let fds = ctx.tx().all_tb_fields(opt.ns()?, opt.db()?, &self.what, None).await?;
+
+		if let Some(self_kind) = &self.kind {
+			for fd in fds.iter() {
+				if self.name.starts_with(&fd.name) && self.name != fd.name {
+					if let Some(fd_kind) = &fd.kind {
+						let path = self.name[fd.name.len()..].to_vec();
+						if !fd_kind.allows_nested_kind(&path, self_kind) {
+							return Err(Error::MismatchedFieldTypes {
+								name: self.name.to_string(),
+								kind: self_kind.to_string(),
+								existing_name: fd.name.to_string(),
+								existing_kind: fd_kind.to_string(),
+							});
+						}
+					}
+				}
+			}
+		}
+
+		Ok(())
 	}
 }
 

--- a/crates/language-tests/tests/language/statements/define/field/mismatch.surql
+++ b/crates/language-tests/tests/language/statements/define/field/mismatch.surql
@@ -1,0 +1,170 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+error = "Cannot set field `fd[*]` with type `number` as it mismatched with field `fd` with type `array<string>`"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+error = "Cannot set field `fd[*]` with type `number` as it mismatched with field `fd` with type `[string, number]`"
+[[test.results]]
+error = "Cannot set field `fd[0]` with type `number` as it mismatched with field `fd` with type `[string, number]`"
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+error = "Cannot set field `fd[*]` with type `number` as it mismatched with field `fd` with type `{ a: string, b: number }`"
+[[test.results]]
+error = "Cannot set field `fd.a` with type `number` as it mismatched with field `fd` with type `{ a: string, b: number }`"
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+error = "Cannot set field `fd[*]` with type `number` as it mismatched with field `fd` with type `{ a: string, b: number } | { a: string, b: bool }`"
+[[test.results]]
+error = "Cannot set field `fd.a` with type `number` as it mismatched with field `fd` with type `{ a: string, b: number } | { a: string, b: bool }`"
+[[test.results]]
+error = "Cannot set field `fd.b` with type `number` as it mismatched with field `fd` with type `{ a: string, b: number } | { a: string, b: bool }`"
+[[test.results]]
+error = "Cannot set field `fd[*]` with type `string` as it mismatched with field `fd` with type `{ a: string, b: number } | { a: string, b: bool }`"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+error = "Cannot set field `fd.b` with type `string` as it mismatched with field `fd` with type `{ a: string, b: number } | { a: string, b: bool }`"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+error = "Cannot set field `fd[0]` with type `number` as it mismatched with field `fd` with type `object`"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+error = "Cannot set field `fd.a` with type `number` as it mismatched with field `fd` with type `object | array<number>`"
+[[test.results]]
+error = "Cannot set field `fd[0]` with type `number` as it mismatched with field `fd` with type `object | array<number>`"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+error = "Cannot set field `fd[*]` with type `'a'` as it mismatched with field `fd` with type `array<'a' | 'b'>`"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+error = "Cannot set field `fd[*]` with type `'a' | 'b'` as it mismatched with field `fd` with type `array<'a'>`"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+error = "Cannot set field `fd[2]` with type `string` as it mismatched with field `fd` with type `array<string, 2>`"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+*/
+
+DEFINE FIELD OVERWRITE fd ON a TYPE array<string>;
+DEFINE FIELD OVERWRITE fd.* ON a TYPE number;
+--
+DEFINE FIELD OVERWRITE fd ON b TYPE [string, number];
+DEFINE FIELD OVERWRITE fd.* ON b TYPE number;
+DEFINE FIELD OVERWRITE fd[0] ON b TYPE number;
+DEFINE FIELD OVERWRITE fd[1] ON b TYPE number;
+--
+DEFINE FIELD OVERWRITE fd ON c TYPE { a: string, b: number };
+DEFINE FIELD OVERWRITE fd.* ON c TYPE number;
+DEFINE FIELD OVERWRITE fd.a ON c TYPE number;
+DEFINE FIELD OVERWRITE fd.b ON c TYPE number;
+--
+DEFINE FIELD OVERWRITE fd ON d TYPE { a: string, b: number } | { a: string, b: bool };
+DEFINE FIELD OVERWRITE fd.* ON d TYPE number;
+DEFINE FIELD OVERWRITE fd.a ON d TYPE number;
+DEFINE FIELD OVERWRITE fd.b ON d TYPE number;
+DEFINE FIELD OVERWRITE fd.* ON d TYPE string;
+DEFINE FIELD OVERWRITE fd.a ON d TYPE string;
+DEFINE FIELD OVERWRITE fd.b ON d TYPE string;
+--
+DEFINE FIELD OVERWRITE fd ON e TYPE object;
+DEFINE FIELD OVERWRITE fd.* ON e TYPE number;
+DEFINE FIELD OVERWRITE fd.a ON e TYPE number;
+DEFINE FIELD OVERWRITE fd[0] ON e TYPE number;
+--
+DEFINE FIELD OVERWRITE fd ON f TYPE object | array<number>;
+DEFINE FIELD OVERWRITE fd.* ON f TYPE number;
+DEFINE FIELD OVERWRITE fd.a ON f TYPE number;
+DEFINE FIELD OVERWRITE fd[0] ON f TYPE number;
+--
+DEFINE FIELD OVERWRITE fd ON g TYPE option<array<number>>;
+DEFINE FIELD OVERWRITE fd.* ON g TYPE number;
+DEFINE FIELD OVERWRITE fd[0] ON g TYPE number;
+--
+DEFINE FIELD OVERWRITE fd ON h TYPE [option<number>, number];
+DEFINE FIELD OVERWRITE fd.* ON h TYPE number;
+DEFINE FIELD OVERWRITE fd[0] ON h TYPE number;
+DEFINE FIELD OVERWRITE fd[1] ON h TYPE number;
+--
+DEFINE FIELD OVERWRITE fd ON i TYPE array<'a' | 'b'>;
+DEFINE FIELD OVERWRITE fd.* ON i TYPE 'a' | 'b';
+DEFINE FIELD OVERWRITE fd.* ON i TYPE 'a';
+--
+DEFINE FIELD OVERWRITE fd ON j TYPE array<'a'>;
+DEFINE FIELD OVERWRITE fd.* ON j TYPE 'a';
+DEFINE FIELD OVERWRITE fd.* ON j TYPE 'a' | 'b';
+--
+DEFINE FIELD OVERWRITE fd ON k TYPE array<string, 2>;
+DEFINE FIELD OVERWRITE fd.* ON k TYPE string;
+DEFINE FIELD OVERWRITE fd[0] ON k TYPE string;
+DEFINE FIELD OVERWRITE fd[1] ON k TYPE string;
+DEFINE FIELD OVERWRITE fd[2] ON k TYPE string;
+--
+DEFINE FIELD OVERWRITE fd ON l TYPE array<string>;
+DEFINE FIELD OVERWRITE fd.* ON l TYPE any;
+--
+DEFINE FIELD OVERWRITE fd ON m TYPE array<any>;
+DEFINE FIELD OVERWRITE fd.* ON m TYPE string;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See #5347. It's currently always allowed to define a field, even when we can know that the types mismatch, causing issues further down the line.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR adds some restrictions when defining nested fields, where both the parent and the nested fields have types defined. It is now no longer possible to have mismatching types, to prevent any impossible type issues once the schema is defined.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #5347

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Maybe in info/warn box in the docs about this behaviour?

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
