### PR TITLE
Build workflow least privilege and benchmark workflow tweaks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,6 +19,7 @@ defaults:
 
 env:
   RUST_VERSION: 1.86.0
+  BRANCH_NAME: "${{ github.head_ref || github.ref_name }}"
 
 #
 # The bench jobs will:
@@ -191,10 +192,10 @@ jobs:
 
       - name: Copy results from AWS S3 bucket
         run: |
-          BRANCH_NAME=$(echo ${{ github.head_ref || github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g')
+          CLEAN_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
 
           aws s3 sync s3://${{ secrets.AWS_S3_GITHUB_ACTIONS_BUCKET_NAME }}/bench-results/${{ github.job }}/main/latest bench-results-main || true
-          aws s3 sync s3://${{ secrets.AWS_S3_GITHUB_ACTIONS_BUCKET_NAME }}/bench-results/${{ github.job }}/$BRANCH_NAME/latest bench-results-previous || true
+          aws s3 sync s3://${{ secrets.AWS_S3_GITHUB_ACTIONS_BUCKET_NAME }}/bench-results/${{ github.job }}/$CLEAN_BRANCH_NAME/latest bench-results-previous || true
 
       - name: Compare current benchmark results vs baseline
         run: |
@@ -216,10 +217,10 @@ jobs:
         env:
           BENCH_FEATURES: "${{ matrix.features }}"
         run: |
-          BRANCH_NAME=$(echo ${{ github.head_ref || github.ref_name }} | sed 's/[^a-zA-Z0-9]/-/g')
+          CLEAN_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
 
           cargo make bench-${{ matrix.target }} -- --load-baseline current --save-baseline previous
           critcmp --export previous > bench-results/${{ matrix.target }}.json
 
-          aws s3 sync bench-results s3://${{ secrets.AWS_S3_GITHUB_ACTIONS_BUCKET_NAME }}/bench-results/${{ github.job }}/$BRANCH_NAME/${{ github.run_id }}
-          aws s3 sync bench-results s3://${{ secrets.AWS_S3_GITHUB_ACTIONS_BUCKET_NAME }}/bench-results/${{ github.job }}/$BRANCH_NAME/latest
+          aws s3 sync bench-results s3://${{ secrets.AWS_S3_GITHUB_ACTIONS_BUCKET_NAME }}/bench-results/${{ github.job }}/$CLEAN_BRANCH_NAME/${{ github.run_id }}
+          aws s3 sync bench-results s3://${{ secrets.AWS_S3_GITHUB_ACTIONS_BUCKET_NAME }}/bench-results/${{ github.job }}/$CLEAN_BRANCH_NAME/latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,6 @@ defaults:
 permissions: 
   contents: read
 
-
 jobs:
   docker-builder:
     name: Prepare docker builder

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,10 @@ defaults:
   run:
     shell: bash
 
+permissions: 
+  contents: read
+
+
 jobs:
   docker-builder:
     name: Prepare docker builder


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

In accordance with OSSF Scorecard best practices:
- Reducing action permissions to least privilege
- Sanitising input to benchmark workflow

## What does this change do?

For build workflow, read permissions are granted at the workflow level, with granular write permissions at the job level where required.

Benchmark workflow tweaked to sanitise input. 


## What is your testing strategy?

Successful GH action runs on branch. 
https://github.com/surrealdb/surrealdb/actions/runs/15294669934
https://github.com/surrealdb/surrealdb/actions/runs/15293856709
https://github.com/surrealdb/surrealdb/actions/runs/15293845206

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
