### PR TITLE
Improve metrics and make consistent

### DIFF
--- a/src/telemetry/metrics/http/mod.rs
+++ b/src/telemetry/metrics/http/mod.rs
@@ -1,20 +1,12 @@
 pub(super) mod tower_layer;
 
 use opentelemetry::global;
-use opentelemetry::metrics::{Histogram, Meter, MetricsError, UpDownCounter};
+use opentelemetry::metrics::{Counter, Histogram, Meter, MetricsError, UpDownCounter};
 use std::sync::LazyLock;
 
 use self::tower_layer::HttpCallMetricTracker;
 
 static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("surrealdb.http"));
-
-pub static HTTP_SERVER_DURATION: LazyLock<Histogram<u64>> = LazyLock::new(|| {
-	METER
-		.u64_histogram("http.server.duration")
-		.with_description("The HTTP server duration in milliseconds.")
-		.with_unit("ms")
-		.init()
-});
 
 pub static HTTP_SERVER_ACTIVE_REQUESTS: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
 	METER
@@ -23,10 +15,25 @@ pub static HTTP_SERVER_ACTIVE_REQUESTS: LazyLock<UpDownCounter<i64>> = LazyLock:
 		.init()
 });
 
+pub static HTTP_SERVER_REQUEST_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+	METER
+		.u64_counter("http.server.request.count")
+		.with_description("The total number of HTTP requests processed.")
+		.init()
+});
+
+pub static HTTP_SERVER_REQUEST_DURATION: LazyLock<Histogram<u64>> = LazyLock::new(|| {
+	METER
+		.u64_histogram("http.server.request.duration")
+		.with_description("The duration of inbound HTTP requests in milliseconds.")
+		.with_unit("ms")
+		.init()
+});
+
 pub static HTTP_SERVER_REQUEST_SIZE: LazyLock<Histogram<u64>> = LazyLock::new(|| {
 	METER
 		.u64_histogram("http.server.request.size")
-		.with_description("Measures the size of HTTP request messages.")
+		.with_description("The size of inbound HTTP request messages.")
 		.with_unit("mb")
 		.init()
 });
@@ -34,7 +41,7 @@ pub static HTTP_SERVER_REQUEST_SIZE: LazyLock<Histogram<u64>> = LazyLock::new(||
 pub static HTTP_SERVER_RESPONSE_SIZE: LazyLock<Histogram<u64>> = LazyLock::new(|| {
 	METER
 		.u64_histogram("http.server.response.size")
-		.with_description("Measures the size of HTTP response messages.")
+		.with_description("The size of outbound HTTP response messages.")
 		.with_unit("mb")
 		.init()
 });
@@ -46,8 +53,12 @@ fn observe_active_request(value: i64, tracker: &HttpCallMetricTracker) -> Result
 }
 
 fn record_request_duration(tracker: &HttpCallMetricTracker) {
-	HTTP_SERVER_DURATION
+	HTTP_SERVER_REQUEST_DURATION
 		.record(tracker.duration().as_millis() as u64, &tracker.request_duration_attrs());
+}
+
+fn record_request_count(tracker: &HttpCallMetricTracker) {
+	HTTP_SERVER_REQUEST_COUNT.add(1, &tracker.request_duration_attrs());
 }
 
 fn record_request_size(tracker: &HttpCallMetricTracker, size: u64) {

--- a/src/telemetry/metrics/http/tower_layer.rs
+++ b/src/telemetry/metrics/http/tower_layer.rs
@@ -261,6 +261,9 @@ pub fn on_request_finish(tracker: &HttpCallMetricTracker) -> Result<(), MetricsE
 	// Record the duration of the request.
 	super::record_request_duration(tracker);
 
+	// Increment the request counter
+	super::record_request_count(tracker);
+
 	// Record the request size if known
 	if let Some(size) = tracker.request_size {
 		super::record_request_size(tracker, size)

--- a/src/telemetry/metrics/ws/mod.rs
+++ b/src/telemetry/metrics/ws/mod.rs
@@ -20,7 +20,7 @@ pub static RPC_SERVER_ACTIVE_CONNECTIONS: LazyLock<UpDownCounter<i64>> = LazyLoc
 
 pub static RPC_SERVER_CONNECTION_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
 	METER
-		.u64_counter("http.server.connection.count")
+		.u64_counter("rpc.server.connection.count")
 		.with_description("The total number of WebSocket connections processed.")
 		.init()
 });

--- a/src/telemetry/metrics/ws/mod.rs
+++ b/src/telemetry/metrics/ws/mod.rs
@@ -4,20 +4,12 @@ use crate::cnf::TELEMETRY_NAMESPACE;
 use opentelemetry::metrics::Meter;
 use opentelemetry::{
 	Context as TelemetryContext,
-	metrics::{Histogram, MetricsError, UpDownCounter},
+	metrics::{Counter, Histogram, MetricsError, UpDownCounter},
 };
 use opentelemetry::{KeyValue, global};
 use std::sync::LazyLock;
 
 static METER: LazyLock<Meter> = LazyLock::new(|| global::meter("surrealdb.rpc"));
-
-pub static RPC_SERVER_DURATION: LazyLock<Histogram<u64>> = LazyLock::new(|| {
-	METER
-		.u64_histogram("rpc.server.duration")
-		.with_description("Measures duration of inbound RPC requests in milliseconds.")
-		.with_unit("ms")
-		.init()
-});
 
 pub static RPC_SERVER_ACTIVE_CONNECTIONS: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
 	METER
@@ -26,10 +18,25 @@ pub static RPC_SERVER_ACTIVE_CONNECTIONS: LazyLock<UpDownCounter<i64>> = LazyLoc
 		.init()
 });
 
+pub static RPC_SERVER_CONNECTION_COUNT: LazyLock<Counter<u64>> = LazyLock::new(|| {
+	METER
+		.u64_counter("http.server.connection.count")
+		.with_description("The total number of WebSocket connections processed.")
+		.init()
+});
+
+pub static RPC_SERVER_REQUEST_DURATION: LazyLock<Histogram<u64>> = LazyLock::new(|| {
+	METER
+		.u64_histogram("rpc.server.request.duration")
+		.with_description("The duration of inbound WebSocket requests in milliseconds.")
+		.with_unit("ms")
+		.init()
+});
+
 pub static RPC_SERVER_REQUEST_SIZE: LazyLock<Histogram<u64>> = LazyLock::new(|| {
 	METER
 		.u64_histogram("rpc.server.request.size")
-		.with_description("Measures the size of HTTP request messages.")
+		.with_description("The size of inbound WebSocket request messages.")
 		.with_unit("mb")
 		.init()
 });
@@ -37,7 +44,7 @@ pub static RPC_SERVER_REQUEST_SIZE: LazyLock<Histogram<u64>> = LazyLock::new(|| 
 pub static RPC_SERVER_RESPONSE_SIZE: LazyLock<Histogram<u64>> = LazyLock::new(|| {
 	METER
 		.u64_histogram("rpc.server.response.size")
-		.with_description("Measures the size of HTTP response messages.")
+		.with_description("The size of outbound WebSocket response messages.")
 		.with_unit("mb")
 		.init()
 });
@@ -55,13 +62,14 @@ pub fn on_connect() -> Result<(), MetricsError> {
 	observe_active_connection(1)
 }
 
-/// Registers the callback that increases the number of active RPC connections.
+/// Registers the callback that decreases the number of active RPC connections.
 pub fn on_disconnect() -> Result<(), MetricsError> {
 	observe_active_connection(-1)
 }
 
 pub(super) fn observe_active_connection(value: i64) -> Result<(), MetricsError> {
 	let attrs = otel_common_attrs();
+	RPC_SERVER_CONNECTION_COUNT.add(1, &attrs);
 	RPC_SERVER_ACTIVE_CONNECTIONS.add(value, &attrs);
 	Ok(())
 }
@@ -152,7 +160,7 @@ pub fn record_rpc(cx: &TelemetryContext, res_size: usize, is_error: bool) {
 		]);
 	};
 
-	RPC_SERVER_DURATION.record(duration, &attrs);
+	RPC_SERVER_REQUEST_DURATION.record(duration, &attrs);
 	RPC_SERVER_REQUEST_SIZE.record(req_size, &attrs);
 	RPC_SERVER_RESPONSE_SIZE.record(res_size as u64, &attrs);
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What does this change do?

Modifies the HTTP and RPC metrics, ensuring that they are consistent. The modifications are:

- Renames `http.server.duration` to `http.server.request.duration`
- Added `rpc.server.connection.count`
- Added `http.server.request.count`

The metrics are now as follows:

| Metric                 | Type                  | Description                   |
| ---------------- | --------------- | ---------------------- |
| `http.server.active_requests` | Up-down counter | The number of active HTTP requests |
| `http.server.request.count` | Total counter | The total number of HTTP requests processed |
| `http.server.request.duration` | Histogram | The duration of inbound HTTP requests in milliseconds |
| `http.server.request.size` | Histogram | The size of inbound HTTP request messages |
| `http.server.response.size` | Histogram | The size of outbound HTTP response messages |
| `rpc.server.active_connections` | Up-down counter | The number of active WebSocket connections |
| `rpc.server.connection.count` | Total counter | The total number of WebSocket connections processed |
| `rpc.server.request.duration` | Histogram | The duration of inbound WebSocket requests in milliseconds |
| `rpc.server.request.size` | Histogram | The size of inbound WebSocket request messages |
| `rpc.server.response.size` | Histogram | The size of outbound WebSocket response messages |

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
