### PR TITLE
Parse back with experimental settings enabled

### DIFF
--- a/crates/core/src/expr/expression.rs
+++ b/crates/core/src/expr/expression.rs
@@ -753,7 +753,7 @@ impl Revisioned for Expr {
 		let query: String = Revisioned::deserialize_revisioned(reader)?;
 
 		let mut stack = Stack::new();
-		let mut parser = crate::syn::parser::Parser::new(query.as_bytes());
+		let mut parser = crate::syn::parser::Parser::new_with_experimental(query.as_bytes(), true);
 		let expr = stack
 			.enter(|stk| parser.parse_expr(stk))
 			.finish()

--- a/crates/core/src/expr/idiom/mod.rs
+++ b/crates/core/src/expr/idiom/mod.rs
@@ -198,7 +198,7 @@ impl FromStr for Idiom {
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		let buf = s.as_bytes();
 		let mut stack = Stack::new();
-		let mut parser = crate::syn::parser::Parser::new(buf);
+		let mut parser = crate::syn::parser::Parser::new_with_experimental(buf, true);
 		let expr = stack
 			.enter(|stk| parser.parse_expr(stk))
 			.finish()

--- a/crates/core/src/syn/parser/mod.rs
+++ b/crates/core/src/syn/parser/mod.rs
@@ -171,6 +171,18 @@ impl Default for ParserSettings {
 	}
 }
 
+impl ParserSettings {
+	pub fn default_with_experimental(enabled: bool) -> Self {
+		ParserSettings {
+			references_enabled: enabled,
+			bearer_access_enabled: enabled,
+			define_api_enabled: enabled,
+			files_enabled: enabled,
+			..Self::default()
+		}
+	}
+}
+
 /// The SurrealQL parser.
 pub struct Parser<'a> {
 	lexer: Lexer<'a>,
@@ -185,6 +197,11 @@ impl<'a> Parser<'a> {
 	/// Create a new parser from a give source.
 	pub fn new(source: &'a [u8]) -> Self {
 		Parser::new_with_settings(source, ParserSettings::default())
+	}
+
+	/// Create a new parser from a give source.
+	pub fn new_with_experimental(source: &'a [u8], enabled: bool) -> Self {
+		Parser::new_with_settings(source, ParserSettings::default_with_experimental(enabled))
 	}
 
 	/// Create a new parser from a give source.


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

#6262 introduced an issue where if you stored syntax which uses an experimental feature, it could not be parsed back. That differs from previous behaviour, where structs would always be deserialized no matter if they contained experimental features

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Parsing back expr and idiom from their stored format, they should be allowed to contain experimental syntaxes, as the user previously parsed them that way, and persisted them to disk that way. Runtime checks will decide if the parsed back expr/idiom is allowed to be executed anyways, just like before

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

#6273 will assert this behaviour

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
