### PR TITLE
[Backport 2.1] Add nu-ansi-term dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6009,6 +6009,7 @@ dependencies = [
  "jsonwebtoken",
  "mimalloc",
  "nix 0.27.1",
+ "nu-ansi-term",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,9 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 urlencoding = "2.1.3"
 uuid = { version = "1.10.0", features = ["serde", "js", "v4", "v7"] }
 
+[target.'cfg(windows)'.dependencies]
+nu-ansi-term = "0.46.0"
+
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.27.1", features = ["user"] }
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Since #6126 The windows build fails on 2.1

## What does this change do?

Add a missing dependency.

## What is your testing strategy?

Github action

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
