### PR TITLE
BP-2.3: Default WS buffer size to 0, reactive RocksDB mapped R/W

### DIFF
--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -147,10 +147,10 @@ impl Datastore {
 		opts.set_row_cache(&cache);
 		// Configure memory-mapped reads
 		info!(target: TARGET, "Enable memory-mapped reads: {}", *cnf::ROCKSDB_ENABLE_MEMORY_MAPPED_READS);
-		opts.set_allow_mmap_reads(true);
+		opts.set_allow_mmap_reads(*cnf::ROCKSDB_ENABLE_MEMORY_MAPPED_READS);
 		// Configure memory-mapped writes
 		info!(target: TARGET, "Enable memory-mapped writes: {}", *cnf::ROCKSDB_ENABLE_MEMORY_MAPPED_WRITES);
-		opts.set_allow_mmap_writes(true);
+		opts.set_allow_mmap_writes(*cnf::ROCKSDB_ENABLE_MEMORY_MAPPED_WRITES);
 		// Set the delete compaction factory
 		info!(target: TARGET, "Setting delete compaction factory: {} / {} ({})",
 			*cnf::ROCKSDB_DELETION_FACTORY_WINDOW_SIZE,

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -75,9 +75,9 @@ pub static WEBSOCKET_MAX_FRAME_SIZE: LazyLock<usize> =
 pub static WEBSOCKET_MAX_MESSAGE_SIZE: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE", usize, 128 << 20);
 
-/// How many responses can be buffered when delivering to the client (defaults to 25).
+/// How many responses can be buffered when delivering to the client (defaults to 0).
 pub static WEBSOCKET_RESPONSE_BUFFER_SIZE: LazyLock<usize> =
-	lazy_env_parse!("SURREAL_WEBSOCKET_RESPONSE_BUFFER_SIZE", usize, 25);
+	lazy_env_parse!("SURREAL_WEBSOCKET_RESPONSE_BUFFER_SIZE", usize, 0);
 
 /// How often are any buffered responses flushed to the WebSocket client (defaults to 3 ms).
 pub static WEBSOCKET_RESPONSE_FLUSH_PERIOD: LazyLock<u64> =


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

backport #5765

## What does this change do?

backport #5765

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

backport #5765

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
