### PR TITLE
Pin the rust toolchains for CI.

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,6 +17,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  RUST_VERSION: 1.86.0
+
 #
 # The bench jobs will:
 # 1. Run the benchmark and save the results as a baseline named "current"
@@ -121,6 +124,9 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          components: rustfmt
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  RUST_VERSION: 1.86
+  RUST_VERSION: 1.86.0
 
 jobs:
   # ----------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  RUST_VERSION: 1.86
+
 jobs:
   # ----------------------------------------
   # Server build
@@ -41,6 +44,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -70,6 +75,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt
 
       - name: Checkout sources
@@ -93,6 +99,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: clippy
 
       - name: Checkout sources
@@ -118,6 +125,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -171,6 +180,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -199,6 +210,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32-unknown-unknown
 
       - name: Checkout sources
@@ -224,6 +236,8 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install revision-lock
         run: cargo install revision-lock
@@ -241,6 +255,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -262,6 +278,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -283,6 +301,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -304,6 +324,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -325,6 +347,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -350,6 +374,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -390,6 +416,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -413,6 +441,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -442,6 +472,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -471,6 +503,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -500,6 +534,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -529,6 +565,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -558,6 +596,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -587,6 +627,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -616,6 +658,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -652,6 +696,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -686,6 +732,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -724,6 +772,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -749,6 +799,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -775,6 +827,8 @@ jobs:
     steps:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -27,7 +27,7 @@ on:
       rust_version:
         required: false
         type: string
-        default: "1.85.0"
+        default: "1.86.0"
         description: "The Rust version to use for building binaries"
       onnx_version:
         required: false

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -46,7 +46,7 @@ defaults:
     shell: bash
 
 env:
-  RUST_VERSION: 1.86
+  RUST_VERSION: 1.86.0
 
 jobs:
   cargo-deny:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -45,6 +45,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  RUST_VERSION: 1.86
+
 jobs:
   cargo-deny:
     name: Check dependencies for known issues
@@ -53,6 +56,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt
 
       - name: Checkout sources
@@ -76,6 +80,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt
 
       - name: Checkout sources
@@ -99,6 +104,7 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt
 
       - name: Checkout sources

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.86.0"


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

A new rust toolchain was released yesterday and caused all of our CI clippy checks to fail. We should use pinned toolchains and explicitly upgrade.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Pins the rust toolchain for CI and supply chain but not for benchmarks or publishing. We may want to pin those too in the future, but for now I think this is a reasonable start.

I will follow up with an explicit upgrade to 1.87 and fix the clippy lints in that change.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
