### PR TITLE
Ensure `NONE` values are maintained in arrays

### DIFF
--- a/crates/core/src/doc/field.rs
+++ b/crates/core/src/doc/field.rs
@@ -47,12 +47,7 @@ impl Document {
 					}
 					true => {
 						// Loop over every field under this field in the document
-						for k in self
-							.current
-							.doc
-							.every(Some(&fd.name), true, ArrayBehaviour::Nested)
-							.into_iter()
-						{
+						for k in self.current.doc.every(Some(&fd.name), true, true).into_iter() {
 							keys.push(k);
 						}
 					}
@@ -81,18 +76,14 @@ impl Document {
 						},
 					}
 				}
-				// NONE values should never be stored
-				if self.current.doc.pick(fd).is_none() {
-					self.current.doc.to_mut().cut(fd);
-				}
 			}
-		} else {
-			// Loop over every field in the document
-			for fd in self.current.doc.every(None, true, ArrayBehaviour::Nested).iter() {
-				// NONE values should never be stored
-				if self.current.doc.pick(fd).is_none() {
-					self.current.doc.to_mut().cut(fd);
-				}
+		}
+
+		// Loop over every field in the document
+		for fd in self.current.doc.every(None, true, ArrayBehaviour::Nested).iter() {
+			// NONE values should never be stored
+			if self.current.doc.pick(fd).is_none() {
+				self.current.doc.to_mut().cut(fd);
 			}
 		}
 		// Carry on

--- a/crates/core/src/doc/field.rs
+++ b/crates/core/src/doc/field.rs
@@ -53,7 +53,7 @@ impl Document {
 				}
 			}
 			// Loop over every field in the document
-			for fd in self.current.doc.every(None, true, true).iter() {
+			for fd in self.current.doc.every(None, true, false).iter() {
 				if !keys.contains(fd) {
 					match fd {
 						// Built-in fields
@@ -82,7 +82,7 @@ impl Document {
 			}
 		} else {
 			// Loop over every field in the document
-			for fd in self.current.doc.every(None, true, true).iter() {
+			for fd in self.current.doc.every(None, true, false).iter() {
 				// NONE values should never be stored
 				if self.current.doc.pick(fd).is_none() {
 					self.current.doc.to_mut().cut(fd);
@@ -115,8 +115,11 @@ impl Document {
 		// which are prefixed with the specified idiom
 		// will be skipped, as the parent object is optional
 		let mut skip: Option<&Idiom> = None;
+		// Stores whether the last iteration was an array type
+		// let mut is_array = false;
 		// Loop through all field statements
 		for fd in self.fd(ctx, opt).await?.iter() {
+			println!("\nfd {:?}", fd);
 			// Check if we should skip this field
 			let skipped = match skip {
 				// We are skipping a parent field
@@ -132,8 +135,12 @@ impl Document {
 				}
 				None => false,
 			};
+
 			// Loop over each field in document
 			for (k, mut val) in self.current.doc.as_ref().walk(&fd.name).into_iter() {
+				println!("\ndoc {:?}", self.current.doc);
+				println!("\nk {:?}", k);
+				println!("\nval {:?}", val);
 				// Get the initial value
 				let old = Arc::new(self.initial.doc.as_ref().pick(&k));
 				// Get the input value
@@ -240,10 +247,7 @@ impl Document {
 						skip = Some(&fd.name);
 					}
 					// Set the new value of the field, or delete it if empty
-					match val.is_none() {
-						false => self.current.doc.to_mut().put(&k, val),
-						true => self.current.doc.to_mut().cut(&k),
-					};
+					self.current.doc.to_mut().put(&k, val);
 				}
 			}
 		}

--- a/crates/core/src/doc/field.rs
+++ b/crates/core/src/doc/field.rs
@@ -59,7 +59,7 @@ impl Document {
 				}
 			}
 			// Loop over every field in the document
-			for fd in self.current.doc.every(None, true, false).iter() {
+			for fd in self.current.doc.every(None, true, true).iter() {
 				if !keys.contains(fd) {
 					match fd {
 						// Built-in fields

--- a/crates/core/src/doc/field.rs
+++ b/crates/core/src/doc/field.rs
@@ -117,7 +117,6 @@ impl Document {
 		let mut skip: Option<&Idiom> = None;
 		// Loop through all field statements
 		for fd in self.fd(ctx, opt).await?.iter() {
-			println!("\nfd {:?}", fd);
 			// Check if we should skip this field
 			let skipped = match skip {
 				// We are skipping a parent field

--- a/crates/core/src/doc/field.rs
+++ b/crates/core/src/doc/field.rs
@@ -115,8 +115,6 @@ impl Document {
 		// which are prefixed with the specified idiom
 		// will be skipped, as the parent object is optional
 		let mut skip: Option<&Idiom> = None;
-		// Stores whether the last iteration was an array type
-		// let mut is_array = false;
 		// Loop through all field statements
 		for fd in self.fd(ctx, opt).await?.iter() {
 			println!("\nfd {:?}", fd);
@@ -138,9 +136,6 @@ impl Document {
 
 			// Loop over each field in document
 			for (k, mut val) in self.current.doc.as_ref().walk(&fd.name).into_iter() {
-				println!("\ndoc {:?}", self.current.doc);
-				println!("\nk {:?}", k);
-				println!("\nval {:?}", val);
 				// Get the initial value
 				let old = Arc::new(self.initial.doc.as_ref().pick(&k));
 				// Get the input value

--- a/crates/core/src/doc/field.rs
+++ b/crates/core/src/doc/field.rs
@@ -12,6 +12,7 @@ use crate::sql::permission::Permission;
 use crate::sql::reference::Refs;
 use crate::sql::statements::DefineFieldStatement;
 use crate::sql::thing::Thing;
+use crate::sql::value::every::ArrayBehaviour;
 use crate::sql::value::Value;
 use crate::sql::Part;
 use reblessive::tree::Stk;
@@ -46,7 +47,12 @@ impl Document {
 					}
 					true => {
 						// Loop over every field under this field in the document
-						for k in self.current.doc.every(Some(&fd.name), true, true).into_iter() {
+						for k in self
+							.current
+							.doc
+							.every(Some(&fd.name), true, ArrayBehaviour::Nested)
+							.into_iter()
+						{
 							keys.push(k);
 						}
 					}
@@ -82,7 +88,7 @@ impl Document {
 			}
 		} else {
 			// Loop over every field in the document
-			for fd in self.current.doc.every(None, true, false).iter() {
+			for fd in self.current.doc.every(None, true, ArrayBehaviour::Nested).iter() {
 				// NONE values should never be stored
 				if self.current.doc.pick(fd).is_none() {
 					self.current.doc.to_mut().cut(fd);

--- a/crates/core/src/sql/value/every.rs
+++ b/crates/core/src/sql/value/every.rs
@@ -3,13 +3,18 @@ use crate::sql::part::Part;
 use crate::sql::value::Value;
 
 impl Value {
-	pub(crate) fn every(&self, path: Option<&[Part]>, steps: bool, arrays: bool) -> Vec<Idiom> {
+	pub(crate) fn every(
+		&self,
+		path: Option<&[Part]>,
+		steps: bool,
+		arrays: impl Into<ArrayBehaviour>,
+	) -> Vec<Idiom> {
 		match path {
-			Some(path) => self.pick(path)._every(steps, arrays, Idiom::from(path)),
-			None => self._every(steps, arrays, Idiom::default()),
+			Some(path) => self.pick(path)._every(steps, arrays.into(), Idiom::from(path)),
+			None => self._every(steps, arrays.into(), Idiom::default()),
 		}
 	}
-	fn _every(&self, steps: bool, arrays: bool, mut prev: Idiom) -> Vec<Idiom> {
+	fn _every(&self, steps: bool, arrays: ArrayBehaviour, mut prev: Idiom) -> Vec<Idiom> {
 		match self {
 			// Current path part is an object and is not empty
 			Value::Object(v) if !v.is_empty() => {
@@ -42,20 +47,57 @@ impl Value {
 				// Check if we should log individual array items
 				match arrays {
 					// Let's log all individual array items
-					true => std::iter::once(prev.clone())
+					ArrayBehaviour::Full => std::iter::once(prev.clone())
 						.chain(v.iter().enumerate().rev().flat_map(|(i, v)| {
 							let p = Part::from(i.to_owned());
 							v._every(steps, arrays, prev.clone().push(p))
 						}))
 						.collect::<Vec<_>>(),
-					// Let's not log individual array items
-					false => vec![prev],
+					// Let's log all nested paths found in the array items
+					ArrayBehaviour::Nested => std::iter::once(prev.clone())
+						.chain(v.iter().enumerate().rev().flat_map(|(i, v)| {
+							let p = Part::from(i.to_owned());
+							let prev = prev.clone().push(p);
+							let r = v._every(steps, arrays, prev.clone());
+							if r.first() != Some(&prev) {
+								r
+							} else {
+								r[1..].to_vec()
+							}
+						}))
+						.collect::<Vec<_>>(),
+					// Let's skip this array's values entirely
+					ArrayBehaviour::Ignore => vec![prev],
 				}
 			}
 			// Process every other path
 			_ if !prev.is_empty() => vec![prev],
 			// Nothing to do
 			_ => vec![],
+		}
+	}
+}
+
+// Assuming a value like: { foo: [{ bar: 123 }] }
+#[derive(Clone, Copy, Debug)]
+pub enum ArrayBehaviour {
+	// Do not process this array at all
+	// [foo]
+	Ignore,
+	// Only give back nested paths, but skip the array indexes themselves
+	// [foo, foo[0].bar ]
+	Nested,
+	// Give back all nested paths and all indexes of the array
+	// [foo, foo[0], foo[0].bar]
+	Full,
+}
+
+impl From<bool> for ArrayBehaviour {
+	fn from(value: bool) -> Self {
+		if value {
+			ArrayBehaviour::Full
+		} else {
+			ArrayBehaviour::Ignore
 		}
 	}
 }
@@ -90,6 +132,19 @@ mod tests {
 		let val = Value::parse("{ test: { something: [{ age: 34, tags: ['code', 'databases'] }, { age: 36, tags: ['design', 'operations'] }] } }");
 		let res = vec![Idiom::parse("test.something")];
 		assert_eq!(res, val.every(None, false, false));
+	}
+
+	#[test]
+	fn every_recursive_without_array_indexes() {
+		let val = Value::parse("{ test: { something: [{ age: 34, tags: ['code', 'databases'] }, { age: 36, tags: ['design', 'operations'] }] } }");
+		let res = vec![
+			Idiom::parse("test.something"),
+			Idiom::parse("test.something[1].age"),
+			Idiom::parse("test.something[1].tags"),
+			Idiom::parse("test.something[0].age"),
+			Idiom::parse("test.something[0].tags"),
+		];
+		assert_eq!(res, val.every(None, false, ArrayBehaviour::Nested));
 	}
 
 	#[test]

--- a/crates/core/src/sql/value/mod.rs
+++ b/crates/core/src/sql/value/mod.rs
@@ -15,7 +15,7 @@ mod def;
 mod del;
 mod diff;
 mod each;
-mod every;
+pub(crate) mod every;
 mod extend;
 mod fetch;
 mod first;

--- a/crates/language-tests/tests/language/statements/define/field/array_with_none.surql
+++ b/crates/language-tests/tests/language/statements/define/field/array_with_none.surql
@@ -1,0 +1,12 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: user:test, test: [NONE, 2, NULL] }]"
+
+*/
+DEFINE FIELD test ON user TYPE array<option<number|NULL>>;
+CREATE user:test SET test = [NONE, 2, NULL];

--- a/crates/language-tests/tests/language/statements/define/field/none_elimination.surql
+++ b/crates/language-tests/tests/language/statements/define/field/none_elimination.surql
@@ -1,0 +1,32 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: test:1, b: {}, c: [NONE, {}, {}] }]"
+[[test.results]]
+value = "[{ id: test:2, a: 123, b: { key: 123 }, c: [NONE, {}, { key: 123 }] }]"
+
+*/
+
+DEFINE FIELD a ON test TYPE option<number>;
+DEFINE FIELD b ON test TYPE { key: option<number> };
+DEFINE FIELD c ON test TYPE array<option<{ key: option<number> }>>;
+
+CREATE test:1 CONTENT {
+	a: NONE,
+	b: { key: NONE },
+	c: [NONE, {}, { key: NONE }]
+};
+
+CREATE test:2 CONTENT {
+	a: 123,
+	b: { key: 123 },
+	c: [NONE, {}, { key: 123 }]
+};


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See #5504. Dropping `NONE` values from arrays breaks the order and structure of arrays, causing unexpected issues and non-sensible behaviors.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

- Ensures `process_table_fields` does not clean up `NONE` values, as it's not responsible for that.
- Ensures that `cleanup_table_fields` does not process array's child values during cleanup.
- Ensures that keys nested inside arrays are still processed

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #5504

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
