### PR TITLE
Expose and tune RocksDB BlobDB options via environment variables

### DIFF
--- a/crates/core/src/kvs/rocksdb/cnf.rs
+++ b/crates/core/src/kvs/rocksdb/cnf.rs
@@ -143,6 +143,35 @@ pub(super) static ROCKSDB_ENABLE_BLOB_FILES: LazyLock<bool> =
 pub(super) static ROCKSDB_MIN_BLOB_SIZE: LazyLock<u64> =
 	lazy_env_parse!(bytes, "SURREAL_ROCKSDB_MIN_BLOB_SIZE", u64, 4 * 1024);
 
+/// The target blob file size (default: 64 MiB)
+pub(super) static ROCKSDB_BLOB_FILE_SIZE: LazyLock<u64> =
+	lazy_env_parse!(bytes, "SURREAL_ROCKSDB_BLOB_FILE_SIZE", u64, 64 * 1024 * 1024);
+
+/// Compression type used for blob files (default: "snappy")
+/// Supported values: "none", "snappy", "lz4", "zstd"
+pub(super) static ROCKSDB_BLOB_COMPRESSION_TYPE: LazyLock<String> =
+	lazy_env_parse!("SURREAL_ROCKSDB_BLOB_COMPRESSION_TYPE", String, "snappy".to_string());
+
+/// Whether to enable blob garbage collection (default: false)
+pub(super) static ROCKSDB_ENABLE_BLOB_GC: LazyLock<bool> =
+	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_BLOB_GC", bool, false);
+
+/// Fractional age cutoff for blob GC eligibility in [0,1] (default: 0.5)
+pub(super) static ROCKSDB_BLOB_GC_AGE_CUTOFF: LazyLock<f64> =
+	lazy_env_parse!("SURREAL_ROCKSDB_BLOB_GC_AGE_CUTOFF", f64, 0.5);
+
+/// Discardable ratio threshold to force GC in [0,1] (default: 0.8)
+pub(super) static ROCKSDB_BLOB_GC_FORCE_THRESHOLD: LazyLock<f64> =
+	lazy_env_parse!("SURREAL_ROCKSDB_BLOB_GC_FORCE_THRESHOLD", f64, 0.8);
+
+/// Readahead size for blob compaction/GC (default: 8 MiB)
+pub(super) static ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE: LazyLock<usize> = lazy_env_parse!(
+	bytes,
+	"SURREAL_ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE",
+	usize,
+	8 * 1024 * 1024
+);
+
 /// The size of the least-recently-used block cache (default: 16 MiB)
 pub(super) static ROCKSDB_BLOCK_CACHE_SIZE: LazyLock<usize> =
 	lazy_env_parse!(bytes, "SURREAL_ROCKSDB_BLOCK_CACHE_SIZE", usize, || {

--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -117,6 +117,29 @@ impl Datastore {
 		// Store large values separate from keys
 		info!(target: TARGET, "Minimum blob value size: {}", *cnf::ROCKSDB_MIN_BLOB_SIZE);
 		opts.set_min_blob_size(*cnf::ROCKSDB_MIN_BLOB_SIZE);
+		// Additional blob file options
+		info!(target: TARGET, "Target blob file size: {}", *cnf::ROCKSDB_BLOB_FILE_SIZE);
+		opts.set_blob_file_size(*cnf::ROCKSDB_BLOB_FILE_SIZE);
+		info!(target: TARGET, "Blob compression type: {}", *cnf::ROCKSDB_BLOB_COMPRESSION_TYPE);
+		opts.set_blob_compression_type(
+			match cnf::ROCKSDB_BLOB_COMPRESSION_TYPE.to_ascii_lowercase().as_str() {
+				"none" => DBCompressionType::None,
+				"snappy" => DBCompressionType::Snappy,
+				"lz4" => DBCompressionType::Lz4,
+				"zstd" => DBCompressionType::Zstd,
+				_ => DBCompressionType::Snappy,
+			},
+		);
+		info!(target: TARGET, "Enable blob garbage collection: {}", *cnf::ROCKSDB_ENABLE_BLOB_GC);
+		opts.set_enable_blob_gc(*cnf::ROCKSDB_ENABLE_BLOB_GC);
+		info!(target: TARGET, "Blob GC age cutoff: {}", *cnf::ROCKSDB_BLOB_GC_AGE_CUTOFF);
+		opts.set_blob_gc_age_cutoff(*cnf::ROCKSDB_BLOB_GC_AGE_CUTOFF);
+		info!(target: TARGET, "Blob GC force threshold: {}", *cnf::ROCKSDB_BLOB_GC_FORCE_THRESHOLD);
+		opts.set_blob_gc_force_threshold(*cnf::ROCKSDB_BLOB_GC_FORCE_THRESHOLD);
+		info!(target: TARGET, "Blob compaction readahead size: {}", *cnf::ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE);
+		opts.set_blob_compaction_readahead_size(
+			(*cnf::ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE) as u64,
+		);
 		// Set the write-ahead-log size limit in MB
 		info!(target: TARGET, "Write-ahead-log file size limit: {}MB", *cnf::ROCKSDB_WAL_SIZE_LIMIT);
 		opts.set_wal_size_limit_mb(*cnf::ROCKSDB_WAL_SIZE_LIMIT);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

- Enable operators to fine‑tune RocksDB BlobDB behavior without code changes, improving performance and storage efficiency for large values.
- Provide explicit control over blob file sizing, compression, and garbage collection to better suit diverse workloads and storage media.
- Make configuration consistent with existing RocksDB tuning exposed through environment variables.

## What does this change do?

This branch adds new configuration knobs (via environment variables) and wires them into RocksDB options when BlobDB is enabled. It also logs their effective values on startup.

Affected files:
- `crates/core/src/kvs/rocksdb/cnf.rs` (new env vars and defaults)
- `crates/core/src/kvs/rocksdb/mod.rs` (apply options and add logging)

New environment variables and defaults
- `SURREAL_ROCKSDB_BLOB_FILE_SIZE` (bytes; default: 64 MiB)
  - Sets target blob file size via `opts.set_blob_file_size(...)`.
- `SURREAL_ROCKSDB_BLOB_COMPRESSION_TYPE` (default: `snappy`; options: `none`, `snappy`, `lz4`, `zstd`)
  - Sets compression for blob files via `opts.set_blob_compression_type(...)`.
- `SURREAL_ROCKSDB_ENABLE_BLOB_GC` (bool; default: `false`)
  - Toggles blob garbage collection via `opts.set_enable_blob_gc(...)`.
- `SURREAL_ROCKSDB_BLOB_GC_AGE_CUTOFF` (f64 in [0, 1]; default: `0.5`)
  - Adjusts GC age cutoff via `opts.set_blob_gc_age_cutoff(...)`.
- `SURREAL_ROCKSDB_BLOB_GC_FORCE_THRESHOLD` (f64 in [0, 1]; default: `0.8`)
  - Sets discardable ratio threshold to force GC via `opts.set_blob_gc_force_threshold(...)`.
- `SURREAL_ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE` (bytes; default: 8 MiB)
  - Sets compaction/GC readahead via `opts.set_blob_compaction_readahead_size(...)`.

Existing related variable (unchanged)
- `SURREAL_ROCKSDB_MIN_BLOB_SIZE` (bytes; default: 4 KiB) is still used to route large values to blob files via `opts.set_min_blob_size(...)`.

Behavioral summary
- When `ROCKSDB_ENABLE_BLOB_FILES` is true (existing toggle), the code now additionally applies the above options and logs their values.
- Compression type strings are case-insensitive; unknown values fall back to `Snappy`.
- Default behavior should be backward-compatible: if no new env vars are set, sensible defaults are applied.

Operational impact
- Users can tune performance and space usage for large-value workloads without recompilation.
- Potential changes in write/read amplification and storage footprint depending on chosen compression and GC settings.

Documentation/update suggestions
- Add the new variables to configuration docs with examples, e.g.:
  - `SURREAL_ROCKSDB_BLOB_FILE_SIZE=134217728` (128 MiB)
  - `SURREAL_ROCKSDB_BLOB_COMPRESSION_TYPE=zstd`
  - `SURREAL_ROCKSDB_ENABLE_BLOB_GC=true`
  - `SURREAL_ROCKSDB_BLOB_GC_AGE_CUTOFF=0.7`
  - `SURREAL_ROCKSDB_BLOB_GC_FORCE_THRESHOLD=0.6`
  - `SURREAL_ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE=16777216` (16 MiB)

Edge cases and notes
- Values are parsed from environment using existing lazy parsers; invalid strings for compression fall back to `Snappy` instead of erroring.
- Ensure that the acceptable ranges for GC parameters are documented (expected [0,1]).
- Consider noting that enabling blob GC may increase background I/O.

In short: this PR exposes and applies a set of BlobDB tuning parameters through environment variables, enabling operational control over blob sizing, compression, and garbage collection with backward-compatible defaults.

## What is your testing strategy?

GIthub action. Existing tests.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
