### PR TITLE
Optimise storage configuration options

### DIFF
--- a/crates/core/src/kvs/rocksdb/cnf.rs
+++ b/crates/core/src/kvs/rocksdb/cnf.rs
@@ -72,6 +72,12 @@ pub static ROCKSDB_BLOCK_CACHE_SIZE: LazyLock<usize> =
 		max(memory as usize, 512 * 1024 * 1024)
 	});
 
+pub static ROCKSDB_ENABLE_MEMORY_MAPPED_READS: LazyLock<bool> =
+	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_MEMORY_MAPPED_READS", bool, false);
+
+pub static ROCKSDB_ENABLE_MEMORY_MAPPED_WRITES: LazyLock<bool> =
+	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_MEMORY_MAPPED_WRITES", bool, false);
+
 pub static ROCKSDB_KEEP_LOG_FILE_NUM: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_ROCKSDB_KEEP_LOG_FILE_NUM", usize, 20);
 

--- a/crates/core/src/kvs/rocksdb/cnf.rs
+++ b/crates/core/src/kvs/rocksdb/cnf.rs
@@ -8,7 +8,7 @@ pub static ROCKSDB_BACKGROUND_FLUSH: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_ROCKSDB_BACKGROUND_FLUSH", bool, false);
 
 pub static ROCKSDB_BACKGROUND_FLUSH_INTERVAL: LazyLock<u64> =
-	lazy_env_parse!("SURREAL_ROCKSDB_BACKGROUND_FLUSH_INTERVAL", u64, 100);
+	lazy_env_parse!("SURREAL_ROCKSDB_BACKGROUND_FLUSH_INTERVAL", u64, 200);
 
 pub static ROCKSDB_THREAD_COUNT: LazyLock<i32> =
 	lazy_env_parse_or_else!("SURREAL_ROCKSDB_THREAD_COUNT", i32, |_| num_cpus::get() as i32);
@@ -19,6 +19,12 @@ pub static ROCKSDB_JOBS_COUNT: LazyLock<i32> =
 pub static ROCKSDB_MAX_OPEN_FILES: LazyLock<i32> =
 	lazy_env_parse!("SURREAL_ROCKSDB_MAX_OPEN_FILES", i32, 1024);
 
+pub static ROCKSDB_BLOCK_SIZE: LazyLock<usize> =
+	lazy_env_parse!("SURREAL_ROCKSDB_BLOCK_SIZE", usize, 64 * 1024);
+
+pub static ROCKSDB_WAL_SIZE_LIMIT: LazyLock<u64> =
+	lazy_env_parse!("SURREAL_ROCKSDB_WAL_SIZE_LIMIT", u64, 1024);
+
 pub static ROCKSDB_MAX_WRITE_BUFFER_NUMBER: LazyLock<i32> =
 	lazy_env_parse!("SURREAL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER", i32, 32);
 
@@ -26,13 +32,22 @@ pub static ROCKSDB_WRITE_BUFFER_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_ROCKSDB_WRITE_BUFFER_SIZE", usize, 256 * 1024 * 1024);
 
 pub static ROCKSDB_TARGET_FILE_SIZE_BASE: LazyLock<u64> =
-	lazy_env_parse!("SURREAL_ROCKSDB_TARGET_FILE_SIZE_BASE", u64, 32 * 1024 * 1024);
+	lazy_env_parse!("SURREAL_ROCKSDB_TARGET_FILE_SIZE_BASE", u64, 128 * 1024 * 1024);
 
 pub static ROCKSDB_TARGET_FILE_SIZE_MULTIPLIER: LazyLock<i32> =
-	lazy_env_parse!("SURREAL_ROCKSDB_TARGET_FILE_SIZE_MULTIPLIER", i32, 2);
+	lazy_env_parse!("SURREAL_ROCKSDB_TARGET_FILE_SIZE_MULTIPLIER", i32, 10);
 
 pub static ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE: LazyLock<i32> =
-	lazy_env_parse!("SURREAL_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE", i32, 4);
+	lazy_env_parse!("SURREAL_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE", i32, 6);
+
+pub static ROCKSDB_FILE_COMPACTION_TRIGGER: LazyLock<i32> =
+	lazy_env_parse!("SURREAL_ROCKSDB_FILE_COMPACTION_TRIGGER", i32, 16);
+
+pub static ROCKSDB_COMPACTION_READAHEAD_SIZE: LazyLock<usize> =
+	lazy_env_parse!("SURREAL_ROCKSDB_COMPACTION_READAHEAD_SIZE", usize, 16 * 1024 * 1024);
+
+pub static ROCKSDB_MAX_CONCURRENT_SUBCOMPACTIONS: LazyLock<u32> =
+	lazy_env_parse!("SURREAL_ROCKSDB_MAX_CONCURRENT_SUBCOMPACTIONS", u32, 4);
 
 pub static ROCKSDB_ENABLE_PIPELINED_WRITES: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_PIPELINED_WRITES", bool, true);

--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -177,6 +177,8 @@ impl Datastore {
 			// means that the WAL will be flushed
 			// whenever a transaction is committed.
 			false => {
+				// Dispay the configuration setting
+				info!(target: TARGET, "Background write-ahead-log flushing: disabled");
 				// Enable manual WAL flush
 				opts.set_manual_wal_flush(false);
 				// Create the optimistic datastore
@@ -186,6 +188,8 @@ impl Datastore {
 			// spawn a background worker thread to
 			// flush the WAL to disk periodically.
 			true => {
+				// Dispay the configuration setting
+				info!(target: TARGET, "Background write-ahead-log flushing: enabled every {}ms", *cnf::ROCKSDB_BACKGROUND_FLUSH_INTERVAL);
 				// Enable manual WAL flush
 				opts.set_manual_wal_flush(true);
 				// Create the optimistic datastore

--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -145,6 +145,12 @@ impl Datastore {
 		opts.set_block_based_table_factory(&block_opts);
 		opts.set_blob_cache(&cache);
 		opts.set_row_cache(&cache);
+		// Configure memory-mapped reads
+		info!(target: TARGET, "Enable memory-mapped reads: {}", *cnf::ROCKSDB_ENABLE_MEMORY_MAPPED_READS);
+		opts.set_allow_mmap_reads(true);
+		// Configure memory-mapped writes
+		info!(target: TARGET, "Enable memory-mapped writes: {}", *cnf::ROCKSDB_ENABLE_MEMORY_MAPPED_WRITES);
+		opts.set_allow_mmap_writes(true);
 		// Set the delete compaction factory
 		info!(target: TARGET, "Setting delete compaction factory: {} / {} ({})",
 			*cnf::ROCKSDB_DELETION_FACTORY_WINDOW_SIZE,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

This pull-request changes the default values for 3 environment variables used to configure the RocksDB storage engine, and introduces 5 new environment variables for configuring the RocksDB storage engine:

- `SURREAL_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE` (default changed from `4` to `6`)
- `SURREAL_ROCKSDB_TARGET_FILE_SIZE_BASE` (default changed from `32`MiB to `128`MiB)
- `SURREAL_ROCKSDB_TARGET_FILE_SIZE_MULTIPLIER` (default changed from `2` to `10`)
- `SURREAL_ROCKSDB_BLOCK_SIZE` (defaulting to `64`KiB)
- `SURREAL_ROCKSDB_WAL_SIZE_LIMIT` (defaulting to `1024`MiB)
- `SURREAL_ROCKSDB_FILE_COMPACTION_TRIGGER` (defaulting to `16`)
- `SURREAL_ROCKSDB_COMPACTION_READAHEAD_SIZE` (defaulting to `16`MiB)
- `SURREAL_ROCKSDB_MAX_CONCURRENT_SUBCOMPACTIONS` (defaulting to `4`)
- `SURREAL_ROCKSDB_ENABLE_MEMORY_MAPPED_READS` (defaulting to `false`)
- `SURREAL_ROCKSDB_ENABLE_MEMORY_MAPPED_WRITES` (defaulting to `false`)

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
