### PR TITLE
Fix ns, ds, and tb ID persistence.

### DIFF
--- a/crates/core/src/sql/statements/define/database.rs
+++ b/crates/core/src/sql/statements/define/database.rs
@@ -55,10 +55,10 @@ impl DefineDatabaseStatement {
 		txn.set(
 			key,
 			revision::to_vec(&DefineDatabaseStatement {
-				id: if self.id.is_none() && nsv.id.is_some() {
-					Some(txn.lock().await.get_next_db_id(nsv.id.unwrap()).await?)
-				} else {
-					None
+				id: match (self.id, nsv.id) {
+					(Some(id), _) => Some(id),
+					(None, Some(nsv_id)) => Some(txn.lock().await.get_next_db_id(nsv_id).await?),
+					(None, None) => None,
 				},
 				// Don't persist the `IF NOT EXISTS` clause to schema
 				if_not_exists: false,

--- a/crates/core/src/sql/statements/define/namespace.rs
+++ b/crates/core/src/sql/statements/define/namespace.rs
@@ -51,10 +51,9 @@ impl DefineNamespaceStatement {
 		txn.set(
 			key,
 			revision::to_vec(&DefineNamespaceStatement {
-				id: if self.id.is_none() {
-					Some(txn.lock().await.get_next_ns_id().await?)
-				} else {
-					None
+				id: match self.id {
+					Some(id) => Some(id),
+					None => Some(txn.lock().await.get_next_ns_id().await?),
 				},
 				// Don't persist the `IF NOT EXISTS` clause to schema
 				if_not_exists: false,

--- a/crates/core/src/sql/statements/define/table.rs
+++ b/crates/core/src/sql/statements/define/table.rs
@@ -88,10 +88,12 @@ impl DefineTableStatement {
 		let nsv = txn.get_or_add_ns(ns, opt.strict).await?;
 		let dbv = txn.get_or_add_db(ns, db, opt.strict).await?;
 		let mut dt = DefineTableStatement {
-			id: if self.id.is_none() && nsv.id.is_some() && dbv.id.is_some() {
-				Some(txn.lock().await.get_next_tb_id(nsv.id.unwrap(), dbv.id.unwrap()).await?)
-			} else {
-				None
+			id: match (self.id, nsv.id, dbv.id) {
+				(Some(id), _, _) => Some(id),
+				(None, Some(nsv_id), Some(dbv_id)) => {
+					Some(txn.lock().await.get_next_tb_id(nsv_id, dbv_id).await?)
+				}
+				_ => None,
 			},
 			// Don't persist the `IF NOT EXISTS` clause to schema
 			if_not_exists: false,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

I noticed IDs were not being stored for the Namespace, Database, and Table statements but only when they're explicitly set in the query. I don't think this code path is possible, but if it becomes possible, this will prevent any possible future issues.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Ensures the IDs are set when provided.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
