### PR TITLE
Add rpc live statement options

### DIFF
--- a/crates/core/src/rpc/statement_options.rs
+++ b/crates/core/src/rpc/statement_options.rs
@@ -2,10 +2,10 @@ use std::collections::BTreeMap;
 
 use crate::{
 	dbs::Capabilities,
-	sql::{Cond, Data, Fields, Limit, Number, Output, Start, Timeout, Value, Version},
+	sql::{Cond, Data, Fetchs, Fields, Limit, Number, Output, Start, Timeout, Value, Version},
 	syn::{
-		condition_with_capabilities, fields_with_capabilities, output_with_capabilities,
-		value_with_capabilities,
+		condition_with_capabilities, fetchs_with_capabilities, fields_with_capabilities,
+		output_with_capabilities, value_with_capabilities,
 	},
 };
 
@@ -96,6 +96,12 @@ pub(crate) struct StatementOptions {
 	/// - An object, containing variables to define during execution of the method
 	/// - For all (`select`, `insert`, `create`, `upsert`, `update`, `relate` and `delete`) methods
 	pub vars: Option<BTreeMap<String, Value>>,
+	/// - A boolean, stating wether the LQ notifications should contain diffs
+	/// - For the `live` method
+	pub diff: bool,
+	/// - A string, containing fields to fetch.
+	/// - For the `select` and `live` methods
+	pub fetch: Option<Fetchs>,
 }
 
 impl StatementOptions {
@@ -225,6 +231,24 @@ impl StatementOptions {
 			if let Some(v) = obj.remove("vars") {
 				if let Value::Object(v) = v {
 					self.vars = Some(v.0)
+				} else {
+					return Err(RpcError::InvalidParams);
+				}
+			}
+
+			// Process "diff" option
+			if let Some(v) = obj.remove("diff") {
+				if let Value::Bool(v) = v {
+					self.diff = v;
+				} else {
+					return Err(RpcError::InvalidParams);
+				}
+			}
+
+			// Process "fetch" option
+			if let Some(v) = obj.remove("fetch") {
+				if let Value::Strand(v) = v {
+					self.fetch = Some(fetchs_with_capabilities(v.as_str(), capabilities)?)
 				} else {
 					return Err(RpcError::InvalidParams);
 				}

--- a/crates/core/src/syn/parser/stmt/parts.rs
+++ b/crates/core/src/syn/parser/stmt/parts.rs
@@ -116,11 +116,15 @@ impl Parser<'_> {
 		if !self.eat(t!("FETCH")) {
 			return Ok(None);
 		}
+		Ok(Some(self.parse_fetchs(ctx).await?))
+	}
+
+	pub async fn parse_fetchs(&mut self, ctx: &mut Stk) -> ParseResult<Fetchs> {
 		let mut fetchs = self.try_parse_param_or_idiom_or_fields(ctx).await?;
 		while self.eat(t!(",")) {
 			fetchs.append(&mut self.try_parse_param_or_idiom_or_fields(ctx).await?);
 		}
-		Ok(Some(Fetchs(fetchs)))
+		Ok(Fetchs(fetchs))
 	}
 
 	pub async fn try_parse_param_or_idiom_or_fields(


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

We forgot to add the statement options for the live method in RPC

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

- Replaces the second argument (currently "diff") with statement options
- Adds `diff` to the statement options
- Adds `fetch` to the statement options, added for live and select

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Yep

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
