### PR TITLE
Rename `type::thing` to `type::record`

### DIFF
--- a/crates/core/src/fnc/mod.rs
+++ b/crates/core/src/fnc/mod.rs
@@ -449,7 +449,6 @@ pub fn synchronous(
 		"type::string" => r#type::string,
 		"type::string_lossy" => r#type::string_lossy,
 		"type::table" => r#type::table,
-		"type::thing" => r#type::thing,
 		"type::uuid" => r#type::uuid,
 		"type::is_array" => r#type::is::array,
 		"type::is_bool" => r#type::is::bool,

--- a/crates/core/src/fnc/type.rs
+++ b/crates/core/src/fnc/type.rs
@@ -8,7 +8,7 @@ use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::doc::CursorDoc;
 use crate::err::Error;
-use crate::expr::{FlowResultExt as _, Idiom, Kind};
+use crate::expr::{FlowResultExt as _, Idiom};
 use crate::syn;
 use crate::val::{
 	Array, Bytes, Datetime, Duration, File, Geometry, Number, Range, RecordId, RecordIdKey,
@@ -101,35 +101,6 @@ pub fn range((val,): (Value,)) -> Result<Value> {
 	Ok(val.cast_to::<Box<Range>>()?.into())
 }
 
-pub fn record((rid, Optional(tb)): (Value, Optional<Value>)) -> Result<Value> {
-	match tb {
-		Some(Value::String(tb)) => {
-			if tb.is_empty() {
-				Err(anyhow::Error::new(Error::TbInvalid {
-					value: tb,
-				}))
-			} else {
-				rid.cast_to_kind(&Kind::Record(vec![tb])).map_err(From::from)
-			}
-		}
-
-		Some(Value::Table(tb)) => {
-			if tb.is_empty() {
-				Err(anyhow::Error::new(Error::TbInvalid {
-					value: tb.into_string(),
-				}))
-			} else {
-				rid.cast_to_kind(&Kind::Record(vec![tb.into_string()])).map_err(From::from)
-			}
-		}
-		Some(_) => Err(anyhow::Error::new(Error::InvalidArguments {
-			name: "type::record".into(),
-			message: "The second argument must be a table name or a string.".into(),
-		})),
-		None => rid.cast_to_kind(&Kind::Record(vec![])).map_err(From::from),
-	}
-}
-
 pub fn string((val,): (Value,)) -> Result<Value> {
 	Ok(val.cast_to::<String>()?.into())
 }
@@ -152,7 +123,7 @@ pub fn table((val,): (Value,)) -> Result<Value> {
 	Ok(Value::Table(Table::new(strand)))
 }
 
-pub fn thing((arg1, Optional(arg2)): (Value, Optional<Value>)) -> Result<Value> {
+pub fn record((arg1, Optional(arg2)): (Value, Optional<Value>)) -> Result<Value> {
 	match (arg1, arg2) {
 		// Empty table name
 		(Value::String(arg1), _) if arg1.is_empty() => bail!(Error::TbInvalid {
@@ -337,7 +308,7 @@ mod tests {
 
 	#[test]
 	fn no_empty_thing() {
-		let value = super::thing(("".into(), Optional(None)));
+		let value = super::record(("".into(), Optional(None)));
 		let _expected = Error::TbInvalid {
 			value: "".into(),
 		};
@@ -345,7 +316,7 @@ mod tests {
 			panic!("An empty thing tb part should result in an error");
 		}
 
-		let value = super::thing(("table".into(), Optional(Some("".into()))));
+		let value = super::record(("table".into(), Optional(Some("".into()))));
 		let _expected = Error::IdInvalid {
 			value: "".into(),
 		};

--- a/crates/core/src/iam/signin.rs
+++ b/crates/core/src/iam/signin.rs
@@ -1767,11 +1767,11 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 				r#"
 				DEFINE ACCESS user ON DATABASE TYPE RECORD
 					SIGNIN (
-						SELECT * FROM type::thing('user', $id)
+						SELECT * FROM type::record('user', $id)
 					)
 					AUTHENTICATE (
 						-- Simple example increasing the record identifier by one
-					    SELECT * FROM type::thing('user', record::id($auth) + 1)
+					    SELECT * FROM type::record('user', record::id($auth) + 1)
 					)
 					DURATION FOR SESSION 2h
 				;
@@ -1929,7 +1929,7 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 				r#"
 				DEFINE ACCESS user ON DATABASE TYPE RECORD
 					SIGNIN (
-						SELECT * FROM type::thing('user', $id)
+						SELECT * FROM type::record('user', $id)
 					)
 					AUTHENTICATE {
 					    -- Not just signin, this clause runs across signin, signup and authenticate, which makes it a nice place to centralize logic
@@ -1984,7 +1984,7 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 				r#"
 				DEFINE ACCESS user ON DATABASE TYPE RECORD
 					SIGNIN (
-					   SELECT * FROM type::thing('user', $id)
+					   SELECT * FROM type::record('user', $id)
 					)
 					AUTHENTICATE {}
 					DURATION FOR SESSION 2h
@@ -2124,7 +2124,7 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 				r#"
 				DEFINE ACCESS user ON DATABASE TYPE RECORD
 				SIGNIN (
-					SELECT * FROM type::thing('user', $id)
+					SELECT * FROM type::record('user', $id)
 				)
 				AUTHENTICATE {
 					-- Concurrently write to the same document

--- a/crates/core/src/iam/signup.rs
+++ b/crates/core/src/iam/signup.rs
@@ -727,11 +727,11 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 				r#"
 				DEFINE ACCESS user ON DATABASE TYPE RECORD
 					SIGNUP (
-						CREATE type::thing('user', $id)
+						CREATE type::record('user', $id)
 					)
 					AUTHENTICATE (
 						-- Simple example increasing the record identifier by one
-					    SELECT * FROM type::thing('user', record::id($auth) + 1)
+					    SELECT * FROM type::record('user', record::id($auth) + 1)
 					)
 					DURATION FOR SESSION 2h
 				;
@@ -891,7 +891,7 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 				r#"
 				DEFINE ACCESS user ON DATABASE TYPE RECORD
 					SIGNUP (
-					   CREATE type::thing('user', $id)
+					   CREATE type::record('user', $id)
 					)
 					AUTHENTICATE {
 					    -- Not just signin, this clause runs across signin, signup and authenticate, which makes it a nice place to centralize logic
@@ -944,7 +944,7 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 				r#"
 				DEFINE ACCESS user ON DATABASE TYPE RECORD
 					SIGNUP (
-					   CREATE type::thing('user', $id)
+					   CREATE type::record('user', $id)
 					)
 					AUTHENTICATE {}
 					DURATION FOR SESSION 2h
@@ -1077,7 +1077,7 @@ dn/RsYEONbwQSjIfMPkvxF+8HQ==
 				r#"
 				DEFINE ACCESS user ON DATABASE TYPE RECORD
 					SIGNUP (
-						CREATE type::thing('user', $id)
+						CREATE type::record('user', $id)
 					)
 					AUTHENTICATE {
 						-- Concurrently write to the same document

--- a/crates/core/src/iam/verify.rs
+++ b/crates/core/src/iam/verify.rs
@@ -1904,7 +1904,7 @@ mod tests {
  				        WITH JWT ALGORITHM HS512 KEY '{secret}'
     					AUTHENTICATE (
 							-- Simple example increasing the record identifier by one
-							SELECT * FROM type::thing('user', record::id($auth) + 1)
+							SELECT * FROM type::record('user', record::id($auth) + 1)
     					)
     					DURATION FOR SESSION 2h
     				;
@@ -1964,7 +1964,7 @@ mod tests {
 					r#"
 				DEFINE ACCESS user ON DATABASE TYPE RECORD
 					SIGNIN (
-						SELECT * FROM type::thing('user', $id)
+						SELECT * FROM type::record('user', $id)
 					)
 					WITH JWT ALGORITHM HS512 KEY '{secret}'
 					AUTHENTICATE (

--- a/crates/core/src/idx/planner/iterators.rs
+++ b/crates/core/src/idx/planner/iterators.rs
@@ -218,7 +218,8 @@ impl IndexItemRecord {
 	fn new_key(t: RecordId, ir: IteratorRecord) -> Self {
 		Self::Key(Arc::new(t), ir)
 	}
-	fn thing(&self) -> &RecordId {
+
+	fn record_id(&self) -> &RecordId {
 		match self {
 			Self::Key(t, _) => t,
 			Self::KeyValue(t, _, _) => t,
@@ -1023,7 +1024,7 @@ impl JoinThingIterator {
 				if ctx.is_done(count % 100 == 0).await? {
 					break;
 				}
-				let thing = r.thing();
+				let thing = r.record_id();
 				let value: Value = Value::from(thing.clone());
 				let k: Key = revision::to_vec(thing)?;
 				if self.distinct.insert(k, true).is_none() {

--- a/crates/core/src/syn/parser/builtin.rs
+++ b/crates/core/src/syn/parser/builtin.rs
@@ -373,7 +373,6 @@ pub(crate) static PATHS: phf::Map<UniCase<&'static str>, PathKind> = phf_map! {
 		UniCase::ascii("type::string") => PathKind::Function,
 		UniCase::ascii("type::string_lossy") => PathKind::Function,
 		UniCase::ascii("type::table") => PathKind::Function,
-		UniCase::ascii("type::thing") => PathKind::Function,
 		UniCase::ascii("type::uuid") => PathKind::Function,
 		UniCase::ascii("type::is_array") => PathKind::Function,
 		UniCase::ascii("type::is_bool") => PathKind::Function,

--- a/crates/core/src/syn/parser/record_id.rs
+++ b/crates/core/src/syn/parser/record_id.rs
@@ -80,7 +80,7 @@ impl Parser<'_> {
 					if token.kind == t!("$param") {
 						let param = self.next_token_value::<Param>()?;
 						bail!("Unexpected token `$param` expected a record-id key",
-							@token.span => "Record-id's can be create from a param with `type::thing(\"{}\",{})`", ident,param);
+							@token.span => "Record-id's can be create from a param with `type::record(\"{}\",{})`", ident,param);
 					}
 
 					// we haven't matched anything so far so we still want any type of id.
@@ -336,16 +336,16 @@ mod tests {
 	use crate::syn::parser::ParserSettings;
 	use crate::{sql, syn};
 
-	fn thing(i: &str) -> ParseResult<RecordIdLit> {
+	fn record(i: &str) -> ParseResult<RecordIdLit> {
 		let mut parser = Parser::new(i.as_bytes());
 		let mut stack = Stack::new();
 		stack.enter(|ctx| async move { parser.parse_record_id(ctx).await }).finish()
 	}
 
 	#[test]
-	fn thing_normal() {
+	fn record_normal() {
 		let sql = "test:id";
-		let res = thing(sql);
+		let res = record(sql);
 		let out = res.unwrap();
 		assert_eq!("test:id", format!("{}", out));
 		assert_eq!(
@@ -358,9 +358,9 @@ mod tests {
 	}
 
 	#[test]
-	fn thing_integer() {
+	fn record_integer() {
 		let sql = "test:001";
-		let res = thing(sql);
+		let res = record(sql);
 		let out = res.unwrap();
 		assert_eq!("test:1", format!("{}", out));
 		assert_eq!(
@@ -373,9 +373,9 @@ mod tests {
 	}
 
 	#[test]
-	fn thing_integer_min() {
+	fn record_integer_min() {
 		let sql = format!("test:{}", i64::MIN);
-		let res = thing(&sql);
+		let res = record(&sql);
 		let out = res.unwrap();
 		assert_eq!(
 			out,
@@ -387,9 +387,9 @@ mod tests {
 	}
 
 	#[test]
-	fn thing_integer_max() {
+	fn record_integer_max() {
 		let sql = format!("test:{}", i64::MAX);
-		let res = thing(&sql);
+		let res = record(&sql);
 		let out = res.unwrap();
 		assert_eq!(
 			out,
@@ -401,10 +401,10 @@ mod tests {
 	}
 
 	#[test]
-	fn thing_integer_more_then_max() {
+	fn record_integer_more_then_max() {
 		let max_str = format!("{}", (i64::MAX as u64) + 1);
 		let sql = format!("test:{}", max_str);
-		let res = thing(&sql);
+		let res = record(&sql);
 		let out = res.unwrap();
 		assert_eq!(
 			out,
@@ -416,10 +416,10 @@ mod tests {
 	}
 
 	#[test]
-	fn thing_integer_more_then_min() {
+	fn record_integer_more_then_min() {
 		let min_str = format!("-{}", (i64::MAX as u64) + 2);
 		let sql = format!("test:{}", min_str);
-		let res = thing(&sql);
+		let res = record(&sql);
 		let out = res.unwrap();
 		assert_eq!(
 			out,
@@ -431,7 +431,7 @@ mod tests {
 	}
 
 	#[test]
-	fn thing_string() {
+	fn record_string() {
 		let sql = "r'test:001'";
 		let res = syn::expr(sql).unwrap();
 		let sql::Expr::Literal(sql::Literal::RecordId(out)) = res else {
@@ -462,9 +462,9 @@ mod tests {
 	}
 
 	#[test]
-	fn thing_quoted_backtick() {
+	fn record_quoted_backtick() {
 		let sql = "`test`:`id`";
-		let res = thing(sql);
+		let res = record(sql);
 		let out = res.unwrap();
 		assert_eq!("test:id", format!("{}", out));
 		assert_eq!(
@@ -477,9 +477,9 @@ mod tests {
 	}
 
 	#[test]
-	fn thing_quoted_brackets() {
+	fn record_quoted_brackets() {
 		let sql = "⟨test⟩:⟨id⟩";
-		let res = thing(sql);
+		let res = record(sql);
 		let out = res.unwrap();
 		assert_eq!("test:id", format!("{}", out));
 		assert_eq!(
@@ -492,9 +492,9 @@ mod tests {
 	}
 
 	#[test]
-	fn thing_object() {
+	fn record_object() {
 		let sql = "test:{ location: 'GBR', year: 2022 }";
-		let res = thing(sql);
+		let res = record(sql);
 		let out = res.unwrap();
 		assert_eq!("test:{ location: 'GBR', year: 2022 }", format!("{}", out));
 		assert_eq!(
@@ -516,9 +516,9 @@ mod tests {
 	}
 
 	#[test]
-	fn thing_array() {
+	fn record_array() {
 		let sql = "test:['GBR', 2022]";
-		let res = thing(sql);
+		let res = record(sql);
 		let out = res.unwrap();
 		assert_eq!("test:['GBR', 2022]", format!("{}", out));
 		assert_eq!(

--- a/crates/core/tests/function.rs
+++ b/crates/core/tests/function.rs
@@ -3080,11 +3080,11 @@ async fn function_type_table() -> Result<()> {
 async fn function_type_thing() -> Result<()> {
 	let sql = r#"
 		USE NS test DB test;
-		CREATE type::thing('person', 'test');
-		CREATE type::thing('person', 1434619);
-		CREATE type::thing(<string> person:john);
-		CREATE type::thing('city', '8e60244d-95f6-4f95-9e30-09a98977efb0');
-		CREATE type::thing('temperature', ['London', '2022-09-30T20:25:01.406828Z']);
+		CREATE type::record('person', 'test');
+		CREATE type::record('person', 1434619);
+		CREATE type::record(<string> person:john);
+		CREATE type::record('city', '8e60244d-95f6-4f95-9e30-09a98977efb0');
+		CREATE type::record('temperature', ['London', '2022-09-30T20:25:01.406828Z']);
 	"#;
 	let mut test = Test::new(sql).await?;
 	// USE NS test DB test;

--- a/crates/core/tests/idiom.rs
+++ b/crates/core/tests/idiom.rs
@@ -950,7 +950,7 @@ async fn idiom_recursion_repeat_recurse_nested_destructure() -> Result<()> {
 async fn idiom_recursion_limits() -> Result<()> {
 	let sql = r#"
 		FOR $i IN 1..=300 {
-			UPSERT type::thing('a', $i) SET link = type::thing('a', $i + 1);
+			UPSERT type::record('a', $i) SET link = type::record('a', $i + 1);
 		};
 
 		a:1.{0..}.link;

--- a/crates/core/tests/relate.rs
+++ b/crates/core/tests/relate.rs
@@ -131,9 +131,9 @@ async fn relate_with_param_or_subquery() -> Result<()> {
         LET $relation = type::table("knows");
 		RELATE $tobie->$relation->$jaime;
 		RELATE $tobie->(type::table("knows"))->$jaime;
-        LET $relation = type::thing("knows:foo");
+        LET $relation = type::record("knows:foo");
 		RELATE $tobie->$relation->$jaime;
-		RELATE $tobie->(type::thing("knows:bar"))->$jaime;
+		RELATE $tobie->(type::record("knows:bar"))->$jaime;
 	"#;
 	let dbs = new_ds().await?;
 	let ses = Session::owner().with_ns("test").with_db("test");
@@ -173,7 +173,7 @@ async fn relate_with_param_or_subquery() -> Result<()> {
 		};
 		assert_eq!(t.table.as_str(), "knows");
 	}
-	// LET $relation = type::thing("knows:foo");
+	// LET $relation = type::record("knows:foo");
 	let tmp = res.remove(0).result?;
 	let val = Value::None;
 	assert_eq!(tmp, val);
@@ -190,7 +190,7 @@ async fn relate_with_param_or_subquery() -> Result<()> {
 	)
 	.unwrap();
 	assert_eq!(tmp, val);
-	// LET $relation = type::thing("knows:bar");
+	// LET $relation = type::record("knows:bar");
 	let tmp = res.remove(0).result?;
 	let val = syn::value(
 		"[

--- a/crates/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_executor.dict
@@ -452,7 +452,7 @@
 "type::string("
 "type::string_lossy("
 "type::table("
-"type::thing("
+"type::record("
 "type::record("
 "type::uuid("
 "type::geometry("

--- a/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/crates/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -450,7 +450,7 @@
 "type::string("
 "type::string_lossy("
 "type::table("
-"type::thing("
+"type::record("
 "type::range("
 "type::record("
 "type::uuid("

--- a/crates/language-tests/tests/language/control_flow/loop/break_within_argument.surql
+++ b/crates/language-tests/tests/language/control_flow/loop/break_within_argument.surql
@@ -13,6 +13,6 @@ FOR $i in 0..3{
 	if $i == 1 {
 		array::all(({ BREAK }))
 	};
-	CREATE type::thing('foo',$i);
+	CREATE type::record('foo',$i);
 };
 SELECT * FROM foo;

--- a/crates/language-tests/tests/language/control_flow/loop/break_within_expression.surql
+++ b/crates/language-tests/tests/language/control_flow/loop/break_within_expression.surql
@@ -13,6 +13,6 @@ FOR $i in 0..3{
 	if $i == 1 {
 		1 + ({ BREAK })
 	};
-	CREATE type::thing('foo',$i);
+	CREATE type::record('foo',$i);
 };
 SELECT * FROM foo;

--- a/crates/language-tests/tests/language/control_flow/loop/break_within_for_loop_range.surql
+++ b/crates/language-tests/tests/language/control_flow/loop/break_within_for_loop_range.surql
@@ -13,6 +13,6 @@ FOR $i in 0..3{
 	if $i == 1 {
 		for $j in 0..({ BREAK }){}
 	};
-	CREATE type::thing('foo',$i);
+	CREATE type::record('foo',$i);
 };
 SELECT * FROM foo;

--- a/crates/language-tests/tests/language/control_flow/loop/break_within_if_condition.surql
+++ b/crates/language-tests/tests/language/control_flow/loop/break_within_if_condition.surql
@@ -13,6 +13,6 @@ FOR $i in 0..3{
 	if $i == 1 {
 		if ({ BREAK }) {}
 	};
-	CREATE type::thing('foo',$i);
+	CREATE type::record('foo',$i);
 };
 SELECT * FROM foo;

--- a/crates/language-tests/tests/language/control_flow/loop/break_within_indexing_idiom.surql
+++ b/crates/language-tests/tests/language/control_flow/loop/break_within_indexing_idiom.surql
@@ -13,6 +13,6 @@ FOR $i in 0..3{
 	if $i == 1 {
 		a[({ BREAK })]
 	};
-	CREATE type::thing('foo',$i);
+	CREATE type::record('foo',$i);
 };
 SELECT * FROM foo;

--- a/crates/language-tests/tests/language/control_flow/loop/break_within_method_argument.surql
+++ b/crates/language-tests/tests/language/control_flow/loop/break_within_method_argument.surql
@@ -13,6 +13,6 @@ FOR $i in 0..3{
 	if $i == 1 {
 		[].all(({ BREAK }))
 	};
-	CREATE type::thing('foo',$i);
+	CREATE type::record('foo',$i);
 };
 SELECT * FROM foo;

--- a/crates/language-tests/tests/language/control_flow/loop/break_within_range.surql
+++ b/crates/language-tests/tests/language/control_flow/loop/break_within_range.surql
@@ -13,6 +13,6 @@ FOR $i in 0..3{
 	if $i == 1 {
 		1..=({ BREAK })
 	};
-	CREATE type::thing('foo',$i);
+	CREATE type::record('foo',$i);
 };
 SELECT * FROM foo;

--- a/crates/language-tests/tests/language/control_flow/loop/continue_within_expression.surql
+++ b/crates/language-tests/tests/language/control_flow/loop/continue_within_expression.surql
@@ -13,6 +13,6 @@ FOR $i in 0..3{
 	if $i == 1 {
 		1 + ({ CONTINUE })
 	};
-	CREATE type::thing('foo',$i);
+	CREATE type::record('foo',$i);
 };
 SELECT * FROM foo;

--- a/crates/language-tests/tests/language/functions/array/max.surql
+++ b/crates/language-tests/tests/language/functions/array/max.surql
@@ -29,7 +29,7 @@ array::max([1,2,"text",3,3,4]);
 
 BEGIN;
 for $a in (<array> 0..$type_array.len()).map(|$x,$i| { i: $i, range: 0..($x+1) }){
-	CREATE type::thing('t',$a.i) SET v = array::max($type_array[$a.range]);
+	CREATE type::record('t',$a.i) SET v = array::max($type_array[$a.range]);
 };
 RETURN SELECT v,id FROM t;
 COMMIT;

--- a/crates/language-tests/tests/language/functions/array/min.surql
+++ b/crates/language-tests/tests/language/functions/array/min.surql
@@ -29,7 +29,7 @@ BEGIN;
 let $len = $type_array.len();
 
 for $i in (<array> 0..$len){
-	CREATE type::thing('t',$i) SET v = array::min($type_array[$i..$len]);
+	CREATE type::record('t',$i) SET v = array::min($type_array[$i..$len]);
 };
 RETURN SELECT v,id FROM t;
 COMMIT;

--- a/crates/language-tests/tests/language/functions/record/is_edge.surql
+++ b/crates/language-tests/tests/language/functions/record/is_edge.surql
@@ -75,8 +75,8 @@ record::is_edge(table);
 -- Test 4: Invalid argument - number, not a record ID (should error)
 record::is_edge(64746);
 
--- Test 5: Non-existent record, using `type::thing` constructor
-record::is_edge(type::thing('person', 'nonexistent'));
+-- Test 5: Non-existent record, using `type::record` constructor
+record::is_edge(type::record('person', 'nonexistent'));
 
 -- Test 6: Non-existent record (before creation)
 record::is_edge(person:john);
@@ -99,8 +99,8 @@ record::is_edge(knows:person);
 -- Test 12: Check if edge record is an edge, using a string (should be true)
 record::is_edge('knows:person');
 
--- Test 13: Check if edge record is an edge, using `type::thing` constructor (should be true)
-record::is_edge(type::thing('knows', 'person'));
+-- Test 13: Check if edge record is an edge, using `type::record` constructor (should be true)
+record::is_edge(type::record('knows', 'person'));
 
 -- Test 14: JavaScript function call for a regular record (should be false)
 function() { return surrealdb.functions.record.is_edge("person:john"); };

--- a/crates/language-tests/tests/language/functions/type/field/record.surql
+++ b/crates/language-tests/tests/language/functions/type/field/record.surql
@@ -9,5 +9,5 @@ value = "person:u'01958299-720d-7c33-9eb6-232ffb1874e5'"
 
 */
 
-type::thing("person", u'01958299-720d-7c33-9eb6-232ffb1874e5');
-type::thing("person", person:u'01958299-720d-7c33-9eb6-232ffb1874e5');
+type::record("person", u'01958299-720d-7c33-9eb6-232ffb1874e5');
+type::record("person", person:u'01958299-720d-7c33-9eb6-232ffb1874e5');

--- a/crates/language-tests/tests/language/statements/create/input_computes_once.surql
+++ b/crates/language-tests/tests/language/statements/create/input_computes_once.surql
@@ -26,7 +26,7 @@ CREATE test SET other = (CREATE ONLY other).id;
 SELECT count() FROM other GROUP ALL;
 
 DEFINE FUNCTION fn::increment($name: string) {
-    RETURN (UPSERT ONLY type::thing('counter', $name) SET value += 1).value;
+    RETURN (UPSERT ONLY type::record('counter', $name) SET value += 1).value;
 };
 
 CREATE test SET id = fn::increment('test');

--- a/crates/language-tests/tests/language/statements/define/event/event_check_doc_always_populated.surql
+++ b/crates/language-tests/tests/language/statements/define/event/event_check_doc_always_populated.surql
@@ -40,7 +40,7 @@ value = """[
 
 DEFINE EVENT test ON test WHEN true THEN {
     LET $doc = $this;
-    CREATE type::thing('log', $event) SET this = $doc, value = $value, before = $before, after = $after;
+    CREATE type::record('log', $event) SET this = $doc, value = $value, before = $before, after = $after;
 };
 CREATE test:1 SET num = 1;
 UPSERT test:1 set num = 2;

--- a/crates/language-tests/tests/language/statements/for/break_in_closure.surql
+++ b/crates/language-tests/tests/language/statements/for/break_in_closure.surql
@@ -13,6 +13,6 @@ FOR $test in 1..10{
 	if $test == 5 {
 		(|| { break; })();
 	};
-	CREATE type::thing('test',$test);
+	CREATE type::record('test',$test);
 };
 SELECT * FROM test;

--- a/crates/language-tests/tests/language/statements/for/break_in_function.surql
+++ b/crates/language-tests/tests/language/statements/for/break_in_function.surql
@@ -20,6 +20,6 @@ FOR $test in 1..10{
 	if $test == 5 {
 		fn::break();
 	};
-	CREATE type::thing('test',$test);
+	CREATE type::record('test',$test);
 };
 SELECT * FROM test;

--- a/crates/language-tests/tests/language/statements/for/continue_in_closure.surql
+++ b/crates/language-tests/tests/language/statements/for/continue_in_closure.surql
@@ -13,6 +13,6 @@ FOR $test in 1..10{
 	if $test == 5 {
 		(|| { continue; })();
 	};
-	CREATE type::thing('test',$test);
+	CREATE type::record('test',$test);
 };
 SELECT * FROM test;

--- a/crates/language-tests/tests/language/statements/for/continue_in_function.surql
+++ b/crates/language-tests/tests/language/statements/for/continue_in_function.surql
@@ -20,6 +20,6 @@ FOR $test in 1..10{
 	if $test == 5 {
 		fn::continue();
 	};
-	CREATE type::thing('test',$test);
+	CREATE type::record('test',$test);
 };
 SELECT * FROM test;

--- a/crates/language-tests/tests/language/statements/for/nested.surql
+++ b/crates/language-tests/tests/language/statements/for/nested.surql
@@ -86,7 +86,7 @@ value = """[
 
 FOR $i IN [1,2,3,4,5] {
 	FOR $j IN [6,7,8,9,0] {
-		CREATE type::thing('person', [$i, $j]);
+		CREATE type::record('person', [$i, $j]);
 	}
 };
 SELECT * FROM person;

--- a/crates/language-tests/tests/language/statements/for/range.surql
+++ b/crates/language-tests/tests/language/statements/for/range.surql
@@ -13,6 +13,6 @@ FOR $test IN 1..4 {
 	IF $test == 2 {
 		BREAK;
 	};
-	UPSERT type::thing('person', $test) SET test = $test;
+	UPSERT type::record('person', $test) SET test = $test;
 };
 SELECT * FROM person;

--- a/crates/language-tests/tests/language/statements/for/simple.surql
+++ b/crates/language-tests/tests/language/statements/for/simple.surql
@@ -19,7 +19,7 @@ FOR $test IN [1, 2, 3] {
 	IF $test == 2 {
 		BREAK;
 	};
-	UPSERT type::thing('person', $test) SET test = $test;
+	UPSERT type::record('person', $test) SET test = $test;
 };
 SELECT * FROM person;
 
@@ -27,7 +27,7 @@ FOR $test IN [4, 5, 6] {
 	IF $test == 5 {
 		CONTINUE;
 	};
-	UPSERT type::thing('person', $test) SET test = $test;
+	UPSERT type::record('person', $test) SET test = $test;
 };
 SELECT * FROM person;
 

--- a/crates/language-tests/tests/language/statements/relate/with_param_or_subquery.surql
+++ b/crates/language-tests/tests/language/statements/relate/with_param_or_subquery.surql
@@ -33,6 +33,6 @@ LET $jaime = person:jaime;
 LET $relation = type::table("knows");
 RELATE $tobie->$relation->$jaime CONTENT { id: "foo" };
 RELATE $tobie->(type::table("knows"))->$jaime CONTENT { id: "bar" };
-LET $relation = type::thing("knows:foo");
+LET $relation = type::record("knows:foo");
 RELATE $tobie->$relation->$jaime;
-RELATE $tobie->(type::thing("knows:bar"))->$jaime;
+RELATE $tobie->(type::record("knows:bar"))->$jaime;

--- a/crates/language-tests/tests/language/statements/select/random_ordering_samples_uniform.surql
+++ b/crates/language-tests/tests/language/statements/select/random_ordering_samples_uniform.surql
@@ -19,19 +19,19 @@ let $RANGE = 10;
 let $SAMPLE = 5;
 
 FOR $i in 0..$RANGE {
-    CREATE type::thing("result",$i) CONTENT { count: 0, };
+    CREATE type::record("result",$i) CONTENT { count: 0, };
 };
 
 FOR $i in 0..$COUNT{
     FOR $v in (SELECT * FROM <array> 0..$RANGE ORDER BY RAND() LIMIT $SAMPLE) {
-        UPDATE type::thing("result",$v) SET count += 1;
+        UPDATE type::record("result",$v) SET count += 1;
     }
 };
 
 // All the possible options should get roughly the same amount of samples.
 // So we test if they are all roughly around 500 samples.
 FOR $i in 0..$RANGE{
-    let $cur = type::thing("result",$i);
+    let $cur = type::record("result",$i);
     fn::assert($cur.count > 400, "The count should be larger then 400, got " + <string> $cur.count);
     fn::assert($cur.count < 600, "The count should be smaller then 600, got " + <string> $cur.count);
 };

--- a/crates/language-tests/tests/upgrade/value/primitives_import.surql
+++ b/crates/language-tests/tests/upgrade/value/primitives_import.surql
@@ -21,7 +21,7 @@ CREATE test:values SET data = [
 	{a: 1},
 	(1,2),
 	encoding::base64::decode("MjMyMw"),
-	type::thing('a','b'),
+	type::record('a','b'),
 	/a/,
 	0..10,
 ];

--- a/crates/sdk/tests/api_integration/basic.rs
+++ b/crates/sdk/tests/api_integration/basic.rs
@@ -973,10 +973,10 @@ pub async fn update_table_with_content(new_db: impl CreateDb) {
 	db.use_ns(Ulid::new().to_string()).use_db(Ulid::new().to_string()).await.unwrap();
 	drop(permit);
 	let sql = "
-        CREATE type::thing($table, 'amos') SET name = 'Amos';
-        CREATE type::thing($table, 'jane') SET name = 'Jane';
-        CREATE type::thing($table, 'john') SET name = 'John';
-        CREATE type::thing($table, 'zoey') SET name = 'Zoey';
+        CREATE type::record($table, 'amos') SET name = 'Amos';
+        CREATE type::record($table, 'jane') SET name = 'Jane';
+        CREATE type::record($table, 'john') SET name = 'John';
+        CREATE type::record($table, 'zoey') SET name = 'Zoey';
     ";
 	let table = "user";
 	let response = db.query(sql).bind(("table", table)).await.unwrap();
@@ -1016,10 +1016,10 @@ pub async fn update_record_range_with_content(new_db: impl CreateDb) {
 	db.use_ns(Ulid::new().to_string()).use_db(Ulid::new().to_string()).await.unwrap();
 	drop(permit);
 	let sql = "
-        CREATE type::thing($table, 'amos') SET name = 'Amos';
-        CREATE type::thing($table, 'jane') SET name = 'Jane';
-        CREATE type::thing($table, 'john') SET name = 'John';
-        CREATE type::thing($table, 'zoey') SET name = 'Zoey';
+        CREATE type::record($table, 'amos') SET name = 'Amos';
+        CREATE type::record($table, 'jane') SET name = 'Jane';
+        CREATE type::record($table, 'john') SET name = 'John';
+        CREATE type::record($table, 'zoey') SET name = 'Zoey';
     ";
 	let table = "user";
 	let response = db.query(sql).bind(("table", table)).await.unwrap();
@@ -1400,10 +1400,10 @@ pub async fn delete_record_range(new_db: impl CreateDb) {
 	db.use_ns(Ulid::new().to_string()).use_db(Ulid::new().to_string()).await.unwrap();
 	drop(permit);
 	let sql = "
-        CREATE type::thing($table, 'amos') SET name = 'Amos';
-        CREATE type::thing($table, 'jane') SET name = 'Jane';
-        CREATE type::thing($table, 'john') SET name = 'John';
-        CREATE type::thing($table, 'zoey') SET name = 'Zoey';
+        CREATE type::record($table, 'amos') SET name = 'Amos';
+        CREATE type::record($table, 'jane') SET name = 'Jane';
+        CREATE type::record($table, 'john') SET name = 'John';
+        CREATE type::record($table, 'zoey') SET name = 'Zoey';
     ";
 	let table = "user";
 	let response = db.query(sql).bind(("table", table)).await.unwrap();

--- a/src/net/key.rs
+++ b/src/net/key.rs
@@ -293,8 +293,8 @@ async fn select_one(
 	let _ = check_ns_db(&session).map_err(ResponseError)?;
 	// Specify the request statement
 	let sql = match query.fields {
-		None => "SELECT * FROM type::thing($table, $id)",
-		_ => "SELECT type::fields($fields) FROM type::thing($table, $id)",
+		None => "SELECT * FROM type::record($table, $id)",
+		_ => "SELECT type::fields($fields) FROM type::record($table, $id)",
 	};
 	// Parse the Record ID as a SurrealQL value
 	let rid = match syn::json(&id) {
@@ -336,7 +336,7 @@ async fn create_one(
 	};
 
 	// Specify the request statement
-	let sql = "CREATE type::thing($table, $id) CONTENT $data";
+	let sql = "CREATE type::record($table, $id) CONTENT $data";
 	// Specify the request variables
 	let vars = Variables::from(map! {
 		String::from("table") => Value::String(table),
@@ -372,7 +372,7 @@ async fn update_one(
 	};
 
 	// Specify the request statement
-	let sql = "UPSERT type::thing($table, $id) CONTENT $data";
+	let sql = "UPSERT type::record($table, $id) CONTENT $data";
 	// Specify the request variables
 	let vars = Variables::from(map! {
 		String::from("table") => Value::String(table),
@@ -408,7 +408,7 @@ async fn modify_one(
 	};
 
 	// Specify the request statement
-	let sql = "UPSERT type::thing($table, $id) MERGE $data";
+	let sql = "UPSERT type::record($table, $id) MERGE $data";
 	// Specify the request variables
 	let vars = Variables::from(map! {
 		String::from("table") => Value::String(table),
@@ -434,7 +434,7 @@ async fn delete_one(
 	// Ensure a NS and DB are set
 	let _ = check_ns_db(&session).map_err(ResponseError)?;
 	// Specify the request statement
-	let sql = "DELETE type::thing($table, $id) RETURN BEFORE";
+	let sql = "DELETE type::record($table, $id) RETURN BEFORE";
 	// Parse the Record ID as a SurrealQL value
 	let rid = match syn::json(&id) {
 		Ok(id) => id,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

We've renamed thing to record, the type function should reflect that.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Renames `type::thing` to `type::record`.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI is sufficient.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- Yes, https://github.com/surrealdb/docs.surrealdb.com/pull/1466

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
