### PR TITLE
Add profiling build profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,11 @@ strip = false
 [profile.make]
 inherits = "dev"
 
+[profile.profiling]
+inherits = "release"
+strip = false
+debug = true
+
 [dependencies]
 # workspace internal dependencies
 surrealdb = { workspace = true, features = ["protocol-http", "protocol-ws", "rustls"] }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

It's useful to have a separate build profile specifically for profiling which inherits from the release profile but with debug info preserved.

> [!WARNING]
No details provided.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

> [!WARNING]
> No details provided.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
