### PR TITLE
Do not collect keys when scanning for count

### DIFF
--- a/crates/core/src/kvs/surrealkv/mod.rs
+++ b/crates/core/src/kvs/surrealkv/mod.rs
@@ -470,6 +470,30 @@ impl super::api::Transaction for Transaction {
 		Ok(res)
 	}
 
+	/// Count the total number of keys within a range.
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
+	async fn count<K>(&mut self, rng: Range<K>) -> Result<usize, Error>
+	where
+		K: KeyEncode + Sprintable + Debug,
+	{
+		// Check to see if transaction is closed
+		if self.done {
+			return Err(Error::TxFinished);
+		}
+		// Set the key range
+		let beg = rng.start.encode_owned()?;
+		let end = rng.end.encode_owned()?;
+		// Execute on the blocking threadpool
+		let count = affinitypool::spawn_local(|| -> Result<_, Error> {
+			// Retrieve the scan range count
+			let count = self.inner.keys(beg.as_slice()..end.as_slice(), None).count();
+			Ok(count)
+		})
+		.await?;
+		// Return result
+		Ok(count)
+	}
+
 	/// Retrieves a range of key-value pairs from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
 	async fn scan<K>(


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

By default, `count()` is implemented by relying on the individual datastores's scan keys methods. Unfortunately, those scan keys methods collect the keys being scanned in a vec, which leads to an extra memory usage and is not needed for counting.

## What does this change do?

This change implements a more effective `count()` method for RocksDB and SurrealKV, both in-memory and disk, by effectively copying the keys method but without collecting the scanned keys.

## What is your testing strategy?

CI.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
