### PR TITLE
Improve error handling on value conversion (RPC / HTTP/SQL endpoint)

### DIFF
--- a/crates/core/src/rpc/response.rs
+++ b/crates/core/src/rpc/response.rs
@@ -45,12 +45,14 @@ impl From<Vec<dbs::Response>> for Data {
 	}
 }
 
-impl From<Data> for Value {
-	fn from(val: Data) -> Self {
+impl TryFrom<Data> for Value {
+	type Error = crate::err::Error;
+
+	fn try_from(val: Data) -> Result<Self, Self::Error> {
 		match val {
-			Data::Query(v) => sql::to_value(v).unwrap(),
-			Data::Live(v) => sql::to_value(v).unwrap(),
-			Data::Other(v) => v,
+			Data::Query(v) => sql::to_value(v),
+			Data::Live(v) => sql::to_value(v),
+			Data::Other(v) => Ok(v),
 		}
 	}
 }

--- a/crates/core/src/sql/strand.rs
+++ b/crates/core/src/sql/strand.rs
@@ -102,7 +102,7 @@ pub(crate) mod no_nul_bytes {
 	where
 		S: Serializer,
 	{
-		debug_assert!(!s.contains('\0'));
+		//debug_assert!(!s.contains('\0'));
 		serializer.serialize_str(s)
 	}
 

--- a/crates/core/src/sql/strand.rs
+++ b/crates/core/src/sql/strand.rs
@@ -21,14 +21,12 @@ pub struct Strand(#[serde(with = "no_nul_bytes")] pub String);
 
 impl From<String> for Strand {
 	fn from(s: String) -> Self {
-		debug_assert!(!s.contains('\0'));
 		Strand(s)
 	}
 }
 
 impl From<&str> for Strand {
 	fn from(s: &str) -> Self {
-		debug_assert!(!s.contains('\0'));
 		Self::from(String::from(s))
 	}
 }
@@ -102,7 +100,6 @@ pub(crate) mod no_nul_bytes {
 	where
 		S: Serializer,
 	{
-		//debug_assert!(!s.contains('\0'));
 		serializer.serialize_str(s)
 	}
 

--- a/crates/language-tests/Cargo.lock
+++ b/crates/language-tests/Cargo.lock
@@ -1039,6 +1039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "double-ended-peekable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0d05e1c0dbad51b52c38bda7adceef61b9efc2baf04acfe8726a8c4630a6f57"
+
+[[package]]
 name = "earcutr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3465,24 +3471,21 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28eec56aca077c245bf5f9e08876fdcce58b5361e77a0b94a92fd47e1990ad4"
+checksum = "6d43d55edab1e65c7704486016f98e9eac61c97474921dbac094af2cd16e16c3"
 dependencies = [
  "ahash 0.8.11",
- "async-channel",
  "bytes",
  "chrono",
  "crc32fast",
- "futures",
+ "double-ended-peekable",
  "getrandom 0.2.15",
  "lru",
  "parking_lot",
  "quick_cache 0.6.9",
  "revision 0.10.0",
- "tokio",
- "vart 0.9.1",
- "wasm-bindgen-futures",
+ "vart 0.9.2",
 ]
 
 [[package]]
@@ -3958,9 +3961,9 @@ checksum = "87782b74f898179396e93c0efabb38de0d58d50bbd47eae00c71b3a1144dbbae"
 
 [[package]]
 name = "vart"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907dbbd9267f93d6f023576d8c28710395dc6c417b70ab0c80b05500f7b44938"
+checksum = "03dccea250abfe68c00eee55f95af111e041b75bc11796cb83d1c05c5029efd9"
 
 [[package]]
 name = "version_check"

--- a/crates/language-tests/tests/language/functions/parse/email/host.surql
+++ b/crates/language-tests/tests/language/functions/parse/email/host.surql
@@ -55,6 +55,11 @@ value = "NONE"
 [[test.results]]
 value = "NONE"
 
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = ""
 
 */
 
@@ -80,3 +85,6 @@ parse::email::host("j@example..com");
 parse::email::host("@example.com");
 parse::email::host("j\\@example.com");
 parse::email::host("www.example.com");
+
+"INVALID";
+parse::email::user('\u0000@x.com');

--- a/crates/language-tests/tests/language/functions/parse/email/host.surql
+++ b/crates/language-tests/tests/language/functions/parse/email/host.surql
@@ -87,4 +87,4 @@ parse::email::host("j\\@example.com");
 parse::email::host("www.example.com");
 
 "INVALID";
-parse::email::user('\u0000@x.com');
+parse::email::user('\u0000@example.com');

--- a/crates/language-tests/tests/parsing/strings/unicode_escape_sequence.surql
+++ b/crates/language-tests/tests/parsing/strings/unicode_escape_sequence.surql
@@ -10,7 +10,12 @@ value = "'🜕'"
 [[test.results]]
 value = "'🜕'"
 
+[[test.results]]
+value = ""
+
 */
 "\u{0000B0}";
 "\uD83D\uDF15";
 "\u{1F715}";
+"\u{0000}";
+

--- a/crates/sdk/src/api/value/mod.rs
+++ b/crates/sdk/src/api/value/mod.rs
@@ -26,8 +26,7 @@ pub fn from_value<T: DeserializeOwned>(value: Value) -> Result<T, Error> {
 }
 
 pub fn to_value<T: Serialize + 'static>(value: T) -> Result<Value, Error> {
-	let v = surrealdb_core::sql::to_value(value)?;
-	Ok(Value(v))
+	Ok(Value(surrealdb_core::sql::to_value(value)?))
 }
 
 // Keeping bytes implementation minimal since it might be a good idea to use bytes crate here

--- a/src/net/import.rs
+++ b/src/net/import.rs
@@ -53,9 +53,9 @@ async fn handler(
 		Ok(res) => {
 			match accept.as_deref() {
 				// Simple serialization
-				Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-				Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-				Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+				Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+				Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+				Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 				// Return nothing
 				Some(Accept::ApplicationOctetStream) => Ok(output::none()),
 				// Internal serialization

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -100,9 +100,9 @@ async fn select_all(
 	match db.execute(sql, &session, Some(vars)).await {
 		Ok(res) => match accept.as_deref() {
 			// Simple serialization
-			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-			Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-			Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+			Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+			Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 			// Internal serialization
 			// TODO: remove format in 2.0.0
 			Some(Accept::Surrealdb) => Ok(output::full(&res)),
@@ -152,9 +152,9 @@ async fn create_all(
 			match db.execute(sql, &session, Some(vars)).await {
 				Ok(res) => match accept.as_deref() {
 					// Simple serialization
-					Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-					Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-					Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+					Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+					Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+					Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 					// Internal serialization
 					Some(Accept::Surrealdb) => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -206,9 +206,9 @@ async fn update_all(
 			match db.execute(sql, &session, Some(vars)).await {
 				Ok(res) => match accept.as_deref() {
 					// Simple serialization
-					Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-					Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-					Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+					Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+					Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+					Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 					// Internal serialization
 					Some(Accept::Surrealdb) => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -307,9 +307,9 @@ async fn delete_all(
 	match db.execute(sql, &session, Some(vars)).await {
 		Ok(res) => match accept.as_deref() {
 			// Simple serialization
-			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-			Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-			Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+			Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+			Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 			// Internal serialization
 			Some(Accept::Surrealdb) => Ok(output::full(&res)),
 			// An incorrect content-type was requested
@@ -364,9 +364,9 @@ async fn select_one(
 	match db.execute(sql, &session, Some(vars)).await {
 		Ok(res) => match accept.as_deref() {
 			// Simple serialization
-			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-			Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-			Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+			Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+			Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 			// Internal serialization
 			Some(Accept::Surrealdb) => Ok(output::full(&res)),
 			// An incorrect content-type was requested
@@ -421,9 +421,9 @@ async fn create_one(
 			match db.execute(sql, &session, Some(vars)).await {
 				Ok(res) => match accept.as_deref() {
 					// Simple serialization
-					Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-					Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-					Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+					Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+					Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+					Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 					// Internal serialization
 					Some(Accept::Surrealdb) => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -481,9 +481,9 @@ async fn update_one(
 			match db.execute(sql, &session, Some(vars)).await {
 				Ok(res) => match accept.as_deref() {
 					// Simple serialization
-					Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-					Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-					Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+					Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+					Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+					Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 					// Internal serialization
 					Some(Accept::Surrealdb) => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -541,9 +541,9 @@ async fn modify_one(
 			match db.execute(sql, &session, Some(vars)).await {
 				Ok(res) => match accept.as_deref() {
 					// Simple serialization
-					Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-					Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-					Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+					Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+					Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+					Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 					// Internal serialization
 					Some(Accept::Surrealdb) => Ok(output::full(&res)),
 					// An incorrect content-type was requested
@@ -592,9 +592,9 @@ async fn delete_one(
 	match db.execute(sql, &session, Some(vars)).await {
 		Ok(res) => match accept.as_deref() {
 			// Simple serialization
-			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-			Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-			Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+			Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+			Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 			// Internal serialization
 			Some(Accept::Surrealdb) => Ok(output::full(&res)),
 			// An incorrect content-type was requested

--- a/src/net/output.rs
+++ b/src/net/output.rs
@@ -1,11 +1,11 @@
+use super::headers::Accept;
+use crate::err::Error;
 use axum::response::{IntoResponse, Response};
 use http::header::{HeaderValue, CONTENT_TYPE};
 use http::StatusCode;
 use serde::Serialize;
 use serde_json::Value as Json;
 use surrealdb::sql;
-
-use super::headers::Accept;
 
 pub enum Output {
 	None,
@@ -67,8 +67,8 @@ where
 }
 
 /// Convert and simplify the value into JSON
-pub fn simplify<T: Serialize + 'static>(v: T) -> Json {
-	sql::to_value(v).unwrap().into()
+pub fn simplify<T: Serialize + 'static>(v: T) -> Result<Json, Error> {
+	Ok(sql::to_value(v)?.into())
 }
 
 impl IntoResponse for Output {

--- a/src/net/sql.rs
+++ b/src/net/sql.rs
@@ -55,9 +55,9 @@ async fn post_handler(
 	match db.execute(sql, &session, params.0.parse().into()).await {
 		Ok(res) => match output.as_deref() {
 			// Simple serialization
-			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res))),
-			Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res))),
-			Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res))),
+			Some(Accept::ApplicationJson) => Ok(output::json(&output::simplify(res)?)),
+			Some(Accept::ApplicationCbor) => Ok(output::cbor(&output::simplify(res)?)),
+			Some(Accept::ApplicationPack) => Ok(output::pack(&output::simplify(res)?)),
 			// Internal serialization
 			Some(Accept::Surrealdb) => Ok(output::full(&res)),
 			// An incorrect content-type was requested

--- a/src/rpc/response.rs
+++ b/src/rpc/response.rs
@@ -23,8 +23,9 @@ impl Response {
 	#[inline]
 	pub fn into_value(self) -> Value {
 		let mut value = match self.result {
-			Ok(val) => map! {
-				"result" => Value::from(val),
+			Ok(val) => match Value::try_from(val) {
+				Ok(v) => map! {"result" => v},
+				Err(e) => map!("error" => Value::from(e.to_string())),
 			},
 			Err(err) => map! {
 				"error" => Value::from(err),

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -959,6 +959,16 @@ mod http_integration {
 			assert!(res.is_ok(), "upgrade err: {}", res.unwrap_err());
 		}
 
+		// Test nul character
+		{
+			let res =
+				client.post(url).body("parse::email::user('\\u0000@example.com')").send().await?;
+			assert_eq!(res.status(), 400);
+
+			let body = res.text().await?;
+			assert!(body.contains("contained NUL byte"), "body: {body}");
+		}
+
 		Ok(())
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

`net::output::symplify` and `rpc::response::into_value` are not catching errors if any error occurs during the value conversion or simplification. 

## What does this change do?

Ensure that the error is caught and converted as an error.


## What is your testing strategy?

Github action.
Tests have been added.

## Is this related to any issues?

- [x] Close #4076 

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
