### PR TITLE
Overwrite by default during import

### DIFF
--- a/crates/core/src/expr/statements/define/access.rs
+++ b/crates/core/src/expr/statements/define/access.rs
@@ -77,7 +77,7 @@ impl DefineAccessStatement {
 				if txn.get_root_access(&self.name).await.is_ok() {
 					if self.if_not_exists {
 						return Ok(Value::None);
-					} else if !self.overwrite {
+					} else if !self.overwrite && !opt.import {
 						bail!(Error::AccessRootAlreadyExists {
 							ac: self.name.to_string(),
 						});
@@ -108,7 +108,7 @@ impl DefineAccessStatement {
 				if txn.get_ns_access(opt.ns()?, &self.name).await.is_ok() {
 					if self.if_not_exists {
 						return Ok(Value::None);
-					} else if !self.overwrite {
+					} else if !self.overwrite && !opt.import {
 						bail!(Error::AccessNsAlreadyExists {
 							ac: self.name.to_string(),
 							ns: opt.ns()?.into(),
@@ -142,7 +142,7 @@ impl DefineAccessStatement {
 				if txn.get_db_access(ns, db, &self.name).await.is_ok() {
 					if self.if_not_exists {
 						return Ok(Value::None);
-					} else if !self.overwrite {
+					} else if !self.overwrite && !opt.import {
 						bail!(Error::AccessDbAlreadyExists {
 							ac: self.name.to_string(),
 							ns: ns.into(),

--- a/crates/core/src/expr/statements/define/analyzer.rs
+++ b/crates/core/src/expr/statements/define/analyzer.rs
@@ -44,7 +44,7 @@ impl DefineAnalyzerStatement {
 		if txn.get_db_analyzer(ns, db, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::AzAlreadyExists {
 					name: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/api.rs
+++ b/crates/core/src/expr/statements/define/api.rs
@@ -47,7 +47,7 @@ impl DefineApiStatement {
 		if txn.get_db_api(ns, db, &self.path.to_string()).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::ApAlreadyExists {
 					value: self.path.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/bucket.rs
+++ b/crates/core/src/expr/statements/define/bucket.rs
@@ -43,7 +43,7 @@ impl DefineBucketStatement {
 		if txn.get_db_bucket(ns, db, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::BuAlreadyExists {
 					value: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/config/mod.rs
+++ b/crates/core/src/expr/statements/define/config/mod.rs
@@ -57,7 +57,7 @@ impl DefineConfigStatement {
 		if txn.get_db_config(ns, db, cg).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::CgAlreadyExists {
 					name: cg.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/database.rs
+++ b/crates/core/src/expr/statements/define/database.rs
@@ -44,7 +44,7 @@ impl DefineDatabaseStatement {
 		if txn.get_db(ns, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::DbAlreadyExists {
 					name: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/event.rs
+++ b/crates/core/src/expr/statements/define/event.rs
@@ -47,7 +47,7 @@ impl DefineEventStatement {
 		if txn.get_tb_event(ns, db, &self.what, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::EvAlreadyExists {
 					name: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/field.rs
+++ b/crates/core/src/expr/statements/define/field.rs
@@ -81,7 +81,7 @@ impl DefineFieldStatement {
 		if txn.get_tb_field(ns, db, &self.what, &fd).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::FdAlreadyExists {
 					name: fd,
 				});

--- a/crates/core/src/expr/statements/define/function.rs
+++ b/crates/core/src/expr/statements/define/function.rs
@@ -47,7 +47,7 @@ impl DefineFunctionStatement {
 		if txn.get_db_function(ns, db, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::FcAlreadyExists {
 					name: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/index.rs
+++ b/crates/core/src/expr/statements/define/index.rs
@@ -58,7 +58,7 @@ impl DefineIndexStatement {
 		if txn.get_tb_index(ns, db, &self.what, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::IxAlreadyExists {
 					name: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/model.rs
+++ b/crates/core/src/expr/statements/define/model.rs
@@ -45,7 +45,7 @@ impl DefineModelStatement {
 		if txn.get_db_model(ns, db, &self.name, &self.version).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::MlAlreadyExists {
 					name: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/namespace.rs
+++ b/crates/core/src/expr/statements/define/namespace.rs
@@ -41,7 +41,7 @@ impl DefineNamespaceStatement {
 		if txn.get_ns(&self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::NsAlreadyExists {
 					name: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/param.rs
+++ b/crates/core/src/expr/statements/define/param.rs
@@ -49,7 +49,7 @@ impl DefineParamStatement {
 		if txn.get_db_param(ns, db, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::PaAlreadyExists {
 					name: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/sequence.rs
+++ b/crates/core/src/expr/statements/define/sequence.rs
@@ -36,7 +36,7 @@ impl DefineSequenceStatement {
 		if txn.get_db_sequence(ns, db, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::SeqAlreadyExists {
 					name: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/table.rs
+++ b/crates/core/src/expr/statements/define/table.rs
@@ -78,7 +78,7 @@ impl DefineTableStatement {
 		if txn.get_tb(ns, db, &self.name).await.is_ok() {
 			if self.if_not_exists {
 				return Ok(Value::None);
-			} else if !self.overwrite {
+			} else if !self.overwrite && !opt.import {
 				bail!(Error::TbAlreadyExists {
 					name: self.name.to_string(),
 				});

--- a/crates/core/src/expr/statements/define/user.rs
+++ b/crates/core/src/expr/statements/define/user.rs
@@ -119,7 +119,7 @@ impl DefineUserStatement {
 				if txn.get_root_user(&self.name).await.is_ok() {
 					if self.if_not_exists {
 						return Ok(Value::None);
-					} else if !self.overwrite {
+					} else if !self.overwrite && !opt.import {
 						bail!(Error::UserRootAlreadyExists {
 							name: self.name.to_string(),
 						});
@@ -150,7 +150,7 @@ impl DefineUserStatement {
 				if txn.get_ns_user(opt.ns()?, &self.name).await.is_ok() {
 					if self.if_not_exists {
 						return Ok(Value::None);
-					} else if !self.overwrite {
+					} else if !self.overwrite && !opt.import {
 						bail!(Error::UserNsAlreadyExists {
 							name: self.name.to_string(),
 							ns: opt.ns()?.into(),
@@ -184,7 +184,7 @@ impl DefineUserStatement {
 				if txn.get_db_user(ns, db, &self.name).await.is_ok() {
 					if self.if_not_exists {
 						return Ok(Value::None);
-					} else if !self.overwrite {
+					} else if !self.overwrite && !opt.import {
 						bail!(Error::UserDbAlreadyExists {
 							name: self.name.to_string(),
 							ns: ns.into(),

--- a/crates/language-tests/tests/language/import/overwrite-by-default.surql
+++ b/crates/language-tests/tests/language/import/overwrite-by-default.surql
@@ -1,0 +1,49 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "{ in: 'DEFINE FIELD in ON test TYPE record<a> PERMISSIONS FULL', out: 'DEFINE FIELD out ON test TYPE record<b> PERMISSIONS FULL' }"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "{ in: 'DEFINE FIELD in ON test TYPE record<a> PERMISSIONS FULL', out: 'DEFINE FIELD out ON test TYPE record<b> PERMISSIONS FULL' }"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = '''{ arr: 'DEFINE FIELD arr ON test TYPE array<number> PERMISSIONS FULL', "arr[*]": 'DEFINE FIELD arr[*] ON test TYPE number PERMISSIONS FULL', in: 'DEFINE FIELD in ON test TYPE record<a> PERMISSIONS FULL', out: 'DEFINE FIELD out ON test TYPE record<b> PERMISSIONS FULL' }'''
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = '''{ arr: 'DEFINE FIELD arr ON test TYPE array<number> PERMISSIONS FULL', "arr[*]": 'DEFINE FIELD arr[*] ON test TYPE number PERMISSIONS FULL', in: 'DEFINE FIELD in ON test TYPE record<a> PERMISSIONS FULL', out: 'DEFINE FIELD out ON test TYPE record<b> PERMISSIONS FULL' }'''
+
+
+*/
+OPTION IMPORT;
+DEFINE TABLE test TYPE RELATION IN a OUT b;
+
+(INFO FOR TB test).fields;
+
+DEFINE FIELD in ON test TYPE record<a>;
+DEFINE FIELD out ON test TYPE record<b>;
+
+(INFO FOR TB test).fields;
+
+DEFINE FIELD arr ON test TYPE array<number>;
+
+(INFO FOR TB test).fields;
+
+DEFINE FIELD arr.* ON test TYPE number;
+
+(INFO FOR TB test).fields;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

When an import has a table definition with a type relation, or array fields which produce nested fields, the import fails because the export will have also included nested fields itself.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR eliminates that problem by setting `OVERWRITE` to true by default during imports

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
