### PR TITLE
Make the default Rust version explicit

### DIFF
--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -37,7 +37,7 @@ on:
       rust_version:
         required: false
         type: string
-        default: "stable"
+        default: "1.85.0"
         description: "The Rust version to use for building binaries"
       onnx_version:
         required: false


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Looks like specifying `stable` for the Rust version when there is already a stable Rust compiler available will end up using that compiler, not the latest stable compiler. 

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It ensures that we use Rust `1.85.0` when building binaries.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
