### PR TITLE
Fix type::thing id convertion for UUID

### DIFF
--- a/crates/core/src/sql/id/mod.rs
+++ b/crates/core/src/sql/id/mod.rs
@@ -84,6 +84,12 @@ impl From<Uuid> for Id {
 	}
 }
 
+impl From<uuid::Uuid> for Id {
+	fn from(v: uuid::Uuid) -> Self {
+		Self::Uuid(v.into())
+	}
+}
+
 impl From<Strand> for Id {
 	fn from(v: Strand) -> Self {
 		Self::String(v.as_string())


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->
Fix a but

## What does this change do?

Fixes uuid converting to sting in `type::thing("table", u"...")`

## What is your testing strategy?

Unit Testing

## Is this related to any issues?

Fixes #5642 

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
