### PR TITLE
[Backport 2.3] Avoid using commit pool in wasm for skv in-memory

### DIFF
--- a/crates/core/src/kvs/mem/mod.rs
+++ b/crates/core/src/kvs/mem/mod.rs
@@ -5,15 +5,17 @@ use crate::key::debug::Sprintable;
 use crate::kvs::{Key, Val, Version};
 use std::fmt::Debug;
 use std::ops::Range;
-use std::sync::OnceLock;
 use surrealkv::Options;
 use surrealkv::Store;
 use surrealkv::Transaction as Tx;
 
 use super::{Check, KeyEncode};
 
+#[cfg(not(target_family = "wasm"))]
+use std::sync::OnceLock;
+#[cfg(not(target_family = "wasm"))]
 pub(crate) static SKV_COMMIT_POOL: OnceLock<affinitypool::Threadpool> = OnceLock::new();
-
+#[cfg(not(target_family = "wasm"))]
 pub(crate) fn commit_pool() -> &'static affinitypool::Threadpool {
 	SKV_COMMIT_POOL.get_or_init(|| {
 		affinitypool::Builder::new()
@@ -152,7 +154,10 @@ impl super::api::Transaction for Transaction {
 			self.inner.take().ok_or_else(|| Error::Tx("Transaction inner is None".into()))?;
 
 		// Commit this transaction in the pool
+		#[cfg(not(target_family = "wasm"))]
 		commit_pool().spawn(move || inner.commit()).await?;
+		#[cfg(target_family = "wasm")]
+		inner.commit()?;
 
 		// Continue
 		Ok(())


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Commit on surrealkv blocks when using wasm because of the usage of commit_pool

## What does this change do?

Commits directly when using wasm

## What is your testing strategy?

Github actions

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
