### PR TITLE
Fix overflow and panics in math functions

### DIFF
--- a/crates/core/src/fnc/math.rs
+++ b/crates/core/src/fnc/math.rs
@@ -16,7 +16,10 @@ use crate::sql::number::{Number, Sort};
 use crate::sql::value::{TryPow, Value};
 
 pub fn abs((arg,): (Number,)) -> Result<Value, Error> {
-	Ok(arg.abs().into())
+	let Some(x) = arg.checked_abs() else {
+		return Err(Error::ArithmeticOverflow(format!("math::abs({arg})")));
+	};
+	Ok(x.into())
 }
 
 pub fn acos((arg,): (Number,)) -> Result<Value, Error> {
@@ -51,6 +54,12 @@ pub fn ceil((arg,): (Number,)) -> Result<Value, Error> {
 }
 
 pub fn clamp((arg, min, max): (Number, Number, Number)) -> Result<Value, Error> {
+	if min > max {
+		return Err(Error::InvalidArguments {
+			name: "math::clamp".to_string(),
+			message: "Lowerbound for clamp must be smaller the the upperbound".to_string(),
+		});
+	}
 	Ok(arg.clamp(min, max).into())
 }
 

--- a/crates/core/src/sql/number.rs
+++ b/crates/core/src/sql/number.rs
@@ -389,6 +389,14 @@ impl Number {
 		}
 	}
 
+	pub fn checked_abs(self) -> Option<Self> {
+		match self {
+			Number::Int(v) => v.checked_abs().map(|x| x.into()),
+			Number::Float(v) => Some(v.abs().into()),
+			Number::Decimal(v) => Some(v.abs().into()),
+		}
+	}
+
 	pub fn acos(self) -> Self {
 		self.to_float().acos().into()
 	}

--- a/crates/language-tests/tests/language/functions/math/abs.surql
+++ b/crates/language-tests/tests/language/functions/math/abs.surql
@@ -1,0 +1,20 @@
+/**
+[test]
+
+[[test.results]]
+value = "0"
+
+[[test.results]]
+value = "100"
+
+[[test.results]]
+value = "100"
+
+[[test.results]]
+error = 'Failed to compute: "math::abs(-9223372036854775808)", as the operation results in an arithmetic overflow.'
+
+*/
+math::abs(0);
+math::abs(100);
+math::abs(-100);
+math::abs(-9_223_372_036_854_775_808);

--- a/crates/language-tests/tests/language/functions/math/clamp.surql
+++ b/crates/language-tests/tests/language/functions/math/clamp.surql
@@ -1,0 +1,28 @@
+/**
+[test]
+
+[[test.results]]
+value = "2"
+
+[[test.results]]
+value = "2f"
+
+[[test.results]]
+value = "4"
+
+[[test.results]]
+value = "4f"
+
+[[test.results]]
+value = "2f"
+
+[[test.results]]
+error = "Incorrect arguments for function math::clamp(). Lowerbound for clamp must be smaller the the upperbound"
+
+*/
+math::clamp(1, 2, 4);
+math::clamp(1f, 2, 4);
+math::clamp(5, 2, 4);
+math::clamp(5.0, 2, 4);
+math::clamp(1, 2f, 4);
+math::clamp(1, 5, 4);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

`math::clamp` can panic if the lowerbound is smaller then the upperbound.
`math::abs` can panic or overflow if called on `i64::MIN`.


## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Fixes these panics returning errors instead.

## What is your testing strategy?

Implemented tests for fixes in the language test suite.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
