### PR TITLE
Implements DNS resolution on Context::check_allowed_net

### DIFF
--- a/crates/core/src/ctx/context.rs
+++ b/crates/core/src/ctx/context.rs
@@ -553,7 +553,10 @@ impl MutableContext {
 				// Check the domain name (if any)
 				is_allowed(&target)?;
 				// Resolve the domain name to a vector of IP addresses
+				#[cfg(not(target_family = "wasm"))]
 				let targets = target.resolve().await?;
+				#[cfg(target_family = "wasm")]
+				let targets = target.resolve()?;
 				for t in &targets {
 					// For each IP address resolved, check it is allowed
 					is_allowed(t)?;

--- a/crates/core/src/ctx/context.rs
+++ b/crates/core/src/ctx/context.rs
@@ -547,7 +547,7 @@ impl MutableContext {
 		match url.host() {
 			Some(host) => {
 				let target = NetTarget::Host(host.to_owned(), url.port_or_known_default());
-				// Check the domain name (if any)
+				// Check the domain name (if any) matches the allow list
 				let host_allowed = self.capabilities.matches_any_allow_net(&target);
 				if !host_allowed {
 					warn!(

--- a/crates/core/src/ctx/context.rs
+++ b/crates/core/src/ctx/context.rs
@@ -608,10 +608,15 @@ impl MutableContext {
 
 #[cfg(test)]
 mod tests {
+	#[cfg(feature = "http")]
 	use crate::ctx::MutableContext;
+	#[cfg(feature = "http")]
 	use crate::dbs::Capabilities;
+	#[cfg(feature = "http")]
 	use crate::dbs::capabilities::{NetTarget, Targets};
+	#[cfg(feature = "http")]
 	use std::str::FromStr;
+	#[cfg(feature = "http")]
 	use url::Url;
 
 	#[cfg(feature = "http")]

--- a/crates/core/src/dbs/capabilities.rs
+++ b/crates/core/src/dbs/capabilities.rs
@@ -1034,25 +1034,17 @@ mod tests {
 	#[tokio::test]
 	#[cfg(all(not(target_family = "wasm"), feature = "http"))]
 	async fn test_net_target_resolve_async() {
-		assert_eq!(
-			NetTarget::from_str("localhost").unwrap().resolve().await.unwrap(),
-			vec![
-				NetTarget::from_str("127.0.0.1").unwrap(),
-				NetTarget::from_str("::1/128").unwrap()
-			]
-		);
+		let r = NetTarget::from_str("localhost").unwrap().resolve().await.unwrap();
+		assert!(r.contains(&NetTarget::from_str("127.0.0.1").unwrap()));
+		assert!(r.contains(&NetTarget::from_str("::1/128").unwrap()));
 	}
 
 	#[test]
 	#[cfg(all(target_family = "wasm", feature = "http"))]
 	fn test_net_target_resolve_sync() {
-		assert_eq!(
-			NetTarget::from_str("localhost").unwrap().resolve().unwrap(),
-			vec![
-				NetTarget::from_str("127.0.0.1").unwrap(),
-				NetTarget::from_str("::1/128").unwrap()
-			]
-		);
+		let r = NetTarget::from_str("localhost").unwrap().resolve().unwrap();
+		assert!(r.contains(&NetTarget::from_str("127.0.0.1").unwrap()));
+		assert!(r.contains(&NetTarget::from_str("::1/128").unwrap()));
 	}
 
 	#[test]

--- a/crates/core/src/dbs/capabilities.rs
+++ b/crates/core/src/dbs/capabilities.rs
@@ -815,6 +815,14 @@ impl Capabilities {
 		self.allow_net.matches(target) && !self.deny_net.matches(target)
 	}
 
+	pub(crate) fn matches_any_allow_net(&self, target: &NetTarget) -> bool {
+		self.allow_net.matches(target)
+	}
+
+	pub(crate) fn matches_any_deny_net(&self, target: &NetTarget) -> bool {
+		self.deny_net.matches(target)
+	}
+
 	pub fn allows_rpc_method(&self, target: &MethodTarget) -> bool {
 		self.allow_rpc.matches(target) && !self.deny_rpc.matches(target)
 	}

--- a/crates/core/src/dbs/capabilities.rs
+++ b/crates/core/src/dbs/capabilities.rs
@@ -815,10 +815,12 @@ impl Capabilities {
 		self.allow_net.matches(target) && !self.deny_net.matches(target)
 	}
 
+	#[cfg(feature = "http")]
 	pub(crate) fn matches_any_allow_net(&self, target: &NetTarget) -> bool {
 		self.allow_net.matches(target)
 	}
 
+	#[cfg(feature = "http")]
 	pub(crate) fn matches_any_deny_net(&self, target: &NetTarget) -> bool {
 		self.deny_net.matches(target)
 	}

--- a/crates/core/src/dbs/capabilities.rs
+++ b/crates/core/src/dbs/capabilities.rs
@@ -6,7 +6,7 @@ use std::net::IpAddr;
 use crate::iam::{Auth, Level};
 use crate::rpc::Method;
 use ipnet::IpNet;
-#[cfg(feature = "http")]
+#[cfg(all(not(target_family = "wasm"), feature = "http"))]
 use tokio::net::lookup_host;
 use url::Url;
 
@@ -188,7 +188,7 @@ pub enum NetTarget {
 	IPNet(IpNet),
 }
 
-#[cfg(feature = "http")]
+#[cfg(all(not(target_family = "wasm"), feature = "http"))]
 impl NetTarget {
 	/// Resolves a `NetTarget` to its associated IP address representations.
 	///
@@ -200,7 +200,7 @@ impl NetTarget {
 	///
 	/// # Returns
 	/// - On success, this function returns a `Vec<Self>` where each resolved `NetTarget::Host` is
-	/// transformed into a `NetTarget::IPNet`.
+	///   transformed into a `NetTarget::IPNet`.
 	/// - On error, it returns a `std::io::Error` indicating the issue during resolution.
 	///
 	/// # Variants

--- a/crates/core/src/dbs/capabilities.rs
+++ b/crates/core/src/dbs/capabilities.rs
@@ -1032,9 +1032,22 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_net_target_resolve() {
+	#[cfg(all(not(target_family = "wasm"), feature = "http"))]
+	async fn test_net_target_resolve_async() {
 		assert_eq!(
 			NetTarget::from_str("localhost").unwrap().resolve().await.unwrap(),
+			vec![
+				NetTarget::from_str("127.0.0.1").unwrap(),
+				NetTarget::from_str("::1/128").unwrap()
+			]
+		);
+	}
+
+	#[test]
+	#[cfg(all(target_family = "wasm", feature = "http"))]
+	fn test_net_target_resolve_sync() {
+		assert_eq!(
+			NetTarget::from_str("localhost").unwrap().resolve().unwrap(),
 			vec![
 				NetTarget::from_str("127.0.0.1").unwrap(),
 				NetTarget::from_str("::1/128").unwrap()

--- a/crates/core/src/fnc/http.rs
+++ b/crates/core/src/fnc/http.rs
@@ -131,6 +131,7 @@ pub mod resolver {
 	use crate::dbs::{Capabilities, capabilities::NetTarget};
 	use ipnet::IpNet;
 	use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+	use std::str::FromStr;
 	use std::{error::Error, net::ToSocketAddrs, sync::Arc};
 
 	pub struct FilteringResolver {
@@ -147,15 +148,23 @@ pub mod resolver {
 
 	impl Resolve for FilteringResolver {
 		fn resolve(&self, name: Name) -> Resolving {
-			let ctx = self.cap.clone();
+			let cap = self.cap.clone();
+
 			let blocking = tokio::task::spawn_blocking(
 				move || -> Result<Addrs, Box<dyn Error + Send + Sync>> {
+					// Check the domain name (if any) matches the allowlist
+					let name_target = NetTarget::from_str(name.as_str())
+						.map_err(|x| Box::new(x) as Box<dyn Error + Send + Sync>)?;
+					let name_is_allowed = cap.matches_any_allow_net(&name_target)
+						&& !cap.matches_any_deny_net(&name_target);
+					// Resolve the addresses
 					let addrs = (name.as_str(), 0)
 						.to_socket_addrs()
 						.map_err(|x| Box::new(x) as Box<dyn Error + Send + Sync>)?;
+					// Build an iterator checking the addresses
 					let iterator = Box::new(addrs.filter(move |addr| {
 						let target = IpNet::new_assert(addr.ip(), 0);
-						ctx.allows_network_target(&NetTarget::IPNet(target))
+						name_is_allowed && !cap.matches_any_deny_net(&NetTarget::IPNet(target))
 					}));
 					Ok(iterator as Addrs)
 				},

--- a/crates/core/src/fnc/util/http/mod.rs
+++ b/crates/core/src/fnc/util/http/mod.rs
@@ -5,10 +5,12 @@ use crate::syn;
 
 use anyhow::{Context as _, Result, bail};
 use reqwest::header::CONTENT_TYPE;
+#[cfg(not(target_family = "wasm"))]
 use reqwest::redirect::Attempt;
 #[cfg(not(target_family = "wasm"))]
 use reqwest::redirect::Policy;
 use reqwest::{Client, Method, RequestBuilder, Response};
+#[cfg(not(target_family = "wasm"))]
 use tokio::runtime::Handle;
 use url::Url;
 

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -650,13 +650,13 @@ mod tests {
 			let s = MockServer::start().await;
 			let get = Mock::given(method("GET"))
 				.and(path("/"))
-				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"))
-				.expect(1);
+				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"));
+			//.expect(1);
 
 			let get2 = Mock::given(method("GET"))
 				.and(path("/test"))
-				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"))
-				.expect(1);
+				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"));
+			//.expect(1);
 
 			s.register(get).await;
 			s.register(get2).await;
@@ -666,8 +666,8 @@ mod tests {
 		let server2 = {
 			let s = MockServer::start().await;
 			let get = Mock::given(method("GET"))
-				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"))
-				.expect(1);
+				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"));
+			//.expect(1);
 			let head =
 				Mock::given(method("HEAD")).respond_with(ResponseTemplate::new(200)).expect(0);
 
@@ -681,10 +681,9 @@ mod tests {
 			let s = MockServer::start().await;
 			let redirect_res = ResponseTemplate::new(301).append_header("Location", server1.uri());
 
-			let redirect = Mock::given(method("GET"))
-				.and(path("redirect"))
-				.respond_with(redirect_res)
-				.expect(1);
+			let redirect =
+				Mock::given(method("GET")).and(path("redirect")).respond_with(redirect_res);
+			//.expect(1);
 
 			s.register(redirect).await;
 			s
@@ -693,7 +692,7 @@ mod tests {
 		// (Datastore, Session, Query, Succeeds, Response Contains)
 		let cases = vec![
 			//
-			// Functions and Networking are allowed
+			// 0 - Functions and Networking are allowed
 			//
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
@@ -707,7 +706,7 @@ mod tests {
 				"SUCCESS".to_string(),
 			),
 			//
-			// Scripting is allowed
+			// 1 - Scripting is allowed
 			//
 			(
 				Datastore::new("memory")
@@ -720,7 +719,7 @@ mod tests {
 				"1".to_string(),
 			),
 			//
-			// Scripting is not allowed
+			// 2 - Scripting is not allowed
 			//
 			(
 				Datastore::new("memory")
@@ -733,7 +732,7 @@ mod tests {
 				"Scripting functions are not allowed".to_string(),
 			),
 			//
-			// Anonymous actor when guest access is allowed and auth is enabled, succeeds
+			// 3 - Anonymous actor when guest access is allowed and auth is enabled, succeeds
 			//
 			(
 				Datastore::new("memory")
@@ -747,7 +746,7 @@ mod tests {
 				"1".to_string(),
 			),
 			//
-			// Anonymous actor when guest access is not allowed and auth is enabled, throws error
+			// 4 - Anonymous actor when guest access is not allowed and auth is enabled, throws error
 			//
 			(
 				Datastore::new("memory")
@@ -761,7 +760,7 @@ mod tests {
 				"Not enough permissions to perform this action".to_string(),
 			),
 			//
-			// Anonymous actor when guest access is not allowed and auth is disabled, succeeds
+			// 5 - Anonymous actor when guest access is not allowed and auth is disabled, succeeds
 			//
 			(
 				Datastore::new("memory")
@@ -775,7 +774,7 @@ mod tests {
 				"1".to_string(),
 			),
 			//
-			// Authenticated user when guest access is not allowed and auth is enabled, succeeds
+			// 6 - Authenticated user when guest access is not allowed and auth is enabled, succeeds
 			//
 			(
 				Datastore::new("memory")
@@ -788,7 +787,7 @@ mod tests {
 				true,
 				"1".to_string(),
 			),
-			// Specific experimental feature enabled
+			// 7 - Specific experimental feature enabled
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
@@ -799,7 +798,7 @@ mod tests {
 				true,
 				"NONE".to_string(),
 			),
-			// Specific experimental feature disabled
+			// 8 - Specific experimental feature disabled
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
@@ -811,7 +810,7 @@ mod tests {
 				"Experimental capability `record_references` is not enabled".to_string(),
 			),
 			//
-			// Some functions are not allowed
+			// 9 - Some functions are not allowed
 			//
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
@@ -828,6 +827,7 @@ mod tests {
 				false,
 				"Function 'string::len' is not allowed".to_string(),
 			),
+			// 10 -
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
@@ -843,6 +843,7 @@ mod tests {
 				true,
 				"a".to_string(),
 			),
+			// 11 -
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
@@ -859,7 +860,7 @@ mod tests {
 				"Function 'time::now' is not allowed".to_string(),
 			),
 			//
-			// Some net targets are not allowed
+			// 12 - Some net targets are not allowed
 			//
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
@@ -881,6 +882,7 @@ mod tests {
 				false,
 				format!("Access to network target '{}' is not allowed", server1.address()),
 			),
+			// 13 -
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
@@ -901,6 +903,7 @@ mod tests {
 				false,
 				"Access to network target '1.1.1.1:80' is not allowed".to_string(),
 			),
+			// 14 -
 			(
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
@@ -918,8 +921,8 @@ mod tests {
 				),
 				Session::owner(),
 				format!("RETURN http::get('{}')", server2.uri()),
-				true,
-				"SUCCESS".to_string(),
+				false,
+				"Access to network target '127.0.0.1/32' is not allowed".to_string(),
 			),
 			(
 				// Ensure redirect fails
@@ -936,10 +939,7 @@ mod tests {
 				Session::owner(),
 				format!("RETURN http::get('{}/redirect')", server3.uri()),
 				false,
-				format!(
-					"here was an error processing a remote HTTP request: error following redirect for url ({}/redirect)",
-					server3.uri()
-				),
+				"Access to network target '127.0.0.1/32' is not allowed".to_string(),
 			),
 			(
 				// Ensure connecting via localhost succeeds
@@ -953,6 +953,7 @@ mod tests {
 				true,
 				"SUCCESS".to_string(),
 			),
+			// - 15
 			(
 				// Ensure redirect fails
 				Datastore::new("memory").await.unwrap().with_capabilities(
@@ -966,10 +967,7 @@ mod tests {
 				Session::owner(),
 				format!("RETURN http::get('http://localhost:{}')", server1.address().port()),
 				false,
-				format!(
-					"There was an error processing a remote HTTP request: error sending request for url (http://localhost:{}/)",
-					server1.address().port()
-				),
+				"Access to network target '127.0.0.1/32' is not allowed".to_string(),
 			),
 		];
 

--- a/src/dbs/mod.rs
+++ b/src/dbs/mod.rs
@@ -585,7 +585,6 @@ pub async fn fix(path: String) -> Result<()> {
 #[cfg(test)]
 mod tests {
 	use std::str::FromStr;
-
 	use surrealdb::iam::verify::verify_root_creds;
 	use surrealdb::kvs::{LockType::*, TransactionType::*};
 	use test_log::test;
@@ -650,13 +649,13 @@ mod tests {
 			let s = MockServer::start().await;
 			let get = Mock::given(method("GET"))
 				.and(path("/"))
-				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"));
-			//.expect(1);
+				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"))
+				.expect(1);
 
 			let get2 = Mock::given(method("GET"))
 				.and(path("/test"))
-				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"));
-			//.expect(1);
+				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"))
+				.expect(1);
 
 			s.register(get).await;
 			s.register(get2).await;
@@ -666,8 +665,8 @@ mod tests {
 		let server2 = {
 			let s = MockServer::start().await;
 			let get = Mock::given(method("GET"))
-				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"));
-			//.expect(1);
+				.respond_with(ResponseTemplate::new(200).set_body_string("SUCCESS"))
+				.expect(1);
 			let head =
 				Mock::given(method("HEAD")).respond_with(ResponseTemplate::new(200)).expect(0);
 
@@ -681,9 +680,10 @@ mod tests {
 			let s = MockServer::start().await;
 			let redirect_res = ResponseTemplate::new(301).append_header("Location", server1.uri());
 
-			let redirect =
-				Mock::given(method("GET")).and(path("redirect")).respond_with(redirect_res);
-			//.expect(1);
+			let redirect = Mock::given(method("GET"))
+				.and(path("redirect"))
+				.respond_with(redirect_res)
+				.expect(1);
 
 			s.register(redirect).await;
 			s
@@ -945,7 +945,7 @@ mod tests {
 				),
 			),
 			(
-				// 16 - Ensure connecting via localhost succeeds
+				// 16 - Ensure connecting via localhost succeed
 				Datastore::new("memory").await.unwrap().with_capabilities(
 					Capabilities::default()
 						.with_functions(Targets::<FuncTarget>::All)


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Close the loophole where an allowed hostname could be pointed (via DNS) to a disallowed IP, by resolving the host and validating every resulting address against the capability rules.

## What does this change do?

Adds a capability-aware guard for outbound HTTP/network requests. 
 
Before any connection is opened, the new helper resolves the host (incl. all DNS records) and verifies every target against the current `Capabilities`.

If a host/port is not permitted the request is aborted with `NetTargetNotAllowed`; otherwise it proceeds, emitting trace logs.

This tightens security by ensuring SurrealDB can only connect to explicitly allowed network targets.

## What is your testing strategy?

Github action
Tests has been added and updated

## Is this related to any issues?

Follow up #6052 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
