### PR TITLE
Ensure session vars are attached to `DEFINE API` execution context

### DIFF
--- a/crates/core/src/api/invocation.rs
+++ b/crates/core/src/api/invocation.rs
@@ -57,6 +57,7 @@ impl ApiInvocation {
 
 		let mut ctx = ds.setup_ctx()?;
 		ctx.set_transaction(tx);
+		sess.context(&mut ctx);
 		let ctx = &ctx.freeze();
 
 		let mut stack = TreeStack::new();


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The variables from the current session were available when a defined api was invoked via `api::invoke`, but not when invoked via HTTP.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR ensures that the session variables are attached to the context

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Tests for "DEFINE API" generally TBD

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
