### PR TITLE
Make sending the AST configurable

### DIFF
--- a/crates/sdk/src/api/engine/remote/ws/wasm.rs
+++ b/crates/sdk/src/api/engine/remote/ws/wasm.rs
@@ -92,7 +92,7 @@ async fn router_handle_request(
 		response,
 	}: Route,
 	state: &mut RouterState,
-	_endpoint: &Endpoint,
+	endpoint: &Endpoint,
 ) -> HandleResult {
 	let RequestData {
 		id,
@@ -183,7 +183,11 @@ async fn router_handle_request(
 			return HandleResult::Ok;
 		};
 		trace!("Request {:?}", req);
-		let payload = serialize(&req.stringify_queries(), true).unwrap();
+		let payload = if endpoint.config.ast_payload {
+			serialize(&req, true).unwrap()
+		} else {
+			serialize(&req.stringify_queries(), true).unwrap()
+		};
 		Message::Binary(payload)
 	};
 

--- a/crates/sdk/src/api/opt/config.rs
+++ b/crates/sdk/src/api/opt/config.rs
@@ -8,6 +8,7 @@ use surrealdb_core::{dbs::Capabilities as CoreCapabilities, iam::Level};
 #[derive(Debug, Clone, Default)]
 pub struct Config {
 	pub(crate) strict: bool,
+	pub(crate) ast_payload: bool,
 	pub(crate) query_timeout: Option<Duration>,
 	pub(crate) transaction_timeout: Option<Duration>,
 	#[cfg(any(feature = "native-tls", feature = "rustls"))]
@@ -41,6 +42,18 @@ impl Config {
 	/// Enables `strict` server mode
 	pub fn strict(mut self) -> Self {
 		self.strict = true;
+		self
+	}
+
+	/// Whether to send queries as AST
+	pub fn set_ast_payload(mut self, ast_payload: bool) -> Self {
+		self.ast_payload = ast_payload;
+		self
+	}
+
+	/// Send queries as AST
+	pub fn ast_payload(mut self) -> Self {
+		self.ast_payload = true;
 		self
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Parsing queries in the client and then parsing them again on the server can be costly for large queries.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It adds `Config::ast_payload` and `Config::set_ast_payload` to make this behaviour configurable.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
