### PR TITLE
Infer `max_frame_size` from `max_message_size`

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -344,7 +344,7 @@ run_task = "ci-api-integration"
 
 [tasks.ci-api-integration-ws]
 category = "CI - INTEGRATION TESTS"
-env = { _TEST_API_ENGINE = "ws", _TEST_FEATURES = "protocol-ws", SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE = 268435456, SURREAL_WEBSOCKET_MAX_FRAME_SIZE = 268435456 }
+env = { _TEST_API_ENGINE = "ws", _TEST_FEATURES = "protocol-ws", SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE = 268435456 }
 run_task = "ci-api-integration"
 
 [tasks.ci-api-integration-any]

--- a/crates/sdk/src/api/engine/any/native.rs
+++ b/crates/sdk/src/api/engine/any/native.rs
@@ -168,7 +168,6 @@ impl conn::Sealed for Any {
 						let WebsocketConfig {
 							read_buffer_size,
 							max_message_size,
-							max_frame_size,
 							max_write_buffer_size,
 							write_buffer_size,
 						} = address.config.websocket;
@@ -183,7 +182,7 @@ impl conn::Sealed for Any {
 
 						let config = WebSocketConfig::default()
 							.max_message_size(max_message_size)
-							.max_frame_size(max_frame_size)
+							.max_frame_size(max_message_size)
 							.max_write_buffer_size(max_write_buffer_size)
 							.write_buffer_size(write_buffer_size)
 							.read_buffer_size(read_buffer_size);

--- a/crates/sdk/src/api/engine/remote/ws/native.rs
+++ b/crates/sdk/src/api/engine/remote/ws/native.rs
@@ -96,7 +96,7 @@ impl conn::Sealed for Client {
 			let ws_config = WebSocketConfig::default()
 				.read_buffer_size(address.config.websocket.read_buffer_size)
 				.max_message_size(address.config.websocket.max_message_size)
-				.max_frame_size(address.config.websocket.max_frame_size)
+				.max_frame_size(address.config.websocket.max_message_size)
 				.max_write_buffer_size(address.config.websocket.max_write_buffer_size)
 				.write_buffer_size(address.config.websocket.write_buffer_size);
 

--- a/crates/sdk/src/api/opt/websocket.rs
+++ b/crates/sdk/src/api/opt/websocket.rs
@@ -12,8 +12,7 @@
 /// let config = WebsocketConfig::new()
 ///     .read_buffer_size(256 * 1024)  // 256 KiB read buffer
 ///     .write_buffer_size(256 * 1024) // 256 KiB write buffer
-///     .max_message_size(16 << 20)    // 16 MiB max message size
-///     .max_frame_size(16 << 20);      // 16 MiB max frame size
+///     .max_message_size(16 << 20);    // 16 MiB max message size
 /// ```
 ///
 /// # Performance Considerations
@@ -24,9 +23,6 @@
 ///
 /// - **Message Size Limits**: Setting appropriate limits helps prevent memory exhaustion from
 ///   malicious or malformed clients while allowing legitimate large messages.
-///
-/// - **Frame Size Limits**: WebSocket frames have their own size limits that should be set
-///   appropriately for your use case.
 #[derive(Debug, Clone)]
 pub struct WebsocketConfig {
 	/// The size of the read buffer for incoming WebSocket data (default: 128 KiB)
@@ -37,8 +33,6 @@ pub struct WebsocketConfig {
 	pub(crate) max_write_buffer_size: usize,
 	/// The maximum size of a complete WebSocket message (default: 64 MiB)
 	pub(crate) max_message_size: Option<usize>,
-	/// The maximum size of a single WebSocket frame (default: 16 MiB)
-	pub(crate) max_frame_size: Option<usize>,
 }
 
 impl Default for WebsocketConfig {
@@ -48,7 +42,6 @@ impl Default for WebsocketConfig {
 	/// - 128 KiB read and write buffers
 	/// - Unlimited write buffer size (no backpressure)
 	/// - 64 MiB maximum message size
-	/// - 16 MiB maximum frame size
 	///
 	/// These defaults are suitable for most applications but can be customized
 	/// based on specific performance and memory requirements.
@@ -58,7 +51,6 @@ impl Default for WebsocketConfig {
 			write_buffer_size: 128 * 1024,
 			max_write_buffer_size: usize::MAX,
 			max_message_size: Some(64 << 20),
-			max_frame_size: Some(16 << 20),
 		}
 	}
 }
@@ -171,32 +163,6 @@ impl WebsocketConfig {
 	/// ```
 	pub fn max_message_size(mut self, max_message_size: impl Into<Option<usize>>) -> Self {
 		self.max_message_size = max_message_size.into();
-		self
-	}
-
-	/// Sets the maximum size of a single WebSocket frame.
-	///
-	/// This limit applies to individual WebSocket frames. Large messages may be split
-	/// across multiple frames, but each frame cannot exceed this limit.
-	///
-	/// # Arguments
-	///
-	/// * `max_frame_size` - The maximum frame size in bytes, or `None` to disable the limit
-	///
-	/// # Examples
-	///
-	/// ```rust
-	/// use surrealdb::opt::WebsocketConfig;
-	///
-	/// let config = WebsocketConfig::new()
-	///     .max_frame_size(16 << 20); // 16 MiB
-	///
-	/// // Or disable the limit entirely
-	/// let config = WebsocketConfig::new()
-	///     .max_frame_size(None);
-	/// ```
-	pub fn max_frame_size(mut self, max_frame_size: impl Into<Option<usize>>) -> Self {
-		self.max_frame_size = max_frame_size.into();
 		self
 	}
 }

--- a/crates/sdk/tests/api_integration/mod.rs
+++ b/crates/sdk/tests/api_integration/mod.rs
@@ -221,8 +221,7 @@ mod ws {
 
 		let permit = PERMITS.acquire().await.unwrap();
 		// Configure WebSocket with custom size limits for testing
-		let ws_config =
-			WebsocketConfig::default().max_message_size(max_size).max_frame_size(max_size);
+		let ws_config = WebsocketConfig::default().max_message_size(max_size);
 		let config = Config::new().websocket(ws_config).unwrap();
 		let db = Surreal::new::<Ws>(("127.0.0.1:8000", config)).await.unwrap();
 		db.signin(Root {

--- a/src/cnf/mod.rs
+++ b/src/cnf/mod.rs
@@ -70,10 +70,6 @@ pub static HTTP_MAX_IMPORT_BODY_SIZE: LazyLock<usize> =
 /// Specifies the frequency with which ping messages are sent to the client
 pub const WEBSOCKET_PING_FREQUENCY: Duration = Duration::from_secs(5);
 
-/// What is the maximum WebSocket frame size (default: 16 MiB)
-pub static WEBSOCKET_MAX_FRAME_SIZE: LazyLock<usize> =
-	lazy_env_parse!(bytes, "SURREAL_WEBSOCKET_MAX_FRAME_SIZE", usize, 16 << 20);
-
 /// What is the maximum WebSocket message size (default: 128 MiB)
 pub static WEBSOCKET_MAX_MESSAGE_SIZE: LazyLock<usize> =
 	lazy_env_parse!(bytes, "SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE", usize, 128 << 20);

--- a/src/net/rpc.rs
+++ b/src/net/rpc.rs
@@ -111,7 +111,7 @@ async fn get_handler(
 		// Set the potential WebSocket protocols (JSON, CBOR, Bincode, etc.)
 		.protocols(PROTOCOLS)
 		// Set the maximum WebSocket frame size to prevent oversized frames
-		.max_frame_size(*cnf::WEBSOCKET_MAX_FRAME_SIZE)
+		.max_frame_size(*cnf::WEBSOCKET_MAX_MESSAGE_SIZE)
 		// Set the maximum WebSocket message size to prevent memory exhaustion
 		.max_message_size(*cnf::WEBSOCKET_MAX_MESSAGE_SIZE)
 		// Configure read buffer size for incoming data optimization


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

> [!WARNING]
No details provided.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

> [!WARNING]
> No details provided.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

> [!WARNING]
> No details provided.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
