### PR TITLE
Enable background flushing functionality

### DIFF
--- a/crates/core/src/kvs/rocksdb/cnf.rs
+++ b/crates/core/src/kvs/rocksdb/cnf.rs
@@ -2,8 +2,13 @@ use std::cmp::max;
 use std::sync::LazyLock;
 use sysinfo::System;
 
-pub static ROCKSDB_SYNC_DATA: LazyLock<bool> =
-	lazy_env_parse!("SURREAL_ROCKSDB_SYNC_DATA", bool, false);
+pub static SYNC_DATA: LazyLock<bool> = lazy_env_parse!("SURREAL_SYNC_DATA", bool, false);
+
+pub static ROCKSDB_BACKGROUND_FLUSH: LazyLock<bool> =
+	lazy_env_parse!("SURREAL_ROCKSDB_BACKGROUND_FLUSH", bool, false);
+
+pub static ROCKSDB_BACKGROUND_FLUSH_INTERVAL: LazyLock<u64> =
+	lazy_env_parse!("SURREAL_ROCKSDB_BACKGROUND_FLUSH_INTERVAL", u64, 100);
 
 pub static ROCKSDB_THREAD_COUNT: LazyLock<i32> =
 	lazy_env_parse_or_else!("SURREAL_ROCKSDB_THREAD_COUNT", i32, |_| num_cpus::get() as i32);

--- a/crates/core/src/kvs/surrealkv/cnf.rs
+++ b/crates/core/src/kvs/surrealkv/cnf.rs
@@ -1,7 +1,6 @@
 use std::sync::LazyLock;
 
-pub static SURREALKV_SYNC_DATA: LazyLock<bool> =
-	lazy_env_parse!("SURREAL_SURREALKV_SYNC_DATA", bool, false);
+pub static SYNC_DATA: LazyLock<bool> = lazy_env_parse!("SURREAL_SYNC_DATA", bool, false);
 
 pub static SURREALKV_MAX_VALUE_THRESHOLD: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_SURREALKV_MAX_VALUE_THRESHOLD", usize, 64);

--- a/crates/core/src/kvs/surrealkv/mod.rs
+++ b/crates/core/src/kvs/surrealkv/mod.rs
@@ -58,8 +58,6 @@ impl Datastore {
 		opts.disk_persistence = true;
 		// Set the data storage directory
 		opts.dir = path.to_string().into();
-		// Log if writes should be synced
-		info!(target: TARGET, "Enabling data durability: {}", *cnf::SURREALKV_SYNC_DATA);
 		// Set the maximum segment size
 		info!(target: TARGET, "Setting maximum segment size: {}", *cnf::SURREALKV_MAX_SEGMENT_SIZE);
 		opts.max_segment_size = *cnf::SURREALKV_MAX_SEGMENT_SIZE;
@@ -69,6 +67,8 @@ impl Datastore {
 		// Set the maximum value cache size
 		info!(target: TARGET, "Setting maximum value cache size: {}", *cnf::SURREALKV_MAX_VALUE_CACHE_SIZE);
 		opts.max_value_cache_size = *cnf::SURREALKV_MAX_VALUE_CACHE_SIZE;
+		// Log if writes should be synced
+		info!(target: TARGET, "Wait for disk sync acknowledgement: {}", *cnf::SYNC_DATA);
 		// Create a new datastore
 		match Store::new(opts) {
 			Ok(db) => Ok(Datastore {
@@ -112,7 +112,7 @@ impl Datastore {
 			false => self.db.begin_with_mode(Mode::ReadOnly),
 		}?;
 		// Set the transaction durability
-		match *cnf::SURREALKV_SYNC_DATA {
+		match *cnf::SYNC_DATA {
 			true => txn.set_durability(Durability::Immediate),
 			false => txn.set_durability(Durability::Eventual),
 		};


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

This pull request does 2 things:

- Removes the `SURREAL_ROCKSDB_SYNC_DATA` and `SURREAL_SURREALKV_SYNC_DATA` environment variables, and introduces a single environment variable `SURREAL_SYNC_DATA` (defaulting to `false`) which controls the behaviour of RocksDB and SurrealKV. This option allows data durability configuration, ensuring that the database can be configured for writes to be synced to disk before transactions are confirmed to be completed.

- Introduces two additional environment variables which allow SurrealDB to use a background worker thread to flush WAL writes to disk, instead of flushing writes on every transaction commit. This behaviour is more inline with MongoDB which flushes the journal periodically. The two new environment variables are:
    - `SURREAL_ROCKSDB_BACKGROUND_FLUSH` (defaulting to `false`)
    - `SURREAL_ROCKSDB_BACKGROUND_FLUSH_INTERVAL` (defaulting to `100` milliseconds)

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [ ] Documentation to be added

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
