### PR TITLE
Fix error expectation for `for/simple.surql` language tests.

### DIFF
--- a/crates/core/src/sql/statements/foreach.rs
+++ b/crates/core/src/sql/statements/foreach.rs
@@ -68,7 +68,7 @@ impl ForeachStatement {
 					Value::Array(arr) => ForeachIter::Array(arr.into_iter()),
 					v => {
 						return Err(ControlFlow::from(Error::InvalidStatementTarget {
-							value: format!("Expected array, got {v}"),
+							value: v.to_string(),
 						}));
 					}
 				}
@@ -76,7 +76,7 @@ impl ForeachStatement {
 
 			v => {
 				return Err(ControlFlow::from(Error::InvalidStatementTarget {
-					value: format!("Expected array or range, got {v}"),
+					value: v.to_string(),
 				}))
 			}
 		};

--- a/crates/language-tests/tests/language/statements/for/simple.surql
+++ b/crates/language-tests/tests/language/statements/for/simple.surql
@@ -1,6 +1,5 @@
 /**
 [test]
-wip = true
 
 [[test.results]]
 value = "NONE"
@@ -15,7 +14,7 @@ value = "NONE"
 value = "[{ id: person:1, test: 1 }, { id: person:4, test: 4 }, { id: person:6, test: 6 }]"
 
 [[test.results]]
-error = "This is an error"
+error = "Can not execute statement using value: <future> { [7, 8, 9] }"
 
 [[test.results]]
 value = "[{ id: person:1, test: 1 }, { id: person:4, test: 4 }, { id: person:6, test: 6 }]"

--- a/crates/language-tests/tests/language/statements/for/simple.surql
+++ b/crates/language-tests/tests/language/statements/for/simple.surql
@@ -14,12 +14,14 @@ value = "NONE"
 value = "[{ id: person:1, test: 1 }, { id: person:4, test: 4 }, { id: person:6, test: 6 }]"
 
 [[test.results]]
-error = "Can not execute statement using value: <future> { [7, 8, 9] }"
+error = "An error occurred: This is an error"
 
 [[test.results]]
 value = "[{ id: person:1, test: 1 }, { id: person:4, test: 4 }, { id: person:6, test: 6 }]"
 
 */
+
+OPTION FUTURES = true;
 
 FOR $test IN [1, 2, 3] {
 	IF $test == 2 {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

I'm working my way through fixing the language tests. This PR is focused on `for/simple.surql`.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This change adds support for using the result of a future in a for loop. This currently only supports futures which return an array. I'd be open to changing that if there's a strong motivation for support on other types.

```sql
FOR $test IN <future> { [7, 8, 9] } {
	UPSERT type::thing('person', $test) SET test = $test;
};
```

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI tests should be sufficient.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

Yes, pending approval I will get a PR opened to update docs.surrealdb.com.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
