### PR TITLE
Use `IndexId` for Index keys

### DIFF
--- a/crates/core/src/catalog/mod.rs
+++ b/crates/core/src/catalog/mod.rs
@@ -214,12 +214,13 @@ mod test {
         returns: Some(Kind::Any),
     }, 34)]
 	#[case::index(IndexDefinition {
+        index_id: IndexId(123),
         name: "test".to_string(),
-        what: "what".to_string(),
+        table_name: "what".to_string(),
         cols: vec![Idiom::from_str("field[0]").unwrap()],
         index: Index::Idx,
         comment: Some("comment".to_string()),
-    }, 32)]
+    }, 33)]
 	#[case::model(MlModelDefinition {
         name: "model".to_string(),
         hash: "hash".to_string(),

--- a/crates/core/src/catalog/providers.rs
+++ b/crates/core/src/catalog/providers.rs
@@ -8,10 +8,9 @@ use anyhow::Result;
 use surrealdb_macros::wasm_async_trait;
 use uuid::Uuid;
 
-use crate::catalog;
 use crate::catalog::{
-	DatabaseDefinition, DatabaseId, NamespaceDefinition, NamespaceId, TableDefinition,
-	UserDefinition,
+	self, DatabaseDefinition, DatabaseId, IndexId, NamespaceDefinition, NamespaceId,
+	TableDefinition, UserDefinition,
 };
 use crate::dbs::node::Node;
 use crate::err::Error;
@@ -417,7 +416,44 @@ pub trait TableProvider {
 		db: DatabaseId,
 		tb: &str,
 		ix: &str,
-	) -> Result<Arc<catalog::IndexDefinition>>;
+	) -> Result<Option<Arc<catalog::IndexDefinition>>>;
+
+	/// Retrieve an index for a table.
+	async fn get_tb_index_by_id(
+		&self,
+		ns: NamespaceId,
+		db: DatabaseId,
+		tb: &str,
+		ix: IndexId,
+	) -> Result<Option<Arc<catalog::IndexDefinition>>>;
+
+	/// Retrieve an index for a table returning an error if it does not exist.
+	async fn expect_tb_index(
+		&self,
+		ns: NamespaceId,
+		db: DatabaseId,
+		tb: &str,
+		ix: &str,
+	) -> Result<Arc<catalog::IndexDefinition>> {
+		self.get_tb_index(ns, db, tb, ix).await?.ok_or_else(|| {
+			Error::IxNotFound {
+				name: ix.to_owned(),
+			}
+			.into()
+		})
+	}
+
+	/// Put an index for a table.
+	async fn put_tb_index(
+		&self,
+		ns: NamespaceId,
+		db: DatabaseId,
+		tb: &str,
+		ix: &catalog::IndexDefinition,
+	) -> Result<()>;
+
+	async fn del_tb_index(&self, ns: NamespaceId, db: DatabaseId, tb: &str, ix: &str)
+	-> Result<()>;
 
 	/// Fetch a specific record value.
 	async fn get_record(

--- a/crates/core/src/catalog/schema/index.rs
+++ b/crates/core/src/catalog/schema/index.rs
@@ -2,7 +2,8 @@ use std::fmt::{self, Display, Formatter};
 use std::hash::{Hash, Hasher};
 
 use anyhow::Result;
-use revision::revisioned;
+use revision::{Revisioned, revisioned};
+use serde::{Deserialize, Serialize};
 
 use crate::expr::Idiom;
 use crate::expr::statements::info::InfoStructure;
@@ -11,11 +12,44 @@ use crate::sql::statements::define::DefineKind;
 use crate::sql::{Ident, ToSql};
 use crate::val::{Array, Number, Strand, Value};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[repr(transparent)]
+pub struct IndexId(pub u32);
+
+impl_kv_value_revisioned!(IndexId);
+
+impl Revisioned for IndexId {
+	fn revision() -> u16 {
+		1
+	}
+
+	#[inline]
+	fn serialize_revisioned<W: std::io::Write>(
+		&self,
+		writer: &mut W,
+	) -> Result<(), revision::Error> {
+		self.0.serialize_revisioned(writer)
+	}
+
+	#[inline]
+	fn deserialize_revisioned<R: std::io::Read>(reader: &mut R) -> Result<Self, revision::Error> {
+		Revisioned::deserialize_revisioned(reader).map(IndexId)
+	}
+}
+
+impl From<u32> for IndexId {
+	fn from(value: u32) -> Self {
+		IndexId(value)
+	}
+}
+
 #[revisioned(revision = 1)]
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct IndexDefinition {
+	pub index_id: IndexId,
 	pub name: String,
-	pub what: String,
+	pub table_name: String,
 	pub cols: Vec<Idiom>,
 	pub index: Index,
 	pub comment: Option<String>,
@@ -28,7 +62,7 @@ impl IndexDefinition {
 		crate::sql::DefineIndexStatement {
 			kind: DefineKind::Default,
 			name: unsafe { Ident::new_unchecked(self.name.clone()) },
-			what: unsafe { Ident::new_unchecked(self.what.clone()) },
+			what: unsafe { Ident::new_unchecked(self.table_name.clone()) },
 			cols: self.cols.iter().cloned().map(Into::into).collect(),
 			index: self.index.to_sql_definition(),
 			comment: self.comment.clone().map(Strand::new_lossy),
@@ -41,7 +75,7 @@ impl InfoStructure for IndexDefinition {
 	fn structure(self) -> Value {
 		Value::from(map! {
 			"name".to_string() => self.name.into(),
-			"what".to_string() => self.what.into(),
+			"what".to_string() => self.table_name.into(),
 			"cols".to_string() => Value::Array(Array(self.cols.into_iter().map(|x| x.structure()).collect())),
 			"index".to_string() => self.index.structure(),
 			"comment".to_string(), if let Some(v) = self.comment => v.into(),

--- a/crates/core/src/expr/statements/analyze.rs
+++ b/crates/core/src/expr/statements/analyze.rs
@@ -31,8 +31,8 @@ impl AnalyzeStatement {
 				opt.is_allowed(Action::View, ResourceKind::Index, &Base::Db)?;
 				// Read the index
 				let (ns, db) = ctx.expect_ns_db_ids(opt).await?;
-				let ix = ctx.tx().get_tb_index(ns, db, tb, idx).await?;
-				let ikb = IndexKeyBase::new(ns, db, &ix.what, &ix.name);
+				let ix = ctx.tx().expect_tb_index(ns, db, tb, idx).await?;
+				let ikb = IndexKeyBase::new(ns, db, &ix.table_name, ix.index_id);
 				// Index operation dispatching
 				let value: Value = match &ix.index {
 					Index::Search(p) => {

--- a/crates/core/src/expr/statements/info.rs
+++ b/crates/core/src/expr/statements/info.rs
@@ -392,7 +392,7 @@ impl InfoStatement {
 					if let Some(ib) = ctx.get_index_builder() {
 						// Obtain the index
 						let (ns, db) = ctx.expect_ns_db_ids(opt).await?;
-						let res = txn.get_tb_index(ns, db, table, index).await?;
+						let res = txn.expect_tb_index(ns, db, table, index).await?;
 						let status = ib.get_status(ns, db, &res).await;
 						let mut out = Object::default();
 						out.insert("building".to_string(), status.into());

--- a/crates/core/src/expr/statements/rebuild.rs
+++ b/crates/core/src/expr/statements/rebuild.rs
@@ -63,14 +63,17 @@ impl RebuildIndexStatement {
 		opt.is_allowed(Action::Edit, ResourceKind::Index, &Base::Db)?;
 		// Get the index definition
 		let (ns, db) = ctx.expect_ns_db_ids(opt).await?;
-		let res = ctx.tx().get_tb_index(ns, db, &self.what, &self.name).await;
+		let res = ctx.tx().get_tb_index(ns, db, &self.what, &self.name).await?;
 		let ix = match res {
-			Ok(x) => x,
-			Err(e) => {
-				if self.if_exists && matches!(e.downcast_ref(), Some(Error::IxNotFound { .. })) {
+			Some(x) => x,
+			None => {
+				if self.if_exists {
 					return Ok(Value::None);
 				} else {
-					return Err(e);
+					return Err(Error::IxNotFound {
+						name: self.name.to_string(),
+					}
+					.into());
 				}
 			}
 		};

--- a/crates/core/src/expr/statements/remove/index.rs
+++ b/crates/core/src/expr/statements/remove/index.rs
@@ -44,12 +44,9 @@ impl RemoveIndexStatement {
 			return Err(e);
 		}
 
-		// Delete the definition
-		let key = crate::key::table::ix::new(ns, db, &self.what, &self.name);
-		txn.del(&key).await?;
-		// Remove the index data
-		let key = crate::key::index::all::new(ns, db, &self.what, &self.name);
-		txn.delp(&key).await?;
+		// Delete the index data.
+		txn.del_tb_index(ns, db, &self.what, &self.name).await?;
+
 		// Refresh the table cache for indexes
 		let Some(tb) = txn.get_tb(ns, db, &self.what).await? else {
 			return Err(Error::TbNotFound {

--- a/crates/core/src/idx/docids/btdocids.rs
+++ b/crates/core/src/idx/docids/btdocids.rs
@@ -236,7 +236,7 @@ impl BTreeDocIdsState {
 
 #[cfg(test)]
 mod tests {
-	use crate::catalog::{DatabaseId, NamespaceId};
+	use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 	use crate::idx::IndexKeyBase;
 	use crate::idx::docids::btdocids::{BTreeDocIds, Resolved};
 	use crate::kvs::TransactionType::*;
@@ -250,7 +250,7 @@ mod tests {
 		let d = BTreeDocIds::new(
 			&tx,
 			tt,
-			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", "ix"),
+			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", IndexId(3)),
 			BTREE_ORDER,
 			100,
 		)

--- a/crates/core/src/idx/docids/seqdocids.rs
+++ b/crates/core/src/idx/docids/seqdocids.rs
@@ -160,7 +160,7 @@ impl SeqDocIds {
 mod tests {
 	use uuid::Uuid;
 
-	use crate::catalog::{DatabaseId, NamespaceId};
+	use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 	use crate::ctx::Context;
 	use crate::idx::IndexKeyBase;
 	use crate::idx::docids::seqdocids::SeqDocIds;
@@ -174,12 +174,12 @@ mod tests {
 	const TEST_NS_ID: NamespaceId = NamespaceId(1);
 	const TEST_DB_ID: DatabaseId = DatabaseId(1);
 	const TEST_TB: &str = "test_tb";
-	const TEST_IX: &str = "test_ix";
+	const TEST_IX_ID: IndexId = IndexId(1);
 
 	async fn new_operation(ds: &Datastore, tt: TransactionType) -> (Context, SeqDocIds) {
 		let mut ctx = ds.setup_ctx().unwrap();
 		let tx = ds.transaction(tt, Optimistic).await.unwrap();
-		let ikb = IndexKeyBase::new(TEST_NS_ID, TEST_DB_ID, TEST_TB, TEST_IX);
+		let ikb = IndexKeyBase::new(TEST_NS_ID, TEST_DB_ID, TEST_TB, TEST_IX_ID);
 		ctx.set_transaction(tx.into());
 		let d = SeqDocIds::new(Uuid::nil(), ikb);
 		(ctx.freeze(), d)
@@ -425,13 +425,13 @@ mod tests {
 					TEST_NS_ID,
 					TEST_DB_ID,
 					TEST_TB,
-					TEST_IX,
+					TEST_IX_ID,
 					RecordIdKey::String(id.to_owned()),
 				);
 				assert!(!tx.exists(&id, None).await.unwrap());
 			}
 			for doc_id in 0..=3 {
-				let bi = Bi::new(TEST_NS_ID, TEST_DB_ID, TEST_TB, TEST_IX, doc_id);
+				let bi = Bi::new(TEST_NS_ID, TEST_DB_ID, TEST_TB, TEST_IX_ID, doc_id);
 				assert!(!tx.exists(&bi, None).await.unwrap());
 			}
 		}

--- a/crates/core/src/idx/ft/fulltext.rs
+++ b/crates/core/src/idx/ft/fulltext.rs
@@ -901,7 +901,7 @@ mod tests {
 	use uuid::Uuid;
 
 	use super::{FullTextIndex, TermDocument};
-	use crate::catalog::{DatabaseId, FullTextParams, NamespaceId};
+	use crate::catalog::{DatabaseId, FullTextParams, IndexId, NamespaceId};
 	use crate::ctx::{Context, MutableContext};
 	use crate::dbs::Options;
 	use crate::expr::statements::DefineAnalyzerStatement;
@@ -971,7 +971,7 @@ mod tests {
 				highlight: true,
 			});
 			let nid = Uuid::from_u128(1);
-			let ikb = IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "t", "i");
+			let ikb = IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "t", IndexId(3));
 			let opt = Options::default()
 				.with_id(nid)
 				.with_ns(Some("testns".into()))

--- a/crates/core/src/idx/ft/search/doclength.rs
+++ b/crates/core/src/idx/ft/search/doclength.rs
@@ -95,7 +95,7 @@ impl DocLengths {
 
 #[cfg(test)]
 mod tests {
-	use crate::catalog::{DatabaseId, NamespaceId};
+	use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 	use crate::idx::IndexKeyBase;
 	use crate::idx::ft::search::doclength::DocLengths;
 	use crate::kvs::LockType::*;
@@ -109,7 +109,7 @@ mod tests {
 		let tx = ds.transaction(TransactionType::Write, Optimistic).await.unwrap();
 		let dl = DocLengths::new(
 			&tx,
-			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", "ix"),
+			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", IndexId(3)),
 			order,
 			tt,
 			100,

--- a/crates/core/src/idx/ft/search/mod.rs
+++ b/crates/core/src/idx/ft/search/mod.rs
@@ -664,7 +664,7 @@ mod tests {
 	use reblessive::tree::Stk;
 	use test_log::test;
 
-	use crate::catalog::{self, DatabaseId, NamespaceId, SearchParams};
+	use crate::catalog::{self, DatabaseId, IndexId, NamespaceId, SearchParams};
 	use crate::ctx::{Context, MutableContext};
 	use crate::dbs::Options;
 	use crate::expr::statements::DefineAnalyzerStatement;
@@ -745,7 +745,7 @@ mod tests {
 			ctx.get_index_stores(),
 			&tx,
 			az,
-			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", "ix"),
+			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", IndexId(3)),
 			&p,
 			tt,
 		)

--- a/crates/core/src/idx/ft/search/postings.rs
+++ b/crates/core/src/idx/ft/search/postings.rs
@@ -95,7 +95,7 @@ impl Postings {
 mod tests {
 	use test_log::test;
 
-	use crate::catalog::{DatabaseId, NamespaceId};
+	use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 	use crate::idx::IndexKeyBase;
 	use crate::idx::ft::search::postings::Postings;
 	use crate::kvs::LockType::*;
@@ -110,7 +110,7 @@ mod tests {
 		let tx = ds.transaction(tt, Optimistic).await.unwrap();
 		let p = Postings::new(
 			&tx,
-			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", "ix"),
+			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", IndexId(3)),
 			order,
 			tt,
 			100,

--- a/crates/core/src/idx/ft/search/terms.rs
+++ b/crates/core/src/idx/ft/search/terms.rs
@@ -211,7 +211,7 @@ mod tests {
 	use test_log::test;
 
 	use super::*;
-	use crate::catalog::{DatabaseId, NamespaceId};
+	use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 	use crate::idx::IndexKeyBase;
 	use crate::idx::ft::TermFrequency;
 	use crate::idx::ft::search::terms::{SearchTerms, SearchTermsState};
@@ -252,7 +252,7 @@ mod tests {
 		let tx = ds.transaction(tt, Optimistic).await.unwrap();
 		let t = SearchTerms::new(
 			&tx,
-			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", "ix"),
+			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", IndexId(3)),
 			order,
 			tt,
 			100,

--- a/crates/core/src/idx/index.rs
+++ b/crates/core/src/idx/index.rs
@@ -97,7 +97,7 @@ impl<'a> IndexOperation<'a> {
 	/// types (Int/Float/Decimal). This means equal numeric values like 0, 0.0 and
 	/// 0dec map to the same index key and therefore conflict on UNIQUE indexes.
 	fn get_unique_index_key(&self, v: &'a StoreKeyArray) -> Result<key::index::Index> {
-		Ok(key::index::Index::new(self.ns, self.db, &self.ix.what, &self.ix.name, v, None))
+		Ok(key::index::Index::new(self.ns, self.db, &self.ix.table_name, self.ix.index_id, v, None))
 	}
 
 	/// Build the KV key for a non-unique index. The record id is appended
@@ -107,8 +107,8 @@ impl<'a> IndexOperation<'a> {
 		Ok(key::index::Index::new(
 			self.ns,
 			self.db,
-			&self.ix.what,
-			&self.ix.name,
+			&self.ix.table_name,
+			self.ix.index_id,
 			v,
 			Some(&self.rid.key),
 		))
@@ -203,7 +203,7 @@ impl<'a> IndexOperation<'a> {
 	}
 
 	async fn index_search(&mut self, stk: &mut Stk, p: &SearchParams) -> Result<()> {
-		let ikb = IndexKeyBase::new(self.ns, self.db, &self.ix.what, &self.ix.name);
+		let ikb = IndexKeyBase::new(self.ns, self.db, &self.ix.table_name, self.ix.index_id);
 
 		let mut ft =
 			SearchIndex::new(self.ctx, self.ns, self.db, &p.az, ikb, p, TransactionType::Write)
@@ -223,7 +223,7 @@ impl<'a> IndexOperation<'a> {
 		p: &FullTextParams,
 		require_compaction: &AtomicBool,
 	) -> Result<()> {
-		let ikb = IndexKeyBase::new(self.ns, self.db, &self.ix.what, &self.ix.name);
+		let ikb = IndexKeyBase::new(self.ns, self.db, &self.ix.table_name, self.ix.index_id);
 		let mut rc = false;
 		// Build a FullText instance
 		let s =
@@ -252,7 +252,7 @@ impl<'a> IndexOperation<'a> {
 
 	async fn index_mtree(&mut self, stk: &mut Stk, p: &MTreeParams) -> Result<()> {
 		let txn = self.ctx.tx();
-		let ikb = IndexKeyBase::new(self.ns, self.db, &self.ix.what, &self.ix.name);
+		let ikb = IndexKeyBase::new(self.ns, self.db, &self.ix.table_name, self.ix.index_id);
 		let mut mt = MTreeIndex::new(&txn, ikb, p, TransactionType::Write).await?;
 		// Delete the old index data
 		if let Some(o) = self.o.take() {

--- a/crates/core/src/idx/mod.rs
+++ b/crates/core/src/idx/mod.rs
@@ -4,13 +4,14 @@ pub(crate) mod index;
 pub mod planner;
 pub mod trees;
 
+use std::borrow::Cow;
 use std::ops::Range;
 use std::sync::Arc;
 
 use anyhow::Result;
 use uuid::Uuid;
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::DocId;
 use crate::idx::ft::search::terms::TermId;
 use crate::idx::trees::hnsw::ElementId;
@@ -46,7 +47,7 @@ use crate::key::index::is::Is;
 use crate::key::index::td::{Td, TdRoot};
 use crate::key::index::tt::Tt;
 use crate::key::index::vm::{Vm, VmRoot};
-use crate::key::root::ic::Ic;
+use crate::key::root::ic::IndexCompactionKey;
 use crate::kvs::Key;
 use crate::val::RecordIdKey;
 
@@ -58,168 +59,167 @@ struct Inner {
 	ns: NamespaceId,
 	db: DatabaseId,
 	tb: String,
-	ix: String,
+	ix: IndexId,
 }
 
 impl IndexKeyBase {
-	pub fn new(ns: impl Into<NamespaceId>, db: impl Into<DatabaseId>, tb: &str, ix: &str) -> Self {
+	pub fn new(
+		ns: impl Into<NamespaceId>,
+		db: impl Into<DatabaseId>,
+		tb: &str,
+		ix: impl Into<IndexId>,
+	) -> Self {
 		Self(Arc::new(Inner {
 			ns: ns.into(),
 			db: db.into(),
 			tb: tb.to_string(),
-			ix: ix.to_string(),
+			ix: ix.into(),
 		}))
-	}
-
-	pub(crate) fn from_ic(ic: &Ic) -> Self {
-		Self(Arc::new(Inner {
-			ns: ic.ns,
-			db: ic.db,
-			tb: ic.tb.to_string(),
-			ix: ic.ix.to_string(),
-		}))
-	}
-
-	pub(crate) fn match_ic(&self, ic: &Ic) -> bool {
-		self.0.ix == ic.ix && self.0.tb == ic.tb && self.0.db == ic.db && self.0.ns == ic.ns
 	}
 
 	fn new_bc_key(&self, term_id: TermId) -> Bc<'_> {
-		Bc::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, term_id)
+		Bc::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, term_id)
 	}
 
 	fn new_bd_root_key(&self) -> BdRoot<'_> {
-		BdRoot::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		BdRoot::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_bd_key(&self, node_id: NodeId) -> Bd<'_> {
-		Bd::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, node_id)
+		Bd::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, node_id)
 	}
 
 	fn new_bk_key(&self, doc_id: DocId) -> Bk<'_> {
-		Bk::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, doc_id)
+		Bk::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, doc_id)
 	}
 
 	fn new_bl_root_key(&self) -> BlRoot<'_> {
-		BlRoot::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		BlRoot::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_bl_key(&self, node_id: NodeId) -> Bl<'_> {
-		Bl::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, node_id)
+		Bl::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, node_id)
 	}
 
 	fn new_bo_key(&self, doc_id: DocId, term_id: TermId) -> Bo<'_> {
-		Bo::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, doc_id, term_id)
+		Bo::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, doc_id, term_id)
 	}
 
 	fn new_bp_root_key(&self) -> BpRoot<'_> {
-		BpRoot::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		BpRoot::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_bp_key(&self, node_id: NodeId) -> Bp<'_> {
-		Bp::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, node_id)
+		Bp::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, node_id)
 	}
 
 	fn new_bf_key(&self, term_id: TermId, doc_id: DocId) -> Bf<'_> {
-		Bf::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, term_id, doc_id)
+		Bf::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, term_id, doc_id)
 	}
 
 	fn new_bt_root_key(&self) -> BtRoot<'_> {
-		BtRoot::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		BtRoot::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_bt_key(&self, node_id: NodeId) -> Bt<'_> {
-		Bt::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, node_id)
+		Bt::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, node_id)
 	}
 
 	fn new_bs_key(&self) -> Bs<'_> {
-		Bs::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		Bs::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_bu_key(&self, term_id: TermId) -> Bu<'_> {
-		Bu::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, term_id)
+		Bu::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, term_id)
 	}
 
 	fn new_hd_root_key(&self) -> HdRoot<'_> {
-		HdRoot::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		HdRoot::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_hd_key(&self, doc_id: DocId) -> Hd<'_> {
-		Hd::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, doc_id)
+		Hd::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, doc_id)
 	}
 
 	fn new_he_key(&self, element_id: ElementId) -> He<'_> {
-		He::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, element_id)
+		He::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, element_id)
 	}
 
 	fn new_hi_key(&self, id: RecordIdKey) -> Hi<'_> {
-		Hi::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, id)
+		Hi::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, id)
 	}
 
 	fn new_hl_key(&self, layer: u16, chunk: u32) -> Hl<'_> {
-		Hl::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, layer, chunk)
+		Hl::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, layer, chunk)
 	}
 
 	fn new_hv_key(&self, vec: Arc<SerializedVector>) -> Hv<'_> {
-		Hv::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, vec)
+		Hv::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, vec)
 	}
 
 	fn new_hs_key(&self) -> Hs<'_> {
-		Hs::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		Hs::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_vm_root_key(&self) -> VmRoot<'_> {
-		VmRoot::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		VmRoot::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_vm_key(&self, node_id: NodeId) -> Vm<'_> {
-		Vm::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, node_id)
+		Vm::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, node_id)
 	}
 
 	fn new_bi_key(&self, doc_id: DocId) -> Bi<'_> {
-		Bi::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, doc_id)
+		Bi::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, doc_id)
 	}
 
 	fn new_ii_key(&self, doc_id: DocId) -> Ii<'_> {
-		Ii::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, doc_id)
+		Ii::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, doc_id)
 	}
 
 	fn new_id_key(&self, id: RecordIdKey) -> IdKey {
-		IdKey::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, id)
+		IdKey::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, id)
 	}
 
 	#[cfg(not(target_family = "wasm"))]
 	pub(crate) fn new_ia_key(&self, i: u32) -> Ia<'_> {
-		Ia::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, i)
+		Ia::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, i)
 	}
 
 	#[cfg(not(target_family = "wasm"))]
 	pub(crate) fn new_ip_key(&self, id: RecordIdKey) -> Ip {
-		Ip::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, id)
+		Ip::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, id)
 	}
 
 	pub(crate) fn new_ib_key(&self, start: i64) -> Ib<'_> {
-		Ib::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, start)
+		Ib::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, start)
 	}
 
-	pub(crate) fn new_ic_key(&self, nid: Uuid) -> Ic {
-		Ic::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, nid, Uuid::now_v7())
+	pub(crate) fn new_ic_key(&self, nid: Uuid) -> IndexCompactionKey {
+		IndexCompactionKey::new(
+			self.0.ns,
+			self.0.db,
+			Cow::Borrowed(&self.0.tb),
+			self.0.ix,
+			nid,
+			Uuid::now_v7(),
+		)
 	}
 
 	pub(crate) fn new_ib_range(&self) -> Result<Range<Key>> {
-		Ib::new_range(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		Ib::new_range(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	pub(crate) fn new_is_key(&self, nid: Uuid) -> Is<'_> {
-		Is::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, nid)
+		Is::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, nid)
 	}
 
 	fn new_td_root<'a>(&'a self, term: &'a str) -> TdRoot<'a> {
-		TdRoot::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, term)
+		TdRoot::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, term)
 	}
 
 	fn new_td<'a>(&'a self, term: &'a str, doc_id: DocId) -> Td<'a> {
-		Td::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, term, doc_id)
+		Td::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, term, doc_id)
 	}
 
 	fn new_tt<'a>(
@@ -230,31 +230,31 @@ impl IndexKeyBase {
 		uid: Uuid,
 		add: bool,
 	) -> Tt<'a> {
-		Tt::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, term, doc_id, nid, uid, add)
+		Tt::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, term, doc_id, nid, uid, add)
 	}
 
 	fn new_tt_term_range(&self, term: &str) -> Result<(Key, Key)> {
-		Tt::term_range(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, term)
+		Tt::term_range(self.0.ns, self.0.db, &self.0.tb, self.0.ix, term)
 	}
 
 	fn new_tt_terms_range(&self) -> Result<(Key, Key)> {
-		Tt::terms_range(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		Tt::terms_range(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_dc_with_id(&self, doc_id: DocId, nid: Uuid, uid: Uuid) -> Dc {
-		Dc::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, doc_id, nid, uid)
+		Dc::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, doc_id, nid, uid)
 	}
 
 	fn new_dc_compacted(&self) -> Result<Key> {
-		Dc::new_root(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		Dc::new_root(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_dc_range(&self) -> Result<(Key, Key)> {
-		Dc::range(self.0.ns, self.0.db, &self.0.tb, &self.0.ix)
+		Dc::range(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
 	fn new_dl(&self, doc_id: DocId) -> Dl<'_> {
-		Dl::new(self.0.ns, self.0.db, &self.0.tb, &self.0.ix, doc_id)
+		Dl::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, doc_id)
 	}
 
 	pub(crate) fn table(&self) -> &str {
@@ -262,7 +262,7 @@ impl IndexKeyBase {
 	}
 
 	#[cfg(not(target_family = "wasm"))]
-	pub(crate) fn index(&self) -> &str {
-		&self.0.ix
+	pub(crate) fn index(&self) -> IndexId {
+		self.0.ix
 	}
 }

--- a/crates/core/src/idx/planner/executor.rs
+++ b/crates/core/src/idx/planner/executor.rs
@@ -173,8 +173,8 @@ impl InnerQueryExecutor {
 							let ikb = IndexKeyBase::new(
 								db.namespace_id,
 								db.database_id,
-								&ix.what,
-								&ix.name,
+								&ix.table_name,
+								ix.index_id,
 							);
 							let si = SearchIndex::new(
 								ctx,
@@ -225,8 +225,8 @@ impl InnerQueryExecutor {
 							let ikb = IndexKeyBase::new(
 								db.namespace_id,
 								db.database_id,
-								&ix.what,
-								&ix.name,
+								&ix.table_name,
+								ix.index_id,
 							);
 							let ft = FullTextIndex::new(
 								opt.id()?,
@@ -288,8 +288,8 @@ impl InnerQueryExecutor {
 								let ikb = IndexKeyBase::new(
 									db.namespace_id,
 									db.database_id,
-									&ix.what,
-									&ix.name,
+									&ix.table_name,
+									ix.index_id,
 								);
 								let tx = ctx.tx();
 								let mti =
@@ -813,7 +813,7 @@ impl QueryExecutor {
 		match self.0.exp_entries.get(exp) {
 			Some(PerExpressionEntry::Search(se)) => {
 				let ix = se.0.index_option.ix_ref();
-				if self.0.table == ix.what.as_str() {
+				if self.0.table == ix.table_name.as_str() {
 					return self.search_matches_with_doc_id(ctx, thg, se).await;
 				}
 				if let Some(PerIndexReferenceIndex::Search(si)) = self.0.ir_map.get(ix) {
@@ -823,7 +823,7 @@ impl QueryExecutor {
 			Some(PerExpressionEntry::FullText(fte)) => {
 				let ix = fte.0.io.ix_ref();
 				if let Some(PerIndexReferenceIndex::FullText(fti)) = self.0.ir_map.get(ix) {
-					if self.0.table == ix.what.as_str() {
+					if self.0.table == ix.table_name.as_str() {
 						return self.fulltext_matches_with_doc_id(ctx, thg, fti, fte).await;
 					}
 					return self.fulltext_matches_with_value(stk, ctx, opt, fti, fte, l, r).await;

--- a/crates/core/src/idx/planner/iterators.rs
+++ b/crates/core/src/idx/planner/iterators.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::{Result, bail};
 use radix_trie::Trie;
 
-use crate::catalog::{DatabaseId, IndexDefinition, NamespaceId};
+use crate::catalog::{DatabaseId, IndexDefinition, IndexId, NamespaceId};
 use crate::ctx::Context;
 use crate::err::Error;
 use crate::expr::BinaryOperator;
@@ -270,14 +270,14 @@ impl IndexEqualThingIterator {
 		Ok(if ix.cols.len() == 1 {
 			// Single column index: straightforward key prefix generation
 			(
-				Index::prefix_ids_beg(ns, db, &ix.what, &ix.name, fd)?,
-				Index::prefix_ids_end(ns, db, &ix.what, &ix.name, fd)?,
+				Index::prefix_ids_beg(ns, db, &ix.table_name, ix.index_id, fd)?,
+				Index::prefix_ids_end(ns, db, &ix.table_name, ix.index_id, fd)?,
 			)
 		} else {
 			// Composite index: handles multiple column values with proper ordering
 			(
-				Index::prefix_ids_composite_beg(ns, db, &ix.what, &ix.name, fd)?,
-				Index::prefix_ids_composite_end(ns, db, &ix.what, &ix.name, fd)?,
+				Index::prefix_ids_composite_beg(ns, db, &ix.table_name, ix.index_id, fd)?,
+				Index::prefix_ids_composite_end(ns, db, &ix.table_name, ix.index_id, fd)?,
 			)
 		})
 	}
@@ -536,8 +536,8 @@ impl IndexRangeThingIterator {
 		to: StoreRangeValue,
 	) -> Result<RangeScan> {
 		let (from_inclusive, to_inclusive) = (from.inclusive, to.inclusive);
-		let beg = Self::compute_beg(ns, db, &ix.what, &ix.name, from)?;
-		let end = Self::compute_end(ns, db, &ix.what, &ix.name, to)?;
+		let beg = Self::compute_beg(ns, db, &ix.table_name, ix.index_id, from)?;
+		let end = Self::compute_end(ns, db, &ix.table_name, ix.index_id, to)?;
 		Ok(RangeScan::new(beg, from_inclusive, end, to_inclusive))
 	}
 
@@ -553,16 +553,16 @@ impl IndexRangeThingIterator {
 		ns: NamespaceId,
 		db: DatabaseId,
 		ix_what: &str,
-		ix_name: &str,
+		index_id: IndexId,
 		from: StoreRangeValue,
 	) -> Result<Vec<u8>> {
 		if from.value.is_none() {
-			return Index::prefix_beg(ns, db, ix_what, ix_name);
+			return Index::prefix_beg(ns, db, ix_what, index_id);
 		}
 		if from.inclusive {
-			Index::prefix_ids_beg(ns, db, ix_what, ix_name, &StoreKeyArray::from(from.value))
+			Index::prefix_ids_beg(ns, db, ix_what, index_id, &StoreKeyArray::from(from.value))
 		} else {
-			Index::prefix_ids_end(ns, db, ix_what, ix_name, &StoreKeyArray::from(from.value))
+			Index::prefix_ids_end(ns, db, ix_what, index_id, &StoreKeyArray::from(from.value))
 		}
 	}
 
@@ -578,16 +578,16 @@ impl IndexRangeThingIterator {
 		ns: NamespaceId,
 		db: DatabaseId,
 		ix_what: &str,
-		ix_name: &str,
+		index_id: IndexId,
 		to: StoreRangeValue,
 	) -> Result<Vec<u8>> {
 		if to.value.is_none() {
-			return Index::prefix_end(ns, db, ix_what, ix_name);
+			return Index::prefix_end(ns, db, ix_what, index_id);
 		}
 		if to.inclusive {
-			Index::prefix_ids_end(ns, db, ix_what, ix_name, &StoreKeyArray::from(to.value))
+			Index::prefix_ids_end(ns, db, ix_what, index_id, &StoreKeyArray::from(to.value))
 		} else {
-			Index::prefix_ids_beg(ns, db, ix_what, ix_name, &StoreKeyArray::from(to.value))
+			Index::prefix_ids_beg(ns, db, ix_what, index_id, &StoreKeyArray::from(to.value))
 		}
 	}
 
@@ -616,15 +616,15 @@ impl IndexRangeThingIterator {
 		let (from_inclusive, to_inclusive) = (from.inclusive, to.inclusive);
 		// Compute the lower bound for the scan
 		let beg = if from.value.is_none() {
-			Index::prefix_ids_composite_beg(ns, db, &ix.what, &ix.name, &prefix_array)?
+			Index::prefix_ids_composite_beg(ns, db, &ix.table_name, ix.index_id, &prefix_array)?
 		} else {
-			Self::compute_beg_with_prefix(ns, db, &ix.what, &ix.name, &prefix_array, from)?
+			Self::compute_beg_with_prefix(ns, db, &ix.table_name, ix.index_id, &prefix_array, from)?
 		};
 		// Compute the upper bound for the scan
 		let end = if to.value.is_none() {
-			Index::prefix_ids_composite_end(ns, db, &ix.what, &ix.name, &prefix_array)?
+			Index::prefix_ids_composite_end(ns, db, &ix.table_name, ix.index_id, &prefix_array)?
 		} else {
-			Self::compute_end_with_prefix(ns, db, &ix.what, &ix.name, &prefix_array, to)?
+			Self::compute_end_with_prefix(ns, db, &ix.table_name, ix.index_id, &prefix_array, to)?
 		};
 		Ok(RangeScan::new(beg, from_inclusive, end, to_inclusive))
 	}
@@ -640,16 +640,16 @@ impl IndexRangeThingIterator {
 		ns: NamespaceId,
 		db: DatabaseId,
 		ix_what: &str,
-		ix_name: &str,
+		index_id: IndexId,
 		prefix: &StoreKeyArray,
 		from: StoreRangeValue,
 	) -> Result<Vec<u8>> {
 		let mut fd = prefix.clone();
 		fd.0.push(from.value);
 		if from.inclusive {
-			Index::prefix_ids_beg(ns, db, ix_what, ix_name, &fd)
+			Index::prefix_ids_beg(ns, db, ix_what, index_id, &fd)
 		} else {
-			Index::prefix_ids_end(ns, db, ix_what, ix_name, &fd)
+			Index::prefix_ids_end(ns, db, ix_what, index_id, &fd)
 		}
 	}
 
@@ -664,16 +664,16 @@ impl IndexRangeThingIterator {
 		ns: NamespaceId,
 		db: DatabaseId,
 		ix_what: &str,
-		ix_name: &str,
+		index_id: IndexId,
 		prefix: &StoreKeyArray,
 		to: StoreRangeValue,
 	) -> Result<Vec<u8>> {
 		let mut fd = prefix.clone();
 		fd.0.push(to.value);
 		if to.inclusive {
-			Index::prefix_ids_end(ns, db, ix_what, ix_name, &fd)
+			Index::prefix_ids_end(ns, db, ix_what, index_id, &fd)
 		} else {
-			Index::prefix_ids_beg(ns, db, ix_what, ix_name, &fd)
+			Index::prefix_ids_beg(ns, db, ix_what, index_id, &fd)
 		}
 	}
 
@@ -1121,7 +1121,7 @@ impl UniqueEqualThingIterator {
 		ix: &IndexDefinition,
 		a: &StoreKeyArray,
 	) -> Result<Self> {
-		let key = Index::new(ns, db, &ix.what, &ix.name, a, None).encode_key()?;
+		let key = Index::new(ns, db, &ix.table_name, ix.index_id, a, None).encode_key()?;
 		Ok(Self {
 			irf,
 			key: Some(key),
@@ -1163,8 +1163,8 @@ impl UniqueRangeThingIterator {
 		from: StoreRangeValue,
 		to: StoreRangeValue,
 	) -> Result<RangeScan> {
-		let beg = Self::compute_beg(ns, db, &ix.what, &ix.name, from.value)?;
-		let end = Self::compute_end(ns, db, &ix.what, &ix.name, to.value)?;
+		let beg = Self::compute_beg(ns, db, &ix.table_name, ix.index_id, from.value)?;
+		let end = Self::compute_end(ns, db, &ix.table_name, ix.index_id, to.value)?;
 		Ok(RangeScan::new(beg, from.inclusive, end, to.inclusive))
 	}
 
@@ -1214,26 +1214,26 @@ impl UniqueRangeThingIterator {
 		ns: NamespaceId,
 		db: DatabaseId,
 		ix_what: &str,
-		ix_name: &str,
+		index_id: IndexId,
 		from: StoreKeyValue,
 	) -> Result<Vec<u8>> {
 		if from.is_none() {
-			return Index::prefix_beg(ns, db, ix_what, ix_name);
+			return Index::prefix_beg(ns, db, ix_what, index_id);
 		}
-		Index::new(ns, db, ix_what, ix_name, &StoreKeyArray::from(from), None).encode_key()
+		Index::new(ns, db, ix_what, index_id, &StoreKeyArray::from(from), None).encode_key()
 	}
 
 	fn compute_end(
 		ns: NamespaceId,
 		db: DatabaseId,
 		ix_what: &str,
-		ix_name: &str,
+		index_id: IndexId,
 		to: StoreKeyValue,
 	) -> Result<Vec<u8>> {
 		if to.is_none() {
-			return Index::prefix_end(ns, db, ix_what, ix_name);
+			return Index::prefix_end(ns, db, ix_what, index_id);
 		}
-		Index::new(ns, db, ix_what, ix_name, &StoreKeyArray::from(to), None).encode_key()
+		Index::new(ns, db, ix_what, index_id, &StoreKeyArray::from(to), None).encode_key()
 	}
 
 	async fn next_batch<B: IteratorBatch>(
@@ -1433,7 +1433,7 @@ impl UniqueUnionThingIterator {
 		// We create a VecDeque to hold the key for each value in the array.
 		let mut keys = VecDeque::with_capacity(fds.len());
 		for fd in fds {
-			let key = Index::new(ns, db, &ix.what, &ix.name, fd, None).encode_key()?;
+			let key = Index::new(ns, db, &ix.table_name, ix.index_id, fd, None).encode_key()?;
 			keys.push_back(key);
 		}
 		Ok(Self {

--- a/crates/core/src/idx/trees/hnsw/mod.rs
+++ b/crates/core/src/idx/trees/hnsw/mod.rs
@@ -448,7 +448,7 @@ mod tests {
 
 	use crate::catalog::providers::CatalogProvider;
 	use crate::catalog::{
-		DatabaseDefinition, DatabaseId, Distance, HnswParams, NamespaceId, VectorType,
+		DatabaseDefinition, DatabaseId, Distance, HnswParams, IndexId, NamespaceId, VectorType,
 	};
 	use crate::ctx::{Context, MutableContext};
 	use crate::idx::IndexKeyBase;
@@ -537,7 +537,7 @@ mod tests {
 	async fn test_hnsw_collection(p: &HnswParams, collection: &TestCollection) {
 		let ds = Datastore::new("memory").await.unwrap();
 		let mut h =
-			HnswFlavor::new(IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", "ix"), p)
+			HnswFlavor::new(IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", IndexId(3)), p)
 				.unwrap();
 		let map = {
 			let tx = ds.transaction(TransactionType::Write, Optimistic).await.unwrap();
@@ -738,7 +738,7 @@ mod tests {
 			let tx = ctx.tx();
 			let mut h = HnswIndex::new(
 				&tx,
-				IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", "ix"),
+				IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", IndexId(3)),
 				"test".to_string(),
 				&p,
 			)
@@ -827,7 +827,7 @@ mod tests {
 			(9, new_i16_vec(-4, -2)),
 			(10, new_i16_vec(0, 3)),
 		]);
-		let ikb = IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", "ix");
+		let ikb = IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", IndexId(3));
 		let p = new_params(2, VectorType::I16, Distance::Euclidean, 3, 500, true, true);
 		let mut h = HnswFlavor::new(ikb, &p).unwrap();
 		let ds = Arc::new(Datastore::new("memory").await.unwrap());
@@ -870,7 +870,7 @@ mod tests {
 		let tx = ctx.tx();
 		let mut h = HnswIndex::new(
 			&tx,
-			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", "ix"),
+			IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", IndexId(3)),
 			"Index".to_string(),
 			&p,
 		)

--- a/crates/core/src/idx/trees/mtree.rs
+++ b/crates/core/src/idx/trees/mtree.rs
@@ -1488,7 +1488,9 @@ mod tests {
 	use test_log::test;
 
 	use crate::catalog::providers::CatalogProvider;
-	use crate::catalog::{DatabaseDefinition, DatabaseId, Distance, NamespaceId, VectorType};
+	use crate::catalog::{
+		DatabaseDefinition, DatabaseId, Distance, IndexId, NamespaceId, VectorType,
+	};
 	use crate::ctx::{Context, MutableContext};
 	use crate::idx::IndexKeyBase;
 	use crate::idx::docids::DocId;
@@ -1778,7 +1780,7 @@ mod tests {
 				let doc_ids = BTreeDocIds::new(
 					&tx,
 					TransactionType::Read,
-					IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", "ix"),
+					IndexKeyBase::new(NamespaceId(1), DatabaseId(2), "tb", IndexId(3)),
 					7,
 					100,
 				)

--- a/crates/core/src/idx/trees/store/mod.rs
+++ b/crates/core/src/idx/trees/store/mod.rs
@@ -235,8 +235,8 @@ impl IndexStores {
 		ix: &IndexDefinition,
 		p: &HnswParams,
 	) -> Result<SharedHnswIndex> {
-		let ikb = IndexKeyBase::new(ns, db, &ix.what, &ix.name);
-		self.0.hnsw_indexes.get(ctx, &ix.what, &ikb, p).await
+		let ikb = IndexKeyBase::new(ns, db, &ix.table_name, ix.index_id);
+		self.0.hnsw_indexes.get(ctx, &ix.table_name, &ikb, p).await
 	}
 
 	pub(crate) async fn index_removed(
@@ -252,7 +252,7 @@ impl IndexStores {
 		if let Some(ib) = ib {
 			ib.remove_index(ns, db, tb, ix)?;
 		}
-		self.remove_index(ns, db, tx.get_tb_index(ns, db, tb, ix).await?.as_ref()).await
+		self.remove_index(ns, db, tx.expect_tb_index(ns, db, tb, ix).await?.as_ref()).await
 	}
 
 	pub(crate) async fn namespace_removed(
@@ -311,7 +311,7 @@ impl IndexStores {
 		ix: &IndexDefinition,
 	) -> Result<()> {
 		if matches!(ix.index, Index::Hnsw(_)) {
-			let ikb = IndexKeyBase::new(ns, db, &ix.what, &ix.name);
+			let ikb = IndexKeyBase::new(ns, db, &ix.table_name, ix.index_id);
 			self.remove_hnsw_index(ikb).await?;
 		}
 		Ok(())

--- a/crates/core/src/key/database/ix.rs
+++ b/crates/core/src/key/database/ix.rs
@@ -1,0 +1,58 @@
+//! Stores the next and available freed IDs for documents
+use serde::{Deserialize, Serialize};
+
+use crate::catalog::{DatabaseId, NamespaceId};
+use crate::idg::u32::U32;
+use crate::key::category::{Categorise, Category};
+use crate::key::database::all::DatabaseRoot;
+use crate::kvs::KVKey;
+
+// Index ID generator
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub(crate) struct IndexIdGeneratorKey {
+	table_root: DatabaseRoot,
+	_c: u8,
+	_d: u8,
+	_e: u8,
+}
+
+impl KVKey for IndexIdGeneratorKey {
+	type ValueType = U32;
+}
+
+pub fn new(ns: NamespaceId, db: DatabaseId) -> IndexIdGeneratorKey {
+	IndexIdGeneratorKey::new(ns, db)
+}
+
+impl Categorise for IndexIdGeneratorKey {
+	fn categorise(&self) -> Category {
+		Category::DatabaseTableIdentifier
+	}
+}
+
+impl IndexIdGeneratorKey {
+	pub fn new(ns: NamespaceId, db: DatabaseId) -> Self {
+		IndexIdGeneratorKey {
+			table_root: DatabaseRoot::new(ns, db),
+			_c: b'!',
+			_d: b't',
+			_e: b'i',
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn key() {
+		#[rustfmt::skip]
+		let val = IndexIdGeneratorKey::new(
+			NamespaceId(123),
+			DatabaseId(234),
+		);
+		let enc = IndexIdGeneratorKey::encode_key(&val).unwrap();
+		assert_eq!(&enc, b"/*\x00\x00\x00\x7b*\x00\x00\x00\xea!\x74\x69");
+	}
+}

--- a/crates/core/src/key/database/mod.rs
+++ b/crates/core/src/key/database/mod.rs
@@ -6,6 +6,7 @@ pub mod az;
 pub mod bu;
 pub mod cg;
 pub mod fc;
+pub mod ix;
 pub mod ml;
 pub mod pa;
 pub mod sq;

--- a/crates/core/src/key/index/all.rs
+++ b/crates/core/src/key/index/all.rs
@@ -1,7 +1,7 @@
 //! Stores the key prefix for all keys under an index
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
 
@@ -15,14 +15,14 @@ pub(crate) struct AllIndexRoot<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 }
 
 impl KVKey for AllIndexRoot<'_> {
 	type ValueType = Vec<u8>;
 }
 
-pub fn new<'a>(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> AllIndexRoot<'a> {
+pub fn new<'a>(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> AllIndexRoot<'a> {
 	AllIndexRoot::new(ns, db, tb, ix)
 }
 
@@ -33,7 +33,7 @@ impl Categorise for AllIndexRoot<'_> {
 }
 
 impl<'a> AllIndexRoot<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -55,9 +55,9 @@ mod tests {
 
 	#[test]
 	fn root() {
-		let val = AllIndexRoot::new(NamespaceId(1), DatabaseId(2), "testtb", "testix");
+		let val = AllIndexRoot::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3));
 		let enc = AllIndexRoot::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03");
 	}
 
 	#[test]
@@ -67,9 +67,9 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 		);
 		let enc = AllIndexRoot::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03");
 	}
 }

--- a/crates/core/src/key/index/bc.rs
+++ b/crates/core/src/key/index/bc.rs
@@ -2,7 +2,7 @@
 use roaring::RoaringTreemap;
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::ft::search::terms::TermId;
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
@@ -17,7 +17,7 @@ pub(crate) struct Bc<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -35,7 +35,7 @@ impl Categorise for Bc<'_> {
 }
 
 impl<'a> Bc<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, term_id: TermId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, term_id: TermId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -65,13 +65,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7
 		);
 		let enc = Bc::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bc\0\0\0\0\0\0\0\x07"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bc\0\0\0\0\0\0\0\x07"
 		);
 	}
 }

--- a/crates/core/src/key/index/bd.rs
+++ b/crates/core/src/key/index/bd.rs
@@ -1,7 +1,7 @@
 //! Stores BTree nodes for doc ids
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::btdocids::BTreeDocIdsState;
 use crate::idx::trees::store::NodeId;
 use crate::key::category::{Categorise, Category};
@@ -17,7 +17,7 @@ pub(crate) struct BdRoot<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -34,7 +34,7 @@ impl Categorise for BdRoot<'_> {
 }
 
 impl<'a> BdRoot<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -62,7 +62,7 @@ pub(crate) struct Bd<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -80,7 +80,7 @@ impl Categorise for Bd<'_> {
 }
 
 impl<'a> Bd<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, node_id: NodeId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, node_id: NodeId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -106,9 +106,9 @@ mod tests {
 
 	#[test]
 	fn root() {
-		let val = BdRoot::new(NamespaceId(1), DatabaseId(2), "testtb", "testix");
+		let val = BdRoot::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3));
 		let enc = BdRoot::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bd");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bd");
 	}
 
 	#[test]
@@ -118,13 +118,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7
 		);
 		let enc = Bd::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bd\0\0\0\0\0\0\0\x07"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bd\0\0\0\0\0\0\0\x07"
 		);
 	}
 }

--- a/crates/core/src/key/index/bf.rs
+++ b/crates/core/src/key/index/bf.rs
@@ -1,7 +1,7 @@
 //! Stores Term/Doc frequency
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::DocId;
 use crate::idx::ft::TermFrequency;
 use crate::idx::ft::search::terms::TermId;
@@ -18,7 +18,7 @@ pub(crate) struct Bf<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -41,7 +41,7 @@ impl<'a> Bf<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		term_id: TermId,
 		doc_id: DocId,
 	) -> Self {
@@ -75,14 +75,14 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7,
 			13
 		);
 		let enc = Bf::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bf\0\0\0\0\0\0\0\x07\0\0\0\0\0\0\0\x0d"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bf\0\0\0\0\0\0\0\x07\0\0\0\0\0\0\0\x0d"
 		);
 	}
 }

--- a/crates/core/src/key/index/bi.rs
+++ b/crates/core/src/key/index/bi.rs
@@ -1,7 +1,7 @@
 //! Stores doc keys for doc_ids
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::DocId;
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
@@ -18,7 +18,7 @@ pub(crate) struct Bi<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -36,7 +36,7 @@ impl Categorise for Bi<'_> {
 }
 
 impl<'a> Bi<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, id: DocId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, id: DocId) -> Self {
 		Bi {
 			__: b'/',
 			_a: b'*',
@@ -66,13 +66,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7
 		);
 		let enc = Bi::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bi\0\0\0\0\0\0\0\x07"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bi\0\0\0\0\0\0\0\x07"
 		);
 	}
 }

--- a/crates/core/src/key/index/bk.rs
+++ b/crates/core/src/key/index/bk.rs
@@ -2,7 +2,7 @@
 use roaring::RoaringTreemap;
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::DocId;
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
@@ -17,7 +17,7 @@ pub(crate) struct Bk<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -35,7 +35,7 @@ impl Categorise for Bk<'_> {
 }
 
 impl<'a> Bk<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, doc_id: DocId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, doc_id: DocId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -65,13 +65,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7
 		);
 		let enc = Bk::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bk\0\0\0\0\0\0\0\x07"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bk\0\0\0\0\0\0\0\x07"
 		);
 	}
 }

--- a/crates/core/src/key/index/bl.rs
+++ b/crates/core/src/key/index/bl.rs
@@ -1,7 +1,7 @@
 //! Stores BTree nodes for doc lengths
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::trees::btree::BState;
 use crate::idx::trees::store::NodeId;
 use crate::key::category::{Categorise, Category};
@@ -17,7 +17,7 @@ pub(crate) struct BlRoot<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -34,7 +34,7 @@ impl Categorise for BlRoot<'_> {
 }
 
 impl<'a> BlRoot<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -62,7 +62,7 @@ pub(crate) struct Bl<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -80,7 +80,7 @@ impl Categorise for Bl<'_> {
 }
 
 impl<'a> Bl<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, node_id: NodeId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, node_id: NodeId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -105,9 +105,9 @@ mod tests {
 
 	#[test]
 	fn root() {
-		let val = BlRoot::new(NamespaceId(1), DatabaseId(2), "testtb", "testix");
+		let val = BlRoot::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3));
 		let enc = BlRoot::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bl");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bl");
 	}
 
 	#[test]
@@ -117,13 +117,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7
 		);
 		let enc = Bl::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bl\0\0\0\0\0\0\0\x07"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bl\0\0\0\0\0\0\0\x07"
 		);
 	}
 }

--- a/crates/core/src/key/index/bo.rs
+++ b/crates/core/src/key/index/bo.rs
@@ -1,7 +1,7 @@
 //! Stores the offsets
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::DocId;
 use crate::idx::ft::offset::OffsetRecords;
 use crate::idx::ft::search::terms::TermId;
@@ -18,7 +18,7 @@ pub(crate) struct Bo<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -41,7 +41,7 @@ impl<'a> Bo<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		doc_id: DocId,
 		term_id: TermId,
 	) -> Self {
@@ -75,13 +75,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			1,2
 		);
 		let enc = Bo::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bo\0\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bo\0\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\x02"
 		);
 	}
 }

--- a/crates/core/src/key/index/bp.rs
+++ b/crates/core/src/key/index/bp.rs
@@ -1,7 +1,7 @@
 //! Stores BTree nodes for postings
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::trees::btree::BState;
 use crate::idx::trees::store::NodeId;
 use crate::key::category::{Categorise, Category};
@@ -17,7 +17,7 @@ pub(crate) struct BpRoot<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -34,7 +34,7 @@ impl KVKey for BpRoot<'_> {
 }
 
 impl<'a> BpRoot<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -62,7 +62,7 @@ pub(crate) struct Bp<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -80,7 +80,7 @@ impl KVKey for Bp<'_> {
 }
 
 impl<'a> Bp<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, node_id: NodeId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, node_id: NodeId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -105,9 +105,9 @@ mod tests {
 
 	#[test]
 	fn root() {
-		let val = BpRoot::new(NamespaceId(1), DatabaseId(2), "testtb", "testix");
+		let val = BpRoot::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3));
 		let enc = BpRoot::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bp");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bp");
 	}
 
 	#[test]
@@ -117,13 +117,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7
 		);
 		let enc = Bp::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bp\0\0\0\0\0\0\0\x07"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bp\0\0\0\0\0\0\0\x07"
 		);
 	}
 }

--- a/crates/core/src/key/index/bs.rs
+++ b/crates/core/src/key/index/bs.rs
@@ -1,7 +1,7 @@
 //! Stores FullText index states
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::ft::search::SearchIndexState;
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
@@ -18,7 +18,7 @@ pub(crate) struct Bs<'a> {
 	_d: u8,
 	_e: u8,
 	_f: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 }
 
 impl KVKey for Bs<'_> {
@@ -32,7 +32,7 @@ impl Categorise for Bs<'_> {
 }
 
 impl<'a> Bs<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> Self {
 		Bs {
 			__: b'/',
 			_a: b'*',
@@ -60,9 +60,9 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 		);
 		let enc = Bs::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0!bstestix\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0!bs\0\0\0\x03");
 	}
 }

--- a/crates/core/src/key/index/bt.rs
+++ b/crates/core/src/key/index/bt.rs
@@ -1,7 +1,7 @@
 //! Stores BTree nodes for terms
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::ft::search::terms::SearchTermsState;
 use crate::idx::trees::store::NodeId;
 use crate::key::category::{Categorise, Category};
@@ -17,7 +17,7 @@ pub(crate) struct BtRoot<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -34,7 +34,7 @@ impl Categorise for BtRoot<'_> {
 }
 
 impl<'a> BtRoot<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -62,7 +62,7 @@ pub(crate) struct Bt<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -80,7 +80,7 @@ impl Categorise for Bt<'_> {
 }
 
 impl<'a> Bt<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, node_id: NodeId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, node_id: NodeId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -110,10 +110,10 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 		);
 		let enc = BtRoot::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bt");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bt");
 	}
 
 	#[test]
@@ -123,13 +123,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7
 		);
 		let enc = Bt::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bt\0\0\0\0\0\0\0\x07"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bt\0\0\0\0\0\0\0\x07"
 		);
 	}
 }

--- a/crates/core/src/key/index/bu.rs
+++ b/crates/core/src/key/index/bu.rs
@@ -1,7 +1,7 @@
 //! Stores terms for term_ids
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::ft::search::terms::TermId;
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
@@ -16,7 +16,7 @@ pub(crate) struct Bu<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -34,7 +34,7 @@ impl Categorise for Bu<'_> {
 }
 
 impl<'a> Bu<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, term_id: TermId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, term_id: TermId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -64,13 +64,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7
 		);
 		let enc = Bu::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!bu\0\0\0\0\0\0\0\x07"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!bu\0\0\0\0\0\0\0\x07"
 		);
 	}
 }

--- a/crates/core/src/key/index/dl.rs
+++ b/crates/core/src/key/index/dl.rs
@@ -16,7 +16,7 @@
 //! - Providing document-specific statistics for the full-text search engine
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::DocId;
 use crate::idx::ft::DocLength;
 use crate::key::category::{Categorise, Category};
@@ -32,7 +32,7 @@ pub(crate) struct Dl<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -63,7 +63,7 @@ impl<'a> Dl<'a> {
 	/// * `tb` - Table identifier
 	/// * `ix` - Index identifier
 	/// * `id` - The document ID whose length is being stored
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, id: DocId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, id: DocId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -88,11 +88,11 @@ mod tests {
 
 	#[test]
 	fn key() {
-		let val = Dl::new(NamespaceId(1), DatabaseId(2), "testtb", "testix", 16);
+		let val = Dl::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3), 16);
 		let enc = Dl::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!dl\0\0\0\0\0\0\0\x10"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!dl\0\0\0\0\0\0\0\x10"
 		);
 	}
 }

--- a/crates/core/src/key/index/hd.rs
+++ b/crates/core/src/key/index/hd.rs
@@ -1,7 +1,7 @@
 //! Stores the DocIds -> Thing of an HNSW index
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::DocId;
 use crate::idx::trees::hnsw::docs::HnswDocsState;
 use crate::kvs::KVKey;
@@ -17,7 +17,7 @@ pub(crate) struct HdRoot<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -28,7 +28,7 @@ impl KVKey for HdRoot<'_> {
 }
 
 impl<'a> HdRoot<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -56,7 +56,7 @@ pub(crate) struct Hd<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -68,7 +68,7 @@ impl KVKey for Hd<'_> {
 }
 
 impl<'a> Hd<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, doc_id: DocId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, doc_id: DocId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -93,9 +93,9 @@ mod tests {
 
 	#[test]
 	fn root() {
-		let val = HdRoot::new(NamespaceId(1), DatabaseId(2), "testtb", "testix");
+		let val = HdRoot::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3));
 		let enc = HdRoot::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!hd");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!hd");
 	}
 
 	#[test]
@@ -105,13 +105,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7
 		);
 		let enc = Hd::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!hd\0\0\0\0\0\0\0\x07"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!hd\0\0\0\0\0\0\0\x07"
 		);
 	}
 }

--- a/crates/core/src/key/index/he.rs
+++ b/crates/core/src/key/index/he.rs
@@ -1,7 +1,7 @@
 //! Stores Vector of an HNSW index
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::trees::hnsw::ElementId;
 use crate::idx::trees::vector::SerializedVector;
 use crate::kvs::KVKey;
@@ -16,7 +16,7 @@ pub(crate) struct He<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -32,7 +32,7 @@ impl<'a> He<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		element_id: ElementId,
 	) -> Self {
 		Self {
@@ -64,13 +64,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			7
 		);
 		let enc = He::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!he\0\0\0\0\0\0\0\x07"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!he\0\0\0\0\0\0\0\x07"
 		);
 	}
 }

--- a/crates/core/src/key/index/hi.rs
+++ b/crates/core/src/key/index/hi.rs
@@ -1,7 +1,7 @@
 //! Stores Things of an HNSW index
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::kvs::KVKey;
 use crate::val::RecordIdKey;
 
@@ -15,7 +15,7 @@ pub(crate) struct Hi<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -27,7 +27,7 @@ impl KVKey for Hi<'_> {
 }
 
 impl<'a> Hi<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, id: RecordIdKey) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, id: RecordIdKey) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -56,13 +56,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			RecordIdKey::String("testid".to_string()),
 		);
 		let enc = Hi::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!hi\0\0\0\x01testid\0",
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!hi\0\0\0\x01testid\0",
 			"{}",
 			String::from_utf8_lossy(&enc)
 		);

--- a/crates/core/src/key/index/hl.rs
+++ b/crates/core/src/key/index/hl.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::kvs::KVKey;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -16,7 +16,7 @@ pub(crate) struct Hl<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -33,7 +33,7 @@ impl<'a> Hl<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		layer: u16,
 		chunk: u32,
 	) -> Self {
@@ -62,11 +62,11 @@ mod tests {
 
 	#[test]
 	fn key() {
-		let val = Hl::new(NamespaceId(1), DatabaseId(2), "testtb", "testix", 7, 8);
+		let val = Hl::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3), 7, 8);
 		let enc = Hl::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!hl\0\x07\0\0\0\x08",
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!hl\0\x07\0\0\0\x08",
 			"{}",
 			String::from_utf8_lossy(&enc)
 		);

--- a/crates/core/src/key/index/hs.rs
+++ b/crates/core/src/key/index/hs.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::trees::hnsw::HnswState;
 use crate::kvs::KVKey;
 
@@ -17,7 +17,7 @@ pub(crate) struct Hs<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -28,7 +28,7 @@ impl KVKey for Hs<'_> {
 }
 
 impl<'a> Hs<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -52,11 +52,11 @@ mod tests {
 
 	#[test]
 	fn key() {
-		let val = Hs::new(NamespaceId(1), DatabaseId(2), "testtb", "testix");
+		let val = Hs::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3));
 		let enc = Hs::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!hs",
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!hs",
 			"{}",
 			String::from_utf8_lossy(&enc)
 		);

--- a/crates/core/src/key/index/hv.rs
+++ b/crates/core/src/key/index/hv.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::trees::hnsw::docs::ElementDocs;
 use crate::idx::trees::vector::SerializedVector;
 use crate::kvs::KVKey;
@@ -19,7 +19,7 @@ pub(crate) struct Hv<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -35,7 +35,7 @@ impl<'a> Hv<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		vec: Arc<SerializedVector>,
 	) -> Self {
 		Self {
@@ -66,13 +66,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			Arc::new(SerializedVector::I16(vec![2])),
 		);
 		let enc = Hv::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!hv\0\0\0\x04\x80\x02\x01",
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!hv\0\0\0\x04\x80\x02\x01",
 			"{}",
 			String::from_utf8_lossy(&enc)
 		);

--- a/crates/core/src/key/index/ia.rs
+++ b/crates/core/src/key/index/ia.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::kvs::KVKey;
 use crate::kvs::index::Appending;
 
@@ -17,7 +17,7 @@ pub(crate) struct Ia<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -29,7 +29,7 @@ impl KVKey for Ia<'_> {
 }
 
 impl<'a> Ia<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, i: u32) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, i: u32) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -54,11 +54,11 @@ mod tests {
 
 	#[test]
 	fn key() {
-		let val = Ia::new(NamespaceId(1), DatabaseId(2), "testtb", "testix", 1);
+		let val = Ia::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3), 1);
 		let enc = Ia::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!ia\x00\x00\x00\x01",
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!ia\x00\x00\x00\x01",
 			"{}",
 			String::from_utf8_lossy(&enc)
 		);

--- a/crates/core/src/key/index/ib.rs
+++ b/crates/core/src/key/index/ib.rs
@@ -34,7 +34,7 @@ use std::ops::Range;
 
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
 use crate::kvs::sequences::BatchValue;
@@ -49,7 +49,7 @@ pub(crate) struct Ib<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -71,7 +71,7 @@ impl<'a> Ib<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		start: i64,
 	) -> Self {
 		Self {
@@ -95,7 +95,7 @@ impl<'a> Ib<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 	) -> anyhow::Result<Range<Vec<u8>>> {
 		let beg = Self::new(ns, db, tb, ix, i64::MIN).encode_key()?;
 		let end = Self::new(ns, db, tb, ix, i64::MAX).encode_key()?;
@@ -109,14 +109,14 @@ mod tests {
 
 	#[test]
 	fn ib_range() {
-		let ib_range = Ib::new_range(NamespaceId(1), DatabaseId(2), "testtb", "testix").unwrap();
+		let ib_range = Ib::new_range(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3)).unwrap();
 		assert_eq!(
 			ib_range.start,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!ib\0\0\0\0\0\0\0\0"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!ib\0\0\0\0\0\0\0\0"
 		);
 		assert_eq!(
 			ib_range.end,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!ib\xff\xff\xff\xff\xff\xff\xff\xff"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!ib\xff\xff\xff\xff\xff\xff\xff\xff"
 		);
 	}
 }

--- a/crates/core/src/key/index/id.rs
+++ b/crates/core/src/key/index/id.rs
@@ -40,7 +40,7 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::DocId;
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
@@ -56,7 +56,7 @@ pub(crate) struct Id<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -75,7 +75,7 @@ impl Categorise for Id<'_> {
 
 impl<'a> Id<'a> {
 	#[cfg_attr(target_family = "wasm", allow(dead_code))]
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, id: RecordIdKey) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, id: RecordIdKey) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -104,13 +104,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			RecordIdKey::from(strand!("id").to_owned()),
 		);
 		let enc = Id::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!id\0\0\0\x01id\0",
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!id\0\0\0\x01id\0",
 			"{}",
 			String::from_utf8_lossy(&enc)
 		);

--- a/crates/core/src/key/index/ii.rs
+++ b/crates/core/src/key/index/ii.rs
@@ -1,7 +1,7 @@
 //! Stores doc keys for doc_ids
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::DocId;
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
@@ -18,7 +18,7 @@ pub(crate) struct Ii<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -36,7 +36,7 @@ impl Categorise for Ii<'_> {
 }
 
 impl<'a> Ii<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, id: DocId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, id: DocId) -> Self {
 		Ii {
 			__: b'/',
 			_a: b'*',
@@ -61,11 +61,11 @@ mod tests {
 
 	#[test]
 	fn key() {
-		let val = Ii::new(NamespaceId(1), DatabaseId(2), "testtb", "testix", 1);
+		let val = Ii::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3), 1);
 		let enc = Ii::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!ii\0\0\0\0\0\0\0\x01"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!ii\0\0\0\0\0\0\0\x01"
 		);
 	}
 }

--- a/crates/core/src/key/index/ip.rs
+++ b/crates/core/src/key/index/ip.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::kvs::KVKey;
 use crate::kvs::index::PrimaryAppending;
 use crate::val::RecordIdKey;
@@ -18,7 +18,7 @@ pub(crate) struct Ip<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -30,7 +30,7 @@ impl KVKey for Ip<'_> {
 }
 
 impl<'a> Ip<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, id: RecordIdKey) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, id: RecordIdKey) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -59,13 +59,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			RecordIdKey::String("id".to_string()),
 		);
 		let enc = Ip::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!ip\0\0\0\x01id\0",
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!ip\0\0\0\x01id\0",
 			"{}",
 			String::from_utf8_lossy(&enc)
 		);

--- a/crates/core/src/key/index/is.rs
+++ b/crates/core/src/key/index/is.rs
@@ -25,7 +25,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
 use crate::kvs::sequences::SequenceState;
@@ -40,7 +40,7 @@ pub(crate) struct Is<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -63,7 +63,7 @@ impl<'a> Is<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		nid: Uuid,
 	) -> Self {
 		Self {
@@ -94,10 +94,10 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			Uuid::from_bytes([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
 		);
 		let enc = Is::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!is\0\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!is\0\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f");
 	}
 }

--- a/crates/core/src/key/index/mod.rs
+++ b/crates/core/src/key/index/mod.rs
@@ -49,7 +49,7 @@ use std::borrow::Cow;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::key::category::{Categorise, Category};
 use crate::key::value::StoreKeyArray;
 use crate::kvs::KVKey;
@@ -65,7 +65,7 @@ struct Prefix<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 }
 
@@ -74,7 +74,7 @@ impl KVKey for Prefix<'_> {
 }
 
 impl<'a> Prefix<'a> {
-	fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+	fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -100,7 +100,7 @@ struct PrefixIds<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	/// Encoded index field values. Uses StoreKeyArray which normalizes numeric
 	/// types (Int/Float/Decimal) into a lexicographically ordered byte form so
@@ -117,7 +117,7 @@ impl<'a> PrefixIds<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		fd: &'a StoreKeyArray,
 	) -> Self {
 		Self {
@@ -146,7 +146,7 @@ pub(crate) struct Index<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	/// Encoded index field values. Uses StoreKeyArray which normalizes numeric
 	/// types (Int/Float/Decimal) into a lexicographically ordered byte form so
@@ -170,7 +170,7 @@ impl<'a> Index<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		fd: &'a StoreKeyArray,
 		id: Option<&'a RecordIdKey>,
 	) -> Self {
@@ -190,13 +190,13 @@ impl<'a> Index<'a> {
 		}
 	}
 
-	fn prefix(ns: NamespaceId, db: DatabaseId, tb: &str, ix: &str) -> Result<Vec<u8>> {
+	fn prefix(ns: NamespaceId, db: DatabaseId, tb: &str, ix: IndexId) -> Result<Vec<u8>> {
 		Prefix::new(ns, db, tb, ix).encode_key()
 	}
 
 	/// Start of the index keyspace: prefix + 0x00. Used as the lower bound
 	/// when iterating all entries for a given index.
-	pub fn prefix_beg(ns: NamespaceId, db: DatabaseId, tb: &str, ix: &str) -> Result<Vec<u8>> {
+	pub fn prefix_beg(ns: NamespaceId, db: DatabaseId, tb: &str, ix: IndexId) -> Result<Vec<u8>> {
 		let mut beg = Self::prefix(ns, db, tb, ix)?;
 		beg.extend_from_slice(&[0x00]); // lower sentinel for entire index keyspace
 		Ok(beg)
@@ -204,7 +204,7 @@ impl<'a> Index<'a> {
 
 	/// End of the index keyspace: prefix + 0xFF. Used as the upper bound (exclusive)
 	/// when iterating all entries for a given index.
-	pub fn prefix_end(ns: NamespaceId, db: DatabaseId, tb: &str, ix: &str) -> Result<Vec<u8>> {
+	pub fn prefix_end(ns: NamespaceId, db: DatabaseId, tb: &str, ix: IndexId) -> Result<Vec<u8>> {
 		let mut beg = Self::prefix(ns, db, tb, ix)?;
 		beg.extend_from_slice(&[0xff]); // upper sentinel for entire index keyspace (exclusive)
 		Ok(beg)
@@ -217,7 +217,7 @@ impl<'a> Index<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &str,
-		ix: &str,
+		ix: IndexId,
 		fd: &StoreKeyArray,
 	) -> Result<Vec<u8>> {
 		PrefixIds::new(ns, db, tb, ix, fd).encode_key()
@@ -232,7 +232,7 @@ impl<'a> Index<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &str,
-		ix: &str,
+		ix: IndexId,
 		fd: &StoreKeyArray,
 	) -> Result<Vec<u8>> {
 		let mut beg = Self::prefix_ids(ns, db, tb, ix, fd)?;
@@ -249,7 +249,7 @@ impl<'a> Index<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &str,
-		ix: &str,
+		ix: IndexId,
 		fd: &StoreKeyArray,
 	) -> Result<Vec<u8>> {
 		let mut beg = Self::prefix_ids(ns, db, tb, ix, fd)?;
@@ -265,7 +265,7 @@ impl<'a> Index<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &str,
-		ix: &str,
+		ix: IndexId,
 		fd: &StoreKeyArray,
 	) -> Result<Vec<u8>> {
 		let mut beg = Self::prefix_ids(ns, db, tb, ix, fd)?;
@@ -281,7 +281,7 @@ impl<'a> Index<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &str,
-		ix: &str,
+		ix: IndexId,
 		fd: &StoreKeyArray,
 	) -> Result<Vec<u8>> {
 		let mut beg = Self::prefix_ids(ns, db, tb, ix, fd)?;
@@ -301,11 +301,11 @@ mod tests {
 		let fd: Array = vec!["testfd1", "testfd2"].into();
 		let fd = fd.into();
 		let id = RecordIdKey::String("testid".to_owned());
-		let val = Index::new(NamespaceId(1), DatabaseId(2), "testtb", "testix", &fd, Some(&id));
+		let val = Index::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3), &fd, Some(&id));
 		let enc = Index::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0*\0\0\0\x04testfd1\0\0\0\0\x04testfd2\0\x01\x01\0\0\0\x01testid\0"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03*\0\0\0\x04testfd1\0\0\0\0\x04testfd2\0\x01\x01\0\0\0\x01testid\0"
 		);
 	}
 
@@ -313,11 +313,11 @@ mod tests {
 	fn key_none() {
 		let fd: Array = vec!["testfd1", "testfd2"].into();
 		let fd = fd.into();
-		let val = Index::new(NamespaceId(1), DatabaseId(2), "testtb", "testix", &fd, None);
+		let val = Index::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3), &fd, None);
 		let enc = Index::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0*\0\0\0\x04testfd1\0\0\0\0\x04testfd2\0\x01\0"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03*\0\0\0\x04testfd1\0\0\0\0\x04testfd2\0\x01\0"
 		);
 	}
 
@@ -326,20 +326,30 @@ mod tests {
 		let fd: Array = vec!["testfd1"].into();
 		let fd = fd.into();
 
-		let enc =
-			Index::prefix_ids_composite_beg(NamespaceId(1), DatabaseId(2), "testtb", "testix", &fd)
-				.unwrap();
+		let enc = Index::prefix_ids_composite_beg(
+			NamespaceId(1),
+			DatabaseId(2),
+			"testtb",
+			IndexId(3),
+			&fd,
+		)
+		.unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0*\0\0\0\x04testfd1\0\x00"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03*\0\0\0\x04testfd1\0\x00"
 		);
 
-		let enc =
-			Index::prefix_ids_composite_end(NamespaceId(1), DatabaseId(2), "testtb", "testix", &fd)
-				.unwrap();
+		let enc = Index::prefix_ids_composite_end(
+			NamespaceId(1),
+			DatabaseId(2),
+			"testtb",
+			IndexId(3),
+			&fd,
+		)
+		.unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0*\0\0\0\x04testfd1\0\xff"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03*\0\0\0\x04testfd1\0\xff"
 		);
 	}
 }

--- a/crates/core/src/key/index/td.rs
+++ b/crates/core/src/key/index/td.rs
@@ -17,7 +17,7 @@
 use roaring::RoaringTreemap;
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::docids::DocId;
 use crate::idx::ft::fulltext::TermDocument;
 use crate::key::category::{Categorise, Category};
@@ -33,7 +33,7 @@ pub(crate) struct TdRoot<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -55,7 +55,7 @@ impl<'a> TdRoot<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		term: &'a str,
 	) -> Self {
 		Self {
@@ -86,7 +86,7 @@ pub(crate) struct Td<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -122,7 +122,7 @@ impl<'a> Td<'a> {
 		ns: NamespaceId,
 		db: DatabaseId,
 		tb: &'a str,
-		ix: &'a str,
+		ix: IndexId,
 		term: &'a str,
 		id: DocId,
 	) -> Self {
@@ -151,18 +151,18 @@ mod tests {
 
 	#[test]
 	fn root() {
-		let val = TdRoot::new(NamespaceId(1), DatabaseId(2), "testtb", "testix", "term");
+		let val = TdRoot::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3), "term");
 		let enc = TdRoot::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!tdterm\0");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!tdterm\0");
 	}
 
 	#[test]
 	fn key() {
-		let val = Td::new(NamespaceId(1), DatabaseId(2), "testtb", "testix", "term", 129);
+		let val = Td::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3), "term", 129);
 		let enc = Td::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!tdterm\0\0\0\0\0\0\0\0\x81"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!tdterm\0\0\0\0\0\0\0\0\x81"
 		);
 	}
 }

--- a/crates/core/src/key/index/vm.rs
+++ b/crates/core/src/key/index/vm.rs
@@ -1,7 +1,7 @@
 //! Stores MTree state and nodes
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::idx::trees::mtree::MState;
 use crate::idx::trees::store::NodeId;
 use crate::kvs::KVKey;
@@ -16,7 +16,7 @@ pub(crate) struct VmRoot<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -27,7 +27,7 @@ impl KVKey for VmRoot<'_> {
 }
 
 impl<'a> VmRoot<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -56,7 +56,7 @@ pub(crate) struct Vm<'a> {
 	_c: u8,
 	pub tb: &'a str,
 	_d: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 	_e: u8,
 	_f: u8,
 	_g: u8,
@@ -68,7 +68,7 @@ impl KVKey for Vm<'_> {
 }
 
 impl<'a> Vm<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str, node_id: NodeId) -> Self {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: IndexId, node_id: NodeId) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -93,9 +93,9 @@ mod tests {
 
 	#[test]
 	fn root() {
-		let val = VmRoot::new(NamespaceId(1), DatabaseId(2), "testtb", "testix");
+		let val = VmRoot::new(NamespaceId(1), DatabaseId(2), "testtb", IndexId(3));
 		let enc = VmRoot::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!vm");
+		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!vm");
 	}
 
 	#[test]
@@ -105,13 +105,13 @@ mod tests {
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
-			"testix",
+			IndexId(3),
 			8
 		);
 		let enc = Vm::encode_key(&val).unwrap();
 		assert_eq!(
 			enc,
-			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+testix\0!vm\0\0\0\0\0\0\0\x08"
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!vm\0\0\0\0\0\0\0\x08"
 		);
 	}
 }

--- a/crates/core/src/key/mod.rs
+++ b/crates/core/src/key/mod.rs
@@ -1,7 +1,7 @@
 //! This crate defines the key structure for the key value store.
 //!
 //! Key struct naming conventions:
-//! `XxKey` - A specific key type. eg. `/*{ns}*{db}*{tb}*{id}`
+//! `XxKey` - A specific key type. eg. `/*{ns}*{db}*{tb_name}*{id}`
 //! `XxRoot` - A root key which prefixes other keys. eg. `/*{ns}*{db}`
 //! `XxRange` - Represents a start and end key. eg. `/*{ns}*{db}#\x00` or
 //! `/*{ns}*{db}#\xff`
@@ -45,62 +45,63 @@
 //! crate::key::namespace::access::gr    /*{ns}&{ac}!gr{gr}
 //!
 //! crate::key::database::all            /*{ns}*{db}
-//! crate::key::database::ac             /*{ns}*{db}!ac{ac}
-//! crate::key::database::az             /*{ns}*{db}!az{az}
-//! crate::key::database::bu             /*{ns}*{db}!bu{bu}
-//! crate::key::database::fc             /*{ns}*{db}!fn{fc}
-//! crate::key::database::ml             /*{ns}*{db}!ml{ml}{vn}
-//! crate::key::database::pa             /*{ns}*{db}!pa{pa}
-//! crate::key::database::sq             /*{ns}*{db}!sq{sq}
+//! crate::key::database::ac             /*{ns}*{db}!ac{ac_name}
+//! crate::key::database::az             /*{ns}*{db}!az{az_name}
+//! crate::key::database::bu             /*{ns}*{db}!bu{bu_name}
+//! crate::key::database::fc             /*{ns}*{db}!fn{fc_name}
+//! crate::key::database::ml             /*{ns}*{db}!ml{ml_name}{vn}
+//! crate::key::database::pa             /*{ns}*{db}!pa{pa_name}
+//! crate::key::database::sq             /*{ns}*{db}!sq{sq_name}
 //! crate::key::database::tb             /*{ns}*{db}!tb{tb_name} -> TableDefinition
 //! crate::key::database::ti             /+{ns}*{db}!ti
 //! crate::key::database::ts             /*{ns}*{db}!ts{ts}
-//! crate::key::database::us             /*{ns}*{db}!us{us}
+//! crate::key::database::us             /*{ns}*{db}!us{us_name}
 //! crate::key::database::vs             /*{ns}*{db}!vs
 //! crate::key::database::cg             /*{ns}*{db}!cg{ty}
 //!
 //! crate::key::database::access::all    /*{ns}*{db}&{ac}
 //! crate::key::database::access::gr     /*{ns}*{db}&{ac}!gr{gr}
 //!
-//! crate::key::table::all               /*{ns}*{db}*{tb}
-//! crate::key::table::ev                /*{ns}*{db}*{tb}!ev{ev}
-//! crate::key::table::fd                /*{ns}*{db}*{tb}!fd{fd}
-//! crate::key::table::ft                /*{ns}*{db}*{tb}!ft{ft}
-//! crate::key::table::ix                /*{ns}*{db}*{tb}!ix{ix}
-//! crate::key::table::lq                /*{ns}*{db}*{tb}!lq{lq}
+//! crate::key::table::all               /*{ns}*{db}*{tb_name}
+//! crate::key::table::ev                /*{ns}*{db}*{tb_name}!ev{ev}
+//! crate::key::table::fd                /*{ns}*{db}*{tb_name}!fd{fd}
+//! crate::key::table::ft                /*{ns}*{db}*{tb_name}!ft{ft}
+//! crate::key::table::ix                /*{ns}*{db}*{tb_name}!il{ix} -> ix_name
+//! crate::key::table::ix                /*{ns}*{db}*{tb_name}!ix{ix_name} -> IndexDefinition
+//! crate::key::table::lq                /*{ns}*{db}*{tb_name}!lq{lq}
 //!
-//! crate::key::index::all               /*{ns}*{db}*{tb}+{ix}
-//! crate::key::index::bc                /*{ns}*{db}*{tb}+{ix}!bc{id}
-//! crate::key::index::bd                /*{ns}*{db}*{tb}+{ix}!bd{id}
-//! crate::key::index::bf                /*{ns}*{db}*{tb}+{ix}!bf{id}
-//! crate::key::index::bi                /*{ns}*{db}*{tb}+{ix}!bi{id}
-//! crate::key::index::bk                /*{ns}*{db}*{tb}+{ix}!bk{id}
-//! crate::key::index::bl                /*{ns}*{db}*{tb}+{ix}!bl{id}
-//! crate::key::index::bo                /*{ns}*{db}*{tb}+{ix}!bo{id}
-//! crate::key::index::bp                /*{ns}*{db}*{tb}+{ix}!bp{id}
-//! crate::key::index::bs                /*{ns}*{db}*{tb}+{ix}!bs
-//! crate::key::index::bt                /*{ns}*{db}*{tb}+{ix}!bt{id}
-//! crate::key::index::bu                /*{ns}*{db}*{tb}+{ix}!bu{id}
-//! crate::key::index::dl                /*{ns}*{db}*{tb}+{ix}!dl{id}
-//! crate::key::index::tf                /*{ns}*{db}*{tb}+{ix}!tf{term}{id}
-//! crate::key::index                    /*{ns}*{db}*{tb}+{ix}*{fd}{id}
+//! crate::key::index::all               /*{ns}*{db}*{tb_name}+{ix}
+//! crate::key::index::bc                /*{ns}*{db}*{tb_name}+{ix}!bc{id}
+//! crate::key::index::bd                /*{ns}*{db}*{tb_name}+{ix}!bd{id}
+//! crate::key::index::bf                /*{ns}*{db}*{tb_name}+{ix}!bf{id}
+//! crate::key::index::bi                /*{ns}*{db}*{tb_name}+{ix}!bi{id}
+//! crate::key::index::bk                /*{ns}*{db}*{tb_name}+{ix}!bk{id}
+//! crate::key::index::bl                /*{ns}*{db}*{tb_name}+{ix}!bl{id}
+//! crate::key::index::bo                /*{ns}*{db}*{tb_name}+{ix}!bo{id}
+//! crate::key::index::bp                /*{ns}*{db}*{tb_name}+{ix}!bp{id}
+//! crate::key::index::bs                /*{ns}*{db}*{tb_name}+{ix}!bs
+//! crate::key::index::bt                /*{ns}*{db}*{tb_name}+{ix}!bt{id}
+//! crate::key::index::bu                /*{ns}*{db}*{tb_name}+{ix}!bu{id}
+//! crate::key::index::dl                /*{ns}*{db}*{tb_name}+{ix}!dl{id}
+//! crate::key::index::tf                /*{ns}*{db}*{tb_name}+{ix}!tf{term}{id}
+//! crate::key::index                    /*{ns}*{db}*{tb_name}+{ix}*{fd}{id}
 //!
 //! crate::key::change::vs_key_prefix    /*{ns}*{db}#
-//! crate::key::change::vs_key_suffix                *{tb}\00
+//! crate::key::change::vs_key_suffix                *{tb_name}\00
 //! crate::key::change::prefix           /*{ns}*{db}#
 //! crate::key::change::prefix_ts        /*{ns}*{db}#{ts}
 //! crate::key::change::suffix           /*{ns}*{db}#\ff
-//! crate::key::change::cf               /*{ns}*{db}#{ts}*{tb}
-//! crate::key::change::vs               /*{ns}*{db}#{ts}/*{ns}/*/{db}!vs*{tb}\0
+//! crate::key::change::cf               /*{ns}*{db}#{ts}*{tb_name}
+//! crate::key::change::vs               /*{ns}*{db}#{ts}/*{ns}/*/{db}!vs*{tb_name}\0
 //! crate::key::change::suffix_vs        /*{ns}*{db}#{ts}/*{ns}/*/{db}!vs
 //!
-//! crate::key::record                   /*{ns}*{db}*{tb}*{id}
+//! crate::key::record                   /*{ns}*{db}*{tb_name}*{id}
 //!
-//! crate::key::graph                    /*{ns}*{db}*{tb}~{id}{eg}{ft}{fk}
-//! crate::key::ref                      /*{ns}*{db}*{tb}&{id}{ft}{fk}{ff}
+//! crate::key::graph                    /*{ns}*{db}*{tb_name}~{id}{eg}{ft}{fk}
+//! crate::key::ref                      /*{ns}*{db}*{tb_name}&{id}{ft}{fk}{ff}
 //!
-//! crate::key::sequence::st             /*{ns}*{db}*{tb}*{sq}!st{id}
-//! crate::key::sequence::ba             /*{ns}*{db}*{tb}*{sq}!ba{start}
+//! crate::key::sequence::st             /*{ns}*{db}*{tb_name}*{sq}!st{id}
+//! crate::key::sequence::ba             /*{ns}*{db}*{tb_name}*{sq}!ba{start}
 pub(crate) mod category;
 pub(crate) mod change;
 pub(crate) mod database;

--- a/crates/core/src/key/root/ic.rs
+++ b/crates/core/src/key/root/ic.rs
@@ -9,10 +9,12 @@
 //! index that needs to be compacted. The compaction thread processes these
 //! entries at regular intervals defined by the `index_compaction_interval`
 //! configuration option.
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::catalog::{DatabaseId, NamespaceId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId};
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
 
@@ -25,41 +27,37 @@ use crate::kvs::KVKey;
 /// Compaction helps optimize index performance by consolidating changes and
 /// removing unnecessary data.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize)]
-pub(crate) struct Ic<'a> {
+pub(crate) struct IndexCompactionKey<'key> {
 	__: u8,
 	_a: u8,
 	_b: u8,
 	_c: u8,
 	pub ns: NamespaceId,
 	pub db: DatabaseId,
-	pub tb: &'a str,
-	pub ix: &'a str,
+	pub tb: Cow<'key, str>,
+	pub ix: IndexId,
 	#[serde(with = "uuid::serde::compact")]
 	pub nid: Uuid,
 	#[serde(with = "uuid::serde::compact")]
 	pub uid: Uuid,
 }
 
-impl KVKey for Ic<'_> {
+impl KVKey for IndexCompactionKey<'_> {
 	type ValueType = ();
 }
 
-impl Categorise for Ic<'_> {
+impl Categorise for IndexCompactionKey<'_> {
 	fn categorise(&self) -> Category {
 		Category::IndexCompaction
 	}
 }
 
-impl<'a> Ic<'a> {
-	pub(crate) fn range() -> (Vec<u8>, Vec<u8>) {
-		(b"/!ic\0".to_vec(), b"/!ic\0xff".to_vec())
-	}
-
+impl<'key> IndexCompactionKey<'key> {
 	pub(crate) fn new(
 		ns: NamespaceId,
 		db: DatabaseId,
-		tb: &'a str,
-		ix: &'a str,
+		tb: Cow<'key, str>,
+		ix: IndexId,
 		nid: Uuid,
 		uid: Uuid,
 	) -> Self {
@@ -77,7 +75,26 @@ impl<'a> Ic<'a> {
 		}
 	}
 
-	pub fn decode_key(k: &[u8]) -> anyhow::Result<Ic<'_>> {
+	pub(crate) fn into_owned(self) -> IndexCompactionKey<'static> {
+		IndexCompactionKey::new(
+			self.ns,
+			self.db,
+			Cow::Owned(self.tb.into_owned()),
+			self.ix,
+			self.nid,
+			self.uid,
+		)
+	}
+
+	pub(crate) fn index_matches(&self, other: &IndexCompactionKey<'_>) -> bool {
+		self.ns == other.ns && self.db == other.db && self.tb == other.tb && self.ix == other.ix
+	}
+
+	pub(crate) fn range() -> (Vec<u8>, Vec<u8>) {
+		(b"/!ic\0".to_vec(), b"/!ic\0xff".to_vec())
+	}
+
+	pub fn decode_key(k: &[u8]) -> anyhow::Result<IndexCompactionKey<'_>> {
 		Ok(storekey::deserialize(k)?)
 	}
 }
@@ -85,18 +102,18 @@ impl<'a> Ic<'a> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::key::root::ic::Ic;
+	use crate::key::root::ic::IndexCompactionKey;
 
 	#[test]
 	fn range() {
-		assert_eq!(Ic::range(), (b"/!ic\0".to_vec(), b"/!ic\0xff".to_vec()));
+		assert_eq!(IndexCompactionKey::range(), (b"/!ic\0".to_vec(), b"/!ic\0xff".to_vec()));
 	}
 
 	#[test]
 	fn key() {
 		#[rustfmt::skip]
-		let val = Ic::new(NamespaceId(1), DatabaseId(2), "testtb", "testix", Uuid::from_u128(1), Uuid::from_u128(2));
-		let enc = Ic::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/!ic\x00\x00\x00\x01\x00\x00\x00\x02testtb\0testix\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x02");
+		let val = IndexCompactionKey::new(NamespaceId(1), DatabaseId(2), Cow::Borrowed("testtb"), IndexId(3), Uuid::from_u128(1), Uuid::from_u128(2));
+		let enc = IndexCompactionKey::encode_key(&val).unwrap();
+		assert_eq!(enc, b"/!ic\x00\x00\x00\x01\x00\x00\x00\x02testtb\0\0\0\0\x03\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x01\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x02");
 	}
 }

--- a/crates/core/src/key/root/ni.rs
+++ b/crates/core/src/key/root/ni.rs
@@ -6,30 +6,30 @@ use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize)]
-pub(crate) struct Ni {
+pub(crate) struct NamespaceIdGeneratorKey {
 	__: u8,
 	_a: u8,
 	_b: u8,
 	_c: u8,
 }
 
-impl KVKey for Ni {
+impl KVKey for NamespaceIdGeneratorKey {
 	type ValueType = U32;
 }
 
-impl Default for Ni {
+impl Default for NamespaceIdGeneratorKey {
 	fn default() -> Self {
 		Self::new()
 	}
 }
 
-impl Categorise for Ni {
+impl Categorise for NamespaceIdGeneratorKey {
 	fn categorise(&self) -> Category {
 		Category::NamespaceIdentifier
 	}
 }
 
-impl Ni {
+impl NamespaceIdGeneratorKey {
 	pub fn new() -> Self {
 		Self {
 			__: b'/',
@@ -46,8 +46,8 @@ mod tests {
 
 	#[test]
 	fn key() {
-		let val = Ni::new();
-		let enc = Ni::encode_key(&val).unwrap();
+		let val = NamespaceIdGeneratorKey::new();
+		let enc = NamespaceIdGeneratorKey::encode_key(&val).unwrap();
 		assert_eq!(&enc, b"/!ni");
 	}
 }

--- a/crates/core/src/key/table/ix.rs
+++ b/crates/core/src/key/table/ix.rs
@@ -2,31 +2,73 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::catalog::{DatabaseId, IndexDefinition, NamespaceId};
+use crate::catalog::{DatabaseId, IndexDefinition, IndexId, NamespaceId};
 use crate::key::category::{Categorise, Category};
 use crate::kvs::KVKey;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
-pub(crate) struct Ix<'a> {
+pub(crate) struct IndexNameLookupKey<'key> {
 	__: u8,
 	_a: u8,
 	pub ns: NamespaceId,
 	_b: u8,
 	pub db: DatabaseId,
 	_c: u8,
-	pub tb: &'a str,
+	pub tb: &'key str,
 	_d: u8,
 	_e: u8,
 	_f: u8,
-	pub ix: &'a str,
+	pub ix: IndexId,
 }
 
-impl KVKey for Ix<'_> {
+impl<'key> KVKey for IndexNameLookupKey<'key> {
+	type ValueType = String;
+}
+
+impl<'key> IndexNameLookupKey<'key> {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'key str, ix: IndexId) -> Self {
+		Self {
+			__: b'/',
+			_a: b'*',
+			ns,
+			_b: b'*',
+			db,
+			_c: b'*',
+			tb,
+			_d: b'!',
+			_e: b'i',
+			_f: b'l',
+			ix,
+		}
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+pub(crate) struct IndexDefinitionKey<'key> {
+	__: u8,
+	_a: u8,
+	pub ns: NamespaceId,
+	_b: u8,
+	pub db: DatabaseId,
+	_c: u8,
+	pub tb: &'key str,
+	_d: u8,
+	_e: u8,
+	_f: u8,
+	pub ix: &'key str,
+}
+
+impl KVKey for IndexDefinitionKey<'_> {
 	type ValueType = IndexDefinition;
 }
 
-pub fn new<'a>(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Ix<'a> {
-	Ix::new(ns, db, tb, ix)
+pub fn new<'key>(
+	ns: NamespaceId,
+	db: DatabaseId,
+	tb: &'key str,
+	ix: &'key str,
+) -> IndexDefinitionKey<'key> {
+	IndexDefinitionKey::new(ns, db, tb, ix)
 }
 
 pub fn prefix(ns: NamespaceId, db: DatabaseId, tb: &str) -> Result<Vec<u8>> {
@@ -41,14 +83,14 @@ pub fn suffix(ns: NamespaceId, db: DatabaseId, tb: &str) -> Result<Vec<u8>> {
 	Ok(k)
 }
 
-impl Categorise for Ix<'_> {
+impl Categorise for IndexDefinitionKey<'_> {
 	fn categorise(&self) -> Category {
 		Category::IndexDefinition
 	}
 }
 
-impl<'a> Ix<'a> {
-	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'a str, ix: &'a str) -> Self {
+impl<'key> IndexDefinitionKey<'key> {
+	pub fn new(ns: NamespaceId, db: DatabaseId, tb: &'key str, ix: &'key str) -> Self {
 		Self {
 			__: b'/',
 			_a: b'*',
@@ -72,13 +114,13 @@ mod tests {
 	#[test]
 	fn key() {
 		#[rustfmt::skip]
-		let val = Ix::new(
+		let val = IndexDefinitionKey::new(
 			NamespaceId(1),
 			DatabaseId(2),
 			"testtb",
 			"testix",
 		);
-		let enc = Ix::encode_key(&val).unwrap();
-		assert_eq!(enc, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0!ixtestix\0");
+		let enc = IndexDefinitionKey::encode_key(&val).unwrap();
+		assert_eq!(enc, b"/*\0\0\0\x01*\0\0\0\x02*testtb\0!ixtestix\0");
 	}
 }

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -54,7 +54,7 @@ use crate::iam::{Action, Auth, Error as IamError, Resource, Role};
 use crate::idx::IndexKeyBase;
 use crate::idx::ft::fulltext::FullTextIndex;
 use crate::idx::trees::store::IndexStores;
-use crate::key::root::ic::Ic;
+use crate::key::root::ic::IndexCompactionKey;
 use crate::kvs::LockType::*;
 use crate::kvs::TransactionType::*;
 use crate::kvs::cache::ds::DatastoreCache;
@@ -838,45 +838,40 @@ impl Datastore {
 			// Create a new transaction
 			let txn = self.transaction(Write, Optimistic).await?;
 			// Collect every item in the queue
-			let (beg, end) = Ic::range();
+			let (beg, end) = IndexCompactionKey::range();
 			let range = beg..end;
-			let mut previous: Option<IndexKeyBase> = None;
+			let mut previous: Option<IndexCompactionKey<'static>> = None;
 			let mut count = 0;
 			// Returns an ordered list of indexes that require compaction
 			for (k, _) in txn.getr(range.clone(), None).await? {
 				count += 1;
 				lh.try_maintain_lease().await?;
-				let ic = Ic::decode_key(&k)?;
+				let ic = IndexCompactionKey::decode_key(&k)?;
 				// If the index has already been compacted, we can ignore the task
 				if let Some(p) = &previous {
-					if p.match_ic(&ic) {
+					if p.index_matches(&ic) {
 						continue;
 					}
 				}
-				match txn.get_tb_index(ic.ns, ic.db, ic.tb, ic.ix).await {
-					Ok(ix) => {
+				match txn.get_tb_index_by_id(ic.ns, ic.db, &ic.tb, ic.ix).await? {
+					Some(ix) => {
 						if let Index::FullText(p) = &ix.index {
 							let ft = FullTextIndex::new(
 								self.id(),
 								&self.index_stores,
 								&txn,
-								IndexKeyBase::from_ic(&ic),
+								IndexKeyBase::new(ic.ns, ic.db, &ix.table_name, ix.index_id),
 								p,
 							)
 							.await?;
 							ft.compaction(&txn).await?;
 						}
 					}
-					Err(e) => {
-						error!(target: TARGET, "Index compaction: Failed to get index: {}", e);
-						if matches!(e.downcast_ref(), Some(Error::IxNotFound { .. })) {
-							trace!(target: TARGET, "Index compaction: Index {} not found, skipping", ic.ix);
-						} else {
-							bail!(e);
-						}
+					None => {
+						trace!(target: TARGET, "Index compaction: Index {:?} not found, skipping", ic.ix);
 					}
 				}
-				previous = Some(IndexKeyBase::from_ic(&ic));
+				previous = Some(ic.into_owned());
 			}
 			if count > 0 {
 				txn.delr(range).await?;

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -192,7 +192,7 @@ impl IndexBuilder {
 		ix: Arc<IndexDefinition>,
 		blocking: bool,
 	) -> Result<Option<Receiver<Result<()>>>> {
-		let key = IndexKey::new(ns, db, &ix.what, &ix.name);
+		let key = IndexKey::new(ns, db, &ix.table_name, &ix.name);
 		let (rcv, sdr) = if blocking {
 			let (s, r) = channel();
 			(Some(r), Some(s))
@@ -229,7 +229,7 @@ impl IndexBuilder {
 		new_values: Option<Vec<Value>>,
 		rid: &RecordId,
 	) -> Result<ConsumeResult> {
-		let key = IndexKey::new(db.namespace_id, db.database_id, &ix.what, &ix.name);
+		let key = IndexKey::new(db.namespace_id, db.database_id, &ix.table_name, &ix.name);
 		if let Some(r) = self.indexes.get(&key) {
 			let (b, _) = r.value();
 			return b.maybe_consume(ctx, old_values, new_values, rid).await;
@@ -243,7 +243,7 @@ impl IndexBuilder {
 		db: DatabaseId,
 		ix: &IndexDefinition,
 	) -> BuildingStatus {
-		let key = IndexKey::new(ns, db, &ix.what, &ix.name);
+		let key = IndexKey::new(ns, db, &ix.table_name, &ix.name);
 		if let Some(a) = self.indexes.get(&key) {
 			a.value().0.status.read().await.clone()
 		} else {
@@ -343,7 +343,7 @@ impl Building {
 		db: DatabaseId,
 		ix: Arc<IndexDefinition>,
 	) -> Result<Self> {
-		let ikb = IndexKeyBase::new(ns, db, &ix.what, &ix.name);
+		let ikb = IndexKeyBase::new(ns, db, &ix.table_name, ix.index_id);
 		Ok(Self {
 			ctx: MutableContext::new_concurrent(ctx).freeze(),
 			opt,

--- a/crates/core/src/kvs/tr.rs
+++ b/crates/core/src/kvs/tr.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 #[allow(unused_imports, reason = "Not used when none of the storage backends are enabled.")]
 use super::api::Transaction;
 use super::{Key, Val, Version};
-use crate::catalog::{DatabaseId, NamespaceId, TableDefinition, TableId};
+use crate::catalog::{DatabaseId, IndexId, NamespaceId, TableDefinition, TableId};
 use crate::cf;
 use crate::cnf::NORMAL_FETCH_SIZE;
 use crate::doc::CursorRecord;
@@ -601,7 +601,7 @@ impl Transactor {
 
 	/// Gets the next namespace id
 	pub(crate) async fn get_next_ns_id(&mut self) -> Result<NamespaceId> {
-		let key = crate::key::root::ni::Ni::default().encode_key()?;
+		let key = crate::key::root::ni::NamespaceIdGeneratorKey::default().encode_key()?;
 		let mut seq = self.get_idg(&key).await?;
 		let nid = seq.get_next_id();
 		self.stash.set(key, seq.clone());
@@ -634,6 +634,20 @@ impl Transactor {
 		let (k, v) = seq.finish().unwrap();
 		self.replace(&k, &v).await?;
 		Ok(TableId(nid))
+	}
+
+	pub(crate) async fn get_next_ix_id(
+		&mut self,
+		ns: NamespaceId,
+		db: DatabaseId,
+	) -> Result<IndexId> {
+		let key = crate::key::database::ix::new(ns, db).encode_key()?;
+		let mut seq = self.get_idg(&key).await?;
+		let nid = seq.get_next_id();
+		self.stash.set(key, seq.clone());
+		let (k, v) = seq.finish().unwrap();
+		self.replace(&k, &v).await?;
+		Ok(IndexId(nid))
 	}
 
 	// complete_changes will complete the changefeed recording for the given

--- a/crates/sdk/benches/index_hnsw.rs
+++ b/crates/sdk/benches/index_hnsw.rs
@@ -218,9 +218,7 @@ async fn hnsw(tx: &Transaction) -> HnswIndex {
 		extend_candidates: false,
 		keep_pruned_connections: false,
 	};
-	HnswIndex::new(tx, IndexKeyBase::new(0, 0, "test", "test"), "test".to_string(), &p)
-		.await
-		.unwrap()
+	HnswIndex::new(tx, IndexKeyBase::new(0, 0, "test", 0), "test".to_string(), &p).await.unwrap()
 }
 
 async fn insert_objects(samples: &[(RecordId, Vec<Value>)]) -> (Datastore, HnswIndex) {

--- a/crates/sdk/benches/index_mtree.rs
+++ b/crates/sdk/benches/index_mtree.rs
@@ -56,7 +56,7 @@ async fn mtree_index(
 		doc_ids_cache: cache_size as u32,
 		mtree_cache: cache_size as u32,
 	};
-	MTreeIndex::new(tx, IndexKeyBase::new(0, 0, "test", "test"), &p, tt).await.unwrap()
+	MTreeIndex::new(tx, IndexKeyBase::new(0, 0, "test", 0), &p, tt).await.unwrap()
 }
 
 fn runtime() -> Runtime {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Rather than storing all of the indexes on disk by their name, we want to store them by a unique ID so that they:
1. Take up a consistent (and small) amount of space (4 bytes, no matter the length of the index name).
2. Allow low-cost renaming in the future.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This change does the following:

```
// Index Lookup key. This maps an Index ID to its name.
crate::key::table::ix                /*{ns}*{db}*{tb_name}!il{ix} -> ix_name
// IndexDefinition is stored keyed by its name because that's the primary way in which it is looked up.
crate::key::table::ix                /*{ns}*{db}*{tb_name}!ix{ix_name} -> IndexDefinition


// The index data keys are all keyed by index ID.
crate::key::index::all               /*{ns}*{db}*{tb_name}+{ix}
crate::key::index::bc                /*{ns}*{db}*{tb_name}+{ix}!bc{id}
crate::key::index::bd                /*{ns}*{db}*{tb_name}+{ix}!bd{id}
crate::key::index::bf                /*{ns}*{db}*{tb_name}+{ix}!bf{id}
crate::key::index::bi                /*{ns}*{db}*{tb_name}+{ix}!bi{id}
crate::key::index::bk                /*{ns}*{db}*{tb_name}+{ix}!bk{id}
crate::key::index::bl                /*{ns}*{db}*{tb_name}+{ix}!bl{id}
crate::key::index::bo                /*{ns}*{db}*{tb_name}+{ix}!bo{id}
crate::key::index::bp                /*{ns}*{db}*{tb_name}+{ix}!bp{id}
crate::key::index::bs                /*{ns}*{db}*{tb_name}+{ix}!bs
crate::key::index::bt                /*{ns}*{db}*{tb_name}+{ix}!bt{id}
crate::key::index::bu                /*{ns}*{db}*{tb_name}+{ix}!bu{id}
crate::key::index::dl                /*{ns}*{db}*{tb_name}+{ix}!dl{id}
crate::key::index::tf                /*{ns}*{db}*{tb_name}+{ix}!tf{term}{id}
crate::key::index                    /*{ns}*{db}*{tb_name}+{ix}*{fd}{id}
```

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
