### PR TITLE
Allow passing `fields` to RPC `live`

### DIFF
--- a/crates/core/src/rpc/protocol/v2.rs
+++ b/crates/core/src/rpc/protocol/v2.rs
@@ -365,7 +365,7 @@ pub trait RpcProtocolV2: RpcContext {
 			expr: if opts.diff {
 				Fields::default()
 			} else {
-				Fields::all()
+				opts.fields.unwrap_or(Fields::all())
 			},
 			cond: opts.cond,
 			fetch: opts.fetch,

--- a/crates/core/src/rpc/statement_options.rs
+++ b/crates/core/src/rpc/statement_options.rs
@@ -238,6 +238,11 @@ impl StatementOptions {
 
 			// Process "diff" option
 			if let Some(v) = obj.remove("diff") {
+				if self.fields.is_some() {
+					// diff and fields cannot co-exist, as diff overwrites the fields
+					return Err(RpcError::InvalidParams);
+				}
+
 				if let Value::Bool(v) = v {
 					self.diff = v;
 				} else {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Forgot to implement support for custom fields in #5878

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Implements custom fields. `diff` and `fields` cannot co-exist.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] Yep

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
