### PR TITLE
Allowed paths must be canonicalized

### DIFF
--- a/crates/core/src/iam/file.rs
+++ b/crates/core/src/iam/file.rs
@@ -42,8 +42,9 @@ pub(crate) fn extract_allowed_paths(input: &str) -> Vec<PathBuf> {
 				None
 			} else {
 				let path = PathBuf::from(trimmed).clean();
-				debug!("Allowed file path: {}", path.to_string_lossy());
-				Some(path)
+				let canonical_path = fs::canonicalize(path).expect("failed to get canonical path");
+				debug!("Allowed file path: {}", canonical_path.to_string_lossy());
+				Some(canonical_path)
 			}
 		})
 		.collect()


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When a file is checked against the allowlist, it gets canonicalised, but the allowlist itself does not canonicalize specified paths configured via `SURREAL_FILE_ALLOWLIST` env var. This can cause issues. For example tmp files on macOS are created in `/var/folders/...` but when canonicalized it's actually `/private/var/folders/...`, and the check that basically does prefix match on paths fails for the files that should be allowed. 

## What does this change do?

Both the allowed paths and the paths being checked must be canonicalized.

> [!WARNING]
> No details provided.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
