### PR TITLE
Remove Error::Ignore variant, moving into it's own type

### DIFF
--- a/crates/core/src/dbs/iterator.rs
+++ b/crates/core/src/dbs/iterator.rs
@@ -5,7 +5,7 @@ use crate::dbs::plan::{Explanation, Plan};
 use crate::dbs::result::Results;
 use crate::dbs::Options;
 use crate::dbs::Statement;
-use crate::doc::Document;
+use crate::doc::{Document, IgnoreError};
 use crate::err::Error;
 use crate::idx::planner::iterators::{IteratorRecord, IteratorRef};
 use crate::idx::planner::{
@@ -674,7 +674,7 @@ impl Iterator {
 		opt: &Options,
 		stm: &Statement<'_>,
 		pro: Processed,
-	) -> Result<Value, Error> {
+	) -> Result<Value, IgnoreError> {
 		// Check if this is a count all
 		let count_all = stm.expr().is_some_and(Fields::is_count_all_only);
 		if count_all {
@@ -697,17 +697,17 @@ impl Iterator {
 		opt: &Options,
 		stm: &Statement<'_>,
 		rs: RecordStrategy,
-		res: Result<Value, Error>,
+		res: Result<Value, IgnoreError>,
 	) {
 		// yield
 		yield_now!();
 		// Process the result
 		match res {
-			Err(Error::Ignore) => {
+			Err(IgnoreError::Ignore) => {
 				return;
 			}
-			Err(e) => {
-				self.error = Some(e);
+			Err(IgnoreError::Error(e)) => {
+				self.error = Some(*e);
 				self.run.cancel();
 				return;
 			}

--- a/crates/core/src/doc/create.rs
+++ b/crates/core/src/doc/create.rs
@@ -2,9 +2,10 @@ use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::dbs::Statement;
 use crate::doc::Document;
-use crate::err::Error;
 use crate::sql::value::Value;
 use reblessive::tree::Stk;
+
+use super::IgnoreError;
 
 impl Document {
 	pub(super) async fn create(
@@ -13,7 +14,7 @@ impl Document {
 		ctx: &Context,
 		opt: &Options,
 		stm: &Statement<'_>,
-	) -> Result<Value, Error> {
+	) -> Result<Value, IgnoreError> {
 		self.check_permissions_quick(stk, ctx, opt, stm).await?;
 		self.check_table_type(ctx, opt, stm).await?;
 		self.check_data_fields(stk, ctx, opt, stm).await?;

--- a/crates/core/src/doc/delete.rs
+++ b/crates/core/src/doc/delete.rs
@@ -2,9 +2,10 @@ use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::dbs::Statement;
 use crate::doc::Document;
-use crate::err::Error;
 use crate::sql::value::Value;
 use reblessive::tree::Stk;
+
+use super::IgnoreError;
 
 impl Document {
 	pub(super) async fn delete(
@@ -13,7 +14,7 @@ impl Document {
 		ctx: &Context,
 		opt: &Options,
 		stm: &Statement<'_>,
-	) -> Result<Value, Error> {
+	) -> Result<Value, IgnoreError> {
 		self.check_record_exists(ctx, opt, stm).await?;
 		self.check_permissions_quick(stk, ctx, opt, stm).await?;
 		self.check_where_condition(stk, ctx, opt, stm).await?;

--- a/crates/core/src/doc/mod.rs
+++ b/crates/core/src/doc/mod.rs
@@ -4,6 +4,8 @@
 //! - `current`: value after the transaction
 //! - `initial`: value before the transaction
 //! - `id`: traditionally an integer but can be an object or collection such as an array
+use crate::err;
+
 pub(crate) use self::document::*;
 
 mod document; // The entry point for a document to be processed
@@ -29,4 +31,16 @@ mod lives; // Processes any live queries relevant for this document
 mod pluck; // Pulls the projected expressions from the document
 mod purge; // Deletes this document, and any edges or indexes
 mod store; // Writes the document content to the storage engine
-mod table; // Processes any foreign tables relevant for this document
+mod table; // Processes any foreign tables relevant for this document'
+
+/// Error result used when a function can result in the value being processed being ignored.
+pub enum IgnoreError {
+	Ignore,
+	Error(Box<err::Error>),
+}
+
+impl From<err::Error> for IgnoreError {
+	fn from(value: err::Error) -> Self {
+		IgnoreError::Error(Box::new(value))
+	}
+}

--- a/crates/core/src/doc/pluck.rs
+++ b/crates/core/src/doc/pluck.rs
@@ -3,7 +3,6 @@ use crate::dbs::Options;
 use crate::dbs::Statement;
 use crate::doc::Document;
 use crate::doc::Permitted::*;
-use crate::err::Error;
 use crate::iam::Action;
 use crate::sql::idiom::Idiom;
 use crate::sql::output::Output;
@@ -13,6 +12,8 @@ use crate::sql::value::Value;
 use crate::sql::FlowResultExt as _;
 use reblessive::tree::Stk;
 use std::sync::Arc;
+
+use super::IgnoreError;
 
 impl Document {
 	/// Evaluates a doc that has been modified so that it can be further computed into a result Value
@@ -24,7 +25,7 @@ impl Document {
 		ctx: &Context,
 		opt: &Options,
 		stm: &Statement<'_>,
-	) -> Result<Value, Error> {
+	) -> Result<Value, IgnoreError> {
 		// Ensure futures are run
 		let opt = &opt.new_with_futures(true);
 		// Check if we can view the output
@@ -32,7 +33,7 @@ impl Document {
 		// Process the desired output
 		let mut out = match stm.output() {
 			Some(v) => match v {
-				Output::None => Err(Error::Ignore),
+				Output::None => Err(IgnoreError::Ignore),
 				Output::Null => Ok(Value::Null),
 				Output::Diff => {
 					// Process the permitted documents
@@ -55,7 +56,8 @@ impl Document {
 							.as_ref()
 							.compute(stk, ctx, opt, Some(&self.current))
 							.await
-							.catch_return(),
+							.catch_return()
+							.map_err(IgnoreError::from),
 					}
 				}
 				Output::Before => {
@@ -70,7 +72,8 @@ impl Document {
 							.as_ref()
 							.compute(stk, ctx, opt, Some(&self.initial))
 							.await
-							.catch_return(),
+							.catch_return()
+							.map_err(IgnoreError::from),
 					}
 				}
 				Output::Fields(v) => {
@@ -85,7 +88,7 @@ impl Document {
 					ctx.add_value("before", initial.doc.as_arc());
 					let ctx = ctx.freeze();
 					// Output the specified fields
-					v.compute(stk, &ctx, opt, Some(current), false).await
+					v.compute(stk, &ctx, opt, Some(current), false).await.map_err(IgnoreError::from)
 				}
 			},
 			None => match stm {
@@ -106,7 +109,10 @@ impl Document {
 							false => &self.current,
 						};
 						// Process the LIVE SELECT statement fields
-						s.expr.compute(stk, ctx, opt, Some(current), false).await
+						s.expr
+							.compute(stk, ctx, opt, Some(current), false)
+							.await
+							.map_err(IgnoreError::from)
 					}
 				},
 				Statement::Select(s) => {
@@ -116,7 +122,10 @@ impl Document {
 						false => &self.current,
 					};
 					// Process the SELECT statement fields
-					s.expr.compute(stk, ctx, opt, Some(current), s.group.is_some()).await
+					s.expr
+						.compute(stk, ctx, opt, Some(current), s.group.is_some())
+						.await
+						.map_err(IgnoreError::from)
 				}
 				Statement::Create(_) => {
 					// Process the permitted documents
@@ -130,7 +139,8 @@ impl Document {
 							.as_ref()
 							.compute(stk, ctx, opt, Some(&self.current))
 							.await
-							.catch_return(),
+							.catch_return()
+							.map_err(IgnoreError::from),
 					}
 				}
 				Statement::Upsert(_) => {
@@ -145,7 +155,8 @@ impl Document {
 							.as_ref()
 							.compute(stk, ctx, opt, Some(&self.current))
 							.await
-							.catch_return(),
+							.catch_return()
+							.map_err(IgnoreError::from),
 					}
 				}
 				Statement::Update(_) => {
@@ -160,7 +171,8 @@ impl Document {
 							.as_ref()
 							.compute(stk, ctx, opt, Some(&self.current))
 							.await
-							.catch_return(),
+							.catch_return()
+							.map_err(IgnoreError::from),
 					}
 				}
 				Statement::Relate(_) => {
@@ -175,7 +187,8 @@ impl Document {
 							.as_ref()
 							.compute(stk, ctx, opt, Some(&self.current))
 							.await
-							.catch_return(),
+							.catch_return()
+							.map_err(IgnoreError::from),
 					}
 				}
 				Statement::Insert(_) => {
@@ -190,10 +203,11 @@ impl Document {
 							.as_ref()
 							.compute(stk, ctx, opt, Some(&self.current))
 							.await
-							.catch_return(),
+							.catch_return()
+							.map_err(IgnoreError::from),
 					}
 				}
-				_ => Err(Error::Ignore),
+				_ => Err(IgnoreError::Ignore),
 			},
 		}?;
 		// Check if this record exists

--- a/crates/core/src/doc/relate.rs
+++ b/crates/core/src/doc/relate.rs
@@ -2,9 +2,10 @@ use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::dbs::Statement;
 use crate::doc::Document;
-use crate::err::Error;
 use crate::sql::value::Value;
 use reblessive::tree::Stk;
+
+use super::IgnoreError;
 
 impl Document {
 	pub(super) async fn relate(
@@ -13,7 +14,7 @@ impl Document {
 		ctx: &Context,
 		opt: &Options,
 		stm: &Statement<'_>,
-	) -> Result<Value, Error> {
+	) -> Result<Value, IgnoreError> {
 		// Check if table has correct relation status
 		self.check_table_type(ctx, opt, stm).await?;
 		// Check whether current record exists
@@ -35,7 +36,7 @@ impl Document {
 		ctx: &Context,
 		opt: &Options,
 		stm: &Statement<'_>,
-	) -> Result<Value, Error> {
+	) -> Result<Value, IgnoreError> {
 		self.check_permissions_quick(stk, ctx, opt, stm).await?;
 		self.check_table_type(ctx, opt, stm).await?;
 		self.check_data_fields(stk, ctx, opt, stm).await?;
@@ -60,7 +61,7 @@ impl Document {
 		ctx: &Context,
 		opt: &Options,
 		stm: &Statement<'_>,
-	) -> Result<Value, Error> {
+	) -> Result<Value, IgnoreError> {
 		self.check_permissions_quick(stk, ctx, opt, stm).await?;
 		self.check_table_type(ctx, opt, stm).await?;
 		self.check_data_fields(stk, ctx, opt, stm).await?;

--- a/crates/core/src/doc/select.rs
+++ b/crates/core/src/doc/select.rs
@@ -2,9 +2,10 @@ use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::dbs::Statement;
 use crate::doc::Document;
-use crate::err::Error;
 use crate::sql::value::Value;
 use reblessive::tree::Stk;
+
+use super::IgnoreError;
 
 impl Document {
 	pub(super) async fn select(
@@ -13,7 +14,7 @@ impl Document {
 		ctx: &Context,
 		opt: &Options,
 		stm: &Statement<'_>,
-	) -> Result<Value, Error> {
+	) -> Result<Value, IgnoreError> {
 		self.check_record_exists(ctx, opt, stm).await?;
 		self.check_permissions_quick(stk, ctx, opt, stm).await?;
 		self.check_where_condition(stk, ctx, opt, stm).await?;

--- a/crates/core/src/doc/update.rs
+++ b/crates/core/src/doc/update.rs
@@ -2,9 +2,10 @@ use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::dbs::Statement;
 use crate::doc::Document;
-use crate::err::Error;
 use crate::sql::value::Value;
 use reblessive::tree::Stk;
+
+use super::IgnoreError;
 
 impl Document {
 	pub(super) async fn update(
@@ -13,7 +14,7 @@ impl Document {
 		ctx: &Context,
 		opt: &Options,
 		stm: &Statement<'_>,
-	) -> Result<Value, Error> {
+	) -> Result<Value, IgnoreError> {
 		self.check_record_exists(ctx, opt, stm).await?;
 		self.check_permissions_quick(stk, ctx, opt, stm).await?;
 		self.check_data_fields(stk, ctx, opt, stm).await?;

--- a/crates/core/src/err/mod.rs
+++ b/crates/core/src/err/mod.rs
@@ -29,11 +29,6 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-	/// This error is used for ignoring a document when processing a query
-	#[doc(hidden)]
-	#[error("Conditional clause is not truthy")]
-	Ignore,
-
 	/// The database encountered unreachable logic
 	#[error("The database encountered unreachable logic: {0}")]
 	Unreachable(String),

--- a/crates/core/src/fnc/array.rs
+++ b/crates/core/src/fnc/array.rs
@@ -43,14 +43,14 @@ pub fn add((mut array, value): (Array, Value)) -> Result<Value, Error> {
 	match value {
 		Value::Array(value) => {
 			for v in value.0 {
-				if !array.0.iter().any(|x| *x == v) {
+				if !array.0.contains(&v) {
 					array.0.push(v)
 				}
 			}
 			Ok(array.into())
 		}
 		value => {
-			if !array.0.iter().any(|x| *x == value) {
+			if !array.0.contains(&value) {
 				array.0.push(value)
 			}
 			Ok(array.into())

--- a/crates/sdk/src/api/engine/remote/http/mod.rs
+++ b/crates/sdk/src/api/engine/remote/http/mod.rs
@@ -170,7 +170,7 @@ async fn export_file(request: RequestBuilder, path: PathBuf) -> Result<()> {
 		.await?
 		.error_for_status()?
 		.bytes_stream()
-		.map_err(|e| futures::io::Error::new(futures::io::ErrorKind::Other, e))
+		.map_err(|e| futures::io::Error::other(e))
 		.into_async_read()
 		.compat();
 	let mut file =

--- a/crates/sdk/src/api/engine/remote/http/mod.rs
+++ b/crates/sdk/src/api/engine/remote/http/mod.rs
@@ -170,7 +170,7 @@ async fn export_file(request: RequestBuilder, path: PathBuf) -> Result<()> {
 		.await?
 		.error_for_status()?
 		.bytes_stream()
-		.map_err(|e| futures::io::Error::other(e))
+		.map_err(futures::io::Error::other)
 		.into_async_read()
 		.compat();
 	let mut file =

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -161,10 +161,10 @@ pub async fn init(args: UpgradeCommandArguments) -> Result<(), Error> {
 	let response = reqwest::get(&url).await?;
 
 	if !response.status().is_success() {
-		return Err(Error::Io(IoError::new(
-			ErrorKind::Other,
-			format!("received status {} when downloading from {url}", response.status()),
-		)));
+		return Err(Error::Io(IoError::other(format!(
+			"received status {} when downloading from {url}",
+			response.status()
+		))));
 	}
 
 	let binary = response.bytes().await?;
@@ -188,10 +188,10 @@ pub async fn init(args: UpgradeCommandArguments) -> Result<(), Error> {
 			.arg(tmp_dir.path())
 			.output()?;
 		if !output.status.success() {
-			return Err(Error::Io(IoError::new(
-				ErrorKind::Other,
-				format!("failed to unarchive: {}", output.status),
-			)));
+			return Err(Error::Io(IoError::other(format!(
+				"failed to unarchive: {}",
+				output.status
+			))));
 		}
 
 		// focus on the extracted path


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The `Error::Ignore` variant is an internal only variant which is used to ignore results of query in the executor.
Having it be part of the external facing error types makes it easy to accidentally leak this error into user facing errors and raising it when it shouldn't be raised.

## What does this change do?

Moves the error variant out of the `core::err::Error` and instead into it's own error variant which is only used for functions which can have this ignoring result. This forces explicit handling of the result preventing bugs and making a future move to anyhow easier.

## What is your testing strategy?

Existing test should suffice.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
