### PR TITLE
Support `INFO FOR` as a subquery

### DIFF
--- a/crates/core/src/sql/block.rs
+++ b/crates/core/src/sql/block.rs
@@ -18,6 +18,7 @@ use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter, Write};
 use std::ops::Deref;
 
+use super::statements::InfoStatement;
 use super::FlowResult;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Block";
@@ -120,6 +121,9 @@ impl Block {
 				Entry::Alter(v) => {
 					v.compute(stk, &ctx, opt, doc).await?;
 				}
+				Entry::Info(v) => {
+					v.compute(stk, &ctx, opt, doc).await?;
+				}
 				Entry::Value(v) => {
 					if i == self.len() - 1 {
 						// If the last entry then return the value
@@ -187,7 +191,7 @@ impl InfoStructure for Block {
 	}
 }
 
-#[revisioned(revision = 4)]
+#[revisioned(revision = 5)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
@@ -214,6 +218,8 @@ pub enum Entry {
 	Upsert(UpsertStatement),
 	#[revision(start = 4)]
 	Alter(AlterStatement),
+	#[revision(start = 5)]
+	Info(InfoStatement),
 }
 
 impl PartialOrd for Entry {
@@ -246,6 +252,7 @@ impl Entry {
 			Self::Continue(v) => v.writeable(),
 			Self::Foreach(v) => v.writeable(),
 			Self::Alter(v) => v.writeable(),
+			Self::Info(v) => v.writeable(),
 		}
 	}
 }
@@ -272,6 +279,7 @@ impl Display for Entry {
 			Self::Continue(v) => write!(f, "{v}"),
 			Self::Foreach(v) => write!(f, "{v}"),
 			Self::Alter(v) => write!(f, "{v}"),
+			Self::Info(v) => write!(f, "{v}"),
 		}
 	}
 }

--- a/crates/core/src/sql/statements/foreach.rs
+++ b/crates/core/src/sql/statements/foreach.rs
@@ -108,6 +108,7 @@ impl ForeachStatement {
 					Entry::Alter(v) => Ok(v.compute(stk, &ctx, opt, doc).await?),
 					Entry::Rebuild(v) => Ok(v.compute(stk, &ctx, opt, doc).await?),
 					Entry::Remove(v) => Ok(v.compute(&ctx, opt, doc).await?),
+					Entry::Info(v) => Ok(v.compute(stk, &ctx, opt, doc).await?),
 					Entry::Output(v) => {
 						return stk.run(|stk| v.compute(stk, &ctx, opt, doc)).await;
 					}

--- a/crates/core/src/sql/statements/info.rs
+++ b/crates/core/src/sql/statements/info.rs
@@ -41,6 +41,10 @@ pub enum InfoStatement {
 }
 
 impl InfoStatement {
+	/// Check if we require a writeable transaction
+	pub(crate) fn writeable(&self) -> bool {
+		false
+	}
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,

--- a/crates/core/src/sql/subquery.rs
+++ b/crates/core/src/sql/subquery.rs
@@ -14,11 +14,12 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::{self, Display, Formatter};
 
+use super::statements::InfoStatement;
 use super::FlowResult;
 
 pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Subquery";
 
-#[revisioned(revision = 4)]
+#[revisioned(revision = 5)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename = "$surrealdb::private::sql::Subquery")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -41,6 +42,8 @@ pub enum Subquery {
 	Upsert(UpsertStatement),
 	#[revision(start = 4)]
 	Alter(AlterStatement),
+	#[revision(start = 5)]
+	Info(InfoStatement),
 }
 
 impl PartialOrd for Subquery {
@@ -68,6 +71,7 @@ impl Subquery {
 			Self::Remove(v) => v.writeable(),
 			Self::Rebuild(v) => v.writeable(),
 			Self::Alter(v) => v.writeable(),
+			Self::Info(v) => v.writeable(),
 		}
 	}
 
@@ -102,6 +106,7 @@ impl Subquery {
 			Self::Relate(ref v) => v.compute(stk, &ctx, opt, doc).await?,
 			Self::Insert(ref v) => v.compute(stk, &ctx, opt, doc).await?,
 			Self::Alter(ref v) => v.compute(stk, &ctx, opt, doc).await?,
+			Self::Info(ref v) => v.compute(stk, &ctx, opt, doc).await?,
 		};
 
 		Ok(res)
@@ -124,6 +129,7 @@ impl Display for Subquery {
 			Self::Remove(v) => write!(f, "({v})"),
 			Self::Rebuild(v) => write!(f, "({v})"),
 			Self::Alter(v) => write!(f, "({v})"),
+			Self::Info(v) => write!(f, "({v})"),
 			Self::Ifelse(v) => Display::fmt(v, f),
 		}
 	}

--- a/crates/core/src/syn/parser/prime.rs
+++ b/crates/core/src/syn/parser/prime.rs
@@ -96,9 +96,8 @@ impl Parser<'_> {
 			| t!("RELATE")
 			| t!("DEFINE")
 			| t!("REMOVE")
-			| t!("REBUILD") => {
-				self.parse_inner_subquery(ctx, None).await.map(|x| Value::Subquery(Box::new(x)))
-			}
+			| t!("REBUILD")
+			| t!("INFO") => self.parse_inner_subquery(ctx, None).await.map(|x| Value::Subquery(Box::new(x))),
 			t!("fn") => {
 				self.pop_peek();
 				let value =
@@ -327,7 +326,8 @@ impl Parser<'_> {
 			| t!("RELATE")
 			| t!("DEFINE")
 			| t!("REMOVE")
-			| t!("REBUILD") => {
+			| t!("REBUILD")
+			| t!("INFO") => {
 				self.parse_inner_subquery(ctx, None).await.map(|x| Value::Subquery(Box::new(x)))?
 			}
 			t!("fn") => {
@@ -573,6 +573,11 @@ impl Parser<'_> {
 				let stmt = self.parse_rebuild_stmt()?;
 				Subquery::Rebuild(stmt)
 			}
+			t!("INFO") => {
+				self.pop_peek();
+				let stmt = ctx.run(|ctx| self.parse_info_stmt(ctx)).await?;
+				Subquery::Info(stmt)
+			}
 			TokenKind::Digits | TokenKind::Glued(Glued::Number) | t!("+") | t!("-") => {
 				if self.glue_and_peek1()?.kind == t!(",") {
 					let number_span = self.peek().span;
@@ -686,6 +691,11 @@ impl Parser<'_> {
 				self.pop_peek();
 				let stmt = self.parse_rebuild_stmt()?;
 				Subquery::Rebuild(stmt)
+			}
+			t!("INFO") => {
+				self.pop_peek();
+				let stmt = ctx.run(|ctx| self.parse_info_stmt(ctx)).await?;
+				Subquery::Info(stmt)
 			}
 			_ => {
 				let value = ctx.run(|ctx| self.parse_value_inherit(ctx)).await?;

--- a/crates/core/src/syn/parser/stmt/mod.rs
+++ b/crates/core/src/syn/parser/stmt/mod.rs
@@ -303,6 +303,10 @@ impl Parser<'_> {
 				self.pop_peek();
 				self.parse_upsert_stmt(ctx).await.map(Entry::Upsert)
 			}
+			t!("INFO") => {
+				self.pop_peek();
+				self.parse_info_stmt(ctx).await.map(Entry::Info)
+			}
 			_ => {
 				// TODO: Provide information about keywords.
 				let v = ctx.run(|ctx| self.parse_value_inherit(ctx)).await?;

--- a/crates/core/src/syn/parser/stmt/relate.rs
+++ b/crates/core/src/syn/parser/stmt/relate.rs
@@ -99,9 +99,8 @@ impl Parser<'_> {
 			| t!("DEFINE")
 			| t!("ALTER")
 			| t!("REMOVE")
-			| t!("REBUILD") => {
-				self.parse_inner_subquery(ctx, None).await.map(|x| Value::Subquery(Box::new(x)))
-			}
+			| t!("REBUILD")
+			| t!("INFO") => self.parse_inner_subquery(ctx, None).await.map(|x| Value::Subquery(Box::new(x))),
 			t!("IF") => {
 				self.pop_peek();
 				ctx.run(|ctx| self.parse_if_stmt(ctx))

--- a/crates/core/src/syn/parser/token.rs
+++ b/crates/core/src/syn/parser/token.rs
@@ -87,7 +87,7 @@ impl Parser<'_> {
 				| t!("DEFINE")
 				| t!("REMOVE")
 				| t!("REBUILD")
-				| t!("IF")
+				| t!("IF") | t!("INFO")
 		)
 	}
 

--- a/crates/language-tests/Cargo.lock
+++ b/crates/language-tests/Cargo.lock
@@ -166,12 +166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "any_ascii"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea50b14b7a4b9343f8c627a7a53c52076482bd4bdad0a24fd3ec533ed616cc2c"
-
-[[package]]
 name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,10 +1060,11 @@ dependencies = [
 
 [[package]]
 name = "dmp"
-version = "0.2.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaa1135a34d26e5cc5b4927a8935af887d4f30a5653a797c33b9a4222beb6d9"
+checksum = "bb2dfc7a18dffd3ef60a442b72a827126f1557d914620f8fc4d1049916da43c1"
 dependencies = [
+ "trice",
  "urlencoding",
 ]
 
@@ -1958,11 +1953,11 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexicmp"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7378d131ddf24063b32cbd7e91668d183140c4b3906270635a4d633d1068ea5d"
+checksum = "0e8f89da8fd95c4eb6274e914694bea90c7826523b26f2a2fd863d44b9d42c43"
 dependencies = [
- "any_ascii",
+ "deunicode",
 ]
 
 [[package]]
@@ -2659,18 +2654,6 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55a1aa7668676bb93926cd4e9cdfe60f03bb866553bcca9112554911b6d3dc"
-dependencies = [
- "ahash 0.8.11",
- "equivalent",
- "hashbrown 0.14.5",
- "parking_lot",
-]
-
-[[package]]
-name = "quick_cache"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f8ed0655cbaf18a26966142ad23b95d8ab47221c50c4f73a1db7d0d2d6e3da8"
@@ -2998,16 +2981,6 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
-]
-
-[[package]]
-name = "rmpv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58450723cd9ee93273ce44a20b6ec4efe17f8ed2e3631474387bfdecf18bb2a9"
-dependencies = [
- "num-traits",
- "rmp",
 ]
 
 [[package]]
@@ -3584,13 +3557,12 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb-core"
-version = "2.3.0"
+version = "3.0.0"
 dependencies = [
  "addr",
  "affinitypool",
  "ahash 0.8.11",
  "ammonia",
- "any_ascii",
  "argon2",
  "async-channel",
  "async-executor",
@@ -3634,7 +3606,7 @@ dependencies = [
  "pharos",
  "phf",
  "pin-project-lite",
- "quick_cache 0.5.2",
+ "quick_cache",
  "radix_trie",
  "rand 0.8.5",
  "rayon",
@@ -3642,7 +3614,6 @@ dependencies = [
  "regex",
  "revision 0.11.0",
  "ring",
- "rmpv",
  "roaring",
  "rocksdb",
  "rquickjs",
@@ -3690,7 +3661,7 @@ dependencies = [
  "getrandom 0.2.15",
  "lru",
  "parking_lot",
- "quick_cache 0.6.12",
+ "quick_cache",
  "revision 0.10.0",
  "vart 0.9.2",
 ]

--- a/crates/language-tests/tests/language/statements/info/subquery.surql
+++ b/crates/language-tests/tests/language/statements/info/subquery.surql
@@ -1,0 +1,16 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "{ test: 'DEFINE TABLE test TYPE NORMAL SCHEMAFULL PERMISSIONS NONE' }"
+
+[[test.results]]
+value = "[{ drop: false, full: true, kind: { kind: 'NORMAL' }, name: 'test', permissions: { create: false, delete: false, select: false, update: false } }]"
+
+*/
+DEFINE TABLE OVERWRITE test SCHEMAFULL;
+(INFO FOR DB).tables;
+(INFO FOR DB STRUCTURE).tables;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See https://github.com/surrealdb/surrealdb/issues/2151.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Allows `INFO FOR` to appear as a subquery.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Adds a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #2151
- [x] Fixes #2839
- [x] Closes #5367 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Yep

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
