### PR TITLE
Remove `any_ascii` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,12 +196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "any_ascii"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea50b14b7a4b9343f8c627a7a53c52076482bd4bdad0a24fd3ec533ed616cc2c"
-
-[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,11 +2987,11 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexicmp"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7378d131ddf24063b32cbd7e91668d183140c4b3906270635a4d633d1068ea5d"
+checksum = "0e8f89da8fd95c4eb6274e914694bea90c7826523b26f2a2fd863d44b9d42c43"
 dependencies = [
- "any_ascii",
+ "deunicode",
 ]
 
 [[package]]
@@ -5704,7 +5698,6 @@ dependencies = [
  "affinitypool",
  "ahash 0.8.11",
  "ammonia",
- "any_ascii",
  "arbitrary",
  "argon2",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ indxdb = "0.6.0"
 ipnet = "2.9.0"
 ## Somewhat a surreal crate as it is maintained by @Delskayn.
 js = { version = "0.9.0", package = "rquickjs" }
-lexicmp = "0.1.0"
+lexicmp = "0.2.0"
 ## Also maintained by @Delskayn
 reblessive = "0.4.3"
 revision = "0.11.0"
@@ -50,7 +50,6 @@ ammonia = "4.0.0"
 arbitrary = "1.3.2"
 argon2 = "0.5.2"
 arrayvec = "0.7.6"
-ascii = { version = "0.3.2", package = "any_ascii" }
 async-channel = "2.3.1"
 async-executor = "1.13.1"
 async-graphql = { version = "7.0.9", default-features = false }
@@ -65,7 +64,7 @@ cedar-policy = "2.4.2"
 chrono = "0.4.38"
 ciborium = "0.2.1"
 dashmap = "5.5.3"
-deunicode = "1.4.1"
+deunicode = "1.6.1"
 ext-sort = "^0.1.4"
 fst = "0.4.7"
 futures = "0.3.30"

--- a/cackle.toml
+++ b/cackle.toml
@@ -880,9 +880,6 @@ allow_unsafe = true
 [pkg.half]
 allow_unsafe = true
 
-[pkg.any_ascii]
-allow_unsafe = true
-
 [pkg.zeroize]
 allow_unsafe = true
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -76,7 +76,6 @@ addr.workspace = true
 ahash.workspace = true
 ammonia.workspace = true
 argon2.workspace = true
-ascii.workspace = true
 async-channel.workspace = true
 async-executor.workspace = true
 async-graphql = { workspace = true, default-features = false, features = ["dynamic-schema"] }

--- a/crates/core/src/fnc/util/string/slug.rs
+++ b/crates/core/src/fnc/util/string/slug.rs
@@ -1,19 +1,19 @@
-use ascii::any_ascii as ascii;
+use deunicode::deunicode;
 use regex::Regex;
 use std::sync::LazyLock;
 
-static SIMPLES: LazyLock<Regex> = LazyLock::new(|| Regex::new("[^a-z0-9-_]").unwrap());
+static ALLOWED: LazyLock<Regex> = LazyLock::new(|| Regex::new("[^a-z0-9-_]").unwrap());
 static HYPHENS: LazyLock<Regex> = LazyLock::new(|| Regex::new("-+").unwrap());
 
 pub fn slug<S: AsRef<str>>(s: S) -> String {
 	// Get a reference
 	let s = s.as_ref();
 	// Convert unicode to ascii
-	let mut s = ascii(s);
+	let mut s = deunicode(s);
 	// Convert string to lowercase
 	s.make_ascii_lowercase();
 	// Replace any non-simple characters
-	let s = SIMPLES.replace_all(s.as_ref(), "-");
+	let s = ALLOWED.replace_all(s.as_ref(), "-");
 	// Replace any duplicated hyphens
 	let s = HYPHENS.replace_all(s.as_ref(), "-");
 	// Remove any surrounding hyphens

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -225,7 +225,7 @@ end = "2025-01-24"
 criteria = "safe-to-deploy"
 user-id = 145457 # Tobie Morgan Hitchcock (tobiemh)
 start = "2023-03-26"
-end = "2025-01-24"
+end = "2026-04-11"
 
 [[trusted.libc]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -95,10 +95,6 @@ criteria = "safe-to-deploy"
 version = "3.0.7"
 criteria = "safe-to-deploy"
 
-[[exemptions.any_ascii]]
-version = "0.3.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.approx]]
 version = "0.4.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -255,8 +255,8 @@ user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.lexicmp]]
-version = "0.1.0"
-when = "2023-03-26"
+version = "0.2.0"
+when = "2025-04-11"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

We currently make use of `deunicode` and `any_ascii` which server the same use. These both bundle large amounts of ascii conversion data, increasing the final bundle size of the database.

## What does this change do?

This change updates `lexicmp` to use `deunicode` crate, and removes the use of `any_ascii` in the source code, so that the more up-to-date `deunicode` is used for ascii conversion in all places.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
