### PR TITLE
Ensure arguments for object idiom methods are computed

### DIFF
--- a/crates/core/src/sql/value/get.rs
+++ b/crates/core/src/sql/value/get.rs
@@ -263,7 +263,7 @@ impl Value {
 						stk.run(|stk| obj.get(stk, ctx, opt, doc, path.next())).await
 					}
 					Part::Method(name, args) => {
-						let a = stk
+						let args = stk
 							.scope(|scope| {
 								try_join_all(
 									args.iter()
@@ -282,7 +282,7 @@ impl Value {
 								..
 							}) => match v.get(name) {
 								Some(v) => {
-									let fnc = Function::Anonymous(v.clone(), a, true);
+									let fnc = Function::Anonymous(v.clone(), args, true);
 									match stk
 										.run(|stk| fnc.compute(stk, ctx, opt, doc))
 										.await


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

I noticed that the uncomputed arguments were being passed.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Ensure that the computed arguments are passed

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI (none of the object idiom methods take args so not much to test)

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
