### PR TITLE
[backport-2.3] Ensure caches of dependent resources are refreshed on TABLE OVERWRITE

### DIFF
--- a/crates/core/src/sql/statements/define/table.rs
+++ b/crates/core/src/sql/statements/define/table.rs
@@ -93,11 +93,16 @@ impl DefineTableStatement {
 			} else {
 				None
 			},
-			// Don't persist the `IF NOT EXISTS` clause to schema
+			// Don't persist the `IF NOT EXISTS` clause to the schema
 			if_not_exists: false,
 			overwrite: false,
 			..self.clone()
 		};
+		// Make sure we are refreshing the caches
+		dt.cache_fields_ts = Uuid::now_v7();
+		dt.cache_events_ts = Uuid::now_v7();
+		dt.cache_indexes_ts = Uuid::now_v7();
+		dt.cache_tables_ts = Uuid::now_v7();
 		// Add table relational fields
 		Self::add_in_out_fields(&txn, ns, db, &mut dt).await?;
 		// Set the table definition

--- a/crates/language-tests/tests/language/statements/define/table/overwrite_field_sync.surql
+++ b/crates/language-tests/tests/language/statements/define/table/overwrite_field_sync.surql
@@ -1,0 +1,43 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: test:1, type: 'make' }]"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: test:2, type: 'bake' }]"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: test:3, type: 'cake' }]"
+
+*/
+
+DEFINE TABLE test;
+DEFINE FIELD type ON test TYPE 'make';
+CREATE test:1 CONTENT { type: 'make' };
+
+DEFINE FIELD OVERWRITE type ON test TYPE 'make' | 'bake';
+DEFINE TABLE OVERWRITE test;
+CREATE test:2 CONTENT { type: 'bake' };
+
+DEFINE FIELD OVERWRITE type ON test TYPE 'make' | 'bake' | 'cake';
+DEFINE TABLE OVERWRITE test;
+CREATE test:3 CONTENT { type: 'cake' };


### PR DESCRIPTION
## What is the motivation?

Backports #5934
Relates to #5602 

## What does this change do?

Backports #5934

## What is your testing strategy?

Github action
Language test

## Is this related to any issues?

Backports #5934

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
