### PR TITLE
Move yield_now to after work has been done

### DIFF
--- a/crates/core/src/cf/gc.rs
+++ b/crates/core/src/cf/gc.rs
@@ -13,12 +13,12 @@ pub async fn gc_all_at(tx: &Transaction, ts: u64) -> Result<(), Error> {
 	let nss = tx.all_ns().await?;
 	// Loop over each namespace
 	for ns in nss.as_ref() {
-		// Pause execution
-		yield_now!();
 		// Trace for debugging
 		trace!("Performing garbage collection on {} for timestamp {ts}", ns.name);
 		// Process the namespace
 		gc_ns(tx, ts, &ns.name).await?;
+		// Pause execution
+		yield_now!();
 	}
 	Ok(())
 }
@@ -31,8 +31,6 @@ pub async fn gc_ns(tx: &Transaction, ts: u64, ns: &str) -> Result<(), Error> {
 	let dbs = tx.all_db(ns).await?;
 	// Loop over each database
 	for db in dbs.as_ref() {
-		// Yield execution
-		yield_now!();
 		// Trace for debugging
 		trace!("Performing garbage collection on {ns}:{} for timestamp {ts}", db.name);
 		// Fetch all tables
@@ -65,6 +63,8 @@ pub async fn gc_ns(tx: &Transaction, ts: u64, ns: &str) -> Result<(), Error> {
 		if let Some(watermark_vs) = watermark_vs {
 			gc_range(tx, ns, &db.name, watermark_vs).await?;
 		}
+		// Yield execution
+		yield_now!();
 	}
 	Ok(())
 }

--- a/crates/core/src/kvs/node.rs
+++ b/crates/core/src/kvs/node.rs
@@ -159,8 +159,6 @@ impl Datastore {
 				trace!(target: TARGET, id = %id, "Deleting live queries for node");
 				// Scan the live queries for this node
 				while let Some(rng) = next {
-					// Pause and yield execution
-					yield_now!();
 					// Fetch the next batch of keys and values
 					let max = *NORMAL_FETCH_SIZE;
 					let res = catch!(txn, txn.batch_keys_vals(rng, max, None).await);
@@ -180,6 +178,8 @@ impl Datastore {
 							catch!(txn, txn.clr(nlq).await);
 						}
 					}
+					// Pause and yield execution
+					yield_now!();
 				}
 			}
 			{
@@ -251,8 +251,6 @@ impl Datastore {
 					let mut next = Some(beg..end);
 					let txn = self.transaction(Write, Optimistic).await?;
 					while let Some(rng) = next {
-						// Pause and yield execution
-						yield_now!();
 						// Fetch the next batch of keys and values
 						let max = *NORMAL_FETCH_SIZE;
 						let res = catch!(txn, txn.batch_keys_vals(rng, max, None).await);
@@ -274,6 +272,8 @@ impl Datastore {
 								catch!(txn, txn.clr(tlq).await);
 							}
 						}
+						// Pause and yield execution
+						yield_now!();
 					}
 					// Commit the changes
 					txn.commit().await?;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The docs of `consume_budget` note that it should be called after work is done.
Because if it's use is nested deeply enough it is possible that the budget is exhausted before any work can be done, resulting in a task getting stuck and never progressing. 

By moving that to after work we can ensure that tasks keep progressing.

## What does this change do?

Moves `yield_now!()` calls to happen after work is done.

## What is your testing strategy?


## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
