### PR TITLE
`DEFINE API` fixes

### DIFF
--- a/crates/core/src/api/method.rs
+++ b/crates/core/src/api/method.rs
@@ -42,12 +42,12 @@ impl TryFrom<&Value> for Method {
 impl Display for Method {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
-			Self::Delete => write!(f, "DELETE"),
-			Self::Get => write!(f, "GET"),
-			Self::Patch => write!(f, "PATCH"),
-			Self::Post => write!(f, "POST"),
-			Self::Put => write!(f, "PUT"),
-			Self::Trace => write!(f, "TRACE"),
+			Self::Delete => write!(f, "delete"),
+			Self::Get => write!(f, "get"),
+			Self::Patch => write!(f, "patch"),
+			Self::Post => write!(f, "post"),
+			Self::Put => write!(f, "put"),
+			Self::Trace => write!(f, "trace"),
 		}
 	}
 }

--- a/crates/core/src/api/path.rs
+++ b/crates/core/src/api/path.rs
@@ -43,10 +43,6 @@ impl<'a> Path {
 		}
 	}
 
-	pub fn to_url(&'a self) -> String {
-		format!("/{}", self)
-	}
-
 	pub fn specifity(&self) -> u8 {
 		self.iter().map(|s| s.specificity()).sum()
 	}

--- a/crates/core/src/sql/statements/define/api.rs
+++ b/crates/core/src/sql/statements/define/api.rs
@@ -104,7 +104,7 @@ impl Display for DefineApiStatement {
 impl InfoStructure for DefineApiStatement {
 	fn structure(self) -> Value {
 		Value::from(map! {
-			"path".to_string() => Value::from(self.path.to_string()),
+			"path".to_string() => self.path,
 			"config".to_string(), if let Some(config) = self.config => config.structure(),
 			"fallback".to_string(), if let Some(fallback) = self.fallback => fallback.structure(),
 			"actions".to_string() => Value::from(self.actions.into_iter().map(InfoStructure::structure).collect::<Vec<Value>>()),

--- a/crates/core/src/sql/statements/define/api.rs
+++ b/crates/core/src/sql/statements/define/api.rs
@@ -84,12 +84,20 @@ impl Display for DefineApiStatement {
 		}
 		write!(f, " {}", self.path)?;
 		let indent = pretty_indent();
-		if let Some(config) = &self.config {
-			write!(f, "{}", config)?;
-		}
 
-		if let Some(fallback) = &self.fallback {
-			write!(f, "FOR any {}", fallback)?;
+		if self.config.is_some() || self.fallback.is_some() {
+			write!(f, "FOR any")?;
+			let indent = pretty_indent();
+
+			if let Some(config) = &self.config {
+				write!(f, "{}", config)?;
+			}
+
+			if let Some(fallback) = &self.fallback {
+				write!(f, "THEN {}", fallback)?;
+			}
+
+			drop(indent);
 		}
 
 		for action in &self.actions {

--- a/crates/core/src/sql/statements/info.rs
+++ b/crates/core/src/sql/statements/info.rs
@@ -172,7 +172,7 @@ impl InfoStatement {
 						"apis".to_string() => {
 							let mut out = Object::default();
 							for v in txn.all_db_apis(ns, db).await?.iter() {
-								out.insert(v.path.to_url(), v.to_string().into());
+								out.insert(v.path.to_string(), v.to_string().into());
 							}
 							out.into()
 						},


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

A few small `DEFINE API` fixes

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

- Fixes the `INFO FOR DB` listings for `DEFINE API` statements
- Makes the `FOR any` (fallback) method consistent with the others
  - The config for the entire `DEFINE API` statement is now placed under `FOR any`. Middleware for `FOR any` apply before the more specific `FOR get, post, etc` middlewares.
  - The body for `FOR any` now also needs to be prefixed by the `THEN` keyword, like the other methods

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI. Tests TBA in a future PR

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] Syntax fixes for `FOR any` to be considered

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
