### PR TITLE
[Backport] Ensure reverse scan is used only with compatible datastore

### DIFF
--- a/crates/core/src/dbs/iterator.rs
+++ b/crates/core/src/dbs/iterator.rs
@@ -298,7 +298,7 @@ impl Iterator {
 		}
 		// Evaluate if we can only scan keys (rather than keys AND values), or count
 		let rs = ctx.check_record_strategy(false, p)?;
-		let sc = ctx.check_scan_direction();
+		let sc = ctx.check_scan_direction(ctx.ctx.tx().has_reverse_scan());
 		// Add the record to the iterator
 		if let (tb, Id::Range(v)) = (v.tb, v.id) {
 			self.ingest(Iterable::Range(tb, *v, rs, sc));

--- a/crates/core/src/idx/planner/mod.rs
+++ b/crates/core/src/idx/planner/mod.rs
@@ -206,12 +206,15 @@ impl<'a> StatementContext<'a> {
 	/// This is used for Table and Range iterators.
 	/// The direction is reversed if the first element of order is ID descending.
 	/// Typically: `ORDER BY id DESC`
-	pub(crate) fn check_scan_direction(&self) -> ScanDirection {
+	#[allow(unused_variables)]
+	pub(crate) fn check_scan_direction(&self, has_reverse_scan: bool) -> ScanDirection {
 		#[cfg(any(feature = "kv-rocksdb", feature = "kv-tikv"))]
-		if let Some(Ordering::Order(o)) = self.order {
-			if let Some(o) = o.first() {
-				if !o.direction && o.value.is_id() {
-					return ScanDirection::Backward;
+		if has_reverse_scan {
+			if let Some(Ordering::Order(o)) = self.order {
+				if let Some(o) = o.first() {
+					if !o.direction && o.value.is_id() {
+						return ScanDirection::Backward;
+					}
 				}
 			}
 		}
@@ -299,7 +302,7 @@ impl QueryPlanner {
 			all_and: tree.all_and,
 			all_expressions_with_index: tree.all_expressions_with_index,
 			all_and_groups: tree.all_and_groups,
-			reverse_scan: ctx.ctx.tx().reverse_scan(),
+			has_reverse_scan: ctx.ctx.tx().has_reverse_scan(),
 		};
 		match PlanBuilder::build(ctx, p).await? {
 			Plan::SingleIndex(exp, io, rs) => {

--- a/crates/core/src/kvs/tx.rs
+++ b/crates/core/src/kvs/tx.rs
@@ -52,7 +52,7 @@ pub struct Transaction {
 	/// Cache the index updates
 	index_caches: IndexTreeCaches,
 	/// Does this supports reverse scan
-	reverse_scan: bool,
+	has_reverse_scan: bool,
 }
 
 impl Transaction {
@@ -60,7 +60,7 @@ impl Transaction {
 	pub fn new(local: bool, tx: Transactor) -> Transaction {
 		Transaction {
 			local,
-			reverse_scan: tx.supports_reverse_scan(),
+			has_reverse_scan: tx.supports_reverse_scan(),
 			tx: Mutex::new(tx),
 			cache: TransactionCache::new(),
 			index_caches: IndexTreeCaches::default(),
@@ -88,8 +88,8 @@ impl Transaction {
 	}
 
 	/// Check if the transaction supports reverse scan
-	pub fn reverse_scan(&self) -> bool {
-		self.reverse_scan
+	pub fn has_reverse_scan(&self) -> bool {
+		self.has_reverse_scan
 	}
 
 	/// Check if the transaction is finished.

--- a/crates/language-tests/tests/language/planner/select_order_by_id.surql
+++ b/crates/language-tests/tests/language/planner/select_order_by_id.surql
@@ -1,0 +1,14 @@
+/**
+[test]
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "[{ id: p:9 }]"
+
+*/
+
+CREATE |p:1..10| RETURN NONE;
+
+SELECT id FROM p ORDER BY id DESC LIMIT 1;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport #6466 

## What does this change do?

Backport #6466

## What is your testing strategy?

Github action / language test

## Is this related to any issues?

Backport #6466

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
