### PR TITLE
Made Ordering, OrderList, OldOrders and OldOrder structs/enums public

### DIFF
--- a/crates/core/src/sql/mod.rs
+++ b/crates/core/src/sql/mod.rs
@@ -132,7 +132,7 @@ pub use self::number::Number;
 pub use self::object::Object;
 pub use self::operation::Operation;
 pub use self::operator::Operator;
-pub use self::order::Order;
+pub use self::order::{Ordering, OrderList, Order, OldOrders, OldOrder};
 pub use self::output::Output;
 pub use self::param::Param;
 pub use self::part::Part;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

My crate does not work anymore it used the previous version of order which is now changed but the order structs and enums are not public

## What does this change do?

Made Ordering, OrderList, OldOrders and OldOrder structs/enums public

## What is your testing strategy?

The default testing more is not needed only made structure/enums public

## Is this related to any issues?

-  #5939

## Does this change need documentation?

- No documentation needed

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
