### PR TITLE
Introduces Regex size limit configuration

### DIFF
--- a/crates/core/src/cnf/mod.rs
+++ b/crates/core/src/cnf/mod.rs
@@ -96,7 +96,7 @@ pub static GENERATION_ALLOCATION_LIMIT: LazyLock<usize> = LazyLock::new(|| {
 pub static REGEX_SIZE_LIMIT: LazyLock<usize> = LazyLock::new(|| {
 	std::env::var("SURREAL_REGEX_SIZE_LIMIT")
 		.map(|s| s.parse::<usize>().unwrap_or(10_485_760))
-		.unwrap_or(20)
+		.unwrap_or(10_485_760)
 });
 
 pub static MAX_HTTP_REDIRECTS: LazyLock<usize> =

--- a/crates/core/src/cnf/mod.rs
+++ b/crates/core/src/cnf/mod.rs
@@ -92,6 +92,13 @@ pub static GENERATION_ALLOCATION_LIMIT: LazyLock<usize> = LazyLock::new(|| {
 	2usize.pow(n)
 });
 
+/// Used to limit allocation for regular expressions
+pub static REGEX_SIZE_LIMIT: LazyLock<usize> = LazyLock::new(|| {
+	std::env::var("SURREAL_REGEX_SIZE_LIMIT")
+		.map(|s| s.parse::<usize>().unwrap_or(10_485_760))
+		.unwrap_or(20)
+});
+
 pub static MAX_HTTP_REDIRECTS: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_MAX_HTTP_REDIRECTS", usize, 10);
 

--- a/crates/core/src/sql/arbitrary.rs
+++ b/crates/core/src/sql/arbitrary.rs
@@ -1,3 +1,4 @@
+use crate::sql::regex::regex_new;
 use crate::sql::{
 	changefeed::ChangeFeed, datetime::Datetime, duration::Duration, regex::Regex,
 	statements::SleepStatement,
@@ -22,9 +23,7 @@ impl<'a> Arbitrary<'a> for Datetime {
 impl<'a> Arbitrary<'a> for Regex {
 	fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
 		let ast = Ast::arbitrary(u)?;
-		Ok(Self(
-			regex::Regex::new(&format!("{ast}")).map_err(|_| arbitrary::Error::IncorrectFormat)?,
-		))
+		Ok(Self(regex_new(&format!("{ast}")).map_err(|_| arbitrary::Error::IncorrectFormat)?))
 	}
 }
 

--- a/crates/core/src/sql/regex.rs
+++ b/crates/core/src/sql/regex.rs
@@ -157,7 +157,7 @@ mod tests {
 	fn regex_compile_limit() {
 		match regex_new("^(a|b|c){1000000}") {
 			Err(e) => {
-				assert!(matches!(e, regex::Error::CompiledTooBig(20)), "{e}");
+				assert!(matches!(e, regex::Error::CompiledTooBig(_)), "{e}");
 			}
 			Ok(_) => panic!("regex should have failed"),
 		}

--- a/crates/core/src/sql/regex.rs
+++ b/crates/core/src/sql/regex.rs
@@ -157,7 +157,7 @@ mod tests {
 	fn regex_compile_limit() {
 		match regex_new("^(a|b|c){1000000}") {
 			Err(e) => {
-				assert!(matches!(e, regex::Error::CompiledTooBig(_)), "{e}");
+				assert!(matches!(e, regex::Error::CompiledTooBig(10_485_760)), "{e}");
 			}
 			Ok(_) => panic!("regex should have failed"),
 		}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

We want to expose the size limit when compiling a regular expression.

## What does this change do?

We enforce the limit: `SURREAL_REGEX_SIZE_LIMIT`

## What is your testing strategy?

Github action.
A test has been added.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] https://github.com/surrealdb/docs.surrealdb.com/pull/1222

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
