### PR TITLE
Add DisplaySql trait for explicit sql conversions.

### DIFF
--- a/crates/core/src/sql/access.rs
+++ b/crates/core/src/sql/access.rs
@@ -53,8 +53,10 @@ impl Deref for Accesses {
 	}
 }
 
-impl Display for Accesses {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Accesses);
+
+impl crate::sql::DisplaySql for Accesses {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&Fmt::comma_separated(&self.0), f)
 	}
 }
@@ -100,8 +102,10 @@ impl Access {
 	}
 }
 
-impl Display for Access {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Access);
+
+impl crate::sql::DisplaySql for Access {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		EscapeIdent(&self.0).fmt(f)
 	}
 }

--- a/crates/core/src/sql/access_type.rs
+++ b/crates/core/src/sql/access_type.rs
@@ -7,7 +7,6 @@ use revision::revisioned;
 use revision::Error as RevisionError;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::fmt::Display;
 use std::str::FromStr;
 
 /// The type of access methods available
@@ -47,8 +46,10 @@ impl Jwt for AccessType {
 	}
 }
 
-impl Display for AccessType {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(AccessType);
+
+impl crate::sql::DisplaySql for AccessType {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			AccessType::Jwt(ac) => {
 				write!(f, "JWT {}", ac)?;
@@ -163,8 +164,10 @@ impl Jwt for JwtAccess {
 	}
 }
 
-impl Display for JwtAccess {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(JwtAccess);
+
+impl crate::sql::DisplaySql for JwtAccess {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match &self.verify {
 			JwtAccessVerify::Key(ref v) => {
 				write!(f, "ALGORITHM {} KEY {}", v.alg, QuoteStr(&v.key))?;

--- a/crates/core/src/sql/algorithm.rs
+++ b/crates/core/src/sql/algorithm.rs
@@ -57,8 +57,10 @@ impl Default for Algorithm {
 	}
 }
 
-impl fmt::Display for Algorithm {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Algorithm);
+
+impl crate::sql::DisplaySql for Algorithm {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str(match self {
 			Self::EdDSA => "EDDSA",
 			Self::Es256 => "ES256",

--- a/crates/core/src/sql/array.rs
+++ b/crates/core/src/sql/array.rs
@@ -10,7 +10,7 @@ use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::fmt::{self, Display, Formatter, Write};
+use std::fmt::{self, Formatter, Write};
 use std::ops;
 use std::ops::Deref;
 use std::ops::DerefMut;
@@ -125,8 +125,10 @@ impl Array {
 	}
 }
 
-impl Display for Array {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Array);
+
+impl crate::sql::DisplaySql for Array {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		let mut f = Pretty::from(f);
 		f.write_char('[')?;
 		if !self.is_empty() {

--- a/crates/core/src/sql/base.rs
+++ b/crates/core/src/sql/base.rs
@@ -22,8 +22,10 @@ impl Default for Base {
 	}
 }
 
-impl fmt::Display for Base {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Base);
+
+impl crate::sql::DisplaySql for Base {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Ns => f.write_str("NAMESPACE"),
 			Self::Db => f.write_str("DATABASE"),

--- a/crates/core/src/sql/block.rs
+++ b/crates/core/src/sql/block.rs
@@ -140,8 +140,10 @@ impl Block {
 	}
 }
 
-impl Display for Block {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Block);
+
+impl crate::sql::DisplaySql for Block {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		let mut f = Pretty::from(f);
 		match (self.len(), self.first()) {
 			(0, _) => f.write_str("{}"),
@@ -257,8 +259,10 @@ impl Entry {
 	}
 }
 
-impl Display for Entry {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Entry);
+
+impl crate::sql::DisplaySql for Entry {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::Set(v) => write!(f, "{v}"),
 			Self::Value(v) => Display::fmt(v, f),

--- a/crates/core/src/sql/bytes.rs
+++ b/crates/core/src/sql/bytes.rs
@@ -5,7 +5,7 @@ use serde::{
 	de::{self, Visitor},
 	Deserialize, Serialize,
 };
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 use std::ops::Deref;
 
 #[revisioned(revision = 1)]
@@ -40,8 +40,10 @@ impl Deref for Bytes {
 	}
 }
 
-impl Display for Bytes {
-	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Bytes);
+
+impl crate::sql::DisplaySql for Bytes {
+	fn fmt_sql(&self, f: &mut Formatter<'_>) -> fmt::Result {
 		write!(f, "b\"{}\"", hex::encode_upper(&self.0))
 	}
 }

--- a/crates/core/src/sql/bytesize.rs
+++ b/crates/core/src/sql/bytesize.rs
@@ -146,8 +146,10 @@ impl Bytesize {
 	}
 }
 
-impl fmt::Display for Bytesize {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Bytesize);
+
+impl crate::sql::DisplaySql for Bytesize {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		let b = self.0;
 		let pb = b / PIB;
 		let b = b % PIB;

--- a/crates/core/src/sql/cast.rs
+++ b/crates/core/src/sql/cast.rs
@@ -60,8 +60,10 @@ impl Cast {
 	}
 }
 
-impl fmt::Display for Cast {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Cast);
+
+impl crate::sql::DisplaySql for Cast {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "<{}> {}", self.0, self.1)
 	}
 }

--- a/crates/core/src/sql/change_feed_include.rs
+++ b/crates/core/src/sql/change_feed_include.rs
@@ -17,8 +17,10 @@ impl Default for ChangeFeedInclude {
 	}
 }
 
-impl fmt::Display for ChangeFeedInclude {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ChangeFeedInclude);
+
+impl crate::sql::DisplaySql for ChangeFeedInclude {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str(match self {
 			Self::Original => "Original",
 		})

--- a/crates/core/src/sql/changefeed.rs
+++ b/crates/core/src/sql/changefeed.rs
@@ -3,7 +3,7 @@ use crate::sql::statements::info::InfoStructure;
 use crate::sql::Value;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 use std::str;
 use std::time;
 
@@ -15,8 +15,10 @@ pub struct ChangeFeed {
 	#[revision(start = 2)]
 	pub store_diff: bool,
 }
-impl Display for ChangeFeed {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ChangeFeed);
+
+impl crate::sql::DisplaySql for ChangeFeed {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "CHANGEFEED {}", Duration(self.expiry))?;
 		if self.store_diff {
 			write!(f, " INCLUDE ORIGINAL")?;

--- a/crates/core/src/sql/closure.rs
+++ b/crates/core/src/sql/closure.rs
@@ -67,8 +67,10 @@ impl Closure {
 	}
 }
 
-impl fmt::Display for Closure {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Closure);
+
+impl crate::sql::DisplaySql for Closure {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str("|")?;
 		for (i, (name, kind)) in self.args.iter().enumerate() {
 			if i > 0 {

--- a/crates/core/src/sql/cond.rs
+++ b/crates/core/src/sql/cond.rs
@@ -18,8 +18,10 @@ impl Deref for Cond {
 	}
 }
 
-impl fmt::Display for Cond {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Cond);
+
+impl crate::sql::DisplaySql for Cond {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "WHERE {}", self.0)
 	}
 }

--- a/crates/core/src/sql/constant.rs
+++ b/crates/core/src/sql/constant.rs
@@ -94,8 +94,10 @@ impl Constant {
 	}
 }
 
-impl fmt::Display for Constant {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Constant);
+
+impl crate::sql::DisplaySql for Constant {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str(match self {
 			Self::MathE => "math::E",
 			Self::MathFrac1Pi => "math::FRAC_1_PI",

--- a/crates/core/src/sql/data.rs
+++ b/crates/core/src/sql/data.rs
@@ -91,8 +91,10 @@ impl Data {
 	}
 }
 
-impl Display for Data {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Data);
+
+impl crate::sql::DisplaySql for Data {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::EmptyExpression => Ok(()),
 			Self::SetExpression(v) => write!(

--- a/crates/core/src/sql/datetime.rs
+++ b/crates/core/src/sql/datetime.rs
@@ -5,7 +5,7 @@ use crate::syn;
 use chrono::{offset::LocalResult, DateTime, SecondsFormat, TimeZone, Utc};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 use std::ops;
 use std::ops::Deref;
 use std::str;
@@ -115,8 +115,10 @@ impl Datetime {
 	}
 }
 
-impl Display for Datetime {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Datetime);
+
+impl crate::sql::DisplaySql for Datetime {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "d{}", &QuoteStr(&self.to_raw()))
 	}
 }

--- a/crates/core/src/sql/dir.rs
+++ b/crates/core/src/sql/dir.rs
@@ -21,8 +21,10 @@ impl Default for Dir {
 	}
 }
 
-impl fmt::Display for Dir {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Dir);
+
+impl crate::sql::DisplaySql for Dir {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str(match self {
 			Self::In => "<-",
 			Self::Out => "->",

--- a/crates/core/src/sql/duration.rs
+++ b/crates/core/src/sql/duration.rs
@@ -172,8 +172,10 @@ impl Duration {
 	}
 }
 
-impl fmt::Display for Duration {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Duration);
+
+impl crate::sql::DisplaySql for Duration {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		// Split up the duration
 		let secs = self.0.as_secs();
 		let nano = self.0.subsec_nanos();

--- a/crates/core/src/sql/edges.rs
+++ b/crates/core/src/sql/edges.rs
@@ -57,8 +57,10 @@ impl Edges {
 	}
 }
 
-impl fmt::Display for Edges {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Edges);
+
+impl crate::sql::DisplaySql for Edges {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self.what.len() {
 			0 => write!(f, "{}{}?", self.from, self.dir,),
 			1 => write!(f, "{}{}{}", self.from, self.dir, self.what),

--- a/crates/core/src/sql/error.rs
+++ b/crates/core/src/sql/error.rs
@@ -54,8 +54,10 @@ impl SqlError {
 }
 
 impl std::error::Error for SqlError {}
-impl fmt::Display for SqlError {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+crate::sql::impl_display_from_sql!(SqlError);
+
+impl crate::sql::DisplaySql for SqlError {
+	fn fmt_sql(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
 			SqlError::Thrown(message) => {
 				write!(f, "An error was raised by a THROW statement: {message}")

--- a/crates/core/src/sql/explain.rs
+++ b/crates/core/src/sql/explain.rs
@@ -8,8 +8,10 @@ use std::fmt;
 #[non_exhaustive]
 pub struct Explain(pub bool);
 
-impl fmt::Display for Explain {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Explain);
+
+impl crate::sql::DisplaySql for Explain {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str("EXPLAIN")?;
 		if self.0 {
 			f.write_str(" FULL")?;

--- a/crates/core/src/sql/expression.rs
+++ b/crates/core/src/sql/expression.rs
@@ -200,8 +200,10 @@ impl Expression {
 	}
 }
 
-impl fmt::Display for Expression {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Expression);
+
+impl crate::sql::DisplaySql for Expression {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Unary {
 				o,

--- a/crates/core/src/sql/fetch.rs
+++ b/crates/core/src/sql/fetch.rs
@@ -34,8 +34,10 @@ impl IntoIterator for Fetchs {
 	}
 }
 
-impl fmt::Display for Fetchs {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Fetchs);
+
+impl crate::sql::DisplaySql for Fetchs {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "FETCH {}", Fmt::comma_separated(&self.0))
 	}
 }
@@ -148,8 +150,10 @@ impl Deref for Fetch {
 	}
 }
 
-impl Display for Fetch {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Fetch);
+
+impl crate::sql::DisplaySql for Fetch {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&self.0, f)
 	}
 }

--- a/crates/core/src/sql/field.rs
+++ b/crates/core/src/sql/field.rs
@@ -90,8 +90,10 @@ impl IntoIterator for Fields {
 	}
 }
 
-impl Display for Fields {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Fields);
+
+impl crate::sql::DisplaySql for Fields {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self.single() {
 			Some(v) => write!(f, "VALUE {}", &v),
 			None => Display::fmt(&Fmt::comma_separated(&self.0), f),
@@ -303,8 +305,10 @@ pub enum Field {
 	},
 }
 
-impl Display for Field {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Field);
+
+impl crate::sql::DisplaySql for Field {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::All => f.write_char('*'),
 			Self::Single {

--- a/crates/core/src/sql/file.rs
+++ b/crates/core/src/sql/file.rs
@@ -40,8 +40,10 @@ impl File {
 	}
 }
 
-impl fmt::Display for File {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(File);
+
+impl crate::sql::DisplaySql for File {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "f\"{}\"", self.display_inner())
 	}
 }

--- a/crates/core/src/sql/filter.rs
+++ b/crates/core/src/sql/filter.rs
@@ -2,7 +2,6 @@ use crate::sql::language::Language;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::fmt::Display;
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -18,8 +17,10 @@ pub enum Filter {
 	Mapper(String),
 }
 
-impl Display for Filter {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Filter);
+
+impl crate::sql::DisplaySql for Filter {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Ascii => f.write_str("ASCII"),
 			Self::EdgeNgram(min, max) => write!(f, "EDGENGRAM({min},{max})"),

--- a/crates/core/src/sql/function.rs
+++ b/crates/core/src/sql/function.rs
@@ -387,8 +387,10 @@ impl Function {
 	}
 }
 
-impl fmt::Display for Function {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Function);
+
+impl crate::sql::DisplaySql for Function {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Normal(s, e) => write!(f, "{s}({})", Fmt::comma_separated(e)),
 			Self::Custom(s, e) => write!(f, "fn::{s}({})", Fmt::comma_separated(e)),

--- a/crates/core/src/sql/future.rs
+++ b/crates/core/src/sql/future.rs
@@ -45,8 +45,10 @@ impl Future {
 	}
 }
 
-impl fmt::Display for Future {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Future);
+
+impl crate::sql::DisplaySql for Future {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "<future> {}", self.0)
 	}
 }

--- a/crates/core/src/sql/geometry.rs
+++ b/crates/core/src/sql/geometry.rs
@@ -565,8 +565,10 @@ impl Geometry {
 	}
 }
 
-impl fmt::Display for Geometry {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Geometry);
+
+impl crate::sql::DisplaySql for Geometry {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Point(v) => {
 				write!(f, "({}, {})", v.x(), v.y())

--- a/crates/core/src/sql/graph.rs
+++ b/crates/core/src/sql/graph.rs
@@ -98,8 +98,10 @@ impl Graph {
 	}
 }
 
-impl Display for Graph {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Graph);
+
+impl crate::sql::DisplaySql for Graph {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		if self.what.0.len() <= 1
 			&& self.cond.is_none()
 			&& self.alias.is_none()
@@ -186,8 +188,10 @@ impl GraphSubjects {
 	}
 }
 
-impl Display for GraphSubjects {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(GraphSubjects);
+
+impl crate::sql::DisplaySql for GraphSubjects {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&Fmt::comma_separated(&self.0), f)
 	}
 }
@@ -307,8 +311,10 @@ impl From<Table> for GraphSubject {
 	}
 }
 
-impl Display for GraphSubject {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(GraphSubject);
+
+impl crate::sql::DisplaySql for GraphSubject {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::Table(tb) => Display::fmt(&tb, f),
 			Self::Range(tb, rng) => write!(f, "{tb}:{rng}"),

--- a/crates/core/src/sql/group.rs
+++ b/crates/core/src/sql/group.rs
@@ -26,8 +26,10 @@ impl IntoIterator for Groups {
 	}
 }
 
-impl Display for Groups {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Groups);
+
+impl crate::sql::DisplaySql for Groups {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		if self.0.is_empty() {
 			write!(f, "GROUP ALL")
 		} else {
@@ -49,8 +51,10 @@ impl Deref for Group {
 	}
 }
 
-impl Display for Group {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Group);
+
+impl crate::sql::DisplaySql for Group {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&self.0, f)
 	}
 }

--- a/crates/core/src/sql/id/mod.rs
+++ b/crates/core/src/sql/id/mod.rs
@@ -221,8 +221,10 @@ impl Id {
 	}
 }
 
-impl Display for Id {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Id);
+
+impl crate::sql::DisplaySql for Id {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::Number(v) => Display::fmt(v, f),
 			Self::String(v) => EscapeRid(v).fmt(f),

--- a/crates/core/src/sql/id/range.rs
+++ b/crates/core/src/sql/id/range.rs
@@ -133,8 +133,10 @@ impl Ord for IdRange {
 	}
 }
 
-impl fmt::Display for IdRange {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(IdRange);
+
+impl crate::sql::DisplaySql for IdRange {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match &self.beg {
 			Bound::Unbounded => write!(f, ""),
 			Bound::Included(v) => write!(f, "{v}"),

--- a/crates/core/src/sql/ident.rs
+++ b/crates/core/src/sql/ident.rs
@@ -58,8 +58,10 @@ impl Ident {
 	}
 }
 
-impl Display for Ident {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Ident);
+
+impl crate::sql::DisplaySql for Ident {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		EscapeIdent(&self.0).fmt(f)
 	}
 }

--- a/crates/core/src/sql/idiom.rs
+++ b/crates/core/src/sql/idiom.rs
@@ -42,8 +42,10 @@ impl IntoIterator for Idioms {
 	}
 }
 
-impl Display for Idioms {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Idioms);
+
+impl crate::sql::DisplaySql for Idioms {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&Fmt::comma_separated(&self.0), f)
 	}
 }
@@ -202,8 +204,10 @@ impl Idiom {
 	}
 }
 
-impl Display for Idiom {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Idiom);
+
+impl crate::sql::DisplaySql for Idiom {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		Display::fmt(
 			&Fmt::new(
 				self.0.iter().enumerate().map(|args| {

--- a/crates/core/src/sql/index.rs
+++ b/crates/core/src/sql/index.rs
@@ -10,7 +10,7 @@ use crate::sql::{Number, Value};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::fmt::{Display, Formatter};
+use std::fmt::Formatter;
 
 #[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -196,8 +196,10 @@ impl Distance {
 	}
 }
 
-impl Display for Distance {
-	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Distance);
+
+impl crate::sql::DisplaySql for Distance {
+	fn fmt_sql(&self, f: &mut Formatter<'_>) -> fmt::Result {
 		match self {
 			Self::Chebyshev => f.write_str("CHEBYSHEV"),
 			Self::Cosine => f.write_str("COSINE"),
@@ -224,8 +226,10 @@ pub enum VectorType {
 	I16,
 }
 
-impl Display for VectorType {
-	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+crate::sql::impl_display_from_sql!(VectorType);
+
+impl crate::sql::DisplaySql for VectorType {
+	fn fmt_sql(&self, f: &mut Formatter<'_>) -> fmt::Result {
 		match self {
 			Self::F64 => f.write_str("F64"),
 			Self::F32 => f.write_str("F32"),
@@ -236,8 +240,10 @@ impl Display for VectorType {
 	}
 }
 
-impl Display for Index {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Index);
+
+impl crate::sql::DisplaySql for Index {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::Idx => Ok(()),
 			Self::Uniq => f.write_str("UNIQUE"),

--- a/crates/core/src/sql/kind.rs
+++ b/crates/core/src/sql/kind.rs
@@ -13,7 +13,7 @@ use revision::revisioned;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::fmt::{self, Display, Formatter, Write};
+use std::fmt::{self, Formatter, Write};
 
 /// The kind, or data type, of a value or field.
 #[revisioned(revision = 2)]
@@ -428,8 +428,10 @@ impl From<&Kind> for Box<Kind> {
 	}
 }
 
-impl Display for Kind {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Kind);
+
+impl crate::sql::DisplaySql for Kind {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Kind::Any => f.write_str("any"),
 			Kind::Null => f.write_str("null"),
@@ -677,8 +679,10 @@ impl Literal {
 	}
 }
 
-impl Display for Literal {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Literal);
+
+impl crate::sql::DisplaySql for Literal {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Literal::String(s) => write!(f, "{}", s),
 			Literal::Number(n) => write!(f, "{}", n),

--- a/crates/core/src/sql/language.rs
+++ b/crates/core/src/sql/language.rs
@@ -1,7 +1,6 @@
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::fmt::Display;
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -53,8 +52,10 @@ impl Language {
 	}
 }
 
-impl Display for Language {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Language);
+
+impl crate::sql::DisplaySql for Language {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str(self.as_str())
 	}
 }

--- a/crates/core/src/sql/limit.rs
+++ b/crates/core/src/sql/limit.rs
@@ -46,8 +46,10 @@ impl Limit {
 	}
 }
 
-impl fmt::Display for Limit {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Limit);
+
+impl crate::sql::DisplaySql for Limit {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "LIMIT {}", self.0)
 	}
 }

--- a/crates/core/src/sql/mock.rs
+++ b/crates/core/src/sql/mock.rs
@@ -66,8 +66,10 @@ impl IntoIterator for Mock {
 	}
 }
 
-impl fmt::Display for Mock {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Mock);
+
+impl crate::sql::DisplaySql for Mock {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Mock::Count(tb, c) => {
 				write!(f, "|{}:{}|", EscapeIdent(tb), c)

--- a/crates/core/src/sql/model.rs
+++ b/crates/core/src/sql/model.rs
@@ -44,8 +44,10 @@ pub struct Model {
 	pub args: Vec<Value>,
 }
 
-impl fmt::Display for Model {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Model);
+
+impl crate::sql::DisplaySql for Model {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "ml::{}<{}>(", self.name, self.version)?;
 		for (idx, p) in self.args.iter().enumerate() {
 			if idx != 0 {

--- a/crates/core/src/sql/number.rs
+++ b/crates/core/src/sql/number.rs
@@ -159,8 +159,10 @@ impl TryFrom<Number> for Decimal {
 	}
 }
 
-impl Display for Number {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Number);
+
+impl crate::sql::DisplaySql for Number {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Number::Int(v) => Display::fmt(v, f),
 			Number::Float(v) => {

--- a/crates/core/src/sql/object.rs
+++ b/crates/core/src/sql/object.rs
@@ -13,7 +13,7 @@ use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::fmt::{self, Display, Formatter, Write};
+use std::fmt::{self, Formatter, Write};
 use std::ops::Deref;
 use std::ops::DerefMut;
 
@@ -304,8 +304,10 @@ impl std::ops::Add for Object {
 	}
 }
 
-impl Display for Object {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Object);
+
+impl crate::sql::DisplaySql for Object {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		let mut f = Pretty::from(f);
 		if is_pretty() {
 			f.write_char('{')?;

--- a/crates/core/src/sql/operator.rs
+++ b/crates/core/src/sql/operator.rs
@@ -75,8 +75,10 @@ impl Default for Operator {
 	}
 }
 
-impl fmt::Display for Operator {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Operator);
+
+impl crate::sql::DisplaySql for Operator {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Neg => f.write_str("-"),
 			Self::Not => f.write_str("!"),

--- a/crates/core/src/sql/order.rs
+++ b/crates/core/src/sql/order.rs
@@ -15,8 +15,10 @@ pub enum Ordering {
 	Order(OrderList),
 }
 
-impl fmt::Display for Ordering {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Ordering);
+
+impl crate::sql::DisplaySql for Ordering {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Ordering::Random => write!(f, "ORDER BY RAND()"),
 			Ordering::Order(list) => writeln!(f, "ORDER BY {list}"),
@@ -37,8 +39,10 @@ impl Deref for OrderList {
 	}
 }
 
-impl fmt::Display for OrderList {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(OrderList);
+
+impl crate::sql::DisplaySql for OrderList {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}", Fmt::comma_separated(&self.0))
 	}
 }
@@ -76,8 +80,10 @@ pub struct Order {
 	pub direction: bool,
 }
 
-impl fmt::Display for Order {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Order);
+
+impl crate::sql::DisplaySql for Order {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}", self.value)?;
 		if self.collate {
 			write!(f, " COLLATE")?;

--- a/crates/core/src/sql/output.rs
+++ b/crates/core/src/sql/output.rs
@@ -22,8 +22,10 @@ impl Default for Output {
 	}
 }
 
-impl Display for Output {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Output);
+
+impl crate::sql::DisplaySql for Output {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str("RETURN ")?;
 		match self {
 			Self::None => f.write_str("NONE"),

--- a/crates/core/src/sql/param.rs
+++ b/crates/core/src/sql/param.rs
@@ -122,8 +122,10 @@ impl Param {
 	}
 }
 
-impl fmt::Display for Param {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Param);
+
+impl crate::sql::DisplaySql for Param {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "${}", &self.0 .0)
 	}
 }

--- a/crates/core/src/sql/part.rs
+++ b/crates/core/src/sql/part.rs
@@ -186,8 +186,10 @@ impl Part {
 	}
 }
 
-impl fmt::Display for Part {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Part);
+
+impl crate::sql::DisplaySql for Part {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Part::All => f.write_str("[*]"),
 			Part::Last => f.write_str("[$]"),
@@ -484,8 +486,10 @@ impl DestructurePart {
 	}
 }
 
-impl fmt::Display for DestructurePart {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DestructurePart);
+
+impl crate::sql::DisplaySql for DestructurePart {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			DestructurePart::All(fd) => write!(f, "{fd}.*"),
 			DestructurePart::Field(fd) => write!(f, "{fd}"),
@@ -533,8 +537,10 @@ impl TryInto<(u32, Option<u32>)> for Recurse {
 	}
 }
 
-impl fmt::Display for Recurse {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Recurse);
+
+impl crate::sql::DisplaySql for Recurse {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Recurse::Fixed(v) => write!(f, "{v}"),
 			Recurse::Range(beg, end) => match (beg, end) {
@@ -760,8 +766,10 @@ impl RecurseInstruction {
 	}
 }
 
-impl fmt::Display for RecurseInstruction {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RecurseInstruction);
+
+impl crate::sql::DisplaySql for RecurseInstruction {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Path {
 				inclusive,

--- a/crates/core/src/sql/permission.rs
+++ b/crates/core/src/sql/permission.rs
@@ -54,8 +54,10 @@ impl Permissions {
 	}
 }
 
-impl Display for Permissions {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Permissions);
+
+impl crate::sql::DisplaySql for Permissions {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "PERMISSIONS")?;
 		if self.is_none() {
 			return write!(f, " NONE");
@@ -152,8 +154,10 @@ impl PermissionKind {
 	}
 }
 
-impl Display for PermissionKind {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(PermissionKind);
+
+impl crate::sql::DisplaySql for PermissionKind {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		f.write_str(self.as_str())
 	}
 }
@@ -183,8 +187,10 @@ impl Permission {
 	}
 }
 
-impl Display for Permission {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Permission);
+
+impl crate::sql::DisplaySql for Permission {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::None => f.write_str("NONE"),
 			Self::Full => f.write_str("FULL"),

--- a/crates/core/src/sql/query.rs
+++ b/crates/core/src/sql/query.rs
@@ -16,7 +16,7 @@ use crate::sql::{Statement, Statements};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt::Write;
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 use std::ops::{Deref, DerefMut};
 use std::str;
 
@@ -140,8 +140,10 @@ impl IntoIterator for Query {
 	}
 }
 
-impl Display for Query {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Query);
+
+impl crate::sql::DisplaySql for Query {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(Pretty::from(f), "{}", &self.0)
 	}
 }

--- a/crates/core/src/sql/range.rs
+++ b/crates/core/src/sql/range.rs
@@ -353,8 +353,10 @@ impl Ord for Range {
 	}
 }
 
-impl fmt::Display for Range {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Range);
+
+impl crate::sql::DisplaySql for Range {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match &self.beg {
 			Bound::Unbounded => write!(f, ""),
 			Bound::Included(v) => {

--- a/crates/core/src/sql/reference.rs
+++ b/crates/core/src/sql/reference.rs
@@ -20,8 +20,10 @@ pub struct Reference {
 	pub on_delete: ReferenceDeleteStrategy,
 }
 
-impl fmt::Display for Reference {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Reference);
+
+impl crate::sql::DisplaySql for Reference {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "ON DELETE {}", &self.on_delete)
 	}
 }
@@ -48,8 +50,10 @@ pub enum ReferenceDeleteStrategy {
 	Custom(Value),
 }
 
-impl fmt::Display for ReferenceDeleteStrategy {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ReferenceDeleteStrategy);
+
+impl crate::sql::DisplaySql for ReferenceDeleteStrategy {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			ReferenceDeleteStrategy::Reject => write!(f, "REJECT"),
 			ReferenceDeleteStrategy::Ignore => write!(f, "IGNORE"),
@@ -115,8 +119,10 @@ impl Refs {
 	}
 }
 
-impl fmt::Display for Refs {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Refs);
+
+impl crate::sql::DisplaySql for Refs {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "[]")
 	}
 }

--- a/crates/core/src/sql/regex.rs
+++ b/crates/core/src/sql/regex.rs
@@ -91,8 +91,10 @@ impl Debug for Regex {
 	}
 }
 
-impl Display for Regex {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Regex);
+
+impl crate::sql::DisplaySql for Regex {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		let t = self.0.to_string().replace('/', "\\/");
 		write!(f, "/{}/", &t)
 	}

--- a/crates/core/src/sql/scoring.rs
+++ b/crates/core/src/sql/scoring.rs
@@ -60,8 +60,10 @@ impl Default for Scoring {
 	}
 }
 
-impl fmt::Display for Scoring {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Scoring);
+
+impl crate::sql::DisplaySql for Scoring {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Bm {
 				k1,

--- a/crates/core/src/sql/script.rs
+++ b/crates/core/src/sql/script.rs
@@ -30,8 +30,10 @@ impl Deref for Script {
 	}
 }
 
-impl Display for Script {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Script);
+
+impl crate::sql::DisplaySql for Script {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&self.0, f)
 	}
 }

--- a/crates/core/src/sql/split.rs
+++ b/crates/core/src/sql/split.rs
@@ -26,8 +26,10 @@ impl IntoIterator for Splits {
 	}
 }
 
-impl fmt::Display for Splits {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Splits);
+
+impl crate::sql::DisplaySql for Splits {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "SPLIT ON {}", Fmt::comma_separated(&self.0))
 	}
 }
@@ -45,8 +47,10 @@ impl Deref for Split {
 	}
 }
 
-impl Display for Split {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Split);
+
+impl crate::sql::DisplaySql for Split {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&self.0, f)
 	}
 }

--- a/crates/core/src/sql/start.rs
+++ b/crates/core/src/sql/start.rs
@@ -46,8 +46,10 @@ impl Start {
 	}
 }
 
-impl fmt::Display for Start {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Start);
+
+impl crate::sql::DisplaySql for Start {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "START {}", self.0)
 	}
 }

--- a/crates/core/src/sql/statement.rs
+++ b/crates/core/src/sql/statement.rs
@@ -47,8 +47,10 @@ impl IntoIterator for Statements {
 	}
 }
 
-impl Display for Statements {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Statements);
+
+impl crate::sql::DisplaySql for Statements {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		Display::fmt(
 			&Fmt::one_line_separated(self.0.iter().map(|v| Fmt::new(v, |v, f| write!(f, "{v};")))),
 			f,
@@ -199,8 +201,10 @@ impl Statement {
 	}
 }
 
-impl Display for Statement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Statement);
+
+impl crate::sql::DisplaySql for Statement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::Value(v) => write!(Pretty::from(f), "{v}"),
 			Self::Access(v) => write!(Pretty::from(f), "{v}"),

--- a/crates/core/src/sql/statements/alter/field.rs
+++ b/crates/core/src/sql/statements/alter/field.rs
@@ -11,7 +11,7 @@ use crate::sql::{Idiom, Kind};
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 use std::ops::Deref;
 use uuid::Uuid;
 
@@ -132,8 +132,10 @@ impl AlterFieldStatement {
 	}
 }
 
-impl Display for AlterFieldStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(AlterFieldStatement);
+
+impl crate::sql::DisplaySql for AlterFieldStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "ALTER FIELD")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/alter/mod.rs
+++ b/crates/core/src/sql/statements/alter/mod.rs
@@ -50,8 +50,10 @@ impl AlterStatement {
 	}
 }
 
-impl Display for AlterStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(AlterStatement);
+
+impl crate::sql::DisplaySql for AlterStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Table(v) => Display::fmt(v, f),
 			Self::Sequence(v) => Display::fmt(v, f),

--- a/crates/core/src/sql/statements/alter/sequence.rs
+++ b/crates/core/src/sql/statements/alter/sequence.rs
@@ -8,7 +8,7 @@ use crate::sql::{Base, Ident, Timeout, Value};
 use crate::key::database::sq::Sq;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Write};
+use std::fmt::{self, Write};
 use std::ops::Deref;
 
 #[revisioned(revision = 1)]
@@ -55,8 +55,10 @@ impl AlterSequenceStatement {
 	}
 }
 
-impl Display for AlterSequenceStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(AlterSequenceStatement);
+
+impl crate::sql::DisplaySql for AlterSequenceStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "ALTER SEQUENCE")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/alter/table.rs
+++ b/crates/core/src/sql/statements/alter/table.rs
@@ -11,7 +11,7 @@ use crate::sql::{Kind, TableType};
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Write};
+use std::fmt::{self, Write};
 use std::ops::Deref;
 
 #[revisioned(revision = 2)]
@@ -95,8 +95,10 @@ impl AlterTableStatement {
 	}
 }
 
-impl Display for AlterTableStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(AlterTableStatement);
+
+impl crate::sql::DisplaySql for AlterTableStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "ALTER TABLE")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/analyze.rs
+++ b/crates/core/src/sql/statements/analyze.rs
@@ -15,7 +15,7 @@ use crate::sql::Base;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::fmt::{Display, Formatter};
+use std::fmt::Formatter;
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -67,8 +67,10 @@ impl AnalyzeStatement {
 	}
 }
 
-impl Display for AnalyzeStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(AnalyzeStatement);
+
+impl crate::sql::DisplaySql for AnalyzeStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::Idx(tb, idx) => write!(f, "ANALYZE INDEX {idx} ON {tb}"),
 		}

--- a/crates/core/src/sql/statements/begin.rs
+++ b/crates/core/src/sql/statements/begin.rs
@@ -8,8 +8,10 @@ use std::fmt;
 #[non_exhaustive]
 pub struct BeginStatement;
 
-impl fmt::Display for BeginStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(BeginStatement);
+
+impl crate::sql::DisplaySql for BeginStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str("BEGIN TRANSACTION")
 	}
 }

--- a/crates/core/src/sql/statements/break.rs
+++ b/crates/core/src/sql/statements/break.rs
@@ -31,8 +31,10 @@ impl BreakStatement {
 	}
 }
 
-impl fmt::Display for BreakStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(BreakStatement);
+
+impl crate::sql::DisplaySql for BreakStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str("BREAK")
 	}
 }

--- a/crates/core/src/sql/statements/cancel.rs
+++ b/crates/core/src/sql/statements/cancel.rs
@@ -8,8 +8,10 @@ use std::fmt;
 #[non_exhaustive]
 pub struct CancelStatement;
 
-impl fmt::Display for CancelStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(CancelStatement);
+
+impl crate::sql::DisplaySql for CancelStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str("CANCEL TRANSACTION")
 	}
 }

--- a/crates/core/src/sql/statements/commit.rs
+++ b/crates/core/src/sql/statements/commit.rs
@@ -8,8 +8,10 @@ use std::fmt;
 #[non_exhaustive]
 pub struct CommitStatement;
 
-impl fmt::Display for CommitStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(CommitStatement);
+
+impl crate::sql::DisplaySql for CommitStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str("COMMIT TRANSACTION")
 	}
 }

--- a/crates/core/src/sql/statements/continue.rs
+++ b/crates/core/src/sql/statements/continue.rs
@@ -30,8 +30,10 @@ impl ContinueStatement {
 	}
 }
 
-impl fmt::Display for ContinueStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ContinueStatement);
+
+impl crate::sql::DisplaySql for ContinueStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str("CONTINUE")
 	}
 }

--- a/crates/core/src/sql/statements/create.rs
+++ b/crates/core/src/sql/statements/create.rs
@@ -99,8 +99,10 @@ impl CreateStatement {
 	}
 }
 
-impl fmt::Display for CreateStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(CreateStatement);
+
+impl crate::sql::DisplaySql for CreateStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "CREATE")?;
 		if self.only {
 			f.write_str(" ONLY")?

--- a/crates/core/src/sql/statements/define/access.rs
+++ b/crates/core/src/sql/statements/define/access.rs
@@ -10,7 +10,7 @@ use rand::distributions::Alphanumeric;
 use rand::Rng;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 #[revisioned(revision = 3)]
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -175,8 +175,10 @@ impl DefineAccessStatement {
 	}
 }
 
-impl Display for DefineAccessStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineAccessStatement);
+
+impl crate::sql::DisplaySql for DefineAccessStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE ACCESS",)?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/analyzer.rs
+++ b/crates/core/src/sql/statements/define/analyzer.rs
@@ -8,7 +8,7 @@ use crate::sql::{filter::Filter, tokenizer::Tokenizer, Array, Base, Ident, Stran
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 #[revisioned(revision = 4)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -68,8 +68,10 @@ impl DefineAnalyzerStatement {
 	}
 }
 
-impl Display for DefineAnalyzerStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineAnalyzerStatement);
+
+impl crate::sql::DisplaySql for DefineAnalyzerStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE ANALYZER")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/api.rs
+++ b/crates/core/src/sql/statements/define/api.rs
@@ -82,8 +82,10 @@ impl DefineApiStatement {
 	}
 }
 
-impl Display for DefineApiStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineApiStatement);
+
+impl crate::sql::DisplaySql for DefineApiStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE API")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?
@@ -167,8 +169,10 @@ impl InfoStructure for ApiDefinition {
 	}
 }
 
-impl Display for ApiDefinition {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ApiDefinition);
+
+impl crate::sql::DisplaySql for ApiDefinition {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		let da: DefineApiStatement = self.clone().into();
 		da.fmt(f)
 	}
@@ -184,8 +188,10 @@ pub struct ApiAction {
 	pub config: Option<ApiConfig>,
 }
 
-impl Display for ApiAction {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ApiAction);
+
+impl crate::sql::DisplaySql for ApiAction {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "FOR {}", Fmt::comma_separated(self.methods.iter()))?;
 		let indent = pretty_indent();
 		if let Some(config) = &self.config {

--- a/crates/core/src/sql/statements/define/bucket.rs
+++ b/crates/core/src/sql/statements/define/bucket.rs
@@ -89,8 +89,10 @@ impl DefineBucketStatement {
 	}
 }
 
-impl Display for DefineBucketStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineBucketStatement);
+
+impl crate::sql::DisplaySql for DefineBucketStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE BUCKET")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?
@@ -165,8 +167,10 @@ impl InfoStructure for BucketDefinition {
 	}
 }
 
-impl Display for BucketDefinition {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(BucketDefinition);
+
+impl crate::sql::DisplaySql for BucketDefinition {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		let db: DefineBucketStatement = self.clone().into();
 		db.fmt(f)
 	}

--- a/crates/core/src/sql/statements/define/config/api.rs
+++ b/crates/core/src/sql/statements/define/config/api.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 use crate::api::middleware::RequestMiddleware;
 use crate::sql::fmt::Fmt;
@@ -22,8 +22,10 @@ impl ApiConfig {
 	}
 }
 
-impl Display for ApiConfig {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ApiConfig);
+
+impl crate::sql::DisplaySql for ApiConfig {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, " API")?;
 
 		if let Some(mw) = &self.middleware {

--- a/crates/core/src/sql/statements/define/config/graphql.rs
+++ b/crates/core/src/sql/statements/define/config/graphql.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display, Write};
+use std::fmt::{self, Write};
 
 use crate::sql::fmt::{pretty_indent, Fmt, Pretty};
 use crate::sql::statements::info::InfoStructure;
@@ -48,8 +48,10 @@ pub enum FunctionsConfig {
 	Exclude(Vec<Ident>),
 }
 
-impl Display for GraphQLConfig {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(GraphQLConfig);
+
+impl crate::sql::DisplaySql for GraphQLConfig {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, " GRAPHQL")?;
 
 		write!(f, " TABLES {}", self.tables)?;
@@ -58,8 +60,10 @@ impl Display for GraphQLConfig {
 	}
 }
 
-impl Display for TablesConfig {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(TablesConfig);
+
+impl crate::sql::DisplaySql for TablesConfig {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			TablesConfig::Auto => write!(f, "AUTO")?,
 			TablesConfig::None => write!(f, "NONE")?,
@@ -112,15 +116,19 @@ impl TryFrom<Value> for TableConfig {
 	}
 }
 
-impl Display for TableConfig {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(TableConfig);
+
+impl crate::sql::DisplaySql for TableConfig {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}", self.name)?;
 		Ok(())
 	}
 }
 
-impl Display for FunctionsConfig {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(FunctionsConfig);
+
+impl crate::sql::DisplaySql for FunctionsConfig {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			FunctionsConfig::Auto => write!(f, "AUTO")?,
 			FunctionsConfig::None => write!(f, "NONE")?,

--- a/crates/core/src/sql/statements/define/config/mod.rs
+++ b/crates/core/src/sql/statements/define/config/mod.rs
@@ -122,8 +122,10 @@ impl InfoStructure for DefineConfigStatement {
 	}
 }
 
-impl Display for DefineConfigStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineConfigStatement);
+
+impl crate::sql::DisplaySql for DefineConfigStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE CONFIG")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?
@@ -138,8 +140,10 @@ impl Display for DefineConfigStatement {
 	}
 }
 
-impl Display for ConfigInner {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ConfigInner);
+
+impl crate::sql::DisplaySql for ConfigInner {
+	fn fmt_sql(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match &self {
 			ConfigInner::GraphQL(v) => Display::fmt(v, f),
 			ConfigInner::Api(v) => Display::fmt(v, f),

--- a/crates/core/src/sql/statements/define/database.rs
+++ b/crates/core/src/sql/statements/define/database.rs
@@ -8,7 +8,7 @@ use crate::sql::{changefeed::ChangeFeed, Base, Ident, Strand, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 #[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -79,8 +79,10 @@ impl DefineDatabaseStatement {
 	}
 }
 
-impl Display for DefineDatabaseStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineDatabaseStatement);
+
+impl crate::sql::DisplaySql for DefineDatabaseStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE DATABASE")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/event.rs
+++ b/crates/core/src/sql/statements/define/event.rs
@@ -9,7 +9,7 @@ use crate::sql::{Base, Ident, Strand, Value, Values};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 use uuid::Uuid;
 
 #[revisioned(revision = 3)]
@@ -91,8 +91,10 @@ impl DefineEventStatement {
 	}
 }
 
-impl Display for DefineEventStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineEventStatement);
+
+impl crate::sql::DisplaySql for DefineEventStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE EVENT",)?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/field.rs
+++ b/crates/core/src/sql/statements/define/field.rs
@@ -15,7 +15,7 @@ use crate::sql::{Relation, TableType};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Write};
+use std::fmt::{self, Write};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -407,8 +407,10 @@ impl DefineFieldStatement {
 	}
 }
 
-impl Display for DefineFieldStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineFieldStatement);
+
+impl crate::sql::DisplaySql for DefineFieldStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE FIELD")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/function.rs
+++ b/crates/core/src/sql/statements/define/function.rs
@@ -74,8 +74,10 @@ impl DefineFunctionStatement {
 	}
 }
 
-impl fmt::Display for DefineFunctionStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineFunctionStatement);
+
+impl crate::sql::DisplaySql for DefineFunctionStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE FUNCTION")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/index.rs
+++ b/crates/core/src/sql/statements/define/index.rs
@@ -15,7 +15,7 @@ use crate::sql::{Output, Values};
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 #[cfg(target_family = "wasm")]
 use std::sync::Arc;
 use uuid::Uuid;
@@ -190,8 +190,10 @@ impl DefineIndexStatement {
 	}
 }
 
-impl Display for DefineIndexStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineIndexStatement);
+
+impl crate::sql::DisplaySql for DefineIndexStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE INDEX")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/mod.rs
+++ b/crates/core/src/sql/statements/define/mod.rs
@@ -143,8 +143,10 @@ impl DefineStatement {
 	}
 }
 
-impl Display for DefineStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineStatement);
+
+impl crate::sql::DisplaySql for DefineStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Namespace(v) => Display::fmt(v, f),
 			Self::Database(v) => Display::fmt(v, f),

--- a/crates/core/src/sql/statements/define/model.rs
+++ b/crates/core/src/sql/statements/define/model.rs
@@ -72,8 +72,10 @@ impl DefineModelStatement {
 	}
 }
 
-impl fmt::Display for DefineModelStatement {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineModelStatement);
+
+impl crate::sql::DisplaySql for DefineModelStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(f, "DEFINE MODEL")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/namespace.rs
+++ b/crates/core/src/sql/statements/define/namespace.rs
@@ -8,7 +8,7 @@ use crate::sql::{Base, Ident, Strand, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 #[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -70,8 +70,10 @@ impl DefineNamespaceStatement {
 	}
 }
 
-impl Display for DefineNamespaceStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineNamespaceStatement);
+
+impl crate::sql::DisplaySql for DefineNamespaceStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE NAMESPACE")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/param.rs
+++ b/crates/core/src/sql/statements/define/param.rs
@@ -10,7 +10,7 @@ use crate::sql::{Base, FlowResultExt as _, Ident, Permission, Strand, Value};
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Write};
+use std::fmt::{self, Write};
 
 #[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -78,8 +78,10 @@ impl DefineParamStatement {
 	}
 }
 
-impl Display for DefineParamStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineParamStatement);
+
+impl crate::sql::DisplaySql for DefineParamStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE PARAM")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/sequence.rs
+++ b/crates/core/src/sql/statements/define/sequence.rs
@@ -9,7 +9,7 @@ use crate::key::database::sq::Sq;
 use crate::key::sequence::Prefix;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -65,8 +65,10 @@ impl DefineSequenceStatement {
 	}
 }
 
-impl Display for DefineSequenceStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineSequenceStatement);
+
+impl crate::sql::DisplaySql for DefineSequenceStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE SEQUENCE")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/table.rs
+++ b/crates/core/src/sql/statements/define/table.rs
@@ -18,7 +18,7 @@ use reblessive::tree::Stk;
 use revision::revisioned;
 use revision::Error as RevisionError;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Write};
+use std::fmt::{self, Write};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -229,8 +229,10 @@ impl DefineTableStatement {
 	}
 }
 
-impl Display for DefineTableStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineTableStatement);
+
+impl crate::sql::DisplaySql for DefineTableStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE TABLE")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/define/user.rs
+++ b/crates/core/src/sql/statements/define/user.rs
@@ -15,7 +15,7 @@ use argon2::{
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 #[revisioned(revision = 4)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -217,8 +217,10 @@ impl DefineUserStatement {
 	}
 }
 
-impl Display for DefineUserStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DefineUserStatement);
+
+impl crate::sql::DisplaySql for DefineUserStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DEFINE USER")?;
 		if self.if_not_exists {
 			write!(f, " IF NOT EXISTS")?

--- a/crates/core/src/sql/statements/delete.rs
+++ b/crates/core/src/sql/statements/delete.rs
@@ -89,8 +89,10 @@ impl DeleteStatement {
 	}
 }
 
-impl fmt::Display for DeleteStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(DeleteStatement);
+
+impl crate::sql::DisplaySql for DeleteStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "DELETE")?;
 		if self.only {
 			f.write_str(" ONLY")?

--- a/crates/core/src/sql/statements/foreach.rs
+++ b/crates/core/src/sql/statements/foreach.rs
@@ -9,7 +9,7 @@ use crate::sql::{ControlFlow, FlowResult};
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -143,8 +143,10 @@ impl ForeachStatement {
 	}
 }
 
-impl Display for ForeachStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ForeachStatement);
+
+impl crate::sql::DisplaySql for ForeachStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "FOR {} IN {} {}", self.param, self.range, self.block)
 	}
 }

--- a/crates/core/src/sql/statements/ifelse.rs
+++ b/crates/core/src/sql/statements/ifelse.rs
@@ -7,7 +7,7 @@ use crate::sql::{FlowResult, Value};
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Write};
+use std::fmt::{self, Write};
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -57,8 +57,10 @@ impl IfelseStatement {
 	}
 }
 
-impl Display for IfelseStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(IfelseStatement);
+
+impl crate::sql::DisplaySql for IfelseStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		let mut f = Pretty::from(f);
 		match self.bracketed() {
 			true => {

--- a/crates/core/src/sql/statements/info.rs
+++ b/crates/core/src/sql/statements/info.rs
@@ -358,8 +358,10 @@ impl InfoStatement {
 	}
 }
 
-impl fmt::Display for InfoStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(InfoStatement);
+
+impl crate::sql::DisplaySql for InfoStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			Self::Root(false) => f.write_str("INFO FOR ROOT"),
 			Self::Root(true) => f.write_str("INFO FOR ROOT STRUCTURE"),

--- a/crates/core/src/sql/statements/insert.rs
+++ b/crates/core/src/sql/statements/insert.rs
@@ -134,8 +134,10 @@ impl InsertStatement {
 	}
 }
 
-impl fmt::Display for InsertStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(InsertStatement);
+
+impl crate::sql::DisplaySql for InsertStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str("INSERT")?;
 		if self.relation {
 			f.write_str(" RELATION")?

--- a/crates/core/src/sql/statements/kill.rs
+++ b/crates/core/src/sql/statements/kill.rs
@@ -89,8 +89,10 @@ impl KillStatement {
 	}
 }
 
-impl fmt::Display for KillStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(KillStatement);
+
+impl crate::sql::DisplaySql for KillStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "KILL {}", self.id)
 	}
 }

--- a/crates/core/src/sql/statements/live.rs
+++ b/crates/core/src/sql/statements/live.rs
@@ -144,8 +144,10 @@ impl LiveStatement {
 	}
 }
 
-impl fmt::Display for LiveStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(LiveStatement);
+
+impl crate::sql::DisplaySql for LiveStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "LIVE SELECT {} FROM {}", self.expr, self.what)?;
 		if let Some(ref v) = self.cond {
 			write!(f, " {v}")?

--- a/crates/core/src/sql/statements/option.rs
+++ b/crates/core/src/sql/statements/option.rs
@@ -13,8 +13,10 @@ pub struct OptionStatement {
 	pub what: bool,
 }
 
-impl fmt::Display for OptionStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(OptionStatement);
+
+impl crate::sql::DisplaySql for OptionStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		if self.what {
 			write!(f, "OPTION {}", self.name)
 		} else {

--- a/crates/core/src/sql/statements/output.rs
+++ b/crates/core/src/sql/statements/output.rs
@@ -51,8 +51,10 @@ impl OutputStatement {
 	}
 }
 
-impl fmt::Display for OutputStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(OutputStatement);
+
+impl crate::sql::DisplaySql for OutputStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "RETURN {}", self.what)?;
 		if let Some(ref v) = self.fetch {
 			write!(f, " {v}")?

--- a/crates/core/src/sql/statements/rebuild.rs
+++ b/crates/core/src/sql/statements/rebuild.rs
@@ -40,8 +40,10 @@ impl RebuildStatement {
 	}
 }
 
-impl Display for RebuildStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RebuildStatement);
+
+impl crate::sql::DisplaySql for RebuildStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::Index(v) => Display::fmt(v, f),
 		}
@@ -91,8 +93,10 @@ impl RebuildIndexStatement {
 	}
 }
 
-impl Display for RebuildIndexStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RebuildIndexStatement);
+
+impl crate::sql::DisplaySql for RebuildIndexStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REBUILD INDEX")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/relate.rs
+++ b/crates/core/src/sql/statements/relate.rs
@@ -191,8 +191,10 @@ impl RelateStatement {
 	}
 }
 
-impl fmt::Display for RelateStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RelateStatement);
+
+impl crate::sql::DisplaySql for RelateStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "RELATE")?;
 		if self.only {
 			f.write_str(" ONLY")?

--- a/crates/core/src/sql/statements/remove/access.rs
+++ b/crates/core/src/sql/statements/remove/access.rs
@@ -6,7 +6,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 
 #[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -98,8 +98,10 @@ impl RemoveAccessStatement {
 	}
 }
 
-impl Display for RemoveAccessStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveAccessStatement);
+
+impl crate::sql::DisplaySql for RemoveAccessStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE ACCESS")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/analyzer.rs
+++ b/crates/core/src/sql/statements/remove/analyzer.rs
@@ -6,7 +6,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 
 #[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -50,8 +50,10 @@ impl RemoveAnalyzerStatement {
 	}
 }
 
-impl Display for RemoveAnalyzerStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveAnalyzerStatement);
+
+impl crate::sql::DisplaySql for RemoveAnalyzerStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE ANALYZER")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/bucket.rs
+++ b/crates/core/src/sql/statements/remove/bucket.rs
@@ -6,7 +6,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -46,8 +46,10 @@ impl RemoveBucketStatement {
 	}
 }
 
-impl Display for RemoveBucketStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveBucketStatement);
+
+impl crate::sql::DisplaySql for RemoveBucketStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE BUCKET")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/database.rs
+++ b/crates/core/src/sql/statements/remove/database.rs
@@ -6,7 +6,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 
 #[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -73,8 +73,10 @@ impl RemoveDatabaseStatement {
 	}
 }
 
-impl Display for RemoveDatabaseStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveDatabaseStatement);
+
+impl crate::sql::DisplaySql for RemoveDatabaseStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE DATABASE")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/event.rs
+++ b/crates/core/src/sql/statements/remove/event.rs
@@ -7,7 +7,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 use uuid::Uuid;
 
 #[revisioned(revision = 2)]
@@ -67,8 +67,10 @@ impl RemoveEventStatement {
 	}
 }
 
-impl Display for RemoveEventStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveEventStatement);
+
+impl crate::sql::DisplaySql for RemoveEventStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE EVENT")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/field.rs
+++ b/crates/core/src/sql/statements/remove/field.rs
@@ -7,7 +7,7 @@ use crate::sql::{Base, Ident, Idiom, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 use uuid::Uuid;
 
 #[revisioned(revision = 2)]
@@ -69,8 +69,10 @@ impl RemoveFieldStatement {
 	}
 }
 
-impl Display for RemoveFieldStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveFieldStatement);
+
+impl crate::sql::DisplaySql for RemoveFieldStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE FIELD")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/function.rs
+++ b/crates/core/src/sql/statements/remove/function.rs
@@ -6,7 +6,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 #[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -47,8 +47,10 @@ impl RemoveFunctionStatement {
 	}
 }
 
-impl Display for RemoveFunctionStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveFunctionStatement);
+
+impl crate::sql::DisplaySql for RemoveFunctionStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		// Bypass ident display since we don't want backticks arround the ident.
 		write!(f, "REMOVE FUNCTION")?;
 		if self.if_exists {

--- a/crates/core/src/sql/statements/remove/index.rs
+++ b/crates/core/src/sql/statements/remove/index.rs
@@ -7,7 +7,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 use uuid::Uuid;
 
 #[revisioned(revision = 2)]
@@ -75,8 +75,10 @@ impl RemoveIndexStatement {
 	}
 }
 
-impl Display for RemoveIndexStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveIndexStatement);
+
+impl crate::sql::DisplaySql for RemoveIndexStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE INDEX")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/mod.rs
+++ b/crates/core/src/sql/statements/remove/mod.rs
@@ -90,8 +90,10 @@ impl RemoveStatement {
 	}
 }
 
-impl Display for RemoveStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveStatement);
+
+impl crate::sql::DisplaySql for RemoveStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::Namespace(v) => Display::fmt(v, f),
 			Self::Database(v) => Display::fmt(v, f),

--- a/crates/core/src/sql/statements/remove/model.rs
+++ b/crates/core/src/sql/statements/remove/model.rs
@@ -6,7 +6,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self};
 
 #[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -49,8 +49,10 @@ impl RemoveModelStatement {
 	}
 }
 
-impl Display for RemoveModelStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveModelStatement);
+
+impl crate::sql::DisplaySql for RemoveModelStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		// Bypass ident display since we don't want backticks arround the ident.
 		write!(f, "REMOVE MODEL")?;
 		if self.if_exists {

--- a/crates/core/src/sql/statements/remove/namespace.rs
+++ b/crates/core/src/sql/statements/remove/namespace.rs
@@ -6,7 +6,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 
 #[revisioned(revision = 3)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -72,8 +72,10 @@ impl RemoveNamespaceStatement {
 	}
 }
 
-impl Display for RemoveNamespaceStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveNamespaceStatement);
+
+impl crate::sql::DisplaySql for RemoveNamespaceStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE NAMESPACE")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/param.rs
+++ b/crates/core/src/sql/statements/remove/param.rs
@@ -6,7 +6,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 
 #[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -47,8 +47,10 @@ impl RemoveParamStatement {
 	}
 }
 
-impl Display for RemoveParamStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveParamStatement);
+
+impl crate::sql::DisplaySql for RemoveParamStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE PARAM")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/sequence.rs
+++ b/crates/core/src/sql/statements/remove/sequence.rs
@@ -8,7 +8,7 @@ use crate::key::database::sq::Sq;
 use crate::key::sequence::Prefix;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -56,8 +56,10 @@ impl RemoveSequenceStatement {
 	}
 }
 
-impl Display for RemoveSequenceStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveSequenceStatement);
+
+impl crate::sql::DisplaySql for RemoveSequenceStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE SEQUENCE")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/table.rs
+++ b/crates/core/src/sql/statements/remove/table.rs
@@ -7,7 +7,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 use uuid::Uuid;
 
 #[revisioned(revision = 3)]
@@ -127,8 +127,10 @@ impl RemoveTableStatement {
 	}
 }
 
-impl Display for RemoveTableStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveTableStatement);
+
+impl crate::sql::DisplaySql for RemoveTableStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE TABLE")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/remove/user.rs
+++ b/crates/core/src/sql/statements/remove/user.rs
@@ -6,7 +6,7 @@ use crate::sql::{Base, Ident, Value};
 
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 
 #[revisioned(revision = 2)]
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -89,8 +89,10 @@ impl RemoveUserStatement {
 	}
 }
 
-impl Display for RemoveUserStatement {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(RemoveUserStatement);
+
+impl crate::sql::DisplaySql for RemoveUserStatement {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "REMOVE USER")?;
 		if self.if_exists {
 			write!(f, " IF EXISTS")?

--- a/crates/core/src/sql/statements/select.rs
+++ b/crates/core/src/sql/statements/select.rs
@@ -156,8 +156,10 @@ impl SelectStatement {
 	}
 }
 
-impl fmt::Display for SelectStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(SelectStatement);
+
+impl crate::sql::DisplaySql for SelectStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "SELECT {}", self.expr)?;
 		if let Some(ref v) = self.omit {
 			write!(f, " OMIT {v}")?

--- a/crates/core/src/sql/statements/set.rs
+++ b/crates/core/src/sql/statements/set.rs
@@ -58,8 +58,10 @@ impl SetStatement {
 	}
 }
 
-impl fmt::Display for SetStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(SetStatement);
+
+impl crate::sql::DisplaySql for SetStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "LET ${}", self.name)?;
 		if let Some(ref kind) = self.kind {
 			write!(f, ": {}", kind)?;

--- a/crates/core/src/sql/statements/show.rs
+++ b/crates/core/src/sql/statements/show.rs
@@ -72,8 +72,10 @@ impl ShowStatement {
 	}
 }
 
-impl fmt::Display for ShowStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ShowStatement);
+
+impl crate::sql::DisplaySql for ShowStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "SHOW CHANGES FOR")?;
 		match self.table {
 			Some(ref v) => write!(f, " TABLE {}", v)?,

--- a/crates/core/src/sql/statements/sleep.rs
+++ b/crates/core/src/sql/statements/sleep.rs
@@ -41,8 +41,10 @@ impl SleepStatement {
 	}
 }
 
-impl fmt::Display for SleepStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(SleepStatement);
+
+impl crate::sql::DisplaySql for SleepStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "SLEEP {}", self.duration)
 	}
 }

--- a/crates/core/src/sql/statements/throw.rs
+++ b/crates/core/src/sql/statements/throw.rs
@@ -36,8 +36,10 @@ impl ThrowStatement {
 	}
 }
 
-impl fmt::Display for ThrowStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(ThrowStatement);
+
+impl crate::sql::DisplaySql for ThrowStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "THROW {}", self.error)
 	}
 }

--- a/crates/core/src/sql/statements/update.rs
+++ b/crates/core/src/sql/statements/update.rs
@@ -90,8 +90,10 @@ impl UpdateStatement {
 	}
 }
 
-impl fmt::Display for UpdateStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(UpdateStatement);
+
+impl crate::sql::DisplaySql for UpdateStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "UPDATE")?;
 		if self.only {
 			f.write_str(" ONLY")?

--- a/crates/core/src/sql/statements/upsert.rs
+++ b/crates/core/src/sql/statements/upsert.rs
@@ -89,8 +89,10 @@ impl UpsertStatement {
 	}
 }
 
-impl fmt::Display for UpsertStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(UpsertStatement);
+
+impl crate::sql::DisplaySql for UpsertStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "UPSERT")?;
 		if self.only {
 			f.write_str(" ONLY")?

--- a/crates/core/src/sql/statements/use.rs
+++ b/crates/core/src/sql/statements/use.rs
@@ -13,8 +13,10 @@ pub struct UseStatement {
 	pub db: Option<String>,
 }
 
-impl fmt::Display for UseStatement {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(UseStatement);
+
+impl crate::sql::DisplaySql for UseStatement {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str("USE")?;
 		if let Some(ref ns) = self.ns {
 			let ns = EscapeIdent(ns);

--- a/crates/core/src/sql/strand.rs
+++ b/crates/core/src/sql/strand.rs
@@ -82,8 +82,10 @@ impl Strand {
 	}
 }
 
-impl Display for Strand {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Strand);
+
+impl crate::sql::DisplaySql for Strand {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		QuoteStr(&self.0).fmt(f)
 	}
 }

--- a/crates/core/src/sql/subquery.rs
+++ b/crates/core/src/sql/subquery.rs
@@ -113,8 +113,10 @@ impl Subquery {
 	}
 }
 
-impl Display for Subquery {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Subquery);
+
+impl crate::sql::DisplaySql for Subquery {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		match self {
 			Self::Value(v) => write!(f, "({v})"),
 			Self::Output(v) => write!(f, "({v})"),

--- a/crates/core/src/sql/table.rs
+++ b/crates/core/src/sql/table.rs
@@ -26,8 +26,10 @@ impl Deref for Tables {
 	}
 }
 
-impl Display for Tables {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Tables);
+
+impl crate::sql::DisplaySql for Tables {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&Fmt::comma_separated(&self.0), f)
 	}
 }
@@ -73,8 +75,10 @@ impl Table {
 	}
 }
 
-impl Display for Table {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Table);
+
+impl crate::sql::DisplaySql for Table {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		EscapeIdent(&self.0).fmt(f)
 	}
 }

--- a/crates/core/src/sql/table_type.rs
+++ b/crates/core/src/sql/table_type.rs
@@ -3,7 +3,6 @@ use crate::sql::{Kind, Value};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::fmt::Display;
 
 /// The type of records stored by a table
 #[revisioned(revision = 1)]
@@ -17,8 +16,10 @@ pub enum TableType {
 	Relation(Relation),
 }
 
-impl Display for TableType {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(TableType);
+
+impl crate::sql::DisplaySql for TableType {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match self {
 			TableType::Normal => {
 				f.write_str(" NORMAL")?;

--- a/crates/core/src/sql/thing.rs
+++ b/crates/core/src/sql/thing.rs
@@ -280,8 +280,10 @@ impl Thing {
 	}
 }
 
-impl fmt::Display for Thing {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Thing);
+
+impl crate::sql::DisplaySql for Thing {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}:{}", EscapeRid(&self.tb), self.id)
 	}
 }

--- a/crates/core/src/sql/timeout.rs
+++ b/crates/core/src/sql/timeout.rs
@@ -17,8 +17,10 @@ impl Deref for Timeout {
 	}
 }
 
-impl fmt::Display for Timeout {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Timeout);
+
+impl crate::sql::DisplaySql for Timeout {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "TIMEOUT {}", self.0)
 	}
 }

--- a/crates/core/src/sql/tokenizer.rs
+++ b/crates/core/src/sql/tokenizer.rs
@@ -1,7 +1,6 @@
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::fmt::Display;
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -14,8 +13,10 @@ pub enum Tokenizer {
 	Punct,
 }
 
-impl Display for Tokenizer {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Tokenizer);
+
+impl crate::sql::DisplaySql for Tokenizer {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str(match self {
 			Self::Blank => "BLANK",
 			Self::Camel => "CAMEL",

--- a/crates/core/src/sql/uuid.rs
+++ b/crates/core/src/sql/uuid.rs
@@ -1,7 +1,7 @@
 use crate::sql::{escape::QuoteStr, strand::Strand};
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Formatter};
 use std::ops::Deref;
 use std::str;
 use std::str::FromStr;
@@ -97,8 +97,10 @@ impl Uuid {
 	}
 }
 
-impl Display for Uuid {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Uuid);
+
+impl crate::sql::DisplaySql for Uuid {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		write!(f, "u{}", QuoteStr(&self.0.to_string()))
 	}
 }

--- a/crates/core/src/sql/value/convert/cast.rs
+++ b/crates/core/src/sql/value/convert/cast.rs
@@ -34,8 +34,10 @@ pub enum CastError {
 	},
 }
 impl std::error::Error for CastError {}
-impl fmt::Display for CastError {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+crate::sql::impl_display_from_sql!(CastError);
+
+impl crate::sql::DisplaySql for CastError {
+	fn fmt_sql(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
 			CastError::InvalidKind {
 				from,
@@ -47,7 +49,7 @@ impl fmt::Display for CastError {
 				inner,
 				into,
 			} => {
-				inner.fmt(f)?;
+				inner.fmt_sql(f)?;
 				write!(f, " when coercing an element of `{into}`")
 			}
 			CastError::InvalidLength {

--- a/crates/core/src/sql/value/convert/coerce.rs
+++ b/crates/core/src/sql/value/convert/coerce.rs
@@ -31,8 +31,11 @@ pub enum CoerceError {
 	},
 }
 impl std::error::Error for CoerceError {}
-impl fmt::Display for CoerceError {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+
+crate::sql::impl_display_from_sql!(CoerceError);
+
+impl crate::sql::DisplaySql for CoerceError {
+	fn fmt_sql(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
 			CoerceError::InvalidKind {
 				from,
@@ -44,7 +47,7 @@ impl fmt::Display for CoerceError {
 				inner,
 				into,
 			} => {
-				inner.fmt(f)?;
+				inner.fmt_sql(f)?;
 				write!(f, " when coercing an element of `{into}`")
 			}
 			CoerceError::InvalidLength {

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -64,8 +64,10 @@ impl IntoIterator for Values {
 	}
 }
 
-impl Display for Values {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Values);
+
+impl crate::sql::DisplaySql for Values {
+	fn fmt_sql(&self, f: &mut Formatter) -> fmt::Result {
 		Display::fmt(&Fmt::comma_separated(&self.0), f)
 	}
 }
@@ -928,8 +930,10 @@ impl Value {
 	}
 }
 
-impl fmt::Display for Value {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Value);
+
+impl crate::sql::DisplaySql for Value {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		let mut f = Pretty::from(f);
 		match self {
 			Value::None => write!(f, "NONE"),

--- a/crates/core/src/sql/version.rs
+++ b/crates/core/src/sql/version.rs
@@ -45,8 +45,10 @@ impl Version {
 	}
 }
 
-impl fmt::Display for Version {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(Version);
+
+impl crate::sql::DisplaySql for Version {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "VERSION {}", self.0)
 	}
 }

--- a/crates/core/src/sql/view.rs
+++ b/crates/core/src/sql/view.rs
@@ -15,8 +15,10 @@ pub struct View {
 	pub group: Option<Groups>,
 }
 
-impl fmt::Display for View {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+crate::sql::impl_display_from_sql!(View);
+
+impl crate::sql::DisplaySql for View {
+	fn fmt_sql(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "AS SELECT {} FROM {}", self.expr, self.what)?;
 		if let Some(ref v) = self.cond {
 			write!(f, " {v}")?

--- a/crates/core/src/sql/with.rs
+++ b/crates/core/src/sql/with.rs
@@ -1,6 +1,6 @@
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter, Result};
+use std::fmt::{Formatter, Result};
 
 #[revisioned(revision = 1)]
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
@@ -11,8 +11,10 @@ pub enum With {
 	Index(Vec<String>),
 }
 
-impl Display for With {
-	fn fmt(&self, f: &mut Formatter) -> Result {
+crate::sql::impl_display_from_sql!(With);
+
+impl crate::sql::DisplaySql for With {
+	fn fmt_sql(&self, f: &mut Formatter) -> Result {
 		f.write_str("WITH")?;
 		match self {
 			With::NoIndex => f.write_str(" NOINDEX"),


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

As we start breaking apart the AST and ExecutionPlan, it will become important to have a clear understanding of the code path involved to convert the AST structs to SQL and nothing else. Having a blanket `Display` implementation which may convert to sql or may just convert to a plain string makes it harder to be confident that nothing was missed during the migration.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This change adds the traits `DisplaySql` and `ToSql` which are 1:1 equivalents of `Display` and `ToString`. Anything that can be converted to a SQL string should go through the `DisplaySql` trait implementation.

For now, I have added implementations for all `DisplaySql` impl blocks for `Display` which just calls the `DisplaySql` method.

Over time we can use this to separate the two implementations and ensure that only the AST related structs and enums implement `DisplaySql`.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing tests should be sufficient.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
