### PR TITLE
Remove unnecessary `Killed` notification from the API

### DIFF
--- a/crates/sdk/src/api/conn/cmd.rs
+++ b/crates/sdk/src/api/conn/cmd.rs
@@ -1,5 +1,5 @@
 use super::MlExportConfig;
-use crate::{Result, opt::Resource, value::Notification};
+use crate::{Result, opt::Resource};
 use async_channel::Sender;
 use bincode::Options;
 use revision::Revisioned;
@@ -7,6 +7,7 @@ use serde::{Serialize, ser::SerializeMap as _};
 use std::borrow::Cow;
 use std::io::Read;
 use std::path::PathBuf;
+use surrealdb_core::dbs::Notification;
 use surrealdb_core::expr::{Array as CoreArray, Object as CoreObject, Query, Value as CoreValue};
 use surrealdb_core::kvs::export::Config as DbExportConfig;
 use uuid::Uuid;
@@ -109,7 +110,7 @@ pub(crate) enum Command {
 	},
 	SubscribeLive {
 		uuid: Uuid,
-		notification_sender: Sender<Notification<CoreValue>>,
+		notification_sender: Sender<Notification>,
 	},
 	Kill {
 		uuid: Uuid,

--- a/crates/sdk/src/api/engine/local/mod.rs
+++ b/crates/sdk/src/api/engine/local/mod.rs
@@ -29,7 +29,6 @@ use crate::{
 	},
 	method::Stats,
 	opt::{IntoEndpoint, Table},
-	value::Notification,
 };
 #[cfg(not(target_family = "wasm"))]
 use anyhow::bail;
@@ -51,7 +50,7 @@ use surrealdb_core::expr::Function;
 #[cfg(not(target_family = "wasm"))]
 use surrealdb_core::kvs::export::Config as DbExportConfig;
 use surrealdb_core::{
-	dbs::{Response, Session},
+	dbs::{Notification, Response, Session},
 	expr::{
 		Data, Field, Output, Query, Statement, Value as CoreValue,
 		statements::{
@@ -99,7 +98,7 @@ pub(crate) mod native;
 #[cfg(target_family = "wasm")]
 pub(crate) mod wasm;
 
-type LiveQueryMap = HashMap<Uuid, Sender<Notification<CoreValue>>>;
+type LiveQueryMap = HashMap<Uuid, Sender<Notification>>;
 
 /// In-memory database
 ///

--- a/crates/sdk/src/api/engine/local/native.rs
+++ b/crates/sdk/src/api/engine/local/native.rs
@@ -1,5 +1,4 @@
 use crate::{
-	Action,
 	api::{
 		ExtraFeatures, Result, Surreal,
 		conn::{self, Route, Router},
@@ -9,7 +8,6 @@ use crate::{
 	},
 	engine::tasks,
 	opt::{WaitFor, auth::Root},
-	value::Notification,
 };
 use async_channel::{Receiver, Sender};
 use futures::{StreamExt, stream::poll_fn};
@@ -173,14 +171,8 @@ pub(crate) async fn run_router(
 					continue
 				};
 
-				let notification = Notification{
-					query_id: *notification.id,
-					action: Action::from_core(notification.action),
-					data: notification.result
-				};
-
 				tokio::spawn(async move {
-					let id = notification.query_id;
+					let id = notification.id.0;
 					if let Some(sender) = live_queries.read().await.get(&id) {
 
 						if sender.send(notification).await.is_err() {

--- a/crates/sdk/src/api/engine/local/wasm.rs
+++ b/crates/sdk/src/api/engine/local/wasm.rs
@@ -14,7 +14,6 @@ use crate::kvs::Datastore;
 use crate::opt::WaitFor;
 use crate::opt::auth::Root;
 use crate::options::EngineOptions;
-use crate::{Action, Notification};
 use async_channel::{Receiver, Sender};
 use futures::FutureExt;
 use futures::StreamExt;
@@ -171,13 +170,6 @@ pub(crate) async fn run_router(
 
 				let id = notification.id;
 				if let Some(sender) = live_queries.read().await.get(&id) {
-
-					let notification = Notification {
-						query_id: notification.id.0,
-						action: Action::from_core(notification.action),
-						data: notification.result,
-					};
-
 					if sender.send(notification).await.is_err() {
 						live_queries.write().await.remove(&id);
 						if let Err(error) =

--- a/crates/sdk/src/api/engine/remote/ws/mod.rs
+++ b/crates/sdk/src/api/engine/remote/ws/mod.rs
@@ -11,12 +11,12 @@ use crate::api::Surreal;
 use crate::api::conn::Command;
 use crate::api::conn::DbResponse;
 use crate::opt::IntoEndpoint;
-use crate::value::Notification;
 use async_channel::Sender;
 use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::time::Duration;
+use surrealdb_core::dbs::Notification;
 use surrealdb_core::expr::Value as CoreValue;
 use trice::Instant;
 use uuid::Uuid;
@@ -63,7 +63,7 @@ struct RouterState<Sink, Stream> {
 	/// Messages which aught to be replayed on a reconnect.
 	replay: IndexMap<ReplayMethod, Command>,
 	/// Pending live queries
-	live_queries: HashMap<Uuid, async_channel::Sender<Notification<CoreValue>>>,
+	live_queries: HashMap<Uuid, async_channel::Sender<Notification>>,
 	/// Send requests which are still awaiting an awnser.
 	pending_requests: HashMap<i64, PendingRequest>,
 	/// The last time a message was recieved from the server.

--- a/crates/sdk/src/api/engine/remote/ws/native.rs
+++ b/crates/sdk/src/api/engine/remote/ws/native.rs
@@ -18,7 +18,6 @@ use crate::api::opt::Tls;
 use crate::engine::IntervalStream;
 use crate::engine::remote::Data;
 use crate::opt::WaitFor;
-use crate::{Action, Notification};
 use async_channel::Receiver;
 use futures::SinkExt;
 use futures::StreamExt;
@@ -343,12 +342,6 @@ async fn router_handle_response(response: Message, state: &mut RouterState) -> H
 								// Check if this live query is registered
 								if let Some(sender) = state.live_queries.get(&live_query_id) {
 									// Send the notification back to the caller or kill live query if the receiver is already dropped
-
-									let notification = Notification {
-										query_id: *notification.id,
-										action: Action::from_core(notification.action),
-										data: notification.result,
-									};
 									if sender.send(notification).await.is_err() {
 										state.live_queries.remove(&live_query_id);
 										let kill = {

--- a/crates/sdk/src/api/engine/remote/ws/wasm.rs
+++ b/crates/sdk/src/api/engine/remote/ws/wasm.rs
@@ -15,7 +15,6 @@ use crate::api::opt::Endpoint;
 use crate::engine::IntervalStream;
 use crate::engine::remote::Data;
 use crate::opt::WaitFor;
-use crate::{Action, Notification};
 use anyhow::Result;
 use async_channel::{Receiver, Sender};
 use futures::FutureExt;
@@ -281,12 +280,6 @@ async fn router_handle_response(
 							// Check if this live query is registered
 							if let Some(sender) = state.live_queries.get(&live_query_id) {
 								// Send the notification back to the caller or kill live query if the receiver is already dropped
-								let notification = Notification {
-									query_id: notification.id.0,
-									action: Action::from_core(notification.action),
-									data: notification.result,
-								};
-
 								if sender.send(notification).await.is_err() {
 									state.live_queries.remove(&live_query_id);
 									let kill = {

--- a/crates/sdk/src/api/method/live.rs
+++ b/crates/sdk/src/api/method/live.rs
@@ -1,3 +1,4 @@
+use crate::Action;
 use crate::Surreal;
 use crate::Value;
 use crate::api::Connection;
@@ -22,6 +23,7 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
+use surrealdb_core::dbs::{Action as CoreAction, Notification as CoreNotification};
 use surrealdb_core::expr::{
 	Cond, Expression, Field, Fields, Ident, Idiom, Operator, Part, Statement, Table,
 	Value as CoreValue, statements::LiveStatement,
@@ -100,10 +102,7 @@ where
 	})
 }
 
-pub(crate) async fn register(
-	router: &Router,
-	id: Uuid,
-) -> Result<Receiver<Notification<CoreValue>>> {
+pub(crate) async fn register(router: &Router, id: Uuid) -> Result<Receiver<CoreNotification>> {
 	let (tx, rx) = async_channel::unbounded();
 	router
 		.execute_unit(Command::SubscribeLive {
@@ -160,7 +159,7 @@ pub struct Stream<R> {
 	// We no longer need the lifetime and the type parameter
 	// Leaving them in for backwards compatibility
 	pub(crate) id: Uuid,
-	pub(crate) rx: Option<Pin<Box<Receiver<Notification<CoreValue>>>>>,
+	pub(crate) rx: Option<Pin<Box<Receiver<CoreNotification>>>>,
 	pub(crate) response_type: PhantomData<R>,
 }
 
@@ -168,7 +167,7 @@ impl<R> Stream<R> {
 	pub(crate) fn new(
 		client: Surreal<Any>,
 		id: Uuid,
-		rx: Option<Receiver<Notification<CoreValue>>>,
+		rx: Option<Receiver<CoreNotification>>,
 	) -> Self {
 		Self {
 			id,
@@ -199,23 +198,26 @@ impl futures::Stream for Stream<Value> {
 
 	poll_next! {
 		notification => {
-			let r = Notification{
-				query_id: notification.query_id,
-				action: notification.action,
-				data: Value::from_inner(notification.data),
-			};
-			Poll::Ready(Some(r))
+			match notification.action {
+				CoreAction::Killed => Poll::Ready(None),
+				action => Poll::Ready(Some(Notification {
+					query_id: *notification.id,
+					action: Action::from_core(action),
+					data: Value::from_inner(notification.result),
+				})),
+			}
 		}
+	}
+
+	fn size_hint(&self) -> (usize, Option<usize>) {
+		(0, None)
 	}
 }
 
 macro_rules! poll_next_and_convert {
 	() => {
 		poll_next! {
-			notification => match notification.map_deserialize(){
-				Ok(data) => Poll::Ready(Some(Ok(data))),
-				Err(error) => Poll::Ready(Some(Err(error.into()))),
-			}
+			notification => Poll::Ready(deserialize(notification))
 		}
 	};
 }
@@ -272,5 +274,24 @@ impl<R> Drop for Stream<R> {
 		if self.rx.is_some() {
 			kill(&self.client, self.id);
 		}
+	}
+}
+
+fn deserialize<R>(notification: CoreNotification) -> Option<Result<crate::Notification<R>>>
+where
+	R: DeserializeOwned,
+{
+	let query_id = *notification.id;
+	let action = notification.action;
+	match action {
+		CoreAction::Killed => None,
+		action => match surrealdb_core::expr::from_value(notification.result) {
+			Ok(data) => Some(Ok(Notification {
+				query_id,
+				data,
+				action: Action::from_core(action),
+			})),
+			Err(error) => Some(Err(error)),
+		},
 	}
 }

--- a/crates/sdk/src/api/value/mod.rs
+++ b/crates/sdk/src/api/value/mod.rs
@@ -476,17 +476,3 @@ pub struct Notification<R> {
 	pub action: Action,
 	pub data: R,
 }
-
-impl Notification<CoreValue> {
-	pub fn map_deserialize<R>(self) -> Result<Notification<R>>
-	where
-		R: DeserializeOwned,
-	{
-		let data = surrealdb_core::expr::from_value(self.data)?;
-		Ok(Notification {
-			query_id: self.query_id,
-			action: self.action,
-			data,
-		})
-	}
-}

--- a/crates/sdk/src/api/value/mod.rs
+++ b/crates/sdk/src/api/value/mod.rs
@@ -450,7 +450,6 @@ pub enum Action {
 	Create,
 	Update,
 	Delete,
-	Killed,
 }
 
 impl Action {
@@ -460,7 +459,6 @@ impl Action {
 			CoreAction::Create => Self::Create,
 			CoreAction::Update => Self::Update,
 			CoreAction::Delete => Self::Delete,
-			CoreAction::Killed => Self::Killed,
 			_ => panic!("unimplemented variant of action"),
 		}
 	}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

`Action::Killed` is not necessary in the Rust SDK. We should just terminate the stream instead.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It removes it and ensures that we handle the notification when the server returns it.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
