### PR TITLE
Implement some bug fixes

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -5,6 +5,8 @@ BENCH_NUM_OPS = { value = "1000", condition = { env_not_set = ["BENCH_NUM_OPS"] 
 BENCH_DURATION = { value = "30", condition = { env_not_set = ["BENCH_DURATION"] } }
 BENCH_SAMPLE_SIZE = { value = "10", condition = { env_not_set = ["BENCH_SAMPLE_SIZE"] } }
 BENCH_FEATURES = { value = "protocol-ws,kv-mem,kv-rocksdb,kv-surrealkv", condition = { env_not_set = ["BENCH_FEATURES"] } }
+# Used to speed up the scripting timeout test, otherwise the test takes 5 seconds.
+SURREAL_SCRIPTING_MAX_TIME_LIMIT = { value = "500", condition = { env_not_set = ["SURREAL_SCRIPTING_MAX_TIME_LIMIT"] } }
 
 [tasks.ci-format]
 category = "CI - CHECK"

--- a/crates/core/src/api/path.rs
+++ b/crates/core/src/api/path.rs
@@ -243,10 +243,7 @@ impl Segment {
 					let val: Value = current.to_owned().into();
 					let val: Option<Value> = match k {
 						None => Some(val),
-						Some(k) => match val.convert_to(k) {
-							Ok(val) => Some(val),
-							_ => None,
-						},
+						Some(k) => val.convert_to(k).ok(),
 					};
 
 					val.map(|val| Some((x.to_owned(), val)))

--- a/crates/core/src/api/response.rs
+++ b/crates/core/src/api/response.rs
@@ -48,7 +48,7 @@ impl TryFrom<Value> for ApiResponse {
 
 			let body = opts.remove("body");
 
-			if opts.len() > 0 {
+			if !opts.is_empty() {
 				Err(ApiError::InvalidApiResponse("Contains invalid properties".into()).into())
 			} else {
 				Ok(Self {

--- a/crates/core/src/cnf/mod.rs
+++ b/crates/core/src/cnf/mod.rs
@@ -70,11 +70,8 @@ pub static SCRIPTING_MAX_MEMORY_LIMIT: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_SCRIPTING_MAX_MEMORY_LIMIT", usize, 2 << 20);
 
 /// Used to limit allocation for builtin functions
-pub static SCRIPTING_MAX_TIME_LIMIT: LazyLock<usize> = LazyLock::new(|| {
-	std::env::var("SURREAL_SCRIPTING_MAX_TIME_LMIT")
-		.map(|s| s.parse::<usize>().unwrap_or(1000 * 5))
-		.unwrap_or(1000 * 5)
-});
+pub static SCRIPTING_MAX_TIME_LIMIT: LazyLock<usize> =
+	lazy_env_parse!("SURREAL_SCRIPTING_MAX_TIME_LIMIT", usize, 1000 * 5);
 
 /// Forward all signup/signin/authenticate query errors to a client performing authentication. Do not use in production.
 pub static INSECURE_FORWARD_ACCESS_ERRORS: LazyLock<bool> =

--- a/crates/core/src/cnf/mod.rs
+++ b/crates/core/src/cnf/mod.rs
@@ -69,6 +69,13 @@ pub static SCRIPTING_MAX_STACK_SIZE: LazyLock<usize> =
 pub static SCRIPTING_MAX_MEMORY_LIMIT: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_SCRIPTING_MAX_MEMORY_LIMIT", usize, 2 << 20);
 
+/// Used to limit allocation for builtin functions
+pub static SCRIPTING_MAX_TIME_LIMIT: LazyLock<usize> = LazyLock::new(|| {
+	std::env::var("SURREAL_SCRIPTING_MAX_TIME_LMIT")
+		.map(|s| s.parse::<usize>().unwrap_or(1000 * 5))
+		.unwrap_or(1000 * 5)
+});
+
 /// Forward all signup/signin/authenticate query errors to a client performing authentication. Do not use in production.
 pub static INSECURE_FORWARD_ACCESS_ERRORS: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_INSECURE_FORWARD_ACCESS_ERRORS", bool, false);
@@ -85,6 +92,9 @@ pub static GENERATION_ALLOCATION_LIMIT: LazyLock<usize> = LazyLock::new(|| {
 		.unwrap_or(20);
 	2usize.pow(n)
 });
+
+pub static MAX_HTTP_REDIRECTS: LazyLock<usize> =
+	lazy_env_parse!("SURREAL_MAX_HTTP_REDIRECTS", usize, 10);
 
 /// Used to limit allocation for builtin functions
 pub static IDIOM_RECURSION_LIMIT: LazyLock<usize> = LazyLock::new(|| {

--- a/crates/core/src/fnc/script/fetch/func.rs
+++ b/crates/core/src/fnc/script/fetch/func.rs
@@ -31,15 +31,16 @@ pub async fn fetch<'js>(
 	let url = js_req.url;
 
 	// Check if the url is allowed to be fetched.
-	if let Some(query_ctx) = ctx.userdata::<QueryContext<'js>>() {
-		query_ctx
-			.context
-			.check_allowed_net(&url)
-			.map_err(|e| Exception::throw_message(&ctx, &e.to_string()))?;
+	let query_ctx = if let Some(query_ctx) = ctx.userdata::<QueryContext<'js>>() {
+		query_ctx.context.clone()
 	} else {
 		#[cfg(debug_assertions)]
 		panic!("Trying to fetch a URL but no QueryContext is present. QueryContext is required for checking if the URL is allowed to be fetched.")
-	}
+	};
+
+	query_ctx
+		.check_allowed_net(&url)
+		.map_err(|e| Exception::throw_message(&ctx, &e.to_string()))?;
 
 	let req = reqwest::Request::new(js_req.init.method, url.clone());
 
@@ -50,13 +51,17 @@ pub async fn fetch<'js>(
 	let mut headers = headers.inner.clone();
 
 	let redirect = js_req.init.request_redirect;
+	let redirect_limit = *crate::cnf::MAX_HTTP_REDIRECTS;
 
 	// set the policy for redirecting requests.
 	let policy = redirect::Policy::custom(move |attempt| {
+		if let Err(e) = query_ctx.check_allowed_net(attempt.url()) {
+			return attempt.error(e.to_string());
+		}
 		match redirect {
 			classes::RequestRedirect::Follow => {
-				// Fetch spec limits redirect to a max of 20
-				if attempt.previous().len() > 20 {
+				// Fetch spec limits redirect to a max of 20 but we follow the configuration.
+				if attempt.previous().len() >= redirect_limit {
 					attempt.error("too many redirects")
 				} else {
 					attempt.follow()

--- a/crates/core/src/fnc/script/fetch/func.rs
+++ b/crates/core/src/fnc/script/fetch/func.rs
@@ -34,7 +34,6 @@ pub async fn fetch<'js>(
 	let query_ctx = if let Some(query_ctx) = ctx.userdata::<QueryContext<'js>>() {
 		query_ctx.context.clone()
 	} else {
-		#[cfg(debug_assertions)]
 		panic!("Trying to fetch a URL but no QueryContext is present. QueryContext is required for checking if the URL is allowed to be fetched.")
 	};
 

--- a/crates/core/src/fnc/util/http/mod.rs
+++ b/crates/core/src/fnc/util/http/mod.rs
@@ -4,7 +4,8 @@ use crate::sql::{Bytes, Object, Strand, Value};
 use crate::syn;
 
 use reqwest::header::CONTENT_TYPE;
-use reqwest::{Client, RequestBuilder, Response};
+use reqwest::redirect::Policy;
+use reqwest::{Client, Method, RequestBuilder, Response};
 use url::Url;
 
 pub(crate) fn uri_is_valid(uri: &str) -> bool {
@@ -53,14 +54,33 @@ async fn decode_response(res: Response) -> Result<Value, Error> {
 	}
 }
 
-pub async fn head(ctx: &Context, uri: Strand, opts: impl Into<Object>) -> Result<Value, Error> {
+async fn request(
+	ctx: &Context,
+	method: Method,
+	uri: Strand,
+	body: Option<Value>,
+	opts: impl Into<Object>,
+) -> Result<Value, Error> {
 	// Check if the URI is valid and allowed
 	let url = Url::parse(&uri).map_err(|_| Error::InvalidUrl(uri.to_string()))?;
 	ctx.check_allowed_net(&url)?;
 	// Set a default client with no timeout
-	let cli = Client::builder().build()?;
+	let count = *crate::cnf::MAX_HTTP_REDIRECTS;
+	let ctx_clone = ctx.clone();
+	let cli = Client::builder()
+		.redirect(Policy::custom(move |attempt| {
+			if let Err(e) = ctx_clone.check_allowed_net(attempt.url()) {
+				return attempt.error(e);
+			}
+			if attempt.previous().len() >= count {
+				return attempt.stop();
+			}
+			return attempt.follow();
+		}))
+		.build()?;
+	let is_head = matches!(method, Method::HEAD);
 	// Start a new HEAD request
-	let mut req = cli.head(url);
+	let mut req = cli.request(method.clone(), url);
 	// Add the User-Agent header
 	if cfg!(not(target_family = "wasm")) {
 		req = req.header("User-Agent", "SurrealDB");
@@ -69,50 +89,44 @@ pub async fn head(ctx: &Context, uri: Strand, opts: impl Into<Object>) -> Result
 	for (k, v) in opts.into().iter() {
 		req = req.header(k.as_str(), v.to_raw_string());
 	}
+
+	if let Some(b) = body {
+		// Submit the request body
+		req = encode_body(req, b);
+	}
+
 	// Send the request and wait
 	let res = match ctx.timeout() {
 		#[cfg(not(target_family = "wasm"))]
 		Some(d) => req.timeout(d).send().await?,
 		_ => req.send().await?,
 	};
-	// Check the response status
-	match res.error_for_status() {
-		Ok(_) => Ok(Value::None),
-		Err(err) => match err.status() {
-			Some(s) => Err(Error::Http(format!(
-				"{} {}",
-				s.as_u16(),
-				s.canonical_reason().unwrap_or_default(),
-			))),
-			None => Err(Error::Http(err.to_string())),
-		},
+
+	if is_head {
+		// Check the response status
+		match res.error_for_status() {
+			Ok(_) => Ok(Value::None),
+			Err(err) => match err.status() {
+				Some(s) => Err(Error::Http(format!(
+					"{} {}",
+					s.as_u16(),
+					s.canonical_reason().unwrap_or_default(),
+				))),
+				None => Err(Error::Http(err.to_string())),
+			},
+		}
+	} else {
+		// Receive the response as a value
+		decode_response(res).await
 	}
 }
 
+pub async fn head(ctx: &Context, uri: Strand, opts: impl Into<Object>) -> Result<Value, Error> {
+	request(ctx, Method::HEAD, uri, None, opts).await
+}
+
 pub async fn get(ctx: &Context, uri: Strand, opts: impl Into<Object>) -> Result<Value, Error> {
-	// Check if the URI is valid and allowed
-	let url = Url::parse(&uri).map_err(|_| Error::InvalidUrl(uri.to_string()))?;
-	ctx.check_allowed_net(&url)?;
-	// Set a default client with no timeout
-	let cli = Client::builder().build()?;
-	// Start a new GET request
-	let mut req = cli.get(url);
-	// Add the User-Agent header
-	if cfg!(not(target_family = "wasm")) {
-		req = req.header("User-Agent", "SurrealDB");
-	}
-	// Add specified header values
-	for (k, v) in opts.into().iter() {
-		req = req.header(k.as_str(), v.to_raw_string());
-	}
-	// Send the request and wait
-	let res = match ctx.timeout() {
-		#[cfg(not(target_family = "wasm"))]
-		Some(d) => req.timeout(d).send().await?,
-		_ => req.send().await?,
-	};
-	// Receive the response as a value
-	decode_response(res).await
+	request(ctx, Method::GET, uri, None, opts).await
 }
 
 pub async fn put(
@@ -121,31 +135,7 @@ pub async fn put(
 	body: Value,
 	opts: impl Into<Object>,
 ) -> Result<Value, Error> {
-	// Check if the URI is valid and allowed
-	let url = Url::parse(&uri).map_err(|_| Error::InvalidUrl(uri.to_string()))?;
-	ctx.check_allowed_net(&url)?;
-	// Set a default client with no timeout
-	let cli = Client::builder().build()?;
-	// Start a new GET request
-	let mut req = cli.put(url);
-	// Add the User-Agent header
-	if cfg!(not(target_family = "wasm")) {
-		req = req.header("User-Agent", "SurrealDB");
-	}
-	// Add specified header values
-	for (k, v) in opts.into().iter() {
-		req = req.header(k.as_str(), v.to_raw_string());
-	}
-	// Submit the request body
-	req = encode_body(req, body);
-	// Send the request and wait
-	let res = match ctx.timeout() {
-		#[cfg(not(target_family = "wasm"))]
-		Some(d) => req.timeout(d).send().await?,
-		_ => req.send().await?,
-	};
-	// Receive the response as a value
-	decode_response(res).await
+	request(ctx, Method::PUT, uri, Some(body), opts).await
 }
 
 pub async fn post(
@@ -154,31 +144,7 @@ pub async fn post(
 	body: Value,
 	opts: impl Into<Object>,
 ) -> Result<Value, Error> {
-	// Check if the URI is valid and allowed
-	let url = Url::parse(&uri).map_err(|_| Error::InvalidUrl(uri.to_string()))?;
-	ctx.check_allowed_net(&url)?;
-	// Set a default client with no timeout
-	let cli = Client::builder().build()?;
-	// Start a new GET request
-	let mut req = cli.post(url);
-	// Add the User-Agent header
-	if cfg!(not(target_family = "wasm")) {
-		req = req.header("User-Agent", "SurrealDB");
-	}
-	// Add specified header values
-	for (k, v) in opts.into().iter() {
-		req = req.header(k.as_str(), v.to_raw_string());
-	}
-	// Submit the request body
-	req = encode_body(req, body);
-	// Send the request and wait
-	let res = match ctx.timeout() {
-		#[cfg(not(target_family = "wasm"))]
-		Some(d) => req.timeout(d).send().await?,
-		_ => req.send().await?,
-	};
-	// Receive the response as a value
-	decode_response(res).await
+	request(ctx, Method::POST, uri, Some(body), opts).await
 }
 
 pub async fn patch(
@@ -187,55 +153,9 @@ pub async fn patch(
 	body: Value,
 	opts: impl Into<Object>,
 ) -> Result<Value, Error> {
-	// Check if the URI is valid and allowed
-	let url = Url::parse(&uri).map_err(|_| Error::InvalidUrl(uri.to_string()))?;
-	ctx.check_allowed_net(&url)?;
-	// Set a default client with no timeout
-	let cli = Client::builder().build()?;
-	// Start a new GET request
-	let mut req = cli.patch(url);
-	// Add the User-Agent header
-	if cfg!(not(target_family = "wasm")) {
-		req = req.header("User-Agent", "SurrealDB");
-	}
-	// Add specified header values
-	for (k, v) in opts.into().iter() {
-		req = req.header(k.as_str(), v.to_raw_string());
-	}
-	// Submit the request body
-	req = encode_body(req, body);
-	// Send the request and wait
-	let res = match ctx.timeout() {
-		#[cfg(not(target_family = "wasm"))]
-		Some(d) => req.timeout(d).send().await?,
-		_ => req.send().await?,
-	};
-	// Receive the response as a value
-	decode_response(res).await
+	request(ctx, Method::PATCH, uri, Some(body), opts).await
 }
 
 pub async fn delete(ctx: &Context, uri: Strand, opts: impl Into<Object>) -> Result<Value, Error> {
-	// Check if the URI is valid and allowed
-	let url = Url::parse(&uri).map_err(|_| Error::InvalidUrl(uri.to_string()))?;
-	ctx.check_allowed_net(&url)?;
-	// Set a default client with no timeout
-	let cli = Client::builder().build()?;
-	// Start a new GET request
-	let mut req = cli.delete(url);
-	// Add the User-Agent header
-	if cfg!(not(target_family = "wasm")) {
-		req = req.header("User-Agent", "SurrealDB");
-	}
-	// Add specified header values
-	for (k, v) in opts.into().iter() {
-		req = req.header(k.as_str(), v.to_raw_string());
-	}
-	// Send the request and wait
-	let res = match ctx.timeout() {
-		#[cfg(not(target_family = "wasm"))]
-		Some(d) => req.timeout(d).send().await?,
-		_ => req.send().await?,
-	};
-	// Receive the response as a value
-	decode_response(res).await
+	request(ctx, Method::DELETE, uri, None, opts).await
 }

--- a/crates/core/src/mac/mod.rs
+++ b/crates/core/src/mac/mod.rs
@@ -16,7 +16,7 @@ macro_rules! bytes {
 macro_rules! yield_now {
 	() => {
 		if tokio::runtime::Handle::try_current().is_ok() {
-			tokio::task::yield_now().await;
+			tokio::task::consume_budget().await;
 		}
 	};
 }

--- a/crates/core/src/sql/statements/foreach.rs
+++ b/crates/core/src/sql/statements/foreach.rs
@@ -68,7 +68,10 @@ impl ForeachStatement {
 		};
 
 		// Loop over the values
-		'foreach: for v in iter {
+		for v in iter {
+			if ctx.is_timedout() {
+				return Err(Error::QueryTimedout);
+			}
 			// Duplicate context
 			let ctx = MutableContext::new(ctx).freeze();
 			// Set the current parameter
@@ -113,12 +116,14 @@ impl ForeachStatement {
 				};
 				// Catch any special errors
 				match res {
-					Err(Error::Continue) => continue 'foreach,
+					Err(Error::Continue) => break,
 					Err(Error::Break) => return Ok(Value::None),
 					Err(err) => return Err(err),
 					_ => (),
 				};
 			}
+			// Cooperitively yield if the task has been running for too long.
+			yield_now!();
 		}
 		// Ok all good
 		Ok(Value::None)

--- a/crates/sdk/tests/script.rs
+++ b/crates/sdk/tests/script.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "scripting")]
 
 mod parse;
+use std::time::Duration;
+use std::time::Instant;
+
 use parse::Parse;
 mod helpers;
 use helpers::new_ds;
@@ -729,5 +732,39 @@ async fn script_parallel_query() -> Result<(), Error> {
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
 	dbs.execute(sql, &ses, None).await?;
+	Ok(())
+}
+
+#[tokio::test]
+async fn script_run_too_long() -> Result<(), Error> {
+	let sql = r#"
+		RETURN function() {
+			for(let i = 0;i < 10000000;i++){
+				for(let j = 0;j < 10000000;j++){
+					for(let k = 0;k < 10000000;k++){
+						if(globalThis.test){
+							globalThis.test();
+						}
+					}
+				}
+			}
+		}
+	"#;
+	let dbs = new_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let mut timeout = *surrealdb_core::cnf::SCRIPTING_MAX_TIME_LIMIT;
+	timeout += timeout / 2;
+
+	let before = Instant::now();
+	let time =
+		tokio::time::timeout(Duration::from_millis(timeout as u64), dbs.execute(sql, &ses, None))
+			.await;
+	if before.elapsed() > Duration::from_millis(timeout as u64) {
+		panic!("Scripting function didn't timeout properly")
+	}
+	// This should timeout within surreal not from the above timeout.
+	let mut resp = time.unwrap().unwrap();
+	resp.pop().unwrap().result.unwrap_err();
+
 	Ok(())
 }

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -863,7 +863,7 @@ mod tests {
 						)),
 				),
 				Session::owner(),
-				format!("RETURN http::get('{}')", format!("{}/redirect", server3.uri())),
+				format!("RETURN http::get('{}/redirect')", server3.uri()),
 				false,
 				format!("here was an error processing a remote HTTP request: error following redirect for url ({}/redirect)",server3.uri()),
 			),


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

## What does this change do?

- Fixes long running FOR loops from stalling the surrealdb and never timing out.
- Introduces a default timeout for scripting functions.
- Checks HTTP redirects against allowed net targets, preventing redirections to disallowed uri's.

- Switches the `yield_now` macro from `tokio::task::yield_now` to `tokio::task::consume_budget`. This stops a future from yield when it isn't really necessary while still cooperatively yielding when required.

## What is your testing strategy?

Added a test for each of the abo.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->
- Created a PR for the new env variable: surrealdb/docs.surrealdb.com#1204
## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
