### PR TITLE
Enable `default` features for nix builds

### DIFF
--- a/pkg/nix/spec/aarch64-apple-darwin.nix
+++ b/pkg/nix/spec/aarch64-apple-darwin.nix
@@ -3,7 +3,7 @@
 {
   inherit target;
 
-  features = with util.features; [ storage-mem storage-rocksdb scripting http storage-tikv ];
+  features = with util.features; [ default storage-tikv ];
 
   buildSpec = with pkgs; {
     depsBuildBuild = [ clang protobuf perl ];

--- a/pkg/nix/spec/x86_64-apple-darwin.nix
+++ b/pkg/nix/spec/x86_64-apple-darwin.nix
@@ -3,7 +3,7 @@
 {
   inherit target;
 
-  features = with util.features; [ storage-mem storage-rocksdb scripting http storage-tikv ];
+  features = with util.features; [ default storage-tikv ];
 
   buildSpec = with pkgs; {
     depsBuildBuild = [ clang protobuf perl ];

--- a/pkg/nix/spec/x86_64-pc-windows-gnu.nix
+++ b/pkg/nix/spec/x86_64-pc-windows-gnu.nix
@@ -3,7 +3,7 @@
 {
   inherit target;
 
-  features = with util.features; [ storage-mem storage-rocksdb scripting http ];
+  features = with util.features; [ default ];
 
   buildSpec = with pkgs; {
     strictDeps = true;

--- a/pkg/nix/spec/x86_64-unknown-linux-gnu.nix
+++ b/pkg/nix/spec/x86_64-unknown-linux-gnu.nix
@@ -4,7 +4,7 @@
   inherit target;
 
   features = with util.features;
-    [ storage-mem storage-rocksdb scripting http storage-tikv ]
+    [ default storage-tikv ]
     ++ pkgs.lib.lists.optional (util.fdbSupported pkgs.fdbPackages)
     [ storage-fdb-7_1 ];
 


### PR DESCRIPTION
## What is the motivation?

Default features were disabled here: #3133. The `ml` feature is no longer default so it shouldn't break nix builds (assuming it still doesn't work). 

## What does this change do?

Enable default features for nix builds where appropriate.

## What is your testing strategy?

Built locally on `x86_64-linux` and tested with `storage-surrealkv` connection.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
