### PR TITLE
Fixes invalid "*" value for SURREAL_CAPS_[ALLOW_ARBITRARY_QUERY | ALLOW_EXPERIMENTAL]

### DIFF
--- a/crates/core/src/dbs/capabilities.rs
+++ b/crates/core/src/dbs/capabilities.rs
@@ -19,7 +19,7 @@ pub struct FuncTarget(pub String, pub Option<String>);
 impl fmt::Display for FuncTarget {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match &self.1 {
-			Some(name) => write!(f, "{}:{}", self.0, name),
+			Some(name) => write!(f, "{}:{name}", self.0),
 			None => write!(f, "{}::*", self.0),
 		}
 	}
@@ -733,10 +733,6 @@ impl Capabilities {
 		self.allow_arbitrary_query.matches(target) && !self.deny_arbitrary_query.matches(target)
 	}
 
-	pub fn allows_query_name(&self, target: &str) -> bool {
-		self.allow_arbitrary_query.matches(target) && !self.deny_arbitrary_query.matches(target)
-	}
-
 	pub fn allows_network_target(&self, target: &NetTarget) -> bool {
 		self.allow_net.matches(target) && !self.deny_net.matches(target)
 	}
@@ -1079,6 +1075,14 @@ mod tests {
 			assert!(!caps.allows_rpc_method(&MethodTarget::from_str("query").unwrap()));
 		}
 
+		// When all RPC methods are denied
+		{
+			let caps = Capabilities::default().without_rpc_methods(Targets::<MethodTarget>::All);
+			assert!(!caps.allows_rpc_method(&MethodTarget::from_str("ping").unwrap()));
+			assert!(!caps.allows_rpc_method(&MethodTarget::from_str("select").unwrap()));
+			assert!(!caps.allows_rpc_method(&MethodTarget::from_str("query").unwrap()));
+		}
+
 		// When some RPC methods are allowed and some are denied, deny overrides the allow rules
 		{
 			let caps = Capabilities::default()
@@ -1129,7 +1133,15 @@ mod tests {
 			assert!(!caps.allows_http_route(&RouteTarget::from_str("sql").unwrap()));
 		}
 
-		// When some HTTP rotues are allowed and some are denied, deny overrides the allow rules
+		// When all HTTP routes are denied at the same time
+		{
+			let caps = Capabilities::default().without_http_routes(Targets::<RouteTarget>::All);
+			assert!(!caps.allows_http_route(&RouteTarget::from_str("version").unwrap()));
+			assert!(!caps.allows_http_route(&RouteTarget::from_str("export").unwrap()));
+			assert!(!caps.allows_http_route(&RouteTarget::from_str("sql").unwrap()));
+		}
+
+		// When some HTTP routes are allowed and some are denied, deny overrides the allow rules
 		{
 			let caps = Capabilities::default()
 				.with_http_routes(Targets::<RouteTarget>::Some(
@@ -1154,6 +1166,58 @@ mod tests {
 			assert!(caps.allows_http_route(&RouteTarget::from_str("key").unwrap()));
 			assert!(!caps.allows_http_route(&RouteTarget::from_str("sql").unwrap()));
 			assert!(!caps.allows_http_route(&RouteTarget::from_str("rpc").unwrap()));
+		}
+
+		// When all arbitrary query targets are allowed
+		{
+			let caps = Capabilities::default()
+				.with_arbitrary_query(Targets::<ArbitraryQueryTarget>::All)
+				.without_arbitrary_query(Targets::<ArbitraryQueryTarget>::None);
+			assert!(caps.allows_query(&ArbitraryQueryTarget::from_str("guest").unwrap()));
+			assert!(caps.allows_query(&ArbitraryQueryTarget::from_str("record").unwrap()));
+			assert!(caps.allows_query(&ArbitraryQueryTarget::from_str("system").unwrap()));
+		}
+
+		// When all arbitrary query targets are allowed and denied at the same time
+		{
+			let caps = Capabilities::default()
+				.with_arbitrary_query(Targets::<ArbitraryQueryTarget>::All)
+				.without_arbitrary_query(Targets::<ArbitraryQueryTarget>::All);
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("guest").unwrap()));
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("record").unwrap()));
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("system").unwrap()));
+		}
+
+		// When all arbitrary query targets are denied
+		{
+			let caps = Capabilities::default()
+				.without_arbitrary_query(Targets::<ArbitraryQueryTarget>::All);
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("guest").unwrap()));
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("record").unwrap()));
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("system").unwrap()));
+		}
+
+		// When some arbitrary query targets are allowed and some are denied, deny overrides the allow rules
+		{
+			let caps = Capabilities::default()
+				.with_arbitrary_query(Targets::<ArbitraryQueryTarget>::Some(
+					[
+						ArbitraryQueryTarget::from_str("guest").unwrap(),
+						ArbitraryQueryTarget::from_str("record").unwrap(),
+					]
+					.into(),
+				))
+				.without_arbitrary_query(Targets::<ArbitraryQueryTarget>::Some(
+					[
+						ArbitraryQueryTarget::from_str("record").unwrap(),
+						ArbitraryQueryTarget::from_str("system").unwrap(),
+					]
+					.into(),
+				));
+
+			assert!(caps.allows_query(&ArbitraryQueryTarget::from_str("guest").unwrap()));
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("record").unwrap()));
+			assert!(!caps.allows_query(&ArbitraryQueryTarget::from_str("system").unwrap()));
 		}
 	}
 }

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -524,8 +524,7 @@ impl Datastore {
 		self.capabilities.allows_http_route(route_target)
 	}
 
-	/// Does the datastore allow requesting an HTTP route?
-	/// This function needs to be public to allow access from the CLI crate.
+	/// Is the user allowed to query?
 	pub fn allows_query_by_subject(&self, subject: impl Into<ArbitraryQueryTarget>) -> bool {
 		self.capabilities.allows_query(&subject.into())
 	}

--- a/src/cli/validator/mod.rs
+++ b/src/cli/validator/mod.rs
@@ -269,4 +269,36 @@ mod tests {
 			)
 		);
 	}
+
+	#[test]
+	fn test_arbitrary_query_targets() {
+		assert_eq!(query_arbitrary_targets("*").unwrap(), Targets::<ArbitraryQueryTarget>::All);
+		assert_eq!(query_arbitrary_targets("").unwrap(), Targets::<ArbitraryQueryTarget>::All);
+		assert_eq!(
+			query_arbitrary_targets("guest").unwrap(),
+			Targets::<ArbitraryQueryTarget>::Some(
+				vec![ArbitraryQueryTarget::Guest].into_iter().collect()
+			)
+		);
+		assert_eq!(
+			query_arbitrary_targets("guest,system").unwrap(),
+			Targets::<ArbitraryQueryTarget>::Some(
+				vec![ArbitraryQueryTarget::Guest, ArbitraryQueryTarget::System]
+					.into_iter()
+					.collect()
+			)
+		);
+		assert_eq!(
+			query_arbitrary_targets("guest,record,system").unwrap(),
+			Targets::<ArbitraryQueryTarget>::Some(
+				vec![
+					ArbitraryQueryTarget::Guest,
+					ArbitraryQueryTarget::Record,
+					ArbitraryQueryTarget::System
+				]
+				.into_iter()
+				.collect()
+			)
+		);
+	}
 }

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -403,35 +403,19 @@ impl DbsCapabilities {
 	}
 
 	fn get_allow_experimental(&self) -> Targets<ExperimentalTarget> {
-		match &self.allow_experimental {
-			Some(t @ Targets::Some(_)) => t.clone(),
-			Some(_) => Targets::None,
-			None => Targets::None,
-		}
+		self.allow_experimental.as_ref().cloned().unwrap_or(Targets::None)
 	}
 
 	fn get_deny_experimental(&self) -> Targets<ExperimentalTarget> {
-		match &self.deny_experimental {
-			Some(t @ Targets::Some(_)) => t.clone(),
-			Some(_) => Targets::None,
-			None => Targets::None,
-		}
+		self.allow_experimental.as_ref().cloned().unwrap_or(Targets::None)
 	}
 
 	fn get_allow_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
-		match &self.allow_arbitrary_query {
-			Some(t @ Targets::Some(_)) => t.clone(),
-			Some(_) => Targets::None,
-			None => Targets::All,
-		}
+		self.allow_arbitrary_query.as_ref().cloned().unwrap_or(Targets::All)
 	}
 
 	fn get_deny_arbitrary_query(&self) -> Targets<ArbitraryQueryTarget> {
-		match &self.deny_arbitrary_query {
-			Some(t @ Targets::Some(_)) => t.clone(),
-			Some(_) => Targets::None,
-			None => Targets::None,
-		}
+		self.deny_arbitrary_query.as_ref().cloned().unwrap_or(Targets::None)
 	}
 
 	pub fn into_cli_capabilities(self) -> Capabilities {
@@ -866,7 +850,7 @@ mod tests {
 				format!("RETURN http::get('{}/redirect')", server3.uri()),
 				false,
 				format!("here was an error processing a remote HTTP request: error following redirect for url ({}/redirect)",server3.uri()),
-			),
+			)
 		];
 
 		for (idx, (ds, sess, query, succeeds, contains)) in cases.into_iter().enumerate() {
@@ -902,5 +886,31 @@ mod tests {
 		server1.verify().await;
 		server2.verify().await;
 		server3.verify().await;
+	}
+
+	#[test]
+	fn test_dbs_capabilities_target_all() {
+		let caps = DbsCapabilities {
+			allow_all: false,
+			allow_scripting: false,
+			allow_guests: false,
+			allow_funcs: None,
+			allow_experimental: Some(Targets::All),
+			allow_arbitrary_query: Some(Targets::All),
+			allow_net: None,
+			allow_rpc: None,
+			allow_http: None,
+			deny_all: false,
+			deny_scripting: false,
+			deny_guests: false,
+			deny_funcs: None,
+			deny_experimental: None,
+			deny_arbitrary_query: None,
+			deny_net: None,
+			deny_rpc: None,
+			deny_http: None,
+		};
+		assert_eq!(caps.get_allow_experimental(), Targets::All);
+		assert_eq!(caps.get_allow_arbitrary_query(), Targets::All);
 	}
 }

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -2030,4 +2030,201 @@ mod http_integration {
 			assert!(res.is_err(), "Request to \"/rpc\" endpoint unexpectedly succeeded")
 		}
 	}
+
+	#[test(tokio::test)]
+	async fn experimental_capabilities() {
+		// Allow 1
+		{
+			// Start server disallowing routes for queries, exporting and importing
+			let (addr, _server) = common::start_server(StartServerArguments {
+				args: "--deny-experimental * --allow-experimental record_references".to_string(),
+				// Auth disabled to ensure unauthorized errors are due to capabilities
+				auth: false,
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			// Prepare HTTP client
+			let mut headers = reqwest::header::HeaderMap::new();
+			let ns = Ulid::new().to_string();
+			let db = Ulid::new().to_string();
+			headers.insert("surreal-ns", ns.parse().unwrap());
+			headers.insert("surreal-db", db.parse().unwrap());
+			headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+			let client = reqwest::Client::builder()
+				.connect_timeout(Duration::from_millis(10))
+				.default_headers(headers)
+				.build()
+				.unwrap();
+			let base_url = &format!("http://{addr}");
+
+			// Check that denied routes are disallowed
+			let res = client
+				.post(format!("{base_url}/sql"))
+				.basic_auth(USER, Some(PASS))
+				.body("DEFINE FIELD a ON deny_all_allow_references TYPE record REFERENCE")
+				.send()
+				.await
+				.unwrap();
+			let res = res.text().await.unwrap();
+			assert!(res.contains("[{\"result\":null,\"status\":\"OK\""), "body: {}", res);
+		}
+		// Deny 1
+		{
+			// Start server disallowing routes for queries, exporting and importing
+			let (addr, _server) = common::start_server(StartServerArguments {
+				args: "--deny-experimental record_references --allow-experimental *".to_string(),
+				// Auth disabled to ensure unauthorized errors are due to capabilities
+				auth: false,
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			// Prepare HTTP client
+			let mut headers = reqwest::header::HeaderMap::new();
+			let ns = Ulid::new().to_string();
+			let db = Ulid::new().to_string();
+			headers.insert("surreal-ns", ns.parse().unwrap());
+			headers.insert("surreal-db", db.parse().unwrap());
+			headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+			let client = reqwest::Client::builder()
+				.connect_timeout(Duration::from_millis(10))
+				.default_headers(headers)
+				.build()
+				.unwrap();
+			let base_url = &format!("http://{addr}");
+
+			// Check that denied routes are disallowed
+			let res = client
+				.post(format!("{base_url}/sql"))
+				.basic_auth(USER, Some(PASS))
+				.body("DEFINE FIELD a ON deny_all_allow_references TYPE record REFERENCE")
+				.send()
+				.await
+				.unwrap();
+			let res = res.text().await.unwrap();
+			assert!(
+				res.contains("Experimental capability `record_references` is not enabled"),
+				"body: {}",
+				res
+			);
+		}
+	}
+
+	#[test(tokio::test)]
+	async fn arbitrary_query_capabilities() {
+		// Allow system
+		{
+			// Start server disallowing routes for queries, exporting and importing
+			let (addr, _server) = common::start_server(StartServerArguments {
+				args: "--allow-arbitrary-query system".to_string(),
+				// Auth disabled to ensure unauthorized errors are due to capabilities
+				auth: false,
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			// Prepare HTTP client
+			let mut headers = reqwest::header::HeaderMap::new();
+			let ns = Ulid::new().to_string();
+			let db = Ulid::new().to_string();
+			headers.insert("surreal-ns", ns.parse().unwrap());
+			headers.insert("surreal-db", db.parse().unwrap());
+			headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+			let client = reqwest::Client::builder()
+				.connect_timeout(Duration::from_millis(10))
+				.default_headers(headers)
+				.build()
+				.unwrap();
+			let base_url = &format!("http://{addr}");
+
+			// Check that denied routes are disallowed
+			let res = client
+				.post(format!("{base_url}/sql"))
+				.basic_auth(USER, Some(PASS))
+				.body("123")
+				.send()
+				.await
+				.unwrap();
+			let res = res.text().await.unwrap();
+			assert!(res.contains("[{\"result\":123,\"status\":\"OK\""), "body: {}", res);
+		}
+		// Allow record
+		{
+			// Start server disallowing routes for queries, exporting and importing
+			let (addr, _server) = common::start_server(StartServerArguments {
+				args: "--allow-arbitrary-query record".to_string(),
+				// Auth disabled to ensure unauthorized errors are due to capabilities
+				auth: false,
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			// Prepare HTTP client
+			let mut headers = reqwest::header::HeaderMap::new();
+			let ns = Ulid::new().to_string();
+			let db = Ulid::new().to_string();
+			headers.insert("surreal-ns", ns.parse().unwrap());
+			headers.insert("surreal-db", db.parse().unwrap());
+			headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+			let client = reqwest::Client::builder()
+				.connect_timeout(Duration::from_millis(10))
+				.default_headers(headers)
+				.build()
+				.unwrap();
+			let base_url = &format!("http://{addr}");
+
+			// Check that denied routes are disallowed
+			let res = client
+				.post(format!("{base_url}/sql"))
+				.basic_auth(USER, Some(PASS))
+				.body("123")
+				.send()
+				.await
+				.unwrap();
+			let res = res.text().await.unwrap();
+			assert!(res.contains("The HTTP route 'sql' is forbidden"), "body: {}", res);
+		}
+		// Deny arbitrary querying
+		{
+			// Start server disallowing routes for queries, exporting and importing
+			let (addr, _server) = common::start_server(StartServerArguments {
+				args: "--deny-arbitrary-query *".to_string(),
+				// Auth disabled to ensure unauthorized errors are due to capabilities
+				auth: false,
+				..Default::default()
+			})
+			.await
+			.unwrap();
+
+			// Prepare HTTP client
+			let mut headers = reqwest::header::HeaderMap::new();
+			let ns = Ulid::new().to_string();
+			let db = Ulid::new().to_string();
+			headers.insert("surreal-ns", ns.parse().unwrap());
+			headers.insert("surreal-db", db.parse().unwrap());
+			headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+			let client = reqwest::Client::builder()
+				.connect_timeout(Duration::from_millis(10))
+				.default_headers(headers)
+				.build()
+				.unwrap();
+			let base_url = &format!("http://{addr}");
+
+			// Check that denied routes are disallowed
+			let res = client
+				.post(format!("{base_url}/sql"))
+				.basic_auth(USER, Some(PASS))
+				.body("123")
+				.send()
+				.await
+				.unwrap();
+			let res = res.text().await.unwrap();
+			assert!(res.contains("The HTTP route 'sql' is forbidden"), "body: {}", res);
+		}
+	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Backports #5890 to 2.2.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
