### PR TITLE
[Backport 2.3] Fix: insert ignore with unique index still creates a record when index violated

### DIFF
--- a/crates/core/src/doc/insert.rs
+++ b/crates/core/src/doc/insert.rs
@@ -112,8 +112,8 @@ impl Document {
 		self.cleanup_table_fields(ctx, opt, stm).await?;
 		self.default_record_data(ctx, opt, stm).await?;
 		self.check_permissions_table(stk, ctx, opt, stm).await?;
-		self.store_record_data(ctx, opt, stm).await?;
 		self.store_index_data(stk, ctx, opt, stm).await?;
+		self.store_record_data(ctx, opt, stm).await?;
 		self.process_table_views(stk, ctx, opt, stm).await?;
 		self.process_table_lives(stk, ctx, opt, stm).await?;
 		self.process_table_events(stk, ctx, opt, stm).await?;
@@ -138,8 +138,8 @@ impl Document {
 		self.cleanup_table_fields(ctx, opt, stm).await?;
 		self.default_record_data(ctx, opt, stm).await?;
 		self.check_permissions_table(stk, ctx, opt, stm).await?;
-		self.store_record_data(ctx, opt, stm).await?;
 		self.store_index_data(stk, ctx, opt, stm).await?;
+		self.store_record_data(ctx, opt, stm).await?;
 		self.process_table_views(stk, ctx, opt, stm).await?;
 		self.process_table_lives(stk, ctx, opt, stm).await?;
 		self.process_table_events(stk, ctx, opt, stm).await?;

--- a/crates/sdk/tests/insert.rs
+++ b/crates/sdk/tests/insert.rs
@@ -783,7 +783,7 @@ async fn insert_ignore() -> Result<(), Error> {
 }
 
 #[tokio::test]
-async fn insert_relation_ignore_unique_index_fix_test() -> Result<()> {
+async fn insert_relation_ignore_unique_index_fix_test() -> Result<(), Error> {
 	let sql = "
         USE NS test DB test;
         DEFINE INDEX key ON wrote FIELDS in, out UNIQUE;
@@ -800,12 +800,17 @@ async fn insert_relation_ignore_unique_index_fix_test() -> Result<()> {
 	t.skip_ok(2)?;
 
 	let first_result = t.next()?.result?;
-	assert_eq!(first_result.as_array().unwrap().len(), 1);
+	let Value::Array(first_result_array) = first_result else {
+		panic!("Expected array")
+	};
+	assert_eq!(first_result_array.len(), 1);
 
 	t.expect_val("[]")?;
 
 	let select_result = t.next()?.result?;
-	let records = select_result.as_array().unwrap();
+	let Value::Array(records) = select_result else {
+		panic!("Expected array")
+	};
 
 	assert_eq!(
 		records.len(),

--- a/crates/sdk/tests/insert.rs
+++ b/crates/sdk/tests/insert.rs
@@ -781,3 +781,38 @@ async fn insert_ignore() -> Result<(), Error> {
 	t.expect_vals(&["[{ id: user:1, name: 'foo' }]", "[]"])?;
 	Ok(())
 }
+
+#[tokio::test]
+async fn insert_relation_ignore_unique_index_fix_test() -> Result<()> {
+	let sql = "
+        USE NS test DB test;
+        DEFINE INDEX key ON wrote FIELDS in, out UNIQUE;
+        INSERT RELATION IGNORE INTO wrote [
+            { in: author:one, out: blog:one },
+            { in: author:one, out: blog:one }
+        ];
+        INSERT RELATION IGNORE INTO wrote { in: author:one, out: blog:one };
+        SELECT * FROM wrote;
+    ";
+	let mut t = Test::new(sql).await?;
+
+	// Skip USE and DEFINE INDEX
+	t.skip_ok(2)?;
+
+	let first_result = t.next()?.result?;
+	assert_eq!(first_result.as_array().unwrap().len(), 1);
+
+	t.expect_val("[]")?;
+
+	let select_result = t.next()?.result?;
+	let records = select_result.as_array().unwrap();
+
+	assert_eq!(
+		records.len(),
+		1,
+		"INSERT IGNORE bug: Expected 1 record, got {}. Duplicates not ignored!",
+		records.len()
+	);
+
+	Ok(())
+}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport #6344

## What does this change do?

Backport #6344

## What is your testing strategy?

Github action / language test

## Is this related to any issues?

Backport #6344

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
