### PR TITLE
Fix LIVE SELECT parsing with type::table() expressions

### DIFF
--- a/crates/core/src/syn/parser/stmt/mod.rs
+++ b/crates/core/src/syn/parser/stmt/mod.rs
@@ -435,7 +435,7 @@ impl Parser<'_> {
 		expected!(self, t!("FROM"));
 		let what = match self.peek().kind {
 			t!("$param") => Expr::Param(self.next_token_value()?),
-			_ => Expr::Table(self.next_token_value()?),
+			_ => self.parse_expr_table(stk).await?,
 		};
 		let cond = self.try_parse_condition(stk).await?;
 		let fetch = self.try_parse_fetch(stk).await?;

--- a/crates/sdk/tests/live.rs
+++ b/crates/sdk/tests/live.rs
@@ -43,7 +43,7 @@ async fn live_permissions() -> Result<()> {
 	)
 	.with_rt(true);
 	let sql = "
-		LIVE SELECT * FROM test;
+		LIVE SELECT * FROM type::table('test');
 		CREATE test:2;
 	";
 	let res = &mut dbs.execute(sql, &ses, None).await?;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The motivation for this change is to fix a parsing inconsistency where the `type::table()` function works correctly in regular SELECT statements but fails when used in LIVE SELECT statements. This creates an unexpected limitation where users cannot use dynamic table references in live queries.

**Problem:**
- `SELECT * FROM type::table("table")` works correctly ✅
- `LIVE SELECT * FROM type::table("table")` throws a parser error ❌

**Root Cause:**
The issue was in the expression parsing logic where the `parse_expr_table()` method in LIVE statement parsing wasn't properly handling builtin function calls like `type::table()` in table contexts.

## What does this change do?

This change ensures that builtin function calls (specifically `type::table()`) are properly parsed and recognized as valid table expressions in the FROM clause of LIVE statements.

**Impact:**
- Enables consistent use of `type::table()` function across all SELECT statement types
- Allows dynamic table references in live queries
- Maintains backward compatibility with existing functionality
- No breaking changes to existing API

## What is your testing strategy?

Github action.
A test has been updated.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
