### PR TITLE
[Backport] Align RocksDB blob defaults with upstream and make blob compression optional

### DIFF
--- a/crates/core/src/kvs/rocksdb/cnf.rs
+++ b/crates/core/src/kvs/rocksdb/cnf.rs
@@ -116,40 +116,39 @@ pub static ROCKSDB_MAX_CONCURRENT_SUBCOMPACTIONS: LazyLock<u32> =
 pub static ROCKSDB_ENABLE_PIPELINED_WRITES: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_PIPELINED_WRITES", bool, true);
 
-pub static ROCKSDB_ENABLE_BLOB_FILES: LazyLock<bool> =
+/// Whether to enable separate key and value file storage (default: true)
+pub(super) static ROCKSDB_ENABLE_BLOB_FILES: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_BLOB_FILES", bool, true);
 
-pub static ROCKSDB_MIN_BLOB_SIZE: LazyLock<u64> =
-	lazy_env_parse!("SURREAL_ROCKSDB_MIN_BLOB_SIZE", u64, 4 * 1024);
+/// The minimum size of a value for it to be stored in blob files (default: 4
+/// KiB)
+pub(super) static ROCKSDB_MIN_BLOB_SIZE: LazyLock<u64> =
+	lazy_env_parse!(bytes, "SURREAL_ROCKSDB_MIN_BLOB_SIZE", u64, 4 * 1024);
 
-/// The target blob file size (default: 64 MiB)
+/// The target blob file size (default: 256 MiB)
 pub(super) static ROCKSDB_BLOB_FILE_SIZE: LazyLock<u64> =
-	lazy_env_parse!(bytes, "SURREAL_ROCKSDB_BLOB_FILE_SIZE", u64, 64 * 1024 * 1024);
+	lazy_env_parse!(bytes, "SURREAL_ROCKSDB_BLOB_FILE_SIZE", u64, 256 * 1024 * 1024);
 
 /// Compression type used for blob files (default: "snappy")
 /// Supported values: "none", "snappy", "lz4", "zstd"
-pub(super) static ROCKSDB_BLOB_COMPRESSION_TYPE: LazyLock<String> =
-	lazy_env_parse!("SURREAL_ROCKSDB_BLOB_COMPRESSION_TYPE", String, "snappy".to_string());
+pub(super) static ROCKSDB_BLOB_COMPRESSION_TYPE: LazyLock<Option<String>> =
+	lazy_env_parse!("SURREAL_ROCKSDB_BLOB_COMPRESSION_TYPE", Option<String>);
 
 /// Whether to enable blob garbage collection (default: false)
 pub(super) static ROCKSDB_ENABLE_BLOB_GC: LazyLock<bool> =
 	lazy_env_parse!("SURREAL_ROCKSDB_ENABLE_BLOB_GC", bool, false);
 
-/// Fractional age cutoff for blob GC eligibility in [0,1] (default: 0.5)
+/// Fractional age cutoff for blob GC eligibility in [0,1] (default: 0.25)
 pub(super) static ROCKSDB_BLOB_GC_AGE_CUTOFF: LazyLock<f64> =
-	lazy_env_parse!("SURREAL_ROCKSDB_BLOB_GC_AGE_CUTOFF", f64, 0.5);
+	lazy_env_parse!("SURREAL_ROCKSDB_BLOB_GC_AGE_CUTOFF", f64, 0.25);
 
-/// Discardable ratio threshold to force GC in [0,1] (default: 0.8)
+/// Discardable ratio threshold to force GC in [0,1] (default: 1.0)
 pub(super) static ROCKSDB_BLOB_GC_FORCE_THRESHOLD: LazyLock<f64> =
-	lazy_env_parse!("SURREAL_ROCKSDB_BLOB_GC_FORCE_THRESHOLD", f64, 0.8);
+	lazy_env_parse!("SURREAL_ROCKSDB_BLOB_GC_FORCE_THRESHOLD", f64, 1.0);
 
-/// Readahead size for blob compaction/GC (default: 8 MiB)
-pub(super) static ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE: LazyLock<usize> = lazy_env_parse!(
-	bytes,
-	"SURREAL_ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE",
-	usize,
-	8 * 1024 * 1024
-);
+/// Readahead size for blob compaction/GC (default: 0)
+pub(super) static ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE: LazyLock<usize> =
+	lazy_env_parse!(bytes, "SURREAL_ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE", usize, 0);
 
 /// The size of the least-recently-used block cache (default: 16 MiB)
 pub(super) static ROCKSDB_BLOCK_CACHE_SIZE: LazyLock<usize> =

--- a/crates/core/src/kvs/rocksdb/mod.rs
+++ b/crates/core/src/kvs/rocksdb/mod.rs
@@ -119,16 +119,18 @@ impl Datastore {
 		// Additional blob file options
 		info!(target: TARGET, "Target blob file size: {}", *cnf::ROCKSDB_BLOB_FILE_SIZE);
 		opts.set_blob_file_size(*cnf::ROCKSDB_BLOB_FILE_SIZE);
-		info!(target: TARGET, "Blob compression type: {}", *cnf::ROCKSDB_BLOB_COMPRESSION_TYPE);
-		opts.set_blob_compression_type(
-			match cnf::ROCKSDB_BLOB_COMPRESSION_TYPE.to_ascii_lowercase().as_str() {
+		if let Some(c) = cnf::ROCKSDB_BLOB_COMPRESSION_TYPE.as_ref() {
+			info!(target: TARGET, "Blob compression type: {c}");
+			opts.set_blob_compression_type(match c.as_str() {
 				"none" => DBCompressionType::None,
 				"snappy" => DBCompressionType::Snappy,
 				"lz4" => DBCompressionType::Lz4,
 				"zstd" => DBCompressionType::Zstd,
-				_ => DBCompressionType::Snappy,
-			},
-		);
+				l => {
+					return Err(Error::Ds(format!("Invalid compression type: {l}")));
+				}
+			});
+		}
 		info!(target: TARGET, "Enable blob garbage collection: {}", *cnf::ROCKSDB_ENABLE_BLOB_GC);
 		opts.set_enable_blob_gc(*cnf::ROCKSDB_ENABLE_BLOB_GC);
 		info!(target: TARGET, "Blob GC age cutoff: {}", *cnf::ROCKSDB_BLOB_GC_AGE_CUTOFF);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport #6464 

## What does this change do?

Backport #6464 

## What is your testing strategy?

Githuv action

## Is this related to any issues?

Backport #6464 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
