### PR TITLE
Implement on duplicate key update rpc protocol

### DIFF
--- a/crates/core/src/rpc/args.rs
+++ b/crates/core/src/rpc/args.rs
@@ -8,6 +8,7 @@ pub trait Take {
 	fn needs_two(self) -> Result<(Value, Value), RpcError>;
 	fn needs_one_or_two(self) -> Result<(Value, Value), RpcError>;
 	fn needs_one_two_or_three(self) -> Result<(Value, Value, Value), RpcError>;
+	fn needs_two_or_three(self) -> Result<(Value, Value, Value), RpcError>;
 	fn needs_three_or_four(self) -> Result<(Value, Value, Value, Value), RpcError>;
 }
 
@@ -57,6 +58,18 @@ impl Take for Array {
 			(Some(a), Some(b), Some(c)) => Ok((a, b, c)),
 			(Some(a), Some(b), None) => Ok((a, b, Value::None)),
 			(Some(a), None, None) => Ok((a, Value::None, Value::None)),
+			(_, _, _) => Ok((Value::None, Value::None, Value::None)),
+		}
+	}
+	/// Convert the array to two or three arguments
+	fn needs_two_or_three(self) -> Result<(Value, Value, Value), RpcError> {
+		if self.len() < 2 || self.len() > 3 {
+			return Err(RpcError::InvalidParams);
+		}
+		let mut x = self.into_iter();
+		match (x.next(), x.next(), x.next()) {
+			(Some(a), Some(b), Some(c)) => Ok((a, b, c)),
+			(Some(a), Some(b), None) => Ok((a, b, Value::None)),
 			(_, _, _) => Ok((Value::None, Value::None, Value::None)),
 		}
 	}

--- a/crates/core/src/rpc/protocol/v1.rs
+++ b/crates/core/src/rpc/protocol/v1.rs
@@ -18,7 +18,7 @@ use crate::{
 			CreateStatement, DeleteStatement, InsertStatement, KillStatement, LiveStatement,
 			RelateStatement, SelectStatement, UpdateStatement, UpsertStatement,
 		},
-		Array, Fields, Function, Model, Output, Query, Strand, Value,
+		Array, Fields, Function, Idiom, Model, Operator, Output, Query, Strand, Value,
 	},
 };
 
@@ -419,9 +419,21 @@ pub trait RpcProtocolV1: RpcContext {
 			return Err(RpcError::MethodNotAllowed);
 		}
 		// Process the method arguments
-		let Ok((what, data)) = params.needs_two() else {
+		let Ok((what, data, update)) = params.needs_two_or_three() else {
 			return Err(RpcError::InvalidParams);
 		};
+
+		//format for UpdateExpression
+		let update = match update {
+			Value::Object(v) => Some(
+				v.iter()
+					.map(|(key, value)| (Idiom::from(key.clone()), Operator::Equal, value.clone()))
+					.collect::<Vec<_>>(),
+			),
+			Value::None | Value::Null => None,
+			_ => return Err(RpcError::InvalidParams),
+		};
+
 		// Specify the SQL query string
 		let sql = InsertStatement {
 			into: match what.is_none_or_null() {
@@ -429,6 +441,7 @@ pub trait RpcProtocolV1: RpcContext {
 				true => None,
 			},
 			data: crate::sql::Data::SingleExpression(data),
+			update: update.map(crate::sql::Data::UpdateExpression),
 			output: Some(Output::After),
 			..Default::default()
 		}

--- a/crates/core/src/rpc/protocol/v2.rs
+++ b/crates/core/src/rpc/protocol/v2.rs
@@ -18,7 +18,7 @@ use crate::{
 			CreateStatement, DeleteStatement, InsertStatement, KillStatement, LiveStatement,
 			RelateStatement, SelectStatement, UpdateStatement, UpsertStatement,
 		},
-		Array, Fields, Function, Model, Output, Query, Strand, Value,
+		Array, Fields, Function, Idiom, Model, Operator, Output, Query, Strand, Value,
 	},
 };
 
@@ -419,9 +419,21 @@ pub trait RpcProtocolV2: RpcContext {
 			return Err(RpcError::MethodNotAllowed);
 		}
 		// Process the method arguments
-		let Ok((what, data)) = params.needs_two() else {
+		let Ok((what, data, update)) = params.needs_two_or_three() else {
 			return Err(RpcError::InvalidParams);
 		};
+
+		//format for UpdateExpression
+		let update = match update {
+			Value::Object(v) => Some(
+				v.iter()
+					.map(|(key, value)| (Idiom::from(key.clone()), Operator::Equal, value.clone()))
+					.collect::<Vec<_>>(),
+			),
+			Value::None | Value::Null => None,
+			_ => return Err(RpcError::InvalidParams),
+		};
+
 		// Specify the SQL query string
 		let sql = InsertStatement {
 			into: match what.is_none_or_null() {
@@ -429,6 +441,7 @@ pub trait RpcProtocolV2: RpcContext {
 				true => None,
 			},
 			data: crate::sql::Data::SingleExpression(data),
+			update: update.map(crate::sql::Data::UpdateExpression),
 			output: Some(Output::After),
 			..Default::default()
 		}

--- a/crates/core/src/rpc/protocol/v2.rs
+++ b/crates/core/src/rpc/protocol/v2.rs
@@ -427,7 +427,20 @@ pub trait RpcProtocolV2: RpcContext {
 		let update = match update {
 			Value::Object(v) => Some(
 				v.iter()
-					.map(|(key, value)| (Idiom::from(key.clone()), Operator::Equal, value.clone()))
+					.map(|(key, value)| match value {
+						//check for optional Operator or default to Operator::Equal
+						Value::Array(arr) if arr.len() == 2 => match &arr[0] {
+							Value::Strand(op) => match op.as_str() {
+								"=" => (Idiom::from(key.clone()), Operator::Equal, arr[1].clone()),
+								"-=" => (Idiom::from(key.clone()), Operator::Dec, arr[1].clone()),
+								"+=" => (Idiom::from(key.clone()), Operator::Inc, arr[1].clone()),
+								"+?=" => (Idiom::from(key.clone()), Operator::Ext, arr[1].clone()),
+								_ => (Idiom::from(key.clone()), Operator::Equal, value.clone()),
+							},
+							_ => (Idiom::from(key.clone()), Operator::Equal, value.clone()),
+						},
+						_ => (Idiom::from(key.clone()), Operator::Equal, value.clone()),
+					})
 					.collect::<Vec<_>>(),
 			),
 			Value::None | Value::Null => None,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

ON DUPLICATE KEY UPDATE is a powerful way to reduce requests to server and combine insert and update. This PR intergrates update for RPC to increase request efficiency.

## What does this change do?

It adds an optional paramter update. This paramter is translated into crate::sql::Data::UpdateExpression.
```javascript
{
   field: 1
   field: 2
}
```
translates to
```sql
field = 1, field = 2
```

As seen this automtically defaults to the opertor Equal. The last [Commit d2b9b02](https://github.com/surrealdb/surrealdb/commit/d2b9b02aad3ca58cb5b0814a2cc35c5336836a60) adds functionality to define other operators like "=", "+=", "-=" or "+?=" (optional).

```javascript
{
   field1: [ "+=", 1]
   field2: [ "=", 2]
}
```
translates to
```sql
field += 1, field = 2
```

Mixed: defined or not is also accepted
```javascript
{
   field1: [ "+=", 1]
   field2: 2
}
```
translates to
```sql
field += 1, field = 2
```

> [!WARNING]
>  I can revert the support for "+=", "-=" or "+?=" and only allow the first case (always default to Equal) if wanted

## What is your testing strategy?

Dont know where rpc tests are, will add if someone tells me.

## Is this related to any issues?

I dont know

- [ ] No related issues

## Does this change need documentation?

Will add that tomorrow

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
