### PR TITLE
Add debugger setup instructions.

### DIFF
--- a/doc/DEBUGGING.md
+++ b/doc/DEBUGGING.md
@@ -1,17 +1,19 @@
-## Using a Debugger with SurrealDB
+# Using a Debugger with SurrealDB
 
 To use the VSCode debugger with SurrealDB there are a few steps to get setup. This guide walks you
 through setup and configuration.
 
-### Setup
+## Setup
 
 Install [CodeLLDB](https://marketplace.visualstudio.com/items/?itemName=vadimcn.vscode-lldb) 1.11.5
 or greater.
 
 Settings:
+
 * Set [`LLDB → Launch: Breakpoint Mode`](vscode://settings/lldb.launch.breakpointMode) to `path`.
 * Set [`LLDB → Launch: Terminal`](vscode://settings/lldb.launch.terminal) to `integrated`.
 * Set [`LLDB → Launch: Init Commands`](vscode://settings/lldb.launch.initCommands) to:
+
     ```json
     "lldb.launch.initCommands": [
        "command script import ${userHome}/.rustup/toolchains/1.86-aarch64-apple-darwin/lib/rustlib/etc/lldb_lookup.py",
@@ -19,7 +21,7 @@ Settings:
     ]
     ```
 
-### Launch Configuration
+## Launch Configuration
 
 The `launch.json` is used to specify debugger configuration. The following configuration will setup
 the interactive `sql` shell to run in the debugger so you can run adhoc commands and inspect the
@@ -45,16 +47,16 @@ state of the program.
                 "sql",
                 "--ns", "ns",
                 "--db", "db",
-                "--endpoint", "memory",
+                "--endpoint", "memory"
             ],
             "cwd": "${workspaceFolder}",
-            "sourceLanguages": ["rust"],
-        },
+            "sourceLanguages": ["rust"]
+        }
     ]
 }
 ```
 
-### Running the Debugger
+## Running the Debugger
 
 1. Add breakpoints in the code you want to debug. You can do this by clicking in the gutter next to
    the line number.

--- a/doc/DEBUGGING.md
+++ b/doc/DEBUGGING.md
@@ -1,10 +1,12 @@
 ## Using a Debugger with SurrealDB
 
-To use the VSCode debugger with SurrealDB there are a few steps to get setup. This guide walks you through setup and configuration.
+To use the VSCode debugger with SurrealDB there are a few steps to get setup. This guide walks you
+through setup and configuration.
 
 ### Setup
 
-Install [CodeLLDB](https://marketplace.visualstudio.com/items/?itemName=vadimcn.vscode-lldb) 1.11.5 or greater.
+Install [CodeLLDB](https://marketplace.visualstudio.com/items/?itemName=vadimcn.vscode-lldb) 1.11.5
+or greater.
 
 Settings:
 * Set [`LLDB → Launch: Breakpoint Mode`](vscode://settings/lldb.launch.breakpointMode) to `path`.
@@ -19,7 +21,9 @@ Settings:
 
 ### Launch Configuration
 
-The `launch.json` is used to specify debugger configuration. The following configuration will setup the interactive `sql` shell to run in the debugger so you can run adhoc commands and inspect the state of the program.
+The `launch.json` is used to specify debugger configuration. The following configuration will setup
+the interactive `sql` shell to run in the debugger so you can run adhoc commands and inspect the
+state of the program.
 
 ```json
 {
@@ -52,12 +56,13 @@ The `launch.json` is used to specify debugger configuration. The following confi
 
 ### Running the Debugger
 
-1. Add breakpoints in the code you want to debug. You can do this by clicking in the gutter next to the line number.
+1. Add breakpoints in the code you want to debug. You can do this by clicking in the gutter next to
+   the line number.
 2. Open the `Debug` view in VSCode. (`Ctrl+Shift+D` or `Cmd+Shift+D` on macOS).
 3. Select the `Debug surrealdb` configuration. (`F5`)
 4. The debugger will start and the `sql` shell will be launched.
 5. You can now run SQL commands in the shell and the debugger will stop at the breakpoints you set.
 6. Use the debugger controls to step through the code, inspect variables, and evaluate expressions.
 7. You can also use the `Debug Console` to run commands and inspect the state of the program.
-8. When you are done debugging, you can stop the debugger by clicking the `Stop` button in the `Debug` view or by pressing `Shift+F5`.
-
+8. When you are done debugging, you can stop the debugger by clicking the `Stop` button in the
+   `Debug` view or by pressing `Shift+F5`.

--- a/doc/DEBUGGING.md
+++ b/doc/DEBUGGING.md
@@ -1,0 +1,63 @@
+## Using a Debugger with SurrealDB
+
+To use the VSCode debugger with SurrealDB there are a few steps to get setup. This guide walks you through setup and configuration.
+
+### Setup
+
+Install [CodeLLDB](https://marketplace.visualstudio.com/items/?itemName=vadimcn.vscode-lldb) 1.11.5 or greater.
+
+Settings:
+* Set [`LLDB → Launch: Breakpoint Mode`](vscode://settings/lldb.launch.breakpointMode) to `path`.
+* Set [`LLDB → Launch: Terminal`](vscode://settings/lldb.launch.terminal) to `integrated`.
+* Set [`LLDB → Launch: Init Commands`](vscode://settings/lldb.launch.initCommands) to:
+    ```json
+    "lldb.launch.initCommands": [
+       "command script import ${userHome}/.rustup/toolchains/1.86-aarch64-apple-darwin/lib/rustlib/etc/lldb_lookup.py",
+       "command source ${userHome}/.rustup/toolchains/1.86-aarch64-apple-darwin/lib/rustlib/etc/lldb_commands"
+    ]
+    ```
+
+### Launch Configuration
+
+The `launch.json` is used to specify debugger configuration. The following configuration will setup the interactive `sql` shell to run in the debugger so you can run adhoc commands and inspect the state of the program.
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug surrealdb",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--no-default-features",
+                    "--features",
+                    "storage-mem,http,scripting"
+                ],
+            },
+            "args": [
+                "sql",
+                "--ns", "ns",
+                "--db", "db",
+                "--endpoint", "memory",
+            ],
+            "cwd": "${workspaceFolder}",
+            "sourceLanguages": ["rust"],
+        },
+    ]
+}
+```
+
+### Running the Debugger
+
+1. Add breakpoints in the code you want to debug. You can do this by clicking in the gutter next to the line number.
+2. Open the `Debug` view in VSCode. (`Ctrl+Shift+D` or `Cmd+Shift+D` on macOS).
+3. Select the `Debug surrealdb` configuration. (`F5`)
+4. The debugger will start and the `sql` shell will be launched.
+5. You can now run SQL commands in the shell and the debugger will stop at the breakpoints you set.
+6. Use the debugger controls to step through the code, inspect variables, and evaluate expressions.
+7. You can also use the `Debug Console` to run commands and inspect the state of the program.
+8. When you are done debugging, you can stop the debugger by clicking the `Stop` button in the `Debug` view or by pressing `Shift+F5`.
+


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The SurrealDB execution path is non-trivial. Print debugging is a massive challenge and requires a lot of code changes to get the information you're looking for. Using a debugger makes stepping through the code significantly easier but it's not super straight forward to get setup.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This change adds instructions on how to setup the VSCode debugger using CodeLLDB.

This change requires the following PR to be merged and deployed to CodeLDDB:
https://github.com/vadimcn/codelldb/pull/1274

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Follow the instructions and validate for yourself whether debugging in VSCode works.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

Documentation has been added to `doc/DEBUGGING.md` in this repo.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
