### PR TITLE
Allow chaining patch operations

### DIFF
--- a/crates/sdk/src/api/method/patch.rs
+++ b/crates/sdk/src/api/method/patch.rs
@@ -103,8 +103,17 @@ where
 	C: Connection,
 {
 	/// Applies JSON Patch changes to all records, or a specific record, in the database.
-	pub fn patch(mut self, PatchOp(patch): PatchOp) -> Patch<'r, C, R> {
-		self.patches.push(patch);
+	pub fn patch(mut self, patch: impl Into<PatchOp>) -> Patch<'r, C, R> {
+		let PatchOp(patch) = patch.into();
+		match patch {
+			Ok(Content::Seq(values)) => {
+				for value in values {
+					self.patches.push(Ok(value));
+				}
+			}
+			Ok(value) => self.patches.push(Ok(value)),
+			Err(error) => self.patches.push(Err(error)),
+		}
 		self
 	}
 }

--- a/crates/sdk/src/api/method/update.rs
+++ b/crates/sdk/src/api/method/update.rs
@@ -156,11 +156,17 @@ where
 	}
 
 	/// Patches the current document / record data with the specified JSON Patch data
-	pub fn patch(self, PatchOp(patch): PatchOp) -> Patch<'r, C, R> {
+	pub fn patch(self, patch: impl Into<PatchOp>) -> Patch<'r, C, R> {
+		let PatchOp(result) = patch.into();
+		let patches = match result {
+			Ok(serde_content::Value::Seq(values)) => values.into_iter().map(Ok).collect(),
+			Ok(value) => vec![Ok(value)],
+			Err(error) => vec![Err(error)],
+		};
 		Patch {
+			patches,
 			client: self.client,
 			resource: self.resource,
-			patches: vec![patch],
 			response_type: PhantomData,
 		}
 	}

--- a/crates/sdk/src/api/method/upsert.rs
+++ b/crates/sdk/src/api/method/upsert.rs
@@ -154,11 +154,17 @@ where
 	}
 
 	/// Patches the current document / record data with the specified JSON Patch data
-	pub fn patch(self, PatchOp(patch): PatchOp) -> Patch<'r, C, R> {
+	pub fn patch(self, patch: impl Into<PatchOp>) -> Patch<'r, C, R> {
+		let PatchOp(result) = patch.into();
+		let patches = match result {
+			Ok(serde_content::Value::Seq(values)) => values.into_iter().map(Ok).collect(),
+			Ok(value) => vec![Ok(value)],
+			Err(error) => vec![Err(error)],
+		};
 		Patch {
+			patches,
 			client: self.client,
 			resource: self.resource,
-			patches: vec![patch],
 			response_type: PhantomData,
 		}
 	}

--- a/crates/sdk/src/api/opt/mod.rs
+++ b/crates/sdk/src/api/opt/mod.rs
@@ -134,6 +134,106 @@ impl PatchOp {
 	}
 }
 
+/// Multiple patch operations
+#[derive(Debug, Default)]
+#[must_use]
+pub struct PatchOps(Vec<PatchOp>);
+
+impl From<PatchOps> for PatchOp {
+	fn from(ops: PatchOps) -> Self {
+		let mut merged = PatchOp(Ok(Content::Seq(Vec::with_capacity(ops.0.len()))));
+		for PatchOp(result) in ops.0 {
+			if let Ok(Content::Seq(value)) = &mut merged.0 {
+				match result {
+					Ok(op) => value.push(op),
+					Err(error) => {
+						merged.0 = Err(error);
+						// This operation produced an error, no need to continue
+						break;
+					}
+				}
+			}
+		}
+		merged
+	}
+}
+
+impl PatchOps {
+	/// Prepare for multiple patch operations
+	pub const fn new() -> Self {
+		Self(Vec::new())
+	}
+
+	/// Adds a value to an object or inserts it into an array.
+	///
+	/// In the case of an array, the value is inserted before the given index.
+	/// The `-` character can be used instead of an index to insert at the end of an array.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// # use serde_json::json;
+	/// # use surrealdb::opt::PatchOps;
+	/// PatchOps::new().add("/biscuits/1", json!({ "name": "Ginger Nut" }))
+	/// # ;
+	/// ```
+	pub fn add<T>(mut self, path: &str, value: T) -> Self
+	where
+		T: Serialize,
+	{
+		self.0.push(PatchOp::add(path, value));
+		self
+	}
+
+	/// Removes a value from an object or array.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// # use surrealdb::opt::PatchOps;
+	/// PatchOps::new().remove("/biscuits")
+	/// # ;
+	/// ```
+	///
+	/// Remove the first element of the array at `biscuits`
+	/// (or just removes the “0” key if `biscuits` is an object)
+	///
+	/// ```
+	/// # use surrealdb::opt::PatchOps;
+	/// PatchOps::new().remove("/biscuits/0")
+	/// # ;
+	/// ```
+	pub fn remove(mut self, path: &str) -> Self {
+		self.0.push(PatchOp::remove(path));
+		self
+	}
+
+	/// Replaces a value.
+	///
+	/// Equivalent to a “remove” followed by an “add”.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// # use surrealdb::opt::PatchOps;
+	/// PatchOps::new().replace("/biscuits/0/name", "Chocolate Digestive")
+	/// # ;
+	/// ```
+	pub fn replace<T>(mut self, path: &str, value: T) -> Self
+	where
+		T: Serialize,
+	{
+		self.0.push(PatchOp::replace(path, value));
+		self
+	}
+
+	/// Changes a value
+	pub fn change(mut self, path: &str, diff: String) -> Self {
+		self.0.push(PatchOp::change(path, diff));
+		self
+	}
+}
+
 /// Makes the client wait for a certain event or call to happen before continuing
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Currently the only way to chain these operations on the same SDK call is to chain the `patch` method repeatedly

```rust
db.update(..)
    .patch(PatchOp::replace("/biscuits/0/name", "Chocolate Digestive"))
    .patch(PatchOp::add("/biscuits/1", json!({ "name": "Ginger Nut" })))
```

This works but is not very elegant.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It introduces a new `PatchOps` type that allows chaining the operations themselves before feeding into `patch`.

```rust
db.update(..)
    .patch(PatchOps::new()
        .replace("/biscuits/0/name", "Chocolate Digestive")
        .add("/biscuits/1", json!({ "name": "Ginger Nut" })))
```

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
