### PR TITLE
BP-2.3: Ensure session vars are attached to `DEFINE API` execution context (#6156)

### DIFF
--- a/crates/core/src/api/invocation.rs
+++ b/crates/core/src/api/invocation.rs
@@ -57,6 +57,7 @@ impl ApiInvocation {
 
 		let mut ctx = ds.setup_ctx()?;
 		ctx.set_transaction(tx);
+		sess.context(&mut ctx);
 		let ctx = &ctx.freeze();
 
 		let mut stack = TreeStack::new();


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport #6156 

## What does this change do?

Backport #6156 

## What is your testing strategy?

Github action

## Is this related to any issues?

Backport #6156 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
