### PR TITLE
Fix: Export GraphSubjects and GraphSubject types

### DIFF
--- a/crates/core/src/sql/mod.rs
+++ b/crates/core/src/sql/mod.rs
@@ -113,7 +113,7 @@ pub use self::filter::Filter;
 pub use self::function::Function;
 pub use self::future::Future;
 pub use self::geometry::Geometry;
-pub use self::graph::Graph;
+pub use self::graph::{Graph, GraphSubject, GraphSubjects};
 pub use self::group::Group;
 pub use self::group::Groups;
 pub use self::id::range::IdRange;


### PR DESCRIPTION
Problem
After recent revision changes, the `what` field in `Graph` and `Edges` structs was changed from `Tables` to `GraphSubjects`. However, while `Tables` was publicly exported from `sql/mod.rs`, the new `GraphSubjects` and `GraphSubject` types were not exported, breaking external code that needs to access or match against these types.

## Context
While these types are not part of SurrealDB's stable public API and may change in future versions, they are needed by:
- Query analyzers that need to traverse and analyze AST structures
- Language Server Protocol (LSP) implementations 
- Other external tooling that works with SurrealQL syntax tree

The previous `Tables` type was exported and available for these use cases, so `GraphSubjects` and `GraphSubject` should maintain the same accessibility to avoid breaking existing tooling from adopting the latest versions of surreal.

## Solution
This PR adds `GraphSubjects` and `GraphSubject` to the public exports in `sql/mod.rs` to maintain the same level of accessibility that `Tables` had before the revision changes.

## Changes
- Added `GraphSubjects` and `GraphSubject` to public exports in `crates/core/src/sql/mod.rs`

## Testing
- Verified that the module compiles successfully with `cargo check --package surrealdb-core --lib`
