### PR TITLE
implement TryFrom<RecordIdKey> for basic types

### DIFF
--- a/crates/sdk/src/api/value/mod.rs
+++ b/crates/sdk/src/api/value/mod.rs
@@ -186,7 +186,7 @@ impl TryFrom<RecordIdKey> for Uuid {
 		} else {
 			Err(Self::Error::FromValue {
 				value: value.into(),
-				error: String::from("inner value is not an Uuid"),
+				error: String::from("inner value is not a UUID"),
 			})
 		}
 	}

--- a/crates/sdk/src/api/value/mod.rs
+++ b/crates/sdk/src/api/value/mod.rs
@@ -102,9 +102,39 @@ impl From<Object> for RecordIdKey {
 	}
 }
 
+impl TryFrom<RecordIdKey> for Object {
+	type Error = crate::error::Api;
+
+	fn try_from(value: RecordIdKey) -> Result<Self, Self::Error> {
+		if let CoreId::Object(x) = value.0 {
+			Ok(Object::from_inner(x))
+		} else {
+			Err(Self::Error::FromValue {
+				value: value.into(),
+				error: String::from("inner value is not an object"),
+			})
+		}
+	}
+}
+
 impl From<String> for RecordIdKey {
 	fn from(value: String) -> Self {
 		Self(CoreId::String(value))
+	}
+}
+
+impl TryFrom<RecordIdKey> for String {
+	type Error = crate::error::Api;
+
+	fn try_from(value: RecordIdKey) -> Result<Self, Self::Error> {
+		if let CoreId::String(x) = value.0 {
+			Ok(x)
+		} else {
+			Err(Self::Error::FromValue {
+				value: value.into(),
+				error: String::from("inner value is not a string"),
+			})
+		}
 	}
 }
 
@@ -126,9 +156,39 @@ impl From<i64> for RecordIdKey {
 	}
 }
 
+impl TryFrom<RecordIdKey> for i64 {
+	type Error = crate::error::Api;
+
+	fn try_from(value: RecordIdKey) -> Result<Self, Self::Error> {
+		if let CoreId::Number(x) = value.0 {
+			Ok(x)
+		} else {
+			Err(Self::Error::FromValue {
+				value: value.into(),
+				error: String::from("inner value is not a number"),
+			})
+		}
+	}
+}
+
 impl From<Uuid> for RecordIdKey {
 	fn from(value: Uuid) -> Self {
 		Self(CoreId::Uuid(value.into()))
+	}
+}
+
+impl TryFrom<RecordIdKey> for Uuid {
+	type Error = crate::error::Api;
+
+	fn try_from(value: RecordIdKey) -> Result<Self, Self::Error> {
+		if let CoreId::Uuid(x) = value.0 {
+			Ok(*x)
+		} else {
+			Err(Self::Error::FromValue {
+				value: value.into(),
+				error: String::from("inner value is not an Uuid"),
+			})
+		}
 	}
 }
 


### PR DESCRIPTION

## What is the motivation?
RecordIdKey allows multiple different types to be used as identifiers for records in the table. It would be nice to be able to get those identifiers back from a recordIdKey

## What does this change do?
It adds a few implementation of `TryFrom<RecordIdKey>` for some basic id types, more might be added if required.

## What is your testing strategy?
No tests added.

## Is this related to any issues?
Not that I am aware of
## Does this change need documentation?
I am not seeing any documentation for the `From<T> for RecordIdKey` implementations (forward conversions), so I guess automatic generated documentation is fine here too.

## Have you read the Contributing Guidelines?

- [X ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
