### PR TITLE
Enable bypassing live query processing and query parsing in the SDK

### DIFF
--- a/crates/sdk/src/api/conn/cmd.rs
+++ b/crates/sdk/src/api/conn/cmd.rs
@@ -4,6 +4,7 @@ use bincode::Options;
 use channel::Sender;
 use revision::Revisioned;
 use serde::{ser::SerializeMap as _, Serialize};
+use std::borrow::Cow;
 use std::io::Read;
 use std::path::PathBuf;
 use surrealdb_core::kvs::export::Config as DbExportConfig;
@@ -67,6 +68,10 @@ pub(crate) enum Command {
 	},
 	Query {
 		query: Query,
+		variables: CoreObject,
+	},
+	RawQuery {
+		query: Cow<'static, str>,
 		variables: CoreObject,
 	},
 	ExportFile {
@@ -295,6 +300,17 @@ impl Command {
 				variables,
 			} => {
 				let params: Vec<CoreValue> = vec![query.into(), variables.into()];
+				RouterRequest {
+					id,
+					method: "query",
+					params: Some(params.into()),
+				}
+			}
+			Command::RawQuery {
+				query,
+				variables,
+			} => {
+				let params: Vec<CoreValue> = vec![query.into_owned().into(), variables.into()];
 				RouterRequest {
 					id,
 					method: "query",

--- a/crates/sdk/src/api/engine/local/mod.rs
+++ b/crates/sdk/src/api/engine/local/mod.rs
@@ -785,6 +785,16 @@ async fn router(
 			let response = process(response);
 			Ok(DbResponse::Query(response))
 		}
+		Command::RawQuery {
+			query,
+			mut variables,
+		} => {
+			let mut vars = vars.read().await.clone();
+			vars.append(&mut variables.0);
+			let response = kvs.execute(query.as_ref(), &*session.read().await, Some(vars)).await?;
+			let response = process(response);
+			Ok(DbResponse::Query(response))
+		}
 
 		#[cfg(target_family = "wasm")]
 		Command::ExportFile {

--- a/crates/sdk/src/api/err/mod.rs
+++ b/crates/sdk/src/api/err/mod.rs
@@ -1,5 +1,6 @@
 use crate::{api::Response, Value};
 use serde::Serialize;
+use std::borrow::Cow;
 use std::path::PathBuf;
 use std::{convert::Infallible, io};
 use surrealdb_core::dbs::capabilities::{ParseFuncTargetError, ParseNetTargetError};
@@ -244,6 +245,10 @@ pub enum Error {
 	/// The engine used does not support data versioning
 	#[error("The '{0}' engine does not support data versioning")]
 	VersionsNotSupported(String),
+
+	#[doc(hidden)] // A raw query being forwarded
+	#[error("{0}")]
+	RawQuery(Cow<'static, str>),
 }
 
 impl serde::ser::Error for Error {

--- a/crates/sdk/src/api/method/live.rs
+++ b/crates/sdk/src/api/method/live.rs
@@ -88,7 +88,7 @@ where
 			Resource::Unspecified => return Err(Error::LiveOnUnspecified.into()),
 		}
 		let query =
-			Query::new(client.clone(), vec![Statement::Live(stmt)], Default::default(), false);
+			Query::normal(client.clone(), vec![Statement::Live(stmt)], Default::default(), false);
 		let CoreValue::Uuid(id) = query.await?.take::<Value>(0)?.into_inner() else {
 			return Err(Error::InternalError(
 				"successufull live query didn't return a uuid".to_string(),

--- a/crates/sdk/src/api/method/query.rs
+++ b/crates/sdk/src/api/method/query.rs
@@ -6,7 +6,6 @@ use crate::api::opt;
 use crate::api::Connection;
 use crate::api::ExtraFeatures;
 use crate::api::Result;
-use crate::engine::any::Any;
 use crate::method::OnceLockExt;
 use crate::method::Stats;
 use crate::method::WithStats;
@@ -32,30 +31,36 @@ use surrealdb_core::sql::{
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Query<'r, C: Connection> {
-	pub(crate) inner: Result<ValidQuery<'r, C>>,
+	pub(crate) client: Cow<'r, Surreal<C>>,
+	pub(crate) inner: Result<ValidQuery>,
 }
 
 #[derive(Debug)]
-pub(crate) struct ValidQuery<'r, C: Connection> {
-	pub client: Cow<'r, Surreal<C>>,
-	pub query: Vec<Statement>,
-	pub bindings: CoreObject,
-	pub register_live_queries: bool,
+pub(crate) enum ValidQuery {
+	Raw {
+		query: Cow<'static, str>,
+		bindings: CoreObject,
+	},
+	Normal {
+		query: Vec<Statement>,
+		register_live_queries: bool,
+		bindings: CoreObject,
+	},
 }
 
 impl<'r, C> Query<'r, C>
 where
 	C: Connection,
 {
-	pub(crate) fn new(
+	pub(crate) fn normal(
 		client: Cow<'r, Surreal<C>>,
 		query: Vec<Statement>,
 		bindings: CoreObject,
 		register_live_queries: bool,
 	) -> Self {
 		Query {
-			inner: Ok(ValidQuery {
-				client,
+			client,
+			inner: Ok(ValidQuery::Normal {
 				query,
 				bindings,
 				register_live_queries,
@@ -65,13 +70,15 @@ where
 
 	pub(crate) fn map_valid<F>(self, f: F) -> Self
 	where
-		F: FnOnce(ValidQuery<'r, C>) -> Result<ValidQuery<'r, C>>,
+		F: FnOnce(ValidQuery) -> Result<ValidQuery>,
 	{
 		match self.inner {
 			Ok(x) => Query {
+				client: self.client,
 				inner: f(x),
 			},
 			x => Query {
+				client: self.client,
 				inner: x,
 			},
 		}
@@ -79,23 +86,9 @@ where
 
 	/// Converts to an owned type which can easily be moved to a different thread
 	pub fn into_owned(self) -> Query<'static, C> {
-		let inner = match self.inner {
-			Ok(ValidQuery {
-				client,
-				query,
-				bindings,
-				register_live_queries,
-			}) => Ok(ValidQuery::<'static, C> {
-				client: Cow::Owned(client.into_owned()),
-				query,
-				bindings,
-				register_live_queries,
-			}),
-			Err(e) => Err(e),
-		};
-
 		Query {
-			inner,
+			client: Cow::Owned(self.client.into_owned()),
+			inner: self.inner,
 		}
 	}
 }
@@ -108,91 +101,100 @@ where
 	type IntoFuture = BoxFuture<'r, Self::Output>;
 
 	fn into_future(self) -> Self::IntoFuture {
-		let ValidQuery {
-			client,
-			query,
-			bindings,
-			register_live_queries,
-		} = match self.inner {
-			Ok(x) => x,
-			Err(error) => return Box::pin(async move { Err(error) }),
-		};
-
-		let query_statements = query;
-
 		Box::pin(async move {
 			// Extract the router from the client
-			let router = client.router.extract()?;
+			let router = self.client.router.extract()?;
 
-			// Collect the indexes of the live queries which should be registerd.
-			let query_indicies = if register_live_queries {
-				query_statements
-					.iter()
-					// BEGIN, COMMIT, and CANCEL don't return a result.
-					.filter(|x| {
-						!matches!(
-							x,
-							Statement::Begin(_) | Statement::Commit(_) | Statement::Cancel(_)
-						)
-					})
-					.enumerate()
-					.filter(|(_, x)| matches!(x, Statement::Live(_)))
-					.map(|(i, _)| i)
-					.collect()
-			} else {
-				Vec::new()
-			};
-
-			// If there are live queries and it is not supported, return an error.
-			if !query_indicies.is_empty() && !router.features.contains(&ExtraFeatures::LiveQueries)
-			{
-				return Err(Error::LiveQueriesNotSupported.into());
-			}
-
-			let mut query = sql::Query::default();
-			query.0 .0 = query_statements;
-
-			let mut response = router
-				.execute_query(Command::Query {
+			match self.inner? {
+				ValidQuery::Raw {
 					query,
-					variables: bindings,
-				})
-				.await?;
-
-			for idx in query_indicies {
-				let Some((_, result)) = response.results.get(&idx) else {
-					continue;
-				};
-
-				// This is a live query. We are using this as a workaround to avoid
-				// creating another public error variant for this internal error.
-				let res = match result {
-					Ok(id) => {
-						let CoreValue::Uuid(uuid) = id else {
-							return Err(Error::InternalError(
-								"successfull live query did not return a uuid".to_string(),
-							)
-							.into());
-						};
-						live::register(router, uuid.0).await.map(|rx| {
-							Stream::new(
-								Surreal::new_from_router_waiter(
-									client.router.clone(),
-									client.waiter.clone(),
-								),
-								uuid.0,
-								Some(rx),
-							)
+					bindings,
+				} => {
+					router
+						.execute_query(Command::RawQuery {
+							query,
+							variables: bindings,
 						})
-					}
-					Err(_) => Err(crate::Error::from(Error::NotLiveQuery(idx))),
-				};
-				response.live_queries.insert(idx, res);
-			}
+						.await
+				}
+				ValidQuery::Normal {
+					query,
+					register_live_queries,
+					bindings,
+				} => {
+					let query_statements = query;
 
-			response.client =
-				Surreal::new_from_router_waiter(client.router.clone(), client.waiter.clone());
-			Ok(response)
+					// Collect the indexes of the live queries which should be registerd.
+					let query_indicies = if register_live_queries {
+						query_statements
+							.iter()
+							// BEGIN, COMMIT, and CANCEL don't return a result.
+							.filter(|x| {
+								!matches!(
+									x,
+									Statement::Begin(_)
+										| Statement::Commit(_) | Statement::Cancel(_)
+								)
+							})
+							.enumerate()
+							.filter(|(_, x)| matches!(x, Statement::Live(_)))
+							.map(|(i, _)| i)
+							.collect()
+					} else {
+						Vec::new()
+					};
+
+					// If there are live queries and it is not supported, return an error.
+					if !query_indicies.is_empty()
+						&& !router.features.contains(&ExtraFeatures::LiveQueries)
+					{
+						return Err(Error::LiveQueriesNotSupported.into());
+					}
+
+					let mut query = sql::Query::default();
+					query.0 .0 = query_statements;
+
+					let mut response = router
+						.execute_query(Command::Query {
+							query,
+							variables: bindings,
+						})
+						.await?;
+
+					for idx in query_indicies {
+						let Some((_, result)) = response.results.get(&idx) else {
+							continue;
+						};
+
+						// This is a live query. We are using this as a workaround to avoid
+						// creating another public error variant for this internal error.
+						let res = match result {
+							Ok(id) => {
+								let CoreValue::Uuid(uuid) = id else {
+									return Err(Error::InternalError(
+										"successfull live query did not return a uuid".to_string(),
+									)
+									.into());
+								};
+								live::register(router, uuid.0).await.map(|rx| {
+									Stream::new(
+										Surreal::new_from_router_waiter(
+											self.client.router.clone(),
+											self.client.waiter.clone(),
+										),
+										uuid.0,
+										Some(rx),
+									)
+								})
+							}
+							Err(_) => Err(crate::Error::from(Error::NotLiveQuery(idx))),
+						};
+						response.live_queries.insert(idx, res);
+					}
+
+					Ok(response)
+				}
+			}
 		})
 	}
 }
@@ -217,11 +219,33 @@ where
 	C: Connection,
 {
 	/// Chains a query onto an existing query
-	pub fn query(self, query: impl opt::IntoQuery) -> Self {
-		self.map_valid(move |mut valid| {
-			let new_query = query.into_query()?;
-			valid.query.extend(new_query);
-			Ok(valid)
+	pub fn query(self, surql: impl opt::IntoQuery) -> Self {
+		self.map_valid(move |valid| match valid {
+			ValidQuery::Raw {
+				..
+			} => {
+				Err(Error::InvalidParams("Appending to raw queries is not supported".to_owned())
+					.into())
+			}
+			ValidQuery::Normal {
+				mut query,
+				register_live_queries,
+				bindings,
+			} => match surql.into_query() {
+				Ok(stmts) => {
+					query.extend(stmts);
+					Ok(ValidQuery::Normal {
+						query,
+						register_live_queries,
+						bindings,
+					})
+				}
+				Err(crate::Error::Api(crate::api::err::Error::RawQuery(..))) => {
+					Err(Error::InvalidParams("Appending raw queries is not supported".to_owned())
+						.into())
+				}
+				Err(error) => Err(error),
+			},
 		})
 	}
 
@@ -270,9 +294,19 @@ where
 	/// ```
 	pub fn bind(self, bindings: impl Serialize + 'static) -> Self {
 		self.map_valid(move |mut valid| {
+			let current_bindings = match &mut valid {
+				ValidQuery::Raw {
+					bindings,
+					..
+				} => bindings,
+				ValidQuery::Normal {
+					bindings,
+					..
+				} => bindings,
+			};
 			let bindings = to_core_value(bindings)?;
 			match bindings {
-				CoreValue::Object(mut map) => valid.bindings.append(&mut map.0),
+				CoreValue::Object(mut map) => current_bindings.append(&mut map.0),
 				CoreValue::Array(array) => {
 					if array.len() != 2 || !matches!(array[0], CoreValue::Strand(_)) {
 						let bindings = CoreValue::Array(array);
@@ -288,7 +322,7 @@ where
 						unreachable!()
 					};
 
-					valid.bindings.0.insert(key.0, value);
+					current_bindings.insert(key.0, value);
 				}
 				_ => {
 					let bindings = Value::from_inner(bindings);
@@ -306,7 +340,6 @@ pub(crate) type QueryResult = Result<CoreValue>;
 /// The response type of a `Surreal::query` request
 #[derive(Debug)]
 pub struct Response {
-	pub(crate) client: Surreal<Any>,
 	pub(crate) results: IndexMap<usize, (Stats, QueryResult)>,
 	pub(crate) live_queries: IndexMap<usize, Result<Stream<Value>>>,
 }
@@ -338,7 +371,6 @@ where
 impl Response {
 	pub(crate) fn new() -> Self {
 		Self {
-			client: Surreal::init(),
 			results: Default::default(),
 			live_queries: Default::default(),
 		}

--- a/crates/sdk/src/api/method/tests/server.rs
+++ b/crates/sdk/src/api/method/tests/server.rs
@@ -44,6 +44,9 @@ pub(super) fn mock(route_rx: Receiver<Route>) {
 				Command::Query {
 					..
 				} => Ok(DbResponse::Query(QueryResponse::new())),
+				Command::RawQuery {
+					..
+				} => Ok(DbResponse::Query(QueryResponse::new())),
 				Command::Create {
 					data,
 					..

--- a/crates/sdk/src/api/opt/mod.rs
+++ b/crates/sdk/src/api/opt/mod.rs
@@ -1,6 +1,7 @@
 //! The different options and types for use in API functions
 
 use serde::Serialize;
+use std::borrow::Cow;
 
 pub mod auth;
 pub mod capabilities;
@@ -242,4 +243,21 @@ pub enum WaitFor {
 	Connection,
 	/// Waits for the desired database to be selected
 	Database,
+}
+
+/// Forwards a raw query without trying to parse for live select statements
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[doc(hidden)]
+pub struct Raw(pub(crate) Cow<'static, str>);
+
+impl From<&'static str> for Raw {
+	fn from(query: &'static str) -> Self {
+		Self(Cow::Borrowed(query))
+	}
+}
+
+impl From<String> for Raw {
+	fn from(query: String) -> Self {
+		Self(Cow::Owned(query))
+	}
 }

--- a/crates/sdk/src/api/opt/query.rs
+++ b/crates/sdk/src/api/opt/query.rs
@@ -17,6 +17,8 @@ use surrealdb_core::{
 	syn,
 };
 
+use super::Raw;
+
 /// A trait for converting inputs into SQL statements
 pub trait IntoQuery {
 	/// Converts an input into SQL statements
@@ -185,6 +187,12 @@ impl IntoQuery for String {
 	}
 }
 
+impl IntoQuery for Raw {
+	fn into_query(self) -> Result<Vec<Statement>> {
+		Err(Error::RawQuery(self.0).into())
+	}
+}
+
 /// Represents a way to take a single query result from a list of responses
 pub trait QueryResult<Response>
 where
@@ -240,7 +248,6 @@ where
 				_ => Err(Error::LossyTake(QueryResponse {
 					results: mem::take(&mut response.results),
 					live_queries: mem::take(&mut response.live_queries),
-					..QueryResponse::new()
 				})
 				.into()),
 			},
@@ -318,7 +325,6 @@ where
 					return Err(Error::LossyTake(QueryResponse {
 						results: mem::take(&mut response.results),
 						live_queries: mem::take(&mut response.live_queries),
-						..QueryResponse::new()
 					})
 					.into());
 				}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

To avoid unnecessary overhead when we don't need to listen for live query notifications and want to parse queries on the server.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It adds `surrealdb::opt::Raw` which can be passed into the `query` method to achieve the said objectives.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
