### PR TITLE
Bug fix: escape issue on index what

### DIFF
--- a/crates/core/src/idx/mod.rs
+++ b/crates/core/src/idx/mod.rs
@@ -56,8 +56,8 @@ impl IndexKeyBase {
 			inner: Arc::new(Inner {
 				ns: ns.to_string(),
 				db: db.to_string(),
-				tb: ix.what.to_string(),
-				ix: ix.name.to_string(),
+				tb: ix.what.to_raw(),
+				ix: ix.name.to_raw(),
 			}),
 		})
 	}

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -328,7 +328,7 @@ impl Building {
 			ctx: MutableContext::new_concurrent(ctx).freeze(),
 			opt,
 			tf,
-			tb: ix.what.to_string(),
+			tb: ix.what.to_raw(),
 			ix,
 			status: Arc::new(RwLock::new(BuildingStatus::Started)),
 			queue: Default::default(),

--- a/crates/language-tests/tests/language/statements/define/analyzer/basic.surql
+++ b/crates/language-tests/tests/language/statements/define/analyzer/basic.surql
@@ -1,4 +1,7 @@
 /**
+# Extra timeout due to file reading.
+timeout = 2000
+
 [test]
 
 [[test.results]]

--- a/crates/language-tests/tests/language/statements/define/index/concurrently.surql
+++ b/crates/language-tests/tests/language/statements/define/index/concurrently.surql
@@ -18,10 +18,16 @@ value = "[{ email: 'testB@surrealdb.com', id: user:3 }]"
 value = "NONE"
 
 [[test.results]]
+error = "The index 'test' already exists"
+
+[[test.results]]
 value = "NONE"
 
 [[test.results]]
 value = "{ events: {  }, fields: {  }, indexes: { test: 'DEFINE INDEX test ON user FIELDS email' }, lives: {  }, tables: {  } }"
+
+[[test.results]]
+value = "{ building: { initial: 3, pending: 0, status: 'ready', updated: 0 } }"
 
 [[test.results]]
 value = "{ building: { initial: 3, pending: 0, status: 'ready', updated: 0 } }"
@@ -40,9 +46,11 @@ CREATE user:1 SET email = 'testA@surrealdb.com';
 CREATE user:2 SET email = 'testA@surrealdb.com';
 CREATE user:3 SET email = 'testB@surrealdb.com';
 DEFINE INDEX test ON user FIELDS email CONCURRENTLY;
+DEFINE INDEX `test` ON `user` FIELDS email CONCURRENTLY;
 SLEEP 1s;
 INFO FOR TABLE user;
 INFO FOR INDEX test ON user;
+INFO FOR INDEX `test` ON `user`;
 SELECT * FROM user WHERE email = 'testA@surrealdb.com' EXPLAIN;
 SELECT * FROM user WHERE email = 'testA@surrealdb.com';
 SELECT * FROM user WHERE email = 'testB@surrealdb.com';

--- a/crates/language-tests/tests/language/statements/define/index/concurrently.surql
+++ b/crates/language-tests/tests/language/statements/define/index/concurrently.surql
@@ -6,13 +6,13 @@ timeout = 2000
 [test]
 
 [[test.results]]
-value = "[{ email: 'testA@surrealdb.com', id: user:1 }]"
+value = "[{ email: 'testA@surrealdb.com', id: `user.csv`:1 }]"
 
 [[test.results]]
-value = "[{ email: 'testA@surrealdb.com', id: user:2 }]"
+value = "[{ email: 'testA@surrealdb.com', id: `user.csv`:2 }]"
 
 [[test.results]]
-value = "[{ email: 'testB@surrealdb.com', id: user:3 }]"
+value = "[{ email: 'testB@surrealdb.com', id: `user.csv`:3 }]"
 
 [[test.results]]
 value = "NONE"
@@ -24,7 +24,7 @@ error = "The index 'test' already exists"
 value = "NONE"
 
 [[test.results]]
-value = "{ events: {  }, fields: {  }, indexes: { test: 'DEFINE INDEX test ON user FIELDS email' }, lives: {  }, tables: {  } }"
+value = "{ events: {  }, fields: {  }, indexes: { test: 'DEFINE INDEX test ON `user.csv` FIELDS email' }, lives: {  }, tables: {  } }"
 
 [[test.results]]
 value = "{ building: { initial: 3, pending: 0, status: 'ready', updated: 0 } }"
@@ -33,24 +33,24 @@ value = "{ building: { initial: 3, pending: 0, status: 'ready', updated: 0 } }"
 value = "{ building: { initial: 3, pending: 0, status: 'ready', updated: 0 } }"
 
 [[test.results]]
-value = "[{ detail: { plan: { index: 'test', operator: '=', value: 'testA@surrealdb.com' }, table: 'user' }, operation: 'Iterate Index' }, { detail: { type: 'Memory' }, operation: 'Collector' }]"
+value = "[{ detail: { plan: { index: 'test', operator: '=', value: 'testA@surrealdb.com' }, table: 'user.csv' }, operation: 'Iterate Index' }, { detail: { type: 'Memory' }, operation: 'Collector' }]"
 
 [[test.results]]
-value = "[{ email: 'testA@surrealdb.com', id: user:1 }, { email: 'testA@surrealdb.com', id: user:2 }]"
+value = "[{ email: 'testA@surrealdb.com', id: `user.csv`:1 }, { email: 'testA@surrealdb.com', id: `user.csv`:2 }]"
 
 [[test.results]]
-value = "[{ email: 'testB@surrealdb.com', id: user:3 }]"
+value = "[{ email: 'testB@surrealdb.com', id: `user.csv`:3 }]"
 */
 
-CREATE user:1 SET email = 'testA@surrealdb.com';
-CREATE user:2 SET email = 'testA@surrealdb.com';
-CREATE user:3 SET email = 'testB@surrealdb.com';
-DEFINE INDEX test ON user FIELDS email CONCURRENTLY;
-DEFINE INDEX `test` ON `user` FIELDS email CONCURRENTLY;
+CREATE `user.csv`:1 SET email = 'testA@surrealdb.com';
+CREATE `user.csv`:2 SET email = 'testA@surrealdb.com';
+CREATE `user.csv`:3 SET email = 'testB@surrealdb.com';
+DEFINE INDEX test ON `user.csv` FIELDS email CONCURRENTLY;
+DEFINE INDEX `test` ON `user.csv` FIELDS email CONCURRENTLY;
 SLEEP 1s;
-INFO FOR TABLE user;
-INFO FOR INDEX test ON user;
-INFO FOR INDEX `test` ON `user`;
-SELECT * FROM user WHERE email = 'testA@surrealdb.com' EXPLAIN;
-SELECT * FROM user WHERE email = 'testA@surrealdb.com';
-SELECT * FROM user WHERE email = 'testB@surrealdb.com';
+INFO FOR TABLE `user.csv`;
+INFO FOR INDEX test ON `user.csv`;
+INFO FOR INDEX `test` ON `user.csv`;
+SELECT * FROM `user.csv` WHERE email = 'testA@surrealdb.com' EXPLAIN;
+SELECT * FROM `user.csv` WHERE email = 'testA@surrealdb.com';
+SELECT * FROM `user.csv` WHERE email = 'testB@surrealdb.com';


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Concurrent indexing is currently not indexing the table if the table is surrounded by quotes in the definition.

Eg.:

```sql
CREATE `user.csv`:1 SET email = 'test@surrealdb.com';
DEFINE INDEX test ON `user.csv` FIELDS email CONCURRENTLY;
INFO FOR test ON `user.csv`;
```

`INFO` returns the status `ready` without having indexed any records:

```js
{
	building: {
		initial: 0,
		pending: 0,
		status: 'ready',
		updated: 0
	}
}
```

But it should show:

```js
{
	building: {
		initial: 1,
		pending: 0,
		status: 'ready',
		updated: 0
	}
}
```
 

## What does this change do?

Fixes the bug by using the unquoted name of the table.

## What is your testing strategy?

Github action - Language tests

## Is this related to any issues?

Relates to #5574

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
