### PR TITLE
Ensure logging CLI options are consistent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1049,7 +1049,7 @@ jobs:
           PYTHONPATH: ./src
           SURREALDB_URL: http://localhost:8000
           SURREALDB_VERSION: ${{ matrix.version }}
-          PYTHONWARNINGS: ignore::ResourceWarning
+          PYTHONWARNINGS: ignore::ResourceWarning,ignore::UserWarning
 
       - name: Run Python tests (WebSocket)
         run: uv run pytest
@@ -1057,7 +1057,7 @@ jobs:
           PYTHONPATH: ./src
           SURREALDB_URL: ws://localhost:8000
           SURREALDB_VERSION: ${{ matrix.version }}
-          PYTHONWARNINGS: ignore::ResourceWarning
+          PYTHONWARNINGS: ignore::ResourceWarning,ignore::UserWarning
 
   sdk-php:
     name: PHP SDK tests (${{ matrix.version }})

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -79,50 +79,67 @@ struct Cli {
 	#[arg(default_value = "text")]
 	#[arg(value_enum)]
 	log_format: LogFormat,
-	#[arg(help = "Override the logging level for file output", help_heading = "Logging")]
-	#[arg(env = "SURREAL_LOG_FILE_LEVEL", long = "log-file-level")]
-	#[arg(global = true)]
-	#[arg(value_parser = CustomFilterParser::new())]
-	log_file_level: Option<CustomFilter>,
-	#[arg(help = "Override the logging level for OpenTelemetry", help_heading = "Logging")]
-	#[arg(env = "SURREAL_LOG_OTEL_LEVEL", long = "log-otel-level")]
-	#[arg(global = true)]
-	#[arg(value_parser = CustomFilterParser::new())]
-	log_otel_level: Option<CustomFilter>,
 	#[arg(help = "Send logs to the specified host:port", help_heading = "Logging")]
 	#[arg(env = "SURREAL_LOG_SOCKET", long = "log-socket")]
 	#[arg(global = true)]
 	log_socket: Option<String>,
 	//
-	// Log file
+	// Log level overrides
+	//
+	#[arg(help = "Override the logging level for file output", help_heading = "Logging")]
+	#[arg(env = "SURREAL_LOG_FILE_LEVEL", long = "log-file-level")]
+	#[arg(global = true)]
+	#[arg(value_parser = CustomFilterParser::new())]
+	log_file_level: Option<CustomFilter>,
+	#[arg(help = "Override the logging level for OpenTelemetry output", help_heading = "Logging")]
+	#[arg(env = "SURREAL_LOG_OTEL_LEVEL", long = "log-otel-level")]
+	#[arg(global = true)]
+	#[arg(value_parser = CustomFilterParser::new())]
+	log_otel_level: Option<CustomFilter>,
+	#[arg(help = "Override the logging level for unix socket output", help_heading = "Logging")]
+	#[arg(env = "SURREAL_LOG_SOCKET_LEVEL", long = "log-socket-level")]
+	#[arg(global = true)]
+	#[arg(value_parser = CustomFilterParser::new())]
+	log_socket_level: Option<CustomFilter>,
+	//
+	// Log socket options
+	//
+	#[arg(help = "The format for socket output", help_heading = "Logging")]
+	#[arg(env = "SURREAL_LOG_SOCKET_FORMAT", long = "log-socket-format")]
+	#[arg(global = true)]
+	#[arg(default_value = "text")]
+	#[arg(value_enum)]
+	log_socket_format: LogFormat,
+	//
+	// Log file options
 	//
 	#[arg(help = "Whether to enable log file output", help_heading = "Logging")]
 	#[arg(env = "SURREAL_LOG_FILE_ENABLED", long = "log-file-enabled")]
 	#[arg(global = true)]
 	#[arg(default_value_t = false)]
-	pub log_file_enabled: bool,
+	log_file_enabled: bool,
 	#[arg(help = "The directory where log files will be stored", help_heading = "Logging")]
 	#[arg(env = "SURREAL_LOG_FILE_PATH", long = "log-file-path")]
 	#[arg(global = true)]
 	#[arg(default_value = "logs")]
-	pub log_file_path: String,
+	log_file_path: String,
 	#[arg(help = "The name of the log file", help_heading = "Logging")]
 	#[arg(env = "SURREAL_LOG_FILE_NAME", long = "log-file-name")]
 	#[arg(global = true)]
 	#[arg(default_value = "surrealdb.log")]
-	pub log_file_name: String,
-	#[arg(help = "The log file rotation interval", help_heading = "Logging")]
-	#[arg(env = "SURREAL_LOG_FILE_ROTATION", long = "log-file-rotation")]
-	#[arg(global = true)]
-	#[arg(default_value = "daily")]
-	#[arg(value_enum)]
-	pub log_file_rotation: LogFileRotation,
+	log_file_name: String,
 	#[arg(help = "The format for log file output", help_heading = "Logging")]
 	#[arg(env = "SURREAL_LOG_FILE_FORMAT", long = "log-file-format")]
 	#[arg(global = true)]
 	#[arg(default_value = "text")]
 	#[arg(value_enum)]
-	pub log_file_format: LogFormat,
+	log_file_format: LogFormat,
+	#[arg(help = "The log file rotation interval", help_heading = "Logging")]
+	#[arg(env = "SURREAL_LOG_FILE_ROTATION", long = "log-file-rotation")]
+	#[arg(global = true)]
+	#[arg(default_value = "daily")]
+	#[arg(value_enum)]
+	log_file_rotation: LogFileRotation,
 	//
 	// Version check
 	//
@@ -208,15 +225,11 @@ pub async fn init() -> ExitCode {
 		let client = version_client::new(Some(Duration::from_millis(500))).unwrap();
 		if let Err(opt_version) = check_upgrade(&client, PKG_VERSION.deref()).await {
 			match opt_version {
-				None => {
-					warn!("A new version of SurrealDB may be available.");
-				}
-				Some(new_version) => {
-					warn!("A new version of SurrealDB is available: {}", new_version);
-				}
-			}
+				None => warn!("A new version of SurrealDB may be available."),
+				Some(v) => warn!("A new version of SurrealDB is available: {v}"),
+			};
 			// TODO ansi_term crate?
-			warn!("You can upgrade using the {} command", "surreal upgrade");
+			warn!("You can upgrade using the 'surreal upgrade' command");
 		}
 	}
 	// Check if we are running the server
@@ -224,16 +237,18 @@ pub async fn init() -> ExitCode {
 	// Initialize opentelemetry and logging
 	let telemetry = crate::telemetry::builder()
 		.with_log_level("info")
+		.with_log_format(args.log_format)
 		.with_filter(args.log.clone())
 		.with_file_filter(args.log_file_level.clone())
 		.with_otel_filter(args.log_otel_level.clone())
-		.with_log_socket(args.log_socket.clone())
-		.with_log_format(args.log_format)
-		.with_log_file_enabled(args.log_file_enabled)
-		.with_log_file_path(Some(args.log_file_path.clone()))
-		.with_log_file_name(Some(args.log_file_name.clone()))
-		.with_log_file_rotation(Some(args.log_file_rotation.as_str().to_string()))
-		.with_log_file_format(args.log_file_format);
+		.with_socket_filter(args.log_socket_level.clone())
+		.with_socket(args.log_socket.clone())
+		.with_socket_format(args.log_socket_format)
+		.with_file_enabled(args.log_file_enabled)
+		.with_file_path(Some(args.log_file_path.clone()))
+		.with_file_name(Some(args.log_file_name.clone()))
+		.with_file_format(args.log_file_format)
+		.with_file_rotation(Some(args.log_file_rotation.as_str().to_string()));
 	// Extract the telemetry log guards
 	let guards = telemetry.init().expect("Unable to configure logs");
 	// After version warning we can run the respective command

--- a/src/telemetry/console/mod.rs
+++ b/src/telemetry/console/mod.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::registry::LookupSpan;
 const DEFAULT_TOKIO_CONSOLE_ADDR: SocketAddr =
 	SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6669);
 
-pub fn new<S>() -> Result<impl Layer<S> + Send + Sync>
+pub fn new<S>() -> Result<Box<dyn Layer<S> + Send + Sync>>
 where
 	S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync,
 {
@@ -23,8 +23,10 @@ where
 		None => DEFAULT_TOKIO_CONSOLE_ADDR,
 	};
 	info!("Tokio Console server configured to run on {socket_addr}");
-	Ok(ConsoleLayer::builder()
-		.server_addr(socket_addr)
-		.retention(Duration::from_secs(*TOKIO_CONSOLE_RETENTION))
-		.spawn())
+	Ok(Box::new(
+		ConsoleLayer::builder()
+			.server_addr(socket_addr)
+			.retention(Duration::from_secs(*TOKIO_CONSOLE_RETENTION))
+			.spawn(),
+	))
 }

--- a/src/telemetry/logs/mod.rs
+++ b/src/telemetry/logs/mod.rs
@@ -1,3 +1,5 @@
+pub mod socket;
+
 use crate::cli::LogFormat;
 use crate::cli::validator::parser::tracing::CustomFilter;
 use anyhow::Result;
@@ -7,9 +9,6 @@ use tracing_appender::non_blocking::NonBlocking;
 use tracing_subscriber::Layer;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
-
-mod socket;
-pub use socket::SocketWriter;
 
 pub fn file<S>(
 	filter: CustomFilter,

--- a/src/telemetry/logs/socket.rs
+++ b/src/telemetry/logs/socket.rs
@@ -1,25 +1,31 @@
 use std::io::{Result, Write};
-use std::net::{TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 
 /// Simple writer that outputs log lines to a TCP socket.
-/// TODO: reconnect when the connection fails?
-/// TODO: metric for when connection fails?
-pub struct SocketWriter {
+pub struct Socket {
 	stream: TcpStream,
 }
 
-impl SocketWriter {
+/// Connect to the given socket address.
+pub fn connect(addr: SocketAddr) -> Result<Socket> {
+	Socket::connect(addr)
+}
+
+impl Socket {
 	/// Connect to the given socket address.
 	pub fn connect<A: ToSocketAddrs>(addr: A) -> Result<Self> {
+		// Open a TCP stream to the given address
 		let stream = TcpStream::connect(addr)?;
+		// Ensure logs are sent immediately
 		stream.set_nodelay(true).ok();
+		// Return the socket writer
 		Ok(Self {
 			stream,
 		})
 	}
 }
 
-impl Write for SocketWriter {
+impl Write for Socket {
 	fn write(&mut self, buf: &[u8]) -> Result<usize> {
 		self.stream.write(buf)
 	}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -7,6 +7,7 @@ use crate::cli::LogFormat;
 use crate::cli::validator::parser::tracing::CustomFilter;
 use crate::cnf::ENABLE_TOKIO_CONSOLE;
 use anyhow::Result;
+use anyhow::anyhow;
 use opentelemetry::KeyValue;
 use opentelemetry::global;
 use opentelemetry_sdk::Resource;
@@ -48,14 +49,19 @@ pub static OTEL_DEFAULT_RESOURCE: LazyLock<Resource> = LazyLock::new(|| {
 pub struct Builder {
 	format: LogFormat,
 	filter: CustomFilter,
+	socket: Option<String>,
+	// Filter options
 	file_filter: Option<CustomFilter>,
 	otel_filter: Option<CustomFilter>,
-	log_socket: Option<String>,
-	log_file_enabled: bool,
-	log_file_format: LogFormat,
-	log_file_path: Option<String>,
-	log_file_name: Option<String>,
-	log_file_rotation: Option<String>,
+	socket_filter: Option<CustomFilter>,
+	// Socket options
+	socket_format: LogFormat,
+	// File options
+	file_enabled: bool,
+	file_format: LogFormat,
+	file_path: Option<String>,
+	file_name: Option<String>,
+	file_rotation: Option<String>,
 }
 
 pub fn builder() -> Builder {
@@ -70,14 +76,19 @@ impl Default for Builder {
 				spans: std::collections::HashMap::new(),
 			},
 			format: LogFormat::Text,
+			socket: None,
+			// Filter options
 			file_filter: None,
 			otel_filter: None,
-			log_socket: None,
-			log_file_format: LogFormat::Text,
-			log_file_enabled: false,
-			log_file_path: Some("logs".to_string()),
-			log_file_name: Some("surrealdb.log".to_string()),
-			log_file_rotation: Some("daily".to_string()),
+			socket_filter: None,
+			// Socket options
+			socket_format: LogFormat::Text,
+			// File options
+			file_format: LogFormat::Text,
+			file_enabled: false,
+			file_path: Some("logs".to_string()),
+			file_name: Some("surrealdb.log".to_string()),
+			file_rotation: Some("daily".to_string()),
 		}
 	}
 }
@@ -122,9 +133,15 @@ impl Builder {
 		self
 	}
 
+	/// Set a custom log filter for socket output
+	pub fn with_socket_filter(mut self, filter: Option<CustomFilter>) -> Self {
+		self.socket_filter = filter;
+		self
+	}
+
 	/// Send logs to the provided socket address
-	pub fn with_log_socket(mut self, socket: Option<String>) -> Self {
-		self.log_socket = socket;
+	pub fn with_socket(mut self, socket: Option<String>) -> Self {
+		self.socket = socket;
 		self
 	}
 
@@ -134,33 +151,39 @@ impl Builder {
 		self
 	}
 
-	/// Enable or disable the log file
-	pub fn with_log_file_enabled(mut self, enabled: bool) -> Self {
-		self.log_file_enabled = enabled;
+	/// Set the log file output format
+	pub fn with_file_format(mut self, format: LogFormat) -> Self {
+		self.file_format = format;
 		self
 	}
 
-	/// Set the log file output format
-	pub fn with_log_file_format(mut self, format: LogFormat) -> Self {
-		self.log_file_format = format;
+	/// Set the terminal log output format
+	pub fn with_socket_format(mut self, format: LogFormat) -> Self {
+		self.format = format;
+		self
+	}
+
+	/// Enable or disable the log file
+	pub fn with_file_enabled(mut self, enabled: bool) -> Self {
+		self.file_enabled = enabled;
 		self
 	}
 
 	/// Set the log file path
-	pub fn with_log_file_path(mut self, path: Option<String>) -> Self {
-		self.log_file_path = path;
+	pub fn with_file_path(mut self, path: Option<String>) -> Self {
+		self.file_path = path;
 		self
 	}
 
 	/// Set the log file name
-	pub fn with_log_file_name(mut self, name: Option<String>) -> Self {
-		self.log_file_name = name;
+	pub fn with_file_name(mut self, name: Option<String>) -> Self {
+		self.file_name = name;
 		self
 	}
 
 	/// Set the log file rotation interval (daily, hourly, or never)
-	pub fn with_log_file_rotation(mut self, rotation: Option<String>) -> Self {
-		self.log_file_rotation = rotation;
+	pub fn with_file_rotation(mut self, rotation: Option<String>) -> Self {
+		self.file_rotation = rotation;
 		self
 	}
 
@@ -181,43 +204,58 @@ impl Builder {
 			.thread_name("surrealdb-logger-stderr")
 			.finish(std::io::stderr());
 		// Create the display destination layer
-		let output_layer = logs::output(self.filter.clone(), stdout, stderr, self.format)?;
-		// Create the otel destination layer
-		let telemetry_filter = self.otel_filter.clone().unwrap_or_else(|| self.filter.clone());
-		let telemetry_layer = traces::new(telemetry_filter)?;
+		let stdio_layer = logs::output(self.filter.clone(), stdout, stderr, self.format)?;
 		// Setup a registry for composing layers
-		let registry = tracing_subscriber::registry().with(output_layer);
+		let registry = tracing_subscriber::registry();
+		// Setup stdio destination layer
+		let registry = registry.with(stdio_layer);
+		// Setup guards
 		let mut guards = vec![stdout_guard, stderr_guard];
+		// Setup layers
 		let mut layers = Vec::new();
-		let registry = registry.with(telemetry_layer);
 
-		// Setup optional socket layer
-		if let Some(addr) = &self.log_socket {
-			let mut addrs_iter = addr.to_socket_addrs()?;
-			let first_address = addrs_iter.next().ok_or("No matching addresses");
-			let writer = logs::SocketWriter::connect(first_address.unwrap())?;
-			let (sock, sock_guard) = NonBlockingBuilder::default()
-				.lossy(false)
-				.thread_name("surrealdb-logger-socket")
-				.finish(writer);
-			let socket_layer = logs::file(
-				self.otel_filter.clone().unwrap_or_else(|| self.filter.clone()),
-				sock,
-				self.log_file_format,
-			)?;
-			layers.push(socket_layer);
-			guards.push(sock_guard);
+		// Setup logging to opentelemetry
+		{
+			// Get the otel filter or global filter
+			let filter = self.otel_filter.clone().unwrap_or_else(|| self.filter.clone());
+			// Create the otel destination layer
+			if let Some(layer) = traces::new(filter)? {
+				// Add the layer to the registry
+				layers.push(layer);
+			}
 		}
 
-		// Setup file logging if enabled
-		if self.log_file_enabled {
+		// Setup logging to socket if enabled
+		if let Some(addr) = &self.socket {
+			// Parse the first socket address
+			let address =
+				addr.to_socket_addrs()?.next().ok_or_else(|| anyhow!("No matching addresses"))?;
+			// Connect to the socket address
+			let socket = logs::socket::connect(address)?;
+			// Create a non-blocking socket log destination
+			let (writer, guard) = NonBlockingBuilder::default()
+				.lossy(false)
+				.thread_name("surrealdb-logger-socket")
+				.finish(socket);
+			// Get the file filter or global filter
+			let filter = self.socket_filter.clone().unwrap_or_else(|| self.filter.clone());
+			// Create the socket destination layer
+			let layer = logs::file(filter, writer, self.socket_format)?;
+			// Add the layer to the registry
+			layers.push(layer);
+			// Add the guard to the guards
+			guards.push(guard);
+		}
+
+		// Setup logging to file if enabled
+		if self.file_enabled {
 			// Create the file appender based on rotation setting
 			let file_appender = {
 				// Parse the path and name
-				let path = self.log_file_path.as_deref().unwrap_or("logs");
-				let name = self.log_file_name.as_deref().unwrap_or("surrealdb.log");
+				let path = self.file_path.as_deref().unwrap_or("logs");
+				let name = self.file_name.as_deref().unwrap_or("surrealdb.log");
 				// Create the file appender based on rotation setting
-				match self.log_file_rotation.as_deref() {
+				match self.file_rotation.as_deref() {
 					Some("hourly") => tracing_appender::rolling::hourly(path, name),
 					Some("daily") => tracing_appender::rolling::daily(path, name),
 					Some("never") => tracing_appender::rolling::never(path, name),
@@ -225,45 +263,32 @@ impl Builder {
 				}
 			};
 			// Create a non-blocking file log destination
-			let (file, file_guard) = NonBlockingBuilder::default()
+			let (writer, guard) = NonBlockingBuilder::default()
 				.lossy(false)
 				.thread_name("surrealdb-logger-file")
 				.finish(file_appender);
+			// Get the file filter or global filter
+			let filter = self.file_filter.clone().unwrap_or_else(|| self.filter.clone());
 			// Create the file destination layer
-			let file_filter = self.file_filter.clone().unwrap_or_else(|| self.filter.clone());
-			let file_layer = logs::file(file_filter, file, self.log_file_format)?;
-			layers.push(file_layer);
-			guards.push(file_guard);
+			let layer = logs::file(filter, writer, self.file_format)?;
+			// Add the layer to the registry
+			layers.push(layer);
+			// Add the guard to the guards
+			guards.push(guard);
 		}
 
-		Ok(match (layers.len(), *ENABLE_TOKIO_CONSOLE) {
-			(0, true) => {
-				// Create the Tokio Console destination layer
-				let console_layer = console::new()?;
-				// Setup the Tokio Console layer
-				let registry = registry.with(console_layer);
-				// Return the registry
-				(Box::new(registry), guards)
-			}
-			(0, false) => {
-				// Return the registry
-				(Box::new(registry), guards)
-			}
-			(_, true) => {
-				let registry = registry.with(layers);
-				// Create the Tokio Console destination layer
-				let console_layer = console::new()?;
-				// Setup the Tokio Console layer
-				let registry = registry.with(console_layer);
-				// Return the registry
-				(Box::new(registry), guards)
-			}
-			(_, false) => {
-				let registry = registry.with(layers);
-				// Return the registry
-				(Box::new(registry), guards)
-			}
-		})
+		// Setup logging to console if enabled
+		if *ENABLE_TOKIO_CONSOLE {
+			// Create the console destination layer
+			let layer = console::new()?;
+			// Add the layer to the registry
+			layers.push(layer);
+		}
+
+		// Setup the registry
+		let registry = registry.with(layers);
+		// Return the registry and guards
+		Ok((Box::new(registry), guards))
 	}
 }
 
@@ -504,7 +529,7 @@ mod tests {
 		});
 
 		let (registry, guards) = telemetry::builder()
-			.with_log_socket(Some(addr.to_string()))
+			.with_socket(Some(addr.to_string()))
 			.with_log_level("all")
 			.build()
 			.unwrap();

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -285,10 +285,18 @@ impl Builder {
 			layers.push(layer);
 		}
 
-		// Setup the registry
-		let registry = registry.with(layers);
-		// Return the registry and guards
-		Ok((Box::new(registry), guards))
+		match layers.len() {
+			0 => {
+				// Return the registry and guards
+				Ok((Box::new(registry), guards))
+			}
+			_ => {
+				// Setup the registry layers
+				let registry = registry.with(layers);
+				// Return the registry and guards
+				Ok((Box::new(registry), guards))
+			}
+		}
 	}
 }
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -447,7 +447,7 @@ mod tests {
 
 		// Test that the server is reachable
 		let client = reqwest::Client::new();
-		let response = client.get(&format!("http://{}/", addr)).send().await;
+		let response = client.get(format!("http://{}/", addr)).send().await;
 		println!("Server response: {:?}", response);
 
 		// The server should not respond to HTTP requests, but we can verify it's running


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Logging options for file and socket designations were not consistent.

## What does this change do?

This changes introduces the following command line arguments and environment variables:

| CLI flag / Environment variable                     | Purpose                                          | Default         |
| --------------------------------------------------- | ------------------------------------------------ | --------------- |
| `--log-socket-format` / `SURREAL_LOG_SOCKET_FORMAT`   | Set the format of the logs to the unix socket | `text` |
| `--log-socket-level` / `SURREAL_LOG_SOCKET_LEVEL`         | Override the logging level for unix socket logs | empty |

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #6208

## Does this change need documentation?

- [ ] Yes, documentation to be updated

## Does this change make any alterations to environment variables or CLI commands?

- [x] Yes environment variable defaults are modified

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
