### PR TITLE
Refactor capabilities to reduce allocations

### DIFF
--- a/crates/core/src/ctx/context.rs
+++ b/crates/core/src/ctx/context.rs
@@ -189,7 +189,7 @@ impl MutableContext {
 	/// Creates a new context from a configured datastore.
 	pub(crate) fn from_ds(
 		time_out: Option<Duration>,
-		capabilities: Capabilities,
+		capabilities: Arc<Capabilities>,
 		index_stores: IndexStores,
 		cache: Arc<DatastoreCache>,
 		#[cfg(not(target_family = "wasm"))] index_builder: IndexBuilder,
@@ -204,7 +204,7 @@ impl MutableContext {
 			query_planner: None,
 			query_executor: None,
 			iteration_stage: None,
-			capabilities: Arc::new(capabilities),
+			capabilities,
 			index_stores,
 			cache: Some(cache),
 			#[cfg(not(target_family = "wasm"))]
@@ -421,8 +421,8 @@ impl MutableContext {
 	//
 
 	/// Set the capabilities for this context
-	pub(crate) fn add_capabilities(&mut self, caps: Capabilities) {
-		self.capabilities = Arc::new(caps);
+	pub(crate) fn add_capabilities(&mut self, caps: Arc<Capabilities>) {
+		self.capabilities = caps;
 	}
 
 	/// Get the capabilities for this context

--- a/crates/core/src/dbs/capabilities.rs
+++ b/crates/core/src/dbs/capabilities.rs
@@ -1,7 +1,7 @@
+use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
 use std::net::IpAddr;
-use std::{collections::HashSet, sync::Arc};
 
 use crate::iam::{Auth, Level};
 use crate::rpc::Method;
@@ -510,18 +510,18 @@ pub struct Capabilities {
 	guest_access: bool,
 	live_query_notifications: bool,
 
-	allow_funcs: Arc<Targets<FuncTarget>>,
-	deny_funcs: Arc<Targets<FuncTarget>>,
-	allow_net: Arc<Targets<NetTarget>>,
-	deny_net: Arc<Targets<NetTarget>>,
-	allow_rpc: Arc<Targets<MethodTarget>>,
-	deny_rpc: Arc<Targets<MethodTarget>>,
-	allow_http: Arc<Targets<RouteTarget>>,
-	deny_http: Arc<Targets<RouteTarget>>,
-	allow_experimental: Arc<Targets<ExperimentalTarget>>,
-	deny_experimental: Arc<Targets<ExperimentalTarget>>,
-	allow_arbitrary_query: Arc<Targets<ArbitraryQueryTarget>>,
-	deny_arbitrary_query: Arc<Targets<ArbitraryQueryTarget>>,
+	allow_funcs: Targets<FuncTarget>,
+	deny_funcs: Targets<FuncTarget>,
+	allow_net: Targets<NetTarget>,
+	deny_net: Targets<NetTarget>,
+	allow_rpc: Targets<MethodTarget>,
+	deny_rpc: Targets<MethodTarget>,
+	allow_http: Targets<RouteTarget>,
+	deny_http: Targets<RouteTarget>,
+	allow_experimental: Targets<ExperimentalTarget>,
+	deny_experimental: Targets<ExperimentalTarget>,
+	allow_arbitrary_query: Targets<ArbitraryQueryTarget>,
+	deny_arbitrary_query: Targets<ArbitraryQueryTarget>,
 }
 
 impl fmt::Display for Capabilities {
@@ -541,18 +541,18 @@ impl Default for Capabilities {
 			guest_access: false,
 			live_query_notifications: true,
 
-			allow_funcs: Arc::new(Targets::All),
-			deny_funcs: Arc::new(Targets::None),
-			allow_net: Arc::new(Targets::None),
-			deny_net: Arc::new(Targets::None),
-			allow_rpc: Arc::new(Targets::All),
-			deny_rpc: Arc::new(Targets::None),
-			allow_http: Arc::new(Targets::All),
-			deny_http: Arc::new(Targets::None),
-			allow_experimental: Arc::new(Targets::None),
-			deny_experimental: Arc::new(Targets::None),
-			allow_arbitrary_query: Arc::new(Targets::All),
-			deny_arbitrary_query: Arc::new(Targets::None),
+			allow_funcs: Targets::All,
+			deny_funcs: Targets::None,
+			allow_net: Targets::None,
+			deny_net: Targets::None,
+			allow_rpc: Targets::All,
+			deny_rpc: Targets::None,
+			allow_http: Targets::All,
+			deny_http: Targets::None,
+			allow_experimental: Targets::None,
+			deny_experimental: Targets::None,
+			allow_arbitrary_query: Targets::All,
+			deny_arbitrary_query: Targets::None,
 		}
 	}
 }
@@ -564,18 +564,18 @@ impl Capabilities {
 			guest_access: true,
 			live_query_notifications: true,
 
-			allow_funcs: Arc::new(Targets::All),
-			deny_funcs: Arc::new(Targets::None),
-			allow_net: Arc::new(Targets::All),
-			deny_net: Arc::new(Targets::None),
-			allow_rpc: Arc::new(Targets::All),
-			deny_rpc: Arc::new(Targets::None),
-			allow_http: Arc::new(Targets::All),
-			deny_http: Arc::new(Targets::None),
-			allow_experimental: Arc::new(Targets::None),
-			deny_experimental: Arc::new(Targets::None),
-			allow_arbitrary_query: Arc::new(Targets::All),
-			deny_arbitrary_query: Arc::new(Targets::None),
+			allow_funcs: Targets::All,
+			deny_funcs: Targets::None,
+			allow_net: Targets::All,
+			deny_net: Targets::None,
+			allow_rpc: Targets::All,
+			deny_rpc: Targets::None,
+			allow_http: Targets::All,
+			deny_http: Targets::None,
+			allow_experimental: Targets::None,
+			deny_experimental: Targets::None,
+			allow_arbitrary_query: Targets::All,
+			deny_arbitrary_query: Targets::None,
 		}
 	}
 
@@ -585,18 +585,18 @@ impl Capabilities {
 			guest_access: false,
 			live_query_notifications: false,
 
-			allow_funcs: Arc::new(Targets::None),
-			deny_funcs: Arc::new(Targets::None),
-			allow_net: Arc::new(Targets::None),
-			deny_net: Arc::new(Targets::None),
-			allow_rpc: Arc::new(Targets::None),
-			deny_rpc: Arc::new(Targets::None),
-			allow_http: Arc::new(Targets::None),
-			deny_http: Arc::new(Targets::None),
-			allow_experimental: Arc::new(Targets::None),
-			deny_experimental: Arc::new(Targets::None),
-			allow_arbitrary_query: Arc::new(Targets::None),
-			deny_arbitrary_query: Arc::new(Targets::None),
+			allow_funcs: Targets::None,
+			deny_funcs: Targets::None,
+			allow_net: Targets::None,
+			deny_net: Targets::None,
+			allow_rpc: Targets::None,
+			deny_rpc: Targets::None,
+			allow_http: Targets::None,
+			deny_http: Targets::None,
+			allow_experimental: Targets::None,
+			deny_experimental: Targets::None,
+			allow_arbitrary_query: Targets::None,
+			deny_arbitrary_query: Targets::None,
 		}
 	}
 
@@ -616,22 +616,30 @@ impl Capabilities {
 	}
 
 	pub fn with_functions(mut self, allow_funcs: Targets<FuncTarget>) -> Self {
-		self.allow_funcs = Arc::new(allow_funcs);
+		self.allow_funcs = allow_funcs;
 		self
+	}
+
+	pub fn allowed_functions_mut(&mut self) -> &mut Targets<FuncTarget> {
+		&mut self.allow_funcs
 	}
 
 	pub fn without_functions(mut self, deny_funcs: Targets<FuncTarget>) -> Self {
-		self.deny_funcs = Arc::new(deny_funcs);
+		self.deny_funcs = deny_funcs;
 		self
 	}
 
+	pub fn denied_functions_mut(&mut self) -> &mut Targets<FuncTarget> {
+		&mut self.deny_funcs
+	}
+
 	pub fn with_experimental(mut self, allow_experimental: Targets<ExperimentalTarget>) -> Self {
-		self.allow_experimental = Arc::new(allow_experimental);
+		self.allow_experimental = allow_experimental;
 		self
 	}
 
 	pub fn without_experimental(mut self, deny_experimental: Targets<ExperimentalTarget>) -> Self {
-		self.deny_experimental = Arc::new(deny_experimental);
+		self.deny_experimental = deny_experimental;
 		self
 	}
 
@@ -639,7 +647,7 @@ impl Capabilities {
 		mut self,
 		allow_arbitrary_query: Targets<ArbitraryQueryTarget>,
 	) -> Self {
-		self.allow_arbitrary_query = Arc::new(allow_arbitrary_query);
+		self.allow_arbitrary_query = allow_arbitrary_query;
 		self
 	}
 
@@ -647,37 +655,45 @@ impl Capabilities {
 		mut self,
 		deny_arbitrary_query: Targets<ArbitraryQueryTarget>,
 	) -> Self {
-		self.deny_arbitrary_query = Arc::new(deny_arbitrary_query);
+		self.deny_arbitrary_query = deny_arbitrary_query;
 		self
 	}
 
 	pub fn with_network_targets(mut self, allow_net: Targets<NetTarget>) -> Self {
-		self.allow_net = Arc::new(allow_net);
+		self.allow_net = allow_net;
 		self
+	}
+
+	pub fn allowed_network_targets_mut(&mut self) -> &mut Targets<NetTarget> {
+		&mut self.allow_net
 	}
 
 	pub fn without_network_targets(mut self, deny_net: Targets<NetTarget>) -> Self {
-		self.deny_net = Arc::new(deny_net);
+		self.deny_net = deny_net;
 		self
 	}
 
+	pub fn denied_network_targets_mut(&mut self) -> &mut Targets<NetTarget> {
+		&mut self.deny_net
+	}
+
 	pub fn with_rpc_methods(mut self, allow_rpc: Targets<MethodTarget>) -> Self {
-		self.allow_rpc = Arc::new(allow_rpc);
+		self.allow_rpc = allow_rpc;
 		self
 	}
 
 	pub fn without_rpc_methods(mut self, deny_rpc: Targets<MethodTarget>) -> Self {
-		self.deny_rpc = Arc::new(deny_rpc);
+		self.deny_rpc = deny_rpc;
 		self
 	}
 
 	pub fn with_http_routes(mut self, allow_http: Targets<RouteTarget>) -> Self {
-		self.allow_http = Arc::new(allow_http);
+		self.allow_http = allow_http;
 		self
 	}
 
 	pub fn without_http_routes(mut self, deny_http: Targets<RouteTarget>) -> Self {
-		self.deny_http = Arc::new(deny_http);
+		self.deny_http = deny_http;
 		self
 	}
 

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -73,7 +73,7 @@ pub struct Datastore {
 	/// The maximum duration timeout for running multiple statements in a transaction.
 	transaction_timeout: Option<Duration>,
 	/// The security and feature capabilities for this datastore.
-	capabilities: Capabilities,
+	capabilities: Arc<Capabilities>,
 	// Whether this datastore enables live query notifications to subscribers.
 	notification_channel: Option<(Sender<Notification>, Receiver<Notification>)>,
 	// The index store cache
@@ -414,7 +414,7 @@ impl Datastore {
 				query_timeout: None,
 				transaction_timeout: None,
 				notification_channel: None,
-				capabilities: Capabilities::default(),
+				capabilities: Arc::new(Capabilities::default()),
 				index_stores: IndexStores::default(),
 				#[cfg(not(target_family = "wasm"))]
 				index_builder: IndexBuilder::new(tf),
@@ -489,7 +489,7 @@ impl Datastore {
 
 	/// Set specific capabilities for this Datastore
 	pub fn with_capabilities(mut self, caps: Capabilities) -> Self {
-		self.capabilities = caps;
+		self.capabilities = Arc::new(caps);
 		self
 	}
 

--- a/crates/sdk/src/api/opt/capabilities.rs
+++ b/crates/sdk/src/api/opt/capabilities.rs
@@ -1,10 +1,10 @@
 //! The capabilities that can be enabled for a database instance
 
-use std::collections::HashSet;
+use std::{collections::HashSet, mem};
 
 use surrealdb_core::dbs::capabilities::{
-	Capabilities as CoreCapabilities, FuncTarget, NetTarget, ParseFuncTargetError,
-	ParseNetTargetError, Targets,
+	Capabilities as CoreCapabilities, FuncTarget, ParseFuncTargetError, ParseNetTargetError,
+	Targets,
 };
 
 /// Capabilities are used to limit what users are allowed to do using queries.
@@ -91,10 +91,6 @@ use surrealdb_core::dbs::capabilities::{
 #[derive(Debug, Clone)]
 pub struct Capabilities {
 	cap: CoreCapabilities,
-	allow_funcs: Targets<FuncTarget>,
-	deny_funcs: Targets<FuncTarget>,
-	allow_net: Targets<NetTarget>,
-	deny_net: Targets<NetTarget>,
 }
 
 impl Default for Capabilities {
@@ -109,33 +105,33 @@ impl Capabilities {
 	/// Default capabilities enables live query notifications and all (non-scripting) functions.
 	pub fn new() -> Self {
 		Capabilities {
-			cap: CoreCapabilities::default(),
-			allow_funcs: Targets::All,
-			deny_funcs: Targets::None,
-			allow_net: Targets::None,
-			deny_net: Targets::None,
+			cap: CoreCapabilities::default()
+				.with_functions(Targets::All)
+				.without_functions(Targets::None)
+				.with_network_targets(Targets::None)
+				.without_network_targets(Targets::None),
 		}
 	}
 
 	/// Create a builder with all capabilities enabled.
 	pub fn all() -> Self {
 		Capabilities {
-			cap: CoreCapabilities::all(),
-			allow_funcs: Targets::All,
-			deny_funcs: Targets::None,
-			allow_net: Targets::All,
-			deny_net: Targets::None,
+			cap: CoreCapabilities::all()
+				.with_functions(Targets::All)
+				.without_functions(Targets::None)
+				.with_network_targets(Targets::All)
+				.without_network_targets(Targets::None),
 		}
 	}
 
 	/// Create a builder with all capabilities disabled.
 	pub fn none() -> Self {
 		Capabilities {
-			cap: CoreCapabilities::none(),
-			allow_funcs: Targets::None,
-			deny_funcs: Targets::None,
-			allow_net: Targets::None,
-			deny_net: Targets::None,
+			cap: CoreCapabilities::none()
+				.with_functions(Targets::None)
+				.without_functions(Targets::None)
+				.with_network_targets(Targets::None)
+				.without_network_targets(Targets::None),
 		}
 	}
 
@@ -143,7 +139,6 @@ impl Capabilities {
 	pub fn with_scripting(self, enabled: bool) -> Self {
 		Self {
 			cap: self.cap.with_scripting(enabled),
-			..self
 		}
 	}
 
@@ -152,7 +147,6 @@ impl Capabilities {
 	pub fn with_guest_access(self, enabled: bool) -> Self {
 		Self {
 			cap: self.cap.with_guest_access(enabled),
-			..self
 		}
 	}
 
@@ -160,13 +154,12 @@ impl Capabilities {
 	pub fn with_live_query_notifications(self, enabled: bool) -> Self {
 		Self {
 			cap: self.cap.with_live_query_notifications(enabled),
-			..self
 		}
 	}
 
 	/// Set the allow list to allow all functions
 	pub fn allow_all_functions(&mut self) -> &mut Self {
-		self.allow_funcs = Targets::All;
+		*self.cap.allowed_functions_mut() = Targets::All;
 		self
 	}
 
@@ -178,7 +171,7 @@ impl Capabilities {
 
 	/// Set the deny list to deny all functions
 	pub fn deny_all_functions(&mut self) -> &mut Self {
-		self.deny_funcs = Targets::All;
+		*self.cap.denied_functions_mut() = Targets::All;
 		self
 	}
 
@@ -190,7 +183,7 @@ impl Capabilities {
 
 	/// Set the allow list to allow no function
 	pub fn allow_none_functions(&mut self) -> &mut Self {
-		self.allow_funcs = Targets::None;
+		*self.cap.allowed_functions_mut() = Targets::None;
 		self
 	}
 
@@ -202,7 +195,7 @@ impl Capabilities {
 
 	/// Set the deny list to deny no function
 	pub fn deny_none_functions(&mut self) -> &mut Self {
-		self.deny_funcs = Targets::None;
+		*self.cap.denied_functions_mut() = Targets::None;
 		self
 	}
 
@@ -237,11 +230,11 @@ impl Capabilities {
 
 	fn allow_function_str(&mut self, s: &str) -> Result<&mut Self, ParseFuncTargetError> {
 		let target: FuncTarget = s.parse()?;
-		match self.allow_funcs {
+		match self.cap.allowed_functions_mut() {
 			Targets::None | Targets::All => {
 				let mut set = HashSet::new();
 				set.insert(target);
-				self.allow_funcs = Targets::Some(set);
+				self.cap = mem::take(&mut self.cap).with_functions(Targets::Some(set));
 			}
 			Targets::Some(ref mut x) => {
 				x.insert(target);
@@ -276,11 +269,11 @@ impl Capabilities {
 
 	fn deny_function_str(&mut self, s: &str) -> Result<&mut Self, ParseFuncTargetError> {
 		let target: FuncTarget = s.parse()?;
-		match self.deny_funcs {
+		match self.cap.denied_functions_mut() {
 			Targets::None | Targets::All => {
 				let mut set = HashSet::new();
 				set.insert(target);
-				self.deny_funcs = Targets::Some(set);
+				*self.cap.denied_functions_mut() = Targets::Some(set);
 			}
 			Targets::Some(ref mut x) => {
 				x.insert(target);
@@ -292,7 +285,7 @@ impl Capabilities {
 
 	/// Set the allow list to allow all net targets
 	pub fn allow_all_net_targets(&mut self) -> &mut Self {
-		self.allow_net = Targets::All;
+		*self.cap.allowed_network_targets_mut() = Targets::All;
 		self
 	}
 
@@ -304,7 +297,7 @@ impl Capabilities {
 
 	/// Set the deny list to deny all net targets
 	pub fn deny_all_net_targets(&mut self) -> &mut Self {
-		self.deny_net = Targets::All;
+		*self.cap.denied_network_targets_mut() = Targets::All;
 		self
 	}
 
@@ -316,7 +309,7 @@ impl Capabilities {
 
 	/// Set the allow list to allow no net targets
 	pub fn allow_none_net_targets(&mut self) -> &mut Self {
-		self.allow_net = Targets::None;
+		*self.cap.allowed_network_targets_mut() = Targets::None;
 		self
 	}
 
@@ -328,7 +321,7 @@ impl Capabilities {
 
 	/// Set the deny list to deny no net targets
 	pub fn deny_none_net_targets(&mut self) -> &mut Self {
-		self.deny_net = Targets::None;
+		*self.cap.denied_network_targets_mut() = Targets::None;
 		self
 	}
 
@@ -363,11 +356,11 @@ impl Capabilities {
 
 	fn allow_net_target_str(&mut self, s: &str) -> Result<&mut Self, ParseNetTargetError> {
 		let target = s.parse()?;
-		match self.allow_net {
+		match self.cap.allowed_network_targets_mut() {
 			Targets::None | Targets::All => {
 				let mut set = HashSet::new();
 				set.insert(target);
-				self.allow_net = Targets::Some(set);
+				*self.cap.allowed_network_targets_mut() = Targets::Some(set);
 			}
 			Targets::Some(ref mut x) => {
 				x.insert(target);
@@ -402,11 +395,11 @@ impl Capabilities {
 
 	fn deny_net_target_str(&mut self, s: &str) -> Result<&mut Self, ParseNetTargetError> {
 		let target = s.parse()?;
-		match self.deny_net {
+		match self.cap.denied_network_targets_mut() {
 			Targets::None | Targets::All => {
 				let mut set = HashSet::new();
 				set.insert(target);
-				self.deny_net = Targets::Some(set);
+				*self.cap.denied_network_targets_mut() = Targets::Some(set);
 			}
 			Targets::Some(ref mut x) => {
 				x.insert(target);
@@ -416,11 +409,7 @@ impl Capabilities {
 		Ok(self)
 	}
 
-	pub(crate) fn build(self) -> CoreCapabilities {
+	pub(crate) fn into_inner(self) -> CoreCapabilities {
 		self.cap
-			.with_functions(self.allow_funcs)
-			.without_functions(self.deny_funcs)
-			.with_network_targets(self.allow_net)
-			.without_network_targets(self.deny_net)
 	}
 }

--- a/crates/sdk/src/api/opt/config.rs
+++ b/crates/sdk/src/api/opt/config.rs
@@ -101,7 +101,7 @@ impl Config {
 
 	/// Set the capabilities for the database
 	pub fn capabilities(mut self, capabilities: Capabilities) -> Self {
-		self.capabilities = capabilities.build();
+		self.capabilities = capabilities.into_inner();
 		self
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Almost every field of the `Capabilities` struct is currently behind an `Arc`. This adds unnecessary overhead when constructing this type, especially considering that this struct has several fields and those will only grow over time as we add more capabilities.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It removes all `Arc`s from the struct's fields and refactors the Rust SDK type to remove unnecessary fields.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
