### PR TITLE
Add env var for accessible output

### DIFF
--- a/crates/core/src/cnf/mod.rs
+++ b/crates/core/src/cnf/mod.rs
@@ -129,3 +129,8 @@ pub static GLOBAL_BUCKET: LazyLock<Option<String>> =
 /// Whether to enforce a global bucket for file data (default: false)
 pub static GLOBAL_BUCKET_ENFORCED: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_GLOBAL_BUCKET_ENFORCED", bool, false);
+
+/// Whether to output in a form readable for devices like screen and braile readers
+/// For example, by showing ⟨ and ⟩ as `
+pub static ACCESSIBLE_OUTPUT: LazyLock<bool> =
+	lazy_env_parse!("SURREAL_ACCESSIBLE_OUTPUT", bool, false);

--- a/crates/core/src/dbs/executor.rs
+++ b/crates/core/src/dbs/executor.rs
@@ -824,4 +824,27 @@ mod tests {
 			);
 		}
 	}
+
+	#[tokio::test]
+	async fn check_standard_output() {
+		let ds = Datastore::new("memory").await.unwrap();
+		let stmt = "CREATE ONLY person:6586756757564567457647564567 RETURN VALUE id";
+		let mut res =
+			ds.execute(stmt, &Session::default().with_ns("NS").with_db("DB"), None).await.unwrap();
+		let as_string = res.remove(0).result.unwrap().to_string();
+		assert_eq!(as_string, "person:⟨6586756757564567457647564567⟩".to_string());
+	}
+
+	#[tokio::test]
+	async fn check_accessible_output() {
+		unsafe {
+			std::env::set_var("SURREAL_ACCESSIBLE_OUTPUT", "true");
+		}
+		let ds = Datastore::new("memory").await.unwrap();
+		let stmt = "CREATE ONLY person:6586756757564567457647564567 RETURN VALUE id";
+		let mut res =
+			ds.execute(stmt, &Session::default().with_ns("NS").with_db("DB"), None).await.unwrap();
+		let as_string = res.remove(0).result.unwrap().to_string();
+		assert_eq!(as_string, "person:`6586756757564567457647564567`".to_string());
+	}
 }

--- a/crates/core/src/expr/escape.rs
+++ b/crates/core/src/expr/escape.rs
@@ -94,7 +94,10 @@ impl fmt::Display for EscapeRid<'_> {
 		if s.contains(|x: char| !x.is_ascii_alphanumeric() && x != '_')
 			|| !s.contains(|x: char| !x.is_ascii_digit() && x != '_')
 		{
-			return f.write_fmt(format_args!("⟨{}⟩", Escape::escape_str(s, '⟩')));
+			return match *crate::cnf::ACCESSIBLE_OUTPUT {
+				true => f.write_fmt(format_args!("`{}`", Escape::escape_str(s, '`'))),
+				false => f.write_fmt(format_args!("⟨{}⟩", Escape::escape_str(s, '⟩'))),
+			};
 		}
 
 		f.write_str(s)

--- a/crates/core/src/sql/escape.rs
+++ b/crates/core/src/sql/escape.rs
@@ -94,7 +94,10 @@ impl fmt::Display for EscapeRid<'_> {
 		if s.contains(|x: char| !x.is_ascii_alphanumeric() && x != '_')
 			|| !s.contains(|x: char| !x.is_ascii_digit() && x != '_')
 		{
-			return f.write_fmt(format_args!("⟨{}⟩", Escape::escape_str(s, '⟩')));
+			return match *crate::cnf::ACCESSIBLE_OUTPUT {
+				true => f.write_fmt(format_args!("`{}`", Escape::escape_str(s, '`'))),
+				false => f.write_fmt(format_args!("⟨{}⟩", Escape::escape_str(s, '⟩'))),
+			};
 		}
 
 		f.write_str(s)


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

This issue https://github.com/surrealdb/surrealdb/issues/5490, according to which the mathematical braces can't be read by screen readers or braile displays.

## What does this change do?

It adds an env var called SURREAL_ACCESSIBLE_OUTPUT that can be set to true for those preferring accessible output. For the moment this changes mathematical brackets to backticks, but with the env var in place other requests for accessible output could be accepted quite easily.

## What is your testing strategy?

Added two tests.

## Is this related to any issues?

This one: https://github.com/surrealdb/surrealdb/issues/5490 

According to the user the mathematical braces are the only issue at the moment.

## Does this change need documentation?

Yes, the env var.

## Does this change make any alterations to environment variables or CLI commands?

Yep, adds

* SURREAL_ACCESSIBLE_OUTPUT, default false

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
