### PR TITLE
Ensure references are cleaned up on delete

### DIFF
--- a/crates/core/src/doc/delete.rs
+++ b/crates/core/src/doc/delete.rs
@@ -18,6 +18,7 @@ impl Document {
 		self.check_permissions_quick(stk, ctx, opt, stm).await?;
 		self.check_where_condition(stk, ctx, opt, stm).await?;
 		self.check_permissions_table(stk, ctx, opt, stm).await?;
+		self.cleanup_table_references(stk, ctx, opt).await?;
 		self.clear_record_data(ctx, opt, stm).await?;
 		self.store_index_data(stk, ctx, opt, stm).await?;
 		self.purge(stk, ctx, opt, stm).await?;

--- a/crates/core/src/doc/field.rs
+++ b/crates/core/src/doc/field.rs
@@ -250,6 +250,56 @@ impl Document {
 		// Carry on
 		Ok(())
 	}
+	/// Processes `DEFINE FIELD` statements which
+	/// have been defined on the table for this
+	/// record, with a `REFERENCE` clause, and remove
+	/// all possible references this record has made.
+	pub(super) async fn cleanup_table_references(
+		&mut self,
+		stk: &mut Stk,
+		ctx: &Context,
+		opt: &Options,
+	) -> Result<(), Error> {
+		// Check import
+		if opt.import {
+			return Ok(());
+		}
+		// Get the record id
+		let rid = self.id()?;
+		// Loop through all field statements
+		for fd in self.fd(ctx, opt).await?.iter() {
+			// Only process reference fields
+			if fd.reference.is_none() {
+				continue;
+			}
+
+			// Loop over each value in document
+			'val: for (_, val) in self.current.doc.as_ref().walk(&fd.name).into_iter() {
+				// Skip if the value is empty
+				if val.is_none() || val.is_empty_array() {
+					continue 'val;
+				}
+
+				// Prepare the field edit context
+				let mut field = FieldEditContext {
+					context: None,
+					doc: self,
+					rid: rid.clone(),
+					def: fd,
+					stk,
+					ctx,
+					opt,
+					old: val.into(),
+					inp: Value::None.into(),
+				};
+
+				// Pass an empty value to delete all the existing references
+				field.process_reference_clause(&Value::None).await?;
+			}
+		}
+
+		Ok(())
+	}
 }
 
 struct FieldEditContext<'a> {

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -935,6 +935,15 @@ impl Value {
 		matches!(self, Value::None)
 	}
 
+	/// Check if this Value is NONE
+	pub fn is_empty_array(&self) -> bool {
+		if let Value::Array(v) = self {
+			v.is_empty()
+		} else {
+			false
+		}
+	}
+
 	/// Check if this Value is NULL
 	pub fn is_null(&self) -> bool {
 		matches!(self, Value::Null)

--- a/crates/language-tests/tests/language/reference/cleanup.surql
+++ b/crates/language-tests/tests/language/reference/cleanup.surql
@@ -1,0 +1,61 @@
+/**
+
+[env.capabilities.allow_experimental]
+value = "record_references"
+
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "[comic_book:one, comic_book:two]"
+
+[[test.results]]
+value = "[person:one, person:two]"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "[comic_book:two]"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "[person:two]"
+
+
+*/
+DEFINE TABLE person;
+DEFINE FIELD comics ON person TYPE option<array<record<comic_book>>> REFERENCE ON DELETE UNSET;
+CREATE person:one, person:two SET comics = [comic_book:one, comic_book:two] RETURN NONE;
+
+DEFINE TABLE comic_book;
+DEFINE FIELD owners ON comic_book TYPE references<person, comics>;
+CREATE comic_book:one, comic_book:two RETURN NONE;
+
+RETURN person:one.comics;
+RETURN comic_book:two.owners;
+
+DELETE comic_book:one;
+RETURN person:one.comics;
+
+DELETE person:one;
+RETURN comic_book:two.owners;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See #5477. When a record from which references originated, was deleted, then these references were not cleaned up, as the fields were no longer being processed.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR introduces a `cleanup_table_references` function on `Document` which loops over the table's field definitions and makes sure references are cleaned up if any are found.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added the example in #5477 as a test.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #5477

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
