### PR TITLE
Add an error for when using deprecated let-less `let` syntax.

### DIFF
--- a/crates/core/src/syn/parser/expression.rs
+++ b/crates/core/src/syn/parser/expression.rs
@@ -10,7 +10,7 @@ use crate::syn::error::bail;
 use crate::syn::lexer::compound::Numeric;
 use crate::syn::parser::mac::expected;
 use crate::syn::parser::{ParseResult, Parser};
-use crate::syn::token::{self, Glued, Token, TokenKind, t};
+use crate::syn::token::{self, Glued, Span, Token, TokenKind, t};
 use crate::val;
 
 impl Parser<'_> {
@@ -661,6 +661,25 @@ impl Parser<'_> {
 		}
 
 		Ok(lhs)
+	}
+
+	pub(crate) fn reject_letless_let(expr: &Expr, span: Span) -> ParseResult<()> {
+		let Expr::Binary {
+			left,
+			op,
+			..
+		} = expr
+		else {
+			return Ok(());
+		};
+		let Expr::Param(_) = &**left else {
+			return Ok(());
+		};
+		let BinaryOperator::Equal = op else {
+			return Ok(());
+		};
+		bail!("Omiting let in a paramater declarations is deprecated",
+			@span => "This syntax previously declared a new parameter but in the future will be an equality test")
 	}
 }
 

--- a/crates/core/src/syn/parser/object.rs
+++ b/crates/core/src/syn/parser/object.rs
@@ -83,13 +83,21 @@ impl Parser<'_> {
 	pub async fn parse_block(&mut self, stk: &mut Stk, start: Span) -> ParseResult<Block> {
 		let mut statements = Vec::new();
 		loop {
+			// Eat empty statements.
 			while self.eat(t!(";")) {}
+
 			if self.eat(t!("}")) {
 				break;
 			}
 
+			let before = self.recent_span();
 			let stmt = stk.run(|ctx| self.parse_expr_inherit(ctx)).await?;
+			let span = before.covers(self.last_span());
+
+			Self::reject_letless_let(&stmt, span)?;
+
 			statements.push(stmt);
+
 			if !self.eat(t!(";")) {
 				self.expect_closing_delimiter(t!("}"), start)?;
 				break;

--- a/crates/core/src/syn/parser/stmt/mod.rs
+++ b/crates/core/src/syn/parser/stmt/mod.rs
@@ -117,7 +117,12 @@ impl Parser<'_> {
 				self.pop_peek();
 				self.parse_show_stmt().map(TopLevelExpr::Show)
 			}
-			_ => self.parse_expr_start(stk).await.map(TopLevelExpr::Expr),
+			_ => {
+				let expr = self.parse_expr_start(stk).await?;
+				let span = token.span.covers(self.last_span);
+				Self::reject_letless_let(&expr, span)?;
+				Ok(TopLevelExpr::Expr(expr))
+			}
 		}
 	}
 

--- a/crates/language-tests/tests/parsing/deprecate/ommited_let_block.surql
+++ b/crates/language-tests/tests/parsing/deprecate/ommited_let_block.surql
@@ -4,11 +4,13 @@
 [test.results]
 parsing-error = """
 Parameter declarations without `let` are deprecated.
-  --> [14:1]
+  --> [15:2]
    |
-14 | $a = 1
+15 | $a = 1;
    | ^^^^^^ Replace with `let $a = ...` to keep the previous behavior.
 """
 
 */
-$a = 1
+{
+	$a = 1;
+};

--- a/crates/language-tests/tests/parsing/deprecate/ommited_let_if.surql
+++ b/crates/language-tests/tests/parsing/deprecate/ommited_let_if.surql
@@ -4,11 +4,13 @@
 [test.results]
 parsing-error = """
 Parameter declarations without `let` are deprecated.
-  --> [14:1]
+  --> [15:2]
    |
-14 | $a = 1
+15 | $a = 1;
    | ^^^^^^ Replace with `let $a = ...` to keep the previous behavior.
 """
 
 */
-$a = 1
+IF true {
+	$a = 1;
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

A let statement could previously be written with the actual `LET` keyword omitted. 
This syntax has been removed as it let to confusion about the semantics of the language and conflicts with equality statements.
However removing it without deprecation could lead to even more confusion as the let statement will now silently re-parse as a equality test.

## What does this change do?

Throw a parsing error for the places where a expression would previously be a let statement telling users about the deprecation and suggesting how to fix their query. 

## What is your testing strategy?

Added 3 test to ensure the error is properly thrown.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
