### PR TITLE
Ensure `INSERT IGNORE` does not throw error

### DIFF
--- a/crates/core/src/doc/insert.rs
+++ b/crates/core/src/doc/insert.rs
@@ -38,19 +38,29 @@ impl Document {
 					true => match self.is_specific_record_id() {
 						// No specific Record ID has been specified, so retry
 						false => Err(Error::RetryWithId(thing)),
-						// A specific Record ID was specified, so error
-						true => Err(Error::IndexExists {
+						// A specific Record ID was specified
+						true => match stm.is_ignore() {
+							// There is no IGNORE keyword specified
+							false => Err(Error::IndexExists {
+								thing,
+								index,
+								value,
+							}),
+							// There is an IGNORE keyword specified
+							true => Err(Error::Ignore),
+						},
+					},
+					// There is no ON DUPLICATE KEY UPDATE clause
+					false => match stm.is_ignore() {
+						// There is no IGNORE keyword specified
+						false => Err(Error::IndexExists {
 							thing,
 							index,
 							value,
 						}),
+						// There is an IGNORE keyword specified
+						true => Err(Error::Ignore),
 					},
-					// There is no ON DUPLICATE KEY UPDATE clause
-					false => Err(Error::IndexExists {
-						thing,
-						index,
-						value,
-					}),
 				},
 				// We attempted to INSERT a document with an ID,
 				// and this ID already exists in the database,
@@ -63,9 +73,11 @@ impl Document {
 					true => Err(Error::RetryWithId(thing)),
 					// There is no ON DUPLICATE KEY UPDATE clause
 					false => match stm.is_ignore() {
+						// There is no IGNORE keyword specified
 						false => Err(Error::RecordExists {
 							thing,
 						}),
+						// There is an IGNORE keyword specified
 						true => Err(Error::Ignore),
 					},
 				},

--- a/crates/language-tests/tests/language/statements/insert/insert_ignore_no_duplicate_key.surql
+++ b/crates/language-tests/tests/language/statements/insert/insert_ignore_no_duplicate_key.surql
@@ -1,0 +1,21 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: person:tobie, name: 'Tobie' }]"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "[]"
+
+*/
+
+DEFINE INDEX name ON person FIELDS name UNIQUE;
+CREATE person:tobie SET name = 'Tobie';
+INSERT IGNORE INTO person { id: 1, name: 'Tobie' };
+INSERT IGNORE INTO person (id, name) VALUES (2, 'Tobie');

--- a/crates/language-tests/tests/language/statements/insert/insert_ignore_on_duplicate_key_update.surql
+++ b/crates/language-tests/tests/language/statements/insert/insert_ignore_on_duplicate_key_update.surql
@@ -1,0 +1,25 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: person:tobie, name: 'Tobie' }]"
+
+[[test.results]]
+value = "[{ id: person:tobias, name: 'Tobias' }]"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "[]"
+
+*/
+
+DEFINE INDEX name ON person FIELDS name UNIQUE;
+CREATE person:tobie SET name = 'Tobie';
+CREATE person:tobias SET name = 'Tobias';
+INSERT IGNORE INTO person { id: 1, name: 'Tobie' } ON DUPLICATE KEY UPDATE name = 'Tobias';
+INSERT IGNORE INTO person (id, name) VALUES (2, 'Tobie') ON DUPLICATE KEY UPDATE name = 'Tobias';

--- a/crates/language-tests/tests/language/statements/insert/insert_relation_ignore_no_duplicate_key.surql
+++ b/crates/language-tests/tests/language/statements/insert/insert_relation_ignore_no_duplicate_key.surql
@@ -1,0 +1,25 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: person:1, name: 'Tobie' }]"
+
+[[test.results]]
+value = "[{ id: person:2, name: 'Tobie' }]"
+
+[[test.results]]
+value = "[{ id: like:1, in: person:1, out: person:2 }]"
+
+[[test.results]]
+value = "[]"
+
+*/
+
+DEFINE INDEX unique ON like FIELDS in, out UNIQUE;
+CREATE person:1 SET name = 'Tobie';
+CREATE person:2 SET name = 'Tobie';
+INSERT RELATION INTO like (id, in, out) VALUES (1, person:1, person:2);
+INSERT RELATION IGNORE INTO like (id, in, out) VALUES (2, person:1, person:2);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Currently when running an `INSERT` statement with a `IGNORE` keyword, sometimes an error is still thrown in certain scenarios:

- When a specific record ID is specified, but the insertion conflicts with an index entry:

```sql
DEFINE INDEX name ON person FIELDS name UNIQUE;
CREATE person:tobie SET name = 'Tobie';
INSERT IGNORE INTO person { id: 1, name: 'Tobie' };
INSERT IGNORE INTO person (id, name) VALUES (2, 'Tobie');
```

- When a specific record ID is specified, and an `ON DUPLICATE KEY UPDATE` clause is specified, but the insertion conflicts with an index entry:

```sql
DEFINE INDEX name ON person FIELDS name UNIQUE;
CREATE person:tobie SET name = 'Tobie';
CREATE person:tobias SET name = 'Tobias';
INSERT IGNORE INTO person { id: 1, name: 'Tobie' } ON DUPLICATE KEY UPDATE name = 'Tobias';
INSERT IGNORE INTO person (id, name) VALUES (2, 'Tobie') ON DUPLICATE KEY UPDATE name = 'Tobias';
```

## What does this change do?

This pull request ensures that when an `IGNORE` keyword is used in an `INSERT` statement, an error is not returned.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #5489

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
