### PR TITLE
Remove anyhow mention

### DIFF
--- a/crates/types/README.md
+++ b/crates/types/README.md
@@ -138,7 +138,6 @@ let map = object! {
 #### Requirements
 
 - All fields must implement the `SurrealValue` trait
-- You need to have `anyhow` in your dependencies, as the `SurrealValue` trait uses it for error handling.
 
 ```rust
 use surrealdb_types::SurrealValue;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

`pub use anyhow` was recently added via #6326 so readme doesn't need this line anymore.

## What does this change do?

It removes the line.

## What is your testing strategy?

Not needed

## Is this related to any issues?

- [X] No related issues

## Does this change need documentation?

It is documentation.

## Does this change make any alterations to environment variables or CLI commands?

- [X] No changes made to env vars

## Have you read the Contributing Guidelines?

- [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
