### PR TITLE
Fix `regex_non_string.surql` language-test for uuids.

### DIFF
--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -594,7 +594,6 @@ impl Value {
 			},
 			Value::Uuid(v) => match other {
 				Value::Uuid(w) => v == w,
-				Value::Regex(w) => w.regex().is_match(v.to_raw().as_str()),
 				_ => false,
 			},
 			Value::Thing(v) => match other {
@@ -609,7 +608,6 @@ impl Value {
 			},
 			Value::Regex(v) => match other {
 				Value::Regex(w) => v == w,
-				Value::Uuid(w) => v.regex().is_match(w.to_raw().as_str()),
 				Value::Thing(w) => v.regex().is_match(w.to_raw().as_str()),
 				Value::Strand(w) => v.regex().is_match(w.as_str()),
 				_ => false,

--- a/crates/language-tests/tests/language/functions/string/matches.surql
+++ b/crates/language-tests/tests/language/functions/string/matches.surql
@@ -10,4 +10,4 @@ value = "true"
 */
 
 let $error = "Found record: `likes:siy1jqk4jjv7njfrf1o0` which is a relation, but expected a  RELATION IN record<person> OUT record<person | thing>";
-string::matches($error,"Found record: `likes:[a-zA-Z0-9]*` which is a relation, but expected a  RELATION IN record<person> OUT record<person \\| thing>")
+string::matches($error, /Found record: `likes:[a-zA-Z0-9]*` which is a relation, but expected a  RELATION IN record<person> OUT record<person \\| thing>/)

--- a/crates/language-tests/tests/language/primitive/regex/regex_non_string.surql
+++ b/crates/language-tests/tests/language/primitive/regex/regex_non_string.surql
@@ -1,6 +1,5 @@
 /**
 [test]
-wip = true
 
 [[test.results]]
 value = "false"
@@ -27,7 +26,7 @@ value = "false"
 value = "false"
 
 [[test.results]]
-value = "true"
+value = "false"
 
 [[test.results]]
 value = "false"

--- a/crates/language-tests/tests/language/primitive/regex/regex_non_string.surql
+++ b/crates/language-tests/tests/language/primitive/regex/regex_non_string.surql
@@ -27,7 +27,7 @@ value = "false"
 value = "false"
 
 [[test.results]]
-value = "false"
+value = "true"
 
 [[test.results]]
 value = "false"

--- a/crates/language-tests/tests/language/primitive/regex/regex_uuid_equality.surql
+++ b/crates/language-tests/tests/language/primitive/regex/regex_uuid_equality.surql
@@ -2,7 +2,7 @@
 [test]
 
 [[test.results]]
-value = "true"
+value = "false"
 
 [[test.results]]
 value = "true"
@@ -14,12 +14,32 @@ value = "false"
 value = "true"
 
 [[test.results]]
+value = "false"
+
+[[test.results]]
+value = "false"
+
+[[test.results]]
+value = "false"
+
+[[test.results]]
+value = "true"
+
+[[test.results]]
+value = "false"
+
+[[test.results]]
 value = "true"
 
 */
 
 /.*/ = u"00000000-0000-0000-0000-000000000000";
+/.*/ = <string> u"00000000-0000-0000-0000-000000000000";
 u"00000000-0000-0000-0000-000000000000" = /.*/;
+<string> u"00000000-0000-0000-0000-000000000000" = /.*/;
 u"00000000-0000-0000-0000-000000000000" = /1/;
+<string> u"00000000-0000-0000-0000-000000000000" = /1/;
 u"00000000-0000-0000-0000-000000000000" = /[0\-]/;
+<string> u"00000000-0000-0000-0000-000000000000" = /[0\-]/;
 u"FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF" = /[0\-]/;
+<string> u"FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF" = /[0\-]/;

--- a/crates/language-tests/tests/language/statements/define/table/type_normal.surql
+++ b/crates/language-tests/tests/language/statements/define/table/type_normal.surql
@@ -9,7 +9,7 @@ value = "[{ id: thing:2gmswqs3pk5j8a5s5tql }]"
 skip-record-id-key = true
 
 [[test.results]]
-match = '''string::matches($error,"Found record: `thing:.*` which is not a relation, but expected a  NORMAL")'''
+match = '''string::matches($error, /Found record: `thing:.*` which is not a relation, but expected a  NORMAL/)'''
 error = true
 */
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

I am working on enabling all of the language tests. This PR's purpose is to fix the `regex_non_string.surql` tests.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This change disables the ability to regex parse a UUID without first casting it to a string. It also fixes up the `regex_non_string.surql` language tests and the `regex_uuid_equality.surql` tests.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

CI testing should be sufficient.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

Yes, pending approval I will get a PR opened to update docs.surrealdb.com.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
