### PR TITLE
Fix `array::fill` sometimes being far slower then it should

### DIFF
--- a/crates/core/src/fnc/array.rs
+++ b/crates/core/src/fnc/array.rs
@@ -198,38 +198,23 @@ pub fn distinct((array,): (Array,)) -> Result<Value, Error> {
 pub fn fill(
 	(mut array, value, start, end): (Array, Value, Option<isize>, Option<isize>),
 ) -> Result<Value, Error> {
-	let min = 0;
-	let max = array.len();
-	let negative_max = -(max as isize);
+	let len = array.len();
 
-	let start = match start {
-		Some(start) if negative_max <= start && start < 0 => (start + max as isize) as usize,
-		Some(start) if start < negative_max => 0,
-		Some(start) => start as usize,
-		None => min,
-	};
-	let end = match end {
-		Some(end) if negative_max <= end && end < 0 => (end + max as isize) as usize,
-		Some(end) if end < negative_max => 0,
-		Some(end) => end as usize,
-		None => max,
+	let start = start.unwrap_or(0);
+	let start = if start < 0 {
+		len.saturating_sub((-start) as usize)
+	} else {
+		(start as usize).min(len)
 	};
 
-	if start == min && end >= max {
-		array.fill(value);
-	} else if end > start {
-		let end_minus_one = end - 1;
+	let end = end.unwrap_or(len as isize);
+	let end = if end < 0 {
+		len.saturating_sub((-end) as usize)
+	} else {
+		(end as usize).min(len)
+	};
 
-		for i in start..end_minus_one {
-			if let Some(elem) = array.get_mut(i) {
-				*elem = value.clone();
-			}
-		}
-
-		if let Some(last_elem) = array.get_mut(end_minus_one) {
-			*last_elem = value;
-		}
-	}
+	array[start..end].fill(value);
 
 	Ok(array.into())
 }

--- a/crates/language-tests/tests/language/functions/array/fill_large_index_fast.surql
+++ b/crates/language-tests/tests/language/functions/array/fill_large_index_fast.surql
@@ -1,0 +1,9 @@
+/**
+[test]
+timeout = 10
+reason = """
+The below function operated in O(n) where N was the last index of the insert, eventhough the actual array was very small.
+If the array is tiny this function should not take more time then it needs to set all the required values to the given value.
+"""
+*/
+array::fill([1,2,3,4,5], 10, 2, 9_223_372_036_854_775_807);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Backports #5546.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
