### PR TITLE
[Backport 2.3] Add support for Docker container timezone customisation (#6106)

### DIFF
--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -102,6 +102,13 @@ You can find a comprehensive list of all the available environment variables in 
 docker run --rm surrealdb/surrealdb:latest start --help
 ```
 
+The image contains timezone data. Specify the required timezone with the `TZ`
+environment variable:
+
+```bash
+docker run -e TZ=Europe/London surrealdb/surrealdb:latest start
+```
+
 SurrealDB can be executed as a non-root user for added security. This ensures that exploiting certain vulnerabilities in the SurrealDB process does not immediately result in privileged access to the container. When doing this, ensure that any files required by SurrealDB are mounted to the container in a volume and that are accessible to that non-root user through their ownership and permissions.
 
 Here is an example of running the container with a persistent volume as a non-root user with Docker Compose:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,15 @@ RUN chmod +x /builder-entrypoint.sh
 ENTRYPOINT ["/builder-entrypoint.sh"]
 
 ###
+# STAGE: tzdata
+# This stage is used to install the timezone files
+###
+
+FROM cgr.dev/chainguard/wolfi-base AS tzdata
+
+RUN apk add --no-cache tzdata
+
+###
 # Final Images
 ###
 
@@ -44,6 +53,10 @@ ARG ARTIFACT_PREFIX
 USER root
 
 COPY ${ARTIFACT_PREFIX}.${TARGETOS}-${TARGETARCH}/surreal /surreal
+
+COPY --from=tzdata /usr/share/zoneinfo /usr/share/zoneinfo
+
+RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime
 
 RUN chmod +x /surreal
 
@@ -69,6 +82,10 @@ ARG TARGETPLATFORM
 
 COPY --from=dev-ci /surreal /surreal
 
+COPY --from=tzdata /usr/share/zoneinfo /usr/share/zoneinfo
+
+RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime
+
 COPY --from=dev-ci /data /data
 
 COPY --from=dev-ci /logs /logs
@@ -87,6 +104,10 @@ FROM cgr.dev/chainguard/glibc-dynamic:latest-dev AS dev
 ARG SURREALDB_BINARY=target/release/surreal
 
 COPY ${SURREALDB_BINARY} /surreal
+
+COPY --from=tzdata /usr/share/zoneinfo /usr/share/zoneinfo
+
+RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime
 
 USER root
 
@@ -111,6 +132,10 @@ ENTRYPOINT ["/surreal"]
 FROM cgr.dev/chainguard/glibc-dynamic:latest AS prod
 
 COPY --from=dev /surreal /surreal
+
+COPY --from=tzdata /usr/share/zoneinfo /usr/share/zoneinfo
+
+RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime
 
 COPY --from=dev /data /data
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport #6106. 

## What does this change do?

Backport #6106.

## What is your testing strategy?

GitHub Actions

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
