### PR TITLE
Add `string::capitalize` function

### DIFF
--- a/crates/core/src/fnc/mod.rs
+++ b/crates/core/src/fnc/mod.rs
@@ -337,6 +337,7 @@ pub fn synchronous(
 		"session::rd" => session::rd(ctx),
 		"session::token" => session::token(ctx),
 		//
+		"string::capitalize" => string::capitalize,
 		"string::concat" => string::concat,
 		"string::contains" => string::contains,
 		"string::ends_with" => string::ends_with,
@@ -1158,6 +1159,7 @@ pub async fn idiom(
 				args.clone(),
 				"no such method found for the string type",
 				//
+				"capitalize" => string::capitalize,
 				"concat" => string::concat,
 				"contains" => string::contains,
 				"ends_with" => string::ends_with,

--- a/crates/core/src/fnc/script/modules/surrealdb/functions/string.rs
+++ b/crates/core/src/fnc/script/modules/surrealdb/functions/string.rs
@@ -11,6 +11,7 @@ pub struct Package;
 impl_module_def!(
 	Package,
 	"string",
+	"capitalize" => run,
 	"concat" => run,
 	"contains" => run,
 	"distance" => (distance::Package),

--- a/crates/core/src/fnc/string.rs
+++ b/crates/core/src/fnc/string.rs
@@ -21,6 +21,25 @@ fn limit(name: &str, n: usize) -> Result<()> {
 	Ok(())
 }
 
+pub fn capitalize((string,): (String,)) -> Result<Value> {
+	if string.is_empty() {
+		return Ok(string.into());
+	}
+	// Capitalize first character of each word (title case)
+	let words: Vec<&str> = string.split_whitespace().collect();
+	let capitalized_words: Vec<String> = words
+		.iter()
+		.map(|word| {
+			let mut chars: Vec<char> = word.chars().collect();
+			if !chars.is_empty() {
+				chars[0] = chars[0].to_uppercase().collect::<Vec<char>>()[0];
+			}
+			chars.iter().collect()
+		})
+		.collect();
+	Ok(capitalized_words.join(" ").into())
+}
+
 pub fn concat(Any(args): Any) -> Result<Value> {
 	let strings = args.into_iter().map(Value::as_raw_string).collect::<Vec<_>>();
 	limit("string::concat", strings.iter().map(String::len).sum::<usize>())?;

--- a/crates/core/src/syn/parser/builtin.rs
+++ b/crates/core/src/syn/parser/builtin.rs
@@ -260,6 +260,7 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		//
 		UniCase::ascii("sleep") => PathKind::Function,
 		//
+		UniCase::ascii("string::capitalize") => PathKind::Function,
 		UniCase::ascii("string::concat") => PathKind::Function,
 		UniCase::ascii("string::contains") => PathKind::Function,
 		UniCase::ascii("string::ends_with") => PathKind::Function,

--- a/crates/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_executor.dict
@@ -324,6 +324,7 @@
 # Sleep is just going to slow the fuzzer down
 # "sleep("
 "string"
+"string::capitalize("
 "string::concat("
 "string::contains("
 "string::distance::damerau_levenshtein("

--- a/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -322,6 +322,7 @@
 "session::origin("
 "sleep("
 "string"
+"string::capitalize("
 "string::concat("
 "string::contains("
 "string::distance::damerau_levenshtein("

--- a/crates/language-tests/tests/language/functions/string/capitalize.surql
+++ b/crates/language-tests/tests/language/functions/string/capitalize.surql
@@ -1,0 +1,24 @@
+/**
+[test]
+
+[[test.results]]
+value = '""'
+
+[[test.results]]
+value = '"Word"'
+
+[[test.results]]
+value = '"Word"'
+
+[[test.results]]
+value = '"A Sentence With Multiple Words"'
+
+[[test.results]]
+value = '"A Sentence With Multiple Words"'
+
+*/
+string::capitalize("");
+string::capitalize("word");
+string::capitalize("Word");
+string::capitalize("a sentence with multiple words");
+string::capitalize("a Sentence with Multiple words");


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

#5329 added a `string::capitalize` function, and incorporated functionality to perform word capitalization, or sentence titlecasing, in the same function.

Firstly, due to significant code changes since that pull-request was opened, it was easier to start with a fresh pull-request.

Secondly, introducing sentence titlecasing requires more thought. Proper titlecasing needs Unicode word-boundary logic so you don’t split inside grapheme clusters and you handle scripts without spaces. Using `true` can't convey the complexity to the user. In addition, titlecasing interacts with language-specific mappings (Turkish dotted/dotless I, Greek final sigma, Lithuanian accents). For proper handling of titlecasing, we would need to ideally support different languages or locales, and that should deserve a new separate function.

## What does this change do?

Adds a `string::capitalize` function for simple capitalization of words.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #5329

## Does this change need documentation?

- [ ] Documentation to be added

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
