### PR TITLE
Ensure CRUD methods only accept object-like data

### DIFF
--- a/crates/sdk/src/api/method/create.rs
+++ b/crates/sdk/src/api/method/create.rs
@@ -13,6 +13,7 @@ use std::future::IntoFuture;
 use std::marker::PhantomData;
 use surrealdb_core::sql::{to_value as to_core_value, Value as CoreValue};
 
+use super::validate_data;
 use super::Content;
 
 /// A record create future
@@ -90,6 +91,8 @@ where
 		Content::from_closure(self.client, || {
 			let content = to_core_value(data)?;
 
+			validate_data(&content, "Tried to create non-object-like data as content, only structs and objects are supported")?;
+
 			let data = match content {
 				CoreValue::None | CoreValue::Null => None,
 				content => Some(content),
@@ -114,6 +117,8 @@ where
 	{
 		Content::from_closure(self.client, || {
 			let content = to_core_value(data)?;
+
+			validate_data(&content, "Tried to create non-object-like data as content, only structs and objects are supported")?;
 
 			let data = match content {
 				CoreValue::None | CoreValue::Null => None,

--- a/crates/sdk/src/api/method/insert.rs
+++ b/crates/sdk/src/api/method/insert.rs
@@ -16,6 +16,7 @@ use std::marker::PhantomData;
 use surrealdb_core::sql::{to_value as to_core_value, Object as CoreObject, Value as CoreValue};
 
 use super::insert_relation::InsertRelation;
+use super::validate_data;
 
 /// An insert future
 #[derive(Debug)]
@@ -122,6 +123,7 @@ where
 	{
 		Content::from_closure(self.client, || {
 			let mut data = to_core_value(data)?;
+			validate_data(&data, "Tried to insert non-object-like data as content, only structs and objects are supported")?;
 			match self.resource? {
 				Resource::Table(table) => Ok(Command::Insert {
 					what: Some(table),
@@ -170,6 +172,7 @@ where
 	{
 		InsertRelation::from_closure(self.client, || {
 			let mut data = to_core_value(data)?;
+			validate_data(&data, "Tried to insert non-object-like data as relation data, only structs and objects are supported")?;
 			match self.resource? {
 				Resource::Table(table) => Ok(Command::InsertRelation {
 					what: Some(table),

--- a/crates/sdk/src/api/method/merge.rs
+++ b/crates/sdk/src/api/method/merge.rs
@@ -1,3 +1,4 @@
+use super::validate_data;
 use crate::api::conn::Command;
 use crate::api::method::BoxFuture;
 use crate::api::opt::Resource;
@@ -49,7 +50,10 @@ macro_rules! into_future {
 			Box::pin(async move {
 				let content = match content? {
 					CoreValue::None | CoreValue::Null => None,
-					x => Some(x),
+					data => {
+						validate_data(&data, "Tried to merge non-object-like data, only structs and objects are supported")?;
+						Some(data)
+					},
 				};
 
 				let router = client.router.extract()?;

--- a/crates/sdk/src/api/method/mod.rs
+++ b/crates/sdk/src/api/method/mod.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 use surrealdb_core::sql::to_value as to_core_value;
+use surrealdb_core::sql::Value as CoreValue;
 
 pub(crate) mod live;
 pub(crate) mod query;
@@ -1411,5 +1412,13 @@ where
 			is_ml: false,
 			import_type: PhantomData,
 		}
+	}
+}
+
+fn validate_data(data: &CoreValue, error_message: &str) -> crate::Result<()> {
+	match data {
+		CoreValue::Object(_) => Ok(()),
+		CoreValue::Array(v) if v.iter().all(CoreValue::is_object) => Ok(()),
+		_ => Err(crate::api::err::Error::InvalidParams(error_message.to_owned()).into()),
 	}
 }

--- a/crates/sdk/src/api/method/update.rs
+++ b/crates/sdk/src/api/method/update.rs
@@ -18,6 +18,8 @@ use std::future::IntoFuture;
 use std::marker::PhantomData;
 use surrealdb_core::sql::{to_value as to_core_value, Value as CoreValue};
 
+use super::validate_data;
+
 /// An update future
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
@@ -127,6 +129,8 @@ where
 	{
 		Content::from_closure(self.client, || {
 			let data = to_core_value(data)?;
+
+			validate_data(&data, "Tried to update non-object-like data as content, only structs and objects are supported")?;
 
 			let what = self.resource?;
 

--- a/crates/sdk/src/api/method/upsert.rs
+++ b/crates/sdk/src/api/method/upsert.rs
@@ -18,6 +18,8 @@ use std::future::IntoFuture;
 use std::marker::PhantomData;
 use surrealdb_core::sql::{to_value as to_core_value, Value as CoreValue};
 
+use super::validate_data;
+
 /// An upsert future
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
@@ -127,6 +129,8 @@ where
 	{
 		Content::from_closure(self.client, || {
 			let data = to_core_value(data)?;
+
+			validate_data(&data, "Tried to upsert non-object-like data as content, only structs and objects are supported")?;
 
 			let data = match data {
 				CoreValue::None => None,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Clauses like `CONTENT` and `MERGE` only accept objects but we currently allow the SDK to send non-object data to the server.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It ensures we only forward structs ad objects to those clauses, otherwise we return an error.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Closes #5356.

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
