### PR TITLE
Make WebSocket limits configurable and enforce max message size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -595,7 +595,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -609,6 +609,42 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-tungstenite 0.24.0",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98e529aee37b5c8206bb4bf4c44797127566d72f76952c970bd3d1e85de8f4e2"
+dependencies = [
+ "axum-core 0.5.4",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
@@ -654,16 +690,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-extra"
-version = "0.9.6"
+name = "axum-core"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+checksum = "0ac7a6beb1182c7e30253ee75c3e918080bfb83f5a3023bcdf7209d85fd147e6"
 dependencies = [
- "axum 0.7.9",
- "axum-core 0.4.5",
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86d701cd16f401888ebe9c3214dc838c7ef27a405d5726196765a913603b5dd"
+dependencies = [
+ "axum 0.8.5",
+ "axum-core 0.5.4",
  "axum-macros",
  "bytes",
- "fastrand",
  "form_urlencoded",
  "futures-util",
  "headers",
@@ -671,21 +725,22 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "mime",
- "multer",
  "percent-encoding",
  "pin-project-lite",
- "serde",
+ "rustversion",
+ "serde_core",
  "serde_html_form",
- "tower 0.5.2",
+ "serde_path_to_error",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -801,7 +856,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -821,7 +876,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -3272,6 +3327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5298,10 +5359,11 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -5324,10 +5386,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5667,7 +5738,7 @@ dependencies = [
  "assert_fs",
  "async-graphql",
  "async-graphql-axum",
- "axum 0.7.9",
+ "axum 0.8.5",
  "axum-extra",
  "axum-server",
  "base64 0.21.7",
@@ -5715,7 +5786,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tonic 0.12.3",
  "tower 0.4.13",
@@ -5779,7 +5850,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
- "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -5894,7 +5965,7 @@ dependencies = [
  "tikv-jemallocator",
  "time",
  "tokio",
- "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "tracing-subscriber",
  "trice",
@@ -6431,9 +6502,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -6443,20 +6526,8 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.2",
- "tungstenite 0.23.0",
+ "tungstenite 0.28.0",
  "webpki-roots",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -6760,28 +6831,6 @@ checksum = "fb1626d07cb5c1bb2cf17d94c0be4852e8a7c02b041acec9a8c5bdda99f9d580"
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.3.1",
- "httparse",
- "log",
- "native-tls",
- "rand 0.8.5",
- "rustls 0.23.25",
- "rustls-pki-types",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
@@ -6795,6 +6844,27 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.9.0",
+ "rustls 0.23.25",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.12",
+ "url",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ tempfile = "3.10.1"
 thiserror = "1.0.63"
 tokio = { version = "1.44.2", default-features = false }
 tokio-stream = "0.1"
-tokio-tungstenite = "0.23.1"
+tokio-tungstenite = "0.28.0"
 tokio-util = "0.7.11"
 tracing = "0.1.40"
 ulid = "1.1.0"
@@ -230,13 +230,13 @@ revision = { workspace = true, features = [
 # Crates only used by the root surrealdb crate
 anyhow.workspace = true
 arc-swap = "1.7.1"
-axum = { version = "0.7.5", features = ["tracing", "ws"] }
-axum-extra = { version = "0.9.3", features = [
+axum = { version = "0.8.5", features = ["tracing", "ws"] }
+axum-extra = { version = "0.10.2", features = [
     "query",
     "typed-routing",
     "typed-header",
 ] }
-axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
+axum-server = { version = "0.7.2", features = ["tls-rustls-no-provider"] }
 bincode.workspace = true
 console-subscriber = "0.4.1"
 clap = { version = "4.4.11", features = [

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -344,7 +344,7 @@ run_task = "ci-api-integration"
 
 [tasks.ci-api-integration-ws]
 category = "CI - INTEGRATION TESTS"
-env = { _TEST_API_ENGINE = "ws", _TEST_FEATURES = "protocol-ws" }
+env = { _TEST_API_ENGINE = "ws", _TEST_FEATURES = "protocol-ws", SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE = 268435456, SURREAL_WEBSOCKET_MAX_FRAME_SIZE = 268435456 }
 run_task = "ci-api-integration"
 
 [tasks.ci-api-integration-any]

--- a/cackle.toml
+++ b/cackle.toml
@@ -1431,5 +1431,5 @@ allow_unsafe = true
 allow_unsafe = true
 
 [pkg.serde_core]
-allow_apis = ["fs"]
+allow_apis = ["fs", "process"]
 

--- a/cackle.toml
+++ b/cackle.toml
@@ -1431,5 +1431,6 @@ allow_unsafe = true
 allow_unsafe = true
 
 [pkg.serde_core]
+allow_unsafe = true
 allow_apis = ["fs", "process"]
 

--- a/cackle.toml
+++ b/cackle.toml
@@ -1430,3 +1430,6 @@ allow_unsafe = true
 [pkg.cssparser]
 allow_unsafe = true
 
+[pkg.serde_core]
+allow_apis = ["fs"]
+

--- a/crates/sdk/src/api/engine/any/native.rs
+++ b/crates/sdk/src/api/engine/any/native.rs
@@ -180,13 +180,11 @@ impl conn::Sealed for Any {
 						#[cfg(not(any(feature = "native-tls", feature = "rustls")))]
 						let maybe_connector = None;
 
-						let config = WebSocketConfig {
-							max_message_size,
-							max_frame_size,
-							max_write_buffer_size,
-							write_buffer_size,
-							..Default::default()
-						};
+						let config = WebSocketConfig::default()
+							.max_message_size(max_message_size)
+							.max_frame_size(max_frame_size)
+							.max_write_buffer_size(max_write_buffer_size)
+							.write_buffer_size(write_buffer_size);
 						let socket = engine::remote::ws::native::connect(
 							&endpoint,
 							Some(config),

--- a/crates/sdk/src/api/engine/any/native.rs
+++ b/crates/sdk/src/api/engine/any/native.rs
@@ -166,6 +166,7 @@ impl conn::Sealed for Any {
 					#[cfg(feature = "protocol-ws")]
 					{
 						let WebsocketConfig {
+							read_buffer_size,
 							max_message_size,
 							max_frame_size,
 							max_write_buffer_size,
@@ -184,7 +185,8 @@ impl conn::Sealed for Any {
 							.max_message_size(max_message_size)
 							.max_frame_size(max_frame_size)
 							.max_write_buffer_size(max_write_buffer_size)
-							.write_buffer_size(write_buffer_size);
+							.write_buffer_size(write_buffer_size)
+							.read_buffer_size(read_buffer_size);
 						let socket = engine::remote::ws::native::connect(
 							&endpoint,
 							Some(config),

--- a/crates/sdk/src/api/engine/remote/ws/native.rs
+++ b/crates/sdk/src/api/engine/remote/ws/native.rs
@@ -94,6 +94,7 @@ impl conn::Sealed for Client {
 			let maybe_connector = None;
 
 			let ws_config = WebSocketConfig::default()
+				.read_buffer_size(address.config.websocket.read_buffer_size)
 				.max_message_size(address.config.websocket.max_message_size)
 				.max_frame_size(address.config.websocket.max_frame_size)
 				.max_write_buffer_size(address.config.websocket.max_write_buffer_size)

--- a/crates/sdk/src/api/engine/remote/ws/native.rs
+++ b/crates/sdk/src/api/engine/remote/ws/native.rs
@@ -236,8 +236,9 @@ async fn router_handle_route(
 	};
 
 	if let Some(max_message_size) = max_message_size {
-		if message.len() > max_message_size {
-			if response.send(Err(Error::MessageTooLong(message.len()).into())).await.is_err() {
+		let size = message.len();
+		if size > max_message_size {
+			if response.send(Err(Error::MessageTooLong(size).into())).await.is_err() {
 				trace!("Receiver dropped");
 			}
 			return HandleResult::Ok;

--- a/crates/sdk/src/api/err/mod.rs
+++ b/crates/sdk/src/api/err/mod.rs
@@ -12,10 +12,6 @@ use crate::core::dbs::capabilities::{ParseFuncTargetError, ParseNetTargetError};
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-	/// The message is too long
-	#[error("The message is too long: {0}")]
-	MessageTooLong(usize),
-
 	/// There was an error processing the query
 	#[error("{0}")]
 	Query(String),
@@ -277,6 +273,13 @@ pub enum Error {
 	/// The engine used does not support data versioning
 	#[error("The '{0}' engine does not support data versioning")]
 	VersionsNotSupported(String),
+
+	/// The message is too long
+	#[error("The message is too long: {0}")]
+	MessageTooLong(usize),
+
+	#[error("The write buffer size is too small")]
+	MaxWriteBufferSizeTooSmall,
 }
 
 impl serde::ser::Error for Error {

--- a/crates/sdk/src/api/err/mod.rs
+++ b/crates/sdk/src/api/err/mod.rs
@@ -278,6 +278,7 @@ pub enum Error {
 	#[error("The message is too long: {0}")]
 	MessageTooLong(usize),
 
+	/// The write buffer size is too small
 	#[error("The write buffer size is too small")]
 	MaxWriteBufferSizeTooSmall,
 }

--- a/crates/sdk/src/api/err/mod.rs
+++ b/crates/sdk/src/api/err/mod.rs
@@ -12,6 +12,10 @@ use crate::core::dbs::capabilities::{ParseFuncTargetError, ParseNetTargetError};
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
+	/// The message is too long
+	#[error("The message is too long: {0}")]
+	MessageTooLong(usize),
+
 	/// There was an error processing the query
 	#[error("{0}")]
 	Query(String),

--- a/crates/sdk/src/api/opt/config.rs
+++ b/crates/sdk/src/api/opt/config.rs
@@ -114,7 +114,7 @@ impl Config {
 
 	/// Set the WebSocket config
 	pub fn websocket(mut self, websocket: WebsocketConfig) -> crate::Result<Self> {
-		if !(websocket.max_write_buffer_size > websocket.write_buffer_size) {
+		if websocket.max_write_buffer_size <= websocket.write_buffer_size {
 			return Err(crate::api::err::Error::MaxWriteBufferSizeTooSmall.into());
 		}
 		self.websocket = websocket;

--- a/crates/sdk/src/api/opt/config.rs
+++ b/crates/sdk/src/api/opt/config.rs
@@ -113,9 +113,12 @@ impl Config {
 	}
 
 	/// Set the WebSocket config
-	pub fn websocket(mut self, websocket: WebsocketConfig) -> Self {
+	pub fn websocket(mut self, websocket: WebsocketConfig) -> crate::Result<Self> {
+		if !(websocket.max_write_buffer_size > websocket.write_buffer_size) {
+			return Err(crate::api::err::Error::MaxWriteBufferSizeTooSmall.into());
+		}
 		self.websocket = websocket;
-		self
+		Ok(self)
 	}
 
 	#[cfg(storage)]

--- a/crates/sdk/src/api/opt/config.rs
+++ b/crates/sdk/src/api/opt/config.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use crate::core::dbs::Capabilities as CoreCapabilities;
 use crate::core::iam::Level;
 use crate::opt::capabilities::Capabilities;
+use crate::opt::websocket::WebsocketConfig;
 
 /// Configuration for server connection, including: strictness, notifications,
 /// query_timeout, transaction_timeout
@@ -22,6 +23,7 @@ pub struct Config {
 	pub(crate) username: String,
 	pub(crate) password: String,
 	pub(crate) capabilities: CoreCapabilities,
+	pub(crate) websocket: WebsocketConfig,
 	#[cfg(storage)]
 	pub(crate) temporary_directory: Option<PathBuf>,
 	pub(crate) node_membership_refresh_interval: Option<Duration>,
@@ -107,6 +109,12 @@ impl Config {
 	/// Set the capabilities for the database
 	pub fn capabilities(mut self, capabilities: Capabilities) -> Self {
 		self.capabilities = capabilities.into();
+		self
+	}
+
+	/// Set the WebSocket config
+	pub fn websocket(mut self, websocket: WebsocketConfig) -> Self {
+		self.websocket = websocket;
 		self
 	}
 

--- a/crates/sdk/src/api/opt/mod.rs
+++ b/crates/sdk/src/api/opt/mod.rs
@@ -13,6 +13,7 @@ mod export;
 pub(crate) mod query;
 mod resource;
 mod tls;
+mod websocket;
 
 pub use config::*;
 pub use endpoint::*;
@@ -22,6 +23,7 @@ pub use resource::*;
 use serde_content::{Serializer, Value as Content};
 #[cfg(any(feature = "native-tls", feature = "rustls"))]
 pub use tls::*;
+pub use websocket::*;
 
 type UnitOp<'a> = InnerOp<'a, ()>;
 

--- a/crates/sdk/src/api/opt/websocket.rs
+++ b/crates/sdk/src/api/opt/websocket.rs
@@ -1,11 +1,10 @@
 #[derive(Debug, Clone)]
-#[non_exhaustive]
 pub struct WebsocketConfig {
-	pub read_buffer_size: usize,
-	pub write_buffer_size: usize,
-	pub max_write_buffer_size: usize,
-	pub max_message_size: Option<usize>,
-	pub max_frame_size: Option<usize>,
+	pub(crate) read_buffer_size: usize,
+	pub(crate) write_buffer_size: usize,
+	pub(crate) max_write_buffer_size: usize,
+	pub(crate) max_message_size: Option<usize>,
+	pub(crate) max_frame_size: Option<usize>,
 }
 
 impl Default for WebsocketConfig {
@@ -17,5 +16,42 @@ impl Default for WebsocketConfig {
 			max_message_size: Some(64 << 20),
 			max_frame_size: Some(16 << 20),
 		}
+	}
+}
+
+impl WebsocketConfig {
+	/// Create a new WebsocketConfig
+	pub fn new() -> Self {
+		Default::default()
+	}
+
+	/// Set the read buffer size
+	pub fn read_buffer_size(mut self, read_buffer_size: usize) -> Self {
+		self.read_buffer_size = read_buffer_size;
+		self
+	}
+
+	/// Set the write buffer size
+	pub fn write_buffer_size(mut self, write_buffer_size: usize) -> Self {
+		self.write_buffer_size = write_buffer_size;
+		self
+	}
+
+	/// Set the maximum write buffer size
+	pub fn max_write_buffer_size(mut self, max_write_buffer_size: usize) -> Self {
+		self.max_write_buffer_size = max_write_buffer_size;
+		self
+	}
+
+	/// Set the maximum WebSocket message size
+	pub fn max_message_size(mut self, max_message_size: impl Into<Option<usize>>) -> Self {
+		self.max_message_size = max_message_size.into();
+		self
+	}
+
+	/// Set the maximum WebSocket frame size
+	pub fn max_frame_size(mut self, max_frame_size: impl Into<Option<usize>>) -> Self {
+		self.max_frame_size = max_frame_size.into();
+		self
 	}
 }

--- a/crates/sdk/src/api/opt/websocket.rs
+++ b/crates/sdk/src/api/opt/websocket.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct WebsocketConfig {
+	pub read_buffer_size: usize,
 	pub write_buffer_size: usize,
 	pub max_write_buffer_size: usize,
 	pub max_message_size: Option<usize>,
@@ -10,6 +11,7 @@ pub struct WebsocketConfig {
 impl Default for WebsocketConfig {
 	fn default() -> Self {
 		Self {
+			read_buffer_size: 128 * 1024,
 			write_buffer_size: 128 * 1024,
 			max_write_buffer_size: usize::MAX,
 			max_message_size: Some(64 << 20),

--- a/crates/sdk/src/api/opt/websocket.rs
+++ b/crates/sdk/src/api/opt/websocket.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct WebsocketConfig {
+	pub write_buffer_size: usize,
+	pub max_write_buffer_size: usize,
+	pub max_message_size: Option<usize>,
+	pub max_frame_size: Option<usize>,
+}
+
+impl Default for WebsocketConfig {
+	fn default() -> Self {
+		Self {
+			write_buffer_size: 128 * 1024,
+			max_write_buffer_size: usize::MAX,
+			max_message_size: Some(64 << 20),
+			max_frame_size: Some(16 << 20),
+		}
+	}
+}

--- a/crates/sdk/src/api/opt/websocket.rs
+++ b/crates/sdk/src/api/opt/websocket.rs
@@ -1,13 +1,57 @@
+/// Configuration options for WebSocket connections.
+///
+/// This struct provides fine-grained control over WebSocket buffer sizes and message limits,
+/// allowing applications to optimize WebSocket performance based on their specific requirements.
+///
+/// # Examples
+///
+/// ```rust
+/// use surrealdb::opt::WebsocketConfig;
+///
+/// // Create a configuration with custom buffer sizes
+/// let config = WebsocketConfig::new()
+///     .read_buffer_size(256 * 1024)  // 256 KiB read buffer
+///     .write_buffer_size(256 * 1024) // 256 KiB write buffer
+///     .max_message_size(16 << 20)    // 16 MiB max message size
+///     .max_frame_size(16 << 20);      // 16 MiB max frame size
+/// ```
+///
+/// # Performance Considerations
+///
+/// - **Read/Write Buffer Sizes**: Larger buffers can improve throughput for high-bandwidth
+///   connections but consume more memory. Smaller buffers reduce memory usage but may limit
+///   performance for large data transfers.
+///
+/// - **Message Size Limits**: Setting appropriate limits helps prevent memory exhaustion from
+///   malicious or malformed clients while allowing legitimate large messages.
+///
+/// - **Frame Size Limits**: WebSocket frames have their own size limits that should be set
+///   appropriately for your use case.
 #[derive(Debug, Clone)]
 pub struct WebsocketConfig {
+	/// The size of the read buffer for incoming WebSocket data (default: 128 KiB)
 	pub(crate) read_buffer_size: usize,
+	/// The size of the write buffer for outgoing WebSocket data (default: 128 KiB)
 	pub(crate) write_buffer_size: usize,
+	/// The maximum size of the write buffer before backpressure is applied (default: unlimited)
 	pub(crate) max_write_buffer_size: usize,
+	/// The maximum size of a complete WebSocket message (default: 64 MiB)
 	pub(crate) max_message_size: Option<usize>,
+	/// The maximum size of a single WebSocket frame (default: 16 MiB)
 	pub(crate) max_frame_size: Option<usize>,
 }
 
 impl Default for WebsocketConfig {
+	/// Creates a new `WebsocketConfig` with sensible defaults for most applications.
+	///
+	/// The default configuration provides:
+	/// - 128 KiB read and write buffers
+	/// - Unlimited write buffer size (no backpressure)
+	/// - 64 MiB maximum message size
+	/// - 16 MiB maximum frame size
+	///
+	/// These defaults are suitable for most applications but can be customized
+	/// based on specific performance and memory requirements.
 	fn default() -> Self {
 		Self {
 			read_buffer_size: 128 * 1024,
@@ -20,36 +64,137 @@ impl Default for WebsocketConfig {
 }
 
 impl WebsocketConfig {
-	/// Create a new WebsocketConfig
+	/// Creates a new `WebsocketConfig` with default values.
+	///
+	/// This is equivalent to calling `WebsocketConfig::default()`.
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use surrealdb::opt::WebsocketConfig;
+	///
+	/// let config = WebsocketConfig::new();
+	/// ```
 	pub fn new() -> Self {
 		Default::default()
 	}
 
-	/// Set the read buffer size
+	/// Sets the read buffer size for incoming WebSocket data.
+	///
+	/// The read buffer is used to buffer incoming data from the WebSocket connection.
+	/// Larger buffers can improve performance for high-throughput connections but
+	/// consume more memory per connection.
+	///
+	/// # Arguments
+	///
+	/// * `read_buffer_size` - The size of the read buffer in bytes
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use surrealdb::opt::WebsocketConfig;
+	///
+	/// let config = WebsocketConfig::new()
+	///     .read_buffer_size(256 * 1024); // 256 KiB
+	/// ```
 	pub fn read_buffer_size(mut self, read_buffer_size: usize) -> Self {
 		self.read_buffer_size = read_buffer_size;
 		self
 	}
 
-	/// Set the write buffer size
+	/// Sets the write buffer size for outgoing WebSocket data.
+	///
+	/// The write buffer is used to buffer outgoing data before it's sent over the
+	/// WebSocket connection. Larger buffers can improve performance for high-throughput
+	/// connections but consume more memory per connection.
+	///
+	/// # Arguments
+	///
+	/// * `write_buffer_size` - The size of the write buffer in bytes
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use surrealdb::opt::WebsocketConfig;
+	///
+	/// let config = WebsocketConfig::new()
+	///     .write_buffer_size(256 * 1024); // 256 KiB
+	/// ```
 	pub fn write_buffer_size(mut self, write_buffer_size: usize) -> Self {
 		self.write_buffer_size = write_buffer_size;
 		self
 	}
 
-	/// Set the maximum write buffer size
+	/// Sets the maximum write buffer size before backpressure is applied.
+	///
+	/// When the write buffer reaches this size, the WebSocket connection will apply
+	/// backpressure to prevent memory exhaustion. Setting this to `usize::MAX` (the default)
+	/// effectively disables write buffer limits.
+	///
+	/// # Arguments
+	///
+	/// * `max_write_buffer_size` - The maximum write buffer size in bytes
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use surrealdb::opt::WebsocketConfig;
+	///
+	/// let config = WebsocketConfig::new()
+	///     .max_write_buffer_size(1024 * 1024); // 1 MiB limit
+	/// ```
 	pub fn max_write_buffer_size(mut self, max_write_buffer_size: usize) -> Self {
 		self.max_write_buffer_size = max_write_buffer_size;
 		self
 	}
 
-	/// Set the maximum WebSocket message size
+	/// Sets the maximum size of a complete WebSocket message.
+	///
+	/// This limit applies to the total size of a WebSocket message, which may consist
+	/// of multiple frames. Messages exceeding this limit will be rejected with an error.
+	///
+	/// # Arguments
+	///
+	/// * `max_message_size` - The maximum message size in bytes, or `None` to disable the limit
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use surrealdb::opt::WebsocketConfig;
+	///
+	/// let config = WebsocketConfig::new()
+	///     .max_message_size(128 << 20); // 128 MiB
+	///
+	/// // Or disable the limit entirely
+	/// let config = WebsocketConfig::new()
+	///     .max_message_size(None);
+	/// ```
 	pub fn max_message_size(mut self, max_message_size: impl Into<Option<usize>>) -> Self {
 		self.max_message_size = max_message_size.into();
 		self
 	}
 
-	/// Set the maximum WebSocket frame size
+	/// Sets the maximum size of a single WebSocket frame.
+	///
+	/// This limit applies to individual WebSocket frames. Large messages may be split
+	/// across multiple frames, but each frame cannot exceed this limit.
+	///
+	/// # Arguments
+	///
+	/// * `max_frame_size` - The maximum frame size in bytes, or `None` to disable the limit
+	///
+	/// # Examples
+	///
+	/// ```rust
+	/// use surrealdb::opt::WebsocketConfig;
+	///
+	/// let config = WebsocketConfig::new()
+	///     .max_frame_size(16 << 20); // 16 MiB
+	///
+	/// // Or disable the limit entirely
+	/// let config = WebsocketConfig::new()
+	///     .max_frame_size(None);
+	/// ```
 	pub fn max_frame_size(mut self, max_frame_size: impl Into<Option<usize>>) -> Self {
 		self.max_frame_size = max_frame_size.into();
 		self

--- a/crates/sdk/tests/api_integration/basic.rs
+++ b/crates/sdk/tests/api_integration/basic.rs
@@ -1783,30 +1783,6 @@ pub async fn field_and_index_methods(new_db: impl CreateDb) {
 	assert_eq!(inside.into_option(), None);
 }
 
-pub async fn check_max_size(new_db: impl CreateDb) {
-	use surrealdb::opt::WebsocketConfig;
-
-	#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-	struct Content {
-		content: String,
-	}
-
-	let (permit, db) = new_db.create_db().await;
-	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
-	drop(permit);
-
-	let max_message_size = WebsocketConfig::default().max_message_size.unwrap();
-
-	let content = Content {
-		content: "a".repeat(max_message_size),
-	};
-
-	let response: Option<Content> =
-		db.upsert(("table", "test")).content(content.clone()).await.unwrap();
-
-	assert_eq!(content, response.unwrap());
-}
-
 define_include_tests!(basic => {
 	#[test_log::test(tokio::test)]
 	connect,
@@ -1914,6 +1890,4 @@ define_include_tests!(basic => {
 	multi_take,
 	#[test_log::test(tokio::test)]
 	field_and_index_methods,
-	#[test_log::test(tokio::test)]
-	check_max_size,
 });

--- a/crates/sdk/tests/api_integration/basic.rs
+++ b/crates/sdk/tests/api_integration/basic.rs
@@ -1783,6 +1783,30 @@ pub async fn field_and_index_methods(new_db: impl CreateDb) {
 	assert_eq!(inside.into_option(), None);
 }
 
+pub async fn check_max_size(new_db: impl CreateDb) {
+	use surrealdb::opt::WebsocketConfig;
+
+	#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+	struct Content {
+		content: String,
+	}
+
+	let (permit, db) = new_db.create_db().await;
+	db.use_ns(NS).use_db(Ulid::new().to_string()).await.unwrap();
+	drop(permit);
+
+	let max_message_size = WebsocketConfig::default().max_message_size.unwrap();
+
+	let content = Content {
+		content: "a".repeat(max_message_size),
+	};
+
+	let response: Option<Content> =
+		db.upsert(("table", "test")).content(content.clone()).await.unwrap();
+
+	assert_eq!(content, response.unwrap());
+}
+
 define_include_tests!(basic => {
 	#[test_log::test(tokio::test)]
 	connect,
@@ -1890,4 +1914,6 @@ define_include_tests!(basic => {
 	multi_take,
 	#[test_log::test(tokio::test)]
 	field_and_index_methods,
+	#[test_log::test(tokio::test)]
+	check_max_size,
 });

--- a/crates/sdk/tests/api_integration/mod.rs
+++ b/crates/sdk/tests/api_integration/mod.rs
@@ -186,18 +186,29 @@ mod ws {
 		drop(permit);
 	}
 
+	/// Test WebSocket message size limits to ensure proper handling of large messages.
+	///
+	/// This test verifies that:
+	/// 1. Messages within the configured size limits are processed successfully
+	/// 2. Messages exceeding the size limits are properly rejected with appropriate error messages
+	/// 3. The WebSocket configuration correctly applies both message and frame size limits
+	///
+	/// The test uses a custom WebSocket configuration with a 256 MiB message size limit
+	/// and tests various message sizes including edge cases.
 	#[test_log::test(tokio::test)]
 	async fn check_max_size() {
 		use serde::{Deserialize, Serialize};
 		use surrealdb::opt::{Config, WebsocketConfig};
 		use ulid::Ulid;
 
+		/// Test content structure for validating large message handling
 		#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 		struct Content {
 			content: String,
 		}
 
 		impl Content {
+			/// Creates test content with a string of the specified length
 			fn new(len: usize) -> Self {
 				Self {
 					content: "a".repeat(len),
@@ -205,9 +216,11 @@ mod ws {
 			}
 		}
 
+		// Set a 256 MiB limit for testing large message handling
 		let max_size = 256 << 20;
 
 		let permit = PERMITS.acquire().await.unwrap();
+		// Configure WebSocket with custom size limits for testing
 		let ws_config =
 			WebsocketConfig::default().max_message_size(max_size).max_frame_size(max_size);
 		let config = Config::new().websocket(ws_config).unwrap();
@@ -221,6 +234,7 @@ mod ws {
 		db.use_ns(Ulid::new().to_string()).use_db(Ulid::new().to_string()).await.unwrap();
 		drop(permit);
 
+		// Test various message sizes that should be accepted
 		{
 			let sizes = [0, 1, 1024, max_size - (1 << 20)];
 
@@ -234,6 +248,7 @@ mod ws {
 			}
 		}
 
+		// Test message size that should be rejected
 		{
 			let content = Content::new(max_size + (1 << 20));
 

--- a/crates/sdk/tests/api_integration/mod.rs
+++ b/crates/sdk/tests/api_integration/mod.rs
@@ -212,12 +212,16 @@ mod ws {
 		let max_message_size = WebsocketConfig::default().max_message_size.unwrap();
 
 		{
-			let content = Content::new(1024);
+			let sizes = [1024, max_message_size - (1 << 20)];
 
-			let response: Option<Content> =
-				db.upsert(("table", "test")).content(content.clone()).await.unwrap();
+			for size in sizes {
+				let content = Content::new(size);
 
-			assert_eq!(content, response.unwrap());
+				let response: Option<Content> =
+					db.upsert(("table", "test")).content(content.clone()).await.unwrap();
+
+				assert_eq!(content, response.unwrap(), "size: {size}");
+			}
 		}
 
 		{
@@ -228,7 +232,8 @@ mod ws {
 				.content(content.clone())
 				.await
 				.unwrap_err();
-			assert_eq!(error.to_string(), "The message is too long: 68157514");
+
+			assert!(error.to_string().starts_with("The message is too long"));
 		}
 	}
 

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -78,15 +78,36 @@ pub static WEBSOCKET_MAX_FRAME_SIZE: LazyLock<usize> =
 pub static WEBSOCKET_MAX_MESSAGE_SIZE: LazyLock<usize> =
 	lazy_env_parse!(bytes, "SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE", usize, 128 << 20);
 
-/// What is the read buffer size (default: 128 KiB)
+/// The size of the read buffer for WebSocket connections (default: 128 KiB)
+///
+/// This controls how much data can be buffered when reading from WebSocket connections.
+/// Larger values can improve performance for high-throughput connections but consume
+/// more memory per connection. The value can be configured via the
+/// `SURREAL_WEBSOCKET_READ_BUFFER_SIZE` environment variable.
 pub static WEBSOCKET_READ_BUFFER_SIZE: LazyLock<usize> =
 	lazy_env_parse!(bytes, "SURREAL_WEBSOCKET_READ_BUFFER_SIZE", usize, 128 * 1024);
 
-/// What is the write buffer size (default: 128 KiB)
+/// The size of the write buffer for WebSocket connections (default: 128 KiB)
+///
+/// This controls how much data can be buffered when writing to WebSocket connections.
+/// Larger values can improve performance for high-throughput connections but consume
+/// more memory per connection. The value can be configured via the
+/// `SURREAL_WEBSOCKET_WRITE_BUFFER_SIZE` environment variable.
 pub static WEBSOCKET_WRITE_BUFFER_SIZE: LazyLock<usize> =
 	lazy_env_parse!(bytes, "SURREAL_WEBSOCKET_WRITE_BUFFER_SIZE", usize, 128 * 1024);
 
-/// What is the maximum WebSocket write buffer size (default: unlimited)
+/// The maximum write buffer size before backpressure is applied (default: unlimited)
+///
+/// When the write buffer reaches this size, the WebSocket connection will apply
+/// backpressure to prevent memory exhaustion. By default, this is set to unlimited
+/// (`usize::MAX`), but it can be configured via the
+/// `SURREAL_WEBSOCKET_MAX_WRITE_BUFFER_SIZE` environment variable.
+///
+/// # Environment Variable
+///
+/// Set `SURREAL_WEBSOCKET_MAX_WRITE_BUFFER_SIZE` to configure this value. The value
+/// must be greater than `WEBSOCKET_WRITE_BUFFER_SIZE` to be effective. If not set
+/// or if the value is invalid, unlimited buffering is used.
 pub static WEBSOCKET_MAX_WRITE_BUFFER_SIZE: LazyLock<usize> = LazyLock::new(|| {
 	let buffer_size = || {
 		let var = env::var("SURREAL_WEBSOCKET_MAX_WRITE_BUFFER_SIZE").ok()?;

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::sync::LazyLock;
 use std::time::Duration;
 
@@ -76,6 +77,28 @@ pub static WEBSOCKET_MAX_FRAME_SIZE: LazyLock<usize> =
 /// What is the maximum WebSocket message size (default: 128 MiB)
 pub static WEBSOCKET_MAX_MESSAGE_SIZE: LazyLock<usize> =
 	lazy_env_parse!(bytes, "SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE", usize, 128 << 20);
+
+/// What is the read buffer size (default: 128 KiB)
+pub static WEBSOCKET_READ_BUFFER_SIZE: LazyLock<usize> =
+	lazy_env_parse!(bytes, "SURREAL_WEBSOCKET_READ_BUFFER_SIZE", usize, 128 * 1024);
+
+/// What is the write buffer size (default: 128 KiB)
+pub static WEBSOCKET_WRITE_BUFFER_SIZE: LazyLock<usize> =
+	lazy_env_parse!(bytes, "SURREAL_WEBSOCKET_WRITE_BUFFER_SIZE", usize, 128 * 1024);
+
+/// What is the maximum WebSocket write buffer size (default: unlimited)
+pub static WEBSOCKET_MAX_WRITE_BUFFER_SIZE: LazyLock<usize> = LazyLock::new(|| {
+	let buffer_size = || {
+		let var = env::var("SURREAL_WEBSOCKET_MAX_WRITE_BUFFER_SIZE").ok()?;
+		let size = var.parse().ok()?;
+		if size > *WEBSOCKET_WRITE_BUFFER_SIZE {
+			Some(size)
+		} else {
+			None
+		}
+	};
+	buffer_size().unwrap_or(usize::MAX)
+});
 
 /// How many messages can be queued for sending down the WebSocket (default:
 /// 100)

--- a/src/net/api.rs
+++ b/src/net/api.rs
@@ -29,7 +29,7 @@ where
 	S: Clone + Send + Sync + 'static,
 {
 	Router::new()
-		.route("/api/:ns/:db/*path", any(handler))
+		.route("/api/{ns}/{db}/{*path}", any(handler))
 		.route_layer(DefaultBodyLimit::disable())
 		.layer(RequestBodyLimitLayer::new(*HTTP_MAX_API_BODY_SIZE))
 }

--- a/src/net/client_ip.rs
+++ b/src/net/client_ip.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use axum::extract::{ConnectInfo, FromRef, FromRequestParts, Request};
 use axum::middleware::Next;
 use axum::response::Response;
-use axum::{Extension, RequestPartsExt, async_trait};
+use axum::{Extension, RequestPartsExt};
 use clap::ValueEnum;
 use http::StatusCode;
 use http::request::Parts;
@@ -68,7 +68,6 @@ impl ClientIp {
 #[derive(Clone)]
 pub(super) struct ExtractClientIP(pub Option<String>);
 
-#[async_trait]
 impl<S> FromRequestParts<S> for ExtractClientIP
 where
 	AppState: FromRef<S>,

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -39,7 +39,7 @@ where
 {
 	Router::new()
 		.route(
-			"/key/:table",
+			"/key/{table}",
 			options(|| async {})
 				.get(select_all)
 				.post(create_all)
@@ -52,7 +52,7 @@ where
 		.merge(
 			Router::new()
 				.route(
-					"/key/:table/:key",
+					"/key/{table}/{key}",
 					options(|| async {})
 						.get(select_one)
 						.post(create_one)

--- a/src/net/ml.rs
+++ b/src/net/ml.rs
@@ -15,7 +15,7 @@ where
 {
 	Router::new()
 		.route("/ml/import", post(implementation::import))
-		.route("/ml/export/:name/:version", get(implementation::export))
+		.route("/ml/export/{name}/{version}", get(implementation::export))
 		.route_layer(DefaultBodyLimit::disable())
 		.layer(RequestBodyLimitLayer::new(*HTTP_MAX_ML_BODY_SIZE))
 }

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -106,21 +106,21 @@ async fn get_handler(
 	if rpc_state.web_sockets.read().await.contains_key(&id) {
 		return Err(NetError::Request);
 	}
-	// Now let's upgrade the WebSocket connection
+	// Now let's upgrade the WebSocket connection with comprehensive buffer configuration
 	Ok(ws
-		// Set the potential WebSocket protocols
+		// Set the potential WebSocket protocols (JSON, CBOR, Bincode, etc.)
 		.protocols(PROTOCOLS)
-		// Set the maximum WebSocket frame size
+		// Set the maximum WebSocket frame size to prevent oversized frames
 		.max_frame_size(*cnf::WEBSOCKET_MAX_FRAME_SIZE)
-		// Set the maximum WebSocket message size
+		// Set the maximum WebSocket message size to prevent memory exhaustion
 		.max_message_size(*cnf::WEBSOCKET_MAX_MESSAGE_SIZE)
-		// Set the read buffer size
+		// Configure read buffer size for incoming data optimization
 		.read_buffer_size(*cnf::WEBSOCKET_READ_BUFFER_SIZE)
-		// Set the write buffer size
+		// Configure write buffer size for outgoing data optimization
 		.write_buffer_size(*cnf::WEBSOCKET_WRITE_BUFFER_SIZE)
-		// Set the maximum write buffer size
+		// Set maximum write buffer size to apply backpressure when needed
 		.max_write_buffer_size(*cnf::WEBSOCKET_MAX_WRITE_BUFFER_SIZE)
-		// Set an error
+		// Handle WebSocket upgrade failures with appropriate logging
 		.on_failed_upgrade(|err| {
 			warn!("Failed to upgrade WebSocket connection: {err}");
 		})

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -114,6 +114,12 @@ async fn get_handler(
 		.max_frame_size(*cnf::WEBSOCKET_MAX_FRAME_SIZE)
 		// Set the maximum WebSocket message size
 		.max_message_size(*cnf::WEBSOCKET_MAX_MESSAGE_SIZE)
+		// Set the read buffer size
+		.read_buffer_size(*cnf::WEBSOCKET_READ_BUFFER_SIZE)
+		// Set the write buffer size
+		.write_buffer_size(*cnf::WEBSOCKET_WRITE_BUFFER_SIZE)
+		// Set the maximum write buffer size
+		.max_write_buffer_size(*cnf::WEBSOCKET_MAX_WRITE_BUFFER_SIZE)
 		// Set an error
 		.on_failed_upgrade(|err| {
 			warn!("Failed to upgrade WebSocket connection: {err}");

--- a/src/net/sql.rs
+++ b/src/net/sql.rs
@@ -97,14 +97,15 @@ async fn handle_socket(state: AppState, ws: WebSocket, session: Session) {
 						v.into_iter().map(|x| x.into_value()).collect::<Vec<_>>(),
 					)) {
 						// Send the JSON response to the client
-						Ok(v) => tx.send(Message::Text(v)).await,
+						Ok(v) => tx.send(Message::Text(v.into())).await,
 						// There was an error converting to JSON
 						Err(e) => {
-							tx.send(Message::Text(format!("Failed to parse JSON: {e}",))).await
+							tx.send(Message::Text(format!("Failed to parse JSON: {e}",).into()))
+								.await
 						}
 					},
 					// There was an error when executing the query
-					Err(e) => tx.send(Message::Text(e.to_string())).await,
+					Err(e) => tx.send(Message::Text(e.to_string().into())).await,
 				};
 			}
 		}

--- a/src/rpc/format.rs
+++ b/src/rpc/format.rs
@@ -105,22 +105,22 @@ impl WsFormat for Format {
 			Format::Json => {
 				let val = crate::core::rpc::format::json::encode_str(res.into_value())
 					.map_err(|_| RpcError::ParseError)?;
-				Ok((val.len(), Message::Text(val)))
+				Ok((val.len(), Message::Text(val.into())))
 			}
 			Format::Cbor => {
 				let val = crate::core::rpc::format::cbor::encode(res.into_value())
 					.map_err(|_| RpcError::ParseError)?;
-				Ok((val.len(), Message::Binary(val)))
+				Ok((val.len(), Message::Binary(val.into())))
 			}
 			Format::Bincode => {
 				let val = crate::core::rpc::format::bincode::encode(&res)
 					.map_err(|_| RpcError::ParseError)?;
-				Ok((val.len(), Message::Binary(val)))
+				Ok((val.len(), Message::Binary(val.into())))
 			}
 			Format::Revision => {
 				let val = crate::core::rpc::format::revision::encode(&res)
 					.map_err(|_| RpcError::ParseError)?;
-				Ok((val.len(), Message::Binary(val)))
+				Ok((val.len(), Message::Binary(val.into())))
 			}
 			Format::Unsupported => Err(Failure::from(RpcError::InvalidRequest)),
 		}

--- a/src/rpc/websocket.rs
+++ b/src/rpc/websocket.rs
@@ -77,7 +77,7 @@ impl Websocket {
 		state: Arc<RpcState>,
 	) {
 		// Log the succesful WebSocket connection
-		debug!("WebSocket {id} connected");
+		trace!("WebSocket {id} connected");
 		// Create a channel for sending messages
 		let (sender, receiver) = channel(*WEBSOCKET_RESPONSE_CHANNEL_SIZE);
 		// Create and store the RPC connection
@@ -131,7 +131,7 @@ impl Websocket {
 		// Close the internal response channel
 		std::mem::drop(sender);
 		// Log the WebSocket disconnection
-		debug!("WebSocket {id} disconnected");
+		trace!("WebSocket {id} disconnected");
 		// Cleanup the live queries for this WebSocket
 		rpc.cleanup_lqs().await;
 		// Remove this WebSocket from the list
@@ -163,7 +163,7 @@ impl Websocket {
 					if let Err(err) = internal_sender.send(msg).await {
 						// Output any errors if not a close error
 						if err.to_string() != CONN_CLOSED_ERR {
-							debug!("WebSocket error: {err}");
+							trace!("WebSocket error: {err}");
 						}
 						// Cancel the WebSocket tasks
 						canceller.cancel();
@@ -209,7 +209,7 @@ impl Websocket {
 					if let Err(err) = res {
 						// Output any errors if not a close error
 						if err.to_string() != CONN_CLOSED_ERR {
-							debug!("WebSocket error: {err}");
+							trace!("WebSocket error: {err}");
 						}
 						// Cancel the WebSocket tasks
 						canceller.cancel();
@@ -223,7 +223,7 @@ impl Websocket {
 					if let Err(err) = socket.flush().await {
 						// Output any errors if not a close error
 						if err.to_string() != CONN_CLOSED_ERR {
-							debug!("WebSocket error: {err}");
+							trace!("WebSocket error: {err}");
 						}
 						// Cancel the WebSocket tasks
 						canceller.cancel();
@@ -278,7 +278,7 @@ impl Websocket {
 						Message::Close(_) => {
 							// Respond with a close message
 							if let Err(err) = internal_sender.send(Message::Close(None)).await {
-								debug!("WebSocket error when replying to the close message: {err}");
+								trace!("WebSocket error when replying to the close message: {err}");
 							};
 							// Cancel the WebSocket tasks
 							canceller.cancel();
@@ -294,7 +294,7 @@ impl Websocket {
 					},
 					Err(err) => {
 						// There was an error with the WebSocket
-						debug!("WebSocket error: {err}");
+						trace!("WebSocket error: {err}");
 						// Cancel the WebSocket tasks
 						canceller.cancel();
 						// Exit out of the loop
@@ -475,13 +475,13 @@ impl RpcContext for Websocket {
 	/// Handles the execution of a LIVE statement
 	async fn handle_live(&self, lqid: &Uuid) {
 		self.state.live_queries.write().await.insert(*lqid, self.id);
-		debug!("Registered live query {lqid} on websocket {}", self.id);
+		trace!("Registered live query {lqid} on websocket {}", self.id);
 	}
 
 	/// Handles the execution of a KILL statement
 	async fn handle_kill(&self, lqid: &Uuid) {
 		if let Some(id) = self.state.live_queries.write().await.remove(lqid) {
-			debug!("Unregistered live query {lqid} on websocket {id}");
+			trace!("Unregistered live query {lqid} on websocket {id}");
 		}
 	}
 
@@ -491,7 +491,7 @@ impl RpcContext for Websocket {
 		// Find all live queries for to this connection
 		self.state.live_queries.write().await.retain(|key, value| {
 			if value == &self.id {
-				debug!("Removing live query: {key}");
+				trace!("Removing live query: {key}");
 				gc.push(*key);
 				return false;
 			}

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -430,7 +430,7 @@ end = "2026-04-11"
 
 [[trusted.libc]]
 criteria = "safe-to-deploy"
-user-id = 51017 # Yuki Okushi (JohnTitor)
+user-id = 51017
 start = "2020-03-17"
 end = "2025-11-14"
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -173,6 +173,10 @@ criteria = "safe-to-deploy"
 version = "0.7.9"
 criteria = "safe-to-deploy"
 
+[[exemptions.axum]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
 [[exemptions.axum-core]]
 version = "0.3.4"
 criteria = "safe-to-deploy"
@@ -181,12 +185,24 @@ criteria = "safe-to-deploy"
 version = "0.4.5"
 criteria = "safe-to-deploy"
 
+[[exemptions.axum-core]]
+version = "0.5.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.axum-extra]]
 version = "0.9.6"
 criteria = "safe-to-deploy"
 
+[[exemptions.axum-extra]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.axum-macros]]
 version = "0.4.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.axum-macros]]
+version = "0.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.axum-server]]
@@ -757,6 +773,10 @@ criteria = "safe-to-deploy"
 version = "0.7.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.matchit]]
+version = "0.8.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.md-5]]
 version = "0.10.6"
 criteria = "safe-to-deploy"
@@ -1209,8 +1229,20 @@ criteria = "safe-to-deploy"
 version = "0.6.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.serde]]
+version = "1.0.228"
+criteria = "safe-to-deploy"
+
 [[exemptions.serde-content]]
 version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_core]]
+version = "1.0.228"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_derive]]
+version = "1.0.228"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_html_form]]
@@ -1365,6 +1397,10 @@ criteria = "safe-to-deploy"
 version = "0.24.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.tokio-tungstenite]]
+version = "0.28.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.toml_datetime]]
 version = "0.6.8"
 criteria = "safe-to-deploy"
@@ -1423,6 +1459,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tungstenite]]
 version = "0.24.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tungstenite]]
+version = "0.28.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.typenum]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -66,10 +66,6 @@ version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.ammonia]]
-version = "4.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ammonia]]
 version = "4.1.2"
 criteria = "safe-to-deploy"
 
@@ -91,10 +87,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.anstyle-wincon]]
 version = "3.0.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.approx]]
-version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.approx]]
@@ -190,15 +182,7 @@ version = "0.5.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.axum-extra]]
-version = "0.9.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.axum-extra]]
 version = "0.10.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.axum-macros]]
-version = "0.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.axum-macros]]
@@ -327,10 +311,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.clap_lex]]
 version = "0.7.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.clipboard-win]]
-version = "4.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.clipboard-win]]
@@ -463,10 +443,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.equator-macro]]
 version = "0.4.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.error-code]]
-version = "2.3.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.error-code]]
@@ -614,10 +590,6 @@ version = "0.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.html5ever]]
-version = "0.27.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.html5ever]]
 version = "0.35.0"
 criteria = "safe-to-deploy"
 
@@ -722,10 +694,6 @@ version = "1.1.22"
 criteria = "safe-to-deploy"
 
 [[exemptions.linfa-linalg]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.linfa-linalg]]
 version = "0.2.1"
 criteria = "safe-to-deploy"
 
@@ -751,10 +719,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.mac]]
 version = "0.1.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.markup5ever]]
-version = "0.12.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.markup5ever]]
@@ -807,14 +771,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.nanoid]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.ndarray]]
-version = "0.15.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.ndarray-stats]]
-version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ndarray-stats]]
@@ -1182,15 +1138,7 @@ version = "0.103.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustyline]]
-version = "12.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustyline]]
 version = "17.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustyline-derive]]
-version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustyline-derive]]
@@ -1283,10 +1231,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.static_assertions_next]]
 version = "1.1.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.str-buf]]
-version = "1.0.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.str_stack]]
@@ -1390,10 +1334,6 @@ version = "0.26.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-tungstenite]]
-version = "0.23.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.tokio-tungstenite]]
 version = "0.24.0"
 criteria = "safe-to-deploy"
 
@@ -1451,10 +1391,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.try_map]]
 version = "0.3.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.tungstenite]]
-version = "0.23.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tungstenite]]
@@ -1567,10 +1503,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.windows-link]]
 version = "0.1.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-sys]]
-version = "0.48.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -329,13 +329,6 @@ user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
-[[publisher.libc]]
-version = "0.2.153"
-when = "2024-01-31"
-user-id = 51017
-user-login = "JohnTitor"
-user-name = "Yuki Okushi"
-
 [[publisher.lzma-rs]]
 version = "0.3.0"
 when = "2023-01-04"
@@ -607,22 +600,8 @@ user-id = 267
 user-login = "tarcieri"
 user-name = "Tony Arcieri"
 
-[[publisher.serde]]
-version = "1.0.219"
-when = "2025-03-09"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
 [[publisher.serde_bytes]]
 version = "0.11.17"
-when = "2025-03-09"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
-[[publisher.serde_derive]]
-version = "1.0.219"
 when = "2025-03-09"
 user-id = 3618
 user-login = "dtolnay"
@@ -678,15 +657,15 @@ user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb]]
-version = "3.0.0-alpha.9"
-when = "2025-09-19"
+version = "3.0.0-alpha.10"
+when = "2025-09-23"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb-core]]
-version = "3.0.0-alpha.9"
-when = "2025-09-19"
+version = "3.0.0-alpha.10"
+when = "2025-09-23"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -706,15 +685,15 @@ user-login = "mumoshu"
 user-name = "Yusuke Kuoka"
 
 [[publisher.surrealdb-types]]
-version = "3.0.0-alpha.9"
-when = "2025-09-19"
+version = "3.0.0-alpha.10"
+when = "2025-09-23"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
 
 [[publisher.surrealdb-types-derive]]
-version = "3.0.0-alpha.9"
-when = "2025-09-19"
+version = "3.0.0-alpha.10"
+when = "2025-09-23"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -811,13 +790,6 @@ user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
 [[publisher.unicode-width]]
-version = "0.1.14"
-when = "2024-09-19"
-user-id = 1139
-user-login = "Manishearth"
-user-name = "Manish Goregaokar"
-
-[[publisher.unicode-width]]
 version = "0.2.0"
 when = "2024-09-19"
 user-id = 1139
@@ -839,15 +811,8 @@ user-login = "KodrAus"
 user-name = "Ashley Mannix"
 
 [[publisher.vart]]
-version = "0.8.1"
-when = "2024-12-06"
-user-id = 145457
-user-login = "tobiemh"
-user-name = "Tobie Morgan Hitchcock"
-
-[[publisher.vart]]
-version = "0.9.2"
-when = "2025-02-22"
+version = "0.9.3"
+when = "2025-09-05"
 user-id = 145457
 user-login = "tobiemh"
 user-name = "Tobie Morgan Hitchcock"
@@ -923,13 +888,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows-targets]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows-targets]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -937,15 +895,8 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows-targets]]
-version = "0.53.0"
-when = "2025-01-07"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_aarch64_gnullvm]]
-version = "0.48.5"
-when = "2023-08-18"
+version = "0.53.3"
+when = "2025-07-28"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -965,13 +916,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows_aarch64_msvc]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_aarch64_msvc]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -981,13 +925,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_aarch64_msvc]]
 version = "0.53.0"
 when = "2025-01-07"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_i686_gnu]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -1021,13 +958,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows_i686_msvc]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_i686_msvc]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -1042,13 +972,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows_x86_64_gnu]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_gnu]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -1063,13 +986,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows_x86_64_gnullvm]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_gnullvm]]
 version = "0.52.6"
 when = "2024-07-03"
 user-id = 64539
@@ -1079,13 +995,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_x86_64_gnullvm]]
 version = "0.53.0"
 when = "2025-01-07"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_msvc]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -1318,24 +1227,6 @@ criteria = "safe-to-deploy"
 delta = "2.1.1 -> 2.3.0"
 notes = "Minor refactoring, nothing new."
 
-[[audits.bytecode-alliance.audits.fd-lock]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-version = "3.0.9"
-notes = "This crate uses unsafe to make Windows syscalls, to borrow an Fd with an appropriate lifetime, and to zero a windows API structure that appears to have a valid representation with zeroed memory."
-
-[[audits.bytecode-alliance.audits.fd-lock]]
-who = "Pat Hickey <phickey@fastly.com>"
-criteria = "safe-to-deploy"
-delta = "3.0.9 -> 3.0.10"
-notes = "Just a dependency version bump"
-
-[[audits.bytecode-alliance.audits.fd-lock]]
-who = "Dan Gohman <dev@sunfishcode.online>"
-criteria = "safe-to-deploy"
-delta = "3.0.10 -> 3.0.12"
-notes = "Just a dependency version bump"
-
 [[audits.bytecode-alliance.audits.foldhash]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -1494,26 +1385,6 @@ it's well-documented and well-tested. Nothing suspicious.
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
 delta = "1.0.11 -> 1.0.14"
-
-[[audits.bytecode-alliance.audits.libc]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.153 -> 0.2.158"
-notes = "More platforms, more definitions, more headers, it's still just `libc`"
-
-[[audits.bytecode-alliance.audits.libc]]
-who = "Dan Gohman <dev@sunfishcode.online>"
-criteria = "safe-to-deploy"
-delta = "0.2.158 -> 0.2.161"
-
-[[audits.bytecode-alliance.audits.libc]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.161 -> 0.2.171"
-notes = """
-Lots of unsafe, but that's par for the course with libc, it's all FFI type
-definitions updates/adjustments/etc.
-"""
 
 [[audits.bytecode-alliance.audits.miniz_oxide]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -3123,13 +2994,6 @@ delta = "2.1.0 -> 2.1.1"
 notes = "Fairly trivial changes, no chance of security regression."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.fd-lock]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "3.0.12 -> 3.0.13"
-notes = "Dependency updates only"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.fnv]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -3424,6 +3288,29 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Benjamin Beurdouche <beurdouche@mozilla.com>"
 criteria = "safe-to-deploy"
 version = "0.2.10"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.nix]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.27.1 -> 0.28.0"
+notes = """
+Many new features and bugfixes. Obviously there's a lot of unsafe code calling
+libc, but the usage looks correct.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.nix]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.28.0 -> 0.29.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.nix]]
+who = "Gabriele Svelto <gsvelto@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.29.0 -> 0.30.1"
+notes = "Some new wrappers, support for minor platforms and lots of work around type safety that reduces the unsafe surafce."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-integer]]
@@ -3801,13 +3688,6 @@ who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.1 -> 0.2.2"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.windows-link]]
-who = "Mark Hammond <mhammond@skippinet.com.au>"
-criteria = "safe-to-deploy"
-version = "0.1.1"
-notes = "A microsoft crate allowing unsafe calls to windows apis."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.write16]]
 who = "Henri Sivonen <hsivonen@hsivonen.fi>"

--- a/tests/common/socket.rs
+++ b/tests/common/socket.rs
@@ -140,7 +140,7 @@ impl Socket {
 
 	fn to_msg(format: Format, message: &serde_json::Value) -> Result<Message> {
 		match format {
-			Format::Json => Ok(Message::Text(serde_json::to_string(message)?)),
+			Format::Json => Ok(Message::Text(serde_json::to_string(message)?.into())),
 			Format::Cbor => {
 				// For tests we need to convert the serde_json::Value
 				// to a SurrealQL value, so that record ids, uuids,
@@ -152,7 +152,7 @@ impl Socket {
 				// Then we convert the SurrealQL in to CBOR.
 				let cbor = surrealdb_core::rpc::format::cbor::encode(surrealql)?;
 				// THen output the message.
-				Ok(Message::Binary(cbor))
+				Ok(Message::Binary(cbor.into()))
 			}
 		}
 	}
@@ -178,7 +178,7 @@ impl Socket {
 						// a serde_json::Value so that test assertions work.
 						// First of all we deserialize the CBOR data.
 						// Then we convert it to a SurrealQL Value.
-						let msg = surrealdb_core::rpc::format::cbor::decode(msg.as_slice())?;
+						let msg = surrealdb_core::rpc::format::cbor::decode(msg.as_ref())?;
 						// Then we convert the SurrealQL to JSON.
 						let msg = msg.into_json_value().unwrap();
 						// Then output the response.


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

WebSocket limits are not currently configurable in the SDK, making it impossible to receive large messages from the server.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It makes the limits configurable.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a new test.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Fixes #2174.

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
