### PR TITLE
Update the toolchain for publish workflow

### DIFF
--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -233,10 +233,10 @@ jobs:
           path: target/llvm-cov/html/
           retention-days: 5
 
-  lint:
-    name: Lint
+  format:
+    name: Check format
     needs: [ prepare-vars ]
-    runs-on: [ runner-amd64-2xlarge ]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # (Actions must be pinned by commit hash) v4.2.2
@@ -253,8 +253,28 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # (Actions must be pinned by commit hash) master
         with:
           toolchain: ${{ steps.info.outputs.toolchain }}
-          targets: wasm32-unknown-unknown
-          components: rustfmt, clippy
+          components: rustfmt
+
+      - name: Install cargo-make
+        run: cargo install --debug --locked cargo-make
+
+      - name: Check format
+        run: cargo make ci-format
+
+  check:
+    name: Check workspace
+    needs: [ prepare-vars ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # (Actions must be pinned by commit hash) v4.2.2
+        with:
+          ref: ${{ needs.prepare-vars.outputs.release-branch }}
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # (Actions must be pinned by commit hash) master
+        with:
+          toolchain: ${{ inputs.rust-version }}
 
       - name: Install cargo-make
         run: cargo install --debug --locked cargo-make
@@ -262,11 +282,46 @@ jobs:
       - name: Check workspace
         run: cargo make ci-check
 
-      - name: Check format
-        run: cargo make ci-format
+  check-wasm:
+    name: Check wasm
+    needs: [ prepare-vars ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # (Actions must be pinned by commit hash) v4.2.2
+        with:
+          ref: ${{ needs.prepare-vars.outputs.release-branch }}
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # (Actions must be pinned by commit hash) master
+        with:
+          toolchain: ${{ inputs.rust-version }}
+          targets: wasm32-unknown-unknown
+
+      - name: Install cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Check wasm
         run: cargo make ci-check-wasm
+
+  clippy:
+    name: Check clippy
+    needs: [ prepare-vars ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # (Actions must be pinned by commit hash) v4.2.2
+        with:
+          ref: ${{ needs.prepare-vars.outputs.release-branch }}
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # (Actions must be pinned by commit hash) master
+        with:
+          toolchain: ${{ inputs.rust-version }}
+          components: clippy
+
+      - name: Install cargo-make
+        run: cargo install --debug --locked cargo-make
 
       - name: Check clippy
         run: cargo make ci-clippy
@@ -289,7 +344,7 @@ jobs:
     name: Publish crate and artifacts binaries
     permissions:
       contents: write
-    needs: [ prepare-vars, test, lint, build ]
+    needs: [ prepare-vars, test, format, check, check-wasm, clippy, build ]
     runs-on: [ runner-amd64-2xlarge ]
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

https://github.com/surrealdb/surrealdb/pull/6224 forgot to update the `publish-version` workflow, resulting in the lint job being broken on nightly.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It ensures that the new nightly toolchain is used for linting.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Ran the nightly workflow manually.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
