### PR TITLE
Ensure a checksum is generated for Windows binaries

### DIFF
--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -435,9 +435,6 @@ jobs:
             build-step: |
               set -x
 
-              echo foo > bar.txt
-              echo $(certutil -hashfile bar.txt SHA256 | sed -n '2p')
-
               # Prepare deps
               vcpkg integrate install
 

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -452,7 +452,7 @@ jobs:
               # Package
               ./target/x86_64-pc-windows-msvc/release/surreal.exe version
               cp target/x86_64-pc-windows-msvc/release/surreal.exe surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe
-              echo $(certutil -hashfile surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe SHA256 | cut -f1 -d' ') > surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.txt
+              echo $(certutil -hashfile surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe SHA256 | cut -f2 -d"'") > surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.txt
 
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -452,7 +452,7 @@ jobs:
               # Package
               ./target/x86_64-pc-windows-msvc/release/surreal.exe version
               cp target/x86_64-pc-windows-msvc/release/surreal.exe surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe
-              echo $(certutil -hashfile surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe SHA256 | cut -f2 -d"'") > surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.txt
+              echo $(certutil -hashfile surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe SHA256 | sed -n '2p') > surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.txt
 
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -437,6 +437,7 @@ jobs:
 
               # Prepare deps
               vcpkg integrate install
+              vcpkg install shasum
 
               # Build
               features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -437,7 +437,6 @@ jobs:
 
               # Prepare deps
               vcpkg integrate install
-              vcpkg install shasum
 
               # Build
               features=storage-tikv,http-compression,jwks,${{ inputs.extra-features }}
@@ -453,7 +452,7 @@ jobs:
               # Package
               ./target/x86_64-pc-windows-msvc/release/surreal.exe version
               cp target/x86_64-pc-windows-msvc/release/surreal.exe surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe
-              echo $(shasum -a 256 surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe | cut -f1 -d' ') > surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.txt
+              echo $(certutil -hashfile surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.exe SHA256 | cut -f1 -d' ') > surreal-${{ needs.prepare-vars.outputs.name }}.windows-amd64.txt
 
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -435,6 +435,9 @@ jobs:
             build-step: |
               set -x
 
+              echo foo > bar.txt
+              echo $(certutil -hashfile bar.txt SHA256 | sed -n '2p')
+
               # Prepare deps
               vcpkg integrate install
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Currently trying to generate a checksum for Windows binaries runs into this error:

```
shasum: command not found
```

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It avoids this problem by switching to `certutil`, a builtin Windows command.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
