### PR TITLE
Remove redundant key encoding & make `Transaction` dyn compatible.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5929,6 +5929,7 @@ dependencies = [
  "async-channel",
  "async-executor",
  "async-graphql",
+ "async-trait",
  "base64 0.21.7",
  "bcrypt",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ async-channel = "2.3.1"
 async-executor = "1.13.1"
 async-graphql = { version = "7.0.9", default-features = false }
 async-graphql-axum = "=7.0.13"
+async-trait = "0.1.88"
 base64 = "0.21.5"
 bcrypt = "0.15.0"
 bincode = "1.3.3"
@@ -169,6 +170,7 @@ ml = ["surrealdb/ml"]
 performance-profiler = ["dep:pprof"]
 scripting = ["surrealdb/scripting"]
 storage-mem = ["surrealdb/kv-mem"]
+storage-indxdb = ["surrealdb/kv-indxdb"]
 storage-rocksdb = ["surrealdb/kv-rocksdb"]
 storage-surrealkv = ["surrealdb/kv-surrealkv"]
 storage-tikv = ["surrealdb/kv-tikv"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -122,6 +122,7 @@ async-executor.workspace = true
 async-graphql = { workspace = true, default-features = false, features = [
     "dynamic-schema",
 ] }
+async-trait.workspace = true
 base64.workspace = true
 bcrypt.workspace = true
 bincode.workspace = true

--- a/crates/core/src/doc/insert.rs
+++ b/crates/core/src/doc/insert.rs
@@ -31,7 +31,7 @@ impl Document {
 		let retryable = stm.update.is_some();
 		if retryable {
 			// it is retryable so generate a save point we can roll back to.
-			ctx.tx().lock().await.new_save_point().await;
+			ctx.tx().lock().await.new_save_point();
 		}
 
 		// First try to create the value and if that is not possible due to an existing value fall
@@ -111,13 +111,13 @@ impl Document {
 			},
 			Err(IgnoreError::Ignore) => {
 				if retryable {
-					ctx.tx().lock().await.release_last_save_point().await?;
+					ctx.tx().lock().await.release_last_save_point()?;
 				}
 				return Err(IgnoreError::Ignore);
 			}
 			Ok(x) => {
 				if retryable {
-					ctx.tx().lock().await.release_last_save_point().await?;
+					ctx.tx().lock().await.release_last_save_point()?;
 				}
 				return Ok(x);
 			}

--- a/crates/core/src/doc/upsert.rs
+++ b/crates/core/src/doc/upsert.rs
@@ -25,7 +25,7 @@ impl Document {
 			return self.upsert_update(stk, ctx, opt, stm).await;
 		}
 
-		ctx.tx().lock().await.new_save_point().await;
+		ctx.tx().lock().await.new_save_point();
 
 		// First try to create the value and if that is not possible due to an existing value fall
 		// back to update instead.
@@ -64,11 +64,11 @@ impl Document {
 				}
 			},
 			Err(IgnoreError::Ignore) => {
-				ctx.tx().lock().await.release_last_save_point().await?;
+				ctx.tx().lock().await.release_last_save_point()?;
 				return Err(IgnoreError::Ignore);
 			}
 			Ok(x) => {
-				ctx.tx().lock().await.release_last_save_point().await?;
+				ctx.tx().lock().await.release_last_save_point()?;
 				return Ok(x);
 			}
 		};

--- a/crates/core/src/gql/cache.rs
+++ b/crates/core/src/gql/cache.rs
@@ -9,19 +9,22 @@ use crate::kvs::Datastore;
 
 use super::{error::GqlError, schema::generate_schema};
 
+#[async_trait::async_trait]
 pub trait Invalidator: Debug + Clone + Send + Sync + 'static {
 	type MetaData: Debug + Clone + Send + Sync + Hash;
 
 	fn is_valid(datastore: &Datastore, session: &Session, meta: &Self::MetaData) -> bool;
 
-	fn generate(
+	async fn generate(
 		datastore: &Arc<Datastore>,
 		session: &Session,
-	) -> impl std::future::Future<Output = Result<(Schema, Self::MetaData), GqlError>> + std::marker::Send;
+	) -> Result<(Schema, Self::MetaData), GqlError>;
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct Pessimistic;
+
+#[async_trait::async_trait]
 impl Invalidator for Pessimistic {
 	type MetaData = ();
 
@@ -40,6 +43,8 @@ impl Invalidator for Pessimistic {
 
 #[derive(Debug, Clone, Copy)]
 pub struct Optimistic;
+
+#[async_trait::async_trait]
 impl Invalidator for Optimistic {
 	type MetaData = ();
 

--- a/crates/core/src/key/debug.rs
+++ b/crates/core/src/key/debug.rs
@@ -1,4 +1,4 @@
-//! Debugging utilities for the `key` crate.
+//! Debugging utilities for the `key` module.
 
 use std::ops::Range;
 

--- a/crates/core/src/key/debug.rs
+++ b/crates/core/src/key/debug.rs
@@ -1,6 +1,10 @@
+//! Debugging utilities for the `key` crate.
+
 use std::ops::Range;
 
+/// A trait for types that can be converted to a string representation for readability.
 pub trait Sprintable {
+	/// Converts the implementing type to a string representation.
 	fn sprint(&self) -> String;
 }
 

--- a/crates/core/src/kvs/api.rs
+++ b/crates/core/src/kvs/api.rs
@@ -1,3 +1,6 @@
+//! This module defines the API for a transaction in a key-value store.
+#![warn(clippy::missing_docs_in_private_items)]
+
 use super::tr::Check;
 use super::util;
 use crate::cnf::COUNT_BATCH_SIZE;
@@ -15,7 +18,7 @@ use std::ops::Range;
 /// This trait defines the API for a transaction in a key-value store.
 ///
 /// All keys and values are represented as byte arrays, encoding is handled
-/// by the [`Transactor`]
+/// by [`super::tr::Transactor`].
 #[allow(dead_code, reason = "Not used when none of the storage backends are enabled.")]
 #[async_trait::async_trait]
 pub trait Transaction: Send {
@@ -511,12 +514,15 @@ pub trait Transaction: Send {
 		self.set(k, val, None).await
 	}
 
+	/// Get the save points for this transaction.
 	fn get_save_points(&mut self) -> &mut SavePoints;
 
+	/// Set a new current save point for this transaction.
 	fn new_save_point(&mut self) {
 		self.get_save_points().new_save_point()
 	}
 
+	/// Rollback to the last save point.
 	async fn rollback_to_save_point(&mut self) -> Result<(), Error> {
 		let sp = self.get_save_points().pop()?;
 
@@ -545,11 +551,13 @@ pub trait Transaction: Send {
 		Ok(())
 	}
 
+	/// Release the last save point.
 	fn release_last_save_point(&mut self) -> Result<(), Error> {
 		self.get_save_points().pop()?;
 		Ok(())
 	}
 
+	/// Prepare a save point for a key.
 	async fn save_point_prepare(
 		&mut self,
 		key: &Key,

--- a/crates/core/src/kvs/api.rs
+++ b/crates/core/src/kvs/api.rs
@@ -484,7 +484,7 @@ pub trait Transaction: Send {
 			None => VersionStamp::from_u64(1),
 		};
 		// Store the timestamp to prevent other transactions from committing
-		self.set(key, ver.as_bytes().to_vec(), None).await?;
+		self.set(key, ver.to_vec(), None).await?;
 		// Return the uint64 representation of the timestamp as the result
 		Ok(ver)
 	}

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -133,32 +133,32 @@ impl TransactionFactory {
 			#[cfg(feature = "kv-mem")]
 			DatastoreFlavor::Mem(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(super::tr::Inner::Mem(tx), true, false)
+				(Box::new(tx) as Box<dyn super::api::Transaction>, true, false)
 			}
 			#[cfg(feature = "kv-rocksdb")]
 			DatastoreFlavor::RocksDB(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(super::tr::Inner::RocksDB(tx), true, true)
+				(Box::new(tx) as Box<dyn super::api::Transaction>, true, true)
 			}
 			#[cfg(feature = "kv-indxdb")]
 			DatastoreFlavor::IndxDB(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(super::tr::Inner::IndxDB(tx), true, false)
+				(Box::new(tx) as Box<dyn super::api::Transaction>, true, false)
 			}
 			#[cfg(feature = "kv-tikv")]
 			DatastoreFlavor::TiKV(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(super::tr::Inner::TiKV(tx), false, true)
+				(Box::new(tx) as Box<dyn super::api::Transaction>, false, true)
 			}
 			#[cfg(feature = "kv-fdb")]
 			DatastoreFlavor::FoundationDB(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(super::tr::Inner::FoundationDB(tx), false, false)
+				(Box::new(tx) as Box<dyn super::api::Transaction>, false, false)
 			}
 			#[cfg(feature = "kv-surrealkv")]
 			DatastoreFlavor::SurrealKV(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(super::tr::Inner::SurrealKV(tx), true, false)
+				(Box::new(tx) as Box<dyn super::api::Transaction>, true, false)
 			}
 			_ => unreachable!(),
 		};

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -133,32 +133,32 @@ impl TransactionFactory {
 			#[cfg(feature = "kv-mem")]
 			DatastoreFlavor::Mem(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(Box::new(tx) as Box<dyn super::api::Transaction>, true, false)
+				(tx, true, false)
 			}
 			#[cfg(feature = "kv-rocksdb")]
 			DatastoreFlavor::RocksDB(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(Box::new(tx) as Box<dyn super::api::Transaction>, true, true)
+				(tx, true, true)
 			}
 			#[cfg(feature = "kv-indxdb")]
 			DatastoreFlavor::IndxDB(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(Box::new(tx) as Box<dyn super::api::Transaction>, true, false)
+				(tx, true, false)
 			}
 			#[cfg(feature = "kv-tikv")]
 			DatastoreFlavor::TiKV(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(Box::new(tx) as Box<dyn super::api::Transaction>, false, true)
+				(tx, false, true)
 			}
 			#[cfg(feature = "kv-fdb")]
 			DatastoreFlavor::FoundationDB(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(Box::new(tx) as Box<dyn super::api::Transaction>, false, false)
+				(tx, false, false)
 			}
 			#[cfg(feature = "kv-surrealkv")]
 			DatastoreFlavor::SurrealKV(v) => {
 				let tx = v.transaction(write, lock).await?;
-				(Box::new(tx) as Box<dyn super::api::Transaction>, true, false)
+				(tx, true, false)
 			}
 			_ => unreachable!(),
 		};

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -169,7 +169,6 @@ impl TransactionFactory {
 				inner,
 				stash: super::stash::Stash::default(),
 				cf: cf::Writer::new(),
-				clock: self.clock.clone(),
 			},
 		))
 	}

--- a/crates/core/src/kvs/fdb/mod.rs
+++ b/crates/core/src/kvs/fdb/mod.rs
@@ -4,7 +4,7 @@ mod cnf;
 
 use crate::err::Error;
 use crate::key::debug::Sprintable;
-use crate::kvs::savepoint::{SaveOperation, SavePointImpl, SavePoints, SavePrepare};
+use crate::kvs::savepoint::{SaveOperation, SavePoints, SavePrepare};
 use crate::kvs::{Check, Key, Val};
 use crate::vs::VersionStamp;
 use foundationdb::options::DatabaseOption;
@@ -159,7 +159,12 @@ impl Transaction {
 	}
 }
 
+#[async_trait::async_trait]
 impl super::api::Transaction for Transaction {
+	fn kind(&self) -> &'static str {
+		"fdb"
+	}
+
 	/// Behaviour if unclosed
 	fn check_level(&mut self, check: Check) {
 		self.check = check;
@@ -525,8 +530,8 @@ impl super::api::Transaction for Transaction {
 	}
 
 	/// Obtain a new change timestamp for a key
-	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn get_timestamp(&mut self, key: Key) -> Result<VersionStamp, Error> {
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = _key.sprint()))]
+	async fn get_timestamp(&mut self, _key: Key) -> Result<VersionStamp, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -540,10 +545,10 @@ impl super::api::Transaction for Transaction {
 	}
 
 	// Sets the value for a versionstamped key prefixed with the user-supplied key.
-	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(ts_key = ts_key.sprint()))]
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(ts_key = _ts_key.sprint()))]
 	async fn set_versionstamp(
 		&mut self,
-		ts_key: Key,
+		_ts_key: Key,
 		prefix: Key,
 		suffix: Key,
 		val: Val,
@@ -571,9 +576,7 @@ impl super::api::Transaction for Transaction {
 		// Return result
 		Ok(())
 	}
-}
 
-impl SavePointImpl for Transaction {
 	fn get_save_points(&mut self) -> &mut SavePoints {
 		&mut self.save_points
 	}

--- a/crates/core/src/kvs/fdb/mod.rs
+++ b/crates/core/src/kvs/fdb/mod.rs
@@ -163,7 +163,8 @@ impl Transaction {
 	}
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl super::api::Transaction for Transaction {
 	fn kind(&self) -> &'static str {
 		"fdb"

--- a/crates/core/src/kvs/fdb/mod.rs
+++ b/crates/core/src/kvs/fdb/mod.rs
@@ -5,7 +5,7 @@ mod cnf;
 use crate::err::Error;
 use crate::key::debug::Sprintable;
 use crate::kvs::savepoint::{SaveOperation, SavePointImpl, SavePoints, SavePrepare};
-use crate::kvs::{Check, Key, KeyEncode, Val};
+use crate::kvs::{Check, Key, Val};
 use crate::vs::VersionStamp;
 use foundationdb::options::DatabaseOption;
 use foundationdb::options::MutationType;
@@ -13,7 +13,6 @@ use foundationdb::Database;
 use foundationdb::RangeOption;
 use foundationdb::Transaction as Tx;
 use futures::StreamExt;
-use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -218,10 +217,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Check if a key exists
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn exists(&mut self, key: Key, version: Option<u64>) -> Result<bool, Error> {
 		// FoundationDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -231,23 +227,14 @@ impl super::api::Transaction for Transaction {
 			return Err(Error::TxFinished);
 		}
 		// Check the key
-		let res = self
-			.inner
-			.as_ref()
-			.unwrap()
-			.get(&key.encode_owned()?, self.snapshot())
-			.await?
-			.is_some();
+		let res = self.inner.as_ref().unwrap().get(&key, self.snapshot()).await?.is_some();
 		// Return result
 		Ok(res)
 	}
 
 	/// Fetch a key from the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn get<K>(&mut self, key: K, version: Option<u64>) -> Result<Option<Val>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn get(&mut self, key: Key, version: Option<u64>) -> Result<Option<Val>, Error> {
 		// FoundationDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -257,24 +244,15 @@ impl super::api::Transaction for Transaction {
 			return Err(Error::TxFinished);
 		}
 		// Get the key
-		let res = self
-			.inner
-			.as_ref()
-			.unwrap()
-			.get(&key.encode_owned()?, self.snapshot())
-			.await?
-			.map(|v| v.to_vec());
+		let res =
+			self.inner.as_ref().unwrap().get(&key, self.snapshot()).await?.map(|v| v.to_vec());
 		// Return result
 		Ok(res)
 	}
 
 	/// Inserts or update a key in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn set<K, V>(&mut self, key: K, val: V, version: Option<u64>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn set(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error> {
 		// FoundationDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -287,8 +265,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Extract the key
-		let key = key.encode_owned()?;
 		// Prepare the savepoint if any
 		let prep = if self.save_points.is_some() {
 			self.save_point_prepare(&key, version, SaveOperation::Set).await?
@@ -296,7 +272,7 @@ impl super::api::Transaction for Transaction {
 			None
 		};
 		// Set the key
-		self.inner.as_ref().unwrap().set(&key, &val.into());
+		self.inner.as_ref().unwrap().set(&key, &val);
 		// Confirm the save point
 		if let Some(prep) = prep {
 			self.save_points.save(prep);
@@ -307,11 +283,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert a key if it doesn't exist in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn put<K, V>(&mut self, key: K, val: V, version: Option<u64>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn put(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error> {
 		// FoundationDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -324,9 +296,7 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let val = val.into();
+
 		// Hydrate the savepoint if any
 		let prep = if self.save_points.is_some() {
 			self.save_point_prepare(&key, version, SaveOperation::Put).await?
@@ -357,11 +327,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert a key if the current value matches a condition.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn putc<K, V>(&mut self, key: K, val: V, chk: Option<V>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn putc(&mut self, key: Key, val: Val, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -370,10 +336,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let val = val.into();
-		let chk = chk.map(Into::into);
 		// Hydrate the savepoint if any
 		let prep = if self.save_points.is_some() {
 			self.save_point_prepare(&key, None, SaveOperation::Put).await?
@@ -404,10 +366,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a key
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn del<K>(&mut self, key: K) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn del(&mut self, key: Key) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -416,8 +375,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Extract the key
-		let key = key.encode_owned()?;
 		// Hydrate the savepoint if any
 		let prep = if self.save_points.is_some() {
 			self.save_point_prepare(&key, None, SaveOperation::Del).await?
@@ -436,11 +393,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a key if the current value matches a condition.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn delc<K, V>(&mut self, key: K, chk: Option<V>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn delc(&mut self, key: Key, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -449,9 +402,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let chk = chk.map(Into::into);
 		// Hydrate the savepoint if any
 		let prep = if self.save_points.is_some() {
 			self.save_point_prepare(&key, None, SaveOperation::Del).await?
@@ -482,10 +432,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a range of keys from the databases
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn delr<K>(&mut self, rng: Range<K>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn delr(&mut self, rng: Range<Key>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -497,25 +444,19 @@ impl super::api::Transaction for Transaction {
 		// TODO: Check if we need savepoint with ranges
 
 		// Delete the key range
-		self.inner
-			.as_ref()
-			.unwrap()
-			.clear_range(&rng.start.encode_owned()?, &rng.end.encode_owned()?);
+		self.inner.as_ref().unwrap().clear_range(&rng.start, &rng.end);
 		// Return result
 		Ok(())
 	}
 
 	/// Retrieve a range of keys from the databases
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keys<K>(
+	async fn keys(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<Key>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<Key>, Error> {
 		// FoundationDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -526,11 +467,7 @@ impl super::api::Transaction for Transaction {
 		}
 		// Get the transaction
 		let inner = self.inner.as_ref().unwrap();
-		// Convert the range to bytes
-		let rng: Range<Key> = Range {
-			start: rng.start.encode_owned()?,
-			end: rng.end.encode_owned()?,
-		};
+
 		// Create result set
 		let mut res = vec![];
 		// Set the key range
@@ -552,15 +489,12 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieve a range of keys from the databases
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn scan<K>(
+	async fn scan(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<(Key, Val)>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<(Key, Val)>, Error> {
 		// FoundationDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -571,11 +505,6 @@ impl super::api::Transaction for Transaction {
 		}
 		// Get the transaction
 		let inner = self.inner.as_ref().unwrap();
-		// Convert the range to bytes
-		let rng: Range<Key> = Range {
-			start: rng.start.encode_owned()?,
-			end: rng.end.encode_owned()?,
-		};
 		// Create result set
 		let mut res = vec![];
 		// Set the key range
@@ -597,10 +526,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Obtain a new change timestamp for a key
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn get_timestamp<K>(&mut self, key: K) -> Result<VersionStamp, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn get_timestamp(&mut self, key: Key) -> Result<VersionStamp, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -615,17 +541,13 @@ impl super::api::Transaction for Transaction {
 
 	// Sets the value for a versionstamped key prefixed with the user-supplied key.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(ts_key = ts_key.sprint()))]
-	async fn set_versionstamp<K, V>(
+	async fn set_versionstamp(
 		&mut self,
-		ts_key: K,
-		prefix: K,
-		suffix: K,
-		val: V,
-	) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+		ts_key: Key,
+		prefix: Key,
+		suffix: Key,
+		val: Val,
+	) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -635,17 +557,15 @@ impl super::api::Transaction for Transaction {
 			return Err(Error::TxReadonly);
 		}
 		// Build the key starting with the prefix
-		let mut key: Vec<u8> = prefix.encode_owned()?;
+		let mut key: Key = prefix.clone();
 		// Get the position of the timestamp
 		let pos = key.len() as u32;
 		// Append the timestamp placeholder
 		key.extend_from_slice(&TIMESTAMP);
 		// Append the suffix to the key
-		key.extend(suffix.encode_owned()?);
+		key.extend(suffix);
 		// Append the 4 byte placeholder position in little endian
 		key.append(&mut pos.to_le_bytes().to_vec());
-		// Convert the value
-		let val = val.into();
 		// Set the versionstamp key
 		self.inner.as_ref().unwrap().atomic_op(&key, &val, MutationType::SetVersionstampedKey);
 		// Return result

--- a/crates/core/src/kvs/fdb/mod.rs
+++ b/crates/core/src/kvs/fdb/mod.rs
@@ -122,7 +122,11 @@ impl Datastore {
 	}
 
 	/// Start a new transaction
-	pub(crate) async fn transaction(&self, write: bool, lock: bool) -> Result<Transaction, Error> {
+	pub(crate) async fn transaction(
+		&self,
+		write: bool,
+		lock: bool,
+	) -> Result<Box<dyn crate::kvs::api::Transaction>, Error> {
 		// Specify the check level
 		#[cfg(not(debug_assertions))]
 		let check = Check::Warn;
@@ -130,14 +134,14 @@ impl Datastore {
 		let check = Check::Error;
 		// Create a new transaction
 		match self.db.create_trx() {
-			Ok(inner) => Ok(Transaction {
+			Ok(inner) => Ok(Box::new(Transaction {
 				done: false,
 				lock,
 				check,
 				write,
 				inner: Some(inner),
 				save_points: Default::default(),
-			}),
+			})),
 			Err(e) => Err(Error::Tx(e.to_string())),
 		}
 	}

--- a/crates/core/src/kvs/indxdb/mod.rs
+++ b/crates/core/src/kvs/indxdb/mod.rs
@@ -182,7 +182,7 @@ impl super::api::Transaction for Transaction {
 			return Err(Error::TxReadonly);
 		}
 		// Set the key
-		self.inner.set(key, val.into()).await?;
+		self.inner.set(key, val).await?;
 		// Return result
 		Ok(())
 	}
@@ -203,7 +203,7 @@ impl super::api::Transaction for Transaction {
 			return Err(Error::TxReadonly);
 		}
 		// Set the key
-		self.inner.put(key, val.into()).await?;
+		self.inner.put(key, val).await?;
 		// Return result
 		Ok(())
 	}
@@ -220,7 +220,7 @@ impl super::api::Transaction for Transaction {
 			return Err(Error::TxReadonly);
 		}
 		// Set the key
-		self.inner.putc(key, val.into(), chk.map(Into::into)).await?;
+		self.inner.putc(key, val, chk.map(Into::into)).await?;
 		// Return result
 		Ok(())
 	}

--- a/crates/core/src/kvs/indxdb/mod.rs
+++ b/crates/core/src/kvs/indxdb/mod.rs
@@ -57,7 +57,11 @@ impl Datastore {
 		Ok(())
 	}
 	/// Start a new transaction
-	pub async fn transaction(&self, write: bool, _: bool) -> Result<Transaction, Error> {
+	pub async fn transaction(
+		&self,
+		write: bool,
+		_: bool,
+	) -> Result<Box<dyn crate::kvs::api::Transaction>, Error> {
 		// Specify the check level
 		#[cfg(not(debug_assertions))]
 		let check = Check::Warn;
@@ -65,13 +69,13 @@ impl Datastore {
 		let check = Check::Error;
 		// Create a new transaction
 		match self.db.begin(write).await {
-			Ok(inner) => Ok(Transaction {
+			Ok(inner) => Ok(Box::new(Transaction {
 				done: false,
 				check,
 				write,
 				inner,
 				save_points: Default::default(),
-			}),
+			})),
 			Err(e) => Err(Error::Tx(e.to_string())),
 		}
 	}

--- a/crates/core/src/kvs/indxdb/mod.rs
+++ b/crates/core/src/kvs/indxdb/mod.rs
@@ -81,7 +81,8 @@ impl Datastore {
 	}
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl super::api::Transaction for Transaction {
 	fn kind(&self) -> &'static str {
 		"indxdb"

--- a/crates/core/src/kvs/indxdb/mod.rs
+++ b/crates/core/src/kvs/indxdb/mod.rs
@@ -151,8 +151,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Fetch a key from the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn get(&mut self, key: Key, version: Option<u64>) -> Result<Option<Val>, Error>
-	{
+	async fn get(&mut self, key: Key, version: Option<u64>) -> Result<Option<Val>, Error> {
 		// IndxDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -169,8 +168,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert or update a key in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn set(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error>
-	{
+	async fn set(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error> {
 		// IndxDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -191,8 +189,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert a key if it doesn't exist in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn put(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error>
-	{
+	async fn put(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error> {
 		// IndxDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -213,8 +210,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert a key if the current value matches a condition
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn putc(&mut self, key: Key, val: Val, chk: Option<Val>) -> Result<(), Error>
-	{
+	async fn putc(&mut self, key: Key, val: Val, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -231,8 +227,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a key
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn del(&mut self, key: Key) -> Result<(), Error>
-	{
+	async fn del(&mut self, key: Key) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -249,8 +244,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a key if the current value matches a condition
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn delc(&mut self, key: Key, chk: Option<Val>) -> Result<(), Error>
-	{
+	async fn delc(&mut self, key: Key, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -272,8 +266,7 @@ impl super::api::Transaction for Transaction {
 		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<Key>, Error>
-	{
+	) -> Result<Vec<Key>, Error> {
 		// IndxDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -295,8 +288,7 @@ impl super::api::Transaction for Transaction {
 		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<(Key, Val)>, Error>
-	{
+	) -> Result<Vec<(Key, Val)>, Error> {
 		// IndxDB does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);

--- a/crates/core/src/kvs/mem/mod.rs
+++ b/crates/core/src/kvs/mem/mod.rs
@@ -3,7 +3,6 @@
 use crate::err::Error;
 use crate::key::debug::Sprintable;
 use crate::kvs::{Key, Val, Version};
-use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::OnceLock;
 use surrealkv::Options;
@@ -162,10 +161,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Checks if a key exists in the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn exists(&mut self, key: Key, version: Option<u64>) -> Result<bool, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -189,10 +185,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Fetch a key from the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn get<K>(&mut self, key: K, version: Option<u64>) -> Result<Option<Val>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn get(&mut self, key: Key, version: Option<u64>) -> Result<Option<Val>, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -215,11 +208,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert or update a key in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn set<K, V>(&mut self, key: K, val: V, version: Option<u64>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn set(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -228,9 +217,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let val = val.into();
 
 		// Get the inner transaction
 		let inner =
@@ -247,11 +233,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert or replace a key in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn replace<K, V>(&mut self, key: K, val: V) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn replace(&mut self, key: Key, val: Val) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -260,9 +242,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let val = val.into();
 
 		// Get the inner transaction
 		let inner =
@@ -277,11 +256,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert a key if it doesn't exist in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn put<K, V>(&mut self, key: K, val: V, version: Option<u64>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn put(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -290,9 +265,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let val = val.into();
 		// Get the inner transaction
 		let inner =
 			self.inner.as_mut().ok_or_else(|| Error::Tx("Transaction inner is None".into()))?;
@@ -313,11 +285,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert a key if the current value matches a condition
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn putc<K, V>(&mut self, key: K, val: V, chk: Option<V>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn putc(&mut self, key: Key, val: Val, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -326,10 +294,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let val = val.into();
-		let chk = chk.map(Into::into);
 		// Get the inner transaction
 		let inner =
 			self.inner.as_mut().ok_or_else(|| Error::Tx("Transaction inner is None".into()))?;
@@ -346,10 +310,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Deletes a key from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn del<K>(&mut self, key: K) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn del(&mut self, key: Key) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -358,8 +319,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
 		// Get the inner transaction
 		let inner =
 			self.inner.as_mut().ok_or_else(|| Error::Tx("Transaction inner is None".into()))?;
@@ -372,11 +331,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a key if the current value matches a condition
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn delc<K, V>(&mut self, key: K, chk: Option<V>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn delc(&mut self, key: Key, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -385,9 +340,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let chk = chk.map(Into::into);
 
 		// Get the inner transaction
 		let inner =
@@ -405,10 +357,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Deletes all versions of a key from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn clr<K>(&mut self, key: K) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn clr(&mut self, key: Key) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -431,11 +380,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete all versions of a key if the current value matches a condition
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn clrc<K, V>(&mut self, key: K, chk: Option<V>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn clrc(&mut self, key: Key, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -444,9 +389,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let chk = chk.map(Into::into);
 
 		// Get the inner transaction
 		let inner =
@@ -465,22 +407,19 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieves a range of key-value pairs from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keys<K>(
+	async fn keys(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<Key>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<Key>, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
 		// Set the key range
-		let beg = rng.start.encode_owned()?;
-		let end = rng.end.encode_owned()?;
+		let beg = rng.start;
+		let end = rng.end;
 
 		// Get the inner transaction
 		let inner =
@@ -503,22 +442,19 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieves a range of key-value pairs from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn scan<K>(
+	async fn scan(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<(Key, Val)>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<(Key, Val)>, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
 		// Set the key range
-		let beg = rng.start.encode_owned()?;
-		let end = rng.end.encode_owned()?;
+		let beg = rng.start;
+		let end = rng.end;
 
 		// Get the inner transaction
 		let inner =
@@ -541,20 +477,17 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieve all the versions from a range of keys from the databases
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn scan_all_versions<K>(
+	async fn scan_all_versions(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
-	) -> Result<Vec<(Key, Val, Version, bool)>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<(Key, Val, Version, bool)>, Error> {
 		if self.done {
 			return Err(Error::TxFinished);
 		}
 		// Set the key range
-		let beg = rng.start.encode_owned()?;
-		let end = rng.end.encode_owned()?;
+		let beg = rng.start;
+		let end = rng.end;
 
 		// Get the inner transaction
 		let inner =

--- a/crates/core/src/kvs/mem/mod.rs
+++ b/crates/core/src/kvs/mem/mod.rs
@@ -106,7 +106,8 @@ impl Datastore {
 	}
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl super::api::Transaction for Transaction {
 	fn kind(&self) -> &'static str {
 		"memory"

--- a/crates/core/src/kvs/mem/mod.rs
+++ b/crates/core/src/kvs/mem/mod.rs
@@ -2,13 +2,13 @@
 
 use crate::err::Error;
 use crate::key::debug::Sprintable;
+use crate::kvs::savepoint::SavePoints;
 use crate::kvs::{Key, Val, Version};
 use std::ops::Range;
 use std::sync::OnceLock;
 use surrealkv::Options;
 use surrealkv::Store;
 use surrealkv::Transaction as Tx;
-use crate::kvs::savepoint::SavePoints;
 
 use super::{Check, KeyEncode};
 

--- a/crates/core/src/kvs/mem/mod.rs
+++ b/crates/core/src/kvs/mem/mod.rs
@@ -514,7 +514,7 @@ impl super::api::Transaction for Transaction {
 	}
 
 	fn get_save_points(&mut self) -> &mut SavePoints {
-		todo!("DO NOT MERGE THIS YET");
+		unimplemented!("Get save points not implemented for the memory backend");
 	}
 
 	fn new_save_point(&mut self) {

--- a/crates/core/src/kvs/mem/mod.rs
+++ b/crates/core/src/kvs/mem/mod.rs
@@ -8,6 +8,7 @@ use std::sync::OnceLock;
 use surrealkv::Options;
 use surrealkv::Store;
 use surrealkv::Transaction as Tx;
+use crate::kvs::savepoint::SavePoints;
 
 use super::{Check, KeyEncode};
 
@@ -101,7 +102,12 @@ impl Datastore {
 	}
 }
 
+#[async_trait::async_trait]
 impl super::api::Transaction for Transaction {
+	fn kind(&self) -> &'static str {
+		"memory"
+	}
+
 	/// Behaviour if unclosed
 	fn check_level(&mut self, check: Check) {
 		self.check = check;
@@ -501,23 +507,25 @@ impl super::api::Transaction for Transaction {
 		// Return result
 		Ok(res)
 	}
-}
 
-impl Transaction {
-	pub(crate) fn new_save_point(&mut self) {
+	fn get_save_points(&mut self) -> &mut SavePoints {
+		todo!("DO NOT MERGE THIS YET");
+	}
+
+	fn new_save_point(&mut self) {
 		if let Some(inner) = &mut self.inner {
 			let _ = inner.set_savepoint();
 		}
 	}
 
-	pub(crate) async fn rollback_to_save_point(&mut self) -> Result<(), Error> {
+	async fn rollback_to_save_point(&mut self) -> Result<(), Error> {
 		if let Some(inner) = &mut self.inner {
 			inner.rollback_to_savepoint()?;
 		}
 		Ok(())
 	}
 
-	pub(crate) fn release_last_save_point(&mut self) -> Result<(), Error> {
+	fn release_last_save_point(&mut self) -> Result<(), Error> {
 		Ok(())
 	}
 }

--- a/crates/core/src/kvs/mem/mod.rs
+++ b/crates/core/src/kvs/mem/mod.rs
@@ -83,7 +83,11 @@ impl Datastore {
 	}
 
 	/// Start a new transaction
-	pub(crate) async fn transaction(&self, write: bool, _: bool) -> Result<Transaction, Error> {
+	pub(crate) async fn transaction(
+		&self,
+		write: bool,
+		_: bool,
+	) -> Result<Box<dyn crate::kvs::api::Transaction>, Error> {
 		// Specify the check level
 		#[cfg(not(debug_assertions))]
 		let check = Check::Warn;
@@ -91,12 +95,12 @@ impl Datastore {
 		let check = Check::Error;
 		// Create a new transaction
 		match self.db.begin() {
-			Ok(inner) => Ok(Transaction {
+			Ok(inner) => Ok(Box::new(Transaction {
 				done: false,
 				check,
 				write,
 				inner: Some(inner),
-			}),
+			})),
 			Err(e) => Err(Error::Tx(e.to_string())),
 		}
 	}

--- a/crates/core/src/kvs/mod.rs
+++ b/crates/core/src/kvs/mod.rs
@@ -15,7 +15,7 @@
 
 pub mod export;
 
-pub(crate) mod api;
+mod api;
 mod batch;
 mod cf;
 mod clock;

--- a/crates/core/src/kvs/mod.rs
+++ b/crates/core/src/kvs/mod.rs
@@ -15,7 +15,7 @@
 
 pub mod export;
 
-mod api;
+pub(crate) mod api;
 mod batch;
 mod cf;
 mod clock;

--- a/crates/core/src/kvs/mod.rs
+++ b/crates/core/src/kvs/mod.rs
@@ -41,8 +41,7 @@ pub(crate) mod cache;
 
 #[cfg(not(target_family = "wasm"))]
 mod index;
-#[cfg(any(feature = "kv-tikv", feature = "kv-fdb", feature = "kv-indxdb",))]
-mod savepoint;
+pub(crate) mod savepoint;
 pub(crate) mod sequences;
 #[cfg(test)]
 mod tests;

--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -707,7 +707,7 @@ impl super::api::Transaction for Transaction {
 	}
 
 	fn get_save_points(&mut self) -> &mut SavePoints {
-		todo!("Implement get_save_points");
+		unimplemented!("Get save points not implemented for for the RocksDB backend");
 	}
 
 	fn new_save_point(&mut self) {

--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -302,7 +302,8 @@ impl Datastore {
 	}
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl super::api::Transaction for Transaction {
 	fn kind(&self) -> &'static str {
 		"rocksdb"

--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -255,7 +255,11 @@ impl Datastore {
 	}
 
 	/// Start a new transaction
-	pub(crate) async fn transaction(&self, write: bool, _: bool) -> Result<Transaction, Error> {
+	pub(crate) async fn transaction(
+		&self,
+		write: bool,
+		_: bool,
+	) -> Result<Box<dyn crate::kvs::api::Transaction>, Error> {
 		// Set the transaction options
 		let mut to = OptimisticTransactionOptions::default();
 		to.set_snapshot(true);
@@ -287,14 +291,14 @@ impl Datastore {
 		#[cfg(debug_assertions)]
 		let check = Check::Error;
 		// Create a new transaction
-		Ok(Transaction {
+		Ok(Box::new(Transaction {
 			done: false,
 			write,
 			check,
 			inner: Some(inner),
 			ro,
 			_db: self.db.clone(),
-		})
+		}))
 	}
 }
 

--- a/crates/core/src/kvs/savepoint.rs
+++ b/crates/core/src/kvs/savepoint.rs
@@ -1,7 +1,6 @@
-#![cfg_attr(target_family = "wasm", expect(dead_code, reason = "Not used in WASM."))]
+#![cfg_attr(not(any(feature = "kv-fdb", feature = "kv-tikv")), expect(dead_code, reason = "This is only used in FoundationDB and TiKV"))]
 
 use crate::err::Error;
-use crate::kvs::api::Transaction;
 use crate::kvs::{Key, Val};
 use std::collections::{HashMap, VecDeque};
 
@@ -15,9 +14,9 @@ pub(super) enum SaveOperation {
 }
 
 pub(super) struct SavedValue {
-	saved_val: Option<Val>,
-	saved_version: Option<u64>,
-	last_operation: SaveOperation,
+	pub(super) saved_val: Option<Val>,
+	pub(super) saved_version: Option<u64>,
+	pub(super) last_operation: SaveOperation,
 }
 
 impl SavedValue {
@@ -29,7 +28,6 @@ impl SavedValue {
 		}
 	}
 
-	#[cfg(any(feature = "kv-fdb", feature = "kv-tikv"))]
 	pub(super) fn get_val(&self) -> Option<&Val> {
 		self.saved_val.as_ref()
 	}
@@ -85,70 +83,5 @@ impl SavePoints {
 				}
 			}
 		}
-	}
-
-	pub(super) async fn rollback<T>(sp: SavePoint, tx: &mut T) -> Result<(), Error>
-	where
-		T: Transaction,
-	{
-		for (key, saved_value) in sp {
-			match saved_value.last_operation {
-				SaveOperation::Set | SaveOperation::Put => {
-					if let Some(initial_value) = saved_value.saved_val {
-						// If the last operation was a SET or PUT
-						// then we just have set back the key to its initial value
-						tx.set(key, initial_value, saved_value.saved_version).await?;
-					} else {
-						// If the last operation on this key was not a DEL operation,
-						// then we have to delete the key
-						tx.del(key).await?;
-					}
-				}
-				SaveOperation::Del => {
-					if let Some(initial_value) = saved_value.saved_val {
-						// If the last operation was a DEL,
-						// then we have to put back the initial value
-						tx.put(key, initial_value, saved_value.saved_version).await?;
-					}
-				}
-			}
-		}
-		Ok(())
-	}
-}
-
-pub(super) trait SavePointImpl: Transaction + Sized {
-	fn get_save_points(&mut self) -> &mut SavePoints;
-
-	fn new_save_point(&mut self) {
-		self.get_save_points().new_save_point()
-	}
-
-	async fn rollback_to_save_point(&mut self) -> Result<(), Error> {
-		let sp = self.get_save_points().pop()?;
-		SavePoints::rollback(sp, self).await
-	}
-
-	fn release_last_save_point(&mut self) -> Result<(), Error> {
-		self.get_save_points().pop()?;
-		Ok(())
-	}
-
-	async fn save_point_prepare(
-		&mut self,
-		key: &Key,
-		version: Option<u64>,
-		op: SaveOperation,
-	) -> Result<Option<SavePrepare>, Error> {
-		let is_saved_key = self.get_save_points().is_saved_key(key);
-		let r = match is_saved_key {
-			None => None,
-			Some(true) => Some(SavePrepare::AlreadyPresent(key.clone(), op)),
-			Some(false) => {
-				let val = self.get(key.clone(), version).await?;
-				Some(SavePrepare::NewKey(key.clone(), SavedValue::new(val, version, op)))
-			}
-		};
-		Ok(r)
 	}
 }

--- a/crates/core/src/kvs/savepoint.rs
+++ b/crates/core/src/kvs/savepoint.rs
@@ -10,20 +10,20 @@ use std::collections::{HashMap, VecDeque};
 type SavePoint = HashMap<Key, SavedValue>;
 
 #[derive(Debug)]
-pub(super) enum SaveOperation {
+pub(crate) enum SaveOperation {
 	Set,
 	Put,
 	Del,
 }
 
-pub(super) struct SavedValue {
-	pub(super) saved_val: Option<Val>,
-	pub(super) saved_version: Option<u64>,
-	pub(super) last_operation: SaveOperation,
+pub(crate) struct SavedValue {
+	pub(crate) saved_val: Option<Val>,
+	pub(crate) saved_version: Option<u64>,
+	pub(crate) last_operation: SaveOperation,
 }
 
 impl SavedValue {
-	pub(super) fn new(val: Option<Val>, version: Option<u64>, op: SaveOperation) -> Self {
+	pub(crate) fn new(val: Option<Val>, version: Option<u64>, op: SaveOperation) -> Self {
 		Self {
 			saved_val: val,
 			saved_version: version,
@@ -31,12 +31,12 @@ impl SavedValue {
 		}
 	}
 
-	pub(super) fn get_val(&self) -> Option<&Val> {
+	pub(crate) fn get_val(&self) -> Option<&Val> {
 		self.saved_val.as_ref()
 	}
 }
 
-pub(super) enum SavePrepare {
+pub(crate) enum SavePrepare {
 	AlreadyPresent(Key, SaveOperation),
 	NewKey(Key, SavedValue),
 }

--- a/crates/core/src/kvs/savepoint.rs
+++ b/crates/core/src/kvs/savepoint.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(not(any(feature = "kv-fdb", feature = "kv-tikv")), expect(dead_code, reason = "This is only used in FoundationDB and TiKV"))]
+#![cfg_attr(
+	not(any(feature = "kv-fdb", feature = "kv-tikv")),
+	expect(dead_code, reason = "This is only used in FoundationDB and TiKV")
+)]
 
 use crate::err::Error;
 use crate::kvs::{Key, Val};

--- a/crates/core/src/kvs/surrealkv/mod.rs
+++ b/crates/core/src/kvs/surrealkv/mod.rs
@@ -5,8 +5,7 @@ mod cnf;
 use crate::err::Error;
 use crate::key::debug::Sprintable;
 use crate::kvs::surrealkv::cnf::commit_pool;
-use crate::kvs::{Check, Key, KeyEncode, Val, Version};
-use std::fmt::Debug;
+use crate::kvs::{Check, Key, Val, Version};
 use std::ops::Range;
 use surrealkv::Options;
 use surrealkv::Store;
@@ -189,16 +188,11 @@ impl super::api::Transaction for Transaction {
 
 	/// Checks if a key exists in the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn exists(&mut self, key: Key, version: Option<u64>) -> Result<bool, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
 
 		// Get the inner transaction
 		let inner =
@@ -215,16 +209,11 @@ impl super::api::Transaction for Transaction {
 
 	/// Fetch a key from the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn get<K>(&mut self, key: K, version: Option<u64>) -> Result<Option<Val>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn get(&mut self, key: Key, version: Option<u64>) -> Result<Option<Val>, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
 
 		// Get the inner transaction
 		let inner =
@@ -241,11 +230,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert or update a key in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn set<K, V>(&mut self, key: K, val: V, version: Option<u64>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn set(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -254,9 +239,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let val = val.into();
 
 		// Get the inner transaction
 		let inner =
@@ -273,11 +255,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert or replace a key in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn replace<K, V>(&mut self, key: K, val: V) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn replace(&mut self, key: Key, val: Val) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -286,9 +264,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let val = val.into();
 
 		// Get the inner transaction
 		let inner =
@@ -303,11 +278,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert a key if it doesn't exist in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn put<K, V>(&mut self, key: K, val: V, version: Option<u64>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn put(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -316,9 +287,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let val = val.into();
 
 		// Get the inner transaction
 		let inner =
@@ -339,11 +307,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert a key if the current value matches a condition
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn putc<K, V>(&mut self, key: K, val: V, chk: Option<V>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn putc(&mut self, key: Key, val: Val, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -352,10 +316,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let val = val.into();
-		let chk = chk.map(Into::into);
 
 		// Get the inner transaction
 		let inner =
@@ -373,10 +333,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Deletes a key from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn del<K>(&mut self, key: K) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn del(&mut self, key: Key) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -385,8 +342,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
 
 		// Get the inner transaction
 		let inner =
@@ -400,11 +355,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a key if the current value matches a condition
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn delc<K, V>(&mut self, key: K, chk: Option<V>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn delc(&mut self, key: Key, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -413,9 +364,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let chk = chk.map(Into::into);
 
 		// Get the inner transaction
 		let inner =
@@ -433,10 +381,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Deletes all versions of a key from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn clr<K>(&mut self, key: K) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn clr(&mut self, key: Key) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -445,8 +390,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
 
 		// Get the inner transaction
 		let inner =
@@ -460,11 +403,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete all versions of a key if the current value matches a condition
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn clrc<K, V>(&mut self, key: K, chk: Option<V>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn clrc(&mut self, key: Key, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -473,9 +412,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the arguments
-		let key = key.encode_owned()?;
-		let chk = chk.map(Into::into);
 
 		// Get the inner transaction
 		let inner =
@@ -493,22 +429,19 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieves a range of key-value pairs from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keys<K>(
+	async fn keys(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<Key>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<Key>, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
 		// Set the key range
-		let beg = rng.start.encode_owned()?;
-		let end = rng.end.encode_owned()?;
+		let beg = rng.start;
+		let end = rng.end;
 
 		// Get the inner transaction
 		let inner =
@@ -537,22 +470,19 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieves a range of key-value pairs from the database.
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn scan<K>(
+	async fn scan(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<(Key, Val)>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<(Key, Val)>, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
 		// Set the key range
-		let beg = rng.start.encode_owned()?;
-		let end = rng.end.encode_owned()?;
+		let beg = rng.start;
+		let end = rng.end;
 
 		// Get the inner transaction
 		let inner =
@@ -581,20 +511,17 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieve all the versions from a range of keys from the databases
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn scan_all_versions<K>(
+	async fn scan_all_versions(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
-	) -> Result<Vec<(Key, Val, Version, bool)>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<(Key, Val, Version, bool)>, Error> {
 		if self.done {
 			return Err(Error::TxFinished);
 		}
 		// Set the key range
-		let beg = rng.start.encode_owned()?;
-		let end = rng.end.encode_owned()?;
+		let beg = rng.start;
+		let end = rng.end;
 
 		// Get the inner transaction
 		let inner =

--- a/crates/core/src/kvs/surrealkv/mod.rs
+++ b/crates/core/src/kvs/surrealkv/mod.rs
@@ -12,6 +12,8 @@ use surrealkv::Store;
 use surrealkv::Transaction as Tx;
 use surrealkv::{Durability, Mode};
 
+use super::savepoint::SavePoints;
+
 const TARGET: &str = "surrealdb::core::kvs::surrealkv";
 
 pub struct Datastore {
@@ -128,7 +130,12 @@ impl Datastore {
 	}
 }
 
+#[async_trait::async_trait]
 impl super::api::Transaction for Transaction {
+	fn kind(&self) -> &'static str {
+		"surrealkv"
+	}
+
 	/// Behaviour if unclosed
 	fn check_level(&mut self, check: Check) {
 		self.check = check;
@@ -541,23 +548,25 @@ impl super::api::Transaction for Transaction {
 		// Return result
 		Ok(res)
 	}
-}
 
-impl Transaction {
-	pub(crate) fn new_save_point(&mut self) {
+	fn get_save_points(&mut self) -> &mut SavePoints {
+		todo!("Implement get_save_points");
+	}
+
+	fn new_save_point(&mut self) {
 		if let Some(inner) = &mut self.inner {
 			let _ = inner.set_savepoint();
 		}
 	}
 
-	pub(crate) async fn rollback_to_save_point(&mut self) -> Result<(), Error> {
+	async fn rollback_to_save_point(&mut self) -> Result<(), Error> {
 		if let Some(inner) = &mut self.inner {
 			inner.rollback_to_savepoint()?;
 		}
 		Ok(())
 	}
 
-	pub(crate) fn release_last_save_point(&mut self) -> Result<(), Error> {
+	fn release_last_save_point(&mut self) -> Result<(), Error> {
 		Ok(())
 	}
 }

--- a/crates/core/src/kvs/surrealkv/mod.rs
+++ b/crates/core/src/kvs/surrealkv/mod.rs
@@ -134,7 +134,8 @@ impl Datastore {
 	}
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl super::api::Transaction for Transaction {
 	fn kind(&self) -> &'static str {
 		"surrealkv"

--- a/crates/core/src/kvs/surrealkv/mod.rs
+++ b/crates/core/src/kvs/surrealkv/mod.rs
@@ -104,7 +104,11 @@ impl Datastore {
 	}
 
 	/// Start a new transaction
-	pub(crate) async fn transaction(&self, write: bool, _: bool) -> Result<Transaction, Error> {
+	pub(crate) async fn transaction(
+		&self,
+		write: bool,
+		_: bool,
+	) -> Result<Box<dyn crate::kvs::api::Transaction>, Error> {
 		// Specify the check level
 		#[cfg(not(debug_assertions))]
 		let check = Check::Warn;
@@ -121,12 +125,12 @@ impl Datastore {
 			false => txn.set_durability(Durability::Eventual),
 		};
 		// Return the new transaction
-		Ok(Transaction {
+		Ok(Box::new(Transaction {
 			done: false,
 			check,
 			write,
 			inner: Some(txn),
-		})
+		}))
 	}
 }
 

--- a/crates/core/src/kvs/surrealkv/mod.rs
+++ b/crates/core/src/kvs/surrealkv/mod.rs
@@ -555,7 +555,7 @@ impl super::api::Transaction for Transaction {
 	}
 
 	fn get_save_points(&mut self) -> &mut SavePoints {
-		todo!("Implement get_save_points");
+		unimplemented!("Get save points not implemented for the SurrealKV backend")
 	}
 
 	fn new_save_point(&mut self) {

--- a/crates/core/src/kvs/tikv/mod.rs
+++ b/crates/core/src/kvs/tikv/mod.rs
@@ -511,7 +511,7 @@ impl super::api::Transaction for Transaction {
 		// Convert the timestamp to a versionstamp
 		let ver = VersionStamp::from_u64(ver);
 		// Store the timestamp to prevent other transactions from committing
-		self.set(key, ver.as_bytes().to_vec(), None).await?;
+		self.set(key, ver.to_vec(), None).await?;
 		// Return the uint64 representation of the timestamp as the result
 		Ok(ver)
 	}

--- a/crates/core/src/kvs/tikv/mod.rs
+++ b/crates/core/src/kvs/tikv/mod.rs
@@ -147,7 +147,8 @@ impl Datastore {
 	}
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl super::api::Transaction for Transaction {
 	fn kind(&self) -> &'static str {
 		"tikv"

--- a/crates/core/src/kvs/tikv/mod.rs
+++ b/crates/core/src/kvs/tikv/mod.rs
@@ -7,10 +7,8 @@ use crate::key::debug::Sprintable;
 use crate::kvs::savepoint::{SaveOperation, SavePointImpl, SavePoints, SavePrepare};
 use crate::kvs::Check;
 use crate::kvs::Key;
-use crate::kvs::KeyEncode;
 use crate::kvs::Val;
 use crate::vs::VersionStamp;
-use std::fmt::Debug;
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -204,10 +202,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Check if a key exists
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn exists<K>(&mut self, key: K, version: Option<u64>) -> Result<bool, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn exists(&mut self, key: Key, version: Option<u64>) -> Result<bool, Error> {
 		// TiKV does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -217,17 +212,14 @@ impl super::api::Transaction for Transaction {
 			return Err(Error::TxFinished);
 		}
 		// Check the key
-		let res = self.inner.key_exists(key.encode_owned()?).await?;
+		let res = self.inner.key_exists(key).await?;
 		// Return result
 		Ok(res)
 	}
 
 	/// Fetch a key from the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn get<K>(&mut self, key: K, version: Option<u64>) -> Result<Option<Val>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn get(&mut self, key: Key, version: Option<u64>) -> Result<Option<Val>, Error> {
 		// TiKV does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -237,18 +229,14 @@ impl super::api::Transaction for Transaction {
 			return Err(Error::TxFinished);
 		}
 		// Get the key
-		let res = self.inner.get(key.encode_owned()?).await?;
+		let res = self.inner.get(key).await?;
 		// Return result
 		Ok(res)
 	}
 
 	/// Insert or update a key in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn set<K, V>(&mut self, key: K, val: V, version: Option<u64>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn set(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error> {
 		// TiKV does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -261,8 +249,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Extract the key
-		let key = key.encode_owned()?;
 		// Prepare the savepoint if any
 		let prep = if self.save_points.is_some() {
 			self.save_point_prepare(&key, version, SaveOperation::Set).await?
@@ -270,7 +256,7 @@ impl super::api::Transaction for Transaction {
 			None
 		};
 		// Set the key
-		self.inner.put(key, val.into()).await?;
+		self.inner.put(key, val).await?;
 		// Confirm the save point
 		if let Some(prep) = prep {
 			self.save_points.save(prep);
@@ -281,11 +267,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert a key if it doesn't exist in the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn put<K, V>(&mut self, key: K, val: V, version: Option<u64>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn put(&mut self, key: Key, val: Val, version: Option<u64>) -> Result<(), Error> {
 		// TiKV does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -298,10 +280,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the key
-		let key = key.encode_owned()?;
-		// Get the val
-		let val = val.into();
 		// Hydrate the savepoint if any
 		let prep = if self.save_points.is_some() {
 			self.save_point_prepare(&key, version, SaveOperation::Put).await?
@@ -330,11 +308,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Insert a key if the current value matches a condition
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn putc<K, V>(&mut self, key: K, val: V, chk: Option<V>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn putc(&mut self, key: Key, val: Val, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -343,12 +317,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the key
-		let key = key.encode_owned()?;
-		// Get the val
-		let val = val.into();
-		// Get the check
-		let chk = chk.map(Into::into);
 		// Hydrate the savepoint if any
 		let prep = if self.save_points.is_some() {
 			self.save_point_prepare(&key, None, SaveOperation::Put).await?
@@ -377,10 +345,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a key
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn del<K>(&mut self, key: K) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn del(&mut self, key: Key) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -389,8 +354,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Extract the key
-		let key = key.encode_owned()?;
 		// Hydrate the savepoint if any
 		let prep = if self.save_points.is_some() {
 			self.save_point_prepare(&key, None, SaveOperation::Del).await?
@@ -409,11 +372,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a key if the current value matches a condition
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn delc<K, V>(&mut self, key: K, chk: Option<V>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-		V: Into<Val> + Debug,
-	{
+	async fn delc(&mut self, key: Key, chk: Option<Val>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -422,10 +381,6 @@ impl super::api::Transaction for Transaction {
 		if !self.write {
 			return Err(Error::TxReadonly);
 		}
-		// Get the key
-		let key = key.encode_owned()?;
-		// Get the check
-		let chk = chk.map(Into::into);
 		// Hydrate the savepoint if any
 		let prep = if self.save_points.is_some() {
 			self.save_point_prepare(&key, None, SaveOperation::Del).await?
@@ -454,10 +409,7 @@ impl super::api::Transaction for Transaction {
 
 	/// Delete a range of keys from the databases
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn delr<K>(&mut self, rng: Range<K>) -> Result<(), Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn delr(&mut self, rng: Range<Key>) -> Result<(), Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
@@ -469,22 +421,19 @@ impl super::api::Transaction for Transaction {
 		// TODO: Check if we need savepoint with ranges
 
 		// Delete the key range
-		self.db.unsafe_destroy_range(rng.start.encode_owned()?..rng.end.encode_owned()?).await?;
+		self.db.unsafe_destroy_range(rng.start..rng.end).await?;
 		// Return result
 		Ok(())
 	}
 
 	/// Retrieve a range of keys from the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keys<K>(
+	async fn keys(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<Key>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<Key>, Error> {
 		let rng = self.prepare_scan(rng, version)?;
 		// Scan the keys
 		let res = self.inner.scan_keys(rng, limit).await?.map(Key::from).collect();
@@ -494,15 +443,12 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieve a range of keys from the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn keysr<K>(
+	async fn keysr(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<Key>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<Key>, Error> {
 		let rng = self.prepare_scan(rng, version)?;
 		// Scan the keys
 		let res = self.inner.scan_keys_reverse(rng, limit).await?.map(Key::from).collect();
@@ -512,15 +458,12 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieve a range of keys from the database
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn scan<K>(
+	async fn scan(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<(Key, Val)>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<(Key, Val)>, Error> {
 		let rng = self.prepare_scan(rng, version)?;
 		// Scan the keys
 		let res = self.inner.scan(rng, limit).await?.map(|kv| (Key::from(kv.0), kv.1)).collect();
@@ -530,15 +473,12 @@ impl super::api::Transaction for Transaction {
 
 	/// Retrieve a range of keys from the database in reverse order
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(rng = rng.sprint()))]
-	async fn scanr<K>(
+	async fn scanr(
 		&mut self,
-		rng: Range<K>,
+		rng: Range<Key>,
 		limit: u32,
 		version: Option<u64>,
-	) -> Result<Vec<(Key, Val)>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	) -> Result<Vec<(Key, Val)>, Error> {
 		let rng = self.prepare_scan(rng, version)?;
 		// Scan the keys
 		let res =
@@ -549,20 +489,15 @@ impl super::api::Transaction for Transaction {
 
 	/// Obtain a new change timestamp for a key
 	#[instrument(level = "trace", target = "surrealdb::core::kvs::api", skip(self), fields(key = key.sprint()))]
-	async fn get_timestamp<K>(&mut self, key: K) -> Result<VersionStamp, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	async fn get_timestamp(&mut self, key: Key) -> Result<VersionStamp, Error> {
 		// Check to see if transaction is closed
 		if self.done {
 			return Err(Error::TxFinished);
 		}
-		// Calculate the version key
-		let key = key.encode_owned()?;
 		// Get the transaction version
 		let ver = self.inner.current_timestamp().await?.version();
 		// Calculate the previous version value
-		if let Some(prev) = self.get(key.as_slice(), None).await? {
+		if let Some(prev) = self.get(key.clone(), None).await? {
 			let prev = VersionStamp::from_slice(prev.as_slice())?.try_into_u64()?;
 			if prev >= ver {
 				return Err(Error::TxFailure);
@@ -571,7 +506,7 @@ impl super::api::Transaction for Transaction {
 		// Convert the timestamp to a versionstamp
 		let ver = VersionStamp::from_u64(ver);
 		// Store the timestamp to prevent other transactions from committing
-		self.set(key.as_slice(), ver.as_bytes(), None).await?;
+		self.set(key, ver.as_bytes().to_vec(), None).await?;
 		// Return the uint64 representation of the timestamp as the result
 		Ok(ver)
 	}
@@ -584,10 +519,7 @@ impl SavePointImpl for Transaction {
 }
 
 impl Transaction {
-	fn prepare_scan<K>(&self, rng: Range<K>, version: Option<u64>) -> Result<Range<Key>, Error>
-	where
-		K: KeyEncode + Sprintable + Debug,
-	{
+	fn prepare_scan(&self, rng: Range<Key>, version: Option<u64>) -> Result<Range<Key>, Error> {
 		// TiKV does not support versioned queries.
 		if version.is_some() {
 			return Err(Error::UnsupportedVersionedQueries);
@@ -596,11 +528,6 @@ impl Transaction {
 		if self.done {
 			return Err(Error::TxFinished);
 		}
-		// Convert the range to bytes
-		let rng: Range<Key> = Range {
-			start: rng.start.encode_owned()?,
-			end: rng.end.encode_owned()?,
-		};
 		Ok(rng)
 	}
 }

--- a/crates/core/src/kvs/tikv/mod.rs
+++ b/crates/core/src/kvs/tikv/mod.rs
@@ -4,7 +4,7 @@ mod cnf;
 
 use crate::err::Error;
 use crate::key::debug::Sprintable;
-use crate::kvs::savepoint::{SaveOperation, SavePointImpl, SavePoints, SavePrepare};
+use crate::kvs::savepoint::{SaveOperation, SavePoints, SavePrepare};
 use crate::kvs::Check;
 use crate::kvs::Key;
 use crate::kvs::Val;
@@ -143,7 +143,12 @@ impl Datastore {
 	}
 }
 
+#[async_trait::async_trait]
 impl super::api::Transaction for Transaction {
+	fn kind(&self) -> &'static str {
+		"tikv"
+	}
+
 	/// Behaviour if unclosed
 	fn check_level(&mut self, check: Check) {
 		self.check = check;
@@ -510,9 +515,7 @@ impl super::api::Transaction for Transaction {
 		// Return the uint64 representation of the timestamp as the result
 		Ok(ver)
 	}
-}
 
-impl SavePointImpl for Transaction {
 	fn get_save_points(&mut self) -> &mut SavePoints {
 		&mut self.save_points
 	}

--- a/crates/core/src/kvs/tr.rs
+++ b/crates/core/src/kvs/tr.rs
@@ -174,9 +174,9 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.encode_owned()?;
 		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), version = version, "GetR");
-		self.inner.getr(beg..end, version).await
+		self.inner.getr(rng, version).await
 	}
 
 	/// Retrieve a specific prefixed range of keys from the datastore.
@@ -273,9 +273,9 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.encode_owned()?;
 		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), "DelR");
-		self.inner.delr(beg..end).await
+		self.inner.delr(rng).await
 	}
 
 	/// Delete a prefixed range of keys from the datastore.
@@ -324,9 +324,9 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.encode_owned()?;
 		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), "ClrR");
-		self.inner.clrr(beg..end).await
+		self.inner.clrr(rng).await
 	}
 
 	/// Delete all versions of a prefixed range of keys from the datastore.
@@ -357,12 +357,12 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.encode_owned()?;
 		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), limit = limit, version = version, "Keys");
-		if beg > end {
+		if rng.start > rng.end {
 			return Ok(vec![]);
 		}
-		self.inner.keys(beg..end, limit, version).await
+		self.inner.keys(rng, limit, version).await
 	}
 
 	/// Retrieve a specific range of keys from the datastore.
@@ -380,12 +380,12 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.encode_owned()?;
 		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), limit = limit, version = version, "Keysr");
-		if beg > end {
+		if rng.start > rng.end {
 			return Ok(vec![]);
 		}
-		self.inner.keysr(beg..end, limit, version).await
+		self.inner.keysr(rng, limit, version).await
 	}
 
 	/// Retrieve a specific range of keys from the datastore.
@@ -403,12 +403,12 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.encode_owned()?;
 		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), limit = limit, version = version, "Scan");
-		if beg > end {
+		if rng.start > rng.end {
 			return Ok(vec![]);
 		}
-		self.inner.scan(beg..end, limit, version).await
+		self.inner.scan(rng, limit, version).await
 	}
 
 	#[instrument(level = "trace", target = TARGET, skip_all)]
@@ -423,12 +423,12 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.into();
 		let end: Key = rng.end.into();
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), limit = limit, version = version, "Scanr");
-		if beg > end {
+		if rng.start > rng.end {
 			return Ok(vec![]);
 		}
-		self.inner.scanr(beg..end, limit, version).await
+		self.inner.scanr(rng, limit, version).await
 	}
 
 	/// Retrieve a batched scan over a specific range of keys in the datastore.
@@ -446,9 +446,9 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.encode_owned()?;
 		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), version = version, "Batch");
-		self.inner.batch_keys(beg..end, batch, version).await
+		self.inner.batch_keys(rng, batch, version).await
 	}
 
 	/// Count the total number of keys within a range in the datastore.
@@ -461,9 +461,9 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.encode_owned()?;
 		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), "Count");
-		self.inner.count(beg..end).await
+		self.inner.count(rng).await
 	}
 
 	/// Retrieve a batched scan over a specific range of keys in the datastore.
@@ -481,9 +481,9 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.encode_owned()?;
 		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), version = version, "Batch");
-		self.inner.batch_keys_vals(beg..end, batch, version).await
+		self.inner.batch_keys_vals(rng, batch, version).await
 	}
 
 	/// Retrieve a batched scan of all versions over a specific range of keys in the datastore.
@@ -500,9 +500,9 @@ impl Transactor {
 	{
 		let beg: Key = rng.start.encode_owned()?;
 		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
+		let rng = beg..end;
 		trace!(target: TARGET, rng = rng.sprint(), "BatchVersions");
-		self.inner.batch_keys_vals_versions(beg..end, batch).await
+		self.inner.batch_keys_vals_versions(rng, batch).await
 	}
 
 	/// Obtain a new change timestamp for a key

--- a/crates/core/src/kvs/tr.rs
+++ b/crates/core/src/kvs/tr.rs
@@ -272,7 +272,7 @@ impl Transactor {
 	{
 		let key = key.encode_owned()?;
 		trace!(target: TARGET, key = key.sprint(), version = version, "Set");
-		expand_inner!(&mut self.inner, v => { v.set(key, val, version).await })
+		expand_inner!(&mut self.inner, v => { v.set(key, val.into(), version).await })
 	}
 
 	/// Insert or replace a key in the datastore.
@@ -284,7 +284,7 @@ impl Transactor {
 	{
 		let key = key.encode_owned()?;
 		trace!(target: TARGET, key = key.sprint(), "Replace");
-		expand_inner!(&mut self.inner, v => { v.replace(key, val).await })
+		expand_inner!(&mut self.inner, v => { v.replace(key, val.into()).await })
 	}
 
 	/// Insert a key if it doesn't exist in the datastore.
@@ -296,7 +296,7 @@ impl Transactor {
 	{
 		let key = key.encode_owned()?;
 		trace!(target: TARGET, key = key.sprint(), version = version, "Put");
-		expand_inner!(&mut self.inner, v => { v.put(key, val, version).await })
+		expand_inner!(&mut self.inner, v => { v.put(key, val.into(), version).await })
 	}
 
 	/// Update a key in the datastore if the current value matches a condition.
@@ -308,7 +308,7 @@ impl Transactor {
 	{
 		let key = key.encode_owned()?;
 		trace!(target: TARGET, key = key.sprint(), "PutC");
-		expand_inner!(&mut self.inner, v => { v.putc(key, val, chk).await })
+		expand_inner!(&mut self.inner, v => { v.putc(key, val.into(), chk.map(Into::into)).await })
 	}
 
 	/// Delete a key from the datastore.
@@ -331,7 +331,7 @@ impl Transactor {
 	{
 		let key = key.encode_owned()?;
 		trace!(target: TARGET, key = key.sprint(), "DelC");
-		expand_inner!(&mut self.inner, v => { v.delc(key, chk).await })
+		expand_inner!(&mut self.inner, v => { v.delc(key, chk.map(Into::into)).await })
 	}
 
 	/// Delete a range of keys from the datastore.
@@ -382,7 +382,7 @@ impl Transactor {
 	{
 		let key = key.encode_owned()?;
 		trace!(target: TARGET, key = key.sprint(), "ClrC");
-		expand_inner!(&mut self.inner, v => { v.clrc(key, chk).await })
+		expand_inner!(&mut self.inner, v => { v.clrc(key, chk.map(Into::into)).await })
 	}
 
 	/// Delete all versions of a range of keys from the datastore.
@@ -604,7 +604,7 @@ impl Transactor {
 		let ts_key = ts_key.encode_owned()?;
 		let prefix = prefix.encode_owned()?;
 		let suffix = suffix.encode_owned()?;
-		expand_inner!(&mut self.inner, v => { v.set_versionstamp(ts_key, prefix, suffix, val).await })
+		expand_inner!(&mut self.inner, v => { v.set_versionstamp(ts_key, prefix, suffix, val.into()).await })
 	}
 
 	// --------------------------------------------------

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -101,7 +101,7 @@ impl Transaction {
 	/// calls to functions on this transaction will result
 	/// in a [`Error::TxFinished`] error.
 	pub async fn closed(&self) -> bool {
-		self.lock().await.closed().await
+		self.lock().await.closed()
 	}
 
 	/// Cancel a transaction.
@@ -144,7 +144,11 @@ impl Transaction {
 	where
 		K: KeyEncode + Debug,
 	{
-		self.lock().await.getm(keys).await
+		let mut keys_encoded = Vec::new();
+		for k in keys {
+			keys_encoded.push(k.encode_owned()?);
+		}
+		self.lock().await.getm(keys_encoded).await
 	}
 
 	/// Retrieve a specific prefix of keys from the datastore.
@@ -155,7 +159,7 @@ impl Transaction {
 	where
 		K: KeyEncode + Debug,
 	{
-		self.lock().await.getp(key).await
+		self.lock().await.getp(key.encode_owned()?).await
 	}
 
 	/// Retrieve a specific range of keys from the datastore.
@@ -170,6 +174,9 @@ impl Transaction {
 	where
 		K: KeyEncode + Debug,
 	{
+		let beg: Key = rng.start.encode_owned()?;
+		let end: Key = rng.end.encode_owned()?;
+		let rng = beg.as_slice()..end.as_slice();
 		self.lock().await.getr(rng, version).await
 	}
 

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -144,11 +144,7 @@ impl Transaction {
 	where
 		K: KeyEncode + Debug,
 	{
-		let mut keys_encoded = Vec::new();
-		for k in keys {
-			keys_encoded.push(k.encode_owned()?);
-		}
-		self.lock().await.getm(keys_encoded).await
+		self.lock().await.getm(keys).await
 	}
 
 	/// Retrieve a specific prefix of keys from the datastore.
@@ -159,7 +155,7 @@ impl Transaction {
 	where
 		K: KeyEncode + Debug,
 	{
-		self.lock().await.getp(key.encode_owned()?).await
+		self.lock().await.getp(key).await
 	}
 
 	/// Retrieve a specific range of keys from the datastore.
@@ -174,9 +170,6 @@ impl Transaction {
 	where
 		K: KeyEncode + Debug,
 	{
-		let beg: Key = rng.start.encode_owned()?;
-		let end: Key = rng.end.encode_owned()?;
-		let rng = beg.as_slice()..end.as_slice();
 		self.lock().await.getr(rng, version).await
 	}
 

--- a/crates/core/src/vs/mod.rs
+++ b/crates/core/src/vs/mod.rs
@@ -134,6 +134,10 @@ impl VersionStamp {
 		self.0
 	}
 
+	pub fn to_vec(self) -> Vec<u8> {
+		self.0.to_vec()
+	}
+
 	pub const fn from_bytes(bytes: [u8; 10]) -> Self {
 		Self(bytes)
 	}

--- a/crates/language-tests/Cargo.lock
+++ b/crates/language-tests/Cargo.lock
@@ -3573,6 +3573,7 @@ dependencies = [
  "async-channel",
  "async-executor",
  "async-graphql",
+ "async-trait",
  "base64 0.21.7",
  "bcrypt",
  "bincode",

--- a/crates/sdk/src/api/opt/endpoint/indxdb.rs
+++ b/crates/sdk/src/api/opt/endpoint/indxdb.rs
@@ -26,6 +26,7 @@ macro_rules! endpoints {
 				type Client = Db;
 
 				fn into_endpoint(self) -> Result<Endpoint> {
+					#[expect(deprecated)]
 					let mut endpoint = IntoEndpoint::<IndxDb>::into_endpoint(self.0)?;
 					endpoint.config = self.1;
 					Ok(endpoint)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ FROM docker.io/rockylinux:8 AS builder
 RUN yum install -y gcc-toolset-13 git cmake llvm-toolset patch zlib-devel python3.11
 
 # Install rust
-ARG RUST_VERSION=1.82.0
+ARG RUST_VERSION=1.84.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh
 RUN bash /tmp/rustup.sh -y --default-toolchain ${RUST_VERSION}
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -67,10 +67,6 @@ criteria = "safe-to-deploy"
 version = "4.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.android-tzdata]]
-version = "0.1.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.anstream]]
 version = "0.6.18"
 criteria = "safe-to-deploy"
@@ -461,10 +457,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.fail]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.fastrand]]
-version = "2.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.findshlibs]]
@@ -1507,14 +1499,6 @@ criteria = "safe-to-deploy"
 version = "0.9.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.vswhom]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.vswhom-sys]]
-version = "0.1.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.wasi]]
 version = "0.9.0+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
@@ -1581,10 +1565,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-link]]
-version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2,20 +2,12 @@
 # cargo-vet imports lock
 
 [[unpublished.surrealdb]]
-version = "2.3.0"
-audited_as = "2.2.2"
-
-[[unpublished.surrealdb]]
 version = "3.0.0"
-audited_as = "2.2.2"
-
-[[unpublished.surrealdb-core]]
-version = "2.3.0"
-audited_as = "2.2.2"
+audited_as = "2.3.0"
 
 [[unpublished.surrealdb-core]]
 version = "3.0.0"
-audited_as = "2.2.2"
+audited_as = "2.3.0"
 
 [[publisher.addr]]
 version = "0.15.6"
@@ -694,15 +686,15 @@ user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb]]
-version = "2.2.2"
-when = "2025-04-10"
+version = "2.3.0"
+when = "2025-05-01"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb-core]]
-version = "2.2.2"
-when = "2025-04-10"
+version = "2.3.0"
+when = "2025-05-01"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -1310,6 +1302,21 @@ who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
 delta = "0.3.9 -> 0.3.10"
 
+[[audits.bytecode-alliance.audits.fastrand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0 -> 2.0.1"
+notes = """
+This update had a few doc updates but no otherwise-substantial source code
+updates.
+"""
+
+[[audits.bytecode-alliance.audits.fastrand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.1 -> 2.3.0"
+notes = "Minor refactoring, nothing new."
+
 [[audits.bytecode-alliance.audits.fd-lock]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -1912,6 +1919,16 @@ criteria = "safe-to-deploy"
 delta = "1.0.1 -> 1.0.2"
 notes = "No changes to any .rs files or Rust code."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.fastrand]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "1.9.0"
+notes = """
+`does-not-implement-crypto` is certified because this crate explicitly says
+that the RNG here is not cryptographically secure.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.flate2]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
@@ -2840,6 +2857,13 @@ end = "2024-06-16"
 notes = "Maintained by Henri Sivonen who works at Mozilla."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.android-tzdata]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "Small crate parsing a file. No unsafe code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.android_system_properties]]
 who = "Nicolas Silva <nical@fastmail.com>"
 criteria = "safe-to-deploy"
@@ -3020,6 +3044,25 @@ aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supp
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.1 -> 0.3.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.9.0 -> 2.0.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "2.0.1 -> 2.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Chris Martin <cmartin@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.1.0 -> 2.1.1"
+notes = "Fairly trivial changes, no chance of security regression."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.fd-lock]]
@@ -3583,6 +3626,13 @@ who = "Henri Sivonen <hsivonen@hsivonen.fi>"
 criteria = "safe-to-deploy"
 version = "1.0.5"
 notes = "I, Henri Sivonen, wrote this crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.windows-link]]
+who = "Mark Hammond <mhammond@skippinet.com.au>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+notes = "A microsoft crate allowing unsafe calls to windows apis."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.write16]]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

We have multiple layers of transactions:
`struct Transaction` -> `struct Transactor` -> `enum Inner` -> `struct db_specific::Transaction`.

At all layers of this transaction hierarchy, we're calling `encode_owned()` on the incoming keys. This results in, at best, a `Vec<u8>` getting moved many times:
```rust
impl KeyEncode for Vec<u8> {
	fn encode(&self) -> Result<Vec<u8>, crate::err::Error> {
		Ok(self.clone())
	}

    fn encode_owned(self) -> Result<Vec<u8>, crate::err::Error> {
		Ok(self)
	}
}
```
and at worst a `&[u8]` getting cloned into a `Vec<u8>` potentially many times:
```rust
impl KeyEncode for &[u8] {
    fn encode_owned(self) -> Result<Vec<u8>, crate::err::Error>
	where
		Self: Sized,
	{
		self.encode()
	}

	fn encode(&self) -> Result<Vec<u8>, crate::err::Error> {
		let mut buf = Vec::new();
		self.encode_into(&mut buf)?;
		Ok(buf)
	}

	fn encode_into(&self, buffer: &mut Vec<u8>) -> Result<(), crate::err::Error> {
		buffer.extend_from_slice(self);
		Ok(())
	}
}
```

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This change modifies the `trait Transaction` to be dyn compatible and removes the `tr::Inner` enum. In order for the Transaction to be dyn compatible, by removing the generics (eg `K: KeyEncode`). All key encodings occur at the `Transactor` layer now.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI tests should be sufficient.

### Performance verification

Overall, as expected, this change makes little difference in terms of performance. Getting a transaction is not our performance bottleneck, so the `crud-bench` results are all on the margins. Below is a comparison between main and this branch.

These results are all from running on my M4 mac.

#### Main

Server:
```
$ git rev-parse --short HEAD
50df71c5
$ cargo run --release --no-default-features --features storage-mem,http,scripting -- start --user root --pass root memory
```

```
$ cargo run -r -- -d surrealdb -e ws://127.0.0.1:8000 -s 1000000 -c 12 -t 24 -r
--------------------------------------------------
Create 100% - Create took 17s 781ms
Read 100% - Read took 2s 500ms
Update 100% - Update took 19s 366ms
Scan::count_all 100% - Scan::count_all took 6s 285ms
Scan::limit_id 100% - Scan::limit_id took 11ms 50µs
Scan::limit_all 100% - Scan::limit_all took 10ms 960µs
Scan::limit_count 100% - Scan::limit_count took 14ms 469µs
Scan::limit_start_id 100% - Scan::limit_start_id took 25ms 525µs
Scan::limit_start_all 100% - Scan::limit_start_all took 26ms 432µs
Scan::limit_start_count 100% - Scan::limit_start_count took 27ms 544µs
Delete 100% - Delete took 18s 411ms
--------------------------------------------------
Benchmark result for Surrealdb; endpoint => ws://127.0.0.1:8000
CPUs: 16 - Blocking threads: 16 - Workers: 16 - Clients: 12 - Threads: 24 - Samples: 1000000 - Key: Integer - Random: true
--------------------------------------------------
╭─────────────────────────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬─────────┬───────────┬────────┬──────────┬───────┬────────┬───────────────────╮
│ Test                            ┆ Total time ┆ Mean       ┆ Max        ┆ 99th       ┆ 95th       ┆ 75th       ┆ 50th       ┆ 25th       ┆ 1st        ┆ Min        ┆ IQR     ┆ OPS       ┆    CPU ┆   Memory ┆ Reads ┆ Writes ┆ System load       │
╞═════════════════════════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪═════════╪═══════════╪════════╪══════════╪═══════╪════════╪═══════════════════╡
│ [C]reate                        ┆ 17s 781ms  ┆ 5.12 ms    ┆ 24.32 ms   ┆ 6.93 ms    ┆ 6.52 ms    ┆ 5.80 ms    ┆ 5.23 ms    ┆ 4.53 ms    ┆ 2.53 ms    ┆ 0.32 ms    ┆ 1.27 ms ┆ 56239.30  ┆  7.09% ┆ 54.3 MiB ┆   0 B ┆    0 B ┆ 18.16/18.11/18.10 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [R]ead                          ┆ 2s 500ms   ┆ 0.72 ms    ┆ 8.46 ms    ┆ 1.81 ms    ┆ 1.24 ms    ┆ 0.83 ms    ┆ 0.66 ms    ┆ 0.56 ms    ┆ 0.14 ms    ┆ 0.05 ms    ┆ 0.27 ms ┆ 399997.77 ┆ 19.98% ┆ 64.6 MiB ┆   0 B ┆    0 B ┆ 19.35/18.36/18.19 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [U]pdate                        ┆ 19s 366ms  ┆ 5.58 ms    ┆ 24.64 ms   ┆ 7.04 ms    ┆ 6.67 ms    ┆ 6.10 ms    ┆ 5.65 ms    ┆ 5.13 ms    ┆ 3.46 ms    ┆ 0.30 ms    ┆ 0.97 ms ┆ 51634.38  ┆  6.55% ┆ 79.0 MiB ┆   0 B ┆    0 B ┆ 20.70/18.74/18.33 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::count_all (100)         ┆ 6s 285ms   ┆ 6075.86 ms ┆ 6287.36 ms ┆ 6287.36 ms ┆ 6287.36 ms ┆ 6287.36 ms ┆ 6287.36 ms ┆ 6287.36 ms ┆ 1049.60 ms ┆ 1048.58 ms ┆ 0.00 ms ┆ 15.91     ┆  0.01% ┆ 84.7 MiB ┆   0 B ┆    0 B ┆ 20.57/18.74/18.33 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_id (100)          ┆ 11ms 50µs  ┆ 7.57 ms    ┆ 10.86 ms   ┆ 10.83 ms   ┆ 10.56 ms   ┆ 8.81 ms    ┆ 7.49 ms    ┆ 6.60 ms    ┆ 1.48 ms    ┆ 1.48 ms    ┆ 2.20 ms ┆ 9049.70   ┆  0.01% ┆ 86.8 MiB ┆   0 B ┆    0 B ┆ 20.57/18.74/18.33 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_all (100)         ┆ 10ms 960µs ┆ 7.50 ms    ┆ 10.75 ms   ┆ 10.73 ms   ┆ 9.99 ms    ┆ 8.82 ms    ┆ 7.64 ms    ┆ 6.32 ms    ┆ 0.73 ms    ┆ 0.73 ms    ┆ 2.50 ms ┆ 9123.84   ┆  0.01% ┆ 89.0 MiB ┆   0 B ┆    0 B ┆ 20.57/18.74/18.33 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_count (100)       ┆ 14ms 469µs ┆ 8.77 ms    ┆ 14.13 ms   ┆ 14.10 ms   ┆ 13.10 ms   ┆ 10.54 ms   ┆ 8.64 ms    ┆ 6.67 ms    ┆ 2.50 ms    ┆ 2.50 ms    ┆ 3.87 ms ┆ 6910.97   ┆  0.00% ┆ 90.0 MiB ┆   0 B ┆    0 B ┆ 20.57/18.74/18.33 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_start_id (100)    ┆ 25ms 525µs ┆ 21.05 ms   ┆ 25.28 ms   ┆ 25.21 ms   ┆ 24.75 ms   ┆ 23.20 ms   ┆ 21.41 ms   ┆ 19.87 ms   ┆ 4.59 ms    ┆ 4.58 ms    ┆ 3.33 ms ┆ 3917.70   ┆  0.01% ┆ 90.8 MiB ┆   0 B ┆    0 B ┆ 20.57/18.74/18.33 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_start_all (100)   ┆ 26ms 432µs ┆ 21.21 ms   ┆ 26.09 ms   ┆ 26.06 ms   ┆ 25.18 ms   ┆ 23.52 ms   ┆ 21.87 ms   ┆ 19.70 ms   ┆ 4.39 ms    ┆ 4.39 ms    ┆ 3.82 ms ┆ 3783.29   ┆  0.01% ┆ 91.8 MiB ┆   0 B ┆    0 B ┆ 20.57/18.74/18.33 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_start_count (100) ┆ 27ms 544µs ┆ 22.03 ms   ┆ 27.31 ms   ┆ 27.28 ms   ┆ 26.61 ms   ┆ 24.66 ms   ┆ 22.54 ms   ┆ 20.30 ms   ┆ 4.52 ms    ┆ 4.52 ms    ┆ 4.35 ms ┆ 3630.46   ┆  0.00% ┆ 93.0 MiB ┆   0 B ┆    0 B ┆ 20.57/18.74/18.33 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [D]elete                        ┆ 18s 411ms  ┆ 5.30 ms    ┆ 31.73 ms   ┆ 7.42 ms    ┆ 6.62 ms    ┆ 5.90 ms    ┆ 5.37 ms    ┆ 4.75 ms    ┆ 3.06 ms    ┆ 0.29 ms    ┆ 1.14 ms ┆ 54314.39  ┆  6.66% ┆ 97.9 MiB ┆   0 B ┆    0 B ┆ 21.69/19.12/18.48 │
╰─────────────────────────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴─────────┴───────────┴────────┴──────────┴───────┴────────┴───────────────────╯
--------------------------------------------------
```

### This change
Server:
```rust
$ git rev-parse --short HEAD
fd17bdbb
$ cargo run --release --no-default-features --features storage-mem,http,scripting -- start --user root --pass root memory
```

```
$ cargo run -r -- -d surrealdb -e ws://127.0.0.1:8000 -s 1000000 -c 12 -t 24 -r
--------------------------------------------------
Create 100% - Create took 17s 508ms
Read 100% - Read took 2s 320ms
Update 100% - Update took 19s 308ms
Scan::count_all 100% - Scan::count_all took 5s 478ms
Scan::limit_id 100% - Scan::limit_id took 12ms 396µs
Scan::limit_all 100% - Scan::limit_all took 12ms 770µs
Scan::limit_count 100% - Scan::limit_count took 14ms 519µs
Scan::limit_start_id 100% - Scan::limit_start_id took 27ms 49µs
Scan::limit_start_all 100% - Scan::limit_start_all took 28ms 392µs
Scan::limit_start_count 100% - Scan::limit_start_count took 28ms 765µs
Delete 100% - Delete took 18s 61ms
--------------------------------------------------
Benchmark result for Surrealdb; endpoint => ws://127.0.0.1:8000
CPUs: 16 - Blocking threads: 16 - Workers: 16 - Clients: 12 - Threads: 24 - Samples: 1000000 - Key: Integer - Random: true
--------------------------------------------------
╭─────────────────────────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬────────────┬───────────┬───────────┬─────────┬───────────┬────────┬──────────┬───────┬────────┬───────────────────╮
│ Test                            ┆ Total time ┆ Mean       ┆ Max        ┆ 99th       ┆ 95th       ┆ 75th       ┆ 50th       ┆ 25th       ┆ 1st       ┆ Min       ┆ IQR     ┆ OPS       ┆    CPU ┆   Memory ┆ Reads ┆ Writes ┆ System load       │
╞═════════════════════════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪════════════╪═══════════╪═══════════╪═════════╪═══════════╪════════╪══════════╪═══════╪════════╪═══════════════════╡
│ [C]reate                        ┆ 17s 508ms  ┆ 5.04 ms    ┆ 18.70 ms   ┆ 6.79 ms    ┆ 6.39 ms    ┆ 5.70 ms    ┆ 5.15 ms    ┆ 4.48 ms    ┆ 2.67 ms   ┆ 0.33 ms   ┆ 1.22 ms ┆ 57115.24  ┆  7.18% ┆ 53.4 MiB ┆   0 B ┆    0 B ┆ 17.23/16.74/16.34 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [R]ead                          ┆ 2s 320ms   ┆ 0.67 ms    ┆ 11.46 ms   ┆ 1.71 ms    ┆ 1.17 ms    ┆ 0.77 ms    ┆ 0.60 ms    ┆ 0.51 ms    ┆ 0.14 ms   ┆ 0.04 ms   ┆ 0.26 ms ┆ 431027.31 ┆ 20.01% ┆ 66.7 MiB ┆   0 B ┆    0 B ┆ 17.23/16.74/16.34 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [U]pdate                        ┆ 19s 308ms  ┆ 5.56 ms    ┆ 35.90 ms   ┆ 7.03 ms    ┆ 6.64 ms    ┆ 6.08 ms    ┆ 5.63 ms    ┆ 5.12 ms    ┆ 3.50 ms   ┆ 0.29 ms   ┆ 0.96 ms ┆ 51790.96  ┆  6.60% ┆ 81.9 MiB ┆   0 B ┆    0 B ┆ 19.27/17.24/16.53 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::count_all (100)         ┆ 5s 478ms   ┆ 5295.69 ms ┆ 5480.45 ms ┆ 5480.45 ms ┆ 5480.45 ms ┆ 5480.45 ms ┆ 5480.45 ms ┆ 5480.45 ms ┆ 910.85 ms ┆ 910.34 ms ┆ 0.00 ms ┆ 18.25     ┆  0.01% ┆ 86.6 MiB ┆   0 B ┆    0 B ┆ 19.25/17.27/16.54 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_id (100)          ┆ 12ms 396µs ┆ 8.51 ms    ┆ 12.06 ms   ┆ 12.04 ms   ┆ 11.86 ms   ┆ 10.23 ms   ┆ 8.78 ms    ┆ 6.77 ms    ┆ 1.16 ms   ┆ 1.16 ms   ┆ 3.46 ms ┆ 8066.52   ┆  0.01% ┆ 89.6 MiB ┆   0 B ┆    0 B ┆ 19.25/17.27/16.54 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_all (100)         ┆ 12ms 770µs ┆ 8.82 ms    ┆ 12.57 ms   ┆ 12.57 ms   ┆ 12.18 ms   ┆ 10.71 ms   ┆ 8.64 ms    ┆ 7.19 ms    ┆ 1.32 ms   ┆ 1.32 ms   ┆ 3.52 ms ┆ 7830.62   ┆  0.01% ┆ 92.2 MiB ┆   0 B ┆    0 B ┆ 19.25/17.27/16.54 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_count (100)       ┆ 14ms 519µs ┆ 8.95 ms    ┆ 14.31 ms   ┆ 14.29 ms   ┆ 13.29 ms   ┆ 11.13 ms   ┆ 8.93 ms    ┆ 6.72 ms    ┆ 1.46 ms   ┆ 1.46 ms   ┆ 4.41 ms ┆ 6887.39   ┆  0.00% ┆ 93.6 MiB ┆   0 B ┆    0 B ┆ 19.25/17.27/16.54 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_start_id (100)    ┆ 27ms 49µs  ┆ 21.04 ms   ┆ 26.77 ms   ┆ 26.73 ms   ┆ 25.95 ms   ┆ 23.50 ms   ┆ 21.28 ms   ┆ 19.82 ms   ┆ 4.96 ms   ┆ 4.96 ms   ┆ 3.68 ms ┆ 3696.94   ┆  0.01% ┆ 94.0 MiB ┆   0 B ┆    0 B ┆ 19.25/17.27/16.54 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_start_all (100)   ┆ 28ms 392µs ┆ 22.18 ms   ┆ 28.08 ms   ┆ 28.05 ms   ┆ 27.15 ms   ┆ 25.17 ms   ┆ 22.69 ms   ┆ 20.32 ms   ┆ 4.33 ms   ┆ 4.32 ms   ┆ 4.85 ms ┆ 3522.04   ┆  0.01% ┆ 95.2 MiB ┆   0 B ┆    0 B ┆ 19.25/17.27/16.54 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [S]can::limit_start_count (100) ┆ 28ms 765µs ┆ 22.89 ms   ┆ 28.53 ms   ┆ 28.51 ms   ┆ 27.95 ms   ┆ 26.06 ms   ┆ 23.21 ms   ┆ 20.98 ms   ┆ 4.43 ms   ┆ 4.43 ms   ┆ 5.09 ms ┆ 3476.44   ┆  0.00% ┆ 96.2 MiB ┆   0 B ┆    0 B ┆ 19.25/17.27/16.54 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [D]elete                        ┆ 18s 61ms   ┆ 5.20 ms    ┆ 31.47 ms   ┆ 7.20 ms    ┆ 6.48 ms    ┆ 5.77 ms    ┆ 5.25 ms    ┆ 4.65 ms    ┆ 3.09 ms   ┆ 0.32 ms   ┆ 1.12 ms ┆ 55365.55  ┆  6.78% ┆ 99.7 MiB ┆   0 B ┆    0 B ┆ 20.63/17.71/16.72 │
╰─────────────────────────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴────────────┴───────────┴───────────┴─────────┴───────────┴────────┴──────────┴───────┴────────┴───────────────────╯
--------------------------------------------------
```

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
