### PR TITLE
 [Backport 2.2] Context cancellation check in prepare mock  (#6035)

### DIFF
--- a/crates/core/src/sql/statements/create.rs
+++ b/crates/core/src/sql/statements/create.rs
@@ -71,7 +71,7 @@ impl CreateStatement {
 		// Loop over the create targets
 		for w in self.what.0.iter() {
 			let v = w.compute(stk, &ctx, opt, doc).await?;
-			i.prepare(&stm, v).map_err(|e| match e {
+			i.prepare(&ctx, &stm, v).map_err(|e| match e {
 				Error::InvalidStatementTarget {
 					value: v,
 				} => Error::CreateStatement {

--- a/crates/core/src/sql/statements/delete.rs
+++ b/crates/core/src/sql/statements/delete.rs
@@ -57,7 +57,7 @@ impl DeleteStatement {
 		// Loop over the delete targets
 		for w in self.what.0.iter() {
 			let v = w.compute(stk, &ctx, opt, doc).await?;
-			i.prepare(&stm, v).map_err(|e| match e {
+			i.prepare(&ctx, &stm, v).map_err(|e| match e {
 				Error::InvalidStatementTarget {
 					value: v,
 				} => Error::DeleteStatement {

--- a/crates/core/src/sql/statements/select.rs
+++ b/crates/core/src/sql/statements/select.rs
@@ -165,7 +165,7 @@ impl SelectStatement {
 					if self.only && !limit_is_one_or_zero {
 						return Err(Error::SingleOnlyOutput);
 					}
-					i.prepare_mock(&stm, v)?;
+					i.prepare_mock(&ctx, &stm, v)?;
 				}
 				Value::Table(t) => {
 					if self.only && !limit_is_one_or_zero {
@@ -190,7 +190,7 @@ impl SelectStatement {
 									planner.add_iterables(stk, &stm_ctx, t, p, &mut i).await?;
 								}
 							}
-							Value::Mock(v) => i.prepare_mock(&stm, v)?,
+							Value::Mock(v) => i.prepare_mock(&ctx, &stm, v)?,
 							Value::Edges(v) => i.prepare_edges(&stm, *v)?,
 							Value::Thing(v) => {
 								let p = planner.check_table_permission(&stm_ctx, &v.tb).await?;

--- a/crates/core/src/sql/statements/update.rs
+++ b/crates/core/src/sql/statements/update.rs
@@ -58,7 +58,7 @@ impl UpdateStatement {
 		// Loop over the update targets
 		for w in self.what.0.iter() {
 			let v = w.compute(stk, &ctx, opt, doc).await?;
-			i.prepare(&stm, v).map_err(|e| match e {
+			i.prepare(&ctx, &stm, v).map_err(|e| match e {
 				Error::InvalidStatementTarget {
 					value: v,
 				} => Error::UpdateStatement {

--- a/crates/core/src/sql/statements/upsert.rs
+++ b/crates/core/src/sql/statements/upsert.rs
@@ -57,7 +57,7 @@ impl UpsertStatement {
 		// Loop over the upsert targets
 		for w in self.what.0.iter() {
 			let v = w.compute(stk, &ctx, opt, doc).await?;
-			i.prepare(&stm, v).map_err(|e| match e {
+			i.prepare(&ctx, &stm, v).map_err(|e| match e {
 				Error::InvalidStatementTarget {
 					value: v,
 				} => Error::UpsertStatement {


### PR DESCRIPTION
(cherry picked from commit 325248bb2ddc4d6b6dcf7a38cd40384e0b92b24a)

Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport #6035

## What does this change do?

Backport #6035

## What is your testing strategy?

N/A

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
