### PR TITLE
Restrict supported types on `id` field

### DIFF
--- a/crates/core/src/err/mod.rs
+++ b/crates/core/src/err/mod.rs
@@ -1416,6 +1416,10 @@ pub enum Error {
 	/// Cannot use the `{0}` keyword on the `id` field
 	#[error("Cannot use the `{0}` keyword on the `id` field.")]
 	IdFieldKeywordConflict(String),
+
+	/// Cannot use the `{0}` keyword on the `id` field
+	#[error("Cannot use the `{0}` type on the `id` field, as that's not a valid record id key.")]
+	IdFieldUnsupportedKind(String),
 }
 
 impl Error {

--- a/crates/core/src/expr/statements/define/field.rs
+++ b/crates/core/src/expr/statements/define/field.rs
@@ -18,7 +18,7 @@ use crate::err::Error;
 use crate::expr::fmt::{is_pretty, pretty_indent};
 use crate::expr::reference::Reference;
 use crate::expr::statements::info::InfoStructure;
-use crate::expr::{Base, Expr, Ident, Idiom, Kind, KindLiteral, Part};
+use crate::expr::{Base, Expr, Ident, Idiom, Kind, KindLiteral, Part, RecordIdKeyLit};
 use crate::iam::{Action, ResourceKind};
 use crate::kvs::Transaction;
 use crate::val::{Strand, Value};
@@ -104,6 +104,9 @@ impl DefineFieldStatement {
 
 		// Disallow mismatched types
 		self.disallow_mismatched_types(ctx, ns, db).await?;
+
+		// Validate id field restrictions
+		self.validate_id_restrictions()?;
 
 		// Fetch the transaction
 		let txn = ctx.tx();
@@ -402,6 +405,35 @@ impl DefineFieldStatement {
 						}
 					}
 				}
+			}
+		}
+
+		Ok(())
+	}
+
+	pub(crate) fn validate_id_restrictions(&self) -> Result<()> {
+		if self.name.is_id() {
+			// Ensure no `VALUE` clause is specified
+			ensure!(self.value.is_none(), Error::IdFieldKeywordConflict("VALUE".into()));
+
+			// Ensure no `REFERENCE` clause is specified
+			ensure!(self.reference.is_none(), Error::IdFieldKeywordConflict("REFERENCE".into()));
+
+			// Ensure no `COMPUTED` clause is specified
+			ensure!(self.computed.is_none(), Error::IdFieldKeywordConflict("COMPUTED".into()));
+
+			// Ensure no `DEFAULT` clause is specified
+			ensure!(
+				matches!(self.default, DefineDefault::None),
+				Error::IdFieldKeywordConflict("DEFAULT".into())
+			);
+
+			// Ensure the field is not a record type
+			if let Some(ref kind) = self.field_kind {
+				ensure!(
+					RecordIdKeyLit::kind_supported(kind),
+					Error::IdFieldUnsupportedKind(kind.to_string())
+				);
 			}
 		}
 

--- a/crates/language-tests/tests/language/statements/define/field/id_kind.surql
+++ b/crates/language-tests/tests/language/statements/define/field/id_kind.surql
@@ -1,0 +1,118 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+error = "Cannot use the `range` type on the `id` field, as that's not a valid record id key."
+
+[[test.results]]
+error = "Cannot use the `function` type on the `id` field, as that's not a valid record id key."
+
+[[test.results]]
+error = "Cannot use the `file` type on the `id` field, as that's not a valid record id key."
+
+[[test.results]]
+error = "Cannot use the `geometry` type on the `id` field, as that's not a valid record id key."
+
+[[test.results]]
+error = "Cannot use the `none` type on the `id` field, as that's not a valid record id key."
+
+[[test.results]]
+error = "Cannot use the `null` type on the `id` field, as that's not a valid record id key."
+
+[[test.results]]
+error = "Cannot use the `bool` type on the `id` field, as that's not a valid record id key."
+
+[[test.results]]
+error = "Cannot use the `bytes` type on the `id` field, as that's not a valid record id key."
+
+[[test.results]]
+error = "Cannot use the `datetime` type on the `id` field, as that's not a valid record id key."
+
+[[test.results]]
+error = "Cannot use the `decimal` type on the `id` field, as that's not a valid record id key."
+
+[[test.results]]
+error = "Cannot use the `duration` type on the `id` field, as that's not a valid record id key."
+
+*/
+
+// Valid
+DEFINE FIELD OVERWRITE id ON a;
+DEFINE FIELD OVERWRITE id ON a TYPE any;
+DEFINE FIELD OVERWRITE id ON a TYPE number;
+DEFINE FIELD OVERWRITE id ON a TYPE int;
+DEFINE FIELD OVERWRITE id ON a TYPE string;
+DEFINE FIELD OVERWRITE id ON a TYPE uuid;
+DEFINE FIELD OVERWRITE id ON a TYPE array;
+DEFINE FIELD OVERWRITE id ON a TYPE array<int>;
+DEFINE FIELD OVERWRITE id ON a TYPE set;
+DEFINE FIELD OVERWRITE id ON a TYPE set<int>;
+DEFINE FIELD OVERWRITE id ON a TYPE object;
+
+DEFINE FIELD OVERWRITE id ON a TYPE 123;
+DEFINE FIELD OVERWRITE id ON a TYPE 'string';
+DEFINE FIELD OVERWRITE id ON a TYPE [uuid, 'string'];
+DEFINE FIELD OVERWRITE id ON a TYPE { uuid: 'string' };
+
+DEFINE FIELD OVERWRITE id ON a TYPE string | int;
+
+// Invalid
+DEFINE FIELD OVERWRITE id ON a TYPE range;
+DEFINE FIELD OVERWRITE id ON a TYPE function;
+DEFINE FIELD OVERWRITE id ON a TYPE file;
+DEFINE FIELD OVERWRITE id ON a TYPE geometry;
+DEFINE FIELD OVERWRITE id ON a TYPE none;
+DEFINE FIELD OVERWRITE id ON a TYPE null;
+DEFINE FIELD OVERWRITE id ON a TYPE bool;
+DEFINE FIELD OVERWRITE id ON a TYPE bytes;
+DEFINE FIELD OVERWRITE id ON a TYPE datetime;
+DEFINE FIELD OVERWRITE id ON a TYPE decimal;
+DEFINE FIELD OVERWRITE id ON a TYPE duration;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See #6154. It is confusing to be able to specify a type on a field when it is later not supported.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Restricts which types and clauses can be specified on the `id` field

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test ensuring all valid types can be specified

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Closes #6154

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
