### PR TITLE
Fixes invalid "*" value for SURREAL_CAPS_[ALLOW_ARBITRARY_QUERY | ALLOW_EXPERIMENTAL]

### DIFF
--- a/crates/core/src/dbs/capabilities.rs
+++ b/crates/core/src/dbs/capabilities.rs
@@ -1079,6 +1079,14 @@ mod tests {
 			assert!(!caps.allows_rpc_method(&MethodTarget::from_str("query").unwrap()));
 		}
 
+		// When all RPC methods are denied
+		{
+			let caps = Capabilities::default().without_rpc_methods(Targets::<MethodTarget>::All);
+			assert!(!caps.allows_rpc_method(&MethodTarget::from_str("ping").unwrap()));
+			assert!(!caps.allows_rpc_method(&MethodTarget::from_str("select").unwrap()));
+			assert!(!caps.allows_rpc_method(&MethodTarget::from_str("query").unwrap()));
+		}
+
 		// When some RPC methods are allowed and some are denied, deny overrides the allow rules
 		{
 			let caps = Capabilities::default()
@@ -1129,6 +1137,14 @@ mod tests {
 			assert!(!caps.allows_http_route(&RouteTarget::from_str("sql").unwrap()));
 		}
 
+		// When all HTTP routes are denied at the same time
+		{
+			let caps = Capabilities::default().without_http_routes(Targets::<RouteTarget>::All);
+			assert!(!caps.allows_http_route(&RouteTarget::from_str("version").unwrap()));
+			assert!(!caps.allows_http_route(&RouteTarget::from_str("export").unwrap()));
+			assert!(!caps.allows_http_route(&RouteTarget::from_str("sql").unwrap()));
+		}
+
 		// When some HTTP routes are allowed and some are denied, deny overrides the allow rules
 		{
 			let caps = Capabilities::default()
@@ -1170,6 +1186,15 @@ mod tests {
 		{
 			let caps = Capabilities::default()
 				.with_arbitrary_query(Targets::<ArbitraryQueryTarget>::All)
+				.without_arbitrary_query(Targets::<ArbitraryQueryTarget>::All);
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("guest").unwrap()));
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("record").unwrap()));
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("system").unwrap()));
+		}
+
+		// When all arbitrary query targets are denied
+		{
+			let caps = Capabilities::default()
 				.without_arbitrary_query(Targets::<ArbitraryQueryTarget>::All);
 			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("guest").unwrap()));
 			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("record").unwrap()));

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -510,8 +510,7 @@ impl Datastore {
 		self.capabilities.allows_http_route(route_target)
 	}
 
-	/// Does the datastore allow requesting an HTTP route?
-	/// This function needs to be public to allow access from the CLI crate.
+	/// Is the user allowed to query?
 	pub fn allows_query_by_subject(&self, subject: impl Into<ArbitraryQueryTarget>) -> bool {
 		self.capabilities.allows_query(&subject.into())
 	}

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -267,4 +267,36 @@ mod tests {
 			)
 		);
 	}
+
+	#[test]
+	fn test_abritrary_query_targets() {
+		assert_eq!(query_arbitrary_targets("*").unwrap(), Targets::<ArbitraryQueryTarget>::All);
+		assert_eq!(query_arbitrary_targets("").unwrap(), Targets::<ArbitraryQueryTarget>::All);
+		assert_eq!(
+			query_arbitrary_targets("guest").unwrap(),
+			Targets::<ArbitraryQueryTarget>::Some(
+				vec![ArbitraryQueryTarget::Guest].into_iter().collect()
+			)
+		);
+		assert_eq!(
+			query_arbitrary_targets("guest,system").unwrap(),
+			Targets::<ArbitraryQueryTarget>::Some(
+				vec![ArbitraryQueryTarget::Guest, ArbitraryQueryTarget::System]
+					.into_iter()
+					.collect()
+			)
+		);
+		assert_eq!(
+			query_arbitrary_targets("guest,record,system").unwrap(),
+			Targets::<ArbitraryQueryTarget>::Some(
+				vec![
+					ArbitraryQueryTarget::Guest,
+					ArbitraryQueryTarget::System,
+					ArbitraryQueryTarget::Record
+				]
+				.into_iter()
+				.collect()
+			)
+		);
+	}
 }

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -291,8 +291,8 @@ mod tests {
 			Targets::<ArbitraryQueryTarget>::Some(
 				vec![
 					ArbitraryQueryTarget::Guest,
-					ArbitraryQueryTarget::System,
-					ArbitraryQueryTarget::Record
+					ArbitraryQueryTarget::Record,
+					ArbitraryQueryTarget::System
 				]
 				.into_iter()
 				.collect()

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -269,7 +269,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_abritrary_query_targets() {
+	fn test_arbitrary_query_targets() {
 		assert_eq!(query_arbitrary_targets("*").unwrap(), Targets::<ArbitraryQueryTarget>::All);
 		assert_eq!(query_arbitrary_targets("").unwrap(), Targets::<ArbitraryQueryTarget>::All);
 		assert_eq!(

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -404,20 +404,10 @@ impl DbsCapabilities {
 
 	fn get_allow_experimental(&self) -> Targets<ExperimentalTarget> {
 		self.allow_experimental.clone().unwrap_or(Targets::None)
-		// match &self.allow_experimental {
-		// 	Some(t @ Targets::Some(_)) => t.clone(),
-		// 	Some(Targets::All) => Targets::All,
-		// 	Some(_) => Targets::None,
-		// 	None => Targets::None,
-		// }
 	}
 
 	fn get_deny_experimental(&self) -> Targets<ExperimentalTarget> {
-		match &self.deny_experimental {
-			Some(t @ Targets::Some(_)) => t.clone(),
-			Some(_) => Targets::None,
-			None => Targets::None,
-		}
+		self.allow_experimental.clone().unwrap_or(Targets::None)
 	}
 
 	fn get_allow_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -403,12 +403,13 @@ impl DbsCapabilities {
 	}
 
 	fn get_allow_experimental(&self) -> Targets<ExperimentalTarget> {
-		match &self.allow_experimental {
-			Some(t @ Targets::Some(_)) => t.clone(),
-			Some(Targets::All) => Targets::All,
-			Some(_) => Targets::None,
-			None => Targets::None,
-		}
+		self.allow_experimental.clone().unwrap_or(Targets::None)
+		// match &self.allow_experimental {
+		// 	Some(t @ Targets::Some(_)) => t.clone(),
+		// 	Some(Targets::All) => Targets::All,
+		// 	Some(_) => Targets::None,
+		// 	None => Targets::None,
+		// }
 	}
 
 	fn get_deny_experimental(&self) -> Targets<ExperimentalTarget> {
@@ -420,20 +421,11 @@ impl DbsCapabilities {
 	}
 
 	fn get_allow_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
-		match &self.allow_arbitrary_query {
-			Some(t @ Targets::Some(_)) => t.clone(),
-			Some(Targets::All) => Targets::All,
-			Some(_) => Targets::None,
-			None => Targets::All,
-		}
+		self.allow_arbitrary_query.clone().unwrap_or(Targets::All)
 	}
 
 	fn get_deny_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
-		match &self.deny_arbitrary_query {
-			Some(t @ Targets::Some(_)) => t.clone(),
-			Some(_) => Targets::None,
-			None => Targets::None,
-		}
+		self.allow_arbitrary_query.clone().unwrap_or(Targets::None)
 	}
 
 	pub fn into_cli_capabilities(self) -> Capabilities {

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -403,19 +403,19 @@ impl DbsCapabilities {
 	}
 
 	fn get_allow_experimental(&self) -> Targets<ExperimentalTarget> {
-		self.allow_experimental.clone().unwrap_or(Targets::None)
+		self.allow_experimental.as_ref().cloned().unwrap_or(Targets::None)
 	}
 
 	fn get_deny_experimental(&self) -> Targets<ExperimentalTarget> {
-		self.allow_experimental.clone().unwrap_or(Targets::None)
+		self.allow_experimental.as_ref().cloned().unwrap_or(Targets::None)
 	}
 
 	fn get_allow_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
-		self.allow_arbitrary_query.clone().unwrap_or(Targets::All)
+		self.allow_arbitrary_query.as_ref().cloned().unwrap_or(Targets::All)
 	}
 
 	fn get_deny_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
-		self.deny_arbitrary_query.clone().unwrap_or(Targets::None)
+		self.deny_arbitrary_query.as_ref().cloned().unwrap_or(Targets::None)
 	}
 
 	pub fn into_cli_capabilities(self) -> Capabilities {

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -405,6 +405,7 @@ impl DbsCapabilities {
 	fn get_allow_experimental(&self) -> Targets<ExperimentalTarget> {
 		match &self.allow_experimental {
 			Some(t @ Targets::Some(_)) => t.clone(),
+			Some(Targets::All) => Targets::All,
 			Some(_) => Targets::None,
 			None => Targets::None,
 		}
@@ -421,6 +422,7 @@ impl DbsCapabilities {
 	fn get_allow_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
 		match &self.allow_arbitrary_query {
 			Some(t @ Targets::Some(_)) => t.clone(),
+			Some(Targets::All) => Targets::All,
 			Some(_) => Targets::None,
 			None => Targets::All,
 		}
@@ -866,7 +868,7 @@ mod tests {
 				format!("RETURN http::get('{}/redirect')", server3.uri()),
 				false,
 				format!("here was an error processing a remote HTTP request: error following redirect for url ({}/redirect)",server3.uri()),
-			),
+			)
 		];
 
 		for (idx, (ds, sess, query, succeeds, contains)) in cases.into_iter().enumerate() {
@@ -902,5 +904,31 @@ mod tests {
 		server1.verify().await;
 		server2.verify().await;
 		server3.verify().await;
+	}
+
+	#[test]
+	fn test_dbs_capabilities_target_all() {
+		let caps = DbsCapabilities {
+			allow_all: false,
+			allow_scripting: false,
+			allow_guests: false,
+			allow_funcs: None,
+			allow_experimental: Some(Targets::All),
+			allow_arbitrary_query: Some(Targets::All),
+			allow_net: None,
+			allow_rpc: None,
+			allow_http: None,
+			deny_all: false,
+			deny_scripting: false,
+			deny_guests: false,
+			deny_funcs: None,
+			deny_experimental: None,
+			deny_arbitrary_query: None,
+			deny_net: None,
+			deny_rpc: None,
+			deny_http: None,
+		};
+		assert_eq!(caps.get_allow_experimental(), Targets::All);
+		assert_eq!(caps.get_allow_arbitrary_query(), Targets::All);
 	}
 }

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -415,7 +415,7 @@ impl DbsCapabilities {
 	}
 
 	fn get_deny_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
-		self.allow_arbitrary_query.clone().unwrap_or(Targets::None)
+		self.deny_arbitrary_query.clone().unwrap_or(Targets::None)
 	}
 
 	pub fn into_cli_capabilities(self) -> Capabilities {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Fixes #5885
The same issue occurs for `SURREAL_CAPS_ALLOW_EXPERIMENTAL`

## What does this change do?

Fixes #5885.

## What is your testing strategy?

Github action.

Tests have been added

## Is this related to any issues?

Fixes #5885.

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
