### PR TITLE
Use LQ ctx & opt

### DIFF
--- a/crates/core/src/doc/lives.rs
+++ b/crates/core/src/doc/lives.rs
@@ -168,10 +168,10 @@ impl Document {
 			if let Some(fetchs) = &lv.fetch {
 				let mut idioms = Vec::with_capacity(fetchs.0.len());
 				for fetch in fetchs.iter() {
-					fetch.compute(stk, ctx, opt, &mut idioms).await?;
+					fetch.compute(stk, &lqctx, &lqopt, &mut idioms).await?;
 				}
 				for i in &idioms {
-					stk.run(|stk| result.fetch(stk, ctx, opt, i)).await?;
+					stk.run(|stk| result.fetch(stk, &lqctx, &lqopt, i)).await?;
 				}
 			}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See #5529 

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Ensures that idiom fetching uses the LQ ctx & opt

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #5529

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
