### PR TITLE
Fix Nix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
             spec =
               import ./pkg/nix/spec/${target}.nix { inherit pkgs target util; };
           in import ./pkg/nix/drv/binary.nix {
-            inherit pkgs util spec crane;
+            inherit pkgs lib util spec crane;
             rustToolchain = mkRustToolchain { inherit target; };
           }) util.platforms);
 

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,8 @@
             spec =
               import ./pkg/nix/spec/${target}.nix { inherit pkgs target util; };
           in import ./pkg/nix/drv/binary.nix {
-            inherit pkgs lib util spec crane;
+            inherit (pkgs) lib;
+            inherit pkgs util spec crane;
             rustToolchain = mkRustToolchain { inherit target; };
           }) util.platforms);
 

--- a/pkg/nix/drv/binary.nix
+++ b/pkg/nix/drv/binary.nix
@@ -12,11 +12,8 @@ let
     rustc = rustToolchain;
   });
 
-  markdownFilter = path: _type: builtins.match ".*md$" path != null;
-  markdownOrCargo = path: type:
-    (markdownFilter path type) || (craneLib.filterCargoSources path type);
+  unfilteredRoot = ../../../.; # The original, unfiltered source
   buildSpec = spec.buildSpec // {
-    unfilteredRoot = ../../../.; # The original, unfiltered source
     src = lib.fileset.toSource {
       root = unfilteredRoot;
       fileset = lib.fileset.unions [

--- a/pkg/nix/drv/binary.nix
+++ b/pkg/nix/drv/binary.nix
@@ -1,4 +1,4 @@
-{ pkgs, spec, util, rustToolchain, crane }:
+{ pkgs, lib, spec, util, rustToolchain, crane }:
 
 let
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The Nix flake is currently broken because of filtered out README that's required for building docs.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Makes sure all markdown files are not filtered out.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added the `nix` label to ensure the Nix workflow is run.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
