### PR TITLE
Update CI runners and limit the features used for CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
 
           # Linux amd64
           - arch: x86_64-unknown-linux-gnu
-            runner: [ runner-amd64-2xlarge ]
+            runner: ubuntu-24.04
             file: surreal-${{ inputs.name }}.linux-amd64
             build-step: |
               # Build
@@ -246,7 +246,7 @@ jobs:
 
           # Linux arm64
           - arch: aarch64-unknown-linux-gnu
-            runner: [ runner-arm64-2xlarge ]
+            runner: ubuntu-24.04
             file: surreal-${{ inputs.name }}.linux-arm64
             build-step: |
               set -x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,7 +293,7 @@ jobs:
 
           # Windows amd64
           - arch: x86_64-pc-windows-msvc
-            runner: windows-latest-16-cores
+            runner: windows-2025
             file: surreal-${{ inputs.name }}.windows-amd64
             build-step: |
               set -x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
               # Build
               extra_args=""
               compile_profile="debug"
-              if [[ "${{ inputs.name }}" == "ci" ]]; then
+              if [[ "${{ inputs.name }}" == "ci" && "${{ inputs.upload }}" == "false" ]]; then
                 extra_args="${extra_args} --features storage-mem,scripting,http,jwks,ml"
               else
                 extra_args="${extra_args} --features default"
@@ -185,7 +185,7 @@ jobs:
               # Build
               extra_args=""
               compile_profile="debug"
-              if [[ "${{ inputs.name }}" == "ci" ]]; then
+              if [[ "${{ inputs.name }}" == "ci" && "${{ inputs.upload }}" == "false" ]]; then
                 extra_args="${extra_args} --features storage-mem,scripting,http,jwks,ml"
               else
                 extra_args="${extra_args} --features default"
@@ -220,7 +220,7 @@ jobs:
               # Build
               extra_args=""
               compile_profile="debug"
-              if [[ "${{ inputs.name }}" == "ci" ]]; then
+              if [[ "${{ inputs.name }}" == "ci" && "${{ inputs.upload }}" == "false" ]]; then
                 extra_args="${extra_args} --features storage-mem,scripting,http,jwks,ml"
               else
                 extra_args="${extra_args} --features default"
@@ -272,7 +272,7 @@ jobs:
               # Build
               extra_args=""
               compile_profile="debug"
-              if [[ "${{ inputs.name }}" == "ci" ]]; then
+              if [[ "${{ inputs.name }}" == "ci" && "${{ inputs.upload }}" == "false" ]]; then
                 extra_args="${extra_args} --features storage-mem,scripting,http,jwks,ml"
               else
                 extra_args="${extra_args} --features default"
@@ -327,7 +327,7 @@ jobs:
               # Build
               extra_args=""
               compile_profile="debug"
-              if [[ "${{ inputs.name }}" == "ci" ]]; then
+              if [[ "${{ inputs.name }}" == "ci" && "${{ inputs.upload }}" == "false" ]]; then
                 extra_args="${extra_args} --features storage-mem,scripting,http,jwks,ml"
               else
                 extra_args="${extra_args} --features default"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,9 @@ jobs:
                 tar -xz -C /tmp/onnxruntime/
               export ORT_STRATEGY=system ORT_LIB_LOCATION=/tmp/onnxruntime/lib
 
+              # Install the target (mac-os seems to need this for some reason)
+              rustup target add x86_64-apple-darwin
+
               cargo build --no-default-features ${extra_args} --locked --target x86_64-apple-darwin
 
               # Package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
 
           # Linux amd64
           - arch: x86_64-unknown-linux-gnu
-            runner: ubuntu-24.04
+            runner: [ runner-amd64-2xlarge ]
             file: surreal-${{ inputs.name }}.linux-amd64
             build-step: |
               # Build
@@ -261,7 +261,7 @@ jobs:
 
           # Linux arm64
           - arch: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04
+            runner: [ runner-arm64-2xlarge ]
             file: surreal-${{ inputs.name }}.linux-arm64
             build-step: |
               set -x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,8 +142,13 @@ jobs:
               # Build
               extra_args=""
               compile_profile="debug"
-              if [[ ! -z "${{ inputs.extra-features }}" ]]; then
-                extra_args="${extra_args} --features ${{ inputs.extra-features }}"
+              if [[ "${{ inputs.name }}" == "ci" ]]; then
+                extra_args="${extra_args} --features storage-mem,scripting,http,jwks,ml"
+              else
+                extra_args="${extra_args} --features default"
+                if [[ ! -z "${{ inputs.extra-features }}" ]]; then
+                  extra_args="${extra_args} --features ${{ inputs.extra-features }}"
+                fi
               fi
               if [[ "${{ inputs.release }}" == "true" ]]; then
                 extra_args="${extra_args} --release"
@@ -156,7 +161,7 @@ jobs:
                 tar -xz -C /tmp/onnxruntime/
               export ORT_STRATEGY=system ORT_LIB_LOCATION=/tmp/onnxruntime/lib
 
-              cargo build ${extra_args} --locked --target x86_64-apple-darwin
+              cargo build --no-default-features ${extra_args} --locked --target x86_64-apple-darwin
 
               # Package
               cp target/x86_64-apple-darwin/${compile_profile}/surreal surreal
@@ -177,8 +182,13 @@ jobs:
               # Build
               extra_args=""
               compile_profile="debug"
-              if [[ ! -z "${{ inputs.extra-features }}" ]]; then
-                extra_args="${extra_args} --features ${{ inputs.extra-features }}"
+              if [[ "${{ inputs.name }}" == "ci" ]]; then
+                extra_args="${extra_args} --features storage-mem,scripting,http,jwks,ml"
+              else
+                extra_args="${extra_args} --features default"
+                if [[ ! -z "${{ inputs.extra-features }}" ]]; then
+                  extra_args="${extra_args} --features ${{ inputs.extra-features }}"
+                fi
               fi
               if [[ "${{ inputs.release }}" == "true" ]]; then
                 extra_args="${extra_args} --release"
@@ -191,7 +201,7 @@ jobs:
                 tar -xz -C /tmp/onnxruntime/
               export ORT_STRATEGY=system ORT_LIB_LOCATION=/tmp/onnxruntime/lib
 
-              cargo build ${extra_args} --locked --target aarch64-apple-darwin
+              cargo build --no-default-features ${extra_args} --locked --target aarch64-apple-darwin
 
               # Package
               cp target/aarch64-apple-darwin/${compile_profile}/surreal surreal
@@ -207,8 +217,13 @@ jobs:
               # Build
               extra_args=""
               compile_profile="debug"
-              if [[ ! -z "${{ inputs.extra-features }}" ]]; then
-                extra_args="${extra_args} --features ${{ inputs.extra-features }}"
+              if [[ "${{ inputs.name }}" == "ci" ]]; then
+                extra_args="${extra_args} --features storage-mem,scripting,http,jwks,ml"
+              else
+                extra_args="${extra_args} --features default"
+                if [[ ! -z "${{ inputs.extra-features }}" ]]; then
+                  extra_args="${extra_args} --features ${{ inputs.extra-features }}"
+                fi
               fi
               if [[ "${{ inputs.release }}" == "true" ]]; then
                 extra_args="${extra_args} --release"
@@ -232,7 +247,7 @@ jobs:
                 -e ORT_LIB_LOCATION=$ORT_LIB_LOCATION \
                 -v $ORT_LIB_LOCATION:$ORT_LIB_LOCATION \
                 ${{ needs.image.outputs.name }}:${{ needs.image.outputs.tag }}-amd64 \
-                  --target x86_64-unknown-linux-gnu ${extra_args} --locked
+                  --target x86_64-unknown-linux-gnu --no-default-features ${extra_args} --locked
 
               # Package
               cp target/x86_64-unknown-linux-gnu/${compile_profile}/surreal surreal
@@ -254,8 +269,13 @@ jobs:
               # Build
               extra_args=""
               compile_profile="debug"
-              if [[ ! -z "${{ inputs.extra-features }}" ]]; then
-                extra_args="${extra_args} --features ${{ inputs.extra-features }}"
+              if [[ "${{ inputs.name }}" == "ci" ]]; then
+                extra_args="${extra_args} --features storage-mem,scripting,http,jwks,ml"
+              else
+                extra_args="${extra_args} --features default"
+                if [[ ! -z "${{ inputs.extra-features }}" ]]; then
+                  extra_args="${extra_args} --features ${{ inputs.extra-features }}"
+                fi
               fi
               if [[ "${{ inputs.release }}" == "true" ]]; then
                 extra_args="${extra_args} --release"
@@ -279,7 +299,7 @@ jobs:
                 -e ORT_LIB_LOCATION=$ORT_LIB_LOCATION \
                 -v $ORT_LIB_LOCATION:$ORT_LIB_LOCATION \
                 ${{ needs.image.outputs.name }}:${{ needs.image.outputs.tag }}-arm64 \
-                  --target aarch64-unknown-linux-gnu ${extra_args} --locked
+                  --target aarch64-unknown-linux-gnu --no-default-features ${extra_args} --locked
 
               # Package
               cp target/aarch64-unknown-linux-gnu/${compile_profile}/surreal surreal
@@ -304,8 +324,13 @@ jobs:
               # Build
               extra_args=""
               compile_profile="debug"
-              if [[ ! -z "${{ inputs.extra-features }}" ]]; then
-                extra_args="${extra_args} --features ${{ inputs.extra-features }}"
+              if [[ "${{ inputs.name }}" == "ci" ]]; then
+                extra_args="${extra_args} --features storage-mem,scripting,http,jwks,ml"
+              else
+                extra_args="${extra_args} --features default"
+                if [[ ! -z "${{ inputs.extra-features }}" ]]; then
+                  extra_args="${extra_args} --features ${{ inputs.extra-features }}"
+                fi
               fi
               if [[ "${{ inputs.release }}" == "true" ]]; then
                 extra_args="${extra_args} --release"
@@ -318,7 +343,7 @@ jobs:
               unzip -d $tmp_dir $tmp_dir/onnxruntime.zip
               export ORT_STRATEGY=system ORT_LIB_LOCATION=$tmp_dir/lib
 
-              cargo build ${extra_args} --locked --target x86_64-pc-windows-msvc
+              cargo build --no-default-features ${extra_args} --locked --target x86_64-pc-windows-msvc
 
               # Package
               ./target/x86_64-pc-windows-msvc/${compile_profile}/surreal.exe version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
         include:
           # MacOS amd64
           - arch: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-15
             file: surreal-${{ inputs.name }}.darwin-amd64
             build-step: |
               set -x
@@ -166,7 +166,7 @@ jobs:
 
           # MacOS arm64
           - arch: aarch64-apple-darwin
-            runner: macos-latest
+            runner: macos-15
             file: surreal-${{ inputs.name }}.darwin-arm64
             build-step: |
               set -x


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Some heavy features like `storage-rocksdb` make building the binaries take too long when running CI tests.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Updates the runners and limits the features enabled when building the binaries.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
