### PR TITLE
Fixes sub-allocation in TrackAlloc

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/publish-version.yml
     with:
       environment: nightly
-      extra-features: storage-surrealkv,ml
+      extra-features: storage-surrealkv,ml,allocation-tracking
       git-ref: main
       publish: ${{ inputs.publish || github.event_name == 'schedule' }}
     secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/publish-version.yml
     with:
       environment: nightly
-      extra-features: storage-surrealkv,ml,allocation-tracking
+      extra-features: storage-surrealkv,ml
       git-ref: main
       publish: ${{ inputs.publish || github.event_name == 'schedule' }}
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ wiremock = "0.6.0"
 # Public features
 default = [
     "allocator",
+    "allocation-tracking",
     "storage-mem",
     "storage-surrealkv",
     "storage-surrealcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ jemallocator = { version = "0.6.0", package = "tikv-jemallocator" }
 jsonwebtoken = "9.3.0"
 linfa-linalg = "=0.1.0"
 md-5 = "0.10.6"
-mimalloc = { version = "0.1.43",  default-features = false }
+mimalloc = { version = "0.1.43", default-features = false }
 nanoid = "0.4.0"
 native-tls = "0.2.11"
 ndarray = "=0.15.6"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,8 +10,8 @@ reduce_output = true
 default_to_workspace = false
 
 [env]
-ALL_FEATURES = { value = "allocator,storage-mem,storage-surrealkv,storage-surrealcs,storage-rocksdb,storage-tikv,storage-fdb,scripting,http,jwks,ml,storage-fdb-7_3", condition = { env_not_set = ["ALL_FEATURES"] } }
-DEV_FEATURES = { value = "allocator,storage-mem,storage-surrealkv,storage-surrealcs,storage-rocksdb,scripting,http,jwks,ml", condition = { env_not_set = ["DEV_FEATURES"] } }
+ALL_FEATURES = { value = "allocator,allocation-tracking,storage-mem,storage-surrealkv,storage-surrealcs,storage-rocksdb,storage-tikv,storage-fdb,scripting,http,jwks,ml,storage-fdb-7_3", condition = { env_not_set = ["ALL_FEATURES"] } }
+DEV_FEATURES = { value = "allocator,allocation-tracking,storage-mem,storage-surrealkv,storage-surrealcs,storage-rocksdb,scripting,http,jwks,ml", condition = { env_not_set = ["DEV_FEATURES"] } }
 SURREAL_LOG = { value = "full", condition = { env_not_set = ["SURREAL_LOG"] } }
 SURREAL_USER = { value = "root", condition = { env_not_set = ["SURREAL_USER"] } }
 SURREAL_PASS = { value = "root", condition = { env_not_set = ["SURREAL_PASS"] } }

--- a/crates/core/src/mem/track.rs
+++ b/crates/core/src/mem/track.rs
@@ -9,9 +9,7 @@ use std::cell::RefCell;
 #[cfg(feature = "allocation-tracking")]
 use std::ptr::null_mut;
 #[cfg(feature = "allocation-tracking")]
-use std::sync::atomic::AtomicPtr;
-#[cfg(feature = "allocation-tracking")]
-use std::sync::atomic::{AtomicIsize, Ordering};
+use std::sync::atomic::{AtomicIsize, AtomicPtr, Ordering};
 
 /// This structure implements a wrapper around the
 /// system allocator, or around a user-specified
@@ -114,7 +112,7 @@ impl<A: GlobalAlloc> TrackAlloc<A> {
 	///
 	/// **Why `unsafe` is used here:**
 	/// - We use `unsafe` when we allocate and write to raw pointers.
-	/// However, this is controlled:
+	///   However, this is controlled:
 	///   1. We allocate memory with `self.alloc` to avoid recursion, ensuring the allocation
 	///      does not go through the tracked allocator and cause infinite recursion.
 	///   2. We immediately initialize the newly allocated memory with `node_raw.write(...)`.
@@ -148,7 +146,7 @@ impl<A: GlobalAlloc> TrackAlloc<A> {
 				unsafe {
 					node_raw.write(ThreadCounterNode {
 						next: AtomicPtr::new(null_mut()),
-						counter: AtomicUsize::new(0),
+						counter: AtomicIsize::new(0),
 					});
 				}
 
@@ -258,5 +256,5 @@ static GLOBAL_LIST_LOCK: Mutex<()> = Mutex::new(());
 thread_local! {
 	/// `THREAD_NODE` stores a pointer to this thread's `ThreadCounterNode`.
 	/// It's initially null, and once the thread first allocates, we initialize the node and store it here.
-	static THREAD_NODE: RefCell<*mut ThreadCounterNode> = RefCell::new(null_mut());
+	static THREAD_NODE: RefCell<*mut ThreadCounterNode> = const {RefCell::new(null_mut())};
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

In the current approach, whenever subtracting usage risked going below zero, the code would simply reset the counter to zero instead of actually performing the subtraction (the idea being “usage can’t be negative, so just don’t subtract this time”). This had the unintended consequence of losing track of how many bytes were really freed when the usage was already at or near zero. Eventually, especially under concurrency, that leads to inaccuracies in the overall usage count.

## What does this change do?

By allowing the counter to go negative temporarily in the internal logic (and then clamping only when reporting), we maintain a real picture of how many “add” and “sub” operations were called, even if they become out of sync for a moment. The final reporting step ensures a sensible user-facing total (i.e., zero or above), while preserving subtract operations in the internal flow.

## What is your testing strategy?

Manual testing. The `allocation-tracking` feature is now enabled by default.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
