### PR TITLE
BP-2.3: Ensure errors are catched when checking permissions for LQ (#6109)

### DIFF
--- a/crates/core/src/doc/lives.rs
+++ b/crates/core/src/doc/lives.rs
@@ -235,7 +235,7 @@ impl Document {
 					// Disable permissions
 					let opt = &opt.new_with_perms(false);
 					// Process the PERMISSION clause
-					if !e.compute(stk, ctx, opt, Some(doc)).await?.is_truthy() {
+					if !e.compute(stk, ctx, opt, Some(doc)).await.is_ok_and(|x| x.is_truthy()) {
 						return Err(Error::Ignore);
 					}
 				}

--- a/crates/sdk/tests/live.rs
+++ b/crates/sdk/tests/live.rs
@@ -1,0 +1,72 @@
+mod helpers;
+mod parse;
+use helpers::new_ds;
+use helpers::skip_ok;
+use parse::Parse;
+use surrealdb::dbs::Session;
+use surrealdb::err::Error;
+use surrealdb::sql::Thing;
+use surrealdb::sql::Value;
+
+#[tokio::test]
+async fn live_permissions() -> Result<(), Error> {
+	let dbs = new_ds().await?.with_auth_enabled(true).with_notifications();
+
+	let ses = Session::owner().with_ns("test").with_db("test").with_rt(true);
+	let sql = "
+			DEFINE TABLE test SCHEMAFULL PERMISSIONS
+				FOR create WHERE { THROW 'create' }
+				FOR select WHERE { THROW 'select' }
+				FOR update WHERE { THROW 'update' }
+				FOR delete WHERE { THROW 'delete' };
+			CREATE test:1;
+		";
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	skip_ok(res, 1)?;
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:1,
+			},
+		]",
+	)
+	.into();
+	assert_eq!(tmp, val);
+	//
+	let ses = Session::for_record("test", "test", "test", Thing::from(("user", "test")).into())
+		.with_rt(true);
+	let sql = "
+		LIVE SELECT * FROM test;
+		CREATE test:2;
+	";
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 2);
+	//
+	skip_ok(res, 1)?;
+	//
+	let tmp = res.remove(0).result.unwrap_err().to_string();
+	let val = "An error occurred: create".to_string();
+	assert_eq!(tmp, val);
+	//
+	let ses = Session::owner().with_ns("test").with_db("test").with_rt(true);
+	let sql = "CREATE test:3;";
+	let res = &mut dbs.execute(sql, &ses, None).await?;
+	assert_eq!(res.len(), 1);
+	//
+	let tmp = res.remove(0).result?;
+	let val = Value::parse(
+		"[
+			{
+				id: test:3,
+			},
+		]",
+	)
+	.into();
+	assert_eq!(tmp, val);
+	//
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Backport #6109

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Backport #6109

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Backport #6109

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
