### PR TITLE
Fix deadlock in memory bucket for files

### DIFF
--- a/crates/core/src/buc/store/memory.rs
+++ b/crates/core/src/buc/store/memory.rs
@@ -121,8 +121,8 @@ impl ObjectStore for MemoryStore {
 		target: &'a ObjectKey,
 	) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
 		Box::pin(async move {
-			if let Some(x) = self.store.get(key) {
-				let data = x.clone();
+			// as_deref().cloned() here is important to prevent a deadlock.
+			if let Some(data) = self.store.get(key).as_deref().cloned() {
 				self.store.insert(target.clone(), data);
 			}
 
@@ -137,8 +137,8 @@ impl ObjectStore for MemoryStore {
 	) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
 		Box::pin(async move {
 			if !self.store.contains_key(target) {
-				if let Some(x) = self.store.get(key) {
-					let data = x.clone();
+				// as_deref().cloned() here is important to prevent a deadlock.
+				if let Some(data) = self.store.get(key).as_deref().cloned() {
 					self.store.insert(target.clone(), data);
 				}
 			}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The memory bucket file API can deadlock

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Prevent a deadlock in the file locking API

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

This change is hard to test as the deadlock is inconsistently triggered. We will know if it worked if we no longer have the test suite occasionally deadlock. 

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
