### PR TITLE
Bug - GraphQL- Avoid duplicate id fields

### DIFF
--- a/crates/core/src/gql/tables.rs
+++ b/crates/core/src/gql/tables.rs
@@ -311,6 +311,11 @@ pub async fn process_tbs(
 			let Some(ref kind) = fd.kind else {
 				continue;
 			};
+			if fd.name.is_id() {
+				// We have already defined "id"
+				// so we don't take any new definition for it.
+				continue;
+			};
 			let fd_name = Name::new(fd.name.to_string());
 			let fd_type = kind_to_type(kind.clone(), types)?;
 			table_orderable = table_orderable.item(fd_name.to_string());

--- a/tests/graphql_integration.rs
+++ b/tests/graphql_integration.rs
@@ -337,6 +337,7 @@ mod graphql_integration {
 				.post(sql_url)
 				.body(
 					r#"
+					DEFINE FIELD id ON TABLE foo TYPE string;
                     DEFINE CONFIG GRAPHQL AUTO;
 					DEFINE TABLE foo;
 					DEFINE FIELD val ON foo TYPE string;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

In SurrealDB, every table has an ID, so GraphQL's implementation automatically defines an ID field. If an ID field is defined explicitly, the ID ends up being defined twice, which is not allowed

## What does this change do?

It ignores a duplicate ID definition once the GraphQL schema has been created.

## What is your testing strategy?

Github actions.
A test has been updated.

## Is this related to any issues?


- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
