### PR TITLE
Fix Graph clauses  `->(SELECT ...` Fixes #5605

### DIFF
--- a/crates/core/src/sql/graph.rs
+++ b/crates/core/src/sql/graph.rs
@@ -81,7 +81,11 @@ impl Graph {
 
 impl Display for Graph {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		if self.what.0.len() <= 1 && self.cond.is_none() && self.alias.is_none() && self.expr.is_none() {
+		if self.what.0.len() <= 1
+			&& self.cond.is_none()
+			&& self.alias.is_none()
+			&& self.expr.is_none()
+		{
 			Display::fmt(&self.dir, f)?;
 			match self.what.len() {
 				0 => f.write_char('?'),

--- a/crates/core/src/sql/graph.rs
+++ b/crates/core/src/sql/graph.rs
@@ -89,6 +89,9 @@ impl Display for Graph {
 			}
 		} else {
 			write!(f, "{}(", self.dir)?;
+			if let Some(expr) = self.expr.as_ref() {
+				write!(f, "select {} FROM ", expr)?;
+			}
 			match self.what.len() {
 				0 => f.write_char('?'),
 				_ => Display::fmt(&self.what, f),

--- a/crates/core/src/sql/graph.rs
+++ b/crates/core/src/sql/graph.rs
@@ -89,7 +89,7 @@ impl Display for Graph {
 			}
 		} else {
 			write!(f, "{}(", self.dir)?;
-			if let Some(expr) = self.expr.as_ref() {
+			if let Some(ref expr) = self.expr {
 				write!(f, "SELECT {} FROM ", expr)?;
 			}
 			match self.what.len() {

--- a/crates/core/src/sql/graph.rs
+++ b/crates/core/src/sql/graph.rs
@@ -81,7 +81,7 @@ impl Graph {
 
 impl Display for Graph {
 	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		if self.what.0.len() <= 1 && self.cond.is_none() && self.alias.is_none() {
+		if self.what.0.len() <= 1 && self.cond.is_none() && self.alias.is_none() && self.expr.is_none() {
 			Display::fmt(&self.dir, f)?;
 			match self.what.len() {
 				0 => f.write_char('?'),

--- a/crates/core/src/sql/graph.rs
+++ b/crates/core/src/sql/graph.rs
@@ -90,7 +90,7 @@ impl Display for Graph {
 		} else {
 			write!(f, "{}(", self.dir)?;
 			if let Some(expr) = self.expr.as_ref() {
-				write!(f, "select {} FROM ", expr)?;
+				write!(f, "SELECT {} FROM ", expr)?;
 			}
 			match self.what.len() {
 				0 => f.write_char('?'),

--- a/crates/core/src/syn/parser/idiom.rs
+++ b/crates/core/src/syn/parser/idiom.rs
@@ -836,23 +836,23 @@ mod tests {
 
 	#[test]
 	fn graph_select() {
-		let sql = "->(select amount from likes WHERE amount > 10)";
+		let sql = "->(SELECT amount FROM likes WHERE amount > 10)";
 		let out = Value::parse(sql);
-		assert_eq!("->(select amount FROM likes WHERE amount > 10)", format!("{}", out));
+		assert_eq!("->(SELECT amount FROM likes WHERE amount > 10)", format!("{}", out));
 	}
 
 	#[test]
 	fn graph_select_order() {
-		let sql = "->(select amount from likes WHERE amount > 10 ORDER BY amount)";
+		let sql = "->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount)";
 		let out = Value::parse(sql);
-		assert_eq!("->(select amount FROM likes WHERE amount > 10 ORDER BY amount\n)", format!("{}", out));
+		assert_eq!("->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount\n)", format!("{}", out));
 	}
 
 	#[test]
 	fn graph_select_order_limit() {
-		let sql = "->(select amount from likes WHERE amount > 10 ORDER BY amount LIMIT 1)";
+		let sql = "->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount LIMIT 1)";
 		let out = Value::parse(sql);
-		assert_eq!("->(select amount FROM likes WHERE amount > 10 ORDER BY amount\n LIMIT 1)", format!("{}", out));
+		assert_eq!("->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount\n LIMIT 1)", format!("{}", out));
 	}
 
 	#[test]

--- a/crates/core/src/syn/parser/idiom.rs
+++ b/crates/core/src/syn/parser/idiom.rs
@@ -835,6 +835,27 @@ mod tests {
 	}
 
 	#[test]
+	fn graph_select() {
+		let sql = "->(select amount from likes WHERE amount > 10)";
+		let out = Value::parse(sql);
+		assert_eq!("->(select amount FROM likes WHERE amount > 10)", format!("{}", out));
+	}
+
+	#[test]
+	fn graph_select_order() {
+		let sql = "->(select amount from likes WHERE amount > 10 ORDER BY amount)";
+		let out = Value::parse(sql);
+		assert_eq!("->(select amount FROM likes WHERE amount > 10 ORDER BY amount\n)", format!("{}", out));
+	}
+
+	#[test]
+	fn graph_select_order_limit() {
+		let sql = "->(select amount from likes WHERE amount > 10 ORDER BY amount LIMIT 1)";
+		let out = Value::parse(sql);
+		assert_eq!("->(select amount FROM likes WHERE amount > 10 ORDER BY amount\n LIMIT 1)", format!("{}", out));
+	}
+
+	#[test]
 	fn idiom_normal() {
 		let sql = "test";
 		let out = Value::parse(sql);

--- a/crates/core/src/syn/parser/idiom.rs
+++ b/crates/core/src/syn/parser/idiom.rs
@@ -840,7 +840,7 @@ mod tests {
 		let out = Value::parse(sql);
 		assert_eq!("->(SELECT amount FROM likes WHERE amount > 10)", format!("{}", out));
 	}
-	
+
 	#[test]
 	fn graph_select_wildcard() {
 		let sql = "->(SELECT * FROM likes WHERE amount > 10)";
@@ -852,14 +852,20 @@ mod tests {
 	fn graph_select_where_order() {
 		let sql = "->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount)";
 		let out = Value::parse(sql);
-		assert_eq!("->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount\n)", format!("{}", out));
+		assert_eq!(
+			"->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount\n)",
+			format!("{}", out)
+		);
 	}
 
 	#[test]
 	fn graph_select_where_order_limit() {
 		let sql = "->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount LIMIT 1)";
 		let out = Value::parse(sql);
-		assert_eq!("->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount\n LIMIT 1)", format!("{}", out));
+		assert_eq!(
+			"->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount\n LIMIT 1)",
+			format!("{}", out)
+		);
 	}
 
 	#[test]
@@ -868,7 +874,7 @@ mod tests {
 		let out = Value::parse(sql);
 		assert_eq!("->(SELECT amount FROM likes LIMIT 1)", format!("{}", out));
 	}
-	
+
 	#[test]
 	fn graph_select_order() {
 		let sql = "->(SELECT amount FROM likes ORDER BY amount)";

--- a/crates/core/src/syn/parser/idiom.rs
+++ b/crates/core/src/syn/parser/idiom.rs
@@ -840,19 +840,47 @@ mod tests {
 		let out = Value::parse(sql);
 		assert_eq!("->(SELECT amount FROM likes WHERE amount > 10)", format!("{}", out));
 	}
+	
+	#[test]
+	fn graph_select_wildcard() {
+		let sql = "->(SELECT * FROM likes WHERE amount > 10)";
+		let out = Value::parse(sql);
+		assert_eq!("->(SELECT * FROM likes WHERE amount > 10)", format!("{}", out));
+	}
 
 	#[test]
-	fn graph_select_order() {
+	fn graph_select_where_order() {
 		let sql = "->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount)";
 		let out = Value::parse(sql);
 		assert_eq!("->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount\n)", format!("{}", out));
 	}
 
 	#[test]
-	fn graph_select_order_limit() {
+	fn graph_select_where_order_limit() {
 		let sql = "->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount LIMIT 1)";
 		let out = Value::parse(sql);
 		assert_eq!("->(SELECT amount FROM likes WHERE amount > 10 ORDER BY amount\n LIMIT 1)", format!("{}", out));
+	}
+
+	#[test]
+	fn graph_select_limit() {
+		let sql = "->(SELECT amount FROM likes LIMIT 1)";
+		let out = Value::parse(sql);
+		assert_eq!("->(SELECT amount FROM likes LIMIT 1)", format!("{}", out));
+	}
+	
+	#[test]
+	fn graph_select_order() {
+		let sql = "->(SELECT amount FROM likes ORDER BY amount)";
+		let out = Value::parse(sql);
+		assert_eq!("->(SELECT amount FROM likes ORDER BY amount\n)", format!("{}", out));
+	}
+
+	#[test]
+	fn graph_select_order_limit() {
+		let sql = "->(SELECT amount FROM likes ORDER BY amount LIMIT 1)";
+		let out = Value::parse(sql);
+		assert_eq!("->(SELECT amount FROM likes ORDER BY amount\n LIMIT 1)", format!("{}", out));
 	}
 
 	#[test]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->
Fixing bug #5605
Well it seems that the rust client parses a query and displays it again before sending it to the DB.

Wenn using Graph clauses, the query will not match the input after being parsed and displayed, this PR should fix that

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Add test that `Graph` with `SELECT` also has `SELECT` in it when displayed.

> Dono where the new line comes form, but does not causes any issues with the execued query

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Extent upon the existing unit-test to cover this untested case.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Fixes #5605
- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
