### PR TITLE
Fix language tests version check for pre-releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1022,10 +1022,10 @@ jobs:
             ./
           cache-directories: crates/language-tests/.binary-cache
 
-  #    - name: Build SurrealQL test tool
-        #run: |
-        #  cd crates/language-tests
-        #  cargo build --features upgrade
+      - name: Build SurrealQL test tool
+        run: |
+          cd crates/language-tests
+          cargo build --features upgrade
 
   #    - name: Run SurrealQL test suite
         #run: |

--- a/crates/language-tests/Cargo.lock
+++ b/crates/language-tests/Cargo.lock
@@ -3559,7 +3559,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb-core"
-version = "3.0.0"
+version = "3.0.0-alpha.8"
 dependencies = [
  "addr",
  "affinitypool",
@@ -3677,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.0.0"
+version = "3.0.0-alpha.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.0.0"
+version = "3.0.0-alpha.8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/language-tests/Cargo.toml
+++ b/crates/language-tests/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 members = []
 
 [features]
-default = ["upgrade"]
+default = []
 backend-surrealkv = ["surrealdb-core/kv-surrealkv"]
 backend-rocksdb = ["surrealdb-core/kv-rocksdb"]
 backend-foundation-7_1 = ["surrealdb-core/kv-fdb-7_1"]

--- a/crates/language-tests/src/cmd/run/mod.rs
+++ b/crates/language-tests/src/cmd/run/mod.rs
@@ -118,14 +118,16 @@ pub async fn run(color: ColorMode, matches: &ArgMatches) -> Result<()> {
 			let config = test.config.clone();
 
 			// Ensure this test can run on this version.
-			if let Some(version_req) = config.test.as_ref().map(|x| &x.version) {
+			if let Some(version_req) = config.test.as_ref().and_then(|x| x.version.as_ref()) {
 				if !version_req.matches(&core_version) {
 					return None;
 				}
 			}
 
 			// Ensure this test imports can run on this version as specified by the test itself.
-			if let Some(version_req) = config.test.as_ref().map(|x| &x.importing_version) {
+			if let Some(version_req) =
+				config.test.as_ref().and_then(|x| x.importing_version.as_ref())
+			{
 				if !version_req.matches(&core_version) {
 					return None;
 				}
@@ -134,7 +136,7 @@ pub async fn run(color: ColorMode, matches: &ArgMatches) -> Result<()> {
 			// Ensure this test imports can run on this version as specified by the imports.
 			for import in test.imports.iter() {
 				if let Some(version_req) =
-					subset[import.id].config.test.as_ref().map(|x| &x.version)
+					subset[import.id].config.test.as_ref().and_then(|x| x.version.as_ref())
 				{
 					if !version_req.matches(&core_version) {
 						return None;

--- a/crates/language-tests/src/cmd/upgrade/mod.rs
+++ b/crates/language-tests/src/cmd/upgrade/mod.rs
@@ -97,14 +97,16 @@ pub fn generate_tasks(
 				}
 
 				// Ensure that the test can run on the upgrading version.
-				if let Some(ver_req) = case.config.test.as_ref().map(|x| &x.version) {
+				if let Some(ver_req) = case.config.test.as_ref().and_then(|x| x.version.as_ref()) {
 					if !ver_req.matches(to_v) {
 						continue 'include_test;
 					}
 				}
 
 				// Ensure that the test can run on the importing version.
-				if let Some(ver_req) = case.config.test.as_ref().map(|x| &x.importing_version) {
+				if let Some(ver_req) =
+					case.config.test.as_ref().and_then(|x| x.importing_version.as_ref())
+				{
 					if !ver_req.matches(from_v) {
 						continue 'include_test;
 					}
@@ -113,7 +115,7 @@ pub fn generate_tasks(
 				// Ensure that the imports can run on importing version.
 				for import in case.imports.iter() {
 					if let Some(ver_req) =
-						subset[import.id].config.test.as_ref().map(|x| &x.version)
+						subset[import.id].config.test.as_ref().and_then(|x| x.version.as_ref())
 					{
 						if !ver_req.matches(from_v) {
 							continue 'include_test;

--- a/crates/language-tests/src/temp_dir.rs
+++ b/crates/language-tests/src/temp_dir.rs
@@ -18,6 +18,7 @@ fn xorshift(state: &mut u32) -> u32 {
 }
 
 impl TempDir {
+	#[allow(dead_code)]
 	pub async fn new(prefix: &str) -> Result<Self, io::Error> {
 		let temp_dir = std::env::temp_dir();
 
@@ -41,19 +42,23 @@ impl TempDir {
 		})
 	}
 
+	#[allow(dead_code)]
 	pub fn path(&self) -> &Path {
 		self.path.as_ref().unwrap().as_path()
 	}
 
+	#[allow(dead_code)]
 	pub fn sub_dir_path(&self) -> PathBuf {
 		let id = self.id_gen.fetch_add(1, Ordering::AcqRel);
 		self.path().join(format!("sub_dir_{id}"))
 	}
 
+	#[allow(dead_code)]
 	pub async fn cleanup(mut self) -> Result<(), io::Error> {
 		tokio::fs::remove_dir_all(&self.path.take().unwrap()).await
 	}
 
+	#[allow(dead_code)]
 	pub fn keep(mut self) {
 		self.path = None;
 	}

--- a/crates/language-tests/src/tests/schema/mod.rs
+++ b/crates/language-tests/src/tests/schema/mod.rs
@@ -317,9 +317,9 @@ pub struct TestDetails {
 	pub upgrade: bool,
 
 	#[serde(default)]
-	pub version: VersionReq,
+	pub version: Option<VersionReq>,
 	#[serde(default)]
-	pub importing_version: VersionReq,
+	pub importing_version: Option<VersionReq>,
 
 	pub results: Option<TestDetailsResults>,
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The language tests stopped working because of the current `-alpha.8` release as the `any` version requirement does not seem to match an `-alpha` release.

## What does this change do?

Changes the check to not do any version check on tests which do not have a version requirement.

## What is your testing strategy?

If the tests run again it works.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
