### PR TITLE
Sdk methods to access Value fields or array indexes

### DIFF
--- a/crates/sdk/src/api/value/mod.rs
+++ b/crates/sdk/src/api/value/mod.rs
@@ -383,6 +383,18 @@ impl Value {
 	}
 
 	/// Returns the value found at a certain field if the Value
+	/// is an Object and the field is present.
+	pub fn field_mut<T: AsRef<str>>(&mut self, v: T) -> Option<&mut Value> {
+		match &mut self.0 {
+			CoreValue::Object(map) => match map.0.get_mut(v.as_ref()) {
+				Some(val) => Some(Value::from_inner_mut(val)),
+				None => None,
+			},
+			_ => None,
+		}
+	}
+
+	/// Returns the value found at a certain index if the Value
 	/// is an Array and a value is found at the index.
 	pub fn index(&self, v: usize) -> Option<&Value> {
 		match &self.0 {
@@ -393,8 +405,19 @@ impl Value {
 			_ => None,
 		}
 	}
-}
 
+	/// Returns the value found at a certain index if the Value
+	/// is an Array and a value is found at the index.
+	pub fn index_mut(&mut self, v: usize) -> Option<&mut Value> {
+		match &mut self.0 {
+			CoreValue::Array(map) => match map.0.get_mut(v) {
+				Some(val) => Some(Value::from_inner_mut(val)),
+				None => None,
+			},
+			_ => None,
+		}
+	}
+}
 
 pub struct ConversionError {
 	from: &'static str,

--- a/crates/sdk/src/api/value/mod.rs
+++ b/crates/sdk/src/api/value/mod.rs
@@ -382,36 +382,12 @@ impl Value {
 		}
 	}
 
-	/// Returns the value found at a certain field if the Value
-	/// is an Object and the field is present.
-	pub fn field_mut<T: AsRef<str>>(&mut self, v: T) -> Option<&mut Value> {
-		match &mut self.0 {
-			CoreValue::Object(map) => match map.0.get_mut(v.as_ref()) {
-				Some(val) => Some(Value::from_inner_mut(val)),
-				None => None,
-			},
-			_ => None,
-		}
-	}
-
 	/// Returns the value found at a certain index if the Value
 	/// is an Array and a value is found at the index.
 	pub fn index(&self, v: usize) -> Option<&Value> {
 		match &self.0 {
 			CoreValue::Array(map) => match map.0.get(v) {
 				Some(val) => Some(Value::from_inner_ref(val)),
-				None => None,
-			},
-			_ => None,
-		}
-	}
-
-	/// Returns the value found at a certain index if the Value
-	/// is an Array and a value is found at the index.
-	pub fn index_mut(&mut self, v: usize) -> Option<&mut Value> {
-		match &mut self.0 {
-			CoreValue::Array(map) => match map.0.get_mut(v) {
-				Some(val) => Some(Value::from_inner_mut(val)),
 				None => None,
 			},
 			_ => None,

--- a/crates/sdk/src/api/value/mod.rs
+++ b/crates/sdk/src/api/value/mod.rs
@@ -369,6 +369,33 @@ impl Value {
 	}
 }
 
+impl Value {
+	/// Returns the value found at a certain field if the Value
+	/// is an Object and the field is present.
+	pub fn field<T: AsRef<str>>(&self, v: T) -> Option<&Value> {
+		match &self.0 {
+			CoreValue::Object(map) => match map.0.get(v.as_ref()) {
+				Some(val) => Some(Value::from_inner_ref(val)),
+				None => None,
+			},
+			_ => None,
+		}
+	}
+
+	/// Returns the value found at a certain field if the Value
+	/// is an Array and a value is found at the index.
+	pub fn index(&self, v: usize) -> Option<&Value> {
+		match &self.0 {
+			CoreValue::Array(map) => match map.0.get(v) {
+				Some(val) => Some(Value::from_inner_ref(val)),
+				None => None,
+			},
+			_ => None,
+		}
+	}
+}
+
+
 pub struct ConversionError {
 	from: &'static str,
 	expected: &'static str,

--- a/crates/sdk/tests/api_integration/basic.rs
+++ b/crates/sdk/tests/api_integration/basic.rs
@@ -1705,10 +1705,11 @@ pub async fn multi_take(new_db: impl CreateDb) {
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
 	drop(permit);
 
-	let mut response = db.query("SELECT b1 FROM CREATE something SET b1.total_peers = 74").await.unwrap();
-    let first: Value = response.take::<Value>(0).unwrap();
-    let inside = first.index(0).unwrap().field("b1").unwrap().field("total_peers").unwrap();
-    assert_eq!(inside, &Value::from_inner(CoreValue::Number(74.into())));
+	let mut response =
+		db.query("SELECT b1 FROM CREATE something SET b1.total_peers = 74").await.unwrap();
+	let first: Value = response.take::<Value>(0).unwrap();
+	let inside = first.index(0).unwrap().field("b1").unwrap().field("total_peers").unwrap();
+	assert_eq!(inside, &Value::from_inner(CoreValue::Number(74.into())));
 }
 
 pub async fn field_and_index_methods(new_db: impl CreateDb) {

--- a/crates/sdk/tests/api_integration/basic.rs
+++ b/crates/sdk/tests/api_integration/basic.rs
@@ -1705,6 +1705,17 @@ pub async fn multi_take(new_db: impl CreateDb) {
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
 	drop(permit);
 
+	let mut response = db.query("SELECT b1 FROM CREATE something SET b1.total_peers = 74").await.unwrap();
+    let first: Value = response.take::<Value>(0).unwrap();
+    let inside = first.index(0).unwrap().field("b1").unwrap().field("total_peers").unwrap();
+    assert_eq!(inside, &Value::from_inner(CoreValue::Number(74.into())));
+}
+
+pub async fn field_and_index_methods(new_db: impl CreateDb) {
+	let (permit, db) = new_db.create_db().await;
+	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+	drop(permit);
+
 	db.query("INSERT INTO user {name: 'John', address: 'USA'};").await.unwrap();
 	db.query("INSERT INTO user {name: 'Adam', address: 'UK'};").await.unwrap();
 

--- a/crates/sdk/tests/api_integration/basic.rs
+++ b/crates/sdk/tests/api_integration/basic.rs
@@ -1705,18 +1705,6 @@ pub async fn multi_take(new_db: impl CreateDb) {
 	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
 	drop(permit);
 
-	let mut response =
-		db.query("SELECT b1 FROM CREATE something SET b1.total_peers = 74").await.unwrap();
-	let first: Value = response.take::<Value>(0).unwrap();
-	let inside = first.index(0).unwrap().field("b1").unwrap().field("total_peers").unwrap();
-	assert_eq!(inside, &Value::from_inner(CoreValue::Number(74.into())));
-}
-
-pub async fn field_and_index_methods(new_db: impl CreateDb) {
-	let (permit, db) = new_db.create_db().await;
-	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
-	drop(permit);
-
 	db.query("INSERT INTO user {name: 'John', address: 'USA'};").await.unwrap();
 	db.query("INSERT INTO user {name: 'Adam', address: 'UK'};").await.unwrap();
 
@@ -1729,6 +1717,18 @@ pub async fn field_and_index_methods(new_db: impl CreateDb) {
 	let mut addresses: Vec<String> = response.take("address").unwrap();
 	addresses.sort();
 	assert_eq!(addresses, vec!["UK".to_owned(), "USA".to_owned()]);
+}
+
+pub async fn field_and_index_methods(new_db: impl CreateDb) {
+	let (permit, db) = new_db.create_db().await;
+	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+	drop(permit);
+
+	let mut response =
+		db.query("SELECT b1 FROM CREATE something SET b1.total_peers = 74").await.unwrap();
+	let first: Value = response.take::<Value>(0).unwrap();
+	let inside = first.index(0).unwrap().field("b1").unwrap().field("total_peers").unwrap();
+	assert_eq!(inside, &Value::from_inner(CoreValue::Number(74.into())));
 }
 
 define_include_tests!(basic => {
@@ -1834,4 +1834,6 @@ define_include_tests!(basic => {
 	run,
 	#[test_log::test(tokio::test)]
 	multi_take,
+	#[test_log::test(tokio::test)]
+	field_and_index_methods,
 });


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

It would be nice to be able to work with a Value in the same way that you can with serde_json which has methods like .get(): https://docs.rs/serde_json/latest/serde_json/enum.Value.html?search=index#method.get

## What does this change do?

The cleanest way seems to be to add two methods, one for field names (if an object) and another for indexes (if an array). There might be a way to do it with a single method but that seems to lead into input arguments like Into<Value> or constructing an enum and a trait and feels like overkill with a lot of conversion into Value first, then matching on variants, as opposed to just doing a single variant check for each method.

Codewise it looks like this but without the sealed trait (could move to a sealed trait for a single method though if that seems better):

https://github.com/serde-rs/json/blob/8a56cfa6d0a93c39ee4ef07d431de0748eed9028/src/value/index.rs#L54

## What is your testing strategy?

Added a test.

## Is this related to any issues?

- [X] No related issues

(But some discussion on Discord)

## Does this change need documentation?

Yes. I'm not entirely sure that this PR will be merged though so will add the documentation if it gets approved.

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
