### PR TITLE
Deprecate implicit let.

### DIFF
--- a/crates/core/src/syn/parser/stmt/mod.rs
+++ b/crates/core/src/syn/parser/stmt/mod.rs
@@ -12,6 +12,7 @@ use crate::sql::statements::{
 	},
 };
 use crate::sql::{Duration, Fields, Ident, Param};
+use crate::syn::error::bail;
 use crate::syn::lexer::compound;
 use crate::syn::parser::enter_query_recursion;
 use crate::syn::token::{Glued, TokenKind, t};
@@ -217,7 +218,21 @@ impl Parser<'_> {
 			_ => {
 				// TODO: Provide information about keywords.
 				let value = ctx.run(|ctx| self.parse_value_field(ctx)).await?;
-				Ok(Self::refine_stmt_value(value))
+				match &value {
+					SqlValue::Expression(x) => {
+						if let Expression::Binary {
+							l: SqlValue::Param(ref x),
+							o: Operator::Equal,
+							..
+						} = **x
+						{
+							let span = token.span.covers(self.recent_span());
+							bail!("Variable declaration without `let` is deprecated", @span => "replace with `let {x} = ..`")
+						}
+					}
+					_ => {}
+				}
+				Ok(Statement::Value(value))
 			}
 		}
 	}
@@ -312,28 +327,6 @@ impl Parser<'_> {
 				let v = ctx.run(|ctx| self.parse_value_inherit(ctx)).await?;
 				Ok(Self::refine_entry_value(v))
 			}
-		}
-	}
-
-	/// Turns [Param] `=` [Value] into a set statment.
-	fn refine_stmt_value(value: SqlValue) -> Statement {
-		match value {
-			SqlValue::Expression(x) => {
-				if let Expression::Binary {
-					l: SqlValue::Param(x),
-					o: Operator::Equal,
-					r,
-				} = *x
-				{
-					return Statement::Set(crate::sql::statements::SetStatement {
-						name: x.0.0,
-						what: r,
-						kind: None,
-					});
-				}
-				Statement::Value(SqlValue::Expression(x))
-			}
-			_ => Statement::Value(value),
 		}
 	}
 

--- a/crates/language-tests/tests/language/parameters/scoping.surql
+++ b/crates/language-tests/tests/language/parameters/scoping.surql
@@ -17,11 +17,11 @@ value = "1"
 value = "NONE"
 
 */
-$a = 1;
+let $a = 1;
 $a;
 {
-	$a = 2;
-	$b = 3;
+	let $a = 2;
+	let $b = 3;
 	{a: $a, b: $b};
 };
 $a;

--- a/crates/language-tests/tests/language/parameters/set_within_transaction.surql
+++ b/crates/language-tests/tests/language/parameters/set_within_transaction.surql
@@ -21,15 +21,15 @@ value = "2"
 
 */
 
-$a = 0;
-$b = 0;
+let $a = 0;
+let $b = 0;
 
 BEGIN;
-$a = 1;
+let $a = 1;
 COMMIT;
 
 BEGIN;
-$b = 2;
+let $b = 2;
 CANCEL;
 
 $a;

--- a/crates/language-tests/tests/language/statements/define/param/basic.surql
+++ b/crates/language-tests/tests/language/statements/define/param/basic.surql
@@ -17,5 +17,5 @@ value = "2"
 
 DEFINE PARAM $a VALUE 1;
 $a;
-$a = 2;
+let $a = 2;
 $a;

--- a/crates/language-tests/tests/language/statements/define/param/cancel_commit.surql
+++ b/crates/language-tests/tests/language/statements/define/param/cancel_commit.surql
@@ -16,7 +16,7 @@ value = "NONE"
 */
 BEGIN;
 DEFINE PARAM $a VALUE 1;
-$b = $a;
+let $b = $a;
 CANCEL;
 
 $b;

--- a/crates/language-tests/tests/language/statements/define/param/shadowed.surql
+++ b/crates/language-tests/tests/language/statements/define/param/shadowed.surql
@@ -11,6 +11,6 @@ value = "NONE"
 value = "1"
 
 */
-$a = 1;
+let $a = 1;
 DEFINE PARAM $a VALUE 2;
 $a

--- a/crates/language-tests/tests/language/statements/select/random_ordering_samples_uniform.surql
+++ b/crates/language-tests/tests/language/statements/select/random_ordering_samples_uniform.surql
@@ -14,9 +14,9 @@ value = "'OK'"
 
 BEGIN;
 
-$COUNT = 1000;
-$RANGE = 10;
-$SAMPLE = 5;
+let $COUNT = 1000;
+let $RANGE = 10;
+let $SAMPLE = 5;
 
 FOR $i in 0..$RANGE {
     CREATE type::thing("result",$i) CONTENT { count: 0, };

--- a/crates/language-tests/tests/parsing/deprecate/ommited_let.surql
+++ b/crates/language-tests/tests/parsing/deprecate/ommited_let.surql
@@ -1,0 +1,14 @@
+/**
+[test]
+
+[test.results]
+parsing-error = """
+Variable declaration without `let` is deprecated
+  --> [14:1]
+   |
+14 | $a = 1
+   | ^^^^^^ replace with `let $a = ..`
+"""
+
+*/
+$a = 1


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The omission of `LET` on variable declarations has been a source of confusion for developers.
When omitted a variable declarations looks like a assignment, which SurrealQL does not actually have.

## What does this change do?

Deprecates implicit let in variable declaration.

## What is your testing strategy?

Added a test for the new deprecation error and otherwise existing tests should suffice.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
