### PR TITLE
Skip processing documents when `START` is specified

### DIFF
--- a/crates/core/src/dbs/iterator.rs
+++ b/crates/core/src/dbs/iterator.rs
@@ -108,7 +108,7 @@ pub(crate) struct Iterator {
 	limit: Option<u32>,
 	/// Iterator start value
 	start: Option<u32>,
-	/// Skip processing
+	/// Counter of remaining documents that can be skipped processing
 	start_skip: Option<usize>,
 	/// Iterator runtime error
 	error: Option<Error>,
@@ -455,6 +455,7 @@ impl Iterator {
 					self.cancel_on_limit = Some(l);
 				}
 			}
+			// Check if we can skip processing the document below "start".
 			if matches!(rs, RecordStrategy::KeysOnly | RecordStrategy::Count) {
 				let s = self.start.unwrap_or(0) as usize;
 				if s > 0 {
@@ -464,10 +465,12 @@ impl Iterator {
 		}
 	}
 
+	/// Check if we can skip processing the upcoming record
 	pub(super) fn is_skippable(&self) -> bool {
 		self.start_skip.map(|s| s > 0).unwrap_or(false)
 	}
 
+	/// Confirm that the record has been skipped
 	pub(super) fn skipped(&mut self) {
 		if let Some(s) = &mut self.start_skip {
 			*s -= 1;

--- a/crates/core/src/dbs/iterator.rs
+++ b/crates/core/src/dbs/iterator.rs
@@ -455,18 +455,19 @@ impl Iterator {
 					self.cancel_on_limit = Some(l);
 				}
 			}
-			if stm.cond().is_none() {
+			if stm.cond().is_none() && stm.fetch().is_none() {
 				self.skip = self.start.unwrap_or(0) as usize;
 			}
 		}
 	}
 
-	pub(super) fn skipped(&mut self) -> bool {
+	pub(super) fn is_skippable(&self) -> bool {
+		self.skip > 0
+	}
+
+	pub(super) fn skipped(&mut self) {
 		if self.skip > 0 {
 			self.skip -= 1;
-			true
-		} else {
-			false
 		}
 	}
 

--- a/crates/core/src/dbs/plan.rs
+++ b/crates/core/src/dbs/plan.rs
@@ -63,6 +63,17 @@ impl Explanation {
 		self.0.push(ExplainItem::new_fallback(reason));
 	}
 
+	pub(super) fn add_record_strategy(&mut self, rs: RecordStrategy) {
+		self.0.push(ExplainItem::new_record_strategy(rs));
+	}
+
+	pub(super) fn add_start_limit(
+		&mut self,
+		start_skip: Option<usize>,
+		cancel_on_limit: Option<u32>,
+	) {
+		self.0.push(ExplainItem::new_start_limit(start_skip, cancel_on_limit));
+	}
 	pub(super) fn output(self) -> Vec<Value> {
 		self.0.into_iter().map(|e| e.into()).collect()
 	}
@@ -172,10 +183,38 @@ impl ExplainItem {
 	pub(super) fn new_collector(
 		collector_type: &str,
 		mut details: Vec<(&'static str, Value)>,
-	) -> ExplainItem {
+	) -> Self {
 		details.insert(0, ("type", collector_type.into()));
 		Self {
 			name: "Collector".into(),
+			details,
+		}
+	}
+	pub(super) fn new_record_strategy(rs: RecordStrategy) -> Self {
+		Self {
+			name: "RecordStrategy".into(),
+			details: vec![(
+				"type",
+				match rs {
+					RecordStrategy::Count => "Count",
+					RecordStrategy::KeysOnly => "KeysOnly",
+					RecordStrategy::KeysAndValues => "KeysAndValues",
+				}
+				.into(),
+			)],
+		}
+	}
+
+	pub(super) fn new_start_limit(start_skip: Option<usize>, cancel_on_limit: Option<u32>) -> Self {
+		let mut details = vec![];
+		if let Some(s) = start_skip {
+			details.push(("SkipStart", s.into()));
+		}
+		if let Some(l) = cancel_on_limit {
+			details.push(("CancelOnLimit", l.into()));
+		}
+		Self {
+			name: "StartLimitStrategy".into(),
 			details,
 		}
 	}

--- a/crates/core/src/dbs/processor.rs
+++ b/crates/core/src/dbs/processor.rs
@@ -93,9 +93,10 @@ impl Collected {
 		self,
 		opt: &Options,
 		txn: &Transaction,
+		skippable: bool,
 	) -> Result<Processed, Error> {
 		match self {
-			Self::Edge(key) => Self::process_edge(opt, txn, key).await,
+			Self::Edge(key) => Self::process_edge(opt, txn, key, skippable).await,
 			Self::RangeKey(key) => Self::process_range_key(key).await,
 			Self::TableKey(key) => Self::process_table_key(key).await,
 			Self::Relatable {
@@ -103,24 +104,33 @@ impl Collected {
 				v,
 				w,
 				o,
-			} => Self::process_relatable(opt, txn, f, v, w, o).await,
-			Self::Thing(thing) => Self::process_thing(opt, txn, thing).await,
-			Self::Yield(table) => Self::process_yield(opt, txn, table).await,
+			} => Self::process_relatable(opt, txn, f, v, w, o, skippable).await,
+			Self::Thing(thing) => Self::process_thing(opt, txn, thing, skippable).await,
+			Self::Yield(table) => Self::process_yield(opt, txn, table, skippable).await,
 			Self::Value(value) => Ok(Self::process_value(value)),
-			Self::Defer(key) => Self::process_defer(opt, txn, key).await,
-			Self::Mergeable(v, o) => Self::process_mergeable(opt, txn, v, o).await,
+			Self::Defer(key) => Self::process_defer(opt, txn, key, skippable).await,
+			Self::Mergeable(v, o) => Self::process_mergeable(opt, txn, v, o, skippable).await,
 			Self::KeyVal(key, val) => Ok(Self::process_key_val(key, val)?),
 			Self::Count(c) => Ok(Self::process_count(c)),
-			Self::IndexItem(i) => Self::process_index_item(opt, txn, i).await,
+			Self::IndexItem(i) => Self::process_index_item(opt, txn, i, skippable).await,
 			Self::IndexItemKey(i) => Ok(Self::process_index_item_key(i)),
 		}
 	}
 
-	async fn process_edge(opt: &Options, txn: &Transaction, key: Key) -> Result<Processed, Error> {
+	async fn process_edge(
+		opt: &Options,
+		txn: &Transaction,
+		key: Key,
+		skippable: bool,
+	) -> Result<Processed, Error> {
 		// Parse the data from the store
 		let gra: graph::Graph = graph::Graph::decode(&key)?;
 		// Fetch the data from the store
-		let val = txn.get_record(opt.ns()?, opt.db()?, gra.ft, &gra.fk, None).await?;
+		let val = if skippable {
+			Arc::new(Value::Null)
+		} else {
+			txn.get_record(opt.ns()?, opt.db()?, gra.ft, &gra.fk, None).await?
+		};
 		let rid = Thing::from((gra.ft, gra.fk));
 		// Parse the data from the store
 		let val = Operable::Value(val);
@@ -172,13 +182,18 @@ impl Collected {
 		v: Thing,
 		w: Thing,
 		o: Option<Value>,
+		skippable: bool,
 	) -> Result<Processed, Error> {
-		// Check that the table exists
-		txn.check_ns_db_tb(opt.ns()?, opt.db()?, &v.tb, opt.strict).await?;
-		// Fetch the data from the store
-		let val = txn.get_record(opt.ns()?, opt.db()?, &v.tb, &v.id, None).await?;
-		// Create a new operable value
-		let val = Operable::Relate(f, val, w, o.map(|v| v.into()));
+		let val = if skippable {
+			Operable::Value(Arc::new(Value::Null))
+		} else {
+			// Check that the table exists
+			txn.check_ns_db_tb(opt.ns()?, opt.db()?, &v.tb, opt.strict).await?;
+			// Fetch the data from the store
+			let val = txn.get_record(opt.ns()?, opt.db()?, &v.tb, &v.id, None).await?;
+			// Create a new operable value
+			Operable::Relate(f, val, w, o.map(|v| v.into()))
+		};
 		// Process the document record
 		let pro = Processed {
 			rs: RecordStrategy::KeysAndValues,
@@ -190,11 +205,20 @@ impl Collected {
 		Ok(pro)
 	}
 
-	async fn process_thing(opt: &Options, txn: &Transaction, v: Thing) -> Result<Processed, Error> {
+	async fn process_thing(
+		opt: &Options,
+		txn: &Transaction,
+		v: Thing,
+		skippable: bool,
+	) -> Result<Processed, Error> {
 		// Check that the table exists
 		txn.check_ns_db_tb(opt.ns()?, opt.db()?, &v.tb, opt.strict).await?;
-		// Fetch the data from the store
-		let val = txn.get_record(opt.ns()?, opt.db()?, &v.tb, &v.id, opt.version).await?;
+		let val = if skippable {
+			Arc::new(Value::Null)
+		} else {
+			// Fetch the data from the store
+			txn.get_record(opt.ns()?, opt.db()?, &v.tb, &v.id, opt.version).await?
+		};
 		// Parse the data from the store
 		let val = Operable::Value(val);
 		// Process the document record
@@ -209,9 +233,16 @@ impl Collected {
 		Ok(pro)
 	}
 
-	async fn process_yield(opt: &Options, txn: &Transaction, v: Table) -> Result<Processed, Error> {
+	async fn process_yield(
+		opt: &Options,
+		txn: &Transaction,
+		v: Table,
+		skippable: bool,
+	) -> Result<Processed, Error> {
 		// Check that the table exists
-		txn.check_ns_db_tb(opt.ns()?, opt.db()?, &v, opt.strict).await?;
+		if !skippable {
+			txn.check_ns_db_tb(opt.ns()?, opt.db()?, &v, opt.strict).await?;
+		}
 		// Pass the value through
 		let pro = Processed {
 			rs: RecordStrategy::KeysAndValues,
@@ -234,9 +265,16 @@ impl Collected {
 		}
 	}
 
-	async fn process_defer(opt: &Options, txn: &Transaction, v: Thing) -> Result<Processed, Error> {
+	async fn process_defer(
+		opt: &Options,
+		txn: &Transaction,
+		v: Thing,
+		skippable: bool,
+	) -> Result<Processed, Error> {
 		// Check that the table exists
-		txn.check_ns_db_tb(opt.ns()?, opt.db()?, &v.tb, opt.strict).await?;
+		if !skippable {
+			txn.check_ns_db_tb(opt.ns()?, opt.db()?, &v.tb, opt.strict).await?;
+		}
 		// Process the document record
 		let pro = Processed {
 			rs: RecordStrategy::KeysAndValues,
@@ -253,9 +291,12 @@ impl Collected {
 		txn: &Transaction,
 		v: Thing,
 		o: Value,
+		skippable: bool,
 	) -> Result<Processed, Error> {
 		// Check that the table exists
-		txn.check_ns_db_tb(opt.ns()?, opt.db()?, &v.tb, opt.strict).await?;
+		if !skippable {
+			txn.check_ns_db_tb(opt.ns()?, opt.db()?, &v.tb, opt.strict).await?;
+		}
 		// Process the document record
 		let pro = Processed {
 			rs: RecordStrategy::KeysAndValues,
@@ -309,11 +350,14 @@ impl Collected {
 		opt: &Options,
 		txn: &Transaction,
 		i: IndexItemRecord,
+		skippable: bool,
 	) -> Result<Processed, Error> {
 		let (t, v, ir) = i.consume();
 		let v = if let Some(v) = v {
 			// The value may already be fetched by the KNN iterator to evaluate the condition
 			v
+		} else if skippable {
+			Value::Null.into()
 		} else {
 			Iterable::fetch_thing(txn, opt, &t).await?
 		};
@@ -338,8 +382,8 @@ pub(super) struct ConcurrentCollector<'a> {
 }
 impl Collector for ConcurrentCollector<'_> {
 	async fn collect(&mut self, collected: Collected) -> Result<(), Error> {
-		let pro = collected.process(self.opt, self.txn).await?;
 		if !self.ite.is_skippable() {
+			let pro = collected.process(self.opt, self.txn, false).await?;
 			self.ite.process(self.stk, self.ctx, self.opt, self.stm, pro).await?;
 		} else {
 			self.ite.skipped();
@@ -355,9 +399,10 @@ pub(super) struct ConcurrentDistinctCollector<'a> {
 
 impl Collector for ConcurrentDistinctCollector<'_> {
 	async fn collect(&mut self, collected: Collected) -> Result<(), Error> {
-		let pro = collected.process(self.coll.opt, self.coll.txn).await?;
+		let skippable = self.coll.ite.is_skippable();
+		let pro = collected.process(self.coll.opt, self.coll.txn, skippable).await?;
 		if !self.dis.check_already_processed(&pro) {
-			if !self.coll.ite.is_skippable() {
+			if !skippable {
 				self.coll
 					.ite
 					.process(self.coll.stk, self.coll.ctx, self.coll.opt, self.coll.stm, pro)

--- a/crates/core/src/dbs/result.rs
+++ b/crates/core/src/dbs/result.rs
@@ -123,9 +123,15 @@ impl Results {
 
 	pub(super) async fn start_limit(
 		&mut self,
+		skip: Option<usize>,
 		start: Option<u32>,
 		limit: Option<u32>,
 	) -> Result<(), Error> {
+		let start = if skip.is_some() {
+			None
+		} else {
+			start
+		};
 		match self {
 			Self::Memory(m) => m.start_limit(start, limit),
 			Self::MemoryOrdered(m) => m.start_limit(start, limit),

--- a/crates/core/src/idx/planner/mod.rs
+++ b/crates/core/src/idx/planner/mod.rs
@@ -167,7 +167,7 @@ impl<'a> StatementContext<'a> {
 		// If there are specific permissions
 		// defined on the table, then we need
 		// to process record values.
-		if matches!(granted_permission, GrantedPermission::None | GrantedPermission::Full) {
+		if matches!(granted_permission, GrantedPermission::Specific) {
 			return Ok(RecordStrategy::KeysAndValues);
 		}
 

--- a/crates/core/src/idx/planner/mod.rs
+++ b/crates/core/src/idx/planner/mod.rs
@@ -289,7 +289,6 @@ impl QueryPlanner {
 		&self.fallbacks
 	}
 
-	#[cfg(not(target_family = "wasm"))]
 	pub(crate) fn is_order(&self, irf: &IteratorRef) -> bool {
 		self.orders.contains(irf)
 	}

--- a/crates/core/src/idx/planner/mod.rs
+++ b/crates/core/src/idx/planner/mod.rs
@@ -80,36 +80,34 @@ impl<'a> StatementContext<'a> {
 		if !self.is_perm {
 			return Ok(GrantedPermission::Full);
 		}
-		if self.opt.check_perms(self.stm.into())? {
-			// Get the table for this planner
-			match self.ctx.tx().get_tb(self.ns, self.db, tb).await {
-				Ok(table) => {
-					// TODO(tobiemh): we should really
-					// not even get here if the table
-					// permissions are NONE, because
-					// there is no point in processing
-					// a table which we can't access.
-					let perms = self.stm.permissions(&table, false);
-					// If permissions are specific, we
-					// need to fetch the record content.
-					if perms.is_specific() {
-						return Ok(GrantedPermission::Specific);
-					}
-					// If permissions are NONE, we also
-					// need to fetch the record content.
-					if perms.is_none() {
-						return Ok(GrantedPermission::None);
-					}
+		// Get the table for this planner
+		match self.ctx.tx().get_tb(self.ns, self.db, tb).await {
+			Ok(table) => {
+				// TODO(tobiemh): we should really
+				// not even get here if the table
+				// permissions are NONE, because
+				// there is no point in processing
+				// a table which we can't access.
+				let perms = self.stm.permissions(&table, false);
+				// If permissions are specific, we
+				// need to fetch the record content.
+				if perms.is_specific() {
+					return Ok(GrantedPermission::Specific);
 				}
-				Err(Error::TbNotFound {
-					..
-				}) => {
-					// We can safely ignore this error,
-					// as it just means that there is no
-					// table and no permissions defined.
+				// If permissions are NONE, we also
+				// need to fetch the record content.
+				if perms.is_none() {
+					return Ok(GrantedPermission::None);
 				}
-				Err(e) => return Err(e),
 			}
+			Err(Error::TbNotFound {
+				..
+			}) => {
+				// We can safely ignore this error,
+				// as it just means that there is no
+				// table and no permissions defined.
+			}
+			Err(e) => return Err(e),
 		}
 		Ok(GrantedPermission::Full)
 	}

--- a/crates/core/src/sql/statements/select.rs
+++ b/crates/core/src/sql/statements/select.rs
@@ -2,7 +2,7 @@ use crate::ctx::{Context, MutableContext};
 use crate::dbs::{Iterable, Iterator, Options, Statement};
 use crate::doc::CursorDoc;
 use crate::err::Error;
-use crate::idx::planner::{QueryPlanner, RecordStrategy, StatementContext};
+use crate::idx::planner::{GrantedPermission, QueryPlanner, RecordStrategy, StatementContext};
 use crate::sql::{
 	order::{OldOrders, Order, OrderList, Ordering},
 	Cond, Explain, Fetchs, Field, Fields, Groups, Idioms, Limit, Splits, Start, Timeout, Value,
@@ -141,14 +141,20 @@ impl SelectStatement {
 		for w in self.what.0.iter() {
 			let v = w.compute(stk, &ctx, &opt, doc).await?;
 			match v {
-				Value::Thing(v) => match v.is_range() {
-					true => {
-						// Evaluate if we can only scan keys (rather than keys AND values), or count
-						let rs = stm_ctx.check_record_strategy(false, &v.tb).await?;
-						i.prepare_range(&stm, v, rs)?
+				Value::Thing(v) => {
+					let p = planner.check_table_permission(&stm_ctx, &v.tb).await?;
+					// We prepare it only if wer have a permission
+					if !matches!(p, GrantedPermission::None) {
+						match v.is_range() {
+							true => {
+								// Evaluate if we can only scan keys (rather than keys AND values), or count
+								let rs = stm_ctx.check_record_strategy(false, p).await?;
+								i.prepare_range(&stm, v, rs)?
+							}
+							false => i.prepare_thing(&stm, v)?,
+						}
 					}
-					false => i.prepare_thing(&stm, v)?,
-				},
+				}
 				Value::Edges(v) => {
 					if self.only && !limit_is_one_or_zero {
 						return Err(Error::SingleOnlyOutput);
@@ -165,7 +171,11 @@ impl SelectStatement {
 					if self.only && !limit_is_one_or_zero {
 						return Err(Error::SingleOnlyOutput);
 					}
-					planner.add_iterables(stk, &stm_ctx, t, &mut i).await?;
+					let p = planner.check_table_permission(&stm_ctx, &t).await?;
+					// We add the iterable only if we have a permission
+					if !matches!(p, GrantedPermission::None) {
+						planner.add_iterables(stk, &stm_ctx, t, p, &mut i).await?;
+					}
 				}
 				Value::Array(v) => {
 					if self.only && !limit_is_one_or_zero {
@@ -174,18 +184,29 @@ impl SelectStatement {
 					for v in v {
 						match v {
 							Value::Table(t) => {
-								planner.add_iterables(stk, &stm_ctx, t, &mut i).await?;
+								let p = planner.check_table_permission(&stm_ctx, &t).await?;
+								// We add the iterable only if we have a permission
+								if !matches!(p, GrantedPermission::None) {
+									planner.add_iterables(stk, &stm_ctx, t, p, &mut i).await?;
+								}
 							}
 							Value::Mock(v) => i.prepare_mock(&stm, v)?,
 							Value::Edges(v) => i.prepare_edges(&stm, *v)?,
-							Value::Thing(v) => match v.is_range() {
-								true => {
-									// Evaluate if we can only scan keys (rather than keys AND values) or just count
-									let rs = stm_ctx.check_record_strategy(false, &v.tb).await?;
-									i.prepare_range(&stm, v, rs)?
+							Value::Thing(v) => {
+								let p = planner.check_table_permission(&stm_ctx, &v.tb).await?;
+								// We prepare it only if wer have a permission
+								if !matches!(p, GrantedPermission::None) {
+									match v.is_range() {
+										true => {
+											// Evaluate if we can only scan keys (rather than keys AND values) or just count
+											let rs =
+												stm_ctx.check_record_strategy(false, p).await?;
+											i.prepare_range(&stm, v, rs)?
+										}
+										false => i.prepare_thing(&stm, v)?,
+									}
 								}
-								false => i.prepare_thing(&stm, v)?,
-							},
+							}
 							_ => i.ingest(Iterable::Value(v)),
 						}
 					}

--- a/crates/sdk/tests/group.rs
+++ b/crates/sdk/tests/group.rs
@@ -818,7 +818,7 @@ async fn select_count_group_all() -> Result<(), Error> {
 
 async fn select_count_group_all_permissions(
 	perm: &str,
-	expect_count_optim: bool,
+	expect_count_optim: Option<bool>,
 	expect_result: &str,
 ) -> Result<(), Error> {
 	// Define the permissions
@@ -846,19 +846,28 @@ async fn select_count_group_all_permissions(
 	.await?;
 	t.expect_size(4)?;
 	// The explain plan is still visible
-	let operation = if expect_count_optim {
-		"Iterate Table Count"
-	} else {
-		"Iterate Table"
+	let operation = match expect_count_optim {
+		None => "",
+		Some(true) => {
+			"{
+				detail: {
+					table: 'table'
+				},
+				operation: 'Iterate Table Count'
+			},"
+		}
+		Some(false) => {
+			"{
+				detail: {
+					table: 'table'
+				},
+				operation: 'Iterate Table'
+			},"
+		}
 	};
 	t.expect_val(&format!(
 		r"[
-					{{
-						detail: {{
-							table: 'table'
-						}},
-						operation: '{operation}'
-					}},
+					{operation}
 					{{
 						detail: {{
 							idioms: {{
@@ -875,27 +884,37 @@ async fn select_count_group_all_permissions(
 	// Check what is returned
 	t.expect_val(expect_result)?;
 	// The explain plan is still visible
-	let operation = if expect_count_optim {
-		"Iterate Range Keys"
-	} else {
-		"Iterate Range"
+	let operation = match expect_count_optim {
+		None => "",
+		Some(true) => {
+			"{
+				detail: {
+					range: 'a'..'z',
+					table: 'table'
+				},
+				operation: 'Iterate Range Keys'
+			},"
+		}
+		Some(false) => {
+			"{
+				detail: {
+					range: 'a'..'z',
+					table: 'table'
+				},
+				operation: 'Iterate Range'
+			},"
+		}
 	};
 	t.expect_val(&format!(
 		r"[
-					{{
-						detail: {{
-							range: 'a'..'z',
-							table: 'table'
-						}},
-						operation: '{operation}'
+				{operation}
+				{{
+					detail: {{
+						type: 'Memory'
 					}},
-					{{
-						detail: {{
-							type: 'Memory'
-						}},
-						operation: 'Collector'
-					}}
-				]",
+					operation: 'Collector'
+				}}
+			]",
 	))?;
 	// Check what is returned
 	t.expect_val(expect_result)?;
@@ -904,17 +923,17 @@ async fn select_count_group_all_permissions(
 
 #[tokio::test]
 async fn select_count_group_all_permissions_select_none() -> Result<(), Error> {
-	select_count_group_all_permissions("FOR SELECT NONE", false, "[]").await
+	select_count_group_all_permissions("FOR SELECT NONE", None, "[]").await
 }
 
 #[tokio::test]
 async fn select_count_group_all_permissions_select_full() -> Result<(), Error> {
-	select_count_group_all_permissions("FOR SELECT FULL", true, "[{ count: 1}]").await
+	select_count_group_all_permissions("FOR SELECT FULL", Some(true), "[{ count: 1}]").await
 }
 
 #[tokio::test]
 async fn select_count_group_all_permissions_select_where_false() -> Result<(), Error> {
-	select_count_group_all_permissions("FOR SELECT WHERE FALSE", false, "[]").await
+	select_count_group_all_permissions("FOR SELECT WHERE FALSE", Some(false), "[]").await
 }
 
 #[tokio::test]
@@ -1000,7 +1019,7 @@ async fn select_count_range_keys_only() -> Result<(), Error> {
 
 async fn select_count_range_keys_only_permissions(
 	perms: &str,
-	expect_count_optim: bool,
+	expect_count_optim: Option<bool>,
 	expect_group_all: &str,
 	expect_count: &str,
 ) -> Result<(), Error> {
@@ -1015,7 +1034,7 @@ async fn select_count_range_keys_only_permissions(
 		"
 	);
 	let mut t = Test::new(&sql).await?;
-	// The first selects should be successful
+	// The first select should be successful
 	t.expect_vals(&["[{count: 0}]", "[]"])?;
 	//
 	t.skip_ok(3)?;
@@ -1034,20 +1053,30 @@ async fn select_count_range_keys_only_permissions(
 	.await?;
 	t.expect_size(4)?;
 	// The explain plan is still accessible
-	let operation = if expect_count_optim {
-		"Iterate Range Count"
-	} else {
-		"Iterate Range"
+	let operation = match expect_count_optim {
+		None => "",
+		Some(true) => {
+			"{
+				detail: {
+					range: 'a'..'z',
+					table: 'table'
+				},
+				operation: 'Iterate Range Count'
+			},"
+		}
+		Some(false) => {
+			"{
+				detail: {
+					range: 'a'..'z',
+					table: 'table'
+				},
+				operation: 'Iterate Range'
+			},"
+		}
 	};
 	t.expect_val(&format!(
 		r"[
-				{{
-					detail: {{
-						range: 'a'..'z',
-						table: 'table'
-					}},
-					operation: '{operation}'
-				}},
+				{operation}
 				{{
 					detail: {{
 						idioms: {{
@@ -1064,27 +1093,37 @@ async fn select_count_range_keys_only_permissions(
 	// Check what is returned
 	t.expect_val_info(expect_group_all, "GROUP ALL")?;
 	// The explain plan is still accessible
-	let operation = if expect_count_optim {
-		"Iterate Range Keys"
-	} else {
-		"Iterate Range"
+	let operation = match expect_count_optim {
+		None => "",
+		Some(true) => {
+			"{
+				detail: {
+					range: 'a'..'z',
+					table: 'table'
+				},
+				operation: 'Iterate Range Keys'
+			},"
+		}
+		Some(false) => {
+			"{
+				detail: {
+					range: 'a'..'z',
+					table: 'table'
+				},
+				operation: 'Iterate Range'
+			},"
+		}
 	};
 	t.expect_val(&format!(
 		r"[
-					{{
-						detail: {{
-							range: 'a'..'z',
-							table: 'table'
-						}},
-						operation: '{operation}'
+				{operation}
+				{{
+					detail: {{
+						type: 'Memory'
 					}},
-					{{
-						detail: {{
-							type: 'Memory'
-						}},
-						operation: 'Collector'
-					}}
-				]",
+					operation: 'Collector'
+				}}
+			]",
 	))?;
 	// Check what is returned
 	t.expect_val_info(expect_count, "COUNT")?;
@@ -1093,14 +1132,14 @@ async fn select_count_range_keys_only_permissions(
 
 #[tokio::test]
 async fn select_count_range_keys_only_permissions_select_none() -> Result<(), Error> {
-	select_count_range_keys_only_permissions("FOR SELECT NONE", false, "[]", "[]").await
+	select_count_range_keys_only_permissions("FOR SELECT NONE", None, "[]", "[]").await
 }
 
 #[tokio::test]
 async fn select_count_range_keys_only_permissions_select_full() -> Result<(), Error> {
 	select_count_range_keys_only_permissions(
 		"FOR SELECT FULL",
-		true,
+		Some(true),
 		"[{ count: 2 }]",
 		"[{ count: 1 }, { count: 1 }]",
 	)
@@ -1109,14 +1148,15 @@ async fn select_count_range_keys_only_permissions_select_full() -> Result<(), Er
 
 #[tokio::test]
 async fn select_count_range_keys_only_permissions_select_where_false() -> Result<(), Error> {
-	select_count_range_keys_only_permissions("FOR SELECT WHERE FALSE", false, "[]", "[]").await
+	select_count_range_keys_only_permissions("FOR SELECT WHERE FALSE", Some(false), "[]", "[]")
+		.await
 }
 
 #[tokio::test]
 async fn select_count_range_only_permissions_select_where_match() -> Result<(), Error> {
 	select_count_range_keys_only_permissions(
 		"FOR SELECT WHERE bar = 'hello'",
-		false,
+		Some(false),
 		"[{ count: 1 }]",
 		"[{ count: 1 }]",
 	)

--- a/crates/sdk/tests/matches.rs
+++ b/crates/sdk/tests/matches.rs
@@ -93,6 +93,12 @@ async fn select_where_matches_without_using_index_iterator() -> Result<(), Error
 				},
 				{
 					detail: {
+						type: 'KeysAndValues'
+					},
+					operation: 'RecordStrategy'
+				},
+				{
+					detail: {
 						count: 1,
 					},
 					operation: 'Fetch'

--- a/crates/sdk/tests/planner.rs
+++ b/crates/sdk/tests/planner.rs
@@ -3269,9 +3269,9 @@ async fn select_memory_ordered_collector() -> Result<(), Error> {
 async fn select_limit_start() -> Result<(), Error> {
 	let sql = r"
 		CREATE |item:1000|;
-		SELECT * FROM item LIMIT 10 START 2 PARALLEL EXPLAIN;
+		SELECT * FROM item LIMIT 10 START 2 PARALLEL EXPLAIN FULL;
 		SELECT * FROM item LIMIT 10 START 2 PARALLEL;
-		SELECT * FROM item LIMIT 10 START 2 EXPLAIN;
+		SELECT * FROM item LIMIT 10 START 2 EXPLAIN FULL;
 		SELECT * FROM item LIMIT 10 START 2;";
 	let mut t = Test::new(sql).await?;
 	t.expect_size(5)?;
@@ -3290,6 +3290,25 @@ async fn select_limit_start() -> Result<(), Error> {
 							type: 'Memory'
 						},
 						operation: 'Collector'
+					},
+					{
+						detail: {
+							type: 'KeysAndValues'
+						},
+						operation: 'RecordStrategy'
+					},
+					{
+						detail: {
+							CancelOnLimit: 12,
+							SkipStart: 2
+						},
+						operation: 'StartLimitStrategy'
+					},
+					{
+						detail: {
+							count: 10
+						},
+						operation: 'Fetch'
 					}
 				]",
 		)?;

--- a/crates/sdk/tests/planner.rs
+++ b/crates/sdk/tests/planner.rs
@@ -3269,10 +3269,10 @@ async fn select_memory_ordered_collector() -> Result<(), Error> {
 async fn select_limit_start() -> Result<(), Error> {
 	let sql = r"
 		CREATE |item:1000|;
-		SELECT * FROM item LIMIT 10 START 0 PARALLEL EXPLAIN;
-		SELECT * FROM item LIMIT 10 START 0 PARALLEL;
-		SELECT * FROM item LIMIT 10 START 0 EXPLAIN;
-		SELECT * FROM item LIMIT 10 START 0;";
+		SELECT * FROM item LIMIT 10 START 2 PARALLEL EXPLAIN;
+		SELECT * FROM item LIMIT 10 START 2 PARALLEL;
+		SELECT * FROM item LIMIT 10 START 2 EXPLAIN;
+		SELECT * FROM item LIMIT 10 START 2;";
 	let mut t = Test::new(sql).await?;
 	t.expect_size(5)?;
 	t.skip_ok(1)?;

--- a/crates/sdk/tests/planner.rs
+++ b/crates/sdk/tests/planner.rs
@@ -210,6 +210,12 @@ fn table_explain(fetch_count: usize) -> String {
 			}},
 			{{
 				detail: {{
+					type: 'KeysAndValues'
+				}},
+				operation: 'RecordStrategy'
+			}},
+			{{
+				detail: {{
 					count: {fetch_count}
 				}},
 				operation: 'Fetch'
@@ -241,6 +247,12 @@ fn table_explain_no_index(fetch_count: usize) -> String {
 			}},
 			{{
 				detail: {{
+					type: 'KeysAndValues'
+				}},
+				operation: 'RecordStrategy'
+			}},
+			{{
+				detail: {{
 					count: {fetch_count}
 				}},
 				operation: 'Fetch'
@@ -268,6 +280,12 @@ fn three_table_explain(parallel: bool) -> String {
 					type: '{collector}'
 				}},
 				operation: 'Collector'
+			}},
+			{{
+				detail: {{
+					type: 'KeysAndValues'
+				}},
+				operation: 'RecordStrategy'
 			}},
 			{{
 				detail: {{
@@ -321,6 +339,12 @@ const THREE_MULTI_INDEX_EXPLAIN: &str = "[
 				},
 				{
 					detail: {
+						type: 'KeysAndValues'
+					},
+					operation: 'RecordStrategy'
+				},
+				{
+					detail: {
 						count: 3
 					},
 					operation: 'Fetch'
@@ -344,6 +368,12 @@ const SINGLE_INDEX_FT_EXPLAIN: &str = "[
 						type: 'MemoryOrdered'
 					},
 					operation: 'Collector'
+				},
+				{
+					detail: {
+						type: 'KeysAndValues'
+					},
+					operation: 'RecordStrategy'
 				},
 				{
 					detail: {
@@ -373,6 +403,12 @@ const SINGLE_INDEX_UNIQ_EXPLAIN: &str = "[
 				},
 				{
 					detail: {
+						type: 'KeysAndValues'
+					},
+					operation: 'RecordStrategy'
+				},
+				{
+					detail: {
 						count: 1
 					},
 					operation: 'Fetch'
@@ -396,6 +432,12 @@ const SINGLE_INDEX_IDX_EXPLAIN: &str = "[
 			type: 'MemoryOrdered'
 		},
 		operation: 'Collector'
+	},
+	{
+		detail: {
+			type: 'KeysAndValues'
+		},
+		operation: 'RecordStrategy'
 	},
 	{
 		detail: {
@@ -433,6 +475,12 @@ const TWO_MULTI_INDEX_EXPLAIN: &str = "[
 							type: 'MemoryOrdered'
 						},
 						operation: 'Collector'
+				},
+				{
+					detail: {
+						type: 'KeysAndValues'
+					},
+					operation: 'RecordStrategy'
 				},
 				{
 					detail: {

--- a/crates/sdk/tests/select.rs
+++ b/crates/sdk/tests/select.rs
@@ -227,6 +227,12 @@ async fn select_expression_value() -> Result<(), Error> {
 				},
 				{
 					detail: {
+						type: 'KeysAndValues'
+					},
+					operation: 'RecordStrategy'
+				},
+				{
+					detail: {
 						count: 2,
 					},
 					operation: 'Fetch'
@@ -561,6 +567,12 @@ async fn select_where_field_is_thing_and_with_index() -> Result<(), Error> {
 				},
 				{
 					detail: {
+						type: 'KeysAndValues'
+					},
+					operation: 'RecordStrategy'
+				},
+				{
+					detail: {
 						count: 2,
 					},
 					operation: 'Fetch'
@@ -809,6 +821,12 @@ async fn select_where_explain() -> Result<(), Error> {
 						type: 'Memory'
 					},
 					operation: 'Collector'
+				},
+				{
+					detail: {
+						type: 'KeysAndValues'
+					},
+					operation: 'RecordStrategy'
 				},
 				{
 					detail: {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When a `SELECT` statement has a `START` clause, under certain conditions (no ordering, no conditions, no groups, no specific permissions), it is possible to avoid processing records until we reach the start position.

## What does this change do?

- Evaluate the conditions that allow skipping records before the start position.
- Implement the skipping logic in the concurrent collector.
- Implement the skipping logic when DISTINCT is required, ensuring the record ID of the document is extracted.
- Add visibility of the record strategy (KeysOnly, KeysAndValues, Count) in the EXPLAIN plan.
- Add visibility of the skipping start and cancel-on-limit strategies in the EXPLAIN plan.
- Compute and cache permissions for each table.
- Avoid adding an iterable where the permission on the table is none.

## What is your testing strategy?

Github action.
Updated tests.

## Is this related to any issues?


- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?


- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
