### PR TITLE
Provide manual GqlError to async-graphql error conversion

### DIFF
--- a/crates/core/src/gql/error.rs
+++ b/crates/core/src/gql/error.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::result_large_err)]
 use std::backtrace;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use async_graphql::{InputType, InputValueError};
 use thiserror::Error;
@@ -58,5 +59,15 @@ where
 {
 	fn from(value: InputValueError<T>) -> Self {
 		GqlError::ResolverError(format!("{value:?}"))
+	}
+}
+
+impl From<GqlError> for async_graphql::Error {
+	fn from(value: GqlError) -> Self {
+		async_graphql::Error {
+			message: value.to_string(),
+			source: Some(Arc::new(value)),
+			extensions: None,
+		}
 	}
 }


### PR DESCRIPTION
## What is the motivation?

Unable to use the `async-graphql` crate on own project level with `custom-error-conversion` feature. The feature unification is enabling the `custom-error-conversion` feature from my own project level to the nested (`surrealdb-core`) dependencies. As a result, we cannot compile our own project because `surrealdb-core` compilation step fails

### What is `custom-error-conversion` feature in `async-graphql`?
PR: https://github.com/async-graphql/async-graphql/pull/1631

`custom-error-conversion` disables the blanket implementation of `From<T>` inside `async-graphql`, allowing the developer to implement their own `From<T>`

## What does this change do?

Manual conversion from `GqlError` to `async_graphql::Error`

## What is your testing strategy?

### Minimal example to reproduce the problem:
1. Create an empty Rust binary project
```bash
cargo new my-project --bin
cd my-project
```

2. Add `surrealdb` crate
```bash
cargo add surrealdb
```

3. Add `async-graphql` crate with the `custom-error-conversion` feature
```bash
cargo add async-graphql --features custom-error-conversion
```

4. Build `my-project`
```bash
cargo build
```

Result
```bash
...
error[E0277]: `?` couldn't convert the error to `async_graphql::Error`
   --> /Users/<user>/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/surrealdb-core-2.3.7/src/gql/tables.rs:408:58
    |
408 |                     .ok_or_else(|| internal_error("failed to downcast"))?;
    |                      ---------------------------------------------------^ the trait `From<GqlError>` is not implemented for `async_graphql::Error`
    |                      |
    |                      this can't be annotated with `?` because it has type `Result<_, GqlError>`
    |
note: `GqlError` needs to implement `Into<async_graphql::Error>`
   --> /Users/<user>/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/surrealdb-core-2.3.7/src/gql/error.rs:9:1
    |
9   | pub enum GqlError {
    | ^^^^^^^^^^^^^^^^^
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:
              `async_graphql::Error` implements `From<&str>`
              `async_graphql::Error` implements `From<std::string::String>`
...
```

### Minimal example to check the fix:
1. Checkout to this branch and use the path for `surrealdb` crate in `my-project`
```toml
surrealdb = { path = "<absolute-path>/surrealdb/crates/sdk" }
```

2. Build `my-project`
```bash
cargo build
```

## Is this related to any issues?

https://github.com/surrealdb/surrealdb/issues/6366

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
