### PR TITLE
Concurrent indexing by default

### DIFF
--- a/crates/core/src/err/mod.rs
+++ b/crates/core/src/err/mod.rs
@@ -1014,6 +1014,10 @@ pub enum Error {
 		name: String,
 	},
 
+	/// A database index entry for the specified table is already building
+	#[error("Index building has been cancelled")]
+	IndexingBuildingCancelled,
+
 	/// The token has expired
 	#[error("The token has expired")]
 	ExpiredToken,

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -30,7 +30,7 @@ use tokio::task::JoinHandle;
 #[derive(Debug, Clone)]
 pub(crate) enum BuildingStatus {
 	Started,
-	RemoveData,
+	Clean,
 	Indexing {
 		initial: Option<usize>,
 		updated: Option<usize>,
@@ -76,7 +76,7 @@ impl From<BuildingStatus> for Value {
 		let mut o = Object::default();
 		let s = match st {
 			BuildingStatus::Started => "started",
-			BuildingStatus::RemoveData => "remove_data",
+			BuildingStatus::Clean => "clean",
 			BuildingStatus::Indexing {
 				initial,
 				pending,
@@ -407,7 +407,7 @@ impl Building {
 		let (ns, db) = self.opt.ns_db()?;
 		// Remove the index data
 		{
-			self.set_status(BuildingStatus::RemoveData).await;
+			self.set_status(BuildingStatus::Clean).await;
 			let ctx = self.new_write_tx_ctx().await?;
 			let key = crate::key::index::all::new(ns, db, &self.tb, &self.ix.name);
 			let tx = ctx.tx();

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -30,7 +30,7 @@ use tokio::task::JoinHandle;
 #[derive(Debug, Clone)]
 pub(crate) enum BuildingStatus {
 	Started,
-	Clean,
+	Cleaning,
 	Indexing {
 		initial: Option<usize>,
 		updated: Option<usize>,
@@ -76,7 +76,7 @@ impl From<BuildingStatus> for Value {
 		let mut o = Object::default();
 		let s = match st {
 			BuildingStatus::Started => "started",
-			BuildingStatus::Clean => "clean",
+			BuildingStatus::Cleaning => "cleaning",
 			BuildingStatus::Indexing {
 				initial,
 				pending,
@@ -407,7 +407,7 @@ impl Building {
 		let (ns, db) = self.opt.ns_db()?;
 		// Remove the index data
 		{
-			self.set_status(BuildingStatus::Clean).await;
+			self.set_status(BuildingStatus::Cleaning).await;
 			let ctx = self.new_write_tx_ctx().await?;
 			let key = crate::key::index::all::new(ns, db, &self.tb, &self.ix.name);
 			let tx = ctx.tx();

--- a/crates/core/src/sql/statements/define/index.rs
+++ b/crates/core/src/sql/statements/define/index.rs
@@ -1,4 +1,6 @@
 use crate::ctx::Context;
+#[cfg(target_family = "wasm")]
+use crate::dbs::Force;
 use crate::dbs::Options;
 use crate::doc::CursorDoc;
 use crate::err::Error;
@@ -14,6 +16,8 @@ use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
+#[cfg(target_family = "wasm")]
+use std::sync::Arc;
 use uuid::Uuid;
 
 #[revisioned(revision = 4)]

--- a/crates/core/src/sql/statements/define/index.rs
+++ b/crates/core/src/sql/statements/define/index.rs
@@ -8,7 +8,7 @@ use crate::iam::{Action, ResourceKind};
 use crate::sql::statements::info::InfoStructure;
 use crate::sql::statements::DefineTableStatement;
 #[cfg(target_family = "wasm")]
-use crate::sql::statements::UpdateStatement;
+use crate::sql::statements::{RemoveIndexStatement, UpdateStatement};
 use crate::sql::{Base, Ident, Idioms, Index, Part, Strand, Value};
 #[cfg(target_family = "wasm")]
 use crate::sql::{Output, Values};

--- a/crates/core/src/syn/parser/mod.rs
+++ b/crates/core/src/syn/parser/mod.rs
@@ -8,15 +8,15 @@
 //!
 //! There are a bunch of common patterns for which this module has some confinence functions.
 //! - Whenever only one token can be next you should use the `expected!` macro. This macro
-//!     ensures that the given token type is next and if not returns a parser error.
+//!   ensures that the given token type is next and if not returns a parser error.
 //! - Whenever a limited set of tokens can be next it is common to match the token kind and then
-//!     have a catch all arm which calles the macro `unexpected!`. This macro will raise an parse
-//!     error with information about the type of token it recieves and what it expected.
+//!   have a catch all arm which calles the macro `unexpected!`. This macro will raise an parse
+//!   error with information about the type of token it recieves and what it expected.
 //! - If a single token can be optionally next use [`Parser::eat`] this function returns a bool
-//!     depending on if the given tokenkind was eaten.
+//!   depending on if the given tokenkind was eaten.
 //! - If a closing delimiting token is expected use `Parser::expect_closing_delimiter`. This
-//!     function will raise an error if the expected delimiter isn't the next token. This error will
-//!     also point to which delimiter the parser expected to be closed.
+//!   function will raise an error if the expected delimiter isn't the next token. This error will
+//!   also point to which delimiter the parser expected to be closed.
 //!
 //! ## Far Token Peek
 //!

--- a/crates/sdk/src/api/engine/remote/ws/native.rs
+++ b/crates/sdk/src/api/engine/remote/ws/native.rs
@@ -224,13 +224,11 @@ async fn router_handle_route(
 		} => {
 			state.replay.insert(ReplayMethod::Signin, command.clone());
 		}
-		Command::Invalidate {
-			..
-		} => {
+		Command::Invalidate => {
 			state.replay.insert(ReplayMethod::Invalidate, command.clone());
 		}
 		Command::Authenticate {
-			..
+			token: _,
 		} => {
 			state.replay.insert(ReplayMethod::Authenticate, command.clone());
 		}

--- a/crates/sdk/tests/define.rs
+++ b/crates/sdk/tests/define.rs
@@ -226,6 +226,10 @@ async fn define_statement_index_concurrently_building_status(
 							info!("Started");
 							continue;
 						}
+						"cleaning" => {
+							info!("Cleaning");
+							continue;
+						}
 						"indexing" => {
 							{
 								if new_initial != initial_count {

--- a/crates/sdk/tests/rebuild.rs
+++ b/crates/sdk/tests/rebuild.rs
@@ -30,9 +30,9 @@ async fn rebuild_index_statement() -> Result<(), Error> {
 	let ses = Session::owner().with_ns("test").with_db("test");
 	let res = &mut dbs.execute(sql, &ses, None).await?;
 	assert_eq!(res.len(), 14);
-	for _ in 0..3 {
+	for i in 0..3 {
 		let tmp = res.remove(0).result;
-		tmp.unwrap();
+		tmp.expect(i.to_string().as_str());
 	}
 	// Check infos output
 	let tmp = res.remove(0).result?;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The current index creation builds the index within a single transaction, performing an UPDATE operation.
The transaction read and write set can be very large, using either a lot of memory or file space depending on the storage engine.
This UPDATE operation loads every record in a memory-based result set.
Index creation can lead to an OOM error or a large amount of temporary file usage

## What does this change do?

#4480 introduced a concurrent way of building the index. The index is built concurrently using batches of records, with each batch using a transaction to limit memory consumption.

This PR replaces the previous behavior by using the concurrent indexing implementation.

## What is your testing strategy?

GitHub Actions.
Existing tests are sufficient.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
