### PR TITLE
Make `INFO FOR TABLE ... STRUCTURE` report `DEFAULT ALWAYS` fields

### DIFF
--- a/crates/core/src/sql/statements/define/field.rs
+++ b/crates/core/src/sql/statements/define/field.rs
@@ -449,6 +449,7 @@ impl InfoStructure for DefineFieldStatement {
 			"kind".to_string(), if let Some(v) = self.kind => v.structure(),
 			"value".to_string(), if let Some(v) = self.value => v.structure(),
 			"assert".to_string(), if let Some(v) = self.assert => v.structure(),
+			"default_always".to_string(), if self.default.is_some() => self.default_always.into(), // Only reported if DEFAULT is also enabled for this field
 			"default".to_string(), if let Some(v) = self.default => v.structure(),
 			"reference".to_string(), if let Some(v) = self.reference => v.structure(),
 			"readonly".to_string() => self.readonly.into(),

--- a/crates/language-tests/tests/language/statements/define/field/basic.surql
+++ b/crates/language-tests/tests/language/statements/define/field/basic.surql
@@ -12,9 +12,13 @@ value = "NONE"
 
 [[test.results]]
 value = "{ events: {  }, fields: { test: 'DEFINE FIELD test ON user PERMISSIONS FULL' }, indexes: {  }, lives: {  }, tables: {  } }"
+[[test.results]]
+value = "{ events: [ ], fields: [ { flex: false, name: 'test', permissions: { create: true, delete: true, select: true, update: true }, readonly: false, what: 'user' } ], indexes: [ ], lives: [ ], tables: [ ] }"
 
 */
 DEFINE FIELD test ON user;
 REMOVE FIELD test ON user;
 DEFINE FIELD test ON TABLE user;
 INFO FOR TABLE user;
+INFO FOR TABLE user STRUCTURE;
+

--- a/crates/language-tests/tests/language/statements/define/field/default_always.surql
+++ b/crates/language-tests/tests/language/statements/define/field/default_always.surql
@@ -7,6 +7,11 @@ value = "NONE"
 value = "NONE"
 
 [[test.results]]
+value = "{ events: { }, fields: { primary: 'DEFINE FIELD primary ON product TYPE number DEFAULT ALWAYS 123.456f PERMISSIONS FULL' }, indexes: { }, lives: { }, tables: { } }"
+[[test.results]]
+value = "{ events: [ ], fields: [ { default: '123.456f', default_always: true, flex: false, kind: 'number', name: 'primary', permissions: { create: true, delete: true, select: true, update: true }, readonly: false, what: 'product' } ], indexes: [ ], lives: [ ], tables: [ ] }"
+
+[[test.results]]
 error = "Found NULL for field `primary`, with record `product:test`, but expected a number"
 
 [[test.results]]
@@ -28,7 +33,7 @@ value = "NONE"
 value = "NONE"
 
 [[test.results]]
-value = "[{ id: post:test, tags: [] }]"
+value = "[{ id: post:test, tags: [ ] }]"
 [[test.results]]
 value = "[{ id: post:test, tags: [{ color: 'red', name: 'test' }] }]"
 [[test.results]]
@@ -39,15 +44,18 @@ value = "[{ id: post:test, tags: [{ color: 'red', name: 'test' }, { color: 'blue
 DEFINE TABLE product SCHEMAFULL;
 DEFINE FIELD primary ON product TYPE number DEFAULT ALWAYS 123.456;
 --
+INFO FOR TABLE product;
+INFO FOR TABLE product STRUCTURE;
+--
 CREATE product:test SET primary = NULL;
 --
 CREATE product:test;
 UPSERT product:test SET primary = 654.321;
 UPSERT product:test SET primary = NONE;
-UPSERT product:test CONTENT {};
+UPSERT product:test CONTENT { };
 --
 DEFINE TABLE post SCHEMAFULL;
-DEFINE FIELD tags ON post TYPE array<object> DEFAULT ALWAYS [];
+DEFINE FIELD tags ON post TYPE array<object> DEFAULT ALWAYS [ ];
 DEFINE FIELD tags.*.color ON post TYPE string DEFAULT ALWAYS 'red';
 DEFINE FIELD tags.*.name ON post TYPE string;
 --

--- a/crates/language-tests/tests/language/statements/define/field/default_value.surql
+++ b/crates/language-tests/tests/language/statements/define/field/default_value.surql
@@ -17,6 +17,11 @@ value = "NONE"
 value = "NONE"
 
 [[test.results]]
+value = "{ events: {  }, fields: { primary: 'DEFINE FIELD primary ON product TYPE number VALUE 123.456f PERMISSIONS FULL', quaternary: 'DEFINE FIELD quaternary ON product TYPE bool VALUE array::all([1, 2]) PERMISSIONS FULL', secondary: 'DEFINE FIELD secondary ON product TYPE bool DEFAULT true VALUE $value PERMISSIONS FULL', tertiary: \"DEFINE FIELD tertiary ON product TYPE string DEFAULT 'hello' VALUE 'tester' PERMISSIONS FULL\" }, indexes: {  }, lives: {  }, tables: {  } }"
+[[test.results]]
+value = "{ events: [], fields: [ { flex: false, kind: 'number', name: 'primary', permissions: { create: true, delete: true, select: true, update: true }, readonly: false, value: '123.456f', what: 'product' }, { flex: false, kind: 'bool', name: 'quaternary', permissions: { create: true, delete: true, select: true, update: true }, readonly: false, value: 'array::all([1, 2])', what: 'product' }, { default: 'true', default_always: false, flex: false, kind: 'bool', name: 'secondary', permissions: { create: true, delete: true, select: true, update: true }, readonly: false, value: '$value', what: 'product' }, { default: \"'hello'\", default_always: false, flex: false, kind: 'string', name: 'tertiary', permissions: { create: true, delete: true, select: true, update: true }, readonly: false, value: \"'tester'\", what: 'product' } ], indexes: [ ], lives: [ ], tables: [ ] }"
+
+[[test.results]]
 error = "Found NULL for field `primary`, with record `product:test`, but expected a number"
 
 [[test.results]]
@@ -44,6 +49,9 @@ DEFINE FIELD primary ON product TYPE number VALUE 123.456;
 DEFINE FIELD secondary ON product TYPE bool DEFAULT true VALUE $value;
 DEFINE FIELD tertiary ON product TYPE string DEFAULT 'hello' VALUE 'tester';
 DEFINE FIELD quaternary ON product TYPE bool VALUE array::all([1, 2]);
+--
+INFO FOR TABLE product;
+INFO FOR TABLE product STRUCTURE;
 --
 CREATE product:test SET primary = NULL;
 CREATE product:test SET secondary = 'oops';


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

See #5727

## What does this change do?

Make `INFO FOR TABLE ... STRUCTURE` report a `default_always` value for fields

## What is your testing strategy?

Added language tests for field definitions for different combinations of `DEFAULT` and `ALWAYS`

## Is this related to any issues?

- [x] Closes #5727

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
