### PR TITLE
Do not over-fetch documents when LIMIT and START used together

### DIFF
--- a/crates/core/src/dbs/iterator.rs
+++ b/crates/core/src/dbs/iterator.rs
@@ -461,11 +461,7 @@ impl Iterator {
 	) {
 		if self.check_set_start_limit(ctx, stm) {
 			if let Some(l) = self.limit {
-				if let Some(s) = self.start {
-					self.cancel_on_limit = Some(l + s);
-				} else {
-					self.cancel_on_limit = Some(l);
-				}
+				self.cancel_on_limit = Some(l);
 			}
 			// Check if we can skip processing the document below "start".
 			if let Some(false) = is_specific_permission {

--- a/crates/sdk/tests/planner.rs
+++ b/crates/sdk/tests/planner.rs
@@ -3448,7 +3448,7 @@ async fn select_limit_start() -> Result<(), Error> {
 					},
 					{
 						detail: {
-							CancelOnLimit: 12,
+							CancelOnLimit: 10,
 							SkipStart: 2
 						},
 						operation: 'StartLimitStrategy'

--- a/crates/sdk/tests/range.rs
+++ b/crates/sdk/tests/range.rs
@@ -121,7 +121,7 @@ async fn select_start_limit_fetch() -> Result<(), Error> {
 				},
 				{
 					detail: {
-						CancelOnLimit: 2,
+						CancelOnLimit: 1,
 						SkipStart: 1
 					},
 					operation: 'StartLimitStrategy'


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When the `LIMIT` and `START` clauses used together in a query, e.g. `SELECT id FROM users LIMIT 10 START 50`, we skip the `START` number of documents, then fetch `LIMIT + SCAN` documents, only to truncate the results to `LIMIT`.

## What does this change do?

Instead of over-fetching `LIMIT + START` documents and then truncating the results to `LIMIT`, only fetch the `LIMIT` number of documents.

## What is your testing strategy?

CI.

## Is this related to any issues?

https://github.com/surrealdb/surrealdb/issues/5589

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)