### PR TITLE
Optimize .uniq() with just HashSet

### DIFF
--- a/crates/core/src/expr/array.rs
+++ b/crates/core/src/expr/array.rs
@@ -10,7 +10,7 @@ use anyhow::{Result, ensure};
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter, Write};
 use std::ops;
 use std::ops::Deref;
@@ -437,19 +437,16 @@ pub(crate) trait Uniq<T> {
 }
 
 impl Uniq<Array> for Array {
-	fn uniq(mut self) -> Array {
+	fn uniq(self) -> Array {
 		#[expect(clippy::mutable_key_type)]
-		let mut set: HashSet<&Value> = HashSet::new();
-		let mut to_remove: Vec<usize> = Vec::new();
-		for (i, item) in self.iter().enumerate() {
-			if !set.insert(item) {
-				to_remove.push(i);
+		let mut map: HashMap<&Value, ()> = HashMap::with_capacity(self.len());
+		let mut to_return = Array::with_capacity(self.len());
+		for i in self.iter() {
+			if map.insert(i, ()).is_some() {
+				to_return.push(i.clone());
 			}
 		}
-		for i in to_remove.iter().rev() {
-			self.remove(*i);
-		}
-		self
+		to_return
 	}
 }
 

--- a/crates/core/src/expr/array.rs
+++ b/crates/core/src/expr/array.rs
@@ -10,7 +10,7 @@ use anyhow::{Result, ensure};
 use reblessive::tree::Stk;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt::{self, Display, Formatter, Write};
 use std::ops;
 use std::ops::Deref;
@@ -439,10 +439,10 @@ pub(crate) trait Uniq<T> {
 impl Uniq<Array> for Array {
 	fn uniq(self) -> Array {
 		#[expect(clippy::mutable_key_type)]
-		let mut map: HashMap<&Value, ()> = HashMap::with_capacity(self.len());
+		let mut set = HashSet::with_capacity(self.len());
 		let mut to_return = Array::with_capacity(self.len());
 		for i in self.iter() {
-			if map.insert(i, ()).is_some() {
+			if set.insert(i) {
 				to_return.push(i.clone());
 			}
 		}

--- a/crates/core/src/sql/array.rs
+++ b/crates/core/src/sql/array.rs
@@ -5,7 +5,7 @@ use crate::sql::{
 use anyhow::Result;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt::{self, Display, Formatter, Write};
 use std::ops;
 use std::ops::Deref;
@@ -175,10 +175,10 @@ pub(crate) trait Uniq<T> {
 impl Uniq<Array> for Array {
 	fn uniq(self) -> Array {
 		#[expect(clippy::mutable_key_type)]
-		let mut map: HashMap<&SqlValue, ()> = HashMap::with_capacity(self.len());
+		let mut set = HashSet::with_capacity(self.len());
 		let mut to_return = Array::with_capacity(self.len());
 		for i in self.iter() {
-			if map.insert(i, ()).is_some() {
+			if set.insert(i) {
 				to_return.push(i.clone());
 			}
 		}

--- a/crates/core/src/sql/array.rs
+++ b/crates/core/src/sql/array.rs
@@ -5,7 +5,7 @@ use crate::sql::{
 use anyhow::Result;
 use revision::revisioned;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter, Write};
 use std::ops;
 use std::ops::Deref;
@@ -173,18 +173,15 @@ pub(crate) trait Uniq<T> {
 }
 
 impl Uniq<Array> for Array {
-	fn uniq(mut self) -> Array {
+	fn uniq(self) -> Array {
 		#[expect(clippy::mutable_key_type)]
-		let mut set: HashSet<&SqlValue> = HashSet::new();
-		let mut to_remove: Vec<usize> = Vec::new();
-		for (i, item) in self.iter().enumerate() {
-			if !set.insert(item) {
-				to_remove.push(i);
+		let mut map: HashMap<&SqlValue, ()> = HashMap::with_capacity(self.len());
+		let mut to_return = Array::with_capacity(self.len());
+		for i in self.iter() {
+			if map.insert(i, ()).is_some() {
+				to_return.push(i.clone());
 			}
 		}
-		for i in to_remove.iter().rev() {
-			self.remove(*i);
-		}
-		self
+		to_return
 	}
 }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -217,3 +217,7 @@ harness = false
 [[bench]]
 name = "allocator"
 harness = false
+
+[[bench]]
+name = "other_uniq_implementations"
+harness = false

--- a/crates/sdk/benches/other_uniq_implementations.rs
+++ b/crates/sdk/benches/other_uniq_implementations.rs
@@ -1,0 +1,62 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::{
+	collections::{BTreeMap, HashMap, HashSet},
+	hint::black_box,
+};
+use surrealdb_core::expr::{Array, Number, Value};
+
+fn current_uniq(mut array: Array) -> Array {
+	let mut set: HashSet<&Value> = HashSet::new();
+	let mut to_remove: Vec<usize> = Vec::new();
+	for (i, item) in array.iter().enumerate() {
+		if !set.insert(item) {
+			to_remove.push(i);
+		}
+	}
+	for i in to_remove.iter().rev() {
+		array.remove(*i);
+	}
+	array
+}
+
+// About 30% faster than current_uniq
+fn uniq_hashmap(array: Array) -> Array {
+	let mut map: HashMap<&Value, ()> = HashMap::with_capacity(array.len());
+	let mut to_return = Array::with_capacity(array.len());
+	for i in array.iter() {
+		if map.insert(i, ()).is_some() {
+			to_return.push(i.clone());
+		}
+	}
+	to_return
+}
+
+// Much slower, only included to compare
+fn uniq_btreemap(array: Array) -> Array {
+	let mut map: BTreeMap<&Value, ()> = BTreeMap::new();
+	let mut to_return = Array::with_capacity(array.len());
+	for i in array.iter() {
+		if map.insert(i, ()).is_some() {
+			to_return.push(i.clone());
+		}
+	}
+	to_return
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+	let mut array = Array::new();
+	for i in 0..100000 {
+		array.push(Value::Number(Number::Int(i)));
+		array.push(i.to_string().into());
+	}
+	for i in 100000..0 {
+		array.push(Value::Number(Number::Int(i)));
+		array.push(i.to_string().into());
+	}
+	c.bench_function("current_uniq", |b| b.iter(|| current_uniq(black_box(array.clone()))));
+	c.bench_function("uniq_hashmap", |b| b.iter(|| uniq_hashmap(black_box(array.clone()))));
+	c.bench_function("uniq_btreemap", |b| b.iter(|| uniq_btreemap(black_box(array.clone()))));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/sdk/benches/other_uniq_implementations.rs
+++ b/crates/sdk/benches/other_uniq_implementations.rs
@@ -1,6 +1,6 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::{
-	collections::{BTreeMap, HashMap, HashSet},
+	collections::{BTreeSet, HashSet},
 	hint::black_box,
 };
 use surrealdb_core::expr::{Array, Number, Value};
@@ -20,11 +20,11 @@ fn current_uniq(mut array: Array) -> Array {
 }
 
 // About 30% faster than current_uniq
-fn uniq_hashmap(array: Array) -> Array {
-	let mut map: HashMap<&Value, ()> = HashMap::with_capacity(array.len());
+fn uniq_hashset(array: Array) -> Array {
+	let mut set: HashSet<&Value> = HashSet::with_capacity(array.len());
 	let mut to_return = Array::with_capacity(array.len());
 	for i in array.iter() {
-		if map.insert(i, ()).is_some() {
+		if set.insert(i) {
 			to_return.push(i.clone());
 		}
 	}
@@ -32,11 +32,11 @@ fn uniq_hashmap(array: Array) -> Array {
 }
 
 // Much slower, only included to compare
-fn uniq_btreemap(array: Array) -> Array {
-	let mut map: BTreeMap<&Value, ()> = BTreeMap::new();
+fn uniq_btreeset(array: Array) -> Array {
+	let mut set: BTreeSet<&Value> = BTreeSet::new();
 	let mut to_return = Array::with_capacity(array.len());
 	for i in array.iter() {
-		if map.insert(i, ()).is_some() {
+		if set.insert(i) {
 			to_return.push(i.clone());
 		}
 	}
@@ -54,8 +54,8 @@ fn criterion_benchmark(c: &mut Criterion) {
 		array.push(i.to_string().into());
 	}
 	c.bench_function("current_uniq", |b| b.iter(|| current_uniq(black_box(array.clone()))));
-	c.bench_function("uniq_hashmap", |b| b.iter(|| uniq_hashmap(black_box(array.clone()))));
-	c.bench_function("uniq_btreemap", |b| b.iter(|| uniq_btreemap(black_box(array.clone()))));
+	c.bench_function("uniq_hashset", |b| b.iter(|| uniq_hashset(black_box(array.clone()))));
+	c.bench_function("uniq_btreeset", |b| b.iter(|| uniq_btreeset(black_box(array.clone()))));
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The current implementation of .uniq() seemed like it could be simplified and optimized with just a HashSet instead of also tracking indexes and then using .remove().

## What does this change do?

It checks to see if an item is already present, and if it is not then it pushes it into an array. Then the array is returned with only the unique items.

## What is your testing strategy?

Added a Criterion benchmark (included BTreeSet for comparison to show that it is worse). On my machine `cargo bench --bench other_uniq_implementations` shows this sort of output:

```
current_uniq            time:   [11.999 ms 12.039 ms 12.084 ms]
uniq_hashset            time:   [8.5845 ms 8.6044 ms 8.6261 ms]
uniq_btreeset           time:   [36.850 ms 36.922 ms 36.993 ms]
```

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

- [X] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [X] No changes made to env vars

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
