### PR TITLE
Revert "Do not over-fetch documents when LIMIT and START used togethe…

### DIFF
--- a/crates/core/src/dbs/iterator.rs
+++ b/crates/core/src/dbs/iterator.rs
@@ -517,7 +517,11 @@ impl Iterator {
 	) {
 		if self.check_set_start_limit(ctx, stm) {
 			if let Some(l) = self.limit {
-				self.cancel_on_limit = Some(l);
+				if let Some(s) = self.start {
+					self.cancel_on_limit = Some(l + s);
+				} else {
+					self.cancel_on_limit = Some(l);
+				}
 			}
 			// Check if we can skip processing the document below "start".
 			if let Some(false) = is_specific_permission {

--- a/crates/sdk/tests/planner.rs
+++ b/crates/sdk/tests/planner.rs
@@ -3424,7 +3424,7 @@ async fn select_limit_start() -> Result<(), Error> {
 					},
 					{
 						detail: {
-							CancelOnLimit: 10,
+							CancelOnLimit: 12,
 							SkipStart: 2
 						},
 						operation: 'StartLimitStrategy'

--- a/crates/sdk/tests/range.rs
+++ b/crates/sdk/tests/range.rs
@@ -122,7 +122,7 @@ async fn select_start_limit_fetch() -> Result<(), Error> {
 				},
 				{
 					detail: {
-						CancelOnLimit: 1,
+						CancelOnLimit: 2,
 						SkipStart: 1
 					},
 					operation: 'StartLimitStrategy'


### PR DESCRIPTION
…r (#5590)"

This reverts commit 7f6031ca5baf782dce12b8d1a52e29fdb45be0f2.

Due to https://github.com/surrealdb/surrealdb/issues/5611. The proper fix is being worked on.

Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

> [!WARNING]
No details provided.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

> [!WARNING]
> No details provided.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
