### PR TITLE
Remove dec when casting decimal to a string, allow string casting from None and Null

### DIFF
--- a/crates/core/src/val/value/convert/cast.rs
+++ b/crates/core/src/val/value/convert/cast.rs
@@ -345,14 +345,14 @@ impl Cast for Strand {
 				}),
 			},
 
-			Value::Null | Value::None => Err(CastError::InvalidKind {
-				from: v,
-				into: "string".into(),
-			}),
-
+			Value::Null => Ok("NULL".into()),
+			Value::None => Ok("NONE".into()),
 			Value::Strand(x) => Ok(x),
 			Value::Uuid(x) => Ok(x.to_raw().into()),
 			Value::Datetime(x) => Ok(x.into_raw_string().into()),
+			Value::Number(Number::Decimal(x)) => {
+				Ok(unsafe { Strand::new_unchecked(x.to_string()) })
+			}
 			// TODO: Handle null bytes
 			x => Ok(unsafe { Strand::new_unchecked(x.to_string()) }),
 		}

--- a/crates/language-tests/tests/language/expression/operators/casting/decimal.surql
+++ b/crates/language-tests/tests/language/expression/operators/casting/decimal.surql
@@ -14,10 +14,16 @@ value = "1f"
 value = "1dec"
 
 [[test.results]]
-value = "1"
+value = "1dec"
 
 [[test.results]]
-value = "'1dec'"
+value = "'1'"
+
+[[test.results]]
+value = "'NONE'"
+
+[[test.results]]
+value = "'NULL'"
 
 [[test.results]]
 error = "Expected `object` but found a `1dec`"
@@ -57,9 +63,11 @@ error = "Expected `range` but found a `1dec`"
 <int> 1dec;
 <float> 1dec;
 <option<decimal>> 1dec;
-
 <decimal> 1dec;
 <string> 1dec;
+<string> none;
+<string> null;
+
 <object> 1dec;
 <array> 1dec;
 <datetime> 1dec;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Users expect a number like 1dec cast to a string to return "1", not "1dec". They also expect <string> in front of NONE and NULL to return a string (currently returns an error)

## What does this change do?

It removes the "dec" when casting, and allows None and Null to be cast into a string.

## What is your testing strategy?

Changed the output of an existing test.

## Is this related to any issues?

* https://github.com/surrealdb/surrealdb/issues/6197
* https://github.com/surrealdb/surrealdb/issues/6221

## Does this change need documentation?

No, it is expected behaviour. However, the `dec` part is a breaking change so should be mentioned in the release notes.

- [X] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [X] No changes made to env vars

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
