### PR TITLE
Better parsing error on define index count/full-text with wrong number of fields

### DIFF
--- a/crates/language-tests/tests/language/indexes/full_text/fulltext.surql
+++ b/crates/language-tests/tests/language/indexes/full_text/fulltext.surql
@@ -44,7 +44,6 @@ value = "[]"
 value = "[]"
 
 */
-
 CREATE b:1 SET t = 'Hello World!';
 CREATE b:2 SET t = 'Yet Another World!';
 CREATE b:3 SET t = 'again hello';

--- a/crates/language-tests/tests/parsing/errors/define_index_count_with_fields.surql
+++ b/crates/language-tests/tests/parsing/errors/define_index_count_with_fields.surql
@@ -1,0 +1,14 @@
+/**
+[test]
+
+[test.results]
+parsing-error = """
+Cannot create a count index with fields
+  --> [14:28]
+   |
+14 | DEFINE INDEX a ON b FIELDS c COUNT;
+   |                            ^ 
+"""
+
+*/
+DEFINE INDEX a ON b FIELDS c COUNT;

--- a/crates/language-tests/tests/parsing/errors/define_index_fulltext_multiple_fields.surql
+++ b/crates/language-tests/tests/parsing/errors/define_index_fulltext_multiple_fields.surql
@@ -1,0 +1,14 @@
+/**
+[test]
+
+[test.results]
+parsing-error = """
+Expected one column for fulltext index, found 2
+  --> [14:30]
+   |
+14 | DEFINE INDEX i ON b FIELDS a,b FULLTEXT BM25 HIGHLIGHTS;
+   |                              ^ 
+"""
+
+*/
+DEFINE INDEX i ON b FIELDS a,b FULLTEXT BM25 HIGHLIGHTS;


### PR DESCRIPTION
…r of fields

Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

> [!WARNING]
No details provided.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

> [!WARNING]
> No details provided.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
