### PR TITLE
Add Out of Disk (OOD) Error Handling for RocksDB Backend

### DIFF
--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -22,6 +22,8 @@ const TARGET: &str = "surrealdb::core::kvs::rocksdb";
 
 pub struct Datastore {
 	db: Pin<Arc<OptimisticTransactionDB>>,
+	/// Whether the database is in read-only mode due to OOD (Out of Disk) condition
+	ood_readonly: bool,
 }
 
 pub struct Transaction {
@@ -191,52 +193,92 @@ impl Datastore {
 				bail!(Error::Ds(format!("Invalid storage engine log level specified: {l}")));
 			}
 		});
-		// Configure background WAL flush behaviour
-		let db = match *cnf::ROCKSDB_BACKGROUND_FLUSH {
-			// Beckground flush is disabled which
-			// means that the WAL will be flushed
-			// whenever a transaction is committed.
-			false => {
-				// Dispay the configuration setting
-				info!(target: TARGET, "Background write-ahead-log flushing: disabled");
-				// Enable manual WAL flush
-				opts.set_manual_wal_flush(false);
-				// Create the optimistic datastore
-				Arc::pin(OptimisticTransactionDB::open(&opts, path)?)
+		// TODO: Background error recovery options are not yet available in rocksdb crate v0.23.0
+		// These would help handle Out of Disk (OOD) errors gracefully by allowing automatic resume
+		// after background errors. When available, uncomment the following:
+		// info!(target: TARGET, "Maximum background error resume count: {}", *cnf::ROCKSDB_MAX_BGERROR_RESUME_COUNT);
+		// opts.set_max_bgerror_resume_count(*cnf::ROCKSDB_MAX_BGERROR_RESUME_COUNT);
+		// info!(target: TARGET, "Background error resume retry interval: {}μs", *cnf::ROCKSDB_BGERROR_RESUME_RETRY_INTERVAL);
+		// opts.set_bgerror_resume_retry_interval(*cnf::ROCKSDB_BGERROR_RESUME_RETRY_INTERVAL);
+		// Configure background WAL flush behaviour and handle OOD errors during startup
+		let (db, ood_readonly) = match Self::open(opts.clone(), false, path).await {
+			Ok(db) => {
+				// Database opened successfully - no OOD condition
+				(db, false)
 			}
-			// Background flush is enabled so we
-			// spawn a background worker thread to
-			// flush the WAL to disk periodically.
-			true => {
-				// Dispay the configuration setting
-				info!(target: TARGET, "Background write-ahead-log flushing: enabled every {}ms", *cnf::ROCKSDB_BACKGROUND_FLUSH_INTERVAL);
-				// Enable manual WAL flush
-				opts.set_manual_wal_flush(true);
-				// Create the optimistic datastore
-				let db = Arc::pin(OptimisticTransactionDB::open(&opts, path)?);
-				// Clone the database reference
-				let dbc = db.clone();
-				// Create a new background thread
-				thread::spawn(move || {
-					loop {
-						// Get the specified flush interval
-						let wait = *cnf::ROCKSDB_BACKGROUND_FLUSH_INTERVAL;
-						// Wait for the specified interval
-						thread::sleep(Duration::from_millis(wait));
-						// Flush the WAL to disk periodically
-						if let Err(err) = dbc.flush_wal(*cnf::SYNC_DATA) {
-							error!("Failed to flush WAL: {err}");
+			Err(err) => {
+				// Check if this is an OOD error during startup
+				if Transaction::is_ood_error(&err) {
+					Transaction::log_ood_error(&err, "database startup");
+					warn!(target: TARGET, "OOD detected during startup - attempting to open in read-only mode");
+					match Self::open(opts, true, path).await {
+						Ok(db) => {
+							warn!(target: TARGET, "Database opened in read-only mode due to OOD condition");
+							(db, true) // Mark as OOD read-only mode
+						}
+						Err(_) => {
+							error!(target: TARGET, "Failed to open database even in read-only mode due to OOD");
+							return Err(err);
 						}
 					}
-				});
-				// Return the datastore
-				db
+				} else {
+					// Not an OOD error, return immediately
+					return Err(err);
+				}
 			}
 		};
+
 		// Return the datastore
 		Ok(Datastore {
 			db,
+			ood_readonly,
 		})
+	}
+
+	/// Open database with normal configuration
+	async fn open(
+		mut opts: Options,
+		read_only: bool,
+		path: &str,
+	) -> Result<Pin<Arc<OptimisticTransactionDB>>> {
+		if !*cnf::ROCKSDB_BACKGROUND_FLUSH || read_only {
+			// Background flush is disabled which
+			// means that the WAL will be flushed
+			// whenever a transaction is committed.
+			// Display the configuration setting
+			info!(target: TARGET, "Background write-ahead-log flushing: disabled");
+			// Enable manual WAL flush
+			opts.set_manual_wal_flush(false);
+			// Create the optimistic datastore
+			Ok(Arc::pin(OptimisticTransactionDB::open(&opts, path)?))
+		} else {
+			// Background flush is enabled so we
+			// spawn a background worker thread to
+			// flush the WAL to disk periodically.
+			// Display the configuration setting
+			info!(target: TARGET, "Background write-ahead-log flushing: enabled every {}ms", *cnf::ROCKSDB_BACKGROUND_FLUSH_INTERVAL);
+			// Enable manual WAL flush
+			opts.set_manual_wal_flush(true);
+			// Create the optimistic datastore
+			let db = Arc::pin(OptimisticTransactionDB::open(&opts, path)?);
+			// Clone the database reference
+			let dbc = db.clone();
+			// Create a new background thread
+			thread::spawn(move || {
+				loop {
+					// Get the specified flush interval
+					let wait = *cnf::ROCKSDB_BACKGROUND_FLUSH_INTERVAL;
+					// Wait for the specified interval
+					thread::sleep(Duration::from_millis(wait));
+					// Flush the WAL to disk periodically
+					if let Err(err) = dbc.flush_wal(*cnf::SYNC_DATA) {
+						error!("Failed to flush WAL: {err}");
+					}
+				}
+			});
+			// Return the datastore
+			Ok(db)
+		}
 	}
 
 	/// Shutdown the database
@@ -263,6 +305,12 @@ impl Datastore {
 		write: bool,
 		_: bool,
 	) -> Result<Box<dyn crate::kvs::api::Transaction>> {
+		// Check if database is in OOD read-only mode and a write transaction is requested
+		if self.ood_readonly && write {
+			warn!(target: TARGET, "Write transaction requested but database is in OOD read-only mode");
+			return Err(Error::TxReadonly.into());
+		}
+
 		// Set the transaction options
 		let mut to = OptimisticTransactionOptions::default();
 		to.set_snapshot(true);
@@ -704,5 +752,20 @@ impl Transaction {
 		// Check to see if transaction is closed
 		ensure!(!self.done, Error::TxFinished);
 		Ok(rng)
+	}
+
+	/// Check if an error is related to Out of Disk (OOD) conditions
+	fn is_ood_error(error: &anyhow::Error) -> bool {
+		let error_msg = error.to_string().to_lowercase();
+		error_msg.contains("no space left on device")
+			|| error_msg.contains("disk full")
+			|| error_msg.contains("out of space")
+			|| error_msg.contains("enospc")
+	}
+
+	/// Log OOD error with appropriate context
+	fn log_ood_error(error: &anyhow::Error, context: &str) {
+		error!(target: TARGET, "Out of Disk error during {}: {}", context, error);
+		warn!(target: TARGET, "Database may enter read-only mode until disk space is available");
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When disk space is exhausted, SurrealDB with RocksDB backend would fail with errors like:
```
There was a problem with the database: There was a problem with a datastore transaction: IO error: No space left on device: While appending to file: data/000071.blob: No space left on device
```

This could lead to:
- Complete service unavailability, even for read operations
- Crash loops where the database repeatedly fails to start
- No graceful degradation when disk space issues occur

## What does this change do?

This implementation provides a unified OOD handling mechanism that:

#### 1. **OOD Detection During Startup**
- Automatically detects OOD errors by examining error messages for patterns:
  - "no space left on device"
  - "disk full" 
  - "out of space"
  - "enospc"

#### 2. **Read-Only Mode Fallback**
- When OOD is detected during database startup:
  - Attempts to open the database with conservative settings (manual WAL flush)
  - If successful, marks the database as operating in read-only mode
  - Maintains service availability for read operations

#### 3. **Transaction-Level Enforcement**
- Added `ood_readonly` field to `Datastore` struct to track read-only state
- Write transaction requests return `TxReadonly` errors when in OOD mode
- Read transactions continue to work normally
- Uses existing SurrealDB error types for consistency

#### 4. **Future-Ready Background Error Recovery**
- Added configuration constants for RocksDB background error recovery options
- Implementation prepared but commented out (methods not yet available in rocksdb crate v0.23.0)
- Will enable automatic resume after background errors when supported

### Key Features

- **Always Enabled**: No configuration required, mechanism is always active
- **Graceful Degradation**: Service remains available for reads during OOD conditions
- **Clear Logging**: Comprehensive logging of OOD detection and read-only mode activation
- **Simple Architecture**: Single unified mechanism without complex retry logic
- **Backward Compatible**: No breaking changes to existing functionality

### Files Changed

- `crates/core/src/kvs/rocksdb/mod.rs`: Main implementation with OOD detection and read-only enforcement
- `crates/core/src/kvs/rocksdb/cnf.rs`: Configuration constants for future background error recovery
- `OOD_STARTUP_HANDLING.md`: Comprehensive documentation

### Example Behavior

**Normal Operation:**
```
INFO  Starting kvs store at rocksdb://data
INFO  Started kvs store at rocksdb://data
```

**OOD Detected:**
```
INFO  Starting kvs store at rocksdb://data
ERROR Out of Disk error during database startup: IO error: No space left on device
WARN  Database may enter read-only mode until disk space is available
WARN  OOD detected during startup - attempting to open in read-only mode
WARN  Database opened in read-only mode due to OOD condition
INFO  Started kvs store at rocksdb://data
```

**Write Attempt in Read-Only Mode:**
```
WARN  Write transaction requested but database is in OOD read-only mode
ERROR Couldn't write to a read only transaction
```

### Benefits

- **Improved Reliability**: Prevents crash loops during OOD situations
- **Service Continuity**: Read operations remain available during disk space issues
- **Operational Clarity**: Clear error messages and logging for troubleshooting
- **Future-Proof**: Ready for enhanced background error recovery when available

### Recovery

To recover from OOD read-only mode:
1. Free up disk space on the storage device
2. Restart the SurrealDB service
3. Database will resume full read/write operations if sufficient space is available

This implementation significantly improves SurrealDB's resilience to disk space issues while maintaining a simple, predictable behavior pattern.

## What is your testing strategy?

Manual

## Is this related to any issues?

Fixes #5751

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
