### PR TITLE
Improve ALL/ANYINSIDE behaviour with strings and arrays of strings

### DIFF
--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -2793,11 +2793,24 @@ impl Value {
 	/// Check if all Values in an Array contain another Value
 	pub fn contains_all(&self, other: &Value) -> bool {
 		match other {
+			Value::Array(v) if v.iter().all(|v| v.is_strand()) && self.is_strand() => {
+				let Value::Strand(this) = self else { return false };
+				v.iter().all(|s| {
+					let Value::Strand(other_string) = s else {
+						return false
+					};
+					this.0.contains(&other_string.0)
+				})
+			},
 			Value::Array(v) => v.iter().all(|v| match self {
 				Value::Array(w) => w.iter().any(|w| v.equal(w)),
 				Value::Geometry(_) => self.contains(v),
 				_ => false,
 			}),
+			Value::Strand(other_strand) => match self {
+				Value::Strand(s) => s.0.contains(&other_strand.0),
+				_ => false
+			}
 			_ => false,
 		}
 	}

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -2794,14 +2794,17 @@ impl Value {
 	pub fn contains_all(&self, other: &Value) -> bool {
 		match other {
 			Value::Array(v) if v.iter().all(|v| v.is_strand()) && self.is_strand() => {
-				let Value::Strand(this) = self else { return false };
+				// confirmed as strand so all return false is unreachable
+				let Value::Strand(this) = self else {
+					return false;
+				};
 				v.iter().all(|s| {
 					let Value::Strand(other_string) = s else {
-						return false
+						return false;
 					};
 					this.0.contains(&other_string.0)
 				})
-			},
+			}
 			Value::Array(v) => v.iter().all(|v| match self {
 				Value::Array(w) => w.iter().any(|w| v.equal(w)),
 				Value::Geometry(_) => self.contains(v),
@@ -2809,8 +2812,8 @@ impl Value {
 			}),
 			Value::Strand(other_strand) => match self {
 				Value::Strand(s) => s.0.contains(&other_strand.0),
-				_ => false
-			}
+				_ => false,
+			},
 			_ => false,
 		}
 	}
@@ -2818,11 +2821,27 @@ impl Value {
 	/// Check if any Values in an Array contain another Value
 	pub fn contains_any(&self, other: &Value) -> bool {
 		match other {
+			Value::Array(v) if v.iter().all(|v| v.is_strand()) && self.is_strand() => {
+				// confirmed as strand so all return false is unreachable
+				let Value::Strand(this) = self else {
+					return false;
+				};
+				v.iter().any(|s| {
+					let Value::Strand(other_string) = s else {
+						return false;
+					};
+					this.0.contains(&other_string.0)
+				})
+			}
 			Value::Array(v) => v.iter().any(|v| match self {
 				Value::Array(w) => w.iter().any(|w| v.equal(w)),
 				Value::Geometry(_) => self.contains(v),
 				_ => false,
 			}),
+			Value::Strand(other_strand) => match self {
+				Value::Strand(s) => s.0.contains(&other_strand.0),
+				_ => false,
+			},
 			_ => false,
 		}
 	}

--- a/crates/language-tests/tests/language/expression/operators/in/all_any_inside.surql
+++ b/crates/language-tests/tests/language/expression/operators/in/all_any_inside.surql
@@ -1,0 +1,51 @@
+/**
+[test]
+
+[[test.results]]
+value = "true"
+
+[[test.results]]
+value = "false"
+
+[[test.results]]
+value = "true"
+
+[[test.results]]
+value = "false"
+
+[[test.results]]
+value = "true"
+
+[[test.results]]
+value = "false"
+
+[[test.results]]
+value = "true"
+
+[[test.results]]
+value = "true"
+
+[[test.results]]
+value = "true"
+
+[[test.results]]
+value = "false"
+
+[[test.results]]
+value = "true"
+
+[[test.results]]
+value = "true"
+*/
+[1,2] ALLINSIDE [1,2,3]; -- true
+[1,2,4] ALLINSIDE [1,2]; -- false
+"in" ALLINSIDE "inout"; -- true
+"inn" ALLINSIDE "inout"; -- false
+["in", "out"] ALLINSIDE "inout"; -- true
+["in", "outt"] ALLINSIDE "inout"; -- false
+[1,2] ANYINSIDE [1,2,3]; -- true
+[1,2,4] ANYINSIDE [1,2,3]; -- true
+"in" ANYINSIDE "inout"; -- true
+"inn" ANYINSIDE "inout"; -- false
+["in", "out"] ANYINSIDE "inout"; -- true
+["in", "outt"] ANYINSIDE "inout"; -- true


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Right now you can see if a value is in an array, and if a string is in a string, and if an array of values are inside an array of values,

```surql
1 IN [1,2];
"in" IN "inout";
[1,2] ALLINSIDE [1,2];
["in", "out"] ALLINSIDE ["in", "out"];
```

but you can't see if an array of strings is inside a string.

```surql
["in", "out"] ALLINSIDE "inout"; -- always returns false
```

The operator also returns false when you compare a string to a string.

```surql
"in" ALLINSIDE "inout" -- returns false
```

The same applies to the ANYINSIDE operator which always returns false.

Note: CONTAINSALL and CONTAINSANY are the same but used in reverse, so they are improved in the same way.

## What does this change do?

It returns true if a string is inside another string, or if each/any string in an array is inside another string.

## What is your testing strategy?

Added a few tests to the language tests module.

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

- [X] No documentation needed (probably expected behaviour)

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
