### PR TITLE
Enable data durability configuration on RocksDB and SurrealKV

### DIFF
--- a/crates/core/src/kvs/rocksdb/cnf.rs
+++ b/crates/core/src/kvs/rocksdb/cnf.rs
@@ -2,6 +2,9 @@ use std::cmp::max;
 use std::sync::LazyLock;
 use sysinfo::System;
 
+pub static ROCKSDB_SYNC_DATA: LazyLock<bool> =
+	lazy_env_parse!("SURREAL_ROCKSDB_SYNC_DATA", bool, false);
+
 pub static ROCKSDB_THREAD_COUNT: LazyLock<i32> =
 	lazy_env_parse_or_else!("SURREAL_ROCKSDB_THREAD_COUNT", i32, |_| num_cpus::get() as i32);
 

--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -69,6 +69,8 @@ impl Datastore {
 		opts.create_if_missing(true);
 		// Create column families if missing
 		opts.create_missing_column_families(true);
+		// Log if writes should be synced
+		info!(target: TARGET, "Enabling data durability: {}", *cnf::ROCKSDB_SYNC_DATA);
 		// Increase the background thread count
 		info!(target: TARGET, "Background thread count: {}", *cnf::ROCKSDB_THREAD_COUNT);
 		opts.increase_parallelism(*cnf::ROCKSDB_THREAD_COUNT);
@@ -196,7 +198,7 @@ impl Datastore {
 		to.set_snapshot(true);
 		// Set the write options
 		let mut wo = WriteOptions::default();
-		wo.set_sync(false);
+		wo.set_sync(*cnf::ROCKSDB_SYNC_DATA);
 		// Create a new transaction
 		let inner = self.db.transaction_opt(&wo, &to);
 		// The database reference must always outlive

--- a/crates/core/src/kvs/surrealkv/cnf.rs
+++ b/crates/core/src/kvs/surrealkv/cnf.rs
@@ -1,5 +1,8 @@
 use std::sync::LazyLock;
 
+pub static SURREALKV_SYNC_DATA: LazyLock<bool> =
+	lazy_env_parse!("SURREAL_SURREALKV_SYNC_DATA", bool, false);
+
 pub static SURREALKV_MAX_VALUE_THRESHOLD: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_SURREALKV_MAX_VALUE_THRESHOLD", usize, 64);
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

This pull request allows data durability configuration, ensuring that the database can be configured for writes to be synced to disk before transactions are confirmed to be completed. To configure this, two new environment variables are introduced for RocksDB and SurrealKV:

- `SURREAL_ROCKSDB_SYNC_DATA` defaulting to `false`
- `SURREAL_SURREALKV_SYNC_DATA` defaulting to `false`

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] Documentation to be added

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
