### PR TITLE
Fix arithmatic wrap panic in duration functions

### DIFF
--- a/crates/core/src/fnc/duration.rs
+++ b/crates/core/src/fnc/duration.rs
@@ -45,11 +45,15 @@ pub mod from {
 	use crate::sql::value::Value;
 
 	pub fn days((val,): (u64,)) -> Result<Value, Error> {
-		Ok(Duration::from_days(val).into())
+		Duration::from_days(val)
+			.map(|x| x.into())
+			.ok_or_else(|| Error::ArithmeticOverflow(format!("duration::from::days({val})")))
 	}
 
 	pub fn hours((val,): (u64,)) -> Result<Value, Error> {
-		Ok(Duration::from_hours(val).into())
+		Duration::from_hours(val)
+			.map(|x| x.into())
+			.ok_or_else(|| Error::ArithmeticOverflow(format!("duration::from::hours({val})")))
 	}
 
 	pub fn micros((val,): (u64,)) -> Result<Value, Error> {
@@ -61,7 +65,9 @@ pub mod from {
 	}
 
 	pub fn mins((val,): (u64,)) -> Result<Value, Error> {
-		Ok(Duration::from_mins(val).into())
+		Duration::from_mins(val)
+			.map(|x| x.into())
+			.ok_or_else(|| Error::ArithmeticOverflow(format!("duration::from::mins({val})")))
 	}
 
 	pub fn nanos((val,): (u64,)) -> Result<Value, Error> {
@@ -73,6 +79,8 @@ pub mod from {
 	}
 
 	pub fn weeks((val,): (u64,)) -> Result<Value, Error> {
-		Ok(Duration::from_weeks(val).into())
+		Duration::from_weeks(val)
+			.map(|x| x.into())
+			.ok_or_else(|| Error::ArithmeticOverflow(format!("duration::from::weeks({val})")))
 	}
 }

--- a/crates/core/src/sql/access.rs
+++ b/crates/core/src/sql/access.rs
@@ -27,9 +27,9 @@ impl Default for AccessDuration {
 	fn default() -> Self {
 		Self {
 			// By default, access grants expire in 30 days.
-			grant: Some(Duration::from_days(30)),
+			grant: Some(Duration::from_days(30).expect("30 days should fit in a duration")),
 			// By default, tokens expire after one hour
-			token: Some(Duration::from_hours(1)),
+			token: Some(Duration::from_hours(1).expect("1 hour should fit in a duration")),
 			// By default, sessions do not expire
 			session: None,
 		}

--- a/crates/core/src/sql/duration.rs
+++ b/crates/core/src/sql/duration.rs
@@ -151,20 +151,20 @@ impl Duration {
 		time::Duration::from_secs(secs).into()
 	}
 	/// Create a duration from minutes
-	pub fn from_mins(mins: u64) -> Duration {
-		time::Duration::from_secs(mins * SECONDS_PER_MINUTE).into()
+	pub fn from_mins(mins: u64) -> Option<Duration> {
+		mins.checked_mul(SECONDS_PER_MINUTE).map(time::Duration::from_secs).map(|x| x.into())
 	}
 	/// Create a duration from hours
-	pub fn from_hours(hours: u64) -> Duration {
-		time::Duration::from_secs(hours * SECONDS_PER_HOUR).into()
+	pub fn from_hours(hours: u64) -> Option<Duration> {
+		hours.checked_mul(SECONDS_PER_HOUR).map(time::Duration::from_secs).map(|x| x.into())
 	}
 	/// Create a duration from days
-	pub fn from_days(days: u64) -> Duration {
-		time::Duration::from_secs(days * SECONDS_PER_DAY).into()
+	pub fn from_days(days: u64) -> Option<Duration> {
+		days.checked_mul(SECONDS_PER_DAY).map(time::Duration::from_secs).map(|x| x.into())
 	}
 	/// Create a duration from weeks
-	pub fn from_weeks(days: u64) -> Duration {
-		time::Duration::from_secs(days * SECONDS_PER_WEEK).into()
+	pub fn from_weeks(weeks: u64) -> Option<Duration> {
+		weeks.checked_mul(SECONDS_PER_WEEK).map(time::Duration::from_secs).map(|x| x.into())
 	}
 }
 

--- a/crates/core/src/sql/user.rs
+++ b/crates/core/src/sql/user.rs
@@ -19,7 +19,7 @@ impl Default for UserDuration {
 	fn default() -> Self {
 		Self {
 			// By default, tokens expire after one hour
-			token: Some(Duration::from_hours(1)),
+			token: Some(Duration::from_hours(1).expect("1 hour should fit in a duration")),
 			// By default, sessions do not expire
 			session: None,
 		}

--- a/crates/core/src/syn/parser/test/stmt.rs
+++ b/crates/core/src/syn/parser/test/stmt.rs
@@ -249,7 +249,7 @@ fn parse_define_user() {
 		assert_eq!(
 			stmt.duration,
 			UserDuration {
-				token: Some(Duration::from_hours(1)),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			}
 		);
@@ -274,7 +274,7 @@ fn parse_define_user() {
 		assert_eq!(
 			stmt.duration,
 			UserDuration {
-				token: Some(Duration::from_hours(1)),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			}
 		);
@@ -298,7 +298,7 @@ fn parse_define_user() {
 		assert_eq!(
 			stmt.duration,
 			UserDuration {
-				token: Some(Duration::from_hours(1)),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			}
 		);
@@ -322,8 +322,8 @@ fn parse_define_user() {
 		assert_eq!(
 			stmt.duration,
 			UserDuration {
-				token: Some(Duration::from_hours(1)),
-				session: Some(Duration::from_hours(6)),
+				token: Some(Duration::from_hours(1).unwrap()),
+				session: Some(Duration::from_hours(6).unwrap()),
 			}
 		);
 	}
@@ -346,8 +346,8 @@ fn parse_define_user() {
 		assert_eq!(
 			stmt.duration,
 			UserDuration {
-				token: Some(Duration::from_mins(15)),
-				session: Some(Duration::from_hours(6)),
+				token: Some(Duration::from_mins(15).unwrap()),
+				session: Some(Duration::from_hours(6).unwrap()),
 			}
 		);
 	}
@@ -412,8 +412,8 @@ fn parse_define_token() {
 			authenticate: None,
 			// Default durations.
 			duration: AccessDuration {
-				grant: Some(Duration::from_days(30)),
-				token: Some(Duration::from_hours(1)),
+				grant: Some(Duration::from_days(30).unwrap()),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			},
 			comment: Some(Strand("bar".to_string())),
@@ -444,8 +444,8 @@ fn parse_define_token_on_scope() {
 		stmt.duration,
 		// Default durations.
 		AccessDuration {
-			grant: Some(Duration::from_days(30)),
-			token: Some(Duration::from_hours(1)),
+			grant: Some(Duration::from_days(30).unwrap()),
+			token: Some(Duration::from_hours(1).unwrap()),
 			session: None,
 		}
 	);
@@ -489,8 +489,8 @@ fn parse_define_token_jwks() {
 			authenticate: None,
 			// Default durations.
 			duration: AccessDuration {
-				grant: Some(Duration::from_days(30)),
-				token: Some(Duration::from_hours(1)),
+				grant: Some(Duration::from_days(30).unwrap()),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			},
 			comment: Some(Strand("bar".to_string())),
@@ -521,8 +521,8 @@ fn parse_define_token_jwks_on_scope() {
 		stmt.duration,
 		// Default durations.
 		AccessDuration {
-			grant: Some(Duration::from_days(30)),
-			token: Some(Duration::from_hours(1)),
+			grant: Some(Duration::from_days(30).unwrap()),
+			token: Some(Duration::from_hours(1).unwrap()),
 			session: None,
 		}
 	);
@@ -565,8 +565,8 @@ fn parse_define_scope() {
 	assert_eq!(
 		stmt.duration,
 		AccessDuration {
-			grant: Some(Duration::from_days(30)),
-			token: Some(Duration::from_hours(1)),
+			grant: Some(Duration::from_days(30).unwrap()),
+			token: Some(Duration::from_hours(1).unwrap()),
 			session: Some(Duration::from_secs(1)),
 		}
 	);
@@ -616,8 +616,8 @@ fn parse_define_access_jwt_key() {
 				authenticate: None,
 				// Default durations.
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
-					token: Some(Duration::from_hours(1)),
+					grant: Some(Duration::from_days(30).unwrap()),
+					token: Some(Duration::from_hours(1).unwrap()),
 					session: None,
 				},
 				comment: Some(Strand("bar".to_string())),
@@ -651,8 +651,8 @@ fn parse_define_access_jwt_key() {
 				authenticate: None,
 				// Default durations.
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
-					token: Some(Duration::from_hours(1)),
+					grant: Some(Duration::from_days(30).unwrap()),
+					token: Some(Duration::from_hours(1).unwrap()),
 					session: None,
 				},
 				comment: None,
@@ -686,8 +686,8 @@ fn parse_define_access_jwt_key() {
 				authenticate: Some(Value::Bool(true)),
 				// Default durations.
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
-					token: Some(Duration::from_hours(1)),
+					grant: Some(Duration::from_days(30).unwrap()),
+					token: Some(Duration::from_hours(1).unwrap()),
 					session: None,
 				},
 				comment: None,
@@ -721,8 +721,8 @@ fn parse_define_access_jwt_key() {
 				authenticate: None,
 				// Default durations.
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
-					token: Some(Duration::from_hours(1)),
+					grant: Some(Duration::from_days(30).unwrap()),
+					token: Some(Duration::from_hours(1).unwrap()),
 					session: None,
 				},
 				comment: None,
@@ -755,7 +755,7 @@ fn parse_define_access_jwt_key() {
 				}),
 				authenticate: None,
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
+					grant: Some(Duration::from_days(30).unwrap()),
 					token: Some(Duration::from_secs(10)),
 					session: None,
 				},
@@ -790,8 +790,8 @@ fn parse_define_access_jwt_key() {
 				authenticate: None,
 				// Default durations.
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
-					token: Some(Duration::from_hours(1)),
+					grant: Some(Duration::from_days(30).unwrap()),
+					token: Some(Duration::from_hours(1).unwrap()),
 					session: None,
 				},
 				comment: None,
@@ -870,8 +870,8 @@ fn parse_define_access_jwt_key() {
 				authenticate: None,
 				// Default durations.
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
-					token: Some(Duration::from_hours(1)),
+					grant: Some(Duration::from_days(30).unwrap()),
+					token: Some(Duration::from_hours(1).unwrap()),
 					session: None,
 				},
 				comment: Some(Strand("bar".to_string())),
@@ -902,8 +902,8 @@ fn parse_define_access_jwt_key() {
 				authenticate: None,
 				// Default durations.
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
-					token: Some(Duration::from_hours(1)),
+					grant: Some(Duration::from_days(30).unwrap()),
+					token: Some(Duration::from_hours(1).unwrap()),
 					session: None,
 				},
 				comment: Some(Strand("bar".to_string())),
@@ -937,8 +937,8 @@ fn parse_define_access_jwt_jwks() {
 				authenticate: None,
 				// Default durations.
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
-					token: Some(Duration::from_hours(1)),
+					grant: Some(Duration::from_days(30).unwrap()),
+					token: Some(Duration::from_hours(1).unwrap()),
 					session: None,
 				},
 				comment: Some(Strand("bar".to_string())),
@@ -971,8 +971,8 @@ fn parse_define_access_jwt_jwks() {
 				authenticate: None,
 				// Default durations.
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
-					token: Some(Duration::from_hours(1)),
+					grant: Some(Duration::from_days(30).unwrap()),
+					token: Some(Duration::from_hours(1).unwrap()),
 					session: None,
 				},
 				comment: None,
@@ -1004,7 +1004,7 @@ fn parse_define_access_jwt_jwks() {
 				}),
 				authenticate: None,
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
+					grant: Some(Duration::from_days(30).unwrap()),
 					token: Some(Duration::from_secs(10)),
 					session: None,
 				},
@@ -1038,8 +1038,8 @@ fn parse_define_access_jwt_jwks() {
 				authenticate: None,
 				// Default durations.
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
-					token: Some(Duration::from_hours(1)),
+					grant: Some(Duration::from_days(30).unwrap()),
+					token: Some(Duration::from_hours(1).unwrap()),
 					session: None,
 				},
 				comment: None,
@@ -1071,9 +1071,9 @@ fn parse_define_access_jwt_jwks() {
 				}),
 				authenticate: None,
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
+					grant: Some(Duration::from_days(30).unwrap()),
 					token: Some(Duration::from_secs(10)),
-					session: Some(Duration::from_days(2)),
+					session: Some(Duration::from_days(2).unwrap()),
 				},
 				comment: None,
 				if_not_exists: false,
@@ -1103,8 +1103,8 @@ fn parse_define_access_record() {
 			stmt.duration,
 			// Default durations.
 			AccessDuration {
-				grant: Some(Duration::from_days(30)),
-				token: Some(Duration::from_hours(1)),
+				grant: Some(Duration::from_days(30).unwrap()),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			}
 		);
@@ -1155,8 +1155,8 @@ fn parse_define_access_record() {
 			stmt.duration,
 			// Default durations.
 			AccessDuration {
-				grant: Some(Duration::from_days(10)),
-				token: Some(Duration::from_hours(1)),
+				grant: Some(Duration::from_days(10).unwrap()),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			}
 		);
@@ -1225,9 +1225,9 @@ fn parse_define_access_record() {
 		assert_eq!(
 			stmt.duration,
 			AccessDuration {
-				grant: Some(Duration::from_days(30)),
-				token: Some(Duration::from_hours(1)),
-				session: Some(Duration::from_days(7)),
+				grant: Some(Duration::from_days(30).unwrap()),
+				token: Some(Duration::from_hours(1).unwrap()),
+				session: Some(Duration::from_days(7).unwrap()),
 			}
 		);
 		assert_eq!(stmt.comment, None);
@@ -1282,9 +1282,9 @@ fn parse_define_access_record() {
 				}),
 				authenticate: None,
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
+					grant: Some(Duration::from_days(30).unwrap()),
 					token: Some(Duration::from_secs(10)),
-					session: Some(Duration::from_mins(15)),
+					session: Some(Duration::from_mins(15).unwrap()),
 				},
 				comment: None,
 				if_not_exists: false,
@@ -1321,9 +1321,9 @@ fn parse_define_access_record() {
 				}),
 				authenticate: None,
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
+					grant: Some(Duration::from_days(30).unwrap()),
 					token: Some(Duration::from_secs(10)),
-					session: Some(Duration::from_mins(15)),
+					session: Some(Duration::from_mins(15).unwrap()),
 				},
 				comment: None,
 				if_not_exists: false,
@@ -1377,9 +1377,9 @@ fn parse_define_access_record() {
 				}),
 				authenticate: None,
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(10)),
+					grant: Some(Duration::from_days(10).unwrap()),
 					token: Some(Duration::from_secs(10)),
-					session: Some(Duration::from_mins(15)),
+					session: Some(Duration::from_mins(15).unwrap()),
 				},
 				comment: None,
 				if_not_exists: false,
@@ -1431,9 +1431,9 @@ fn parse_define_access_record() {
 				}),
 				authenticate: None,
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(10)),
+					grant: Some(Duration::from_days(10).unwrap()),
 					token: Some(Duration::from_secs(10)),
-					session: Some(Duration::from_mins(15)),
+					session: Some(Duration::from_mins(15).unwrap()),
 				},
 				comment: None,
 				if_not_exists: false,
@@ -1470,9 +1470,9 @@ fn parse_define_access_record() {
 				}),
 				authenticate: None,
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(30)),
+					grant: Some(Duration::from_days(30).unwrap()),
 					token: Some(Duration::from_secs(10)),
-					session: Some(Duration::from_mins(15)),
+					session: Some(Duration::from_mins(15).unwrap()),
 				},
 				comment: None,
 				if_not_exists: false,
@@ -1541,8 +1541,8 @@ fn parse_define_access_bearer() {
 			stmt.duration,
 			// Default durations.
 			AccessDuration {
-				grant: Some(Duration::from_days(30)),
-				token: Some(Duration::from_hours(1)),
+				grant: Some(Duration::from_days(30).unwrap()),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			}
 		);
@@ -1580,8 +1580,8 @@ fn parse_define_access_bearer() {
 			stmt.duration,
 			// Default durations.
 			AccessDuration {
-				grant: Some(Duration::from_days(30)),
-				token: Some(Duration::from_hours(1)),
+				grant: Some(Duration::from_days(30).unwrap()),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			}
 		);
@@ -1619,8 +1619,8 @@ fn parse_define_access_bearer() {
 			stmt.duration,
 			// Default durations.
 			AccessDuration {
-				grant: Some(Duration::from_days(30)),
-				token: Some(Duration::from_hours(1)),
+				grant: Some(Duration::from_days(30).unwrap()),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			}
 		);
@@ -1657,8 +1657,8 @@ fn parse_define_access_bearer() {
 			stmt.duration,
 			// Default durations.
 			AccessDuration {
-				grant: Some(Duration::from_days(30)),
-				token: Some(Duration::from_hours(1)),
+				grant: Some(Duration::from_days(30).unwrap()),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			}
 		);
@@ -1734,7 +1734,7 @@ fn parse_define_access_bearer() {
 				}),
 				authenticate: None,
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(90)),
+					grant: Some(Duration::from_days(90).unwrap()),
 					token: Some(Duration::from_secs(10)),
 					session: Some(Duration::from_secs(900)),
 				},
@@ -1775,7 +1775,7 @@ fn parse_define_access_bearer() {
 				}),
 				authenticate: None,
 				duration: AccessDuration {
-					grant: Some(Duration::from_days(90)),
+					grant: Some(Duration::from_days(90).unwrap()),
 					token: Some(Duration::from_secs(10)),
 					session: Some(Duration::from_secs(900)),
 				},
@@ -3211,7 +3211,7 @@ fn parse_access_purge() {
 				base: Some(Base::Db),
 				expired: true,
 				revoked: false,
-				grace: Duration::from_days(90),
+				grace: Duration::from_days(90).unwrap(),
 			}))
 		);
 	}
@@ -3233,7 +3233,7 @@ fn parse_access_purge() {
 				base: Some(Base::Db),
 				expired: false,
 				revoked: true,
-				grace: Duration::from_days(90),
+				grace: Duration::from_days(90).unwrap(),
 			}))
 		);
 	}
@@ -3255,7 +3255,7 @@ fn parse_access_purge() {
 				base: Some(Base::Db),
 				expired: true,
 				revoked: true,
-				grace: Duration::from_days(90),
+				grace: Duration::from_days(90).unwrap(),
 			}))
 		);
 	}

--- a/crates/core/src/syn/parser/test/streaming.rs
+++ b/crates/core/src/syn/parser/test/streaming.rs
@@ -232,8 +232,8 @@ fn statements() -> Vec<Statement> {
 			authenticate: None,
 			// Default durations.
 			duration: AccessDuration {
-				grant: Some(Duration::from_days(30)),
-				token: Some(Duration::from_hours(1)),
+				grant: Some(Duration::from_days(30).unwrap()),
+				token: Some(Duration::from_hours(1).unwrap()),
 				session: None,
 			},
 			comment: Some(Strand("bar".to_string())),

--- a/crates/language-tests/tests/language/functions/duration/from_days.surql
+++ b/crates/language-tests/tests/language/functions/duration/from_days.surql
@@ -1,0 +1,24 @@
+/**
+[test]
+
+[[test.results]]
+value = "3d"
+
+[[test.results]]
+value = "7w1d"
+
+[[test.results]]
+value = "7w1d"
+
+[[test.results]]
+error = 'Failed to compute: "duration::from::days(9223372036854775807)", as the operation results in an arithmetic overflow.'
+
+[[test.results]]
+error = 'Failed to compute: "duration::from::days(18446744073709551615)", as the operation results in an arithmetic overflow.'
+
+*/
+duration::from::days(3);
+duration::from::days(50);
+duration::from::days(50);
+duration::from::days(9_223_372_036_854_775_807);
+duration::from::days(-1);

--- a/crates/language-tests/tests/language/functions/duration/from_hours.surql
+++ b/crates/language-tests/tests/language/functions/duration/from_hours.surql
@@ -1,0 +1,24 @@
+/**
+[test]
+
+[[test.results]]
+value = "3h"
+
+[[test.results]]
+value = "2d2h"
+
+[[test.results]]
+value = "2d2h"
+
+[[test.results]]
+error = 'Failed to compute: "duration::from::hours(9223372036854775807)", as the operation results in an arithmetic overflow.'
+
+[[test.results]]
+error = 'Failed to compute: "duration::from::hours(18446744073709551615)", as the operation results in an arithmetic overflow.'
+
+*/
+duration::from::hours(3);
+duration::from::hours(50);
+duration::from::hours(50);
+duration::from::hours(9_223_372_036_854_775_807);
+duration::from::hours(-1);

--- a/crates/language-tests/tests/language/functions/duration/from_mins.surql
+++ b/crates/language-tests/tests/language/functions/duration/from_mins.surql
@@ -1,0 +1,20 @@
+/**
+[test]
+
+[[test.results]]
+value = "3m"
+
+[[test.results]]
+value = "1h40m"
+
+[[test.results]]
+error = 'Failed to compute: "duration::from::mins(9223372036854775807)", as the operation results in an arithmetic overflow.'
+
+[[test.results]]
+error = 'Failed to compute: "duration::from::mins(18446744073709551615)", as the operation results in an arithmetic overflow.'
+
+*/
+duration::from::mins(3);
+duration::from::mins(100);
+duration::from::mins(9_223_372_036_854_775_807);
+duration::from::mins(-1);

--- a/crates/language-tests/tests/language/functions/duration/from_weeks.surql
+++ b/crates/language-tests/tests/language/functions/duration/from_weeks.surql
@@ -1,0 +1,20 @@
+/**
+[test]
+
+[[test.results]]
+value = "3w"
+
+[[test.results]]
+value = "1y7w6d"
+
+[[test.results]]
+error = 'Failed to compute: "duration::from::weeks(9223372036854775807)", as the operation results in an arithmetic overflow.'
+
+[[test.results]]
+error = 'Failed to compute: "duration::from::weeks(18446744073709551615)", as the operation results in an arithmetic overflow.'
+
+*/
+RETURN duration::from::weeks(3);
+RETURN duration::from::weeks(60);
+RETURN duration::from::weeks(9_223_372_036_854_775_807);
+RETURN duration::from::weeks(-1);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Some of the `duration::from::*` functions can cause a panic when overflowing in debug mode. Will also cause bad results in release mode.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Returns an error on duration overflow.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added test to the testing suite for duration.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
