### PR TITLE
Disable permissions for pluck during CREATE, UPDATE, and UPSERT.

### DIFF
--- a/crates/core/src/doc/create.rs
+++ b/crates/core/src/doc/create.rs
@@ -29,6 +29,8 @@ impl Document {
 		self.process_table_lives(stk, ctx, opt, stm).await?;
 		self.process_table_events(stk, ctx, opt, stm).await?;
 		self.process_changefeeds(ctx, opt, stm).await?;
+		// We have already checked the permissions for CREATE, disable them for the pluck.
+		let opt = &opt.new_with_perms(false);
 		self.pluck(stk, ctx, opt, stm).await
 	}
 }

--- a/crates/core/src/doc/update.rs
+++ b/crates/core/src/doc/update.rs
@@ -31,6 +31,8 @@ impl Document {
 		self.process_table_lives(stk, ctx, opt, stm).await?;
 		self.process_table_events(stk, ctx, opt, stm).await?;
 		self.process_changefeeds(ctx, opt, stm).await?;
+		// We have already checked the permissions for CREATE, disable them for the pluck.
+		let opt = &opt.new_with_perms(false);
 		self.pluck(stk, ctx, opt, stm).await
 	}
 }

--- a/crates/core/src/doc/upsert.rs
+++ b/crates/core/src/doc/upsert.rs
@@ -113,6 +113,8 @@ impl Document {
 		self.process_table_lives(stk, ctx, opt, stm).await?;
 		self.process_table_events(stk, ctx, opt, stm).await?;
 		self.process_changefeeds(ctx, opt, stm).await?;
+		// We have already checked the permissions for CREATE, disable them for the pluck.
+		let opt = &opt.new_with_perms(false);
 		self.pluck(stk, ctx, opt, stm).await
 	}
 	/// Attempt to run an UPSERT statement to
@@ -140,6 +142,8 @@ impl Document {
 		self.process_table_lives(stk, ctx, opt, stm).await?;
 		self.process_table_events(stk, ctx, opt, stm).await?;
 		self.process_changefeeds(ctx, opt, stm).await?;
+		// We have already checked the permissions for CREATE, disable them for the pluck.
+		let opt = &opt.new_with_perms(false);
 		self.pluck(stk, ctx, opt, stm).await
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

During create, update, or upsert, we are already checking permissions before we add the data. Once we've added the record, it would be reasonable to be able to see what was just created, even without select permissions. If you were to then select from the table you'd still only be able to select what you had permissions for.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Disables permissions only for the `pluck` when calling `create`, `update`, or `upsert`.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
