### PR TITLE
Add `--workspace` to clippy tasks.

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -57,6 +57,7 @@ category = "CI - CHECK"
 command = "cargo"
 args = [
     "clippy",
+    "--workspace",
     "--all-targets",
     "--features",
     "storage-mem,storage-surrealkv,storage-rocksdb,storage-tikv,storage-fdb,scripting,http,jwks,ml,storage-fdb-7_1",
@@ -73,7 +74,9 @@ category = "CI - CHECK"
 command = "cargo"
 args = [
     "clippy",
+    "--workspace",
     "--all-targets",
+    "--release",
     "--features",
     "storage-mem,storage-surrealkv,storage-rocksdb,storage-tikv,storage-fdb,scripting,http,jwks,ml,storage-fdb-7_1",
     "--tests",

--- a/crates/core/src/iam/verify.rs
+++ b/crates/core/src/iam/verify.rs
@@ -1151,7 +1151,7 @@ mod tests {
 			for id in &case.ids {
 				// Prepare the claims object
 				let mut claims = claims.clone();
-				claims.id = Some(id.to_string());
+				claims.id = Some((*id).to_string());
 				claims.roles =
 					case.roles.clone().map(|roles| roles.into_iter().map(String::from).collect());
 

--- a/crates/core/src/idx/trees/dynamicset.rs
+++ b/crates/core/src/idx/trees/dynamicset.rs
@@ -123,7 +123,7 @@ mod tests {
 		// Test insertions
 		for sample in 0..capacity {
 			assert_eq!(dyn_set.len(), control.len(), "{capacity} - {sample}");
-			let v: HashSet<ElementId> = dyn_set.iter().cloned().collect();
+			let v: HashSet<ElementId> = dyn_set.iter().copied().collect();
 			assert_eq!(v, control, "{capacity} - {sample}");
 			// We should not have the element yet
 			assert!(!dyn_set.contains(&sample), "{capacity} - {sample}");
@@ -148,7 +148,7 @@ mod tests {
 			control.remove(&sample);
 			// The control structure and the dyn_set should be identical
 			assert_eq!(dyn_set.len(), control.len(), "{capacity} - {sample}");
-			let v: HashSet<ElementId> = dyn_set.iter().cloned().collect();
+			let v: HashSet<ElementId> = dyn_set.iter().copied().collect();
 			assert_eq!(v, control, "{capacity} - {sample}");
 		}
 	}

--- a/crates/core/src/idx/trees/graph.rs
+++ b/crates/core/src/idx/trees/graph.rs
@@ -124,7 +124,7 @@ where
 		for (n, e) in g {
 			let edges: HashSet<ElementId> = e.into_iter().collect();
 			let n_edges: Option<HashSet<ElementId>> =
-				self.get_edges(&n).map(|e| e.iter().cloned().collect());
+				self.get_edges(&n).map(|e| e.iter().copied().collect());
 			assert_eq!(n_edges, Some(edges), "{n:?}");
 		}
 	}
@@ -186,7 +186,7 @@ mod tests {
 		let res = g.remove_node_and_bidirectional_edges(&2);
 		assert_eq!(
 			res.map(|v| {
-				let mut v: Vec<ElementId> = v.iter().cloned().collect();
+				let mut v: Vec<ElementId> = v.iter().copied().collect();
 				v.sort();
 				v
 			}),

--- a/crates/core/src/idx/trees/mtree.rs
+++ b/crates/core/src/idx/trees/mtree.rs
@@ -1712,7 +1712,7 @@ mod tests {
 			// We check that the results are sorted by ascending distance
 			let mut dist = 0.0;
 			for (doc, d) in res.docs {
-				let o = map.get(&doc).unwrap();
+				let o = &map[&doc];
 				debug!("doc: {doc} - d: {d} - {obj:?} - {o:?}");
 				assert!(d >= dist, "d: {d} - dist: {dist}");
 				dist = d;

--- a/crates/core/src/sql/kind.rs
+++ b/crates/core/src/sql/kind.rs
@@ -554,7 +554,7 @@ impl Literal {
 					let value = x.get(key).unwrap_or(&Value::None);
 					if let Some(o) = discriminants
 						.iter()
-						.find(|o| value.to_owned().coerce_to_kind(o.get(key).unwrap()).is_ok())
+						.find(|o| value.to_owned().coerce_to_kind(&o[key]).is_ok())
 					{
 						if o.len() < x.len() {
 							return false;

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -1099,13 +1099,13 @@ impl TryNeg for Value {
 /// Macro implementing conversion methods for the variants of the value enum.
 macro_rules! subtypes {
 	($($name:ident$( ( $($t:tt)* ) )? => ($is:ident,$as:ident,$into:ident)),*$(,)?) => {
-		pub enum Type{
+		pub enum Type {
 			$($name),*
 		}
 
 		impl Value {
 
-			pub fn type_of(&self) -> Type{
+			pub fn type_of(&self) -> Type {
 				match &self{
 					$(subtypes!{@pat $name $( ($($t)*) )?} => Type::$name),*
 				}

--- a/crates/language-tests/src/cli.rs
+++ b/crates/language-tests/src/cli.rs
@@ -123,7 +123,7 @@ pub fn parse() -> ArgMatches {
             Command::new("run")
                 .about("Run surrealdb tests")
                 .arg(arg!([filter] "Filter the tests by their path"))
-                .arg(arg!(--path <PATH> "The path to tests directory").default_value("./crates/language-tests/tests"))
+                .arg(arg!(--path <PATH> "The path to tests directory").default_value("./tests"))
                 .arg(
                     arg!(-j --jobs <JOBS> "The number of test running in parallel, defaults to available parallism")
                         .value_parser(value_parser!(u32).range(1..))

--- a/crates/language-tests/src/cli.rs
+++ b/crates/language-tests/src/cli.rs
@@ -123,7 +123,7 @@ pub fn parse() -> ArgMatches {
             Command::new("run")
                 .about("Run surrealdb tests")
                 .arg(arg!([filter] "Filter the tests by their path"))
-                .arg(arg!(--path <PATH> "The path to tests directory").default_value("./tests"))
+                .arg(arg!(--path <PATH> "The path to tests directory").default_value("./crates/language-tests/tests"))
                 .arg(
                     arg!(-j --jobs <JOBS> "The number of test running in parallel, defaults to available parallism")
                         .value_parser(value_parser!(u32).range(1..))

--- a/crates/language-tests/src/cmd/list.rs
+++ b/crates/language-tests/src/cmd/list.rs
@@ -5,7 +5,7 @@ use crate::tests::TestSet;
 
 pub async fn run(matches: &ArgMatches) -> Result<()> {
 	let path: &String = matches.get_one("path").unwrap();
-	let (testset, errors) = TestSet::collect_directory(&path).await?;
+	let (testset, errors) = TestSet::collect_directory(path).await?;
 	if !errors.is_empty() {
 		println!(" Failed to load some of the tests");
 	}

--- a/crates/language-tests/src/cmd/run/mod.rs
+++ b/crates/language-tests/src/cmd/run/mod.rs
@@ -63,7 +63,7 @@ fn try_collect_reports<W: io::Write>(
 
 pub async fn run(color: ColorMode, matches: &ArgMatches) -> Result<()> {
 	let path: &String = matches.get_one("path").unwrap();
-	let (testset, load_errors) = TestSet::collect_directory(&path).await?;
+	let (testset, load_errors) = TestSet::collect_directory(path).await?;
 	let backend = *matches.get_one::<Backend>("backend").unwrap();
 
 	// Check if the backend is supported by the enabled features.
@@ -232,7 +232,7 @@ pub async fn run(color: ColorMode, matches: &ArgMatches) -> Result<()> {
 	}
 
 	if reports.iter().any(|x| x.grade() == TestGrade::Failed) {
-		bail!("Not all tests where successfull")
+		bail!("Not all tests were successful")
 	}
 
 	if !load_errors.is_empty() {
@@ -305,6 +305,8 @@ async fn run_test_with_dbs(
 		.map(|x| x.timeout().map(Duration::from_millis).unwrap_or(Duration::MAX))
 		.unwrap_or(Duration::from_secs(1));
 
+	eprintln!("\n\nRunning test `{}`: ({timeout_duration:?})\n\n", set[id].path);
+
 	let mut import_session = Session::owner();
 	if let Some(ns) = session.ns.as_ref() {
 		import_session = import_session.with_ns(ns)
@@ -317,14 +319,14 @@ async fn run_test_with_dbs(
 		let Some(test) = set.find_all(import) else {
 			return Ok(TestTaskResult::Import(
 				import.to_string(),
-				format!("Could not find import."),
+				"Could not find import.".to_string(),
 			));
 		};
 
 		let Ok(source) = str::from_utf8(&set[test].source) else {
 			return Ok(TestTaskResult::Import(
 				import.to_string(),
-				format!("Import file was not valid utf-8."),
+				"Import file was not valid utf-8.".to_string(),
 			));
 		};
 

--- a/crates/language-tests/src/cmd/run/provisioner.rs
+++ b/crates/language-tests/src/cmd/run/provisioner.rs
@@ -29,7 +29,7 @@ fn xorshift(state: &mut u32) -> u32 {
 	x ^= x >> 17;
 	x ^= x << 5;
 	*state = x;
-	return x;
+	x
 }
 
 impl CreateInfo {

--- a/crates/language-tests/src/tests/testset.rs
+++ b/crates/language-tests/src/tests/testset.rs
@@ -119,14 +119,14 @@ impl TestSet {
 		if !name.starts_with(std::path::MAIN_SEPARATOR) {
 			name = Cow::Owned(format!("{}{name}", std::path::MAIN_SEPARATOR));
 		}
-		self.all_map.get(name.as_ref()).cloned()
+		self.all_map.get(name.as_ref()).copied()
 	}
 
 	pub async fn collect_directory(path: &str) -> Result<(Self, Vec<TestLoadError>)> {
 		let mut all = Vec::new();
 		let mut map = HashMap::new();
 		let mut errors = Vec::new();
-		Self::collect_recursive(path, &path, &mut map, &mut all, &mut errors).await?;
+		Self::collect_recursive(path, path, &mut map, &mut all, &mut errors).await?;
 		let map = Arc::new(map);
 		Ok((
 			Self {

--- a/crates/sdk/benches/hash_trie_btree.rs
+++ b/crates/sdk/benches/hash_trie_btree.rs
@@ -28,7 +28,7 @@ fn bench_hash_trie_btree_ix_key(c: &mut Criterion) {
 	for i in 0..N {
 		let mut key = b"/*test\0*test\0*test\0!ixtest".to_vec();
 		key.append(&mut i.to_be_bytes().to_vec());
-		samples.push((key.to_vec(), i));
+		samples.push((key.clone(), i));
 	}
 
 	let mut g = new_group(c, "bench_hash_trie_btree_ix_key", N);

--- a/crates/sdk/src/api/method/query.rs
+++ b/crates/sdk/src/api/method/query.rs
@@ -1045,13 +1045,13 @@ mod tests {
 		let errors = response.take_errors();
 		assert_eq!(response.num_statements(), 8);
 		assert_eq!(errors.len(), 3);
-		let crate::Error::Api(Error::DuplicateRequestId(0)) = errors.get(&10).unwrap() else {
+		let crate::Error::Api(Error::DuplicateRequestId(0)) = errors[&10] else {
 			panic!("index `10` is not `DuplicateRequestId`");
 		};
-		let crate::Error::Api(Error::BackupsNotSupported) = errors.get(&7).unwrap() else {
+		let crate::Error::Api(Error::BackupsNotSupported) = errors[&7] else {
 			panic!("index `7` is not `BackupsNotSupported`");
 		};
-		let crate::Error::Api(Error::ConnectionUninitialised) = errors.get(&3).unwrap() else {
+		let crate::Error::Api(Error::ConnectionUninitialised) = errors[&3] else {
 			panic!("index `3` is not `ConnectionUninitialised`");
 		};
 		let Some(value): Option<i32> = response.take(2).unwrap() else {

--- a/crates/sdk/tests/access.rs
+++ b/crates/sdk/tests/access.rs
@@ -400,7 +400,7 @@ async fn access_bearer_revoke() {
 		let re =
 			Regex::new(r"\{ ac: 'srv', creation: .*?, expiration: .*, grant: \{ id: '(.*?)', key: .*? \}, id: .*?, revocation: NONE, subject: \{ user: 'tobie' \}, type: 'bearer' \}")
 					.unwrap();
-		let kid = re.captures(&tmp).unwrap().get(1).unwrap().as_str();
+		let kid = &re.captures(&tmp).unwrap()[1];
 		// Consume the results of the other three
 		res.remove(0).result.unwrap();
 		res.remove(0).result.unwrap();
@@ -542,7 +542,7 @@ async fn access_bearer_show() {
 		let re =
 			Regex::new(r"\{ ac: 'srv', creation: .*?, expiration: .*, grant: \{ id: '(.*?)', key: .*? \}, id: .*?, revocation: NONE, subject: \{ user: 'tobie' \}, type: 'bearer' \}")
 					.unwrap();
-		let kid = re.captures(&tmp).unwrap().get(1).unwrap().as_str();
+		let kid = &re.captures(&tmp).unwrap()[1];
 		// Consume the results of the other three
 		res.remove(0).result.unwrap();
 		res.remove(0).result.unwrap();
@@ -703,7 +703,7 @@ async fn access_bearer_purge() {
 		let re =
 			Regex::new(r"\{ ac: 'srv', creation: .*?, expiration: d'.*?', grant: \{ id: '(.*?)', key: .*? \}, id: .*?, revocation: NONE, subject: \{ user: 'tobie' \}, type: 'bearer' \}")
 					.unwrap();
-		let kid = re.captures(&tmp).unwrap().get(1).unwrap().as_str();
+		let kid = &re.captures(&tmp).unwrap()[1];
 		// Consume the results of the other three
 		res.remove(0).result.unwrap();
 		res.remove(0).result.unwrap();

--- a/crates/sdk/tests/api_integration/basic.rs
+++ b/crates/sdk/tests/api_integration/basic.rs
@@ -1451,7 +1451,7 @@ pub async fn changefeed(new_db: impl CreateDb) {
 	let CoreValue::Number(_versionstamp1) = a.get("versionstamp").unwrap() else {
 		unreachable!()
 	};
-	let changes = a.get("changes").unwrap().clone().to_owned();
+	let changes = a.get("changes").unwrap().clone().clone();
 	assert_eq!(
 		Value::from_inner(changes),
 		"[
@@ -1465,7 +1465,7 @@ pub async fn changefeed(new_db: impl CreateDb) {
 		.unwrap()
 	);
 	// UPDATE testuser:amos
-	let a = array.get(1).unwrap();
+	let a = &array[1];
 	let CoreValue::Object(a) = a.clone() else {
 		unreachable!()
 	};
@@ -1487,7 +1487,7 @@ pub async fn changefeed(new_db: impl CreateDb) {
 		.unwrap()
 	);
 	// UPDATE testuser:jane
-	let a = array.get(2).unwrap();
+	let a = &array[2];
 	let CoreValue::Object(a) = a.clone() else {
 		unreachable!()
 	};
@@ -1510,7 +1510,7 @@ pub async fn changefeed(new_db: impl CreateDb) {
 		.unwrap()
 	);
 	// UPDATE testuser:amos
-	let a = array.get(3).unwrap();
+	let a = &array[3];
 	let CoreValue::Object(a) = a.clone() else {
 		unreachable!()
 	};
@@ -1533,7 +1533,7 @@ pub async fn changefeed(new_db: impl CreateDb) {
 		.unwrap()
 	);
 	// UPDATE table
-	let a = array.get(4).unwrap();
+	let a = &array[4];
 	let CoreValue::Object(a) = a.clone() else {
 		unreachable!()
 	};

--- a/crates/sdk/tests/changefeeds.rs
+++ b/crates/sdk/tests/changefeeds.rs
@@ -423,7 +423,7 @@ async fn changefeed_with_ts() -> Result<(), Error> {
 		.unwrap()
 	);
 	// UPDATE user:amos
-	let a = array.get(1).unwrap();
+	let a = &array[1];
 	let Value::Object(a) = a else {
 		unreachable!()
 	};
@@ -446,7 +446,7 @@ async fn changefeed_with_ts() -> Result<(), Error> {
 		.unwrap()
 	);
 	// UPDATE user:jane
-	let a = array.get(2).unwrap();
+	let a = &array[2];
 	let Value::Object(a) = a else {
 		unreachable!()
 	};
@@ -470,7 +470,7 @@ async fn changefeed_with_ts() -> Result<(), Error> {
 		.unwrap()
 	);
 	// UPDATE user:amos
-	let a = array.get(3).unwrap();
+	let a = &array[3];
 	let Value::Object(a) = a else {
 		unreachable!()
 	};
@@ -494,7 +494,7 @@ async fn changefeed_with_ts() -> Result<(), Error> {
 		.unwrap()
 	);
 	// UPDATE table
-	let a = array.get(4).unwrap();
+	let a = &array[4];
 	let Value::Object(a) = a else {
 		unreachable!()
 	};

--- a/crates/sdk/tests/helpers.rs
+++ b/crates/sdk/tests/helpers.rs
@@ -119,7 +119,7 @@ pub async fn iam_check_cases(
 		let expected_result = if *should_succeed {
 			check_results.first().unwrap()
 		} else {
-			check_results.get(1).unwrap()
+			&check_results[1]
 		};
 		// Auth enabled
 		{
@@ -151,7 +151,7 @@ pub async fn iam_check_cases(
 			);
 			let ds = new_ds().await.unwrap().with_auth_enabled(auth_enabled);
 			let expected_result = if auth_enabled {
-				check_results.get(1).unwrap()
+				&check_results[1]
 			} else {
 				check_results.first().unwrap()
 			};
@@ -294,7 +294,7 @@ impl Test {
 	/// The panic message will include the last position in the responses list before it was emptied.
 	#[track_caller]
 	#[allow(dead_code)]
-	#[expect(clippy::should_implement_trait)]
+	#[allow(clippy::should_implement_trait)]
 	pub fn next(&mut self) -> Result<Response, Error> {
 		assert!(!self.responses.is_empty(), "No response left - last position: {}", self.pos);
 		self.pos += 1;
@@ -345,8 +345,9 @@ impl Test {
 				tmp.as_number().map(|x| x.is_nan()).unwrap_or(false),
 				"Expected NaN but got {info}: {tmp}"
 			);
+		} else {
+			assert_eq!(tmp, val, "{info} {tmp:#}");
 		}
-		assert_eq!(tmp, val, "{info} {tmp:#}");
 		//
 		Ok(self)
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Clippy was not being applied to all sub-crates.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This change adds `--workspace` to the clippy commands in order to ensure they run on all sub-crates and fixes all surfaced issues. It also fixes the `ci-clippy-release` job to actually have the `--release` flag added (before this change it was exactly identical to the `ci-clippy` job so we were just doing the same work twice).

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI tests should be sufficient.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
