### PR TITLE
Make latest release logic and Github releases more robust

### DIFF
--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -639,6 +639,7 @@ jobs:
           body: "Release ${{ needs.prepare-vars.outputs.version }}"
           target_commitish: ${{ needs.prepare-vars.outputs.release-branch }}
           prerelease: ${{ needs.prepare-vars.outputs.environment != 'stable' }}
+          make_latest: ${{ inputs.latest }}
           fail_on_unmatched_files: true
           files: |
             LICENSE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,5 +50,5 @@ jobs:
       release-type: ${{ inputs.release-type }}
       publish: ${{ inputs.publish }}
       extra-features: ${{ inputs.extra-features }}
-      create-release: ${{ inputs.publish }}
+      create-release: ${{ inputs.publish && inputs.release-type != 'nightly' }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/publish-version.yml
     with:
       git-ref: ${{ inputs.git-ref }}
-      latest: ${{ inputs.latest }}
+      latest: ${{ inputs.latest && (inputs.release-type == 'patch' || inputs.release-type == 'release') }}
       release-type: ${{ inputs.release-type }}
       publish: ${{ inputs.publish }}
       extra-features: ${{ inputs.extra-features }}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

- The Github releases action is not explicitly set to mark whether a release is latest or not. This makes it defer to its default behaviour, which is sometimes wrong.
- The `Release` workflow is set to create a Github release for any release set to publish. Nightly releases shouldn't have Github releases.
- Only stable releases should be considered as latest.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

- Sets the Github releases action's `make_latest` option.
- It ensures `create-release` is set to `true` only for non-nightly releases.
- It ensures `latest` is set to `true` only for stable releases.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

[Published a new nightly](https://github.com/surrealdb/surrealdb/actions/runs/15007131591) using this changeset.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
