### PR TITLE
Switch to `tokio::mpsc` from `async_channel` in WebSocket

### DIFF
--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -71,9 +71,13 @@ pub static WEBSOCKET_MAX_FRAME_SIZE: LazyLock<usize> =
 pub static WEBSOCKET_MAX_MESSAGE_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE", usize, 128 << 20);
 
-/// How many messages can be buffered while attempting to deliver to the client.
+/// How many responses can be buffered when delivering to the client (defaults to 25).
 pub static WEBSOCKET_RESPONSE_BUFFER_SIZE: LazyLock<usize> =
-	lazy_env_parse!("SURREAL_WEBSOCKET_RESPONSE_BUFFER_SIZE", usize, 0);
+	lazy_env_parse!("SURREAL_WEBSOCKET_RESPONSE_BUFFER_SIZE", usize, 25);
+
+/// How often are any buffered responses flushed to the WebSocket client (defaults to 3 ms).
+pub static WEBSOCKET_RESPONSE_FLUSH_PERIOD: LazyLock<u64> =
+	lazy_env_parse!("SURREAL_WEBSOCKET_RESPONSE_FLUSH_PERIOD", u64, 3);
 
 /// How many messages can be queued for sending to the buffered WebSocket connection.
 pub static WEBSOCKET_RESPONSE_CHANNEL_SIZE: LazyLock<usize> =

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -87,7 +87,7 @@ pub(crate) async fn notifications(
 							// Get the WebSocket output format
 							let format = rpc.format;
 							// Get the WebSocket sending channel
-							let sender = rpc.channel.0.clone();
+							let sender = rpc.channel.clone();
 							// Send the notification to the client
 							let future = message.send(cx, format, sender);
 							// Pus the future to the pipeline

--- a/src/rpc/response.rs
+++ b/src/rpc/response.rs
@@ -6,10 +6,10 @@ use opentelemetry::Context as TelemetryContext;
 use revision::revisioned;
 use serde::Serialize;
 use std::sync::Arc;
-use surrealdb::channel::Sender;
 use surrealdb::rpc::format::Format;
 use surrealdb::rpc::Data;
 use surrealdb::sql::Value;
+use tokio::sync::mpsc::Sender;
 use tracing::Span;
 
 #[revisioned(revision = 1)]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

This pull request switches from using `async_channel::bounded()` in the WebSocket implementation to using `tokio::sync::mpsc::channel()`. This enables reduced context switching and fewer wakes in the Tokio runtime.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
