### PR TITLE
Add count_value function

### DIFF
--- a/crates/core/src/doc/table.rs
+++ b/crates/core/src/doc/table.rs
@@ -401,7 +401,7 @@ impl Document {
 				// Process the field projection
 				match expr {
 					Value::Function(f) if f.is_rolling() => match f.name() {
-						Some("count" | "count_all") => {
+						Some("count" | "count_value") => {
 							let val =
 								f.compute(stk, ctx, opt, Some(fdc.doc)).await.catch_return()?;
 							self.chg(&mut set_ops, &mut del_ops, &fdc.act, idiom, val)?;

--- a/crates/core/src/doc/table.rs
+++ b/crates/core/src/doc/table.rs
@@ -401,7 +401,7 @@ impl Document {
 				// Process the field projection
 				match expr {
 					Value::Function(f) if f.is_rolling() => match f.name() {
-						Some("count") => {
+						Some("count" | "count_all") => {
 							let val =
 								f.compute(stk, ctx, opt, Some(fdc.doc)).await.catch_return()?;
 							self.chg(&mut set_ops, &mut del_ops, &fdc.act, idiom, val)?;

--- a/crates/core/src/expr/function.rs
+++ b/crates/core/src/expr/function.rs
@@ -150,6 +150,7 @@ impl Function {
 	pub fn is_rolling(&self) -> bool {
 		match self {
 			Self::Normal(f, _) if f == "count" => true,
+			Self::Normal(f, _) if f == "count_all" => true,
 			Self::Normal(f, _) if f == "math::max" => true,
 			Self::Normal(f, _) if f == "math::mean" => true,
 			Self::Normal(f, _) if f == "math::min" => true,
@@ -168,6 +169,7 @@ impl Function {
 			Self::Normal(f, _) if f == "array::group" => true,
 			Self::Normal(f, _) if f == "array::last" => true,
 			Self::Normal(f, _) if f == "count" => true,
+			Self::Normal(f, _) if f == "count_all" => true,
 			Self::Normal(f, _) if f == "math::bottom" => true,
 			Self::Normal(f, _) if f == "math::interquartile" => true,
 			Self::Normal(f, _) if f == "math::max" => true,
@@ -192,7 +194,7 @@ impl Function {
 	}
 	pub(crate) fn get_optimised_aggregate(&self) -> OptimisedAggregate {
 		match self {
-			Self::Normal(f, v) if f == "count" => {
+			Self::Normal(f, v) if f == "count" && f == "count_all" => {
 				if v.is_empty() {
 					OptimisedAggregate::Count
 				} else {

--- a/crates/core/src/expr/function.rs
+++ b/crates/core/src/expr/function.rs
@@ -150,7 +150,7 @@ impl Function {
 	pub fn is_rolling(&self) -> bool {
 		match self {
 			Self::Normal(f, _) if f == "count" => true,
-			Self::Normal(f, _) if f == "count_all" => true,
+			Self::Normal(f, _) if f == "count_value" => true,
 			Self::Normal(f, _) if f == "math::max" => true,
 			Self::Normal(f, _) if f == "math::mean" => true,
 			Self::Normal(f, _) if f == "math::min" => true,
@@ -169,7 +169,7 @@ impl Function {
 			Self::Normal(f, _) if f == "array::group" => true,
 			Self::Normal(f, _) if f == "array::last" => true,
 			Self::Normal(f, _) if f == "count" => true,
-			Self::Normal(f, _) if f == "count_all" => true,
+			Self::Normal(f, _) if f == "count_value" => true,
 			Self::Normal(f, _) if f == "math::bottom" => true,
 			Self::Normal(f, _) if f == "math::interquartile" => true,
 			Self::Normal(f, _) if f == "math::max" => true,
@@ -194,7 +194,7 @@ impl Function {
 	}
 	pub(crate) fn get_optimised_aggregate(&self) -> OptimisedAggregate {
 		match self {
-			Self::Normal(f, v) if f == "count" && f == "count_all" => {
+			Self::Normal(f, v) if f == "count" && f == "count_value" => {
 				if v.is_empty() {
 					OptimisedAggregate::Count
 				} else {

--- a/crates/core/src/expr/function.rs
+++ b/crates/core/src/expr/function.rs
@@ -194,7 +194,7 @@ impl Function {
 	}
 	pub(crate) fn get_optimised_aggregate(&self) -> OptimisedAggregate {
 		match self {
-			Self::Normal(f, v) if f == "count" && f == "count_value" => {
+			Self::Normal(f, v) if f == "count" || f == "count_value" => {
 				if v.is_empty() {
 					OptimisedAggregate::Count
 				} else {
@@ -212,7 +212,7 @@ impl Function {
 	}
 
 	pub(crate) fn is_count_all(&self) -> bool {
-		matches!(self, Self::Normal(f, p) if f == "count" && p.is_empty() )
+		matches!(self, Self::Normal(f, p) if (f == "count" || f == "count_value") && p.is_empty() )
 	}
 }
 

--- a/crates/core/src/fnc/count.rs
+++ b/crates/core/src/fnc/count.rs
@@ -9,7 +9,7 @@ pub fn count((Optional(arg),): (Optional<Value>,)) -> Result<Value> {
 			Value::Array(v) => v.iter().filter(|v| v.is_truthy()).count().into(),
 			v => (v.is_truthy() as i64).into(),
 		})
-		.unwrap_or_else(|| 0.into()))
+		.unwrap_or_else(|| 1.into()))
 }
 
 // Counts all values, even if they are not truthy
@@ -19,5 +19,5 @@ pub fn count_value((Optional(arg),): (Optional<Value>,)) -> Result<Value> {
 			Value::Array(v) => v.iter().count().into(),
 			_ => 1.into(),
 		})
-		.unwrap_or_else(|| 0.into()))
+		.unwrap_or_else(|| 1.into()))
 }

--- a/crates/core/src/fnc/count.rs
+++ b/crates/core/src/fnc/count.rs
@@ -2,6 +2,7 @@ use super::args::Optional;
 use crate::expr::value::Value;
 use anyhow::Result;
 
+// Counts all truthy values
 pub fn count((Optional(arg),): (Optional<Value>,)) -> Result<Value> {
 	Ok(arg
 		.map(|val| match val {
@@ -11,7 +12,8 @@ pub fn count((Optional(arg),): (Optional<Value>,)) -> Result<Value> {
 		.unwrap_or_else(|| 0.into()))
 }
 
-pub fn count_all((Optional(arg),): (Optional<Value>,)) -> Result<Value> {
+// Counts all values, even if they are not truthy
+pub fn count_value((Optional(arg),): (Optional<Value>,)) -> Result<Value> {
 	Ok(arg
 		.map(|val| match val {
 			Value::Array(v) => v.iter().count().into(),

--- a/crates/core/src/fnc/count.rs
+++ b/crates/core/src/fnc/count.rs
@@ -8,5 +8,14 @@ pub fn count((Optional(arg),): (Optional<Value>,)) -> Result<Value> {
 			Value::Array(v) => v.iter().filter(|v| v.is_truthy()).count().into(),
 			v => (v.is_truthy() as i64).into(),
 		})
-		.unwrap_or_else(|| 1.into()))
+		.unwrap_or_else(|| 0.into()))
+}
+
+pub fn count_all((Optional(arg),): (Optional<Value>,)) -> Result<Value> {
+	Ok(arg
+		.map(|val| match val {
+			Value::Array(v) => v.iter().count().into(),
+			_ => 1.into(),
+		})
+		.unwrap_or_else(|| 0.into()))
 }

--- a/crates/core/src/fnc/mod.rs
+++ b/crates/core/src/fnc/mod.rs
@@ -197,7 +197,7 @@ pub fn synchronous(
 		"bytes::len" => bytes::len,
 		//
 		"count" => count::count,
-		"count_all" => count::count_all,
+		"count_value" => count::count_value,
 		//
 		"crypto::blake3" => crypto::blake3,
 		"crypto::md5" => crypto::md5,

--- a/crates/core/src/fnc/mod.rs
+++ b/crates/core/src/fnc/mod.rs
@@ -197,6 +197,7 @@ pub fn synchronous(
 		"bytes::len" => bytes::len,
 		//
 		"count" => count::count,
+		"count_all" => count::count_all,
 		//
 		"crypto::blake3" => crypto::blake3,
 		"crypto::md5" => crypto::md5,

--- a/crates/core/src/fnc/script/modules/surrealdb/functions/mod.rs
+++ b/crates/core/src/fnc/script/modules/surrealdb/functions/mod.rs
@@ -41,6 +41,7 @@ impl_module_def!(
 	"array" => (array::Package),
 	"bytes" => (bytes::Package),
 	"count" => run,
+	"count_all" => run,
 	"crypto" => (crypto::Package),
 	"duration" => (duration::Package),
 	"encoding" => (encoding::Package),

--- a/crates/core/src/fnc/script/modules/surrealdb/functions/mod.rs
+++ b/crates/core/src/fnc/script/modules/surrealdb/functions/mod.rs
@@ -41,7 +41,7 @@ impl_module_def!(
 	"array" => (array::Package),
 	"bytes" => (bytes::Package),
 	"count" => run,
-	"count_all" => run,
+	"count_value" => run,
 	"crypto" => (crypto::Package),
 	"duration" => (duration::Package),
 	"encoding" => (encoding::Package),

--- a/crates/core/src/sql/function.rs
+++ b/crates/core/src/sql/function.rs
@@ -152,7 +152,7 @@ impl Function {
 	pub fn is_rolling(&self) -> bool {
 		match self {
 			Self::Normal(f, _) if f == "count" => true,
-			Self::Normal(f, _) if f == "count_all" => true,
+			Self::Normal(f, _) if f == "count_value" => true,
 			Self::Normal(f, _) if f == "math::max" => true,
 			Self::Normal(f, _) if f == "math::mean" => true,
 			Self::Normal(f, _) if f == "math::min" => true,
@@ -171,7 +171,7 @@ impl Function {
 			Self::Normal(f, _) if f == "array::group" => true,
 			Self::Normal(f, _) if f == "array::last" => true,
 			Self::Normal(f, _) if f == "count" => true,
-			Self::Normal(f, _) if f == "count_all" => true,
+			Self::Normal(f, _) if f == "count_value" => true,
 			Self::Normal(f, _) if f == "math::bottom" => true,
 			Self::Normal(f, _) if f == "math::interquartile" => true,
 			Self::Normal(f, _) if f == "math::max" => true,

--- a/crates/core/src/sql/function.rs
+++ b/crates/core/src/sql/function.rs
@@ -152,6 +152,7 @@ impl Function {
 	pub fn is_rolling(&self) -> bool {
 		match self {
 			Self::Normal(f, _) if f == "count" => true,
+			Self::Normal(f, _) if f == "count_all" => true,
 			Self::Normal(f, _) if f == "math::max" => true,
 			Self::Normal(f, _) if f == "math::mean" => true,
 			Self::Normal(f, _) if f == "math::min" => true,
@@ -170,6 +171,7 @@ impl Function {
 			Self::Normal(f, _) if f == "array::group" => true,
 			Self::Normal(f, _) if f == "array::last" => true,
 			Self::Normal(f, _) if f == "count" => true,
+			Self::Normal(f, _) if f == "count_all" => true,
 			Self::Normal(f, _) if f == "math::bottom" => true,
 			Self::Normal(f, _) if f == "math::interquartile" => true,
 			Self::Normal(f, _) if f == "math::max" => true,

--- a/crates/core/src/syn/parser/builtin.rs
+++ b/crates/core/src/syn/parser/builtin.rs
@@ -87,6 +87,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("bytes::len") => PathKind::Function,
 		//
 		UniCase::ascii("count") => PathKind::Function,
+		UniCase::ascii("count_all") => PathKind::Function,
 		//
 		UniCase::ascii("crypto::blake3") => PathKind::Function,
 		UniCase::ascii("crypto::md5") => PathKind::Function,

--- a/crates/core/src/syn/parser/builtin.rs
+++ b/crates/core/src/syn/parser/builtin.rs
@@ -87,7 +87,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("bytes::len") => PathKind::Function,
 		//
 		UniCase::ascii("count") => PathKind::Function,
-		UniCase::ascii("count_all") => PathKind::Function,
+		UniCase::ascii("count_value") => PathKind::Function,
 		//
 		UniCase::ascii("crypto::blake3") => PathKind::Function,
 		UniCase::ascii("crypto::md5") => PathKind::Function,

--- a/crates/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_executor.dict
@@ -212,7 +212,7 @@
 "array::transpose("
 "array::union("
 "count("
-"count_all("
+"count_value("
 "crypto"
 "crypto::"
 "crypto::blake3("

--- a/crates/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_executor.dict
@@ -212,6 +212,7 @@
 "array::transpose("
 "array::union("
 "count("
+"count_all("
 "crypto"
 "crypto::"
 "crypto::blake3("

--- a/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -211,7 +211,7 @@
 "array::transpose("
 "array::union("
 "count("
-"count_all("
+"count_value("
 "crypto"
 "crypto::"
 "crypto::blake3("

--- a/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -211,6 +211,7 @@
 "array::transpose("
 "array::union("
 "count("
+"count_all("
 "crypto"
 "crypto::"
 "crypto::blake3("

--- a/crates/language-tests/tests/language/functions/count.surql
+++ b/crates/language-tests/tests/language/functions/count.surql
@@ -85,7 +85,7 @@ count({a: 1, b: 2});
 count(1d);
 
 
-count_all();
+count_value();
 count_all(true);
 count_all(false);
 count_all(15 > 10);

--- a/crates/language-tests/tests/language/functions/count.surql
+++ b/crates/language-tests/tests/language/functions/count.surql
@@ -4,7 +4,7 @@
 # count results
 
 [[test.results]]
-value = "0"
+value = "1"
 
 [[test.results]]
 value = "1"
@@ -39,7 +39,7 @@ value = "1"
 # count_value results
 
 [[test.results]]
-value = "0"
+value = "1"
 
 [[test.results]]
 value = "1"

--- a/crates/language-tests/tests/language/functions/count.surql
+++ b/crates/language-tests/tests/language/functions/count.surql
@@ -36,7 +36,7 @@ value = "1"
 [[test.results]]
 value = "1"
 
-# count_all results
+# count_value results
 
 [[test.results]]
 value = "0"
@@ -86,13 +86,13 @@ count(1d);
 
 
 count_value();
-count_all(true);
-count_all(false);
-count_all(15 > 10);
-count_all(15 < 10);
-count_all([1]);
-count_all([1,2]);
-count_all(0..2);
-count_all(|test:0..2|);
-count_all({a: 1, b: 2});
-count_all(1d);
+count_value(true);
+count_value(false);
+count_value(15 > 10);
+count_value(15 < 10);
+count_value([1]);
+count_value([1,2]);
+count_value(0..2);
+count_value(|test:0..2|);
+count_value({a: 1, b: 2});
+count_value(1d);

--- a/crates/language-tests/tests/language/functions/count.surql
+++ b/crates/language-tests/tests/language/functions/count.surql
@@ -1,8 +1,10 @@
 /**
 [test]
 
+# count results
+
 [[test.results]]
-value = "1"
+value = "0"
 
 [[test.results]]
 value = "1"
@@ -34,6 +36,41 @@ value = "1"
 [[test.results]]
 value = "1"
 
+# count_all results
+
+[[test.results]]
+value = "0"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "2"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "1"
+
 */
 count();
 count(true);
@@ -46,3 +83,16 @@ count(0..2);
 count(|test:0..2|);
 count({a: 1, b: 2});
 count(1d);
+
+
+count_all();
+count_all(true);
+count_all(false);
+count_all(15 > 10);
+count_all(15 < 10);
+count_all([1]);
+count_all([1,2]);
+count_all(0..2);
+count_all(|test:0..2|);
+count_all({a: 1, b: 2});
+count_all(1d);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The count() function checks to see if a value is truthy, which includes values that are default or empty. A user might want to count the number of empty bytes in an array, empty strings, NONE values, and so on.

```
count([0,0,0,0,0,0,0]); -- returns 0
```

## What does this change do?

It creates a function called count_value(), which just counts the number of values regardless of whether they are truthy or not.

```
count_value([0,0,0,0,0,0,0]); -- returns 7
count_value([NONE, NONE, NONE]); -- returns 3
```

(Note: originally went with count_all but count_value feels more explicit)

There is a tiny performance increase with this function too because it is a bit simpler.

## What is your testing strategy?

Added some tests.

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

- [X] Yes

## Does this change make any alterations to environment variables or CLI commands?

- [X] No changes made to env vars

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
