### PR TITLE
Fix two bugs in parser

### DIFF
--- a/crates/core/src/syn/lexer/compound/number.rs
+++ b/crates/core/src/syn/lexer/compound/number.rs
@@ -70,6 +70,13 @@ pub fn numeric_kind(lexer: &mut Lexer, start: Token) -> Result<NumericKind, Synt
 			Some(b'n' | b'm' | b's' | b'h' | b'y' | b'w' | b'u') => {
 				duration(lexer, start).map(NumericKind::Duration)
 			}
+			Some(b'd') => {
+				if let Some(b'e') = lexer.reader.peek1() {
+					number_kind(lexer, start).map(NumericKind::Number)
+				} else {
+					duration(lexer, start).map(NumericKind::Duration)
+				}
+			}
 			Some(x) if !x.is_ascii() => duration(lexer, start).map(NumericKind::Duration),
 			_ => number_kind(lexer, start).map(NumericKind::Number),
 		},

--- a/crates/core/src/syn/parser/basic/mod.rs
+++ b/crates/core/src/syn/parser/basic/mod.rs
@@ -140,6 +140,11 @@ impl TokenValue for Regex {
 		match peek.kind {
 			t!("/") => {
 				parser.pop_peek();
+				if parser.has_peek() {
+					// If the parser peeks past a `/` lexing the compound token can fail.
+					// Peeking past `/` can happen when parsing `{/bla`.
+					parser.backup_after(peek.span);
+				}
 				let v = parser.lexer.lex_compound(peek, compound::regex)?.value;
 				Ok(Regex(v))
 			}

--- a/crates/language-tests/tests/parsing/far_peeking/object_regex.surql
+++ b/crates/language-tests/tests/parsing/far_peeking/object_regex.surql
@@ -2,7 +2,7 @@
 [test]
 
 [[test.results]]
-value = "1d2h"
-*/
+value = "/a/"
 
-{1d2h}
+*/
+{/a/}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

## What does this change do?

Fixes two bugs in the parser:
- `{1d2h}` was not properly parsed as a duration within a block statement.
- `{/k/}` caused a panic.

## What is your testing strategy?

Added tests to the language suite.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
