### PR TITLE
Re-export anyhow in the types crate and use in macros.

### DIFF
--- a/crates/types-derive/src/lib.rs
+++ b/crates/types-derive/src/lib.rs
@@ -185,9 +185,9 @@ pub fn surreal_value(input: TokenStream) -> TokenStream {
 					quote! {
 						let #field_name = <#field_type as surrealdb_types::SurrealValue>::from_value(
 							obj.get(#field_name_str)
-								.ok_or_else(|| anyhow::anyhow!("Failed to convert to {}: Missing field '{}'", Self::kind_of(), #field_name_str))?
+								.ok_or_else(|| surrealdb_types::anyhow::anyhow!("Failed to convert to {}: Missing field '{}'", Self::kind_of(), #field_name_str))?
 								.clone()
-						).map_err(|e| anyhow::anyhow!("Failed to convert to {}: {}", Self::kind_of(), e))?;
+						).map_err(|e| surrealdb_types::anyhow::anyhow!("Failed to convert to {}: {}", Self::kind_of(), e))?;
 					}
 				})
 				.collect();
@@ -225,9 +225,9 @@ pub fn surreal_value(input: TokenStream) -> TokenStream {
 						])))
 					}
 
-					fn from_value(value: surrealdb_types::Value) -> anyhow::Result<Self> {
+					fn from_value(value: surrealdb_types::Value) -> surrealdb_types::anyhow::Result<Self> {
 						let surrealdb_types::Value::Object(obj) = value else {
-							return Err(anyhow::anyhow!("Failed to convert to {}: Expected Object, got {:?}", Self::kind_of(), value.value_kind()));
+							return Err(surrealdb_types::anyhow::anyhow!("Failed to convert to {}: Expected Object, got {:?}", Self::kind_of(), value.value_kind()));
 						};
 
 						#(#from_value_fields)*
@@ -272,9 +272,9 @@ pub fn surreal_value(input: TokenStream) -> TokenStream {
 					quote! {
 						let #field_ident = <#field_type as surrealdb_types::SurrealValue>::from_value(
 							values.get(#i)
-								.ok_or_else(|| anyhow::anyhow!("Failed to convert to {}: Missing field at index {}", Self::kind_of(), #i))?
+								.ok_or_else(|| surrealdb_types::anyhow::anyhow!("Failed to convert to {}: Missing field at index {}", Self::kind_of(), #i))?
 								.clone()
-						).map_err(|e| anyhow::anyhow!("Failed to convert to {}: {}", Self::kind_of(), e))?;
+						).map_err(|e| surrealdb_types::anyhow::anyhow!("Failed to convert to {}: {}", Self::kind_of(), e))?;
 					}
 				})
 				.collect();
@@ -318,13 +318,13 @@ pub fn surreal_value(input: TokenStream) -> TokenStream {
 						]))
 					}
 
-					fn from_value(value: surrealdb_types::Value) -> anyhow::Result<Self> {
+					fn from_value(value: surrealdb_types::Value) -> surrealdb_types::anyhow::Result<Self> {
 						let surrealdb_types::Value::Array(values) = value else {
-							return Err(anyhow::anyhow!("Failed to convert to {}: Expected Array, got {:?}", Self::kind_of(), value.value_kind()));
+							return Err(surrealdb_types::anyhow::anyhow!("Failed to convert to {}: Expected Array, got {:?}", Self::kind_of(), value.value_kind()));
 						};
 
 						if values.len() != #field_count {
-							return Err(anyhow::anyhow!("Failed to convert to {}: Expected Array of length {}, got {}", Self::kind_of(), #field_count, values.len()));
+							return Err(surrealdb_types::anyhow::anyhow!("Failed to convert to {}: Expected Array of length {}, got {}", Self::kind_of(), #field_count, values.len()));
 						}
 
 						#(#from_value_fields)*
@@ -353,10 +353,10 @@ pub fn surreal_value(input: TokenStream) -> TokenStream {
 						surrealdb_types::Value::Object(surrealdb_types::Object::new())
 					}
 
-					fn from_value(value: surrealdb_types::Value) -> anyhow::Result<Self> {
+					fn from_value(value: surrealdb_types::Value) -> surrealdb_types::anyhow::Result<Self> {
 						match value {
 							surrealdb_types::Value::Object(obj) if obj.is_empty() => Ok(Self),
-							_ => Err(anyhow::anyhow!("Failed to convert to {}: Expected empty Object, got {:?}", Self::kind_of(), value.value_kind())),
+							_ => Err(surrealdb_types::anyhow::anyhow!("Failed to convert to {}: Expected empty Object, got {:?}", Self::kind_of(), value.value_kind())),
 						}
 					}
 				}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -7,6 +7,7 @@ mod traits;
 pub(crate) mod utils;
 mod value;
 
+pub use anyhow;
 pub use flatbuffers::*;
 pub use kind::*;
 // Re-export the derive macro


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Using the surrealdb-types crate requires an implicit dependency on anyhow. We should re-export anyhow in the types crate and use it from the derive macros so that end-users do not need to arbitrarily add anyhow as a dependency.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This change re-exports anyhow in the types crate and points to the re-exported types in the types-derive crate.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI is sufficient.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
