### PR TITLE
Implements SURREAL_FILE_ALLOWLIST

### DIFF
--- a/crates/core/src/cnf/mod.rs
+++ b/crates/core/src/cnf/mod.rs
@@ -1,3 +1,5 @@
+use crate::iam::file::extract_allowed_paths;
+use std::path::PathBuf;
 use std::sync::LazyLock;
 
 /// The characters which are supported in server record IDs.
@@ -93,7 +95,7 @@ pub static IDIOM_RECURSION_LIMIT: LazyLock<usize> = LazyLock::new(|| {
 		.unwrap_or(256)
 });
 
-pub static MEMORY_THRESHOLD: LazyLock<usize> = std::sync::LazyLock::new(|| {
+pub static MEMORY_THRESHOLD: LazyLock<usize> = LazyLock::new(|| {
 	std::env::var("SURREAL_MEMORY_THRESHOLD")
 		.map(|input| {
 			// Trim the input of any spaces
@@ -123,4 +125,11 @@ pub static MEMORY_THRESHOLD: LazyLock<usize> = std::sync::LazyLock::new(|| {
 			bytes
 		})
 		.unwrap_or(0)
+});
+
+/// Used to limit file access
+pub static FILE_ALLOWLIST: LazyLock<Vec<PathBuf>> = LazyLock::new(|| {
+	std::env::var("SURREAL_FILE_ALLOWLIST")
+		.map(|input| extract_allowed_paths(&input))
+		.unwrap_or_default()
 });

--- a/crates/core/src/err/mod.rs
+++ b/crates/core/src/err/mod.rs
@@ -1295,6 +1295,9 @@ pub enum Error {
 
 	#[error("The string could not be parsed into a path: {0}")]
 	InvalidPath(String),
+
+	#[error("File access denied: {0}")]
+	FileAccessDenied(String),
 }
 
 impl From<Error> for String {

--- a/crates/core/src/iam/file.rs
+++ b/crates/core/src/iam/file.rs
@@ -1,0 +1,111 @@
+use crate::cnf::FILE_ALLOWLIST;
+use crate::err::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn is_path_allowed(path: &Path) -> Result<PathBuf, Error> {
+	check_is_path_allowed(path, &FILE_ALLOWLIST)
+}
+
+/// Checks if the requested file path is within any of the allowed directories.
+fn check_is_path_allowed(path: &Path, allowed_path: &[PathBuf]) -> Result<PathBuf, Error> {
+	// Convert the requested path to its canonical form.
+	let canonical_path = fs::canonicalize(path)?;
+
+	// If the list is empty, we don't operate any control
+	if allowed_path.is_empty() {
+		return Ok(canonical_path);
+	}
+
+	// Check if the canonical path starts with any of the allowed paths.
+	if allowed_path.iter().any(|allowed| canonical_path.starts_with(allowed)) {
+		Ok(canonical_path)
+	} else {
+		Err(Error::FileAccessDenied(path.to_string_lossy().to_string()))
+	}
+}
+
+pub(crate) fn extract_allowed_paths(input: &str) -> Vec<PathBuf> {
+	// or a semicolon on Windows.
+	let delimiter = if cfg!(target_os = "windows") {
+		";"
+	} else {
+		":"
+	};
+	// Split the allowlist string, canonicalize each path, and collect valid paths.
+	input
+		.split(delimiter)
+		.filter_map(|s| {
+			let trimmed = s.trim();
+			if trimmed.is_empty() {
+				None
+			} else {
+				// Convert to a PathBuf and canonicalize it.
+				fs::canonicalize(trimmed).ok().inspect(|p| {
+					debug!("Allowed file path: {}", p.to_string_lossy());
+				})
+			}
+		})
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use tempfile::tempdir;
+
+	#[test]
+	fn test_empty_allow_list_allows_access() {
+		// Create a temporary file in a temp directory.
+		let dir = tempdir().expect("failed to create temp dir");
+		let file_path = dir.path().join("test.txt");
+		fs::write(&file_path, "content").expect("failed to write file in file_path");
+
+		// With an empty allowlist, access should be allowed.
+		let result = check_is_path_allowed(&file_path, &vec![]);
+		assert!(result.is_ok(), "File access should be allowed when no restrictions are set");
+	}
+
+	#[test]
+	fn test_allow_list_access() {
+		// Use the appropriate delimiter for the platform.
+		let delimiter = if cfg!(target_os = "windows") {
+			";"
+		} else {
+			":"
+		};
+
+		// Create 3 temporary directories.
+		let (dir1, dir2, dir3) = (tempdir().unwrap(), tempdir().unwrap(), tempdir().unwrap());
+		// First two directories are allowed
+		let combined = format!(
+			"{}{}{}",
+			dir1.path().to_string_lossy(),
+			delimiter,
+			dir2.path().to_string_lossy()
+		);
+		let allowlist = extract_allowed_paths(&combined);
+
+		// Create a file in the first allowed directory.
+		let allowed_file1 = dir1.path().join("file1.txt");
+		fs::write(&allowed_file1, "content").expect("failed to write file in allowed_file1");
+
+		// Create a file in the second allowed directory.
+		let allowed_file2 = dir2.path().join("file2.txt");
+		fs::write(&allowed_file2, "content").expect("failed to write file in allowed_file2");
+
+		// Create a file in the third denied directory.
+		let denied_file3 = dir3.path().join("file3.txt");
+		fs::write(&denied_file3, "content").expect("failed to write file in denied_file3");
+
+		// Check that files in allowed directories are permitted.
+		let res1 = check_is_path_allowed(&allowed_file1, &allowlist);
+		let res2 = check_is_path_allowed(&allowed_file2, &allowlist);
+		assert!(res1.is_ok(), "File in the first allowed directory should be permitted");
+		assert!(res2.is_ok(), "File in the second allowed directory should be permitted");
+
+		// Check that the file outside is denied.
+		let res_outside = check_is_path_allowed(&denied_file3, &allowlist);
+		assert!(res_outside.is_err(), "File outside allowed directories should be denied");
+	}
+}

--- a/crates/core/src/iam/mod.rs
+++ b/crates/core/src/iam/mod.rs
@@ -8,6 +8,7 @@ pub mod base;
 pub mod check;
 pub mod clear;
 pub mod entities;
+pub(crate) mod file;
 pub mod issue;
 #[cfg(feature = "jwks")]
 pub mod jwks;

--- a/crates/core/src/idx/ft/analyzer/mapper.rs
+++ b/crates/core/src/idx/ft/analyzer/mapper.rs
@@ -1,4 +1,5 @@
 use crate::err::Error;
+use crate::iam::file::is_path_allowed;
 use crate::idx::ft::analyzer::filter::{FilterResult, Term};
 #[cfg(target_family = "wasm")]
 use std::fs::File;
@@ -13,6 +14,7 @@ use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use vart::art::Tree;
 use vart::VariableSizeKey;
+
 #[derive(Clone, Default)]
 pub(in crate::idx) struct Mapper {
 	terms: Arc<Tree<VariableSizeKey, String>>,
@@ -21,7 +23,8 @@ pub(in crate::idx) struct Mapper {
 impl Mapper {
 	pub(in crate::idx) async fn new(path: &Path) -> Result<Self, Error> {
 		let mut terms = Tree::new();
-		Self::iterate_file(&mut terms, path).await?;
+		let path = is_path_allowed(path)?;
+		Self::iterate_file(&mut terms, &path).await?;
 		Ok(Self {
 			terms: Arc::new(terms),
 		})

--- a/crates/core/src/idx/trees/store/mapper.rs
+++ b/crates/core/src/idx/trees/store/mapper.rs
@@ -1,4 +1,5 @@
 use crate::err::Error;
+use crate::iam::file::is_path_allowed;
 use crate::idx::ft::analyzer::mapper::Mapper;
 use crate::sql::statements::DefineAnalyzerStatement;
 use crate::sql::Filter;
@@ -39,6 +40,8 @@ impl Mappers {
 
 	async fn insert(&self, path: &str) -> Result<(), Error> {
 		let p = Path::new(path);
+		// Check the path is allowed
+		is_path_allowed(p)?;
 		if !p.exists() || !p.is_file() {
 			return Err(Error::Internal(format!("Invalid mapper path: {p:?}")));
 		}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?


The mapper filter currently allows reading CSV files from any location on the server. For example:

```sql
DEFINE ANALYZER az TOKENIZERS blank,class FILTERS lowercase,mapper('/Users/john/test');
```

We need a mechanism to restrict file access, ensuring that only files within specific directories can be read by the mapper.

## What does this change do?

Introduces a new environment variable, `SURREAL_FILE_ALLOWLIST,` which contains a list of allowed file paths.

When a mapping file is processed, the mapper checks if the file’s path is within one of the allowed paths.

If the file is located outside of these approved directories, an error is generated, preventing unauthorized file access.

## What is your testing strategy?

Github Actions.
Tests have been added.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] https://github.com/surrealdb/docs.surrealdb.com/pull/1206

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
