### PR TITLE
Fix `merge` and `patch` when `upsert`ing a new record

### DIFF
--- a/crates/sdk/src/api/conn/cmd.rs
+++ b/crates/sdk/src/api/conn/cmd.rs
@@ -1,5 +1,4 @@
 use super::MlExportConfig;
-use crate::api::engine::resource_to_values;
 use crate::{opt::Resource, value::Notification, Result};
 use bincode::Options;
 use channel::Sender;
@@ -125,6 +124,7 @@ pub(crate) enum Command {
 impl Command {
 	#[cfg(any(feature = "protocol-ws", feature = "protocol-http"))]
 	pub(crate) fn into_router_request(self, id: Option<i64>) -> Option<RouterRequest> {
+		use crate::api::engine::resource_to_values;
 		use surrealdb_core::sql::{
 			statements::{UpdateStatement, UpsertStatement},
 			Data, Output,

--- a/crates/sdk/src/api/engine/local/mod.rs
+++ b/crates/sdk/src/api/engine/local/mod.rs
@@ -706,21 +706,27 @@ async fn router(
 		Command::Patch {
 			what,
 			data,
+			upsert,
 		} => {
 			let mut query = Query::default();
-			let one = what.is_single_recordid();
-			let statement = {
+			let statement = if upsert {
+				let mut stmt = UpsertStatement::default();
+				stmt.what = resource_to_values(what);
+				stmt.data = data.map(Data::PatchExpression);
+				stmt.output = Some(Output::After);
+				Statement::Upsert(stmt)
+			} else {
 				let mut stmt = UpdateStatement::default();
 				stmt.what = resource_to_values(what);
 				stmt.data = data.map(Data::PatchExpression);
 				stmt.output = Some(Output::After);
-				stmt
+				Statement::Update(stmt)
 			};
-			query.0 .0 = vec![Statement::Update(statement)];
+			query.0 .0 = vec![statement];
 			let vars = vars.read().await.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 			let response = kvs.process(query, &*session.read().await, Some(vars)).await?;
-			let value = take(one, response).await?;
-			Ok(DbResponse::Other(value))
+			let response = process(response);
+			Ok(DbResponse::Query(response))
 		}
 		Command::Merge {
 			what,

--- a/crates/sdk/src/api/engine/local/mod.rs
+++ b/crates/sdk/src/api/engine/local/mod.rs
@@ -725,21 +725,27 @@ async fn router(
 		Command::Merge {
 			what,
 			data,
+			upsert,
 		} => {
 			let mut query = Query::default();
-			let one = what.is_single_recordid();
-			let statement = {
+			let statement = if upsert {
+				let mut stmt = UpsertStatement::default();
+				stmt.what = resource_to_values(what);
+				stmt.data = data.map(Data::MergeExpression);
+				stmt.output = Some(Output::After);
+				Statement::Upsert(stmt)
+			} else {
 				let mut stmt = UpdateStatement::default();
 				stmt.what = resource_to_values(what);
 				stmt.data = data.map(Data::MergeExpression);
 				stmt.output = Some(Output::After);
-				stmt
+				Statement::Update(stmt)
 			};
-			query.0 .0 = vec![Statement::Update(statement)];
+			query.0 .0 = vec![statement];
 			let vars = vars.read().await.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 			let response = kvs.process(query, &*session.read().await, Some(vars)).await?;
-			let value = take(one, response).await?;
-			Ok(DbResponse::Other(value))
+			let response = process(response);
+			Ok(DbResponse::Query(response))
 		}
 		Command::Select {
 			what,

--- a/crates/sdk/src/api/engine/mod.rs
+++ b/crates/sdk/src/api/engine/mod.rs
@@ -39,7 +39,7 @@ use super::opt::Table;
 
 // used in http and all local engines.
 #[allow(dead_code)]
-fn resource_to_values(r: Resource) -> CoreValues {
+pub(crate) fn resource_to_values(r: Resource) -> CoreValues {
 	let mut res = CoreValues::default();
 	match r {
 		Resource::Table(x) => {

--- a/crates/sdk/src/api/method/merge.rs
+++ b/crates/sdk/src/api/method/merge.rs
@@ -21,6 +21,7 @@ pub struct Merge<'r, C: Connection, D, R> {
 	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) resource: Result<Resource>,
 	pub(super) content: D,
+	pub(super) upsert: bool,
 	pub(super) response_type: PhantomData<R>,
 }
 
@@ -38,12 +39,13 @@ where
 }
 
 macro_rules! into_future {
-	($method:ident) => {
+	() => {
 		fn into_future(self) -> Self::IntoFuture {
 			let Merge {
 				client,
 				resource,
 				content,
+				upsert,
 				..
 			} = self;
 			let content = to_core_value(content);
@@ -58,10 +60,11 @@ macro_rules! into_future {
 
 				let router = client.router.extract()?;
 				let cmd = Command::Merge {
+					upsert,
 					what: resource?,
 					data: content,
 				};
-				router.$method(cmd).await
+				router.execute_query(cmd).await?.take(0)
 			})
 		}
 	};
@@ -75,7 +78,7 @@ where
 	type Output = Result<Value>;
 	type IntoFuture = BoxFuture<'r, Self::Output>;
 
-	into_future! {execute_value}
+	into_future! {}
 }
 
 impl<'r, Client, D, R> IntoFuture for Merge<'r, Client, D, Option<R>>
@@ -87,7 +90,7 @@ where
 	type Output = Result<Option<R>>;
 	type IntoFuture = BoxFuture<'r, Self::Output>;
 
-	into_future! {execute_opt}
+	into_future! {}
 }
 
 impl<'r, Client, D, R> IntoFuture for Merge<'r, Client, D, Vec<R>>
@@ -99,5 +102,5 @@ where
 	type Output = Result<Vec<R>>;
 	type IntoFuture = BoxFuture<'r, Self::Output>;
 
-	into_future! {execute_vec}
+	into_future! {}
 }

--- a/crates/sdk/src/api/method/patch.rs
+++ b/crates/sdk/src/api/method/patch.rs
@@ -21,6 +21,7 @@ pub struct Patch<'r, C: Connection, R> {
 	pub(super) client: Cow<'r, Surreal<C>>,
 	pub(super) resource: Result<Resource>,
 	pub(super) patches: Vec<serde_content::Result<Content<'static>>>,
+	pub(super) upsert: bool,
 	pub(super) response_type: PhantomData<R>,
 }
 
@@ -38,12 +39,13 @@ where
 }
 
 macro_rules! into_future {
-	($method:ident) => {
+	() => {
 		fn into_future(self) -> Self::IntoFuture {
 			let Patch {
 				client,
 				resource,
 				patches,
+				upsert,
 				..
 			} = self;
 			Box::pin(async move {
@@ -56,11 +58,12 @@ macro_rules! into_future {
 				let patches = CoreValue::from(vec);
 				let router = client.router.extract()?;
 				let cmd = Command::Patch {
+					upsert,
 					what: resource?,
 					data: Some(patches),
 				};
 
-				router.$method(cmd).await
+				router.execute_query(cmd).await?.take(0)
 			})
 		}
 	};
@@ -73,7 +76,7 @@ where
 	type Output = Result<Value>;
 	type IntoFuture = BoxFuture<'r, Self::Output>;
 
-	into_future! {execute_value}
+	into_future! {}
 }
 
 impl<'r, Client, R> IntoFuture for Patch<'r, Client, Option<R>>
@@ -84,7 +87,7 @@ where
 	type Output = Result<Option<R>>;
 	type IntoFuture = BoxFuture<'r, Self::Output>;
 
-	into_future! {execute_opt}
+	into_future! {}
 }
 
 impl<'r, Client, R> IntoFuture for Patch<'r, Client, Vec<R>>
@@ -95,7 +98,7 @@ where
 	type Output = Result<Vec<R>>;
 	type IntoFuture = BoxFuture<'r, Self::Output>;
 
-	into_future! {execute_vec}
+	into_future! {}
 }
 
 impl<'r, C, R> Patch<'r, C, R>

--- a/crates/sdk/src/api/method/tests/server.rs
+++ b/crates/sdk/src/api/method/tests/server.rs
@@ -43,8 +43,14 @@ pub(super) fn mock(route_rx: Receiver<Route>) {
 				} => Ok(DbResponse::Other(CoreValue::None)),
 				Command::Query {
 					..
-				} => Ok(DbResponse::Query(QueryResponse::new())),
-				Command::RawQuery {
+				}
+				| Command::RawQuery {
+					..
+				}
+				| Command::Patch {
+					..
+				}
+				| Command::Merge {
 					..
 				} => Ok(DbResponse::Query(QueryResponse::new())),
 				Command::Create {
@@ -75,14 +81,6 @@ pub(super) fn mock(route_rx: Receiver<Route>) {
 					..
 				}
 				| Command::Update {
-					what,
-					..
-				}
-				| Command::Merge {
-					what,
-					..
-				}
-				| Command::Patch {
 					what,
 					..
 				} => match what {

--- a/crates/sdk/src/api/method/update.rs
+++ b/crates/sdk/src/api/method/update.rs
@@ -155,6 +155,7 @@ where
 			client: self.client,
 			resource: self.resource,
 			content: data,
+			upsert: false,
 			response_type: PhantomData,
 		}
 	}

--- a/crates/sdk/src/api/method/update.rs
+++ b/crates/sdk/src/api/method/update.rs
@@ -172,6 +172,7 @@ where
 			patches,
 			client: self.client,
 			resource: self.resource,
+			upsert: false,
 			response_type: PhantomData,
 		}
 	}

--- a/crates/sdk/src/api/method/upsert.rs
+++ b/crates/sdk/src/api/method/upsert.rs
@@ -153,6 +153,7 @@ where
 			client: self.client,
 			resource: self.resource,
 			content: data,
+			upsert: true,
 			response_type: PhantomData,
 		}
 	}

--- a/crates/sdk/src/api/method/upsert.rs
+++ b/crates/sdk/src/api/method/upsert.rs
@@ -170,6 +170,7 @@ where
 			patches,
 			client: self.client,
 			resource: self.resource,
+			upsert: true,
 			response_type: PhantomData,
 		}
 	}

--- a/crates/sdk/tests/api_integration/basic.rs
+++ b/crates/sdk/tests/api_integration/basic.rs
@@ -1069,7 +1069,7 @@ struct Person {
 	marketing: bool,
 }
 
-pub async fn merge_record_id(new_db: impl CreateDb) {
+pub async fn update_merge_record_id(new_db: impl CreateDb) {
 	let (permit, db) = new_db.create_db().await;
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
 	drop(permit);
@@ -1655,7 +1655,7 @@ define_include_tests!(basic => {
 	#[test_log::test(tokio::test)]
 	update_record_id_with_content,
 	#[test_log::test(tokio::test)]
-	merge_record_id,
+	update_merge_record_id,
 	#[test_log::test(tokio::test)]
 	patch_record_id,
 	#[test_log::test(tokio::test)]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Trying to `merge` or `patch` when creating a new record doesn't create the record. This is because these modifiers are currently using `UPDATE` instead of `UPSERT`.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It ensures that these modifiers use the correct statement.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added new tests.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Fixes #5472.

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
