### PR TITLE
[Backport 2.2] Bug fix: The standard index should not fail if a value already exists

### DIFF
--- a/crates/core/src/doc/index.rs
+++ b/crates/core/src/doc/index.rs
@@ -354,12 +354,7 @@ impl<'a> IndexOperation<'a> {
 			let i = Indexable::new(n, self.ix);
 			for n in i {
 				let key = self.get_non_unique_index_key(&n)?;
-				if txn.putc(key, revision::to_vec(self.rid)?, None).await.is_err() {
-					let key = self.get_non_unique_index_key(&n)?;
-					let val = txn.get(key, None).await?.unwrap();
-					let rid: Thing = revision::from_slice(&val)?;
-					return self.err_index_exists(rid, n);
-				}
+				txn.set(key, revision::to_vec(self.rid)?, None).await?;
 			}
 		}
 		Ok(())

--- a/crates/core/src/idx/index.rs
+++ b/crates/core/src/idx/index.rs
@@ -119,12 +119,7 @@ impl<'a> IndexOperation<'a> {
 			let i = Indexable::new(n, self.ix);
 			for n in i {
 				let key = self.get_non_unique_index_key(&n)?;
-				if txn.putc(key, revision::to_vec(self.rid)?, None).await.is_err() {
-					let key = self.get_non_unique_index_key(&n)?;
-					let val = txn.get(key, None).await?.unwrap();
-					let rid: Thing = revision::from_slice(&val)?;
-					return self.err_index_exists(rid, n);
-				}
+				txn.set(key, revision::to_vec(self.rid)?, None).await?;
 			}
 		}
 		Ok(())

--- a/crates/language-tests/tests/language/statements/create/create_with_std_index_with_flattened_field.surql
+++ b/crates/language-tests/tests/language/statements/create/create_with_std_index_with_flattened_field.surql
@@ -1,0 +1,50 @@
+/**
+[test]
+
+[[test.results]]
+value = "None"
+
+[[test.results]]
+value = "[{ id: student:1, marks: [{ mark: 40, subject: 'english' }] }]"
+
+[[test.results]]
+value = "[{ id: student:2, marks: [{ mark: 40, subject: 'maths' }, { mark: 40, subject: 'english' }, { mark: 45, subject: 'hindi' }] }]"
+
+[[test.results]]
+value = "[{ detail: { plan: { index: 'mark_idx', operator: '=', value: 40 }, table: 'student' }, operation: 'Iterate Index' }, { detail: { type: 'Memory' }, operation: 'Collector' }]"
+
+[[test.results]]
+value = "[{ id: student:1, marks: [{ mark: 40, subject: 'english' }] }, { id: student:2, marks: [{ mark: 40, subject: 'maths' }, { mark: 40, subject: 'english' }, { mark: 45, subject: 'hindi' }]}]"
+
+[[test.results]]
+value = "None"
+
+[[test.results]]
+value = "[{ id: student:1, marks: [{ mark: 40, subject: 'english' }] }, { id: student:2, marks: [{ mark: 40, subject: 'maths' }, { mark: 40, subject: 'english' }, { mark: 45, subject: 'hindi' }]}]"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "[{ id: student:1, marks: [{ mark: 40, subject: 'english' }] }]"
+
+*/
+DEFINE INDEX mark_idx ON student COLUMNS marks.*.mark;
+CREATE student:1 CONTENT {
+    marks: [
+        { subject: "english", mark: 40 }
+    ]
+};
+CREATE student:2 CONTENT {
+    marks: [
+        { subject: "maths", mark: 40 },
+        { subject: "english", mark: 40 },
+        { subject: "hindi", mark: 45 }
+    ]
+};
+SELECT * FROM student WHERE marks.*.mark CONTAINS 40 EXPLAIN;
+SELECT * FROM student WITH NOINDEX WHERE marks.*.mark CONTAINS 40;
+REBUILD INDEX mark_idx ON student;
+SELECT * FROM student WITH NOINDEX WHERE marks.*.mark CONTAINS 40;
+DELETE student:2;
+SELECT * FROM student WITH NOINDEX WHERE marks.*.mark CONTAINS 40;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport #6155

## What does this change do?

Backport #6155

## What is your testing strategy?

Github action

## Is this related to any issues?

Backport #6155

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
