### PR TITLE
Align arbitrary and experimental capabilities

### DIFF
--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -722,6 +722,28 @@ mod tests {
 				true,
 				"1".to_string(),
 			),
+			// Specific experimental feature enabled
+			(
+				Datastore::new("memory").await.unwrap().with_capabilities(
+					Capabilities::default()
+						.with_experimental(ExperimentalTarget::RecordReferences.into())
+				),
+				Session::owner().with_ns("test").with_db("test"),
+				"DEFINE FIELD a ON allow_record TYPE record REFERENCE".to_string(),
+				true,
+				"NONE".to_string(),
+			),
+			// Specific experimental feature disabled
+			(
+				Datastore::new("memory").await.unwrap().with_capabilities(
+					Capabilities::default()
+						.without_experimental(ExperimentalTarget::RecordReferences.into())
+				),
+				Session::owner().with_ns("test").with_db("test"),
+				"DEFINE FIELD a ON deny_record TYPE record REFERENCE".to_string(),
+				false,
+				"Experimental capability `record_references` is not enabled".to_string(),
+			),
 			//
 			// Some functions are not allowed
 			//

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -359,12 +359,12 @@ impl DbsCapabilities {
 	}
 
 	fn get_allow_experimental(&self) -> Targets<ExperimentalTarget> {
-		// If there was a global deny, we allow if there is a general allow or some specific allows for HTTP
+		// If there was a global deny, we allow if there is a general allow or some specific allows for experimental features
 		if self.deny_all {
 			return self.allow_experimental.as_ref().cloned().unwrap_or(Targets::None);
 		}
 
-		// If there was a general deny for HTTP, we allow if there are specific allows for HTTP routes
+		// If there was a general deny for experimental features, we allow if there are specific targets
 		if let Some(Targets::All) = self.deny_experimental {
 			match &self.allow_experimental {
 				Some(t @ Targets::Some(_)) => return t.clone(),
@@ -374,7 +374,7 @@ impl DbsCapabilities {
 
 		// If there are no high level denies, we allow the provided Experimental features
 		// If nothing was provided, we deny Experimental targets by default (Targets::None)
-		self.allow_experimental.clone().unwrap_or(Targets::None) // Experimental targets are disabled by default for the server
+		self.allow_experimental.as_ref().cloned().unwrap_or(Targets::None) // Experimental targets are disabled by default for the server
 	}
 
 	fn get_allow_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
@@ -398,7 +398,7 @@ impl DbsCapabilities {
 
 		// If there are no high level denies, we allow the provided arbitrary query subjects
 		// If nothing was provided, we allow arbitrary queries by default (Targets::All)
-		self.allow_arbitrary_query.clone().unwrap_or(Targets::All) // arbitrary queries are enabled by default for the server
+		self.allow_arbitrary_query.as_ref().cloned().unwrap_or(Targets::All) // arbitrary queries are enabled by default for the server
 	}
 
 	fn get_deny_funcs(&self) -> Targets<FuncTarget> {

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -407,7 +407,7 @@ impl DbsCapabilities {
 	}
 
 	fn get_deny_experimental(&self) -> Targets<ExperimentalTarget> {
-		self.allow_experimental.as_ref().cloned().unwrap_or(Targets::None)
+		self.deny_experimental.as_ref().cloned().unwrap_or(Targets::None)
 	}
 
 	fn get_allow_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -378,11 +378,6 @@ impl DbsCapabilities {
 	}
 
 	fn get_allow_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
-		// If there was a global deny, we allow if there is a general allow or some specific allows for arbitrary queries
-		if self.deny_all {
-			return self.allow_arbitrary_query.as_ref().cloned().unwrap_or(Targets::None);
-		}
-
 		// If there was a general deny for arbitrary queries, we allow if there are specific allows for arbitrary query subjects
 		if let Some(Targets::All) = self.deny_arbitrary_query {
 			match &self.allow_arbitrary_query {

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -358,6 +358,49 @@ impl DbsCapabilities {
 		self.allow_http.clone().unwrap_or(Targets::All) // HTTP is enabled by default for the server
 	}
 
+	fn get_allow_experimental(&self) -> Targets<ExperimentalTarget> {
+		// If there was a global deny, we allow if there is a general allow or some specific allows for HTTP
+		if self.deny_all {
+			return self.allow_experimental.as_ref().cloned().unwrap_or(Targets::None);
+		}
+
+		// If there was a general deny for HTTP, we allow if there are specific allows for HTTP routes
+		if let Some(Targets::All) = self.deny_experimental {
+			match &self.allow_experimental {
+				Some(t @ Targets::Some(_)) => return t.clone(),
+				_ => return Targets::None,
+			}
+		}
+
+		// If there are no high level denies, we allow the provided Experimental features
+		// If nothing was provided, we deny Experimental targets by default (Targets::None)
+		self.allow_experimental.clone().unwrap_or(Targets::None) // Experimental targets are disabled by default for the server
+	}
+
+	fn get_allow_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
+		// If there was a global deny, we allow if there is a general allow or some specific allows for arbitrary queries
+		if self.deny_all {
+			return self.allow_arbitrary_query.as_ref().cloned().unwrap_or(Targets::None);
+		}
+
+		// If there was a general deny for arbitrary queries, we allow if there are specific allows for arbitrary query subjects
+		if let Some(Targets::All) = self.deny_arbitrary_query {
+			match &self.allow_arbitrary_query {
+				Some(t @ Targets::Some(_)) => return t.clone(),
+				_ => return Targets::None,
+			}
+		}
+
+		// If there are no high level denies but there is a global allow, we allow arbitrary queries
+		if self.allow_all {
+			return Targets::All;
+		}
+
+		// If there are no high level denies, we allow the provided arbitrary query subjects
+		// If nothing was provided, we allow arbitrary queries by default (Targets::All)
+		self.allow_arbitrary_query.clone().unwrap_or(Targets::All) // arbitrary queries are enabled by default for the server
+	}
+
 	fn get_deny_funcs(&self) -> Targets<FuncTarget> {
 		// Allowed functions already consider a global deny and a general deny for functions
 		// On top of what is explicitly allowed, we deny what is specifically denied
@@ -402,20 +445,24 @@ impl DbsCapabilities {
 		}
 	}
 
-	fn get_allow_experimental(&self) -> Targets<ExperimentalTarget> {
-		self.allow_experimental.as_ref().cloned().unwrap_or(Targets::None)
-	}
-
 	fn get_deny_experimental(&self) -> Targets<ExperimentalTarget> {
-		self.deny_experimental.as_ref().cloned().unwrap_or(Targets::None)
-	}
-
-	fn get_allow_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
-		self.allow_arbitrary_query.as_ref().cloned().unwrap_or(Targets::All)
+		// Allowed experimental targets already consider a global deny and a general deny for experimental targets
+		// On top of what is explicitly allowed, we deny what is specifically denied
+		if let Some(t @ Targets::Some(_)) = &self.deny_experimental {
+			t.clone()
+		} else {
+			Targets::None
+		}
 	}
 
 	fn get_deny_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
-		self.deny_arbitrary_query.as_ref().cloned().unwrap_or(Targets::None)
+		// Allowed arbitrary queryies already consider a global deny and a general deny for arbitr
+		// On top of what is explicitly allowed, we deny what is specifically denied
+		if let Some(t @ Targets::Some(_)) = &self.deny_arbitrary_query {
+			t.clone()
+		} else {
+			Targets::None
+		}
 	}
 
 	pub fn into_cli_capabilities(self) -> Capabilities {

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -2016,4 +2016,164 @@ mod http_integration {
 			assert!(res.is_err(), "Request to \"/rpc\" endpoint unexpectedly succeeded")
 		}
 	}
+
+	#[test(tokio::test)]
+	async fn experimental_capabilities() {
+		// Allow 1
+		{
+			// Start server disallowing routes for queries, exporting and importing
+			let (addr, _server) = common::start_server(StartServerArguments {
+				args: "--deny-experimental * --allow-experimental record_references".to_string(),
+				// Auth disabled to ensure unauthorized errors are due to capabilities
+				auth: false,
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			// Prepare HTTP client
+			let mut headers = reqwest::header::HeaderMap::new();
+			let ns = Ulid::new().to_string();
+			let db = Ulid::new().to_string();
+			headers.insert("surreal-ns", ns.parse().unwrap());
+			headers.insert("surreal-db", db.parse().unwrap());
+			headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+			let client = reqwest::Client::builder()
+				.connect_timeout(Duration::from_millis(10))
+				.default_headers(headers)
+				.build()
+				.unwrap();
+			let base_url = &format!("http://{addr}");
+
+			// Check that denied routes are disallowed
+			let res = client
+				.post(format!("{base_url}/sql"))
+				.basic_auth(USER, Some(PASS))
+				.body("DEFINE FIELD a ON deny_all_allow_references TYPE record REFERENCE")
+				.send()
+				.await
+				.unwrap();
+			let res = res.text().await.unwrap();
+			assert!(res.contains("[{\"result\":null,\"status\":\"OK\""), "body: {}", res);
+		}
+		// Deny 1
+		{
+			// Start server disallowing routes for queries, exporting and importing
+			let (addr, _server) = common::start_server(StartServerArguments {
+				args: "--deny-experimental record_references --allow-experimental *".to_string(),
+				// Auth disabled to ensure unauthorized errors are due to capabilities
+				auth: false,
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			// Prepare HTTP client
+			let mut headers = reqwest::header::HeaderMap::new();
+			let ns = Ulid::new().to_string();
+			let db = Ulid::new().to_string();
+			headers.insert("surreal-ns", ns.parse().unwrap());
+			headers.insert("surreal-db", db.parse().unwrap());
+			headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+			let client = reqwest::Client::builder()
+				.connect_timeout(Duration::from_millis(10))
+				.default_headers(headers)
+				.build()
+				.unwrap();
+			let base_url = &format!("http://{addr}");
+
+			// Check that denied routes are disallowed
+			let res = client
+				.post(format!("{base_url}/sql"))
+				.basic_auth(USER, Some(PASS))
+				.body("DEFINE FIELD a ON deny_all_allow_references TYPE record REFERENCE")
+				.send()
+				.await
+				.unwrap();
+			let res = res.text().await.unwrap();
+			assert!(
+				res.contains("Experimental capability `record_references` is not enabled"),
+				"body: {}",
+				res
+			);
+		}
+	}
+
+	#[test(tokio::test)]
+	async fn arbitrary_query_capabilities() {
+		// Allow system
+		{
+			// Start server disallowing routes for queries, exporting and importing
+			let (addr, _server) = common::start_server(StartServerArguments {
+				args: "--allow-arbitrary-query system".to_string(),
+				// Auth disabled to ensure unauthorized errors are due to capabilities
+				auth: false,
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			// Prepare HTTP client
+			let mut headers = reqwest::header::HeaderMap::new();
+			let ns = Ulid::new().to_string();
+			let db = Ulid::new().to_string();
+			headers.insert("surreal-ns", ns.parse().unwrap());
+			headers.insert("surreal-db", db.parse().unwrap());
+			headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+			let client = reqwest::Client::builder()
+				.connect_timeout(Duration::from_millis(10))
+				.default_headers(headers)
+				.build()
+				.unwrap();
+			let base_url = &format!("http://{addr}");
+
+			// Check that denied routes are disallowed
+			let res = client
+				.post(format!("{base_url}/sql"))
+				.basic_auth(USER, Some(PASS))
+				.body("123")
+				.send()
+				.await
+				.unwrap();
+			let res = res.text().await.unwrap();
+			assert!(res.contains("[{\"result\":123,\"status\":\"OK\""), "body: {}", res);
+		}
+		// Allow record
+		{
+			// Start server disallowing routes for queries, exporting and importing
+			let (addr, _server) = common::start_server(StartServerArguments {
+				args: "--allow-arbitrary-query record".to_string(),
+				// Auth disabled to ensure unauthorized errors are due to capabilities
+				auth: false,
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			// Prepare HTTP client
+			let mut headers = reqwest::header::HeaderMap::new();
+			let ns = Ulid::new().to_string();
+			let db = Ulid::new().to_string();
+			headers.insert("surreal-ns", ns.parse().unwrap());
+			headers.insert("surreal-db", db.parse().unwrap());
+			headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+			let client = reqwest::Client::builder()
+				.connect_timeout(Duration::from_millis(10))
+				.default_headers(headers)
+				.build()
+				.unwrap();
+			let base_url = &format!("http://{addr}");
+
+			// Check that denied routes are disallowed
+			let res = client
+				.post(format!("{base_url}/sql"))
+				.basic_auth(USER, Some(PASS))
+				.body("123")
+				.send()
+				.await
+				.unwrap();
+			let res = res.text().await.unwrap();
+			assert!(res.contains("The HTTP route 'sql' is forbidden"), "body: {}", res);
+		}
+	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

#5887 introduced a regression, and while fixing it we noticed that the arbitrary query and experimental capabilities in general are not aligned with the others.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR aligns these two capabilities with the behaviour of others.
They are now aligned, with the exception that `--deny-all` does not deny arbitrary querying, as that would be a breaking change. Instead, you need to explicitely deny that or allow only a subset.

### How do they work now?
**Arbitrary queries** by default are `allow: *, deny: unset`, which means that all type of users can query by default. When you set `--allow-arbitrary-query system`, it means that only system users can query, as there is a implicit deny by default. As mentioned before, `--deny-all` does not influence arbitrary querying.

**Experimental queries** by default are `allow: unset, deny: unset`, which means that no experimental capability is enabled by default. You instead need to explicitely enable them, or deny only a couple like: `--allow-experimental * --deny-experimental files`. Just like before, `--allow-all` does not influence experimental capabilities, as we always want them to be controlled explicitely.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a few tests

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
