### PR TITLE
Reverse-ordered iteration to be applied for WHERE ID range (pre-sorted DESC)

### DIFF
--- a/crates/core/src/kvs/tests/reverse_iterator.rs
+++ b/crates/core/src/kvs/tests/reverse_iterator.rs
@@ -17,7 +17,9 @@ async fn test(new_ds: impl CreateDs, index: &str) -> Vec<Response> {
 		"USE NS test;
 		USE DB test;
 		{index};
-		CREATE |i:1500| SET v = rand::uuid::v7() RETURN NONE;
+		FOR $i IN 1..=1500 {{ CREATE i:[$i] SET v = $i; }};
+        SELECT v FROM i WHERE v > 500 ORDER BY v DESC LIMIT 3 EXPLAIN;
+		SELECT v FROM i WHERE v > 500 ORDER BY v DESC LIMIT 3;
 		SELECT v FROM i ORDER BY v DESC LIMIT 3 EXPLAIN;
 		SELECT v FROM i ORDER BY v DESC LIMIT 3;
 		SELECT v FROM i ORDER BY v DESC EXPLAIN;
@@ -25,7 +27,7 @@ async fn test(new_ds: impl CreateDs, index: &str) -> Vec<Response> {
 	);
 
 	let mut r = ds.execute(&sql, &Session::owner(), None).await.unwrap();
-	assert_eq!(r.len(), 8);
+	assert_eq!(r.len(), 10);
 	// Check the first statements are successful
 	for _ in 0..4 {
 		r.remove(0).result.unwrap();
@@ -54,6 +56,37 @@ fn check_array_is_sorted(v: &Value, expected_len: usize) {
 
 pub async fn standard(new_ds: impl CreateDs) {
 	let r = &mut (test(new_ds, "DEFINE INDEX idx ON TABLE i COLUMNS v").await);
+	check(
+		r,
+		"[
+			{
+				detail: {
+					plan: {
+						direction: 'backward',
+						from: {
+							inclusive: false,
+							value: 500
+						},
+						index: 'idx',
+						to: {
+							inclusive: false,
+							value: NONE
+						}
+					},
+					table: 'i'
+				},
+				operation: 'Iterate Index'
+			},
+			{
+				detail: {
+					limit: 3,
+					type: 'MemoryOrderedLimit'
+				},
+				operation: 'Collector'
+			}
+		]",
+	);
+	check_array_is_sorted(&r.remove(0).result.unwrap(), 3);
 	check(
 		r,
 		"[
@@ -103,6 +136,37 @@ pub async fn standard(new_ds: impl CreateDs) {
 
 pub async fn unique(new_ds: impl CreateDs) {
 	let r = &mut (test(new_ds, "DEFINE INDEX idx ON TABLE i COLUMNS v UNIQUE").await);
+	check(
+		r,
+		"[
+			{
+				detail: {
+					plan: {
+						direction: 'backward',
+						from: {
+							inclusive: false,
+							value: 500
+						},
+						index: 'idx',
+						to: {
+							inclusive: false,
+							value: NONE
+						}
+					},
+					table: 'i'
+				},
+				operation: 'Iterate Index'
+			},
+			{
+				detail: {
+					limit: 3,
+					type: 'MemoryOrderedLimit'
+				},
+				operation: 'Collector'
+			}
+		]",
+	);
+	check_array_is_sorted(&r.remove(0).result.unwrap(), 3);
 	check(
 		r,
 		"[


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

> [!WARNING]
No details provided.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

> [!WARNING]
> No details provided.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
