### PR TITLE
Improve import memory usage

### DIFF
--- a/crates/core/src/dbs/executor.rs
+++ b/crates/core/src/dbs/executor.rs
@@ -560,7 +560,7 @@ impl Executor {
 		qry: Query,
 	) -> Result<Vec<Response>> {
 		let stream = futures::stream::iter(qry.into_iter().map(Ok));
-		Self::execute_stream(kvs, ctx, opt, stream).await
+		Self::execute_stream(kvs, ctx, opt, false, stream).await
 	}
 
 	pub async fn execute_plan(
@@ -592,6 +592,7 @@ impl Executor {
 		kvs: &Datastore,
 		ctx: Context,
 		opt: Options,
+		skip_success_results: bool,
 		stream: S,
 	) -> Result<Vec<Response>>
 	where
@@ -634,11 +635,13 @@ impl Executor {
 
 					let now = Instant::now();
 					let result = this.execute_bare_statement(kvs, stmt).await;
-					this.results.push(Response {
-						time: now.elapsed(),
-						result,
-						query_type,
-					});
+					if !skip_success_results || result.is_err() {
+						this.results.push(Response {
+							time: now.elapsed(),
+							result,
+							query_type,
+						});
+					}
 				}
 			}
 		}

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -892,7 +892,7 @@ impl Datastore {
 			}
 		});
 
-		Executor::execute_stream(self, Arc::new(ctx), opt, stream).await
+		Executor::execute_stream(self, Arc::new(ctx), opt, true, stream).await
 	}
 
 	/// Execute a pre-parsed SQL query


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The fast majority of memory used during an import is just the buffered results of all the queries run.
This memory usage gets worse with larger imports eventually making it impossible to import a sufficiently large query as the results won't fit in memory.

## What does this change do?

Skips storing any successful rust during an import. 

This does have the side effect of imports no longer returning successful results to clients after the import. 
However both the SDK and the CLI ignore these anyway.

Maybe in the future we can stream back results to the client instead of buffering them all and only sending when the import completes.

## What is your testing strategy?

I did a local test with a enlarged version of surreal deal dataset.
Without this change the import required 3 gigs but with this change it was brought down to about 400mb.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] Probably fixes #5720


## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
