### PR TITLE
ci: run upgrade-test only on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -843,6 +843,7 @@ jobs:
           ./target/debug/surrealql-test --color always run --no-wip -j 3
 
   upgrade-tests:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     name: Run SurrealQL upgrade tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
'

Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

- The upgrade-test pulls large artifacts and runs a time-consuming end-to-end scenario; it is relevant only once code is merged into . `main`
- Avoids duplicated effort: running upgrade-test both in PRs and after merge yields no extra coverage, because the binary it tests is the post-merge one.
- Frees up CI runners for other tasks and shortens the overall queue time

## What does this change do?

Restricts the **upgrade-test** job in the CI workflow so that it is executed **only on and only for direct pushes`main`**.
This prevents the job from running on every pull-request, merge-group, or feature-branch build, saving minutes and keeping PR feedback loops faster

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
