### PR TITLE
Fix panic when obtaining pid for Environment struct in WASM

### DIFF
--- a/crates/core/src/sys/mod.rs
+++ b/crates/core/src/sys/mod.rs
@@ -50,6 +50,9 @@ impl Default for Environment {
 	fn default() -> Self {
 		Self {
 			sys: System::new_all(),
+			#[cfg(target_family = "wasm")]
+			pid: 0.into(),
+			#[cfg(not(target_family = "wasm"))]
 			pid: Pid::from(std::process::id() as usize),
 		}
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

`std::process::id()` panics when called from WASM.

## What does this change do?

Fixes the panic by setting pid to 0.

## What is your testing strategy?

I switched my application to use my branch to see if it fixed the issue.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
