### PR TITLE
Re-enable workspace tests

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -241,8 +241,6 @@ category = "CI - INTEGRATION TESTS"
 command = "cargo"
 args = [
     "llvm-cov",
-    "-j",
-    "10",
     "--html",
     "--locked",
     "--no-default-features",
@@ -250,7 +248,6 @@ args = [
     "storage-mem,scripting,http,jwks",
     "--workspace",
     "--",
-    "cf::writer::tests",
     "--skip",
     "api_integration",
     "--skip",


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

A lot of the workspace tests seem to have been accidentally disabled

## What does this change do?

Renables workspace tests.

## What is your testing strategy?

N/A
## Is this related to any issues?

N/A

## Does this change need documentation?
N/A

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
