### PR TITLE
Remove duplicate tagging job

### DIFF
--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -529,7 +529,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.git-ref }}
+          ref: ${{ needs.prepare-vars.outputs.release-branch }}
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@nightly
@@ -646,25 +646,6 @@ jobs:
           for file in artifacts/**/*.{tgz,txt,exe}; do
             aws s3 cp --cache-control 'no-store' $file s3://download.surrealdb.com/${{ needs.prepare-vars.outputs.name }}/
           done
-
-  tag-release:
-    name: Tag release
-    needs: [publish, prepare-vars]
-    environment: ${{ needs.prepare-vars.outputs.environment }}
-    if: ${{ inputs.publish }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare-vars.outputs.release-branch }}
-
-      - name: Tag the release
-        if: ${{ inputs.suffix != 'nightly' }}
-        run: |
-          set -x
-          git tag -a v${{ needs.prepare-vars.outputs.version }} -m "Release ${{ needs.prepare-vars.outputs.version }}"
-          git push --tags
 
   docker:
     name: Docker images

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -148,7 +148,7 @@ jobs:
           git checkout -b ${{ steps.outputs.outputs.release-branch }}
 
       - name: Patch release version
-        if: ${{ inputs.suffix != 'none' }}
+        if: ${{ steps.outputs.outputs.environment != 'stable' }}
         run: |
           set -x
 
@@ -260,6 +260,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-vars.outputs.release-branch }}
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
@@ -549,10 +551,11 @@ jobs:
           version=${major}.${minor}.${{ needs.prepare-vars.outputs.patch }}
 
           # Update the version to a nightly one
-          sed -i "s#^version = \"${currentVersion}\"#version = \"${version}\"#" crates/sdk/Cargo.toml
-          sed -i "s#^version = \"${currentVersion}\"#version = \"${version}\"#" crates/core/Cargo.toml
-          sed -i "s#surrealdb = { version = \"=${currentVersion}\"#surrealdb = { version = \"=${version}\"#" Cargo.toml
-          sed -i "s#surrealdb-core = { version = \"=${currentVersion}\"#surrealdb-core = { version = \"=${version}\"#" Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${version}\"#" Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${version}\"#" crates/sdk/Cargo.toml
+          sed -i "s#^version = \".*\"#version = \"${version}\"#" crates/core/Cargo.toml
+          sed -i "s#surrealdb = { version = \"=${{ needs.prepare-vars.outputs.version }}\"#surrealdb = { version = \"=${version}\"#" Cargo.toml
+          sed -i "s#surrealdb-core = { version = \"=${{ needs.prepare-vars.outputs.version }}\"#surrealdb-core = { version = \"=${version}\"#" Cargo.toml
 
       - name: Patch crate name and description
         if: ${{ needs.prepare-vars.outputs.environment != 'stable' }}
@@ -725,10 +728,11 @@ jobs:
   cleanup:
     name: Cleanup
     needs: [publish, prepare-vars]
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
 
       - name: Delete ${{ needs.prepare-vars.outputs.release-branch }}
-        run: git push origin --delete ${{ needs.prepare-vars.outputs.release-branch }}
+        run: git push origin --delete ${{ needs.prepare-vars.outputs.release-branch }} || true

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -611,8 +611,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: ${{ inputs.publish && inputs.create-release }}
         with:
-          name: "Release ${{ needs.prepare-vars.outputs.version }}"
           tag_name: v${{ needs.prepare-vars.outputs.version }}
+          name: "Release ${{ needs.prepare-vars.outputs.version }}"
+          body: "Release ${{ needs.prepare-vars.outputs.version }}"
+          target_commitish: ${{ needs.prepare-vars.outputs.release-branch }}
           prerelease: ${{ needs.prepare-vars.outputs.environment != 'stable' }}
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -573,8 +573,13 @@ jobs:
           sed -i "s/package = \"surrealdb-core\"/package = \"surrealdb-core-${environment}\"/" Cargo.toml
 
           # Patch the description
-          sed -i "s#^description = \".*\"#description = \"A ${environment} release of the surrealdb crate\"#" crates/sdk/Cargo.toml
-          sed -i "s#^description = \".*\"#description = \"A ${environment} release of the surrealdb-core crate\"#" crates/core/Cargo.toml
+          if [[ $environment == 'alpha' ]]; then
+            start="An"
+          else
+            start="A"
+          fi
+          sed -i "s#^description = \".*\"#description = \"${start} ${environment} release of the surrealdb crate\"#" crates/sdk/Cargo.toml
+          sed -i "s#^description = \".*\"#description = \"${start} ${environment} release of the surrealdb-core crate\"#" crates/core/Cargo.toml
 
           # Temporarily commit patches
           # These should not be pushed back to the repo


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The `tag-release` job is unnecessary since `action-gh-release` also handles tagging the release.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It removes the job.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
