### PR TITLE
Backport v2.0 - Check limit to string::replace with regular expressions

### DIFF
--- a/core/src/fnc/string.rs
+++ b/core/src/fnc/string.rs
@@ -82,7 +82,28 @@ pub fn replace((val, search, replace): (String, Value, String)) -> Result<Value,
 			}
 			Ok(val.replace(&search.0, &replace).into())
 		}
-		Value::Regex(search) => Ok(search.0.replace_all(&val, replace).into_owned().into()),
+		Value::Regex(search) => {
+			let mut new_val = String::with_capacity(val.len());
+			let mut last = 0;
+
+			for m in search.0.find_iter(&val) {
+				// Push everything until the match
+				new_val.push_str(&val[last..m.start()]);
+
+				// Push replacement
+				new_val.push_str(&replace);
+
+				// Abort early if we'd exceed the allowed limit
+				limit("string::replace", new_val.len())?;
+
+				last = m.end();
+			}
+
+			// Finally, push anything after the last match
+			new_val.push_str(&val[last..]);
+			limit("string::replace", new_val.len())?;
+			Ok(new_val.into())
+		}
 		_ => Err(Error::InvalidArguments {
 			name: "string::replace".to_string(),
 			message: format!(
@@ -428,6 +449,7 @@ pub mod semver {
 #[cfg(test)]
 mod tests {
 	use super::{contains, matches, replace, slice};
+	use crate::err::Error;
 	use crate::sql::Value;
 
 	#[test]
@@ -485,6 +507,21 @@ mod tests {
 
 		test("foo bar", Value::Regex("foo".parse().unwrap()), "bar", "bar bar");
 		test("foo bar", "bar".into(), "foo", "foo foo");
+	}
+
+	#[test]
+	fn string_replace_limit() {
+		let r = replace(("A".repeat(1000), Value::Regex("()".parse().unwrap()), "B".repeat(10000)));
+		match r {
+			Err(Error::InvalidArguments {
+				name,
+				message,
+			}) => {
+				assert_eq!(name, "string::replace");
+				assert_eq!(message, "Output must not exceed 1048576 bytes.");
+			}
+			_ => panic!("Unexpected result: {:?}", r),
+		}
 	}
 
 	#[test]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport #5619 

## What does this change do?

(cherry picked from commit 0976a94b93c9480f01800a738ccbb01b912f3015)

## What is your testing strategy?

Github action

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
