### PR TITLE
Remove incorrectly named, deprecated schemes

### DIFF
--- a/crates/sdk/src/api/engine/local/mod.rs
+++ b/crates/sdk/src/api/engine/local/mod.rs
@@ -369,11 +369,6 @@ pub struct FDb;
 #[derive(Debug)]
 pub struct SurrealKv;
 
-/// SurrealKV database
-#[deprecated(note = "Incorrect case, use SurrealKv instead")]
-#[cfg(feature = "kv-surrealkv")]
-pub type SurrealKV = SurrealKv;
-
 /// SurrealCS database
 ///
 /// # Examples
@@ -409,11 +404,6 @@ pub type SurrealKV = SurrealKv;
 #[cfg_attr(docsrs, doc(cfg(feature = "kv-surrealcs")))]
 #[derive(Debug)]
 pub struct SurrealCs;
-
-/// SurrealCS database
-#[deprecated(note = "Incorrect case, use SurrealCs instead")]
-#[cfg(feature = "kv-surrealcs")]
-pub type SurrealCS = SurrealCs;
 
 /// An embedded database
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Some Rust SDK engine schemes were incorrectly named, and thus deprecated shortly afterwards.

## What does this change do?

This removes the schemes completely.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
