### PR TITLE
Fix flaky TiKV CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -672,7 +672,6 @@ jobs:
           df -h
           ps auxf
 
-  # TODO(DB-662): TiKV engine tests stopped working after July 29th
   tikv-engine:
     name: Rust SDK - TiKV engine
     runs-on: ubuntu-latest
@@ -701,7 +700,6 @@ jobs:
         run: cargo install --debug --locked cargo-make
 
       - name: Test TiKV engine
-        continue-on-error: true
         run: cargo make ci-api-integration-tikv
 
       - name: Debug info

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -391,6 +391,7 @@ run_task = { name = [
     "start-tikv",
     "test-kvs",
     "stop-tikv",
+    "sleep",
     "start-tikv",
     "test-api-integration",
     "stop-tikv",
@@ -469,8 +470,6 @@ script = """
     #!/bin/bash -ex
 	echo "Installing TiKV playground..."
     ${HOME}/.tiup/bin/tiup install pd tikv playground
-	echo "Cleaning TiKV playground..."
-	${HOME}/.tiup/bin/tiup clean --all
 	echo "Starting TiKV playground..."
 	nohup ${HOME}/.tiup/bin/tiup playground --mode tikv-slim --kv 1 --pd 1 --db 0 --ticdc 0 --tiflash 0 --without-monitor > /tmp/tiup.log &
 	set +e
@@ -493,9 +492,9 @@ script = """
 [tasks.stop-tikv]
 category = "CI - SERVICES"
 script = """
-${HOME}/.tiup/bin/tiup clean --all
+    #!/bin/bash -ex
+    ${HOME}/.tiup/bin/tiup clean --all
 """
-
 
 [tasks.clear-fdb]
 category = "CI - SERVICES"
@@ -508,6 +507,11 @@ args = [
     "--timeout",
     "20",
 ]
+
+[tasks.sleep]
+category = "CI - SERVICES"
+command = "sleep"
+args = ["30"]
 
 #
 # Builds

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -467,11 +467,19 @@ script = """
 category = "CI - SERVICES"
 script = """
     #!/bin/bash -ex
+
 	echo "Installing TiKV playground..."
     ${HOME}/.tiup/bin/tiup install pd tikv playground
+
+    echo "Cleaning TiKV playground..."
+    ${HOME}/.tiup/bin/tiup clean --all
+    killall -q tiup-playground || true
+    rm -rf ${HOME}/.tiup/data/testing
+
 	echo "Starting TiKV playground..."
 	nohup ${HOME}/.tiup/bin/tiup playground --mode tikv-slim --kv 1 --pd 1 --db 0 --ticdc 0 --tiflash 0 --without-monitor --tag "testing" > /tmp/tiup.log &
-	set +e
+
+    set +e
 	tries=0
 	echo "Waiting for TiKV playground to start..."
 	while [[ $tries -lt 5 ]]; do
@@ -483,8 +491,10 @@ script = """
 		fi
 		exit 0;
 	done
+
 	echo "PANIC: Couldn't start TiKV playground! Here are the logs for the last attempt:"
     cat /tmp/tiup.log
+
     exit 1
 """
 
@@ -492,8 +502,12 @@ script = """
 category = "CI - SERVICES"
 script = """
     #!/bin/bash -ex
+
     echo "Cleaning TiKV playground..."
-    ${HOME}/.tiup/bin/tiup clean "testing"
+    ${HOME}/.tiup/bin/tiup clean --all
+    killall -q tiup-playground || true
+    rm -rf ${HOME}/.tiup/data/testing
+
     set +e
 	tries=0
 	echo "Waiting for TiKV playground to stop..."
@@ -506,8 +520,10 @@ script = """
 		fi
 		exit 0;
 	done
+
 	echo "PANIC: Couldn't stop TiKV playground! Here are the logs for the last attempt:"
     cat /tmp/tiup.log
+
     exit 1
 """
 
@@ -541,6 +557,7 @@ args = [
 #
 # Benchmarks - Common
 #
+
 [tasks.ci-bench]
 category = "CI - BENCHMARK"
 command = "cargo"

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -391,7 +391,6 @@ run_task = { name = [
     "start-tikv",
     "test-kvs",
     "stop-tikv",
-    "sleep",
     "start-tikv",
     "test-api-integration",
     "stop-tikv",
@@ -471,11 +470,11 @@ script = """
 	echo "Installing TiKV playground..."
     ${HOME}/.tiup/bin/tiup install pd tikv playground
 	echo "Starting TiKV playground..."
-	nohup ${HOME}/.tiup/bin/tiup playground --mode tikv-slim --kv 1 --pd 1 --db 0 --ticdc 0 --tiflash 0 --without-monitor > /tmp/tiup.log &
+	nohup ${HOME}/.tiup/bin/tiup playground --mode tikv-slim --kv 1 --pd 1 --db 0 --ticdc 0 --tiflash 0 --without-monitor --tag "testing" > /tmp/tiup.log &
 	set +e
 	tries=0
-	echo "Waiting for TiKV playground to be ready..."
-	while [[ $tries -lt 10 ]]; do
+	echo "Waiting for TiKV playground to start..."
+	while [[ $tries -lt 5 ]]; do
 		sleep 5
 		echo "Displaying playground status..."
 		if ! ${HOME}/.tiup/bin/tiup playground display >/dev/null; then
@@ -484,7 +483,7 @@ script = """
 		fi
 		exit 0;
 	done
-	echo "PANIC: Couldn't start tiup playground! Here are the logs for the last attempt:"
+	echo "PANIC: Couldn't start TiKV playground! Here are the logs for the last attempt:"
     cat /tmp/tiup.log
     exit 1
 """
@@ -493,7 +492,23 @@ script = """
 category = "CI - SERVICES"
 script = """
     #!/bin/bash -ex
-    ${HOME}/.tiup/bin/tiup clean --all
+    echo "Cleaning TiKV playground..."
+    ${HOME}/.tiup/bin/tiup clean "testing"
+    set +e
+	tries=0
+	echo "Waiting for TiKV playground to stop..."
+	while [[ $tries -lt 5 ]]; do
+		sleep 5
+		echo "Displaying playground status..."
+		if ${HOME}/.tiup/bin/tiup playground display >/dev/null; then
+			tries=$((tries + 1));
+			continue
+		fi
+		exit 0;
+	done
+	echo "PANIC: Couldn't stop TiKV playground! Here are the logs for the last attempt:"
+    cat /tmp/tiup.log
+    exit 1
 """
 
 [tasks.clear-fdb]
@@ -507,11 +522,6 @@ args = [
     "--timeout",
     "20",
 ]
-
-[tasks.sleep]
-category = "CI - SERVICES"
-command = "sleep"
-args = ["30"]
 
 #
 # Builds


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

TiKV tests stopped working, and became flaky. This was due to the cluster cleanup command appearing to succeed, but operating asynchronously after the command exited.

## What does this change do?

Adds a timeout delay after cleaning up the TiKV cluster.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
