### PR TITLE
Update BUILDING.md

### DIFF
--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -324,6 +324,41 @@ docker run --pull --rm -v $PWD:/volume -t clux/muslrust:stable cargo build --rel
 
 </details>
 
+<!-- -------------------------------------------------- -->
+<!-- -------------------------------------------------- -->
+<!-- -------------------------------------------------- -->
+<!-- -------------------------------------------------- -->
+<!-- -------------------------------------------------- -->
+
+## Building on Debian 13 Trixie (amd64)
+
+<details><summary>Click to show details</summary>
+
+### ✅ Compile for `x86_64-unknown-linux-gnu` (Linux)
+```bash
+# Setup
+sudo apt-get -y update
+sudo apt-get -y install \
+	curl \
+	llvm \
+	cmake \
+	binutils \
+	clang \
+	qemu-user \
+	musl-tools \
+	libssl-dev \
+	pkg-config \
+	build-essential \
+	protobuf-compiler
+# Install rustlang and cargo
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+# Add extra targets for rust
+rustup target add x86_64-unknown-linux-gnu
+# Compile for x86_64-unknown-linux-gnu
+cargo build --release --locked --target x86_64-unknown-linux-gnu
+```
+</details>
 
 ## Building on Windows-amd64 (Windows OS)
 


### PR DESCRIPTION
Added Debian 13 as slight differences from Ubuntu
- need to use sudo with apt
- clang-11 is not available, use clang and at trhe moment get version 19

Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

I use Debian 13 and the Ubuntu building documentation failed as a) need to use sudo for apt-get and b) clang-11 isn't available

> [!WARNING]
No details provided.

## What does this change do?

It corrects the code to copy/paste into a terminal

> [!WARNING]
> No details provided.

## What is your testing strategy?

I copied and pasted it into a terminal, it worked

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

This is a documentation change

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [X] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
