### PR TITLE
Wrap event failure with a pointer to origin

### DIFF
--- a/crates/language-tests/tests/language/statements/define/event/error.surql
+++ b/crates/language-tests/tests/language/statements/define/event/error.surql
@@ -1,0 +1,22 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ fail: false, id: test:1 }]"
+
+[[test.results]]
+error = "Error while processing event test: An error occurred: Failed"
+
+*/
+
+DEFINE EVENT test ON test WHEN true THEN {
+    IF fail {
+        THROW "Failed";
+    }
+};
+
+CREATE test:1 SET fail = false;
+CREATE test:2 SET fail = true;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

See #5801. It can sometimes be hard to see where failures originate from when there are multiple events

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Wraps the error with a message pointing towards the originating event

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] Fixes #5801

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
