### PR TITLE
[Backport 2.3] Add environment variable to lower import memory usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.86
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -905,12 +907,14 @@ jobs:
         env:
           PYTHONPATH: ./src
           SURREALDB_URL: http://localhost:8000
+          SURREALDB_VERSION: ${{ matrix.version }}
 
       - name: Run Python tests (WebSocket)
         run: python -m unittest discover -s tests
         env:
           PYTHONPATH: ./src
           SURREALDB_URL: ws://localhost:8000
+          SURREALDB_VERSION: ${{ matrix.version }}
 
   sdk-php:
     name: PHP SDK tests (${{ matrix.version }})

--- a/crates/core/src/cnf/mod.rs
+++ b/crates/core/src/cnf/mod.rs
@@ -147,3 +147,7 @@ pub static FILE_ALLOWLIST: LazyLock<Vec<PathBuf>> = LazyLock::new(|| {
 		.map(|input| extract_allowed_paths(&input))
 		.unwrap_or_default()
 });
+
+/// Used to limit file access
+pub static SKIP_IMPORT_SUCCESS_RESULTS: LazyLock<bool> =
+	LazyLock::new(|| std::env::var("SURREAL_SKIP_IMPORT_SUCCESS_RESULTS").is_ok());

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -913,8 +913,14 @@ impl Datastore {
 			}
 		});
 
-		Executor::execute_stream(self, Arc::new(ctx), opt, cnf::SKIP_IMPORT_SUCCESS_RESULTS, stream)
-			.await
+		Executor::execute_stream(
+			self,
+			Arc::new(ctx),
+			opt,
+			*cnf::SKIP_IMPORT_SUCCESS_RESULTS,
+			stream,
+		)
+		.await
 	}
 
 	/// Execute a pre-parsed SQL query

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -2,7 +2,6 @@ use super::export;
 use super::tr::Transactor;
 use super::tx::Transaction;
 use super::version::Version;
-use crate::cf;
 use crate::ctx::MutableContext;
 #[cfg(feature = "jwks")]
 use crate::dbs::capabilities::NetTarget;
@@ -28,6 +27,7 @@ use crate::kvs::{LockType, LockType::*, TransactionType, TransactionType::*};
 use crate::sql::{statements::DefineUserStatement, Base, Query, Value};
 use crate::syn;
 use crate::syn::parser::{ParserSettings, StatementStream};
+use crate::{cf, cnf};
 use async_channel::{Receiver, Sender};
 use bytes::{Bytes, BytesMut};
 use futures::{Future, Stream};
@@ -913,7 +913,8 @@ impl Datastore {
 			}
 		});
 
-		Executor::execute_stream(self, Arc::new(ctx), opt, stream).await
+		Executor::execute_stream(self, Arc::new(ctx), opt, cnf::SKIP_IMPORT_SUCCESS_RESULTS, stream)
+			.await
 	}
 
 	/// Execute a pre-parsed SQL query


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport of #6027 with an environment variable to enable.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
