### PR TITLE
Add method syntax for record::is::edge()

### DIFF
--- a/crates/core/src/fnc/mod.rs
+++ b/crates/core/src/fnc/mod.rs
@@ -953,6 +953,7 @@ pub async fn idiom(
 				"no such method found for the record type",
 				//
 				"exists" => record::exists((stk, ctx, Some(opt), doc)).await,
+				"is_edge" => record::is::edge((stk, ctx, Some(opt), doc)).await,
 				"id" => record::id,
 				"table" => record::tb,
 				"tb" => record::tb,

--- a/crates/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_executor.dict
@@ -299,6 +299,7 @@
 "record::"
 "record::exists("
 "record::id("
+"record::is::edge("
 "record::table("
 "record::tb("
 "uuid"

--- a/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -298,6 +298,7 @@
 "record::"
 "record::exists("
 "record::id("
+"record::is::edge("
 "record::table("
 "record::tb("
 "uuid"

--- a/crates/language-tests/tests/language/functions/record/is_edge.surql
+++ b/crates/language-tests/tests/language/functions/record/is_edge.surql
@@ -58,6 +58,9 @@ value = "[]"
 
 [[test.results]]
 value = "[{ id: knows:person, in: person:john, out: person:jane, since: '2023-01-01' }]"
+
+[[test.results]]
+value = "true"
 */
 
 -- Test 1: Non-existent record, using a record ID
@@ -116,3 +119,6 @@ SELECT * FROM person WHERE record::is::edge(id) = true;
 
 -- Test 19: Check if the function works as expected inside a select filter (should not be empty)
 SELECT * FROM knows WHERE record::is::edge(id) = true;
+
+-- Test 20: Check if edge record is an edge with method syntax, using a record ID (should be true)
+knows:person.is_edge();


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

There is a new [record::is::edge()](https://github.com/surrealdb/surrealdb/pull/6266) method now and it would be nice to call it using .is_edge() syntax do.

## What does this change do?

It does exactly that.

## What is your testing strategy?

Added a test

## Is this related to any issues?

No, just a nice to have.

## Does this change need documentation?

- [X] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [X] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
