### PR TITLE
Improve test schema parsing and error handling

### DIFF
--- a/crates/language-tests/tests/language/statements/define/analyzer/basic.surql
+++ b/crates/language-tests/tests/language/statements/define/analyzer/basic.surql
@@ -1,6 +1,6 @@
 /**
 # Extra timeout due to file reading.
-timeout = 4000
+timeout = 8000
 
 [test]
 

--- a/crates/language-tests/tests/language/statements/define/table/redefinition.surql
+++ b/crates/language-tests/tests/language/statements/define/table/redefinition.surql
@@ -14,7 +14,7 @@ value = "NONE"
 value = "NONE"
 
 [[test.results]]
-match = "$error = /Couldn't coerce value for field `out` of `likes:[0-9a-z]+`: Expected `record<person>` but found `thing:[0-9a-z]+`"
+match = """$error = /Couldn't coerce value for field `out` of `likes:[0-9a-z]+`: Expected `record<person>` but found `thing:[0-9a-z]+`/"""
 error = true
 
 [[test.results]]
@@ -28,7 +28,7 @@ value = "[{ id: likes:60l77luoejr1s5th7d4r, in: person:15nrffr4aoneyjt6l2ft, out
 skip-record-id-key = true
 
 [[test.results]]
-match = "$error = <regex> 'Couldn't coerce value for field `out` of `likes:[0-9a-z]+`: Expected `record<person\\|thing>` but found `other:[0-9a-z]+`'"
+match = """$error = <regex> 'Couldn\\'t coerce value for field `out` of `likes:[0-9a-z]+`: Expected `record<person|thing>` but found `other:[0-9a-z]+`'"""
 error = true
 
 [[test.results]]

--- a/crates/language-tests/tests/language/statements/define/table/relation_in_out.surql
+++ b/crates/language-tests/tests/language/statements/define/table/relation_in_out.surql
@@ -26,11 +26,11 @@ skip-record-id-key = true
 
 
 [[test.results]]
-match = "$error = <regex> 'Found record: `likes:[a-z0-9]+` which is a relation, but expected a  RELATION IN record<person> OUT record<person \\| thing>'"
+match = "$error = <regex> 'Found record: `likes:[a-z0-9]+` which is a relation, but expected a  RELATION IN record<person> OUT record<person | thing>'"
 error = true
 
 [[test.results]]
-match = "$error = <regex> 'Couldn't coerce value for field `out` of `likes:[a-z0-9]+`: Expected `record<person\\|thing>` but found `other:[0-9a-z]+`'"
+match = "$error = <regex> 'Couldn\\'t coerce value for field `out` of `likes:[a-z0-9]+`: Expected `record<person|thing>` but found `other:[0-9a-z]+`'"
 error = true
 
 [[test.results]]

--- a/crates/language-tests/tests/language/statements/define/table/relation_redefinition.surql
+++ b/crates/language-tests/tests/language/statements/define/table/relation_redefinition.surql
@@ -28,7 +28,7 @@ value = "[{ id: likes:loxurikpwrb2o242gsgu, in: person:euupzy7py15hmh1rbant, out
 skip-record-id-key = true
 
 [[test.results]]
-match = "$error = <regex> 'Couldn't coerce value for field `out` of `likes:[0-9a-z]+`: Expected `record<person\\|thing>` but found `other:[0-9a-z]+`'"
+match = "$error = <regex> 'Couldn\\'t coerce value for field `out` of `likes:[0-9a-z]+`: Expected `record<person|thing>` but found `other:[0-9a-z]+`'"
 error = true
 
 [[test.results]]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Current errors in the configuration of the test is not reported properly, often just saying that it couldn't find a match.

## What does this change do?

Improves the error handling to properly point out errors.

## What is your testing strategy?

N/A

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
