### PR TITLE
Destructure aliases to support any expression

### DIFF
--- a/crates/core/src/sql/value/get.rs
+++ b/crates/core/src/sql/value/get.rs
@@ -249,12 +249,23 @@ impl Value {
 						stk.run(|stk| v.get(stk, ctx, opt, doc, path.next())).await
 					}
 					Part::Destructure(p) => {
+						let cur_doc = CursorDoc::from(self.clone());
 						let mut obj = BTreeMap::<String, Value>::new();
 						for p in p.iter() {
 							let path = p.path();
-							let v = stk
-								.run(|stk| self.get(stk, ctx, opt, doc, path.as_slice()))
-								.await?;
+							let v = if let Some(Part::Start(start)) = path.get(0) {
+								let start = start.compute(stk, ctx, opt, Some(&cur_doc)).await?;
+								stk.run(|stk| {
+									start.get(stk, ctx, opt, Some(&cur_doc), &path.as_slice()[1..])
+								})
+								.await?
+							} else {
+								stk.run(|stk| {
+									self.get(stk, ctx, opt, Some(&cur_doc), path.as_slice())
+								})
+								.await?
+							};
+
 							obj.insert(p.field().to_raw(), v);
 						}
 

--- a/crates/core/src/syn/parser/idiom.rs
+++ b/crates/core/src/syn/parser/idiom.rs
@@ -332,38 +332,11 @@ impl Parser<'_> {
 			let part = match self.peek_kind() {
 				t!(":") => {
 					self.pop_peek();
-					let start = match self.peek_kind() {
-						x if Parser::kind_is_identifier(x) => Part::Field(self.next_token_value()?),
-						t!("->") => {
-							self.pop_peek();
-							let graph = ctx.run(|ctx| self.parse_graph(ctx, Dir::Out)).await?;
-							Part::Graph(graph)
-						}
-						found @ t!("<") => match self.peek_whitespace1().kind {
-							t!("-") => {
-								self.pop_peek();
-								self.pop_peek();
-								let graph = ctx.run(|ctx| self.parse_graph(ctx, Dir::In)).await?;
-								Part::Graph(graph)
-							}
-							t!("->") => {
-								self.pop_peek();
-								self.pop_peek();
-								let graph = ctx.run(|ctx| self.parse_graph(ctx, Dir::Both)).await?;
-								Part::Graph(graph)
-							}
-							_ => {
-								bail!("Unexpected token `{}` expected an identifier, `->`, `<-` or `<->`", found, @self.recent_span());
-							}
-						},
-						found => {
-							bail!("Unexpected token `{}` expected an identifier, `->`, `<-` or `<->`", found, @self.recent_span());
-						}
+					let idiom = match self.parse_value_inherit(ctx).await? {
+						Value::Idiom(x) => x,
+						v => Idiom(vec![Part::Start(v)]),
 					};
-					DestructurePart::Aliased(
-						field,
-						self.parse_remaining_idiom(ctx, vec![start]).await?,
-					)
+					DestructurePart::Aliased(field, idiom)
 				}
 				t!(".") => {
 					self.pop_peek();

--- a/crates/language-tests/tests/language/idiom/destructure-any-expression.surql
+++ b/crates/language-tests/tests/language/idiom/destructure-any-expression.surql
@@ -1,0 +1,26 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "{ doc: { id: place:{ name: 'Earth' }, level: 1 }, double_level: 2, rels: [{ doc: { id: place:{ name: 'US' }, level: 2 }, double_level: 4, rels: [{ doc: { id: place:{ name: 'NYC' }, level: 3 }, double_level: 6, rels: [] }] }] }"
+
+*/
+{
+    DELETE place, contains;
+
+    UPSERT place:{ name: "Earth" } SET level = 1;
+    UPSERT place:{ name: "US" } SET level = 2;
+    UPSERT place:{ name: "NYC" } SET level = 3;
+
+    RELATE place:{ name: "Earth" }->contains->place:{ name: "US" };
+    RELATE place:{ name: "US" }->contains->place:{ name: "NYC" };
+};
+
+place:{ name: "Earth" }.{..}.{
+    doc: $this,
+    rels: ->?->?.@,
+    double_level: level * 2
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The destructuring aliasing syntax is currently somewhat limited, because the initial idiom start it accepts is custom to destructuring syntax. This makes it feel incomplete, besides the fact that that is totally unnecessary.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR changes the parsing behaviour to accept any type of expression or start of idiom path, just like we do in normal objects. If an idiom value is parsed, it's inner idiom is extracted. If any other value is parsed, it's stored as `Idiom(Part::Start(v))`. Then, during execution, if the first part is `Part::Start`, we compute that value and replacing the starting value from the inputted object to that. Now the change is not breaking :)

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test to showcase that arbitrary expressions are now supported in destructuring syntax, just like in normal objects.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Yep

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
