### PR TITLE
Fix `DEFINE API` stored key

### DIFF
--- a/crates/core/src/sql/statements/define/api.rs
+++ b/crates/core/src/sql/statements/define/api.rs
@@ -51,9 +51,9 @@ impl DefineApiStatement {
 			}
 		}
 		// Process the statement
-		let name = self.path.to_string();
 		let path: Path =
 			self.path.compute(stk, ctx, opt, doc).await?.coerce_to_string()?.parse()?;
+		let name = path.to_string();
 		let key = crate::key::database::ap::new(ns, db, &name);
 		txn.get_or_add_ns(ns, opt.strict).await?;
 		txn.get_or_add_db(ns, db, opt.strict).await?;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The name used in the key was created before the path was actually computed and parsed.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Fixes the key by which an API endpoint it stored.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
