### PR TITLE
Idiom fallback functions

### DIFF
--- a/crates/language-tests/Cargo.lock
+++ b/crates/language-tests/Cargo.lock
@@ -3559,7 +3559,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb-core"
-version = "3.0.0"
+version = "3.0.0-alpha.8"
 dependencies = [
  "addr",
  "affinitypool",
@@ -3677,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.0.0"
+version = "3.0.0-alpha.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.0.0"
+version = "3.0.0-alpha.8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/language-tests/tests/language/idiom/fallback_function.surql
+++ b/crates/language-tests/tests/language/idiom/fallback_function.surql
@@ -1,0 +1,57 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "['fnc', 'keys']"
+
+[[test.results]]
+value = "2"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "1"
+
+[[test.results]]
+value = "'test'"
+
+[[test.results]]
+value = "2"
+
+*/
+
+LET $obj = { 
+    fnc: || 1, 
+    keys: || 2 
+};
+
+$obj.fnc();
+($obj.fnc)();
+
+// built-in idiom methods get priority
+$obj.keys();
+($obj.keys)();
+
+--------------------------------------
+
+LET $rid = (CREATE ONLY test:1 SET fnc = || 1, tb = || 2).id;
+
+$rid.fnc();
+($rid.fnc)();
+
+// built-in idiom methods get priority
+$rid.tb();
+($rid.tb)();


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See #5374. While working on that issue, I also noticed that #6079 changed the behaviour of fallback idiom functions, I reverted that change, as built-in idiom functions should receive priority over functions specified on a value.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Implements idiom fallback functions for objects and record ids. Fallback functions, meaning surrealdb will first attempt run see if the idiom function is built-in, and otherwise check if the function may be specified on a record or object. Otherwise the original `InvalidFunction` error will be thrown

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test showcasing the behaviour

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #5374

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] The order of operations should potentially be documented

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
