### PR TITLE
bugfix-5906

### DIFF
--- a/crates/core/src/rpc/context.rs
+++ b/crates/core/src/rpc/context.rs
@@ -41,10 +41,9 @@ pub trait RpcContext {
 	fn handle_kill(&self, _lqid: &Uuid) -> impl std::future::Future<Output = ()> + Send {
 		async { unimplemented!("handle_kill function must be implemented if LQ_SUPPORT = true") }
 	}
+
 	/// Handles the cleanup of live queries
-	fn cleanup_lqs(&self) -> impl std::future::Future<Output = ()> + Send {
-		async { unimplemented!("cleanup_lqs function must be implemented if LQ_SUPPORT = true") }
-	}
+	fn cleanup_lqs(&self) -> impl std::future::Future<Output = ()> + Send;
 
 	// ------------------------------
 	// GraphQL

--- a/src/rpc/http.rs
+++ b/src/rpc/http.rs
@@ -59,6 +59,11 @@ impl RpcContext for Http {
 	/// Live queries are disabled on HTTP
 	const LQ_SUPPORT: bool = false;
 
+	/// Handles the cleanup of live queries
+	async fn cleanup_lqs(&self) {
+		// Do nothing as HTTP is stateless
+	}
+
 	// ------------------------------
 	// GraphQL
 	// ------------------------------


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Fixing the issue

## What does this change do?

When using http to call the reset method, the server panics. This is misleading as session variables and auth are still cleared.   Added the trait to Http to do nothing, seemed the simplest approach.


## What is your testing strategy?

four lines got changed....


## Is this related to any issues?

Fixes #5906 

## Does this change need documentation?

Reset shouldnt be a websocket only method, eventhough until now it was. Since the docs already didnt mention this isn an websocket only method no changes are needed.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
