### PR TITLE
BP: Remove `surrealdb_unstable` (#5799)

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -94,8 +94,6 @@ jobs:
 
       - name: Create version bump branch
         if: ${{ steps.bump.outputs.beta-num == '1' }}
-        env:
-          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: |
           set -x
 

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -49,8 +49,6 @@ jobs:
           sudo mv taplo /usr/bin/taplo
 
       - name: Prepare patch branch
-        env:
-          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: |
           set -x
 

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -59,9 +59,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  RUSTFLAGS: "--cfg surrealdb_unstable"
-
 jobs:
   prepare-vars:
     name: Prepare vars

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           cargo install --debug --locked cargo-acl
           sudo apt-get install -y bubblewrap
-      
+
       # See https://etbe.coker.com.au/2024/04/24/ubuntu-24-04-bubblewrap/
       - name: Configure bubblewrap
         run: |
@@ -127,8 +127,6 @@ jobs:
           sudo systemctl reload apparmor
 
       - name: Check dependencies for unauthorized access
-        env:
-          RUSTFLAGS: "--cfg surrealdb_unstable"
         run: cargo acl -n
 
       - name: Dependency check failure

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,7 @@ license-file = "LICENSE"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 
 [workspace]
-members = [
-    "crates/core",
-    "crates/sdk",
-]
+members = ["crates/core", "crates/sdk"]
 
 [workspace.dependencies]
 # workspace internal dependencies
@@ -38,7 +35,9 @@ trice = "0.4.0"
 vart = "0.8.1"
 
 # External Kv stores
-foundationdb = { version = "0.9.0", default-features = false, features = ["embedded-fdb-include"] }
+foundationdb = { version = "0.9.0", default-features = false, features = [
+    "embedded-fdb-include",
+] }
 rocksdb = { version = "0.23.0", features = ["lz4", "snappy"] }
 # Managed by surreal but mostly external code
 tikv = { version = "0.3.0-surreal.1", default-features = false, package = "surrealdb-tikv-client" }
@@ -199,18 +198,38 @@ inherits = "dev"
 
 [dependencies]
 # workspace internal dependencies
-surrealdb = { workspace = true, features = ["protocol-http", "protocol-ws", "rustls"] }
+surrealdb = { workspace = true, features = [
+    "protocol-http",
+    "protocol-ws",
+    "rustls",
+] }
 surrealdb-core.workspace = true
 
 # External surreal crates
-revision = { workspace = true, features = ["chrono", "geo", "roaring", "regex", "rust_decimal", "uuid"] }
+revision = { workspace = true, features = [
+    "chrono",
+    "geo",
+    "roaring",
+    "regex",
+    "rust_decimal",
+    "uuid",
+] }
 
 # Crates only used by the root surrealdb crate
 arc-swap = "1.7.1"
 axum = { version = "0.7.5", features = ["tracing", "ws"] }
-axum-extra = { version = "0.9.3", features = ["query", "typed-routing", "typed-header"] }
+axum-extra = { version = "0.9.3", features = [
+    "query",
+    "typed-routing",
+    "typed-header",
+] }
 axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
-clap = { version = "4.4.11", features = ["env", "derive", "wrap_help", "unicode"] }
+clap = { version = "4.4.11", features = [
+    "env",
+    "derive",
+    "wrap_help",
+    "unicode",
+] }
 glob = "0.3.1"
 http-body = "1.0.0"
 http-body-util = "0.1.1"
@@ -221,7 +240,19 @@ opentelemetry-otlp = { version = "0.17.0", features = ["metrics"] }
 rustyline = { version = "12.0.0", features = ["derive"] }
 serde_pack = { version = "1.1.2", package = "rmp-serde" }
 tower = { version = "0.4.13", features = ["limit", "load-shed"] }
-tower-http = { version = "0.5.2", features = ["trace", "sensitive-headers", "auth", "request-id", "util", "catch-panic", "cors", "set-header", "limit", "add-extension", "compression-full"] }
+tower-http = { version = "0.5.2", features = [
+    "trace",
+    "sensitive-headers",
+    "auth",
+    "request-id",
+    "util",
+    "catch-panic",
+    "cors",
+    "set-header",
+    "limit",
+    "add-extension",
+    "compression-full",
+] }
 tower-service = "0.3.3"
 tracing-appender = "0.2.3"
 tracing-opentelemetry = "0.25.0"
@@ -244,7 +275,11 @@ http.workspace = true
 num_cpus.workspace = true
 pin-project-lite.workspace = true
 rand.workspace = true
-reqwest = { workspace = true, default-features = false, features = ["blocking", "gzip", "http2"] }
+reqwest = { workspace = true, default-features = false, features = [
+    "blocking",
+    "gzip",
+    "http2",
+] }
 rmpv.workspace = true
 rust_decimal.workspace = true
 semver.workspace = true
@@ -260,7 +295,10 @@ tracing.workspace = true
 uuid = { workspace = true, features = ["serde", "js", "v4", "v7"] }
 
 # Optional crates
-pprof = { workspace = true, features = ["flamegraph", "prost-codec"], optional = true }
+pprof = { workspace = true, features = [
+    "flamegraph",
+    "prost-codec",
+], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 nu-ansi-term = "0.46.0"
@@ -274,7 +312,11 @@ nix = { version = "0.27.1", features = ["signal", "user"] }
 [dev-dependencies]
 # Crates only used by the root surrealdb crate
 assert_fs = "1.0.13"
-opentelemetry-proto = { version = "0.7.0", features = ["gen-tonic", "metrics", "logs"] }
+opentelemetry-proto = { version = "0.7.0", features = [
+    "gen-tonic",
+    "metrics",
+    "logs",
+] }
 rcgen = "0.13.2"
 tonic = "0.12.3"
 
@@ -317,5 +359,4 @@ license-file = ["LICENSE", "4"]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(docker)',
     'cfg(storage)',
-    'cfg(surrealdb_unstable)',
 ] }

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -1,12 +1,26 @@
 [env]
-RUSTFLAGS = { value = "-D warnings --cfg surrealdb_unstable", condition = { env_not_set = ["RUSTFLAGS"] } }
-BENCH_WORKER_THREADS = { value = "1", condition = { env_not_set = ["BENCH_WORKER_THREADS"] } }
-BENCH_NUM_OPS = { value = "1000", condition = { env_not_set = ["BENCH_NUM_OPS"] } }
-BENCH_DURATION = { value = "30", condition = { env_not_set = ["BENCH_DURATION"] } }
-BENCH_SAMPLE_SIZE = { value = "10", condition = { env_not_set = ["BENCH_SAMPLE_SIZE"] } }
-BENCH_FEATURES = { value = "protocol-ws,kv-mem,kv-rocksdb,kv-surrealkv", condition = { env_not_set = ["BENCH_FEATURES"] } }
+RUSTFLAGS = { value = "-D warnings", condition = { env_not_set = [
+    "RUSTFLAGS",
+] } }
+BENCH_WORKER_THREADS = { value = "1", condition = { env_not_set = [
+    "BENCH_WORKER_THREADS",
+] } }
+BENCH_NUM_OPS = { value = "1000", condition = { env_not_set = [
+    "BENCH_NUM_OPS",
+] } }
+BENCH_DURATION = { value = "30", condition = { env_not_set = [
+    "BENCH_DURATION",
+] } }
+BENCH_SAMPLE_SIZE = { value = "10", condition = { env_not_set = [
+    "BENCH_SAMPLE_SIZE",
+] } }
+BENCH_FEATURES = { value = "protocol-ws,kv-mem,kv-rocksdb,kv-surrealkv", condition = { env_not_set = [
+    "BENCH_FEATURES",
+] } }
 # Used to speed up the scripting timeout test, otherwise the test takes 5 seconds.
-SURREAL_SCRIPTING_MAX_TIME_LIMIT = { value = "500", condition = { env_not_set = ["SURREAL_SCRIPTING_MAX_TIME_LIMIT"] } }
+SURREAL_SCRIPTING_MAX_TIME_LIMIT = { value = "500", condition = { env_not_set = [
+    "SURREAL_SCRIPTING_MAX_TIME_LIMIT",
+] } }
 
 [tasks.ci-format]
 category = "CI - CHECK"
@@ -16,28 +30,74 @@ args = ["fmt", "--all", "--check"]
 [tasks.ci-check]
 category = "CI - CHECK"
 command = "cargo"
-args = ["check", "--locked", "--workspace", "--all-targets", "--features", "${ALL_FEATURES}"]
+args = [
+    "check",
+    "--locked",
+    "--workspace",
+    "--all-targets",
+    "--features",
+    "${ALL_FEATURES}",
+]
 
 [tasks.ci-check-release]
 category = "CI - CHECK"
 command = "cargo"
-args = ["check", "--release", "--locked", "--workspace", "--all-targets", "--features", "${ALL_FEATURES}"]
+args = [
+    "check",
+    "--release",
+    "--locked",
+    "--workspace",
+    "--all-targets",
+    "--features",
+    "${ALL_FEATURES}",
+]
 
 [tasks.ci-clippy]
 category = "CI - CHECK"
 command = "cargo"
-args = ["clippy", "--all-targets", "--features", "storage-mem,storage-surrealkv,storage-rocksdb,storage-tikv,storage-fdb,scripting,http,jwks,ml,storage-fdb-7_1", "--tests", "--benches", "--bins", "--", "-D", "warnings"]
+args = [
+    "clippy",
+    "--all-targets",
+    "--features",
+    "storage-mem,storage-surrealkv,storage-rocksdb,storage-tikv,storage-fdb,scripting,http,jwks,ml,storage-fdb-7_1",
+    "--tests",
+    "--benches",
+    "--bins",
+    "--",
+    "-D",
+    "warnings",
+]
 
 [tasks.ci-clippy-release]
 category = "CI - CHECK"
 command = "cargo"
-args = ["clippy", "--all-targets", "--features", "storage-mem,storage-surrealkv,storage-rocksdb,storage-tikv,storage-fdb,scripting,http,jwks,ml,storage-fdb-7_1", "--tests", "--benches", "--bins", "--", "-D", "warnings"]
+args = [
+    "clippy",
+    "--all-targets",
+    "--features",
+    "storage-mem,storage-surrealkv,storage-rocksdb,storage-tikv,storage-fdb,scripting,http,jwks,ml,storage-fdb-7_1",
+    "--tests",
+    "--benches",
+    "--bins",
+    "--",
+    "-D",
+    "warnings",
+]
 
 [tasks.ci-check-wasm]
 category = "CI - CHECK"
 command = "cargo"
-env = { RUSTFLAGS='--cfg getrandom_backend="wasm_js"' }
-args = ["check", "--locked", "--package", "surrealdb", "--features", "protocol-ws,protocol-http,kv-mem,kv-indxdb,http,jwks", "--target", "wasm32-unknown-unknown"]
+env = { RUSTFLAGS = '--cfg getrandom_backend="wasm_js"' }
+args = [
+    "check",
+    "--locked",
+    "--package",
+    "surrealdb",
+    "--features",
+    "protocol-ws,protocol-http,kv-mem,kv-indxdb,http,jwks",
+    "--target",
+    "wasm32-unknown-unknown",
+]
 
 #
 # Integration Tests
@@ -46,32 +106,97 @@ args = ["check", "--locked", "--package", "surrealdb", "--features", "protocol-w
 [tasks.ci-cli-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "cli_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,storage-surrealkv,http,scripting,jwks", "--workspace", "--test", "cli_integration", "--", "cli_integration"]
+env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "cli_integration=debug", condition = { env_not_set = [
+    "RUST_LOG",
+] } } }
+args = [
+    "test",
+    "--locked",
+    "--no-default-features",
+    "--features",
+    "storage-mem,storage-surrealkv,http,scripting,jwks",
+    "--workspace",
+    "--test",
+    "cli_integration",
+    "--",
+    "cli_integration",
+]
 
 [tasks.ci-http-integration]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "http_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem,http-compression,jwks", "--workspace", "--test", "http_integration", "--", "http_integration"]
+env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "http_integration=debug", condition = { env_not_set = [
+    "RUST_LOG",
+] } } }
+args = [
+    "test",
+    "--locked",
+    "--no-default-features",
+    "--features",
+    "storage-mem,http-compression,jwks",
+    "--workspace",
+    "--test",
+    "http_integration",
+    "--",
+    "http_integration",
+]
 
 [tasks.ci-ws-integration]
 category = "WS - INTEGRATION TESTS"
 command = "cargo"
-env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "ws_integration=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--no-default-features", "--features", "storage-mem", "--workspace", "--test", "ws_integration", "--", "ws_integration"]
+env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "ws_integration=debug", condition = { env_not_set = [
+    "RUST_LOG",
+] } } }
+args = [
+    "test",
+    "--locked",
+    "--no-default-features",
+    "--features",
+    "storage-mem",
+    "--workspace",
+    "--test",
+    "ws_integration",
+    "--",
+    "ws_integration",
+]
 
 [tasks.ci-ml-integration]
 category = "ML - INTEGRATION TESTS"
 command = "cargo"
-env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "cli_integration::common=debug", condition = { env_not_set = ["RUST_LOG"] } } }
-args = ["test", "--locked", "--features", "storage-mem,ml", "--workspace", "--test", "ml_integration", "--", "ml_integration", "--nocapture"]
+env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "cli_integration::common=debug", condition = { env_not_set = [
+    "RUST_LOG",
+] } } }
+args = [
+    "test",
+    "--locked",
+    "--features",
+    "storage-mem,ml",
+    "--workspace",
+    "--test",
+    "ml_integration",
+    "--",
+    "ml_integration",
+    "--nocapture",
+]
 
 [tasks.ci-graphql-integration]
 category = "GRAPHQL - INTEGRATION TESTS"
 command = "cargo"
-env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "cli_integration::common=debug", condition = { env_not_set = ["RUST_LOG"] } }, SURREAL_CAPS_ALLOW_EXPERIMENTAL = "graphql" }
-args = ["test", "--locked", "--features", "storage-mem", "--workspace", "--test", "graphql_integration", "--", "graphql_integration", "--nocapture"]
+env = { RUST_BACKTRACE = 1, RUST_LOG = { value = "cli_integration::common=debug", condition = { env_not_set = [
+    "RUST_LOG",
+] } }, SURREAL_CAPS_ALLOW_EXPERIMENTAL = "graphql" }
+args = [
+    "test",
+    "--locked",
+    "--features",
+    "storage-mem",
+    "--workspace",
+    "--test",
+    "graphql_integration",
+    "--",
+    "graphql_integration",
+    "--nocapture",
+]
 
 [tasks.ci-test-workspace]
 category = "CI - INTEGRATION TESTS"
@@ -131,15 +256,27 @@ args = [
 [tasks.test-workspace-coverage-complete]
 category = "CI - INTEGRATION TESTS"
 command = "cargo"
-args = ["llvm-cov", "--html", "--locked", "--no-default-features", "--features", "protocol-ws,protocol-http,kv-mem,kv-rocksdb", "--workspace"]
+args = [
+    "llvm-cov",
+    "--html",
+    "--locked",
+    "--no-default-features",
+    "--features",
+    "protocol-ws,protocol-http,kv-mem,kv-rocksdb",
+    "--workspace",
+]
 
 [tasks.ci-workspace-coverage-complete]
 env = { _START_SURREALDB_PATH = "memory" }
 category = "CI - INTEGRATION TESTS"
-run_task = { name = ["start-surrealdb", "test-workspace-coverage-complete", "stop-surrealdb"], fork = true }
+run_task = { name = [
+    "start-surrealdb",
+    "test-workspace-coverage-complete",
+    "stop-surrealdb",
+], fork = true }
 
 [tasks.ci-database-upgrade]
-env = { _TEST_FEATURES = "storage-rocksdb", RUSTFLAGS = "-D warnings --cfg surrealdb_unstable --cfg docker" }
+env = { _TEST_FEATURES = "storage-rocksdb", RUSTFLAGS = "-D warnings --cfg docker" }
 category = "CI - DATABASE UPGRADE TESTS"
 run_task = { name = ["test-database-upgrade"], fork = true }
 
@@ -151,24 +288,61 @@ run_task = { name = ["test-database-upgrade"], fork = true }
 private = true
 command = "cargo"
 env = { RUST_BACKTRACE = 1 }
-args = ["test", "--locked", "--package", "surrealdb-core", "--no-default-features", "--features", "${_TEST_FEATURES}", "--lib", "kvs::tests"]
+args = [
+    "test",
+    "--locked",
+    "--package",
+    "surrealdb-core",
+    "--no-default-features",
+    "--features",
+    "${_TEST_FEATURES}",
+    "--lib",
+    "kvs::tests",
+]
 
 [tasks.test-api-integration]
 private = true
 command = "cargo"
 env = { RUST_BACKTRACE = 1 }
-args = ["test", "--locked", "--package", "surrealdb", "--no-default-features", "--features", "${_TEST_FEATURES}", "--test", "api", "api_integration::${_TEST_API_ENGINE}"]
+args = [
+    "test",
+    "--locked",
+    "--package",
+    "surrealdb",
+    "--no-default-features",
+    "--features",
+    "${_TEST_FEATURES}",
+    "--test",
+    "api",
+    "api_integration::${_TEST_API_ENGINE}",
+]
 
 [tasks.ci-api-integration]
 private = true
 env = { RUST_BACKTRACE = 1, _START_SURREALDB_PATH = "memory" }
-run_task = { name = ["start-surrealdb", "test-api-integration", "stop-surrealdb"], fork = true }
+run_task = { name = [
+    "start-surrealdb",
+    "test-api-integration",
+    "stop-surrealdb",
+], fork = true }
 
 [tasks.test-database-upgrade]
 private = true
 command = "cargo"
 env = { RUST_LOG = "info" }
-args = ["test", "--locked", "--no-default-features", "--features", "${_TEST_FEATURES}", "--workspace", "--test", "database_upgrade", "--", "database_upgrade", "--show-output"]
+args = [
+    "test",
+    "--locked",
+    "--no-default-features",
+    "--features",
+    "${_TEST_FEATURES}",
+    "--workspace",
+    "--test",
+    "database_upgrade",
+    "--",
+    "database_upgrade",
+    "--show-output",
+]
 
 #
 # Integration tests with background services
@@ -195,37 +369,64 @@ run_task = "ci-api-integration"
 [tasks.ci-api-integration-mem]
 category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "mem", _TEST_FEATURES = "kv-mem" }
-run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+run_task = { name = [
+    "test-kvs",
+    "test-api-integration",
+], fork = true, parallel = true }
 
 [tasks.ci-api-integration-file]
 category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "file", _TEST_FEATURES = "kv-rocksdb" }
-run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+run_task = { name = [
+    "test-kvs",
+    "test-api-integration",
+], fork = true, parallel = true }
 
 [tasks.ci-api-integration-rocksdb]
 category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "rocksdb", _TEST_FEATURES = "kv-rocksdb" }
-run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = true }
+run_task = { name = [
+    "test-kvs",
+    "test-api-integration",
+], fork = true, parallel = true }
 
 [tasks.ci-api-integration-surrealkv]
 category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "surrealkv", _TEST_FEATURES = "kv-surrealkv" }
-run_task = { name = ["test-kvs", "test-api-integration"], fork = true, parallel = false }
+run_task = { name = [
+    "test-kvs",
+    "test-api-integration",
+], fork = true, parallel = false }
 
 [tasks.ci-api-integration-tikv]
 category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "tikv", _TEST_FEATURES = "kv-tikv" }
-run_task = { name = ["start-tikv", "test-kvs", "stop-tikv", "start-tikv", "test-api-integration", "stop-tikv"], fork = true, parallel = false }
+run_task = { name = [
+    "start-tikv",
+    "test-kvs",
+    "stop-tikv",
+    "start-tikv",
+    "test-api-integration",
+    "stop-tikv",
+], fork = true, parallel = false }
 
 [tasks.ci-api-integration-fdb-7_1]
 category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "fdb", _TEST_FEATURES = "kv-fdb-7_1" }
-run_task = { name = ["test-kvs", "clear-fdb", "test-api-integration"], fork = true, parallel = false }
+run_task = { name = [
+    "test-kvs",
+    "clear-fdb",
+    "test-api-integration",
+], fork = true, parallel = false }
 
 [tasks.ci-api-integration-fdb-7_3]
 category = "CI - INTEGRATION TESTS"
 env = { _TEST_API_ENGINE = "fdb", _TEST_FEATURES = "kv-fdb-7_3" }
-run_task = { name = ["test-kvs", "clear-fdb", "test-api-integration"], fork = true, parallel = false }
+run_task = { name = [
+    "test-kvs",
+    "clear-fdb",
+    "test-api-integration",
+], fork = true, parallel = false }
 
 #
 # Services
@@ -298,7 +499,14 @@ ${HOME}/.tiup/bin/tiup clean --all
 [tasks.clear-fdb]
 category = "CI - SERVICES"
 command = "fdbcli"
-args = ["-C", "/etc/foundationdb/fdb.cluster", "--exec", "writemode on; clearrange \"\" \\xFF", "--timeout", "20"]
+args = [
+    "-C",
+    "/etc/foundationdb/fdb.cluster",
+    "--exec",
+    "writemode on; clearrange \"\" \\xFF",
+    "--timeout",
+    "20",
+]
 
 #
 # Builds
@@ -307,7 +515,13 @@ args = ["-C", "/etc/foundationdb/fdb.cluster", "--exec", "writemode on; clearran
 [tasks.build-surrealdb]
 category = "CI - BUILD"
 command = "cargo"
-args = ["build", "--locked", "--no-default-features", "--features", "storage-mem"]
+args = [
+    "build",
+    "--locked",
+    "--no-default-features",
+    "--features",
+    "storage-mem",
+]
 
 #
 # Benchmarks - Common
@@ -315,7 +529,16 @@ args = ["build", "--locked", "--no-default-features", "--features", "storage-mem
 [tasks.ci-bench]
 category = "CI - BENCHMARK"
 command = "cargo"
-args = ["bench", "--quiet", "--package", "surrealdb", "--no-default-features", "--features", "kv-mem,scripting,http,jwks", "${@}"]
+args = [
+    "bench",
+    "--quiet",
+    "--package",
+    "surrealdb",
+    "--no-default-features",
+    "--features",
+    "kv-mem,scripting,http,jwks",
+    "${@}",
+]
 
 #
 # Benchmarks - SDB - Per Target
@@ -325,7 +548,17 @@ args = ["bench", "--quiet", "--package", "surrealdb", "--no-default-features", "
 private = true
 category = "CI - BENCHMARK - SurrealDB Target"
 command = "cargo"
-args = ["bench", "--package", "surrealdb", "--bench", "sdb", "--no-default-features", "--features", "${BENCH_FEATURES}", "${@}"]
+args = [
+    "bench",
+    "--package",
+    "surrealdb",
+    "--bench",
+    "sdb",
+    "--no-default-features",
+    "--features",
+    "${BENCH_FEATURES}",
+    "${@}",
+]
 
 [tasks.bench-lib-mem]
 category = "CI - BENCHMARK - SurrealDB Target"

--- a/Makefile.local.toml
+++ b/Makefile.local.toml
@@ -1,5 +1,7 @@
 [env]
-RUSTFLAGS = { value = "-D warnings --cfg surrealdb_unstable", condition = { env_not_set = ["RUSTFLAGS"] } }
+RUSTFLAGS = { value = "-D warnings", condition = { env_not_set = [
+    "RUSTFLAGS",
+] } }
 
 # Setup
 [tasks.cargo-upgrade]
@@ -20,7 +22,15 @@ dependencies = ["cargo-upgrade", "cargo-update"]
 [tasks.docs]
 category = "LOCAL USAGE"
 command = "cargo"
-args = ["doc", "--open", "--no-deps", "--package", "surrealdb", "--features", "rustls,native-tls,protocol-ws,protocol-http,kv-mem,kv-rocksdb,kv-tikv,http,scripting,jwks"]
+args = [
+    "doc",
+    "--open",
+    "--no-deps",
+    "--package",
+    "surrealdb",
+    "--features",
+    "rustls,native-tls,protocol-ws,protocol-http,kv-mem,kv-rocksdb,kv-tikv,http,scripting,jwks",
+]
 
 # Test
 [tasks.test]
@@ -38,13 +48,32 @@ args = ["fmt", "--all", "--check"]
 [tasks.cargo-check]
 category = "LOCAL USAGE"
 command = "cargo"
-args = ["check", "--profile", "make", "--workspace", "--all-targets", "--features", "${ALL_FEATURES}"]
+args = [
+    "check",
+    "--profile",
+    "make",
+    "--workspace",
+    "--all-targets",
+    "--features",
+    "${ALL_FEATURES}",
+]
 
 # Clippy
 [tasks.cargo-clippy]
 category = "LOCAL USAGE"
 command = "cargo"
-args = ["clippy", "--profile", "make", "--workspace", "--all-targets", "--features", "${ALL_FEATURES}", "--", "-D", "warnings"]
+args = [
+    "clippy",
+    "--profile",
+    "make",
+    "--workspace",
+    "--all-targets",
+    "--features",
+    "${ALL_FEATURES}",
+    "--",
+    "-D",
+    "warnings",
+]
 
 [tasks.check]
 category = "LOCAL USAGE"
@@ -64,33 +93,90 @@ args = ["clean"]
 [tasks.bench]
 category = "LOCAL USAGE"
 command = "cargo"
-args = ["bench", "--package", "surrealdb", "--no-default-features", "--features", "kv-mem,http,scripting,jwks", "--", "${@}"]
+args = [
+    "bench",
+    "--package",
+    "surrealdb",
+    "--no-default-features",
+    "--features",
+    "kv-mem,http,scripting,jwks",
+    "--",
+    "${@}",
+]
 
 # Run
 [tasks.run]
 category = "LOCAL USAGE"
 command = "cargo"
-args = ["run", "--profile", "make", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "${@}"]
+args = [
+    "run",
+    "--profile",
+    "make",
+    "--no-default-features",
+    "--features",
+    "${DEV_FEATURES}",
+    "--",
+    "${@}",
+]
 
 # Serve
 [tasks.serve]
 category = "LOCAL USAGE"
 command = "cargo"
-args = ["run", "--profile", "make", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "start", "--allow-all", "${@}"]
+args = [
+    "run",
+    "--profile",
+    "make",
+    "--no-default-features",
+    "--features",
+    "${DEV_FEATURES}",
+    "--",
+    "start",
+    "--allow-all",
+    "${@}",
+]
 
 # SQL
 [tasks.sql]
 category = "LOCAL USAGE"
 command = "cargo"
 env = { SURREAL_LOG = "error" }
-args = ["run", "--profile", "make", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "sql", "--pretty", "${@}"]
+args = [
+    "run",
+    "--profile",
+    "make",
+    "--no-default-features",
+    "--features",
+    "${DEV_FEATURES}",
+    "--",
+    "sql",
+    "--pretty",
+    "${@}",
+]
 
 # REPL
 [tasks.repl]
 category = "LOCAL USAGE"
 command = "cargo"
 env = { SURREAL_LOG = "error" }
-args = ["run", "--profile", "make", "--no-default-features", "--features", "${DEV_FEATURES}", "--", "sql", "--pretty", "--conn", "memory", "--ns", "test", "--db", "test", "${@}"]
+args = [
+    "run",
+    "--profile",
+    "make",
+    "--no-default-features",
+    "--features",
+    "${DEV_FEATURES}",
+    "--",
+    "sql",
+    "--pretty",
+    "--conn",
+    "memory",
+    "--ns",
+    "test",
+    "--db",
+    "test",
+    "${@}",
+]
 
 # Build
 [tasks.build]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,19 +24,44 @@ resolver = "2"
 [features]
 # Public features
 default = ["kv-mem"]
-kv-mem = ["dep:surrealkv", "tokio/time", "dep:tempfile", "dep:ext-sort", "dep:affinitypool"]
+kv-mem = [
+    "dep:surrealkv",
+    "tokio/time",
+    "dep:tempfile",
+    "dep:ext-sort",
+    "dep:affinitypool",
+]
 kv-indxdb = ["dep:indxdb"]
-kv-rocksdb = ["dep:rocksdb", "tokio/time", "dep:tempfile", "dep:ext-sort", "dep:affinitypool"]
+kv-rocksdb = [
+    "dep:rocksdb",
+    "tokio/time",
+    "dep:tempfile",
+    "dep:ext-sort",
+    "dep:affinitypool",
+]
 kv-tikv = ["dep:tikv", "tokio/time", "dep:tempfile", "dep:ext-sort"]
 kv-fdb = ["dep:foundationdb", "tokio/time", "dep:tempfile", "dep:ext-sort"]
-kv-surrealkv = ["dep:surrealkv", "tokio/time", "dep:tempfile", "dep:ext-sort", "dep:affinitypool"]
+kv-surrealkv = [
+    "dep:surrealkv",
+    "tokio/time",
+    "dep:tempfile",
+    "dep:ext-sort",
+    "dep:affinitypool",
+]
 kv-surrealcs = ["dep:surrealcs", "tokio/time", "dep:tempfile", "dep:ext-sort"]
 scripting = ["dep:js"]
 http = ["dep:reqwest"]
 ml = ["dep:surrealml"]
 jwks = ["dep:reqwest"]
 allocator = ["dep:jemallocator", "dep:mimalloc"]
-arbitrary = ["dep:arbitrary", "dep:regex-syntax","regex-syntax/arbitrary", "rust_decimal/rust-fuzz", "geo-types/arbitrary", "uuid/arbitrary"]
+arbitrary = [
+    "dep:arbitrary",
+    "dep:regex-syntax",
+    "regex-syntax/arbitrary",
+    "rust_decimal/rust-fuzz",
+    "geo-types/arbitrary",
+    "uuid/arbitrary",
+]
 allocation-tracking = []
 # Special features
 kv-fdb-7_1 = ["foundationdb/fdb-7_1", "kv-fdb"]
@@ -57,11 +82,28 @@ surrealml = { workspace = true, optional = true }
 affinitypool = { workspace = true, optional = true }
 #derive.workspace = true
 dmp.workspace = true
-indxdb = { workspace = true, optional = true}
-js = { workspace = true, features = ["array-buffer", "bindgen", "classes", "futures", "loader", "macro", "parallel", "properties", "rust-alloc"], optional = true }
+indxdb = { workspace = true, optional = true }
+js = { workspace = true, features = [
+    "array-buffer",
+    "bindgen",
+    "classes",
+    "futures",
+    "loader",
+    "macro",
+    "parallel",
+    "properties",
+    "rust-alloc",
+], optional = true }
 lexicmp.workspace = true
 reblessive = { workspace = true, features = ["tree"] }
-revision = { workspace = true, features = ["chrono", "geo", "roaring", "regex", "rust_decimal", "uuid"] }
+revision = { workspace = true, features = [
+    "chrono",
+    "geo",
+    "roaring",
+    "regex",
+    "rust_decimal",
+    "uuid",
+] }
 serde-content.workspace = true
 storekey.workspace = true
 vart.workspace = true
@@ -79,7 +121,9 @@ argon2.workspace = true
 ascii.workspace = true
 async-channel.workspace = true
 async-executor.workspace = true
-async-graphql = { workspace = true, default-features = false, features = ["dynamic-schema"] }
+async-graphql = { workspace = true, default-features = false, features = [
+    "dynamic-schema",
+] }
 base64.workspace = true
 bcrypt.workspace = true
 bincode.workspace = true
@@ -94,7 +138,7 @@ deunicode.workspace = true
 fst.workspace = true
 futures.workspace = true
 fuzzy-matcher.workspace = true
-geo = { workspace = true, features = ["use-serde"]}
+geo = { workspace = true, features = ["use-serde"] }
 geo-types = { workspace = true }
 http.workspace = true
 hex.workspace = true
@@ -113,7 +157,7 @@ pbkdf2 = { workspace = true, features = ["simple"] }
 phf = { workspace = true, features = ["macros", "unicase"] }
 pin-project-lite.workspace = true
 quick_cache.workspace = true
-radix_trie = { workspace = true, features = ["serde"]}
+radix_trie = { workspace = true, features = ["serde"] }
 rand.workspace = true
 rayon.workspace = true
 regex.workspace = true
@@ -122,7 +166,7 @@ roaring = { workspace = true, features = ["serde"] }
 rust_decimal = { workspace = true, features = ["maths", "serde-str"] }
 rust-stemmers.workspace = true
 scrypt.workspace = true
-semver = { workspace = true, features = ["serde"]}
+semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha1.workspace = true
@@ -142,7 +186,11 @@ url.workspace = true
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 ext-sort = { workspace = true, optional = true }
 regex-syntax = { workspace = true, optional = true }
-reqwest = { workspace = true, default-features = false, features = ["json", "stream", "multipart"], optional = true }
+reqwest = { workspace = true, default-features = false, features = [
+    "json",
+    "stream",
+    "multipart",
+], optional = true }
 tempfile = { workspace = true, optional = true }
 
 
@@ -150,7 +198,7 @@ tempfile = { workspace = true, optional = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 env_logger.workspace = true
 flate2.workspace = true
-pprof = { workspace = true , features = ["flamegraph", "criterion"] }
+pprof = { workspace = true, features = ["flamegraph", "criterion"] }
 serial_test.workspace = true
 temp-dir.workspace = true
 test-log = { workspace = true, features = ["trace"] }
@@ -163,14 +211,25 @@ wiremock.workspace = true
 getrandom = { workspace = true, features = ["wasm_js"] }
 pharos.workspace = true
 ring = { workspace = true, features = ["wasm32_unknown_unknown_js"] }
-tokio = { workspace = true, default-features = false, features = ["rt", "sync"] }
+tokio = { workspace = true, default-features = false, features = [
+    "rt",
+    "sync",
+] }
 uuid = { workspace = true, features = ["serde", "js", "v4", "v7"] }
 wasm-bindgen-futures.workspace = true
 wasmtimer = { workspace = true, default-features = false, features = ["tokio"] }
 ws_stream_wasm.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio = { workspace = true, default-features = false, features = ["macros", "io-util", "io-std", "fs", "rt-multi-thread", "time", "sync"] }
+tokio = { workspace = true, default-features = false, features = [
+    "macros",
+    "io-util",
+    "io-std",
+    "fs",
+    "rt-multi-thread",
+    "time",
+    "sync",
+] }
 tokio-tungstenite = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["serde", "v4", "v7"] }
 
@@ -181,10 +240,7 @@ mimalloc = { workspace = true, optional = true, default-features = false }
 jemallocator = { workspace = true, optional = true }
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(storage)',
-    'cfg(surrealdb_unstable)',
-] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(storage)'] }
 
 [lib]
 name = "surrealdb_core"

--- a/crates/core/src/gql/mod.rs
+++ b/crates/core/src/gql/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(all(not(target_family = "wasm"), surrealdb_unstable))]
+#![cfg(not(target_family = "wasm"))]
 
 pub mod cache;
 pub mod error;

--- a/crates/core/src/rpc/context.rs
+++ b/crates/core/src/rpc/context.rs
@@ -1,4 +1,4 @@
-#[cfg(all(not(target_family = "wasm"), surrealdb_unstable))]
+#[cfg(not(target_family = "wasm"))]
 use crate::gql::SchemaCache;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -51,11 +51,11 @@ pub trait RpcContext {
 	// ------------------------------
 
 	/// GraphQL queries are disabled by default
-	#[cfg(all(not(target_family = "wasm"), surrealdb_unstable))]
+	#[cfg(not(target_family = "wasm"))]
 	const GQL_SUPPORT: bool = false;
 
 	/// Returns the GraphQL schema cache used in GraphQL queries
-	#[cfg(all(not(target_family = "wasm"), surrealdb_unstable))]
+	#[cfg(not(target_family = "wasm"))]
 	fn graphql_schema_cache(&self) -> &SchemaCache {
 		unimplemented!("graphql_schema_cache function must be implemented if GQL_SUPPORT = true")
 	}

--- a/crates/core/src/rpc/protocol/v1.rs
+++ b/crates/core/src/rpc/protocol/v1.rs
@@ -1,9 +1,9 @@
-#[cfg(all(not(target_family = "wasm"), surrealdb_unstable))]
+#[cfg(not(target_family = "wasm"))]
 use async_graphql::BatchRequest;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-#[cfg(all(not(target_family = "wasm"), surrealdb_unstable))]
+#[cfg(not(target_family = "wasm"))]
 use crate::dbs::capabilities::ExperimentalTarget;
 use crate::err::Error;
 use crate::rpc::Data;
@@ -852,12 +852,12 @@ pub trait RpcProtocolV1: RpcContext {
 	// Methods for querying with GraphQL
 	// ------------------------------
 
-	#[cfg(any(target_family = "wasm", not(surrealdb_unstable)))]
+	#[cfg(target_family = "wasm")]
 	async fn graphql(&self, _: Array) -> Result<Data, RpcError> {
 		Err(RpcError::MethodNotFound)
 	}
 
-	#[cfg(all(not(target_family = "wasm"), surrealdb_unstable))]
+	#[cfg(not(target_family = "wasm"))]
 	async fn graphql(&self, params: Array) -> Result<Data, RpcError> {
 		// Check if the user is allowed to query
 		if !self.kvs().allows_query_by_subject(self.session().au.as_ref()) {

--- a/crates/core/src/rpc/protocol/v2.rs
+++ b/crates/core/src/rpc/protocol/v2.rs
@@ -1,9 +1,9 @@
-#[cfg(all(not(target_family = "wasm"), surrealdb_unstable))]
+#[cfg(not(target_family = "wasm"))]
 use async_graphql::BatchRequest;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-#[cfg(all(not(target_family = "wasm"), surrealdb_unstable))]
+#[cfg(not(target_family = "wasm"))]
 use crate::dbs::capabilities::ExperimentalTarget;
 use crate::err::Error;
 use crate::rpc::Data;
@@ -852,12 +852,12 @@ pub trait RpcProtocolV2: RpcContext {
 	// Methods for querying with GraphQL
 	// ------------------------------
 
-	#[cfg(any(target_family = "wasm", not(surrealdb_unstable)))]
+	#[cfg(target_family = "wasm")]
 	async fn graphql(&self, _: Array) -> Result<Data, RpcError> {
 		Err(RpcError::MethodNotFound)
 	}
 
-	#[cfg(all(not(target_family = "wasm"), surrealdb_unstable))]
+	#[cfg(not(target_family = "wasm"))]
 	async fn graphql(&self, params: Array) -> Result<Data, RpcError> {
 		// Check if the user is allowed to query
 		if !self.kvs().allows_query_by_subject(self.session().au.as_ref()) {

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -174,7 +174,6 @@ wiremock.workspace = true
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(kv_fdb)',
     'cfg(storage)',
-    'cfg(surrealdb_unstable)',
 ] }
 
 [lib]

--- a/crates/sdk/src/api/method/mod.rs
+++ b/crates/sdk/src/api/method/mod.rs
@@ -260,16 +260,6 @@ where
 		}
 	}
 
-	/// Not supported yet
-	#[doc(hidden)]
-	#[cfg(surrealdb_unstable)] // Mark this API as unstable
-	pub fn transaction(self) -> Begin<C> {
-		warn!("Client side transactions are not yet supported. This API doesn't do anything yet.");
-		Begin {
-			client: self,
-		}
-	}
-
 	/// Switch to a specific namespace
 	///
 	/// # Examples

--- a/src/gql/mod.rs
+++ b/src/gql/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(surrealdb_unstable)]
-
 use std::{
 	convert::Infallible,
 	sync::Arc,

--- a/src/rpc/http.rs
+++ b/src/rpc/http.rs
@@ -10,14 +10,12 @@ use surrealdb_core::rpc::RpcProtocolV2;
 use surrealdb_core::sql::Array;
 use tokio::sync::Semaphore;
 
-#[cfg(surrealdb_unstable)]
 use surrealdb_core::gql::{Pessimistic, SchemaCache};
 
 pub struct Http {
 	pub kvs: Arc<Datastore>,
 	pub lock: Arc<Semaphore>,
 	pub session: Arc<Session>,
-	#[cfg(surrealdb_unstable)]
 	pub gql_schema: SchemaCache<Pessimistic>,
 }
 
@@ -27,7 +25,6 @@ impl Http {
 			kvs: kvs.clone(),
 			lock: Arc::new(Semaphore::new(1)),
 			session: Arc::new(session),
-			#[cfg(surrealdb_unstable)]
 			gql_schema: SchemaCache::new(kvs.clone()),
 		}
 	}
@@ -67,10 +64,8 @@ impl RpcContext for Http {
 	// ------------------------------
 
 	/// GraphQL queries are enabled on HTTP
-	#[cfg(surrealdb_unstable)]
 	const GQL_SUPPORT: bool = true;
 
-	#[cfg(surrealdb_unstable)]
 	fn graphql_schema_cache(&self) -> &SchemaCache {
 		&self.gql_schema
 	}

--- a/src/rpc/websocket.rs
+++ b/src/rpc/websocket.rs
@@ -21,7 +21,6 @@ use opentelemetry::Context as TelemetryContext;
 use std::sync::Arc;
 use std::time::Duration;
 use surrealdb::dbs::Session;
-#[cfg(surrealdb_unstable)]
 use surrealdb::gql::{Pessimistic, SchemaCache};
 use surrealdb::kvs::Datastore;
 use surrealdb::mem::ALLOC;
@@ -67,7 +66,6 @@ pub struct Websocket {
 	/// The channels used to send and receive WebSocket messages
 	pub(crate) channel: Sender<Message>,
 	/// The GraphQL schema cache stored in advance
-	#[cfg(surrealdb_unstable)]
 	pub(crate) gql_schema: SchemaCache<Pessimistic>,
 }
 
@@ -95,7 +93,6 @@ impl Websocket {
 			canceller: CancellationToken::new(),
 			session: ArcSwap::from(Arc::new(session)),
 			channel: sender.clone(),
-			#[cfg(surrealdb_unstable)]
 			gql_schema: SchemaCache::new(datastore.clone()),
 			datastore,
 		});
@@ -512,10 +509,8 @@ impl RpcContext for Websocket {
 	// ------------------------------
 
 	/// GraphQL queries are enabled on WebSockets
-	#[cfg(surrealdb_unstable)]
 	const GQL_SUPPORT: bool = true;
 
-	#[cfg(surrealdb_unstable)]
 	fn graphql_schema_cache(&self) -> &SchemaCache {
 		&self.gql_schema
 	}

--- a/tests/graphql_integration.rs
+++ b/tests/graphql_integration.rs
@@ -1,6 +1,5 @@
 mod common;
 
-#[cfg(surrealdb_unstable)]
 mod graphql_integration {
 	use std::{str::FromStr, time::Duration};
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Graphql is currently not working in 2.3 because `surrealdb_unstable` is no longer set in CI

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Backport #5799 to remove surrealdb_unstable

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

GitHub CI

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
