### PR TITLE
[Backport 2.3] Fix allowing null bytes in strings (#5652)

### DIFF
--- a/crates/core/src/syn/lexer/compound/strand.rs
+++ b/crates/core/src/syn/lexer/compound/strand.rs
@@ -130,8 +130,14 @@ fn lex_unicode_sequence(lexer: &mut Lexer) -> Result<char, SyntaxError> {
 		});
 	}
 
-	char::from_u32(leading as u32)
-		.ok_or_else(|| syntax_error!("Unicode escape sequences encode invalid character codepoint", @lexer.current_span()))
+	let c = char::from_u32(leading as u32)
+		.ok_or_else(|| syntax_error!("Unicode escape sequences encode invalid character codepoint", @lexer.current_span()))?;
+
+	if c == '\0' {
+		return Err(syntax_error!("Null bytes are not allowed in strings",@lexer.current_span()));
+	}
+
+	Ok(c)
 }
 
 fn lex_bracket_unicode_sequence(lexer: &mut Lexer) -> Result<char, SyntaxError> {
@@ -163,8 +169,14 @@ fn lex_bracket_unicode_sequence(lexer: &mut Lexer) -> Result<char, SyntaxError> 
 		bail!("Missing end brace `}}` of unicode escape sequence", @lexer.current_span())
 	};
 
-	char::from_u32(accum)
-		.ok_or_else(|| syntax_error!("Unicode escape sequences encode invalid character codepoint", @lexer.current_span()))
+	let c = char::from_u32(accum)
+		.ok_or_else(|| syntax_error!("Unicode escape sequences encode invalid character codepoint", @lexer.current_span()))?;
+
+	if c == '\0' {
+		return Err(syntax_error!("Null bytes are not allowed in strings",@lexer.current_span()));
+	}
+
+	Ok(c)
 }
 
 fn lex_bare_unicode_sequence(lexer: &mut Lexer) -> Result<u16, SyntaxError> {

--- a/crates/language-tests/tests/language/functions/rand/string.surql
+++ b/crates/language-tests/tests/language/functions/rand/string.surql
@@ -1,4 +1,7 @@
 /**
+[env]
+timeout = 2000
+
 [test]
 
 [[test.results]]

--- a/crates/language-tests/tests/parsing/strings/unicode_escape_sequence.surql
+++ b/crates/language-tests/tests/parsing/strings/unicode_escape_sequence.surql
@@ -10,7 +10,6 @@ value = "'🜕'"
 [[test.results]]
 value = "'🜕'"
 
-
 */
 
 "\u{0000B0}";

--- a/crates/language-tests/tests/parsing/strings/unicode_escape_squence_null.surql
+++ b/crates/language-tests/tests/parsing/strings/unicode_escape_squence_null.surql
@@ -1,0 +1,14 @@
+/**
+[test]
+
+[test.results]
+parsing-error = '''
+Null bytes are not allowed in strings
+  --> [14:1]
+   |
+14 | "\u{0000}";
+   | ^^^^^^^^^ 
+'''
+
+*/
+"\u{0000}";

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -966,7 +966,7 @@ mod http_integration {
 			assert_eq!(res.status(), 400);
 
 			let body = res.text().await?;
-			assert!(body.contains("contained NUL byte"), "body: {body}");
+			assert!(body.contains("Null bytes are not allowed"), "body: {body}");
 		}
 
 		Ok(())


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport #5652

## What does this change do?

Backport #5652

## What is your testing strategy?

Language test

## Is this related to any issues?

Backport #5652

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
