### PR TITLE
Add more granular publish gates

### DIFF
--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -748,6 +748,7 @@ jobs:
   docker:
     name: Docker images
     needs: [prepare-vars, publish]
+    if: ${{ inputs.publish }}
     uses: ./.github/workflows/docker.yml
     with:
       environment: ${{ inputs.environment }}

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -703,13 +703,14 @@ jobs:
           done
 
       - name: Download artifacts
+        if: ${{ inputs.publish }}
         uses: actions/download-artifact@v4
         with:
           path: artifacts
 
       - name: Publish release
         uses: softprops/action-gh-release@v2
-        if: ${{ inputs.create-release }}
+        if: ${{ inputs.publish && inputs.create-release }}
         with:
           name: "Release ${{ needs.prepare-vars.outputs.git-ref }}"
           tag_name: ${{ needs.prepare-vars.outputs.git-ref }}
@@ -722,13 +723,14 @@ jobs:
 
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v4
+        if: ${{ inputs.publish }}
         with:
           aws-region: us-east-2
           aws-access-key-id: ${{ secrets.AMAZON_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AMAZON_SECRET_KEY }}
 
       - name: Set latest release version
-        if: ${{ inputs.create-release && inputs.latest }}
+        if: ${{ inputs.publish && inputs.create-release && inputs.latest }}
         run: |
           echo ${{ needs.prepare-vars.outputs.git-ref }} > latest.txt
           aws s3 cp --cache-control 'no-store' latest.txt s3://download.surrealdb.com/latest.txt
@@ -740,6 +742,7 @@ jobs:
           aws s3 cp --cache-control 'no-store' ${{ inputs.environment }}.txt s3://download.surrealdb.com/${{ inputs.environment }}.txt
 
       - name: Publish binaries
+        if: ${{ inputs.publish }}
         run: |
           for file in artifacts/**/*.{tgz,txt,exe}; do
             aws s3 cp --cache-control 'no-store' $file s3://download.surrealdb.com/${{ needs.prepare-vars.outputs.name }}/


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

To allow more parts of the release workflows to be tested in dry run mode.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

#5577 made it possible to test more steps but inadvertently left the Docker job not publish-gated.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
