### PR TITLE
Add tests to ensure `core::sql` and `core::expr` structs stay in sync.

### DIFF
--- a/crates/core/src/expr/cast.rs
+++ b/crates/core/src/expr/cast.rs
@@ -32,9 +32,7 @@ impl Cast {
 	pub fn to_idiom(&self) -> Idiom {
 		self.1.to_idiom()
 	}
-}
 
-impl Cast {
 	/// Check if we require a writeable transaction
 	pub(crate) fn writeable(&self) -> bool {
 		self.1.writeable()

--- a/crates/core/src/expr/datetime.rs
+++ b/crates/core/src/expr/datetime.rs
@@ -26,6 +26,26 @@ pub struct Datetime(pub DateTime<Utc>);
 impl Datetime {
 	pub const MIN_UTC: Self = Datetime(DateTime::<Utc>::MIN_UTC);
 	pub const MAX_UTC: Self = Datetime(DateTime::<Utc>::MAX_UTC);
+
+	/// Convert the Datetime to a raw String
+	pub fn to_raw(&self) -> String {
+		self.0.to_rfc3339_opts(SecondsFormat::AutoSi, true)
+	}
+
+	/// Convert to nanosecond timestamp.
+	pub fn to_u64(&self) -> Option<u64> {
+		self.0.timestamp_nanos_opt().map(|v| v as u64)
+	}
+
+	/// Convert to nanosecond timestamp.
+	pub fn to_i64(&self) -> Option<i64> {
+		self.0.timestamp_nanos_opt()
+	}
+
+	/// Convert to second timestamp.
+	pub fn to_secs(&self) -> i64 {
+		self.0.timestamp()
+	}
 }
 
 impl Default for Datetime {
@@ -91,28 +111,6 @@ impl Deref for Datetime {
 	type Target = DateTime<Utc>;
 	fn deref(&self) -> &Self::Target {
 		&self.0
-	}
-}
-
-impl Datetime {
-	/// Convert the Datetime to a raw String
-	pub fn to_raw(&self) -> String {
-		self.0.to_rfc3339_opts(SecondsFormat::AutoSi, true)
-	}
-
-	/// Convert to nanosecond timestamp.
-	pub fn to_u64(&self) -> Option<u64> {
-		self.0.timestamp_nanos_opt().map(|v| v as u64)
-	}
-
-	/// Convert to nanosecond timestamp.
-	pub fn to_i64(&self) -> Option<i64> {
-		self.0.timestamp_nanos_opt()
-	}
-
-	/// Convert to second timestamp.
-	pub fn to_secs(&self) -> i64 {
-		self.0.timestamp()
 	}
 }
 

--- a/crates/core/src/expr/duration.rs
+++ b/crates/core/src/expr/duration.rs
@@ -36,65 +36,7 @@ pub struct Duration(pub time::Duration);
 
 impl Duration {
 	pub const MAX: Duration = Duration(time::Duration::MAX);
-}
 
-impl From<time::Duration> for Duration {
-	fn from(v: time::Duration) -> Self {
-		Self(v)
-	}
-}
-
-impl From<Duration> for time::Duration {
-	fn from(s: Duration) -> Self {
-		s.0
-	}
-}
-
-impl From<time::Duration> for Value {
-	fn from(value: time::Duration) -> Self {
-		Self::Duration(value.into())
-	}
-}
-
-impl FromStr for Duration {
-	type Err = ();
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		Self::try_from(s)
-	}
-}
-
-impl TryFrom<String> for Duration {
-	type Error = ();
-	fn try_from(v: String) -> Result<Self, Self::Error> {
-		Self::try_from(v.as_str())
-	}
-}
-
-impl TryFrom<Strand> for Duration {
-	type Error = ();
-	fn try_from(v: Strand) -> Result<Self, Self::Error> {
-		Self::try_from(v.as_str())
-	}
-}
-
-impl TryFrom<&str> for Duration {
-	type Error = ();
-	fn try_from(v: &str) -> Result<Self, Self::Error> {
-		match syn::duration(v) {
-			Ok(v) => Ok(v.into()),
-			_ => Err(()),
-		}
-	}
-}
-
-impl Deref for Duration {
-	type Target = time::Duration;
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
-}
-
-impl Duration {
 	/// Create a duration from both seconds and nanoseconds components
 	pub fn new(secs: u64, nanos: u32) -> Duration {
 		time::Duration::new(secs, nanos).into()
@@ -170,6 +112,62 @@ impl Duration {
 	/// Create a duration from weeks
 	pub fn from_weeks(weeks: u64) -> Option<Duration> {
 		weeks.checked_mul(SECONDS_PER_WEEK).map(time::Duration::from_secs).map(|x| x.into())
+	}
+}
+
+impl From<time::Duration> for Duration {
+	fn from(v: time::Duration) -> Self {
+		Self(v)
+	}
+}
+
+impl From<Duration> for time::Duration {
+	fn from(s: Duration) -> Self {
+		s.0
+	}
+}
+
+impl From<time::Duration> for Value {
+	fn from(value: time::Duration) -> Self {
+		Self::Duration(value.into())
+	}
+}
+
+impl FromStr for Duration {
+	type Err = ();
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Self::try_from(s)
+	}
+}
+
+impl TryFrom<String> for Duration {
+	type Error = ();
+	fn try_from(v: String) -> Result<Self, Self::Error> {
+		Self::try_from(v.as_str())
+	}
+}
+
+impl TryFrom<Strand> for Duration {
+	type Error = ();
+	fn try_from(v: Strand) -> Result<Self, Self::Error> {
+		Self::try_from(v.as_str())
+	}
+}
+
+impl TryFrom<&str> for Duration {
+	type Error = ();
+	fn try_from(v: &str) -> Result<Self, Self::Error> {
+		match syn::duration(v) {
+			Ok(v) => Ok(v.into()),
+			_ => Err(()),
+		}
+	}
+}
+
+impl Deref for Duration {
+	type Target = time::Duration;
+	fn deref(&self) -> &Self::Target {
+		&self.0
 	}
 }
 

--- a/crates/core/src/expr/expression.rs
+++ b/crates/core/src/expr/expression.rs
@@ -54,9 +54,7 @@ impl Expression {
 			r,
 		}
 	}
-}
 
-impl Expression {
 	pub(crate) fn writeable(&self) -> bool {
 		match self {
 			Self::Unary {

--- a/crates/core/src/expr/field.rs
+++ b/crates/core/src/expr/field.rs
@@ -73,39 +73,7 @@ impl Fields {
 		}
 		is_count_only
 	}
-}
 
-impl Deref for Fields {
-	type Target = Vec<Field>;
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
-}
-
-impl IntoIterator for Fields {
-	type Item = Field;
-	type IntoIter = std::vec::IntoIter<Self::Item>;
-	fn into_iter(self) -> Self::IntoIter {
-		self.0.into_iter()
-	}
-}
-
-impl Display for Fields {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		match self.single() {
-			Some(v) => write!(f, "VALUE {}", &v),
-			None => Display::fmt(&Fmt::comma_separated(&self.0), f),
-		}
-	}
-}
-
-impl InfoStructure for Fields {
-	fn structure(self) -> Value {
-		self.to_string().into()
-	}
-}
-
-impl Fields {
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,
@@ -284,6 +252,36 @@ impl Fields {
 			}
 		}
 		Ok(out)
+	}
+}
+
+impl Deref for Fields {
+	type Target = Vec<Field>;
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl IntoIterator for Fields {
+	type Item = Field;
+	type IntoIter = std::vec::IntoIter<Self::Item>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.into_iter()
+	}
+}
+
+impl Display for Fields {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		match self.single() {
+			Some(v) => write!(f, "VALUE {}", &v),
+			None => Display::fmt(&Fmt::comma_separated(&self.0), f),
+		}
+	}
+}
+
+impl InfoStructure for Fields {
+	fn structure(self) -> Value {
+		self.to_string().into()
 	}
 }
 

--- a/crates/core/src/expr/function.rs
+++ b/crates/core/src/expr/function.rs
@@ -50,28 +50,7 @@ impl Function {
 	) -> Result<Self, revision::Error> {
 		Ok(Function::Anonymous(old.0, old.1, false))
 	}
-}
 
-pub(crate) enum OptimisedAggregate {
-	None,
-	Count,
-	CountFunction,
-	MathMax,
-	MathMin,
-	MathSum,
-	MathMean,
-	TimeMax,
-	TimeMin,
-}
-
-impl PartialOrd for Function {
-	#[inline]
-	fn partial_cmp(&self, _: &Self) -> Option<Ordering> {
-		None
-	}
-}
-
-impl Function {
 	/// Get function name if applicable
 	pub fn name(&self) -> Option<&str> {
 		match self {
@@ -212,9 +191,7 @@ impl Function {
 	pub(crate) fn is_count_all(&self) -> bool {
 		matches!(self, Self::Normal(f, p) if f == "count" && p.is_empty() )
 	}
-}
 
-impl Function {
 	/// Process this type returning a computed simple Value
 	///
 	/// Was marked recursive
@@ -413,4 +390,23 @@ impl fmt::Display for Function {
 			}
 		}
 	}
+}
+
+impl PartialOrd for Function {
+	#[inline]
+	fn partial_cmp(&self, _: &Self) -> Option<Ordering> {
+		None
+	}
+}
+
+pub(crate) enum OptimisedAggregate {
+	None,
+	Count,
+	CountFunction,
+	MathMax,
+	MathMin,
+	MathSum,
+	MathMean,
+	TimeMax,
+	TimeMin,
 }

--- a/crates/core/src/expr/geometry.rs
+++ b/crates/core/src/expr/geometry.rs
@@ -265,198 +265,7 @@ impl Geometry {
 		};
 		Some(Point::from(((*a).try_into().ok()?, (*b).try_into().ok()?)))
 	}
-}
 
-impl PartialOrd for Geometry {
-	#[rustfmt::skip]
-	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		fn coord(v: &Coord) -> (f64, f64) {
-			v.x_y()
-		}
-
-		fn point(v: &Point) -> (f64, f64) {
-			coord(&v.0)
-		}
-
-		fn line(v: &LineString) -> impl Iterator<Item = (f64, f64)> + '_ {
-			v.into_iter().map(coord)
-		}
-
-		fn polygon(v: &Polygon) -> impl Iterator<Item = (f64, f64)> + '_ {
-			v.interiors().iter().chain(once(v.exterior())).flat_map(line)
-		}
-
-		fn multipoint(v: &MultiPoint) -> impl Iterator<Item = (f64, f64)> + '_ {
-			v.iter().map(point)
-		}
-
-		fn multiline(v: &MultiLineString) -> impl Iterator<Item = (f64, f64)> + '_ {
-			v.iter().flat_map(line)
-		}
-
-		fn multipolygon(v: &MultiPolygon) -> impl Iterator<Item = (f64, f64)> + '_ {
-			v.iter().flat_map(polygon)
-		}
-
-		match (self, other) {
-			//
-			(Self::Point(_), Self::Line(_)) => Some(Ordering::Less),
-			(Self::Point(_), Self::Polygon(_)) => Some(Ordering::Less),
-			(Self::Point(_), Self::MultiPoint(_)) => Some(Ordering::Less),
-			(Self::Point(_), Self::MultiLine(_)) => Some(Ordering::Less),
-			(Self::Point(_), Self::MultiPolygon(_)) => Some(Ordering::Less),
-			(Self::Point(_), Self::Collection(_)) => Some(Ordering::Less),
-			//
-			(Self::Line(_), Self::Point(_)) => Some(Ordering::Greater),
-			(Self::Line(_), Self::Polygon(_)) => Some(Ordering::Less),
-			(Self::Line(_), Self::MultiPoint(_)) => Some(Ordering::Less),
-			(Self::Line(_), Self::MultiLine(_)) => Some(Ordering::Less),
-			(Self::Line(_), Self::MultiPolygon(_)) => Some(Ordering::Less),
-			(Self::Line(_), Self::Collection(_)) => Some(Ordering::Less),
-			//
-			(Self::Polygon(_), Self::Point(_)) => Some(Ordering::Greater),
-			(Self::Polygon(_), Self::Line(_)) => Some(Ordering::Greater),
-			(Self::Polygon(_), Self::MultiPoint(_)) => Some(Ordering::Less),
-			(Self::Polygon(_), Self::MultiLine(_)) => Some(Ordering::Less),
-			(Self::Polygon(_), Self::MultiPolygon(_)) => Some(Ordering::Less),
-			(Self::Polygon(_), Self::Collection(_)) => Some(Ordering::Less),
-			//
-			(Self::MultiPoint(_), Self::Point(_)) => Some(Ordering::Greater),
-			(Self::MultiPoint(_), Self::Line(_)) => Some(Ordering::Greater),
-			(Self::MultiPoint(_), Self::Polygon(_)) => Some(Ordering::Greater),
-			(Self::MultiPoint(_), Self::MultiLine(_)) => Some(Ordering::Less),
-			(Self::MultiPoint(_), Self::MultiPolygon(_)) => Some(Ordering::Less),
-			(Self::MultiPoint(_), Self::Collection(_)) => Some(Ordering::Less),
-			//
-			(Self::MultiLine(_), Self::Point(_)) => Some(Ordering::Greater),
-			(Self::MultiLine(_), Self::Line(_)) => Some(Ordering::Greater),
-			(Self::MultiLine(_), Self::Polygon(_)) => Some(Ordering::Greater),
-			(Self::MultiLine(_), Self::MultiPoint(_)) => Some(Ordering::Greater),
-			(Self::MultiLine(_), Self::MultiPolygon(_)) => Some(Ordering::Less),
-			(Self::MultiLine(_), Self::Collection(_)) => Some(Ordering::Less),
-			//
-			(Self::MultiPolygon(_), Self::Point(_)) => Some(Ordering::Greater),
-			(Self::MultiPolygon(_), Self::Line(_)) => Some(Ordering::Greater),
-			(Self::MultiPolygon(_), Self::Polygon(_)) => Some(Ordering::Greater),
-			(Self::MultiPolygon(_), Self::MultiPoint(_)) => Some(Ordering::Greater),
-			(Self::MultiPolygon(_), Self::MultiLine(_)) => Some(Ordering::Greater),
-			(Self::MultiPolygon(_), Self::Collection(_)) => Some(Ordering::Less),
-			//
-			(Self::Collection(_), Self::Point(_)) => Some(Ordering::Greater),
-			(Self::Collection(_), Self::Line(_)) => Some(Ordering::Greater),
-			(Self::Collection(_), Self::Polygon(_)) => Some(Ordering::Greater),
-			(Self::Collection(_), Self::MultiPoint(_)) => Some(Ordering::Greater),
-			(Self::Collection(_), Self::MultiLine(_)) => Some(Ordering::Greater),
-			(Self::Collection(_), Self::MultiPolygon(_)) => Some(Ordering::Greater),
-			//
-			(Self::Point(a), Self::Point(b)) => point(a).partial_cmp(&point(b)),
-			(Self::Line(a), Self::Line(b)) => line(a).partial_cmp(line(b)),
-			(Self::Polygon(a), Self::Polygon(b)) => polygon(a).partial_cmp(polygon(b)),
-			(Self::MultiPoint(a), Self::MultiPoint(b)) => multipoint(a).partial_cmp(multipoint(b)),
-			(Self::MultiLine(a), Self::MultiLine(b)) => multiline(a).partial_cmp(multiline(b)),
-			(Self::MultiPolygon(a), Self::MultiPolygon(b)) => multipolygon(a).partial_cmp(multipolygon(b)),
-			(Self::Collection(a), Self::Collection(b)) => a.partial_cmp(b),
-		}
-	}
-}
-
-impl From<(f64, f64)> for Geometry {
-	fn from(v: (f64, f64)) -> Self {
-		Self::Point(v.into())
-	}
-}
-
-impl From<[f64; 2]> for Geometry {
-	fn from(v: [f64; 2]) -> Self {
-		Self::Point(v.into())
-	}
-}
-
-impl From<Point<f64>> for Geometry {
-	fn from(v: Point<f64>) -> Self {
-		Self::Point(v)
-	}
-}
-
-impl From<LineString<f64>> for Geometry {
-	fn from(v: LineString<f64>) -> Self {
-		Self::Line(v)
-	}
-}
-
-impl From<Polygon<f64>> for Geometry {
-	fn from(v: Polygon<f64>) -> Self {
-		Self::Polygon(v)
-	}
-}
-
-impl From<MultiPoint<f64>> for Geometry {
-	fn from(v: MultiPoint<f64>) -> Self {
-		Self::MultiPoint(v)
-	}
-}
-
-impl From<MultiLineString<f64>> for Geometry {
-	fn from(v: MultiLineString<f64>) -> Self {
-		Self::MultiLine(v)
-	}
-}
-
-impl From<MultiPolygon<f64>> for Geometry {
-	fn from(v: MultiPolygon<f64>) -> Self {
-		Self::MultiPolygon(v)
-	}
-}
-
-impl From<Vec<Geometry>> for Geometry {
-	fn from(v: Vec<Geometry>) -> Self {
-		Self::Collection(v)
-	}
-}
-
-impl From<Vec<Point<f64>>> for Geometry {
-	fn from(v: Vec<Point<f64>>) -> Self {
-		Self::MultiPoint(MultiPoint(v))
-	}
-}
-
-impl From<Vec<LineString<f64>>> for Geometry {
-	fn from(v: Vec<LineString<f64>>) -> Self {
-		Self::MultiLine(MultiLineString(v))
-	}
-}
-
-impl From<Vec<Polygon<f64>>> for Geometry {
-	fn from(v: Vec<Polygon<f64>>) -> Self {
-		Self::MultiPolygon(MultiPolygon(v))
-	}
-}
-
-impl From<Geometry> for geo::Geometry<f64> {
-	fn from(v: Geometry) -> Self {
-		match v {
-			Geometry::Point(v) => v.into(),
-			Geometry::Line(v) => v.into(),
-			Geometry::Polygon(v) => v.into(),
-			Geometry::MultiPoint(v) => v.into(),
-			Geometry::MultiLine(v) => v.into(),
-			Geometry::MultiPolygon(v) => v.into(),
-			Geometry::Collection(v) => v.into_iter().collect::<geo::Geometry<f64>>(),
-		}
-	}
-}
-
-impl FromIterator<Geometry> for geo::Geometry<f64> {
-	fn from_iter<I: IntoIterator<Item = Geometry>>(iter: I) -> Self {
-		let mut c: Vec<geo::Geometry<f64>> = vec![];
-		for i in iter {
-			c.push(i.into())
-		}
-		geo::Geometry::GeometryCollection(geo::GeometryCollection(c))
-	}
-}
-
-impl Geometry {
 	// -----------------------------------
 	// Value operations
 	// -----------------------------------
@@ -567,6 +376,99 @@ impl Geometry {
 				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
 			},
 			Self::Collection(v) => v.iter().all(|x| x.intersects(other)),
+		}
+	}
+}
+
+impl PartialOrd for Geometry {
+	#[rustfmt::skip]
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		fn coord(v: &Coord) -> (f64, f64) {
+			v.x_y()
+		}
+
+		fn point(v: &Point) -> (f64, f64) {
+			coord(&v.0)
+		}
+
+		fn line(v: &LineString) -> impl Iterator<Item = (f64, f64)> + '_ {
+			v.into_iter().map(coord)
+		}
+
+		fn polygon(v: &Polygon) -> impl Iterator<Item = (f64, f64)> + '_ {
+			v.interiors().iter().chain(once(v.exterior())).flat_map(line)
+		}
+
+		fn multipoint(v: &MultiPoint) -> impl Iterator<Item = (f64, f64)> + '_ {
+			v.iter().map(point)
+		}
+
+		fn multiline(v: &MultiLineString) -> impl Iterator<Item = (f64, f64)> + '_ {
+			v.iter().flat_map(line)
+		}
+
+		fn multipolygon(v: &MultiPolygon) -> impl Iterator<Item = (f64, f64)> + '_ {
+			v.iter().flat_map(polygon)
+		}
+
+		match (self, other) {
+			//
+			(Self::Point(_), Self::Line(_)) => Some(Ordering::Less),
+			(Self::Point(_), Self::Polygon(_)) => Some(Ordering::Less),
+			(Self::Point(_), Self::MultiPoint(_)) => Some(Ordering::Less),
+			(Self::Point(_), Self::MultiLine(_)) => Some(Ordering::Less),
+			(Self::Point(_), Self::MultiPolygon(_)) => Some(Ordering::Less),
+			(Self::Point(_), Self::Collection(_)) => Some(Ordering::Less),
+			//
+			(Self::Line(_), Self::Point(_)) => Some(Ordering::Greater),
+			(Self::Line(_), Self::Polygon(_)) => Some(Ordering::Less),
+			(Self::Line(_), Self::MultiPoint(_)) => Some(Ordering::Less),
+			(Self::Line(_), Self::MultiLine(_)) => Some(Ordering::Less),
+			(Self::Line(_), Self::MultiPolygon(_)) => Some(Ordering::Less),
+			(Self::Line(_), Self::Collection(_)) => Some(Ordering::Less),
+			//
+			(Self::Polygon(_), Self::Point(_)) => Some(Ordering::Greater),
+			(Self::Polygon(_), Self::Line(_)) => Some(Ordering::Greater),
+			(Self::Polygon(_), Self::MultiPoint(_)) => Some(Ordering::Less),
+			(Self::Polygon(_), Self::MultiLine(_)) => Some(Ordering::Less),
+			(Self::Polygon(_), Self::MultiPolygon(_)) => Some(Ordering::Less),
+			(Self::Polygon(_), Self::Collection(_)) => Some(Ordering::Less),
+			//
+			(Self::MultiPoint(_), Self::Point(_)) => Some(Ordering::Greater),
+			(Self::MultiPoint(_), Self::Line(_)) => Some(Ordering::Greater),
+			(Self::MultiPoint(_), Self::Polygon(_)) => Some(Ordering::Greater),
+			(Self::MultiPoint(_), Self::MultiLine(_)) => Some(Ordering::Less),
+			(Self::MultiPoint(_), Self::MultiPolygon(_)) => Some(Ordering::Less),
+			(Self::MultiPoint(_), Self::Collection(_)) => Some(Ordering::Less),
+			//
+			(Self::MultiLine(_), Self::Point(_)) => Some(Ordering::Greater),
+			(Self::MultiLine(_), Self::Line(_)) => Some(Ordering::Greater),
+			(Self::MultiLine(_), Self::Polygon(_)) => Some(Ordering::Greater),
+			(Self::MultiLine(_), Self::MultiPoint(_)) => Some(Ordering::Greater),
+			(Self::MultiLine(_), Self::MultiPolygon(_)) => Some(Ordering::Less),
+			(Self::MultiLine(_), Self::Collection(_)) => Some(Ordering::Less),
+			//
+			(Self::MultiPolygon(_), Self::Point(_)) => Some(Ordering::Greater),
+			(Self::MultiPolygon(_), Self::Line(_)) => Some(Ordering::Greater),
+			(Self::MultiPolygon(_), Self::Polygon(_)) => Some(Ordering::Greater),
+			(Self::MultiPolygon(_), Self::MultiPoint(_)) => Some(Ordering::Greater),
+			(Self::MultiPolygon(_), Self::MultiLine(_)) => Some(Ordering::Greater),
+			(Self::MultiPolygon(_), Self::Collection(_)) => Some(Ordering::Less),
+			//
+			(Self::Collection(_), Self::Point(_)) => Some(Ordering::Greater),
+			(Self::Collection(_), Self::Line(_)) => Some(Ordering::Greater),
+			(Self::Collection(_), Self::Polygon(_)) => Some(Ordering::Greater),
+			(Self::Collection(_), Self::MultiPoint(_)) => Some(Ordering::Greater),
+			(Self::Collection(_), Self::MultiLine(_)) => Some(Ordering::Greater),
+			(Self::Collection(_), Self::MultiPolygon(_)) => Some(Ordering::Greater),
+			//
+			(Self::Point(a), Self::Point(b)) => point(a).partial_cmp(&point(b)),
+			(Self::Line(a), Self::Line(b)) => line(a).partial_cmp(line(b)),
+			(Self::Polygon(a), Self::Polygon(b)) => polygon(a).partial_cmp(polygon(b)),
+			(Self::MultiPoint(a), Self::MultiPoint(b)) => multipoint(a).partial_cmp(multipoint(b)),
+			(Self::MultiLine(a), Self::MultiLine(b)) => multiline(a).partial_cmp(multiline(b)),
+			(Self::MultiPolygon(a), Self::MultiPolygon(b)) => multipolygon(a).partial_cmp(multipolygon(b)),
+			(Self::Collection(a), Self::Collection(b)) => a.partial_cmp(b),
 		}
 	}
 }
@@ -727,5 +629,101 @@ impl hash::Hash for Geometry {
 				v.iter().for_each(|v| v.hash(state));
 			}
 		}
+	}
+}
+
+impl From<(f64, f64)> for Geometry {
+	fn from(v: (f64, f64)) -> Self {
+		Self::Point(v.into())
+	}
+}
+
+impl From<[f64; 2]> for Geometry {
+	fn from(v: [f64; 2]) -> Self {
+		Self::Point(v.into())
+	}
+}
+
+impl From<Point<f64>> for Geometry {
+	fn from(v: Point<f64>) -> Self {
+		Self::Point(v)
+	}
+}
+
+impl From<LineString<f64>> for Geometry {
+	fn from(v: LineString<f64>) -> Self {
+		Self::Line(v)
+	}
+}
+
+impl From<Polygon<f64>> for Geometry {
+	fn from(v: Polygon<f64>) -> Self {
+		Self::Polygon(v)
+	}
+}
+
+impl From<MultiPoint<f64>> for Geometry {
+	fn from(v: MultiPoint<f64>) -> Self {
+		Self::MultiPoint(v)
+	}
+}
+
+impl From<MultiLineString<f64>> for Geometry {
+	fn from(v: MultiLineString<f64>) -> Self {
+		Self::MultiLine(v)
+	}
+}
+
+impl From<MultiPolygon<f64>> for Geometry {
+	fn from(v: MultiPolygon<f64>) -> Self {
+		Self::MultiPolygon(v)
+	}
+}
+
+impl From<Vec<Geometry>> for Geometry {
+	fn from(v: Vec<Geometry>) -> Self {
+		Self::Collection(v)
+	}
+}
+
+impl From<Vec<Point<f64>>> for Geometry {
+	fn from(v: Vec<Point<f64>>) -> Self {
+		Self::MultiPoint(MultiPoint(v))
+	}
+}
+
+impl From<Vec<LineString<f64>>> for Geometry {
+	fn from(v: Vec<LineString<f64>>) -> Self {
+		Self::MultiLine(MultiLineString(v))
+	}
+}
+
+impl From<Vec<Polygon<f64>>> for Geometry {
+	fn from(v: Vec<Polygon<f64>>) -> Self {
+		Self::MultiPolygon(MultiPolygon(v))
+	}
+}
+
+impl From<Geometry> for geo::Geometry<f64> {
+	fn from(v: Geometry) -> Self {
+		match v {
+			Geometry::Point(v) => v.into(),
+			Geometry::Line(v) => v.into(),
+			Geometry::Polygon(v) => v.into(),
+			Geometry::MultiPoint(v) => v.into(),
+			Geometry::MultiLine(v) => v.into(),
+			Geometry::MultiPolygon(v) => v.into(),
+			Geometry::Collection(v) => v.into_iter().collect::<geo::Geometry<f64>>(),
+		}
+	}
+}
+
+impl FromIterator<Geometry> for geo::Geometry<f64> {
+	fn from_iter<I: IntoIterator<Item = Geometry>>(iter: I) -> Self {
+		let mut c: Vec<geo::Geometry<f64>> = vec![];
+		for i in iter {
+			c.push(i.into())
+		}
+		geo::Geometry::GeometryCollection(geo::GeometryCollection(c))
 	}
 }

--- a/crates/core/src/expr/id/mod.rs
+++ b/crates/core/src/expr/id/mod.rs
@@ -220,27 +220,7 @@ impl Id {
 			Self::Range(v) => v.to_string(),
 		}
 	}
-}
 
-impl Display for Id {
-	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-		match self {
-			Self::Number(v) => Display::fmt(v, f),
-			Self::String(v) => EscapeRid(v).fmt(f),
-			Self::Uuid(v) => Display::fmt(v, f),
-			Self::Array(v) => Display::fmt(v, f),
-			Self::Object(v) => Display::fmt(v, f),
-			Self::Generate(v) => match v {
-				Gen::Rand => Display::fmt("rand()", f),
-				Gen::Ulid => Display::fmt("ulid()", f),
-				Gen::Uuid => Display::fmt("uuid()", f),
-			},
-			Self::Range(v) => Display::fmt(v, f),
-		}
-	}
-}
-
-impl Id {
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,
@@ -267,6 +247,24 @@ impl Id {
 				Gen::Uuid => Ok(Self::uuid()),
 			},
 			Id::Range(v) => Ok(Id::Range(Box::new(v.compute(stk, ctx, opt, doc).await?))),
+		}
+	}
+}
+
+impl Display for Id {
+	fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+		match self {
+			Self::Number(v) => Display::fmt(v, f),
+			Self::String(v) => EscapeRid(v).fmt(f),
+			Self::Uuid(v) => Display::fmt(v, f),
+			Self::Array(v) => Display::fmt(v, f),
+			Self::Object(v) => Display::fmt(v, f),
+			Self::Generate(v) => match v {
+				Gen::Rand => Display::fmt("rand()", f),
+				Gen::Ulid => Display::fmt("ulid()", f),
+				Gen::Uuid => Display::fmt("uuid()", f),
+			},
+			Self::Range(v) => Display::fmt(v, f),
 		}
 	}
 }

--- a/crates/core/src/expr/idiom.rs
+++ b/crates/core/src/expr/idiom.rs
@@ -153,9 +153,7 @@ impl Idiom {
 	pub(crate) fn starts_with(&self, other: &[Part]) -> bool {
 		self.0.starts_with(other)
 	}
-}
 
-impl Idiom {
 	/// Check if we require a writeable transaction
 	pub(crate) fn writeable(&self) -> bool {
 		self.0.iter().any(|v| v.writeable())

--- a/crates/core/src/expr/object.rs
+++ b/crates/core/src/expr/object.rs
@@ -246,9 +246,7 @@ impl Object {
 			})),
 		}
 	}
-}
 
-impl Object {
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,

--- a/crates/core/src/expr/part.rs
+++ b/crates/core/src/expr/part.rs
@@ -57,15 +57,6 @@ pub enum Part {
 	RepeatRecurse,
 }
 
-impl Part {
-	fn convert_recurse_add_instruction(
-		fields: OldRecurseFields,
-		_revision: u16,
-	) -> Result<Self, revision::Error> {
-		Ok(Part::Recurse(fields.0, fields.1, None))
-	}
-}
-
 impl From<i32> for Part {
 	fn from(v: i32) -> Self {
 		Self::Index(v.into())
@@ -118,6 +109,13 @@ impl From<&str> for Part {
 }
 
 impl Part {
+	fn convert_recurse_add_instruction(
+		fields: OldRecurseFields,
+		_revision: u16,
+	) -> Result<Self, revision::Error> {
+		Ok(Part::Recurse(fields.0, fields.1, None))
+	}
+
 	pub(crate) fn is_index(&self) -> bool {
 		matches!(self, Part::Index(_) | Part::First | Part::Last)
 	}

--- a/crates/core/src/expr/statements/define/access.rs
+++ b/crates/core/src/expr/statements/define/access.rs
@@ -56,9 +56,7 @@ impl DefineAccessStatement {
 		};
 		das
 	}
-}
 
-impl DefineAccessStatement {
 	/// Process this type returning a computed simple Value
 	pub(crate) async fn compute(
 		&self,

--- a/crates/core/src/expr/statements/define/mod.rs
+++ b/crates/core/src/expr/statements/define/mod.rs
@@ -107,9 +107,7 @@ impl DefineStatement {
 	) -> Result<Self, revision::Error> {
 		Ok(DefineStatement::Access(fields.0.into()))
 	}
-}
 
-impl DefineStatement {
 	/// Check if we require a writeable transaction
 	pub(crate) fn writeable(&self) -> bool {
 		true

--- a/crates/core/src/expr/statements/define/table.rs
+++ b/crates/core/src/expr/statements/define/table.rs
@@ -172,9 +172,7 @@ impl DefineTableStatement {
 	fn convert_cache_ts(&self, _revision: u16, _value: Uuid) -> Result<(), RevisionError> {
 		Ok(())
 	}
-}
 
-impl DefineTableStatement {
 	/// Checks if this is a TYPE RELATION table
 	pub fn is_relation(&self) -> bool {
 		matches!(self.kind, TableType::Relation(_))

--- a/crates/core/src/expr/strand.rs
+++ b/crates/core/src/expr/strand.rs
@@ -39,6 +39,19 @@ impl Strand {
 		debug_assert!(!s.contains('\0'));
 		Strand(s)
 	}
+
+	/// Get the underlying String slice
+	pub fn as_str(&self) -> &str {
+		self.0.as_str()
+	}
+	/// Returns the underlying String
+	pub fn as_string(self) -> String {
+		self.0
+	}
+	/// Convert the Strand to a raw String
+	pub fn to_raw(self) -> String {
+		self.0
+	}
 }
 
 impl From<String> for Strand {
@@ -65,21 +78,6 @@ impl Deref for Strand {
 impl From<Strand> for String {
 	fn from(s: Strand) -> Self {
 		s.0
-	}
-}
-
-impl Strand {
-	/// Get the underlying String slice
-	pub fn as_str(&self) -> &str {
-		self.0.as_str()
-	}
-	/// Returns the underlying String
-	pub fn as_string(self) -> String {
-		self.0
-	}
-	/// Convert the Strand to a raw String
-	pub fn to_raw(self) -> String {
-		self.0
 	}
 }
 

--- a/crates/core/src/expr/thing.rs
+++ b/crates/core/src/expr/thing.rs
@@ -182,6 +182,33 @@ impl Thing {
 
 		Ok(ids)
 	}
+
+	/// Convert the Thing to a raw String
+	pub fn to_raw(&self) -> String {
+		self.to_string()
+	}
+	/// Check if this Thing is a range
+	pub fn is_range(&self) -> bool {
+		matches!(self.id, Id::Range(_))
+	}
+	/// Check if this Thing is of a certain table type
+	pub fn is_record_type(&self, types: &[Table]) -> bool {
+		types.is_empty() || types.iter().any(|tb| tb.0 == self.tb)
+	}
+
+	/// Process this type returning a computed simple Value
+	pub(crate) async fn compute(
+		&self,
+		stk: &mut Stk,
+		ctx: &Context,
+		opt: &Options,
+		doc: Option<&CursorDoc>,
+	) -> Result<Value> {
+		Ok(Value::Thing(Thing {
+			tb: self.tb.clone(),
+			id: self.id.compute(stk, ctx, opt, doc).await?,
+		}))
+	}
 }
 
 impl From<(&str, Id)> for Thing {
@@ -263,40 +290,9 @@ impl TryFrom<&str> for Thing {
 	}
 }
 
-impl Thing {
-	/// Convert the Thing to a raw String
-	pub fn to_raw(&self) -> String {
-		self.to_string()
-	}
-	/// Check if this Thing is a range
-	pub fn is_range(&self) -> bool {
-		matches!(self.id, Id::Range(_))
-	}
-	/// Check if this Thing is of a certain table type
-	pub fn is_record_type(&self, types: &[Table]) -> bool {
-		types.is_empty() || types.iter().any(|tb| tb.0 == self.tb)
-	}
-}
-
 impl fmt::Display for Thing {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}:{}", EscapeRid(&self.tb), self.id)
-	}
-}
-
-impl Thing {
-	/// Process this type returning a computed simple Value
-	pub(crate) async fn compute(
-		&self,
-		stk: &mut Stk,
-		ctx: &Context,
-		opt: &Options,
-		doc: Option<&CursorDoc>,
-	) -> Result<Value> {
-		Ok(Value::Thing(Thing {
-			tb: self.tb.clone(),
-			id: self.id.compute(stk, ctx, opt, doc).await?,
-		}))
 	}
 }
 

--- a/crates/core/src/expr/value/value.rs
+++ b/crates/core/src/expr/value/value.rs
@@ -163,17 +163,7 @@ impl Value {
 			})),
 		}))
 	}
-}
 
-impl Eq for Value {}
-
-impl Ord for Value {
-	fn cmp(&self, other: &Self) -> Ordering {
-		self.partial_cmp(other).unwrap_or(Ordering::Equal)
-	}
-}
-
-impl Value {
 	// -----------------------------------
 	// Initial record value
 	// -----------------------------------
@@ -972,6 +962,14 @@ impl fmt::Display for Value {
 impl InfoStructure for Value {
 	fn structure(self) -> Value {
 		self.to_string().into()
+	}
+}
+
+impl Eq for Value {}
+
+impl Ord for Value {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.partial_cmp(other).unwrap_or(Ordering::Equal)
 	}
 }
 

--- a/crates/core/src/idx/planner/iterators.rs
+++ b/crates/core/src/idx/planner/iterators.rs
@@ -803,9 +803,7 @@ impl JoinThingIterator {
 			distinct: Default::default(),
 		})
 	}
-}
 
-impl JoinThingIterator {
 	async fn next_current_remote_batch(
 		&mut self,
 		ctx: &Context,

--- a/crates/core/src/idx/trees/mtree.rs
+++ b/crates/core/src/idx/trees/mtree.rs
@@ -268,23 +268,10 @@ impl MTree {
 			visited_nodes,
 		))
 	}
-}
 
-enum InsertionResult {
-	DocAdded,
-	CoveringRadius(f64),
-	PromotedEntries(SharedVector, RoutingProperties, SharedVector, RoutingProperties),
-}
+	// Insertion
 
-enum DeletionResult {
-	NotFound,
-	DocRemoved,
-	CoveringRadius(f64),
-	Underflown(MStoredNode, bool),
-}
-
-// Insertion
-impl MTree {
+	/// Create a new node id
 	fn new_node_id(&mut self) -> NodeId {
 		let new_node_id = self.state.next_node_id;
 		self.state.next_node_id += 1;
@@ -1176,6 +1163,19 @@ impl MTree {
 			Ok(DeletionResult::DocRemoved)
 		}
 	}
+}
+
+enum InsertionResult {
+	DocAdded,
+	CoveringRadius(f64),
+	PromotedEntries(SharedVector, RoutingProperties, SharedVector, RoutingProperties),
+}
+
+enum DeletionResult {
+	NotFound,
+	DocRemoved,
+	CoveringRadius(f64),
+	Underflown(MStoredNode, bool),
 }
 
 struct DistanceCache(HashMap<(SharedVector, SharedVector), f64>);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -54,6 +54,9 @@ pub mod str;
 pub mod syn;
 pub mod vs;
 
+#[cfg(test)]
+mod revision_checks;
+
 #[cfg(feature = "ml")]
 pub use surrealml as ml;
 

--- a/crates/core/src/mem/fake.rs
+++ b/crates/core/src/mem/fake.rs
@@ -20,9 +20,7 @@ impl FakeAlloc {
 	pub const fn new() -> Self {
 		Self {}
 	}
-}
 
-impl FakeAlloc {
 	/// Returns the number of bytes that are allocated to the process
 	pub fn current_usage(&self) -> (usize, usize) {
 		(0, 0)

--- a/crates/core/src/revision_checks.rs
+++ b/crates/core/src/revision_checks.rs
@@ -1,0 +1,997 @@
+//! Tests to check that the SQL and Expr structs are equivalent.
+
+#![allow(non_snake_case)]
+
+use crate::{expr, sql};
+use revision::Revisioned;
+use std::ops::Bound;
+
+macro_rules! test_memory_equality {
+	($test:ident, $sql_ty:ty, $expr_ty:ty, $sql_example:expr) => {
+		#[test]
+		fn $test() {
+			{
+				let size_of_sql = std::mem::size_of::<$sql_ty>();
+				let size_of_expr = std::mem::size_of::<$expr_ty>();
+				assert_eq!(size_of_sql, size_of_expr, "Size of SQL and Expr structs do not match");
+
+				let align_of_sql = std::mem::align_of::<$sql_ty>();
+				let align_of_expr = std::mem::align_of::<$expr_ty>();
+				assert_eq!(
+					align_of_sql, align_of_expr,
+					"Alignment of SQL and Expr structs do not match"
+				);
+			}
+
+			{
+				let sql_instance = $sql_example;
+				let expr_instance: $expr_ty = sql_instance.clone().into();
+
+				assert_eq!(<$sql_ty>::revision(), <$expr_ty>::revision(), "Revisions do not match");
+
+				let sql_revisioned_bytes = revision::to_vec(&sql_instance).unwrap();
+				let expr_revisioned_bytes = revision::to_vec(&expr_instance).unwrap();
+
+				assert_eq!(
+					sql_revisioned_bytes, expr_revisioned_bytes,
+					"Serialized bytes do not match"
+				);
+				let sql_from_sql_bytes: $sql_ty =
+					revision::from_slice(&sql_revisioned_bytes).unwrap();
+				let sql_from_expr_bytes: $sql_ty =
+					revision::from_slice(&expr_revisioned_bytes).unwrap();
+				let expr_from_sql_bytes: $expr_ty =
+					revision::from_slice(&sql_revisioned_bytes).unwrap();
+				let expr_from_expr_bytes: $expr_ty =
+					revision::from_slice(&expr_revisioned_bytes).unwrap();
+
+				assert_eq!(
+					sql_instance, sql_from_sql_bytes,
+					"Deserialized SQL instance from SQL bytes does not match original"
+				);
+				assert_eq!(
+					sql_instance, sql_from_expr_bytes,
+					"Deserialized SQL instance from Expr bytes does not match original"
+				);
+				assert_eq!(
+					expr_instance, expr_from_sql_bytes,
+					"Deserialized Expr instance from SQL bytes does not match original"
+				);
+				assert_eq!(
+					expr_instance, expr_from_expr_bytes,
+					"Deserialized Expr instance from Expr bytes does not match original"
+				);
+			}
+		}
+	};
+}
+
+test_memory_equality!(sql_Id_Number, sql::Id, expr::Id, sql::Id::Number(5));
+test_memory_equality!(sql_Id_String, sql::Id, expr::Id, sql::Id::String("test".to_string()));
+test_memory_equality!(sql_Id_Uuid, sql::Id, expr::Id, sql::Id::Uuid(sql::Uuid::new_v4()));
+test_memory_equality!(
+	sql_Id_Array,
+	sql::Id,
+	expr::Id,
+	sql::Id::Array(sql::Array(vec![1.into(), 2.into(), 3.into()]))
+);
+test_memory_equality!(
+	sql_Id_Object,
+	sql::Id,
+	expr::Id,
+	sql::Id::Object([("key".to_string(), sql::SqlValue::from(1))].into_iter().collect())
+);
+test_memory_equality!(sql_Id_Generate, sql::Id, expr::Id, sql::Id::Generate(sql::id::Gen::Ulid));
+test_memory_equality!(
+	sql_Id_Range,
+	sql::Id,
+	expr::Id,
+	sql::Id::Range(Box::new(sql::id::range::IdRange {
+		beg: Bound::Included(1.into()),
+		end: Bound::Excluded(2.into())
+	}))
+);
+
+test_memory_equality!(
+	sql_IdRange,
+	sql::IdRange,
+	expr::IdRange,
+	sql::id::range::IdRange {
+		beg: Bound::Included(1.into()),
+		end: Bound::Excluded(2.into())
+	}
+);
+
+test_memory_equality!(
+	sql_statements_alter_AlterFieldStatement,
+	sql::statements::alter::AlterFieldStatement,
+	expr::statements::alter::AlterFieldStatement,
+	sql::statements::alter::AlterFieldStatement::default()
+);
+test_memory_equality!(
+	sql_statements_alter_AlterSequenceStatement,
+	sql::statements::alter::AlterSequenceStatement,
+	expr::statements::alter::AlterSequenceStatement,
+	sql::statements::alter::AlterSequenceStatement::default()
+);
+test_memory_equality!(
+	sql_statements_alter_AlterTableStatement,
+	sql::statements::alter::AlterTableStatement,
+	expr::statements::alter::AlterTableStatement,
+	sql::statements::alter::AlterTableStatement::default()
+);
+test_memory_equality!(
+	sql_statements_AlterStatement,
+	sql::statements::AlterStatement,
+	expr::statements::AlterStatement,
+	sql::statements::AlterStatement::Field(sql::statements::alter::AlterFieldStatement::default())
+);
+
+test_memory_equality!(
+	sql_statements_define_config_api_ApiConfig,
+	sql::statements::define::config::api::ApiConfig,
+	expr::statements::define::config::api::ApiConfig,
+	sql::statements::define::config::api::ApiConfig::default()
+);
+test_memory_equality!(
+	sql_statements_define_config_graphql_GraphQLConfig,
+	sql::statements::define::config::graphql::GraphQLConfig,
+	expr::statements::define::config::graphql::GraphQLConfig,
+	sql::statements::define::config::graphql::GraphQLConfig::default()
+);
+test_memory_equality!(
+	sql_statements_define_config_graphql_TablesConfig,
+	sql::statements::define::config::graphql::TablesConfig,
+	expr::statements::define::config::graphql::TablesConfig,
+	sql::statements::define::config::graphql::TablesConfig::default()
+);
+test_memory_equality!(
+	sql_statements_define_config_graphql_TableConfig,
+	sql::statements::define::config::graphql::TableConfig,
+	expr::statements::define::config::graphql::TableConfig,
+	sql::statements::define::config::graphql::TableConfig::default()
+);
+test_memory_equality!(
+	sql_statements_define_config_graphql_FunctionsConfig,
+	sql::statements::define::config::graphql::FunctionsConfig,
+	expr::statements::define::config::graphql::FunctionsConfig,
+	sql::statements::define::config::graphql::FunctionsConfig::default()
+);
+test_memory_equality!(
+	sql_statements_define_DefineConfigStatement,
+	sql::statements::define::DefineConfigStatement,
+	expr::statements::define::DefineConfigStatement,
+	sql::statements::define::DefineConfigStatement {
+		inner: sql::statements::define::config::ConfigInner::Api(
+			sql::statements::define::config::api::ApiConfig::default()
+		),
+		if_not_exists: false,
+		overwrite: false,
+	}
+);
+test_memory_equality!(
+	sql_statements_define_config_ConfigInner,
+	sql::statements::define::config::ConfigInner,
+	expr::statements::define::config::ConfigInner,
+	sql::statements::define::config::ConfigInner::Api(
+		sql::statements::define::config::api::ApiConfig::default()
+	)
+);
+test_memory_equality!(
+	sql_statements_DefineAccessStatement,
+	sql::statements::DefineAccessStatement,
+	expr::statements::DefineAccessStatement,
+	sql::statements::DefineAccessStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineAnalyzerStatement,
+	sql::statements::DefineAnalyzerStatement,
+	expr::statements::DefineAnalyzerStatement,
+	sql::statements::DefineAnalyzerStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineApiStatement,
+	sql::statements::DefineApiStatement,
+	expr::statements::DefineApiStatement,
+	sql::statements::DefineApiStatement::default()
+);
+test_memory_equality!(
+	sql_statements_define_ApiAction,
+	sql::statements::define::ApiAction,
+	expr::statements::define::ApiAction,
+	sql::statements::define::ApiAction::default()
+);
+test_memory_equality!(
+	sql_statements_define_DefineBucketStatement,
+	sql::statements::define::DefineBucketStatement,
+	expr::statements::define::DefineBucketStatement,
+	sql::statements::define::DefineBucketStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineDatabaseStatement,
+	sql::statements::DefineDatabaseStatement,
+	expr::statements::DefineDatabaseStatement,
+	sql::statements::DefineDatabaseStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineEventStatement,
+	sql::statements::DefineEventStatement,
+	expr::statements::DefineEventStatement,
+	sql::statements::DefineEventStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineFieldStatement,
+	sql::statements::DefineFieldStatement,
+	expr::statements::DefineFieldStatement,
+	sql::statements::DefineFieldStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineFunctionStatement,
+	sql::statements::DefineFunctionStatement,
+	expr::statements::DefineFunctionStatement,
+	sql::statements::DefineFunctionStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineIndexStatement,
+	sql::statements::DefineIndexStatement,
+	expr::statements::DefineIndexStatement,
+	sql::statements::DefineIndexStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineStatement,
+	sql::statements::DefineStatement,
+	expr::statements::DefineStatement,
+	sql::statements::DefineStatement::Namespace(
+		sql::statements::DefineNamespaceStatement::default()
+	)
+);
+test_memory_equality!(
+	sql_statements_DefineModelStatement,
+	sql::statements::DefineModelStatement,
+	expr::statements::DefineModelStatement,
+	sql::statements::DefineModelStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineNamespaceStatement,
+	sql::statements::DefineNamespaceStatement,
+	expr::statements::DefineNamespaceStatement,
+	sql::statements::DefineNamespaceStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineParamStatement,
+	sql::statements::DefineParamStatement,
+	expr::statements::DefineParamStatement,
+	sql::statements::DefineParamStatement::default()
+);
+test_memory_equality!(
+	sql_statements_define_DefineSequenceStatement,
+	sql::statements::define::DefineSequenceStatement,
+	expr::statements::define::DefineSequenceStatement,
+	sql::statements::define::DefineSequenceStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineTableStatement,
+	sql::statements::DefineTableStatement,
+	expr::statements::DefineTableStatement,
+	sql::statements::DefineTableStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DefineUserStatement,
+	sql::statements::DefineUserStatement,
+	expr::statements::DefineUserStatement,
+	sql::statements::DefineUserStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveAccessStatement,
+	sql::statements::RemoveAccessStatement,
+	expr::statements::RemoveAccessStatement,
+	sql::statements::RemoveAccessStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveAnalyzerStatement,
+	sql::statements::RemoveAnalyzerStatement,
+	expr::statements::RemoveAnalyzerStatement,
+	sql::statements::RemoveAnalyzerStatement::default()
+);
+test_memory_equality!(
+	sql_statements_remove_RemoveBucketStatement,
+	sql::statements::remove::RemoveBucketStatement,
+	expr::statements::remove::RemoveBucketStatement,
+	sql::statements::remove::RemoveBucketStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveDatabaseStatement,
+	sql::statements::RemoveDatabaseStatement,
+	expr::statements::RemoveDatabaseStatement,
+	sql::statements::RemoveDatabaseStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveEventStatement,
+	sql::statements::RemoveEventStatement,
+	expr::statements::RemoveEventStatement,
+	sql::statements::RemoveEventStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveFieldStatement,
+	sql::statements::RemoveFieldStatement,
+	expr::statements::RemoveFieldStatement,
+	sql::statements::RemoveFieldStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveFunctionStatement,
+	sql::statements::RemoveFunctionStatement,
+	expr::statements::RemoveFunctionStatement,
+	sql::statements::RemoveFunctionStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveIndexStatement,
+	sql::statements::RemoveIndexStatement,
+	expr::statements::RemoveIndexStatement,
+	sql::statements::RemoveIndexStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveStatement,
+	sql::statements::RemoveStatement,
+	expr::statements::RemoveStatement,
+	sql::statements::RemoveStatement::Namespace(
+		sql::statements::RemoveNamespaceStatement::default()
+	)
+);
+test_memory_equality!(
+	sql_statements_RemoveModelStatement,
+	sql::statements::RemoveModelStatement,
+	expr::statements::RemoveModelStatement,
+	sql::statements::RemoveModelStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveNamespaceStatement,
+	sql::statements::RemoveNamespaceStatement,
+	expr::statements::RemoveNamespaceStatement,
+	sql::statements::RemoveNamespaceStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveParamStatement,
+	sql::statements::RemoveParamStatement,
+	expr::statements::RemoveParamStatement,
+	sql::statements::RemoveParamStatement::default()
+);
+test_memory_equality!(
+	sql_statements_remove_RemoveSequenceStatement,
+	sql::statements::remove::RemoveSequenceStatement,
+	expr::statements::remove::RemoveSequenceStatement,
+	sql::statements::remove::RemoveSequenceStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveTableStatement,
+	sql::statements::RemoveTableStatement,
+	expr::statements::RemoveTableStatement,
+	sql::statements::RemoveTableStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RemoveUserStatement,
+	sql::statements::RemoveUserStatement,
+	expr::statements::RemoveUserStatement,
+	sql::statements::RemoveUserStatement::default()
+);
+test_memory_equality!(
+	sql_statements_access_AccessStatement,
+	sql::statements::access::AccessStatement,
+	expr::statements::access::AccessStatement,
+	sql::statements::access::AccessStatement::Show(
+		sql::statements::access::AccessStatementShow::default()
+	)
+);
+test_memory_equality!(
+	sql_statements_access_AccessStatementGrant,
+	sql::statements::access::AccessStatementGrant,
+	expr::statements::access::AccessStatementGrant,
+	sql::statements::access::AccessStatementGrant {
+		ac: sql::Ident::default(),
+		base: Some(sql::Base::default()),
+		subject: sql::statements::access::Subject::Record(sql::Thing {
+			tb: "table".to_string(),
+			id: sql::Id::Number(1),
+		}),
+	}
+);
+test_memory_equality!(
+	sql_statements_access_AccessStatementShow,
+	sql::statements::access::AccessStatementShow,
+	expr::statements::access::AccessStatementShow,
+	sql::statements::access::AccessStatementShow::default()
+);
+test_memory_equality!(
+	sql_statements_access_AccessStatementRevoke,
+	sql::statements::access::AccessStatementRevoke,
+	expr::statements::access::AccessStatementRevoke,
+	sql::statements::access::AccessStatementRevoke::default()
+);
+test_memory_equality!(
+	sql_statements_access_AccessStatementPurge,
+	sql::statements::access::AccessStatementPurge,
+	expr::statements::access::AccessStatementPurge,
+	sql::statements::access::AccessStatementPurge::default()
+);
+test_memory_equality!(
+	sql_statements_access_Subject,
+	sql::statements::access::Subject,
+	expr::statements::access::Subject,
+	sql::statements::access::Subject::Record(sql::Thing {
+		tb: "table".to_string(),
+		id: sql::Id::Number(1),
+	})
+);
+test_memory_equality!(
+	sql_statements_analyze_AnalyzeStatement,
+	sql::statements::analyze::AnalyzeStatement,
+	expr::statements::analyze::AnalyzeStatement,
+	sql::statements::analyze::AnalyzeStatement::Idx(sql::Ident::default(), sql::Ident::default())
+);
+test_memory_equality!(
+	sql_statements_begin_BeginStatement,
+	sql::statements::begin::BeginStatement,
+	expr::statements::begin::BeginStatement,
+	sql::statements::begin::BeginStatement::default()
+);
+test_memory_equality!(
+	sql_statements_BreakStatement,
+	sql::statements::BreakStatement,
+	expr::statements::BreakStatement,
+	sql::statements::BreakStatement::default()
+);
+test_memory_equality!(
+	sql_statements_cancel_CancelStatement,
+	sql::statements::cancel::CancelStatement,
+	expr::statements::cancel::CancelStatement,
+	sql::statements::cancel::CancelStatement::default()
+);
+test_memory_equality!(
+	sql_statements_commit_CommitStatement,
+	sql::statements::commit::CommitStatement,
+	expr::statements::commit::CommitStatement,
+	sql::statements::commit::CommitStatement::default()
+);
+test_memory_equality!(
+	sql_statements_ContinueStatement,
+	sql::statements::ContinueStatement,
+	expr::statements::ContinueStatement,
+	sql::statements::ContinueStatement::default()
+);
+test_memory_equality!(
+	sql_statements_CreateStatement,
+	sql::statements::CreateStatement,
+	expr::statements::CreateStatement,
+	sql::statements::CreateStatement::default()
+);
+test_memory_equality!(
+	sql_statements_DeleteStatement,
+	sql::statements::DeleteStatement,
+	expr::statements::DeleteStatement,
+	sql::statements::DeleteStatement::default()
+);
+test_memory_equality!(
+	sql_statements_ForeachStatement,
+	sql::statements::ForeachStatement,
+	expr::statements::ForeachStatement,
+	sql::statements::ForeachStatement::default()
+);
+test_memory_equality!(
+	sql_statements_IfelseStatement,
+	sql::statements::IfelseStatement,
+	expr::statements::IfelseStatement,
+	sql::statements::IfelseStatement::default()
+);
+test_memory_equality!(
+	sql_statements_InfoStatement,
+	sql::statements::InfoStatement,
+	expr::statements::InfoStatement,
+	sql::statements::InfoStatement::Root(true)
+);
+test_memory_equality!(
+	sql_statements_InsertStatement,
+	sql::statements::InsertStatement,
+	expr::statements::InsertStatement,
+	sql::statements::InsertStatement::default()
+);
+test_memory_equality!(
+	sql_statements_KillStatement,
+	sql::statements::KillStatement,
+	expr::statements::KillStatement,
+	sql::statements::KillStatement::default()
+);
+test_memory_equality!(
+	sql_statements_LiveStatement,
+	sql::statements::LiveStatement,
+	expr::statements::LiveStatement,
+	sql::statements::LiveStatement::default()
+);
+test_memory_equality!(
+	sql_statements_OptionStatement,
+	sql::statements::OptionStatement,
+	expr::statements::OptionStatement,
+	sql::statements::OptionStatement::default()
+);
+test_memory_equality!(
+	sql_statements_OutputStatement,
+	sql::statements::OutputStatement,
+	expr::statements::OutputStatement,
+	sql::statements::OutputStatement::default()
+);
+test_memory_equality!(
+	sql_statements_rebuild_RebuildStatement,
+	sql::statements::rebuild::RebuildStatement,
+	expr::statements::rebuild::RebuildStatement,
+	sql::statements::rebuild::RebuildStatement::Index(
+		sql::statements::rebuild::RebuildIndexStatement::default()
+	)
+);
+test_memory_equality!(
+	sql_statements_rebuild_RebuildIndexStatement,
+	sql::statements::rebuild::RebuildIndexStatement,
+	expr::statements::rebuild::RebuildIndexStatement,
+	sql::statements::rebuild::RebuildIndexStatement::default()
+);
+test_memory_equality!(
+	sql_statements_RelateStatement,
+	sql::statements::RelateStatement,
+	expr::statements::RelateStatement,
+	sql::statements::RelateStatement::default()
+);
+test_memory_equality!(
+	sql_statements_SelectStatement,
+	sql::statements::SelectStatement,
+	expr::statements::SelectStatement,
+	sql::statements::SelectStatement::default()
+);
+test_memory_equality!(
+	sql_statements_SetStatement,
+	sql::statements::SetStatement,
+	expr::statements::SetStatement,
+	sql::statements::SetStatement::default()
+);
+test_memory_equality!(
+	sql_statements_show_ShowSince,
+	sql::statements::show::ShowSince,
+	expr::statements::show::ShowSince,
+	sql::statements::show::ShowSince::Timestamp(sql::Datetime::default())
+);
+test_memory_equality!(
+	sql_statements_ShowStatement,
+	sql::statements::ShowStatement,
+	expr::statements::ShowStatement,
+	sql::statements::ShowStatement {
+		table: Some(sql::Table::default()),
+		since: sql::statements::show::ShowSince::Timestamp(sql::Datetime::default()),
+		limit: Some(1),
+	}
+);
+test_memory_equality!(
+	sql_statements_SleepStatement,
+	sql::statements::SleepStatement,
+	expr::statements::SleepStatement,
+	sql::statements::SleepStatement::default()
+);
+test_memory_equality!(
+	sql_statements_ThrowStatement,
+	sql::statements::ThrowStatement,
+	expr::statements::ThrowStatement,
+	sql::statements::ThrowStatement::default()
+);
+test_memory_equality!(
+	sql_statements_UpdateStatement,
+	sql::statements::UpdateStatement,
+	expr::statements::UpdateStatement,
+	sql::statements::UpdateStatement::default()
+);
+test_memory_equality!(
+	sql_statements_UpsertStatement,
+	sql::statements::UpsertStatement,
+	expr::statements::UpsertStatement,
+	sql::statements::UpsertStatement::default()
+);
+test_memory_equality!(
+	sql_statements_UseStatement,
+	sql::statements::UseStatement,
+	expr::statements::UseStatement,
+	sql::statements::UseStatement::default()
+);
+test_memory_equality!(sql_SqlValues, sql::SqlValues, expr::Values, sql::SqlValues::default());
+test_memory_equality!(sql_SqlValue, sql::SqlValue, expr::Value, sql::SqlValue::default());
+test_memory_equality!(
+	sql_AccessType,
+	sql::AccessType,
+	expr::AccessType,
+	sql::AccessType::default()
+);
+test_memory_equality!(sql_JwtAccess, sql::JwtAccess, expr::JwtAccess, sql::JwtAccess::default());
+test_memory_equality!(
+	sql_access_type_JwtAccessIssue,
+	sql::access_type::JwtAccessIssue,
+	expr::access_type::JwtAccessIssue,
+	sql::access_type::JwtAccessIssue::default()
+);
+test_memory_equality!(
+	sql_access_type_JwtAccessVerify,
+	sql::access_type::JwtAccessVerify,
+	expr::access_type::JwtAccessVerify,
+	sql::access_type::JwtAccessVerify::default()
+);
+test_memory_equality!(
+	sql_access_type_JwtAccessVerifyKey,
+	sql::access_type::JwtAccessVerifyKey,
+	expr::access_type::JwtAccessVerifyKey,
+	sql::access_type::JwtAccessVerifyKey::default()
+);
+test_memory_equality!(
+	sql_access_type_JwtAccessVerifyJwks,
+	sql::access_type::JwtAccessVerifyJwks,
+	expr::access_type::JwtAccessVerifyJwks,
+	sql::access_type::JwtAccessVerifyJwks::default()
+);
+test_memory_equality!(
+	sql_RecordAccess,
+	sql::RecordAccess,
+	expr::RecordAccess,
+	sql::RecordAccess::default()
+);
+test_memory_equality!(
+	sql_access_type_BearerAccess,
+	sql::access_type::BearerAccess,
+	expr::access_type::BearerAccess,
+	sql::access_type::BearerAccess::default()
+);
+test_memory_equality!(
+	sql_access_type_BearerAccessType,
+	sql::access_type::BearerAccessType,
+	expr::access_type::BearerAccessType,
+	sql::access_type::BearerAccessType::Bearer
+);
+test_memory_equality!(
+	sql_access_type_BearerAccessSubject,
+	sql::access_type::BearerAccessSubject,
+	expr::access_type::BearerAccessSubject,
+	sql::access_type::BearerAccessSubject::Record
+);
+test_memory_equality!(
+	sql_access_AccessDuration,
+	sql::access::AccessDuration,
+	expr::access::AccessDuration,
+	sql::access::AccessDuration::default()
+);
+test_memory_equality!(sql_Algorithm, sql::Algorithm, expr::Algorithm, sql::Algorithm::default());
+test_memory_equality!(sql_Array, sql::Array, expr::Array, sql::Array::default());
+test_memory_equality!(sql_Base, sql::Base, expr::Base, sql::Base::default());
+test_memory_equality!(sql_Block, sql::Block, expr::Block, sql::Block::default());
+test_memory_equality!(
+	sql_Entry,
+	sql::Entry,
+	expr::Entry,
+	sql::Entry::Value(sql::SqlValue::default())
+);
+test_memory_equality!(sql_Bytes, sql::Bytes, expr::Bytes, sql::Bytes::default());
+test_memory_equality!(
+	sql_Cast,
+	sql::Cast,
+	expr::Cast,
+	sql::Cast(sql::Kind::default(), sql::SqlValue::default())
+);
+test_memory_equality!(
+	sql_ChangeFeed,
+	sql::ChangeFeed,
+	expr::ChangeFeed,
+	sql::ChangeFeed::default()
+);
+test_memory_equality!(
+	sql_Closure,
+	sql::Closure,
+	expr::Closure,
+	sql::Closure {
+		args: vec![(sql::Ident::default(), sql::Kind::default())],
+		returns: Some(sql::Kind::default()),
+		body: sql::SqlValue::default(),
+	}
+);
+test_memory_equality!(sql_Cond, sql::Cond, expr::Cond, sql::Cond::default());
+test_memory_equality!(sql_Constant, sql::Constant, expr::Constant, sql::Constant::MathE);
+test_memory_equality!(sql_Data, sql::Data, expr::Data, sql::Data::default());
+test_memory_equality!(sql_Datetime, sql::Datetime, expr::Datetime, sql::Datetime::default());
+test_memory_equality!(sql_Dir, sql::Dir, expr::Dir, sql::Dir::default());
+test_memory_equality!(sql_Duration, sql::Duration, expr::Duration, sql::Duration::default());
+test_memory_equality!(
+	sql_Edges,
+	sql::Edges,
+	expr::Edges,
+	sql::Edges {
+		dir: sql::Dir::default(),
+		from: sql::Thing {
+			tb: "table".to_string(),
+			id: sql::Id::Number(1),
+		},
+		what: sql::graph::GraphSubjects::default(),
+	}
+);
+test_memory_equality!(sql_Explain, sql::Explain, expr::Explain, sql::Explain::default());
+test_memory_equality!(
+	sql_Expression,
+	sql::Expression,
+	expr::Expression,
+	sql::Expression::default()
+);
+test_memory_equality!(sql_Fetchs, sql::Fetchs, expr::Fetchs, sql::Fetchs::default());
+test_memory_equality!(sql_Fetch, sql::Fetch, expr::Fetch, sql::Fetch::default());
+test_memory_equality!(
+	sql_field_Fields,
+	sql::field::Fields,
+	expr::field::Fields,
+	sql::field::Fields::default()
+);
+test_memory_equality!(
+	sql_field_Field,
+	sql::field::Field,
+	expr::field::Field,
+	sql::field::Field::default()
+);
+test_memory_equality!(
+	sql_File,
+	sql::File,
+	expr::File,
+	sql::File {
+		bucket: "bucket".to_string(),
+		key: "key".to_string(),
+	}
+);
+test_memory_equality!(sql_Filter, sql::Filter, expr::Filter, sql::Filter::Ascii);
+test_memory_equality!(
+	sql_Function,
+	sql::Function,
+	expr::Function,
+	sql::Function::Normal("test".to_string(), vec![sql::SqlValue::default()])
+);
+test_memory_equality!(sql_Future, sql::Future, expr::Future, sql::Future(sql::Block::default()));
+test_memory_equality!(
+	sql_Geometry,
+	sql::Geometry,
+	expr::Geometry,
+	sql::Geometry::Point(geo::Point::default())
+);
+test_memory_equality!(sql_Graph, sql::Graph, expr::Graph, sql::Graph::default());
+test_memory_equality!(
+	sql_graph_GraphSubjects,
+	sql::graph::GraphSubjects,
+	expr::graph::GraphSubjects,
+	sql::graph::GraphSubjects::default()
+);
+test_memory_equality!(
+	sql_graph_GraphSubject,
+	sql::graph::GraphSubject,
+	expr::graph::GraphSubject,
+	sql::graph::GraphSubject::Table(sql::Table::default())
+);
+test_memory_equality!(sql_Groups, sql::Groups, expr::Groups, sql::Groups::default());
+test_memory_equality!(sql_Group, sql::Group, expr::Group, sql::Group::default());
+test_memory_equality!(sql_Ident, sql::Ident, expr::Ident, sql::Ident::default());
+test_memory_equality!(sql_Idioms, sql::Idioms, expr::Idioms, sql::Idioms::default());
+test_memory_equality!(sql_Idiom, sql::Idiom, expr::Idiom, sql::Idiom::default());
+test_memory_equality!(
+	sql_index_Index,
+	sql::index::Index,
+	expr::index::Index,
+	sql::index::Index::default()
+);
+test_memory_equality!(
+	sql_index_SearchParams,
+	sql::index::SearchParams,
+	expr::index::SearchParams,
+	sql::index::SearchParams {
+		az: sql::Ident::default(),
+		hl: true,
+		sc: sql::scoring::Scoring::default(),
+		doc_ids_order: 0,
+		doc_lengths_order: 1,
+		postings_order: 2,
+		terms_order: 3,
+		doc_ids_cache: 4,
+		doc_lengths_cache: 5,
+		postings_cache: 6,
+		terms_cache: 7,
+	}
+);
+test_memory_equality!(
+	sql_index_MTreeParams,
+	sql::index::MTreeParams,
+	expr::index::MTreeParams,
+	sql::index::MTreeParams {
+		dimension: 0,
+		distance: sql::index::Distance::default(),
+		vector_type: sql::index::VectorType::default(),
+		capacity: 1,
+		doc_ids_order: 2,
+		doc_ids_cache: 3,
+		mtree_cache: 4,
+	}
+);
+test_memory_equality!(
+	sql_index_HnswParams,
+	sql::index::HnswParams,
+	expr::index::HnswParams,
+	sql::index::HnswParams {
+		dimension: 0,
+		distance: sql::index::Distance::default(),
+		vector_type: sql::index::VectorType::default(),
+		m: 1,
+		m0: 2,
+		ef_construction: 3,
+		extend_candidates: true,
+		keep_pruned_connections: false,
+		ml: sql::Number::default(),
+	}
+);
+test_memory_equality!(
+	sql_index_Distance,
+	sql::index::Distance,
+	expr::index::Distance,
+	sql::index::Distance::default()
+);
+test_memory_equality!(
+	sql_index_VectorType,
+	sql::index::VectorType,
+	expr::index::VectorType,
+	sql::index::VectorType::default()
+);
+test_memory_equality!(sql_Kind, sql::Kind, expr::Kind, sql::Kind::default());
+test_memory_equality!(
+	sql_Literal,
+	sql::Literal,
+	expr::Literal,
+	sql::Literal::Number(sql::Number::default())
+);
+test_memory_equality!(
+	sql_language_Language,
+	sql::language::Language,
+	expr::language::Language,
+	sql::language::Language::English
+);
+test_memory_equality!(sql_Limit, sql::Limit, expr::Limit, sql::Limit::default());
+test_memory_equality!(sql_Mock, sql::Mock, expr::Mock, sql::Mock::Count("test".to_string(), 1));
+test_memory_equality!(sql_Model, sql::Model, expr::Model, sql::Model::default());
+test_memory_equality!(sql_Number, sql::Number, expr::Number, sql::Number::default());
+test_memory_equality!(sql_Object, sql::Object, expr::Object, sql::Object::default());
+test_memory_equality!(sql_Operator, sql::Operator, expr::Operator, sql::Operator::default());
+test_memory_equality!(
+	sql_order_Ordering,
+	sql::order::Ordering,
+	expr::order::Ordering,
+	sql::order::Ordering::Random
+);
+test_memory_equality!(
+	sql_order_OrderList,
+	sql::order::OrderList,
+	expr::order::OrderList,
+	sql::order::OrderList::default()
+);
+test_memory_equality!(
+	sql_order_Order,
+	sql::order::Order,
+	expr::order::Order,
+	sql::order::Order::default()
+);
+test_memory_equality!(sql_Output, sql::Output, expr::Output, sql::Output::default());
+test_memory_equality!(sql_Param, sql::Param, expr::Param, sql::Param::default());
+test_memory_equality!(sql_Part, sql::Part, expr::Part, sql::Part::All);
+test_memory_equality!(
+	sql_part_DestructurePart,
+	sql::part::DestructurePart,
+	expr::part::DestructurePart,
+	sql::part::DestructurePart::All(sql::Ident::default())
+);
+test_memory_equality!(
+	sql_part_Recurse,
+	sql::part::Recurse,
+	expr::part::Recurse,
+	sql::part::Recurse::Fixed(5)
+);
+test_memory_equality!(
+	sql_part_RecurseInstruction,
+	sql::part::RecurseInstruction,
+	expr::part::RecurseInstruction,
+	sql::part::RecurseInstruction::Path {
+		inclusive: true
+	}
+);
+test_memory_equality!(
+	sql_Permissions,
+	sql::Permissions,
+	expr::Permissions,
+	sql::Permissions::default()
+);
+test_memory_equality!(
+	sql_Permission,
+	sql::Permission,
+	expr::Permission,
+	sql::Permission::default()
+);
+test_memory_equality!(sql_Query, sql::Query, expr::Query, sql::Query::default());
+test_memory_equality!(
+	sql_Range,
+	sql::Range,
+	expr::Range,
+	sql::Range {
+		beg: Bound::Included(1.into()),
+		end: Bound::Excluded(2.into())
+	}
+);
+test_memory_equality!(
+	sql_reference_Reference,
+	sql::reference::Reference,
+	expr::reference::Reference,
+	sql::reference::Reference {
+		on_delete: sql::reference::ReferenceDeleteStrategy::Reject,
+	}
+);
+test_memory_equality!(
+	sql_reference_ReferenceDeleteStrategy,
+	sql::reference::ReferenceDeleteStrategy,
+	expr::reference::ReferenceDeleteStrategy,
+	sql::reference::ReferenceDeleteStrategy::Unset
+);
+test_memory_equality!(
+	sql_reference_Refs,
+	sql::reference::Refs,
+	expr::reference::Refs,
+	sql::reference::Refs(vec![(Some(sql::Table::default()), Some(sql::Idiom::default()))])
+);
+test_memory_equality!(
+	sql_Regex,
+	sql::Regex,
+	expr::Regex,
+	sql::Regex(regex::Regex::new("test").unwrap())
+);
+test_memory_equality!(sql_Scoring, sql::Scoring, expr::Scoring, sql::Scoring::default());
+test_memory_equality!(sql_Script, sql::Script, expr::Script, sql::Script::default());
+test_memory_equality!(sql_Splits, sql::Splits, expr::Splits, sql::Splits::default());
+test_memory_equality!(sql_Split, sql::Split, expr::Split, sql::Split::default());
+test_memory_equality!(sql_Start, sql::Start, expr::Start, sql::Start::default());
+test_memory_equality!(
+	sql_Statements,
+	sql::Statements,
+	expr::LogicalPlans,
+	sql::Statements::default()
+);
+test_memory_equality!(
+	sql_Statement,
+	sql::Statement,
+	expr::LogicalPlan,
+	sql::Statement::Value(sql::SqlValue::default())
+);
+test_memory_equality!(sql_Strand, sql::Strand, expr::Strand, sql::Strand::default());
+test_memory_equality!(
+	sql_Subquery,
+	sql::Subquery,
+	expr::Subquery,
+	sql::Subquery::Value(sql::SqlValue::default())
+);
+test_memory_equality!(sql_TableType, sql::TableType, expr::TableType, sql::TableType::default());
+test_memory_equality!(sql_Relation, sql::Relation, expr::Relation, sql::Relation::default());
+test_memory_equality!(sql_Tables, sql::Tables, expr::Tables, sql::Tables::default());
+test_memory_equality!(sql_Table, sql::Table, expr::Table, sql::Table::default());
+test_memory_equality!(
+	sql_Thing,
+	sql::Thing,
+	expr::Thing,
+	sql::Thing {
+		tb: "table".to_string(),
+		id: sql::Id::Number(1),
+	}
+);
+test_memory_equality!(sql_Timeout, sql::Timeout, expr::Timeout, sql::Timeout::default());
+test_memory_equality!(sql_Tokenizer, sql::Tokenizer, expr::Tokenizer, sql::Tokenizer::Class);
+test_memory_equality!(
+	sql_user_UserDuration,
+	sql::user::UserDuration,
+	expr::user::UserDuration,
+	sql::user::UserDuration::default()
+);
+test_memory_equality!(sql_Uuid, sql::Uuid, expr::Uuid, sql::Uuid::default());
+test_memory_equality!(sql_Version, sql::Version, expr::Version, sql::Version::default());
+test_memory_equality!(sql_View, sql::View, expr::View, sql::View::default());
+test_memory_equality!(sql_With, sql::With, expr::With, sql::With::NoIndex);

--- a/crates/core/src/rpc/method.rs
+++ b/crates/core/src/rpc/method.rs
@@ -82,9 +82,7 @@ impl Method {
 			_ => Self::Unknown,
 		}
 	}
-}
 
-impl Method {
 	pub fn to_str(&self) -> &str {
 		match self {
 			Self::Unknown => "unknown",
@@ -116,17 +114,15 @@ impl Method {
 			Self::InsertRelation => "insert_relation",
 		}
 	}
+
+	/// Checks if the provided method is a valid and supported RPC method
+	pub fn is_valid(&self) -> bool {
+		!matches!(self, Self::Unknown)
+	}
 }
 
 impl std::fmt::Display for Method {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		write!(f, "{}", self.to_str())
-	}
-}
-
-impl Method {
-	/// Checks if the provided method is a valid and supported RPC method
-	pub fn is_valid(&self) -> bool {
-		!matches!(self, Self::Unknown)
 	}
 }

--- a/crates/core/src/sql/access_type.rs
+++ b/crates/core/src/sql/access_type.rs
@@ -329,7 +329,7 @@ impl From<crate::expr::access_type::JwtAccessVerifyKey> for JwtAccessVerifyKey {
 }
 
 #[revisioned(revision = 1)]
-#[derive(Debug, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
+#[derive(Debug, Default, Serialize, Deserialize, Hash, Clone, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct JwtAccessVerifyJwks {
 	pub url: String,

--- a/crates/core/src/sql/array.rs
+++ b/crates/core/src/sql/array.rs
@@ -97,9 +97,7 @@ impl Array {
 	pub fn is_empty(&self) -> bool {
 		self.0.is_empty()
 	}
-}
 
-impl Array {
 	/// Checks whether all array values are static values
 	pub(crate) fn is_static(&self) -> bool {
 		self.iter().all(SqlValue::is_static)

--- a/crates/core/src/sql/base.rs
+++ b/crates/core/src/sql/base.rs
@@ -4,21 +4,16 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[revisioned(revision = 1)]
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Base {
+	#[default]
 	Root,
 	Ns,
 	Db,
 	// TODO(gguillemas): This variant is kept in 2.0.0 for backward compatibility. Drop in 3.0.0.
 	Sc(Ident),
-}
-
-impl Default for Base {
-	fn default() -> Self {
-		Self::Root
-	}
 }
 
 impl fmt::Display for Base {

--- a/crates/core/src/sql/cast.rs
+++ b/crates/core/src/sql/cast.rs
@@ -25,9 +25,7 @@ impl Cast {
 	pub fn to_idiom(&self) -> Idiom {
 		self.1.to_idiom()
 	}
-}
 
-impl Cast {
 	/// Checks whether all array values are static values
 	pub(crate) fn is_static(&self) -> bool {
 		self.1.is_static()

--- a/crates/core/src/sql/datetime.rs
+++ b/crates/core/src/sql/datetime.rs
@@ -24,6 +24,26 @@ pub struct Datetime(pub DateTime<Utc>);
 impl Datetime {
 	pub const MIN_UTC: Self = Datetime(DateTime::<Utc>::MIN_UTC);
 	pub const MAX_UTC: Self = Datetime(DateTime::<Utc>::MAX_UTC);
+
+	/// Convert the Datetime to a raw String
+	pub fn to_raw(&self) -> String {
+		self.0.to_rfc3339_opts(SecondsFormat::AutoSi, true)
+	}
+
+	/// Convert to nanosecond timestamp.
+	pub fn to_u64(&self) -> Option<u64> {
+		self.0.timestamp_nanos_opt().map(|v| v as u64)
+	}
+
+	/// Convert to nanosecond timestamp.
+	pub fn to_i64(&self) -> Option<i64> {
+		self.0.timestamp_nanos_opt()
+	}
+
+	/// Convert to second timestamp.
+	pub fn to_secs(&self) -> i64 {
+		self.0.timestamp()
+	}
 }
 
 impl Default for Datetime {
@@ -101,28 +121,6 @@ impl Deref for Datetime {
 	type Target = DateTime<Utc>;
 	fn deref(&self) -> &Self::Target {
 		&self.0
-	}
-}
-
-impl Datetime {
-	/// Convert the Datetime to a raw String
-	pub fn to_raw(&self) -> String {
-		self.0.to_rfc3339_opts(SecondsFormat::AutoSi, true)
-	}
-
-	/// Convert to nanosecond timestamp.
-	pub fn to_u64(&self) -> Option<u64> {
-		self.0.timestamp_nanos_opt().map(|v| v as u64)
-	}
-
-	/// Convert to nanosecond timestamp.
-	pub fn to_i64(&self) -> Option<i64> {
-		self.0.timestamp_nanos_opt()
-	}
-
-	/// Convert to second timestamp.
-	pub fn to_secs(&self) -> i64 {
-		self.0.timestamp()
 	}
 }
 

--- a/crates/core/src/sql/duration.rs
+++ b/crates/core/src/sql/duration.rs
@@ -36,77 +36,7 @@ pub struct Duration(pub time::Duration);
 
 impl Duration {
 	pub const MAX: Duration = Duration(time::Duration::MAX);
-}
 
-impl From<time::Duration> for Duration {
-	fn from(v: time::Duration) -> Self {
-		Self(v)
-	}
-}
-
-impl From<Duration> for time::Duration {
-	fn from(s: Duration) -> Self {
-		s.0
-	}
-}
-
-impl From<time::Duration> for SqlValue {
-	fn from(value: time::Duration) -> Self {
-		Self::Duration(value.into())
-	}
-}
-
-impl FromStr for Duration {
-	type Err = ();
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		Self::try_from(s)
-	}
-}
-
-impl TryFrom<String> for Duration {
-	type Error = ();
-	fn try_from(v: String) -> Result<Self, Self::Error> {
-		Self::try_from(v.as_str())
-	}
-}
-
-impl TryFrom<Strand> for Duration {
-	type Error = ();
-	fn try_from(v: Strand) -> Result<Self, Self::Error> {
-		Self::try_from(v.as_str())
-	}
-}
-
-impl TryFrom<&str> for Duration {
-	type Error = ();
-	fn try_from(v: &str) -> Result<Self, Self::Error> {
-		match syn::duration(v) {
-			Ok(v) => Ok(v),
-			_ => Err(()),
-		}
-	}
-}
-
-impl From<Duration> for crate::expr::Duration {
-	fn from(v: Duration) -> Self {
-		crate::expr::Duration(v.0)
-	}
-}
-
-impl From<crate::expr::Duration> for Duration {
-	fn from(v: crate::expr::Duration) -> Self {
-		Self(v.0)
-	}
-}
-
-impl Deref for Duration {
-	type Target = time::Duration;
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
-}
-
-impl Duration {
 	/// Create a duration from both seconds and nanoseconds components
 	pub fn new(secs: u64, nanos: u32) -> Duration {
 		time::Duration::new(secs, nanos).into()
@@ -182,6 +112,74 @@ impl Duration {
 	/// Create a duration from weeks
 	pub fn from_weeks(weeks: u64) -> Option<Duration> {
 		weeks.checked_mul(SECONDS_PER_WEEK).map(time::Duration::from_secs).map(|x| x.into())
+	}
+}
+
+impl From<time::Duration> for Duration {
+	fn from(v: time::Duration) -> Self {
+		Self(v)
+	}
+}
+
+impl From<Duration> for time::Duration {
+	fn from(s: Duration) -> Self {
+		s.0
+	}
+}
+
+impl From<time::Duration> for SqlValue {
+	fn from(value: time::Duration) -> Self {
+		Self::Duration(value.into())
+	}
+}
+
+impl FromStr for Duration {
+	type Err = ();
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Self::try_from(s)
+	}
+}
+
+impl TryFrom<String> for Duration {
+	type Error = ();
+	fn try_from(v: String) -> Result<Self, Self::Error> {
+		Self::try_from(v.as_str())
+	}
+}
+
+impl TryFrom<Strand> for Duration {
+	type Error = ();
+	fn try_from(v: Strand) -> Result<Self, Self::Error> {
+		Self::try_from(v.as_str())
+	}
+}
+
+impl TryFrom<&str> for Duration {
+	type Error = ();
+	fn try_from(v: &str) -> Result<Self, Self::Error> {
+		match syn::duration(v) {
+			Ok(v) => Ok(v),
+			_ => Err(()),
+		}
+	}
+}
+
+impl From<Duration> for crate::expr::Duration {
+	fn from(v: Duration) -> Self {
+		crate::expr::Duration(v.0)
+	}
+}
+
+impl From<crate::expr::Duration> for Duration {
+	fn from(v: crate::expr::Duration) -> Self {
+		Self(v.0)
+	}
+}
+
+impl Deref for Duration {
+	type Target = time::Duration;
+	fn deref(&self) -> &Self::Target {
+		&self.0
 	}
 }
 

--- a/crates/core/src/sql/expression.rs
+++ b/crates/core/src/sql/expression.rs
@@ -46,9 +46,7 @@ impl Expression {
 			r,
 		}
 	}
-}
 
-impl Expression {
 	/// Checks whether all expression parts are static values
 	pub(crate) fn is_static(&self) -> bool {
 		match self {

--- a/crates/core/src/sql/function.rs
+++ b/crates/core/src/sql/function.rs
@@ -39,50 +39,7 @@ impl Function {
 	) -> Result<Self, revision::Error> {
 		Ok(Function::Anonymous(old.0, old.1, false))
 	}
-}
 
-impl From<Function> for crate::expr::Function {
-	fn from(v: Function) -> Self {
-		match v {
-			Function::Normal(s, e) => Self::Normal(s, e.into_iter().map(Into::into).collect()),
-			Function::Custom(s, e) => Self::Custom(s, e.into_iter().map(Into::into).collect()),
-			Function::Script(s, e) => {
-				Self::Script(s.into(), e.into_iter().map(Into::into).collect())
-			}
-			Function::Anonymous(p, e, b) => {
-				Self::Anonymous(p.into(), e.into_iter().map(Into::into).collect(), b)
-			}
-		}
-	}
-}
-
-impl From<crate::expr::Function> for Function {
-	fn from(v: crate::expr::Function) -> Self {
-		match v {
-			crate::expr::Function::Normal(s, e) => {
-				Self::Normal(s, e.into_iter().map(Into::into).collect())
-			}
-			crate::expr::Function::Custom(s, e) => {
-				Self::Custom(s, e.into_iter().map(Into::into).collect())
-			}
-			crate::expr::Function::Script(s, e) => {
-				Self::Script(s.into(), e.into_iter().map(Into::into).collect())
-			}
-			crate::expr::Function::Anonymous(p, e, b) => {
-				Self::Anonymous(p.into(), e.into_iter().map(Into::into).collect(), b)
-			}
-		}
-	}
-}
-
-impl PartialOrd for Function {
-	#[inline]
-	fn partial_cmp(&self, _: &Self) -> Option<Ordering> {
-		None
-	}
-}
-
-impl Function {
 	/// Get function name if applicable
 	pub fn name(&self) -> Option<&str> {
 		match self {
@@ -191,6 +148,47 @@ impl Function {
 			Self::Normal(f, _) if f == "time::min" => true,
 			_ => false,
 		}
+	}
+}
+
+impl From<Function> for crate::expr::Function {
+	fn from(v: Function) -> Self {
+		match v {
+			Function::Normal(s, e) => Self::Normal(s, e.into_iter().map(Into::into).collect()),
+			Function::Custom(s, e) => Self::Custom(s, e.into_iter().map(Into::into).collect()),
+			Function::Script(s, e) => {
+				Self::Script(s.into(), e.into_iter().map(Into::into).collect())
+			}
+			Function::Anonymous(p, e, b) => {
+				Self::Anonymous(p.into(), e.into_iter().map(Into::into).collect(), b)
+			}
+		}
+	}
+}
+
+impl From<crate::expr::Function> for Function {
+	fn from(v: crate::expr::Function) -> Self {
+		match v {
+			crate::expr::Function::Normal(s, e) => {
+				Self::Normal(s, e.into_iter().map(Into::into).collect())
+			}
+			crate::expr::Function::Custom(s, e) => {
+				Self::Custom(s, e.into_iter().map(Into::into).collect())
+			}
+			crate::expr::Function::Script(s, e) => {
+				Self::Script(s.into(), e.into_iter().map(Into::into).collect())
+			}
+			crate::expr::Function::Anonymous(p, e, b) => {
+				Self::Anonymous(p.into(), e.into_iter().map(Into::into).collect(), b)
+			}
+		}
+	}
+}
+
+impl PartialOrd for Function {
+	#[inline]
+	fn partial_cmp(&self, _: &Self) -> Option<Ordering> {
+		None
 	}
 }
 

--- a/crates/core/src/sql/geometry.rs
+++ b/crates/core/src/sql/geometry.rs
@@ -259,6 +259,119 @@ impl Geometry {
 		};
 		Some(Point::from(((*a).try_into().ok()?, (*b).try_into().ok()?)))
 	}
+
+	// -----------------------------------
+	// Value operations
+	// -----------------------------------
+
+	pub fn contains(&self, other: &Self) -> bool {
+		match self {
+			Self::Point(v) => match other {
+				Self::Point(w) => v.contains(w),
+				Self::MultiPoint(w) => w.iter().all(|x| v.contains(x)),
+				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
+				_ => false,
+			},
+			Self::Line(v) => match other {
+				Self::Point(w) => v.contains(w),
+				Self::Line(w) => v.contains(w),
+				Self::MultiLine(w) => w.iter().all(|x| w.contains(x)),
+				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
+				_ => false,
+			},
+			Self::Polygon(v) => match other {
+				Self::Point(w) => v.contains(w),
+				Self::Line(w) => v.contains(w),
+				Self::Polygon(w) => v.contains(w),
+				Self::MultiPolygon(w) => w.iter().all(|x| w.contains(x)),
+				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
+				_ => false,
+			},
+			Self::MultiPoint(v) => match other {
+				Self::Point(w) => v.contains(w),
+				Self::MultiPoint(w) => w.iter().all(|x| w.contains(x)),
+				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
+				_ => false,
+			},
+			Self::MultiLine(v) => match other {
+				Self::Point(w) => v.contains(w),
+				Self::Line(w) => v.contains(w),
+				Self::MultiLine(w) => w.iter().all(|x| w.contains(x)),
+				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
+				_ => false,
+			},
+			Self::MultiPolygon(v) => match other {
+				Self::Point(w) => v.contains(w),
+				Self::Line(w) => v.contains(w),
+				Self::Polygon(w) => v.contains(w),
+				Self::MultiPoint(w) => v.contains(w),
+				Self::MultiLine(w) => v.contains(w),
+				Self::MultiPolygon(w) => v.contains(w),
+				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
+			},
+			Self::Collection(v) => v.iter().all(|x| x.contains(other)),
+		}
+	}
+
+	pub fn intersects(&self, other: &Self) -> bool {
+		match self {
+			Self::Point(v) => match other {
+				Self::Point(w) => v.intersects(w),
+				Self::Line(w) => v.intersects(w),
+				Self::Polygon(w) => v.intersects(w),
+				Self::MultiPoint(w) => v.intersects(w),
+				Self::MultiLine(w) => w.iter().any(|x| v.intersects(x)),
+				Self::MultiPolygon(w) => v.intersects(w),
+				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
+			},
+			Self::Line(v) => match other {
+				Self::Point(w) => v.intersects(w),
+				Self::Line(w) => v.intersects(w),
+				Self::Polygon(w) => v.intersects(w),
+				Self::MultiPoint(w) => v.intersects(w),
+				Self::MultiLine(w) => w.iter().any(|x| v.intersects(x)),
+				Self::MultiPolygon(w) => v.intersects(w),
+				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
+			},
+			Self::Polygon(v) => match other {
+				Self::Point(w) => v.intersects(w),
+				Self::Line(w) => v.intersects(w),
+				Self::Polygon(w) => v.intersects(w),
+				Self::MultiPoint(w) => v.intersects(w),
+				Self::MultiLine(w) => v.intersects(w),
+				Self::MultiPolygon(w) => v.intersects(w),
+				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
+			},
+			Self::MultiPoint(v) => match other {
+				Self::Point(w) => v.intersects(w),
+				Self::Line(w) => v.intersects(w),
+				Self::Polygon(w) => v.intersects(w),
+				Self::MultiPoint(w) => v.intersects(w),
+				Self::MultiLine(w) => w.iter().any(|x| v.intersects(x)),
+				Self::MultiPolygon(w) => v.intersects(w),
+				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
+			},
+			Self::MultiLine(v) => match other {
+				Self::Point(w) => v.intersects(w),
+				Self::Line(w) => v.intersects(w),
+				Self::Polygon(w) => v.intersects(w),
+				Self::MultiPoint(w) => v.intersects(w),
+				Self::MultiLine(w) => w.iter().any(|x| v.intersects(x)),
+				Self::MultiPolygon(w) => v.intersects(w),
+				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
+			},
+			Self::MultiPolygon(v) => match other {
+				Self::Point(w) => v.intersects(w),
+				Self::Line(w) => v.intersects(w),
+				Self::Polygon(w) => v.intersects(w),
+				Self::MultiPoint(w) => v.intersects(w),
+				Self::MultiLine(w) => v.intersects(w),
+				Self::MultiPolygon(w) => v.intersects(w),
+				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
+			},
+			Self::Collection(v) => v.iter().all(|x| x.intersects(other)),
+		}
+	}
 }
 
 impl PartialOrd for Geometry {
@@ -476,121 +589,6 @@ impl From<crate::expr::Geometry> for Geometry {
 			crate::expr::Geometry::Collection(v) => {
 				Self::Collection(v.into_iter().map(Into::into).collect())
 			}
-		}
-	}
-}
-
-impl Geometry {
-	// -----------------------------------
-	// Value operations
-	// -----------------------------------
-
-	pub fn contains(&self, other: &Self) -> bool {
-		match self {
-			Self::Point(v) => match other {
-				Self::Point(w) => v.contains(w),
-				Self::MultiPoint(w) => w.iter().all(|x| v.contains(x)),
-				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
-				_ => false,
-			},
-			Self::Line(v) => match other {
-				Self::Point(w) => v.contains(w),
-				Self::Line(w) => v.contains(w),
-				Self::MultiLine(w) => w.iter().all(|x| w.contains(x)),
-				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
-				_ => false,
-			},
-			Self::Polygon(v) => match other {
-				Self::Point(w) => v.contains(w),
-				Self::Line(w) => v.contains(w),
-				Self::Polygon(w) => v.contains(w),
-				Self::MultiPolygon(w) => w.iter().all(|x| w.contains(x)),
-				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
-				_ => false,
-			},
-			Self::MultiPoint(v) => match other {
-				Self::Point(w) => v.contains(w),
-				Self::MultiPoint(w) => w.iter().all(|x| w.contains(x)),
-				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
-				_ => false,
-			},
-			Self::MultiLine(v) => match other {
-				Self::Point(w) => v.contains(w),
-				Self::Line(w) => v.contains(w),
-				Self::MultiLine(w) => w.iter().all(|x| w.contains(x)),
-				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
-				_ => false,
-			},
-			Self::MultiPolygon(v) => match other {
-				Self::Point(w) => v.contains(w),
-				Self::Line(w) => v.contains(w),
-				Self::Polygon(w) => v.contains(w),
-				Self::MultiPoint(w) => v.contains(w),
-				Self::MultiLine(w) => v.contains(w),
-				Self::MultiPolygon(w) => v.contains(w),
-				Self::Collection(w) => w.iter().all(|x| self.contains(x)),
-			},
-			Self::Collection(v) => v.iter().all(|x| x.contains(other)),
-		}
-	}
-
-	pub fn intersects(&self, other: &Self) -> bool {
-		match self {
-			Self::Point(v) => match other {
-				Self::Point(w) => v.intersects(w),
-				Self::Line(w) => v.intersects(w),
-				Self::Polygon(w) => v.intersects(w),
-				Self::MultiPoint(w) => v.intersects(w),
-				Self::MultiLine(w) => w.iter().any(|x| v.intersects(x)),
-				Self::MultiPolygon(w) => v.intersects(w),
-				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
-			},
-			Self::Line(v) => match other {
-				Self::Point(w) => v.intersects(w),
-				Self::Line(w) => v.intersects(w),
-				Self::Polygon(w) => v.intersects(w),
-				Self::MultiPoint(w) => v.intersects(w),
-				Self::MultiLine(w) => w.iter().any(|x| v.intersects(x)),
-				Self::MultiPolygon(w) => v.intersects(w),
-				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
-			},
-			Self::Polygon(v) => match other {
-				Self::Point(w) => v.intersects(w),
-				Self::Line(w) => v.intersects(w),
-				Self::Polygon(w) => v.intersects(w),
-				Self::MultiPoint(w) => v.intersects(w),
-				Self::MultiLine(w) => v.intersects(w),
-				Self::MultiPolygon(w) => v.intersects(w),
-				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
-			},
-			Self::MultiPoint(v) => match other {
-				Self::Point(w) => v.intersects(w),
-				Self::Line(w) => v.intersects(w),
-				Self::Polygon(w) => v.intersects(w),
-				Self::MultiPoint(w) => v.intersects(w),
-				Self::MultiLine(w) => w.iter().any(|x| v.intersects(x)),
-				Self::MultiPolygon(w) => v.intersects(w),
-				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
-			},
-			Self::MultiLine(v) => match other {
-				Self::Point(w) => v.intersects(w),
-				Self::Line(w) => v.intersects(w),
-				Self::Polygon(w) => v.intersects(w),
-				Self::MultiPoint(w) => v.intersects(w),
-				Self::MultiLine(w) => w.iter().any(|x| v.intersects(x)),
-				Self::MultiPolygon(w) => v.intersects(w),
-				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
-			},
-			Self::MultiPolygon(v) => match other {
-				Self::Point(w) => v.intersects(w),
-				Self::Line(w) => v.intersects(w),
-				Self::Polygon(w) => v.intersects(w),
-				Self::MultiPoint(w) => v.intersects(w),
-				Self::MultiLine(w) => v.intersects(w),
-				Self::MultiPolygon(w) => v.intersects(w),
-				Self::Collection(w) => w.iter().all(|x| self.intersects(x)),
-			},
-			Self::Collection(v) => v.iter().all(|x| x.intersects(other)),
 		}
 	}
 }

--- a/crates/core/src/sql/id/mod.rs
+++ b/crates/core/src/sql/id/mod.rs
@@ -271,5 +271,3 @@ impl Display for Id {
 		}
 	}
 }
-
-impl Id {}

--- a/crates/core/src/sql/object.rs
+++ b/crates/core/src/sql/object.rs
@@ -230,9 +230,7 @@ impl Object {
 			})),
 		}
 	}
-}
 
-impl Object {
 	/// Checks whether all object values are static values
 	pub(crate) fn is_static(&self) -> bool {
 		self.values().all(SqlValue::is_static)

--- a/crates/core/src/sql/range.rs
+++ b/crates/core/src/sql/range.rs
@@ -26,6 +26,28 @@ pub struct Range {
 }
 
 impl Range {
+	/// Construct a new range
+	pub fn new(beg: Bound<SqlValue>, end: Bound<SqlValue>) -> Self {
+		Self {
+			beg,
+			end,
+		}
+	}
+
+	/// Validate that a Range contains only computed Values
+	pub fn validate_computed(&self) -> Result<()> {
+		match &self.beg {
+			Bound::Included(v) | Bound::Excluded(v) => v.validate_computed()?,
+			Bound::Unbounded => {}
+		}
+		match &self.end {
+			Bound::Included(v) | Bound::Excluded(v) => v.validate_computed()?,
+			Bound::Unbounded => {}
+		}
+
+		Ok(())
+	}
+
 	pub fn can_coerce_to_typed<T: Coerce>(&self) -> bool {
 		match self.beg {
 			Bound::Included(ref x) | Bound::Excluded(ref x) => {
@@ -274,30 +296,6 @@ impl FromStr for Range {
 			Ok(v) => Ok(v),
 			_ => Err(()),
 		}
-	}
-}
-
-impl Range {
-	/// Construct a new range
-	pub fn new(beg: Bound<SqlValue>, end: Bound<SqlValue>) -> Self {
-		Self {
-			beg,
-			end,
-		}
-	}
-
-	/// Validate that a Range contains only computed Values
-	pub fn validate_computed(&self) -> Result<()> {
-		match &self.beg {
-			Bound::Included(v) | Bound::Excluded(v) => v.validate_computed()?,
-			Bound::Unbounded => {}
-		}
-		match &self.end {
-			Bound::Included(v) | Bound::Excluded(v) => v.validate_computed()?,
-			Bound::Unbounded => {}
-		}
-
-		Ok(())
 	}
 }
 

--- a/crates/core/src/sql/statements/define/config/graphql.rs
+++ b/crates/core/src/sql/statements/define/config/graphql.rs
@@ -73,7 +73,7 @@ impl From<crate::expr::statements::define::config::graphql::TablesConfig> for Ta
 }
 
 #[revisioned(revision = 1)]
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub struct TableConfig {

--- a/crates/core/src/sql/statements/define/config/mod.rs
+++ b/crates/core/src/sql/statements/define/config/mod.rs
@@ -49,8 +49,6 @@ pub enum ConfigInner {
 	Api(ApiConfig),
 }
 
-impl DefineConfigStatement {}
-
 impl ConfigInner {
 	pub fn name(&self) -> String {
 		ConfigKind::from(self).to_string()

--- a/crates/core/src/sql/statements/define/table.rs
+++ b/crates/core/src/sql/statements/define/table.rs
@@ -54,9 +54,7 @@ impl DefineTableStatement {
 	fn convert_cache_ts(&self, _revision: u16, _value: Uuid) -> Result<(), RevisionError> {
 		Ok(())
 	}
-}
 
-impl DefineTableStatement {
 	/// Checks if this is a TYPE RELATION table
 	pub fn is_relation(&self) -> bool {
 		matches!(self.kind, TableType::Relation(_))

--- a/crates/core/src/sql/strand.rs
+++ b/crates/core/src/sql/strand.rs
@@ -39,6 +39,19 @@ impl Strand {
 		debug_assert!(!s.contains('\0'));
 		Strand(s)
 	}
+
+	/// Get the underlying String slice
+	pub fn as_str(&self) -> &str {
+		self.0.as_str()
+	}
+	/// Returns the underlying String
+	pub fn as_string(self) -> String {
+		self.0
+	}
+	/// Convert the Strand to a raw String
+	pub fn to_raw(self) -> String {
+		self.0
+	}
 }
 
 impl From<String> for Strand {
@@ -77,21 +90,6 @@ impl Deref for Strand {
 impl From<Strand> for String {
 	fn from(s: Strand) -> Self {
 		s.0
-	}
-}
-
-impl Strand {
-	/// Get the underlying String slice
-	pub fn as_str(&self) -> &str {
-		self.0.as_str()
-	}
-	/// Returns the underlying String
-	pub fn as_string(self) -> String {
-		self.0
-	}
-	/// Convert the Strand to a raw String
-	pub fn to_raw(self) -> String {
-		self.0
 	}
 }
 

--- a/crates/core/src/sql/thing.rs
+++ b/crates/core/src/sql/thing.rs
@@ -21,6 +21,21 @@ pub struct Thing {
 	pub id: Id,
 }
 
+impl Thing {
+	/// Convert the Thing to a raw String
+	pub fn to_raw(&self) -> String {
+		self.to_string()
+	}
+	/// Check if this Thing is a range
+	pub fn is_range(&self) -> bool {
+		matches!(self.id, Id::Range(_))
+	}
+	/// Check if this Thing is of a certain table type
+	pub fn is_record_type(&self, types: &[Table]) -> bool {
+		types.is_empty() || types.iter().any(|tb| tb.0 == self.tb)
+	}
+}
+
 impl From<(&str, Id)> for Thing {
 	fn from((tb, id): (&str, Id)) -> Self {
 		Self {
@@ -118,28 +133,11 @@ impl From<crate::expr::Thing> for Thing {
 	}
 }
 
-impl Thing {
-	/// Convert the Thing to a raw String
-	pub fn to_raw(&self) -> String {
-		self.to_string()
-	}
-	/// Check if this Thing is a range
-	pub fn is_range(&self) -> bool {
-		matches!(self.id, Id::Range(_))
-	}
-	/// Check if this Thing is of a certain table type
-	pub fn is_record_type(&self, types: &[Table]) -> bool {
-		types.is_empty() || types.iter().any(|tb| tb.0 == self.tb)
-	}
-}
-
 impl fmt::Display for Thing {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}:{}", EscapeRid(&self.tb), self.id)
 	}
 }
-
-impl Thing {}
 
 #[cfg(test)]
 mod test {

--- a/crates/core/src/sql/value/value.rs
+++ b/crates/core/src/sql/value/value.rs
@@ -172,17 +172,7 @@ impl SqlValue {
 			_ => SqlValue::None,
 		}
 	}
-}
 
-impl Eq for SqlValue {}
-
-impl Ord for SqlValue {
-	fn cmp(&self, other: &Self) -> Ordering {
-		self.partial_cmp(other).unwrap_or(Ordering::Equal)
-	}
-}
-
-impl SqlValue {
 	// -----------------------------------
 	// Initial record value
 	// -----------------------------------
@@ -886,6 +876,14 @@ impl SqlValue {
 			Range(r) => r.validate_computed(),
 			_ => Err(anyhow::Error::new(Error::NonComputed)),
 		}
+	}
+}
+
+impl Eq for SqlValue {}
+
+impl Ord for SqlValue {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.partial_cmp(other).unwrap_or(Ordering::Equal)
 	}
 }
 

--- a/crates/sdk/src/api/value/mod.rs
+++ b/crates/sdk/src/api/value/mod.rs
@@ -370,35 +370,7 @@ impl Value {
 			std::mem::transmute::<&mut Vec<Value>, &mut Vec<CoreValue>>(v)
 		}
 	}
-}
 
-impl Index<usize> for Value {
-	type Output = Self;
-
-	fn index(&self, index: usize) -> &Self::Output {
-		match &self.0 {
-			CoreValue::Array(map) => {
-				map.0.get(index).map(Self::from_inner_ref).unwrap_or(&Value(CoreValue::None))
-			}
-			_ => &Value(CoreValue::None),
-		}
-	}
-}
-
-impl Index<&str> for Value {
-	type Output = Self;
-
-	fn index(&self, index: &str) -> &Self::Output {
-		match &self.0 {
-			CoreValue::Object(map) => {
-				map.0.get(index).map(Self::from_inner_ref).unwrap_or(&Value(CoreValue::None))
-			}
-			_ => &Value(CoreValue::None),
-		}
-	}
-}
-
-impl Value {
 	/// Accesses the value found at a certain field
 	/// if an object, and a certain index if an array.
 	/// Will not err if no value is found at this point,
@@ -424,6 +396,32 @@ impl Value {
 	/// Checks to see if a Value is a Value::None.
 	pub fn is_none(&self) -> bool {
 		matches!(&self, Value(CoreValue::None))
+	}
+}
+
+impl Index<usize> for Value {
+	type Output = Self;
+
+	fn index(&self, index: usize) -> &Self::Output {
+		match &self.0 {
+			CoreValue::Array(map) => {
+				map.0.get(index).map(Self::from_inner_ref).unwrap_or(&Value(CoreValue::None))
+			}
+			_ => &Value(CoreValue::None),
+		}
+	}
+}
+
+impl Index<&str> for Value {
+	type Output = Self;
+
+	fn index(&self, index: &str) -> &Self::Output {
+		match &self.0 {
+			CoreValue::Object(map) => {
+				map.0.get(index).map(Self::from_inner_ref).unwrap_or(&Value(CoreValue::None))
+			}
+			_ => &Value(CoreValue::None),
+		}
 	}
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

`core::sql` and `core::expr` have duplicate struct / revision definitions which must be kept in sync.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR adds tests which assert they're the same.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

I made a test change that should cause a failure:

```diff
--- a/crates/core/src/expr/geometry.rs
+++ b/crates/core/src/expr/geometry.rs
@@ -24,8 +24,8 @@ pub(crate) const TOKEN: &str = "$surrealdb::private::sql::Geometry";
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum Geometry {
-       Point(Point<f64>),
        Line(LineString<f64>),
+       Point(Point<f64>),
        Polygon(Polygon<f64>),
        MultiPoint(MultiPoint<f64>),
        MultiLine(MultiLineString<f64>),
```

```
---- revision_checks::sql_Geometry stdout ----

thread 'revision_checks::sql_Geometry' panicked at crates/core/src/revision_checks.rs:751:1:
assertion `left == right` failed: Serialized bytes do not match
  left: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 right: [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
