### PR TITLE
Disable buffering by default

### DIFF
--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -73,7 +73,7 @@ pub static WEBSOCKET_MAX_MESSAGE_SIZE: LazyLock<usize> =
 
 /// How many messages can be buffered while attempting to deliver to the client.
 pub static WEBSOCKET_RESPONSE_BUFFER_SIZE: LazyLock<usize> =
-	lazy_env_parse!("SURREAL_WEBSOCKET_RESPONSE_BUFFER_SIZE", usize, 100);
+	lazy_env_parse!("SURREAL_WEBSOCKET_RESPONSE_BUFFER_SIZE", usize, 0);
 
 /// How many messages can be queued for sending to the buffering WebSocket connection.
 pub static WEBSOCKET_RESPONSE_CHANNEL_SIZE: LazyLock<usize> =

--- a/src/rpc/connection.rs
+++ b/src/rpc/connection.rs
@@ -127,13 +127,13 @@ impl Connection {
 				// Split the socket into sending and receiving streams
 				let (sender, receiver) = buffer.split();
 				tasks.spawn(Self::read(rpc.clone(), receiver, internal_sender.clone()));
-				tasks.spawn(Self::write(rpc.clone(), sender, internal_receiver.clone()));
+				tasks.spawn(Self::write(rpc.clone(), sender, internal_receiver));
 			}
 			false => {
 				// Split the socket into sending and receiving streams
 				let (sender, receiver) = ws.split();
 				tasks.spawn(Self::read(rpc.clone(), receiver, internal_sender.clone()));
-				tasks.spawn(Self::write(rpc.clone(), sender, internal_receiver.clone()));
+				tasks.spawn(Self::write(rpc.clone(), sender, internal_receiver));
 			}
 		}
 		// Wait for all tasks to finish


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

To disable buffering when `SURREAL_WEBSOCKET_RESPONSE_BUFFER_SIZE` is `0`.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It defaults to `0` and disables buffering.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
