### PR TITLE
Do not return error if there are no results in info RPC.

### DIFF
--- a/crates/core/src/rpc/protocol/v1.rs
+++ b/crates/core/src/rpc/protocol/v1.rs
@@ -319,9 +319,7 @@ pub trait RpcProtocolV1: RpcContext {
 
 		let result = res.remove(0).result?;
 
-		let first = result
-			.first()
-			.ok_or_else(|| RpcError::Thrown("Got not results from info query".to_string()))?;
+		let first = result.first().unwrap_or_default();
 		Ok(DbResult::Other(first))
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

I am working through getting the python SDK tests working again. I looked at the 2.3 implementation and it actually did not error if there were no results, it just returned None.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Makes the info RPC no longer return an error if there are no results.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

This gets the python tests passing:
```
uv run pytest -x
========================================================== test session starts ===========================================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0 -- /Users/stu/dev/ssttuu/surrealdb.py/.venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /Users/stu/dev/ssttuu/surrealdb.py
configfile: pyproject.toml
testpaths: tests
plugins: asyncio-1.1.0, cov-6.2.1, hypothesis-6.135.32
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 306 items                                                                                                                      

tests/unit_tests/connections/authenticate/test_async_ws.py::test_authenticate PASSED                                               [  0%]
tests/unit_tests/connections/batch_async/test_async_ws.py::test_batch PASSED                                                       [  0%]
tests/unit_tests/connections/create/test_async_http.py::test_create_string PASSED                                                  [  0%]
tests/unit_tests/connections/create/test_async_http.py::test_create_string_with_data PASSED                                        [  1%]
tests/unit_tests/connections/create/test_async_http.py::test_create_string_with_data_and_id PASSED                                 [  1%]
tests/unit_tests/connections/create/test_async_http.py::test_create_record_id PASSED                                               [  1%]
tests/unit_tests/connections/create/test_async_http.py::test_create_record_id_with_data PASSED                                     [  2%]
tests/unit_tests/connections/create/test_async_http.py::test_create_table PASSED                                                   [  2%]
tests/unit_tests/connections/create/test_async_http.py::test_create_table_with_data PASSED                                         [  2%]
tests/unit_tests/connections/create/test_async_ws.py::test_create_string PASSED                                                    [  3%]
tests/unit_tests/connections/create/test_async_ws.py::test_create_string_with_data PASSED                                          [  3%]
tests/unit_tests/connections/create/test_async_ws.py::test_create_string_with_data_and_id PASSED                                   [  3%]
tests/unit_tests/connections/create/test_async_ws.py::test_create_record_id PASSED                                                 [  4%]
tests/unit_tests/connections/create/test_async_ws.py::test_create_record_id_with_data PASSED                                       [  4%]
tests/unit_tests/connections/create/test_async_ws.py::test_create_table PASSED                                                     [  4%]
tests/unit_tests/connections/create/test_async_ws.py::test_create_table_with_data PASSED                                           [  5%]
tests/unit_tests/connections/create/test_blocking_http.py::test_create_string PASSED                                               [  5%]
tests/unit_tests/connections/create/test_blocking_http.py::test_create_string_with_data PASSED                                     [  5%]
tests/unit_tests/connections/create/test_blocking_http.py::test_create_string_with_data_and_id PASSED                              [  6%]
tests/unit_tests/connections/create/test_blocking_http.py::test_create_record_id PASSED                                            [  6%]
tests/unit_tests/connections/create/test_blocking_http.py::test_create_record_id_with_data PASSED                                  [  6%]
tests/unit_tests/connections/create/test_blocking_http.py::test_create_table PASSED                                                [  7%]
tests/unit_tests/connections/create/test_blocking_http.py::test_create_table_with_data PASSED                                      [  7%]
tests/unit_tests/connections/create/test_blocking_ws.py::test_create_string PASSED                                                 [  7%]
tests/unit_tests/connections/create/test_blocking_ws.py::test_create_string_with_data PASSED                                       [  8%]
tests/unit_tests/connections/create/test_blocking_ws.py::test_create_string_with_data_and_id PASSED                                [  8%]
tests/unit_tests/connections/create/test_blocking_ws.py::test_create_record_id PASSED                                              [  8%]
tests/unit_tests/connections/create/test_blocking_ws.py::test_create_record_id_with_data PASSED                                    [  9%]
tests/unit_tests/connections/create/test_blocking_ws.py::test_create_table PASSED                                                  [  9%]
tests/unit_tests/connections/create/test_blocking_ws.py::test_create_table_with_data PASSED                                        [  9%]
tests/unit_tests/connections/delete/test_async_http.py::test_delete_string PASSED                                                  [ 10%]
tests/unit_tests/connections/delete/test_async_http.py::test_delete_record_id PASSED                                               [ 10%]
tests/unit_tests/connections/delete/test_async_http.py::test_delete_table PASSED                                                   [ 10%]
tests/unit_tests/connections/delete/test_async_ws.py::test_delete_string PASSED                                                    [ 11%]
tests/unit_tests/connections/delete/test_async_ws.py::test_delete_record_id PASSED                                                 [ 11%]
tests/unit_tests/connections/delete/test_async_ws.py::test_delete_table PASSED                                                     [ 11%]
tests/unit_tests/connections/delete/test_blocking_http.py::test_debug_delete PASSED                                                [ 12%]
tests/unit_tests/connections/delete/test_blocking_http.py::test_delete_string PASSED                                               [ 12%]
tests/unit_tests/connections/delete/test_blocking_http.py::test_delete_record_id PASSED                                            [ 12%]
tests/unit_tests/connections/delete/test_blocking_http.py::test_delete_table PASSED                                                [ 13%]
tests/unit_tests/connections/delete/test_blocking_ws.py::test_delete_string PASSED                                                 [ 13%]
tests/unit_tests/connections/delete/test_blocking_ws.py::test_delete_record_id PASSED                                              [ 13%]
tests/unit_tests/connections/delete/test_blocking_ws.py::test_delete_table PASSED                                                  [ 14%]
tests/unit_tests/connections/info/test_async_http.py::test_info PASSED                                                             [ 14%]
tests/unit_tests/connections/info/test_async_ws.py::test_info PASSED                                                               [ 14%]
tests/unit_tests/connections/info/test_block_ws.py::test_info PASSED                                                               [ 15%]
tests/unit_tests/connections/info/test_blocking_http.py::test_info PASSED                                                          [ 15%]
tests/unit_tests/connections/insert/test_async_http.py::test_insert_string_with_data PASSED                                        [ 15%]
tests/unit_tests/connections/insert/test_async_http.py::test_insert_record_id_result_error PASSED                                  [ 16%]
tests/unit_tests/connections/insert/test_async_ws.py::test_insert_string_with_data PASSED                                          [ 16%]
tests/unit_tests/connections/insert/test_async_ws.py::test_insert_record_id_result_error PASSED                                    [ 16%]
tests/unit_tests/connections/insert/test_blocking_http.py::test_insert_string_with_data PASSED                                     [ 16%]
tests/unit_tests/connections/insert/test_blocking_http.py::test_insert_record_id_result_error PASSED                               [ 17%]
tests/unit_tests/connections/insert/test_blocking_ws.py::test_insert_string_with_data PASSED                                       [ 17%]
tests/unit_tests/connections/insert/test_blocking_ws.py::test_insert_record_id_result_error PASSED                                 [ 17%]
tests/unit_tests/connections/insert_relation/test_async_http.py::test_insert_relation_record_ids PASSED                            [ 18%]
tests/unit_tests/connections/insert_relation/test_async_http.py::test_insert_relation_record_id PASSED                             [ 18%]
tests/unit_tests/connections/insert_relation/test_async_ws.py::test_insert_relation_record_ids PASSED                              [ 18%]
tests/unit_tests/connections/insert_relation/test_async_ws.py::test_insert_relation_record_id PASSED                               [ 19%]
tests/unit_tests/connections/insert_relation/test_blocking_http.py::test_insert_relation_record_ids PASSED                         [ 19%]
tests/unit_tests/connections/insert_relation/test_blocking_http.py::test_insert_relation_record_id PASSED                          [ 19%]
tests/unit_tests/connections/insert_relation/test_blocking_ws.py::test_insert_relation_record_ids PASSED                           [ 20%]
tests/unit_tests/connections/insert_relation/test_blocking_ws.py::test_insert_relation_record_id PASSED                            [ 20%]
tests/unit_tests/connections/invalidate/test_async_http.py::test_invalidate_with_guest_mode_on PASSED                              [ 20%]
tests/unit_tests/connections/invalidate/test_async_http.py::test_invalidate_test_for_no_guest_mode PASSED                          [ 21%]
tests/unit_tests/connections/invalidate/test_async_ws.py::test_invalidate_with_guest_mode_on PASSED                                [ 21%]
tests/unit_tests/connections/invalidate/test_async_ws.py::test_invalidate_test_for_no_guest_mode PASSED                            [ 21%]
tests/unit_tests/connections/invalidate/test_blocking_http.py::test_invalidate_test_for_no_guest_mode PASSED                       [ 22%]
tests/unit_tests/connections/invalidate/test_blocking_http.py::test_invalidate_with_guest_mode_on PASSED                           [ 22%]
tests/unit_tests/connections/invalidate/test_blocking_ws.py::test_invalidate_with_guest_mode_on PASSED                             [ 22%]
tests/unit_tests/connections/invalidate/test_blocking_ws.py::test_invalidate_test_for_no_guest_mode PASSED                         [ 23%]
tests/unit_tests/connections/let/test_async_http.py::test_let PASSED                                                               [ 23%]
tests/unit_tests/connections/let/test_async_ws.py::test_let PASSED                                                                 [ 23%]
tests/unit_tests/connections/let/test_blocking_http.py::test_let PASSED                                                            [ 24%]
tests/unit_tests/connections/let/test_blocking_ws.py::test_let PASSED                                                              [ 24%]
tests/unit_tests/connections/live/test_async_http.py::test_query XFAIL (live method not implemented for HTTP connections)          [ 24%]
tests/unit_tests/connections/live/test_async_ws.py::test_query PASSED                                                              [ 25%]
tests/unit_tests/connections/live/test_blocking_ws.py::test_query PASSED                                                           [ 25%]
tests/unit_tests/connections/merge/test_async_http.py::test_merge_string PASSED                                                    [ 25%]
tests/unit_tests/connections/merge/test_async_http.py::test_merge_string_with_data PASSED                                          [ 26%]
tests/unit_tests/connections/merge/test_async_http.py::test_merge_record_id PASSED                                                 [ 26%]
tests/unit_tests/connections/merge/test_async_http.py::test_merge_record_id_with_data PASSED                                       [ 26%]
tests/unit_tests/connections/merge/test_async_http.py::test_merge_table PASSED                                                     [ 27%]
tests/unit_tests/connections/merge/test_async_http.py::test_merge_table_with_data PASSED                                           [ 27%]
tests/unit_tests/connections/merge/test_async_ws.py::test_merge_string PASSED                                                      [ 27%]
tests/unit_tests/connections/merge/test_async_ws.py::test_merge_string_with_data PASSED                                            [ 28%]
tests/unit_tests/connections/merge/test_async_ws.py::test_merge_record_id PASSED                                                   [ 28%]
tests/unit_tests/connections/merge/test_async_ws.py::test_merge_record_id_with_data PASSED                                         [ 28%]
tests/unit_tests/connections/merge/test_async_ws.py::test_merge_table PASSED                                                       [ 29%]
tests/unit_tests/connections/merge/test_async_ws.py::test_merge_table_with_data PASSED                                             [ 29%]
tests/unit_tests/connections/merge/test_blocking_http.py::test_merge_string PASSED                                                 [ 29%]
tests/unit_tests/connections/merge/test_blocking_http.py::test_merge_string_with_data PASSED                                       [ 30%]
tests/unit_tests/connections/merge/test_blocking_http.py::test_merge_record_id PASSED                                              [ 30%]
tests/unit_tests/connections/merge/test_blocking_http.py::test_merge_record_id_with_data PASSED                                    [ 30%]
tests/unit_tests/connections/merge/test_blocking_http.py::test_merge_table PASSED                                                  [ 31%]
tests/unit_tests/connections/merge/test_blocking_http.py::test_merge_table_with_data PASSED                                        [ 31%]
tests/unit_tests/connections/merge/test_blocking_ws.py::test_merge_string PASSED                                                   [ 31%]
tests/unit_tests/connections/merge/test_blocking_ws.py::test_merge_string_with_data PASSED                                         [ 32%]
tests/unit_tests/connections/merge/test_blocking_ws.py::test_merge_record_id PASSED                                                [ 32%]
tests/unit_tests/connections/merge/test_blocking_ws.py::test_merge_record_id_with_data PASSED                                      [ 32%]
tests/unit_tests/connections/merge/test_blocking_ws.py::test_merge_table PASSED                                                    [ 33%]
tests/unit_tests/connections/merge/test_blocking_ws.py::test_merge_table_with_data PASSED                                          [ 33%]
tests/unit_tests/connections/patch/test_async_http.py::test_patch_string_with_data PASSED                                          [ 33%]
tests/unit_tests/connections/patch/test_async_http.py::test_patch_record_id_with_data PASSED                                       [ 33%]
tests/unit_tests/connections/patch/test_async_http.py::test_patch_table_with_data PASSED                                           [ 34%]
tests/unit_tests/connections/patch/test_async_ws.py::test_patch_string_with_data PASSED                                            [ 34%]
tests/unit_tests/connections/patch/test_async_ws.py::test_patch_record_id_with_data PASSED                                         [ 34%]
tests/unit_tests/connections/patch/test_async_ws.py::test_patch_table_with_data PASSED                                             [ 35%]
tests/unit_tests/connections/patch/test_blocking_http.py::test_patch_string_with_data PASSED                                       [ 35%]
tests/unit_tests/connections/patch/test_blocking_http.py::test_patch_record_id_with_data PASSED                                    [ 35%]
tests/unit_tests/connections/patch/test_blocking_http.py::test_patch_table_with_data PASSED                                        [ 36%]
tests/unit_tests/connections/patch/test_blocking_ws.py::test_patch_string_with_data PASSED                                         [ 36%]
tests/unit_tests/connections/patch/test_blocking_ws.py::test_patch_record_id_with_data PASSED                                      [ 36%]
tests/unit_tests/connections/patch/test_blocking_ws.py::test_patch_table_with_data PASSED                                          [ 37%]
tests/unit_tests/connections/query/test_async_http.py::test_query PASSED                                                           [ 37%]
tests/unit_tests/connections/query/test_async_ws.py::test_query PASSED                                                             [ 37%]
tests/unit_tests/connections/query/test_blocking_http.py::test_query PASSED                                                        [ 38%]
tests/unit_tests/connections/query/test_blocking_ws.py::test_query PASSED                                                          [ 38%]
tests/unit_tests/connections/select/test_async_http.py::test_select PASSED                                                         [ 38%]
tests/unit_tests/connections/select/test_async_ws.py::test_select PASSED                                                           [ 39%]
tests/unit_tests/connections/select/test_blocking_http.py::test_select PASSED                                                      [ 39%]
tests/unit_tests/connections/select/test_blocking_ws.py::test_select PASSED                                                        [ 39%]
tests/unit_tests/connections/signin/test_async_http.py::test_signin_root PASSED                                                    [ 40%]
tests/unit_tests/connections/signin/test_async_http.py::test_signin_namespace PASSED                                               [ 40%]
tests/unit_tests/connections/signin/test_async_http.py::test_signin_database PASSED                                                [ 40%]
tests/unit_tests/connections/signin/test_async_http.py::test_signin_record PASSED                                                  [ 41%]
tests/unit_tests/connections/signin/test_async_ws.py::test_signin_root PASSED                                                      [ 41%]
tests/unit_tests/connections/signin/test_async_ws.py::test_signin_namespace PASSED                                                 [ 41%]
tests/unit_tests/connections/signin/test_async_ws.py::test_signin_database PASSED                                                  [ 42%]
tests/unit_tests/connections/signin/test_async_ws.py::test_signin_record PASSED                                                    [ 42%]
tests/unit_tests/connections/signin/test_blocking_http.py::test_signin_root PASSED                                                 [ 42%]
tests/unit_tests/connections/signin/test_blocking_http.py::test_signin_namespace PASSED                                            [ 43%]
tests/unit_tests/connections/signin/test_blocking_http.py::test_signin_database PASSED                                             [ 43%]
tests/unit_tests/connections/signin/test_blocking_http.py::test_signin_record PASSED                                               [ 43%]
tests/unit_tests/connections/signin/test_blocking_ws.py::test_signin_root PASSED                                                   [ 44%]
tests/unit_tests/connections/signin/test_blocking_ws.py::test_signin_namespace PASSED                                              [ 44%]
tests/unit_tests/connections/signin/test_blocking_ws.py::test_signin_database PASSED                                               [ 44%]
tests/unit_tests/connections/signin/test_blocking_ws.py::test_signin_record PASSED                                                 [ 45%]
tests/unit_tests/connections/signup/test_async_http.py::test_signup PASSED                                                         [ 45%]
tests/unit_tests/connections/signup/test_async_ws.py::test_signup PASSED                                                           [ 45%]
tests/unit_tests/connections/signup/test_blocking_http.py::test_signup PASSED                                                      [ 46%]
tests/unit_tests/connections/signup/test_blocking_ws.py::test_signup PASSED                                                        [ 46%]
tests/unit_tests/connections/subscribe_live/test_async_ws.py::test_live_subscription PASSED                                        [ 46%]
tests/unit_tests/connections/subscribe_live/test_blocking_ws.py::test_live_subscription PASSED                                     [ 47%]
tests/unit_tests/connections/test_connection_constructor.py::test_blocking___init__ PASSED                                         [ 47%]
tests/unit_tests/connections/test_connection_constructor.py::test_async___init__ PASSED                                            [ 47%]
tests/unit_tests/connections/test_url.py::test_url_init PASSED                                                                     [ 48%]
tests/unit_tests/connections/unset/test_async_http.py::test_unset PASSED                                                           [ 48%]
tests/unit_tests/connections/unset/test_async_ws.py::test_unset PASSED                                                             [ 48%]
tests/unit_tests/connections/unset/test_blocking_http.py::test_unset PASSED                                                        [ 49%]
tests/unit_tests/connections/unset/test_blocking_ws.py::test_unset PASSED                                                          [ 49%]
tests/unit_tests/connections/update/test_async_http.py::test_update_string PASSED                                                  [ 49%]
tests/unit_tests/connections/update/test_async_http.py::test_update_string_with_data PASSED                                        [ 50%]
tests/unit_tests/connections/update/test_async_http.py::test_update_record_id PASSED                                               [ 50%]
tests/unit_tests/connections/update/test_async_http.py::test_update_record_id_with_data PASSED                                     [ 50%]
tests/unit_tests/connections/update/test_async_http.py::test_update_table PASSED                                                   [ 50%]
tests/unit_tests/connections/update/test_async_http.py::test_update_table_with_data PASSED                                         [ 51%]
tests/unit_tests/connections/update/test_async_ws.py::test_update_string PASSED                                                    [ 51%]
tests/unit_tests/connections/update/test_async_ws.py::test_update_string_with_data PASSED                                          [ 51%]
tests/unit_tests/connections/update/test_async_ws.py::test_update_record_id PASSED                                                 [ 52%]
tests/unit_tests/connections/update/test_async_ws.py::test_update_record_id_with_data PASSED                                       [ 52%]
tests/unit_tests/connections/update/test_async_ws.py::test_update_table PASSED                                                     [ 52%]
tests/unit_tests/connections/update/test_async_ws.py::test_update_table_with_data PASSED                                           [ 53%]
tests/unit_tests/connections/update/test_blocking_http.py::test_update_string PASSED                                               [ 53%]
tests/unit_tests/connections/update/test_blocking_http.py::test_update_string_with_data PASSED                                     [ 53%]
tests/unit_tests/connections/update/test_blocking_http.py::test_update_record_id PASSED                                            [ 54%]
tests/unit_tests/connections/update/test_blocking_http.py::test_update_record_id_with_data PASSED                                  [ 54%]
tests/unit_tests/connections/update/test_blocking_http.py::test_update_table PASSED                                                [ 54%]
tests/unit_tests/connections/update/test_blocking_http.py::test_update_table_with_data PASSED                                      [ 55%]
tests/unit_tests/connections/update/test_blocking_ws.py::test_update_string PASSED                                                 [ 55%]
tests/unit_tests/connections/update/test_blocking_ws.py::test_update_string_with_data PASSED                                       [ 55%]
tests/unit_tests/connections/update/test_blocking_ws.py::test_update_record_id PASSED                                              [ 56%]
tests/unit_tests/connections/update/test_blocking_ws.py::test_update_record_id_with_data PASSED                                    [ 56%]
tests/unit_tests/connections/update/test_blocking_ws.py::test_update_table PASSED                                                  [ 56%]
tests/unit_tests/connections/update/test_blocking_ws.py::test_update_table_with_data PASSED                                        [ 57%]
tests/unit_tests/connections/upsert/test_async_http.py::test_upsert_string PASSED                                                  [ 57%]
tests/unit_tests/connections/upsert/test_async_http.py::test_upsert_string_with_data PASSED                                        [ 57%]
tests/unit_tests/connections/upsert/test_async_http.py::test_upsert_record_id PASSED                                               [ 58%]
tests/unit_tests/connections/upsert/test_async_http.py::test_upsert_record_id_with_data PASSED                                     [ 58%]
tests/unit_tests/connections/upsert/test_async_http.py::test_upsert_table PASSED                                                   [ 58%]
tests/unit_tests/connections/upsert/test_async_http.py::test_upsert_table_with_data PASSED                                         [ 59%]
tests/unit_tests/connections/upsert/test_async_ws.py::test_upsert_string PASSED                                                    [ 59%]
tests/unit_tests/connections/upsert/test_async_ws.py::test_upsert_string_with_data PASSED                                          [ 59%]
tests/unit_tests/connections/upsert/test_async_ws.py::test_upsert_record_id PASSED                                                 [ 60%]
tests/unit_tests/connections/upsert/test_async_ws.py::test_upsert_record_id_with_data PASSED                                       [ 60%]
tests/unit_tests/connections/upsert/test_async_ws.py::test_upsert_table PASSED                                                     [ 60%]
tests/unit_tests/connections/upsert/test_async_ws.py::test_upsert_table_with_data PASSED                                           [ 61%]
tests/unit_tests/connections/upsert/test_blocking_http.py::test_upsert_string PASSED                                               [ 61%]
tests/unit_tests/connections/upsert/test_blocking_http.py::test_upsert_string_with_data PASSED                                     [ 61%]
tests/unit_tests/connections/upsert/test_blocking_http.py::test_upsert_record_id PASSED                                            [ 62%]
tests/unit_tests/connections/upsert/test_blocking_http.py::test_upsert_record_id_with_data PASSED                                  [ 62%]
tests/unit_tests/connections/upsert/test_blocking_http.py::test_upsert_table PASSED                                                [ 62%]
tests/unit_tests/connections/upsert/test_blocking_http.py::test_upsert_table_with_data PASSED                                      [ 63%]
tests/unit_tests/connections/upsert/test_blocking_ws.py::test_upsert_string PASSED                                                 [ 63%]
tests/unit_tests/connections/upsert/test_blocking_ws.py::test_upsert_string_with_data PASSED                                       [ 63%]
tests/unit_tests/connections/upsert/test_blocking_ws.py::test_upsert_record_id PASSED                                              [ 64%]
tests/unit_tests/connections/upsert/test_blocking_ws.py::test_upsert_record_id_with_data PASSED                                    [ 64%]
tests/unit_tests/connections/upsert/test_blocking_ws.py::test_upsert_table PASSED                                                  [ 64%]
tests/unit_tests/connections/upsert/test_blocking_ws.py::test_upsert_table_with_data PASSED                                        [ 65%]
tests/unit_tests/connections/version/test_async_http.py::test_version PASSED                                                       [ 65%]
tests/unit_tests/connections/version/test_async_ws.py::test_version PASSED                                                         [ 65%]
tests/unit_tests/connections/version/test_blocking_http.py::test_version PASSED                                                    [ 66%]
tests/unit_tests/connections/version/test_blocking_ws.py::test_version PASSED                                                      [ 66%]
tests/unit_tests/data_types/test_cbor_property.py::test_cbor_roundtrip_int PASSED                                                  [ 66%]
tests/unit_tests/data_types/test_cbor_property.py::test_cbor_roundtrip_float PASSED                                                [ 66%]
tests/unit_tests/data_types/test_cbor_property.py::test_cbor_roundtrip_str PASSED                                                  [ 67%]
tests/unit_tests/data_types/test_cbor_property.py::test_cbor_roundtrip_bool PASSED                                                 [ 67%]
tests/unit_tests/data_types/test_cbor_property.py::test_cbor_roundtrip_none PASSED                                                 [ 67%]
tests/unit_tests/data_types/test_cbor_property.py::test_cbor_roundtrip_list PASSED                                                 [ 68%]
tests/unit_tests/data_types/test_cbor_property.py::test_cbor_roundtrip_dict PASSED                                                 [ 68%]
tests/unit_tests/data_types/test_cbor_property.py::test_cbor_roundtrip_nested PASSED                                               [ 68%]
tests/unit_tests/data_types/test_cbor_property.py::test_cbor_roundtrip_empty_list PASSED                                           [ 69%]
tests/unit_tests/data_types/test_cbor_property.py::test_cbor_roundtrip_empty_dict PASSED                                           [ 69%]
tests/unit_tests/data_types/test_datetimes.py::test_native_datetime PASSED                                                         [ 69%]
tests/unit_tests/data_types/test_datetimes.py::test_datetime_iso_format PASSED                                                     [ 70%]
tests/unit_tests/data_types/test_decimal.py::test_dec_literal PASSED                                                               [ 70%]
tests/unit_tests/data_types/test_decimal.py::test_float_parameter PASSED                                                           [ 70%]
tests/unit_tests/data_types/test_duration.py::test_duration_init PASSED                                                            [ 71%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_int PASSED                                                       [ 71%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_str_seconds PASSED                                               [ 71%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_str_minutes PASSED                                               [ 72%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_str_hours PASSED                                                 [ 72%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_str_days PASSED                                                  [ 72%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_str_weeks PASSED                                                 [ 73%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_str_milliseconds PASSED                                          [ 73%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_str_microseconds PASSED                                          [ 73%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_str_nanoseconds PASSED                                           [ 74%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_invalid_unit PASSED                                              [ 74%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_invalid_type PASSED                                              [ 74%]
tests/unit_tests/data_types/test_duration.py::test_duration_parse_with_nanoseconds PASSED                                          [ 75%]
tests/unit_tests/data_types/test_duration.py::test_duration_get_seconds_and_nano PASSED                                            [ 75%]
tests/unit_tests/data_types/test_duration.py::test_duration_equality PASSED                                                        [ 75%]
tests/unit_tests/data_types/test_duration.py::test_duration_properties PASSED                                                      [ 76%]
tests/unit_tests/data_types/test_duration.py::test_duration_to_string PASSED                                                       [ 76%]
tests/unit_tests/data_types/test_duration.py::test_duration_to_compact PASSED                                                      [ 76%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_point_class_methods PASSED                                             [ 77%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_point_db_insert_and_retrieve PASSED                                    [ 77%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_point_db_insert_and_retrieve_as_python_object PASSED                   [ 77%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_point_mixed_coordinates PASSED                                         [ 78%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_line_class_methods PASSED                                              [ 78%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_line_db_insert_and_retrieve PASSED                                     [ 78%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_line_db_insert_and_retrieve_as_python_object PASSED                    [ 79%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_polygon_class_methods PASSED                                           [ 79%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_polygon_db_insert_and_retrieve PASSED                                  [ 79%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_multipoint_class_methods PASSED                                        [ 80%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_multipoint_db_insert_and_retrieve PASSED                               [ 80%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_multipoint_db_insert_and_retrieve_as_python_object PASSED              [ 80%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_multiline_class_methods PASSED                                         [ 81%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_multiline_db_insert_and_retrieve PASSED                                [ 81%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_multiline_db_insert_and_retrieve_as_python_object PASSED               [ 81%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_multipolygon_class_methods PASSED                                      [ 82%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_multipolygon_db_insert_and_retrieve PASSED                             [ 82%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_collection_class_methods PASSED                                        [ 82%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_collection_db_insert_and_retrieve PASSED                               [ 83%]
tests/unit_tests/data_types/test_geometry.py::test_geometry_collection_db_insert_and_retrieve_as_python_object PASSED              [ 83%]
tests/unit_tests/data_types/test_none.py::test_none PASSED                                                                         [ 83%]
tests/unit_tests/data_types/test_none.py::test_none_with_query PASSED                                                              [ 83%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_use_pass PASSED                                                 [ 84%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_use_fail PASSED                                                 [ 84%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_info_pass PASSED                                                [ 84%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_version_pass PASSED                                             [ 85%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_signin_pass_root PASSED                                         [ 85%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_signin_pass_root_with_none PASSED                               [ 85%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_signin_pass_account PASSED                                      [ 86%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_authenticate_pass PASSED                                        [ 86%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_invalidate_pass PASSED                                          [ 86%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_let_pass PASSED                                                 [ 87%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_unset_pass PASSED                                               [ 87%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_live_pass PASSED                                                [ 87%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_kill_pass PASSED                                                [ 88%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_query_pass PASSED                                               [ 88%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_create_pass_params PASSED                                       [ 88%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_insert_pass_dict PASSED                                         [ 89%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_insert_pass_list PASSED                                         [ 89%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_patch_pass PASSED                                               [ 89%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_select_pass PASSED                                              [ 90%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_update_pass PASSED                                              [ 90%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_upsert_pass PASSED                                              [ 90%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_merge_pass PASSED                                               [ 91%]
tests/unit_tests/request_message/descriptors/test_cbor_ws.py::test_delete_pass PASSED                                              [ 91%]
tests/unit_tests/request_message/test_adapter.py::test_sql_adapter_from_docstring PASSED                                           [ 91%]
tests/unit_tests/request_message/test_adapter.py::test_sql_adapter_from_list PASSED                                                [ 92%]
tests/unit_tests/request_message/test_adapter.py::test_sql_adapter_from_file PASSED                                                [ 92%]
tests/unit_tests/request_message/test_request_message.py::test_request_message_init PASSED                                         [ 92%]
tests/unit_tests/test_deprecated_cbor_modules.py::test_deprecated_decoder_module PASSED                                            [ 93%]
tests/unit_tests/test_deprecated_cbor_modules.py::test_deprecated_encoder_module PASSED                                            [ 93%]
tests/unit_tests/test_deprecated_cbor_modules.py::test_deprecated_types_module PASSED                                              [ 93%]
tests/unit_tests/test_errors.py::test_surrealdb_method_error_init PASSED                                                           [ 94%]
tests/unit_tests/test_errors.py::test_surrealdb_method_error_str PASSED                                                            [ 94%]
tests/unit_tests/test_errors.py::test_surrealdb_method_error_inheritance PASSED                                                    [ 94%]
tests/unit_tests/test_init_functions.py::test_surreal_http PASSED                                                                  [ 95%]
tests/unit_tests/test_init_functions.py::test_surreal_https PASSED                                                                 [ 95%]
tests/unit_tests/test_init_functions.py::test_surreal_ws PASSED                                                                    [ 95%]
tests/unit_tests/test_init_functions.py::test_surreal_wss PASSED                                                                   [ 96%]
tests/unit_tests/test_init_functions.py::test_surreal_invalid_protocol PASSED                                                      [ 96%]
tests/unit_tests/test_init_functions.py::test_async_surreal_http PASSED                                                            [ 96%]
tests/unit_tests/test_init_functions.py::test_async_surreal_https PASSED                                                           [ 97%]
tests/unit_tests/test_init_functions.py::test_async_surreal_ws PASSED                                                              [ 97%]
tests/unit_tests/test_init_functions.py::test_async_surreal_wss PASSED                                                             [ 97%]
tests/unit_tests/test_init_functions.py::test_async_surreal_invalid_protocol PASSED                                                [ 98%]
tests/unit_tests/test_init_functions.py::test_blocking_meta_class_positional_arg PASSED                                            [ 98%]
tests/unit_tests/test_init_functions.py::test_blocking_meta_class_keyword_arg PASSED                                               [ 98%]
tests/unit_tests/test_init_functions.py::test_blocking_meta_class_missing_url PASSED                                               [ 99%]
tests/unit_tests/test_init_functions.py::test_async_meta_class_positional_arg PASSED                                               [ 99%]
tests/unit_tests/test_init_functions.py::test_async_meta_class_keyword_arg PASSED                                                  [ 99%]
tests/unit_tests/test_init_functions.py::test_async_meta_class_missing_url PASSED                                                  [100%]

============================================================ warnings summary ============================================================
src/surrealdb/cbor2/decoder.py:7
  /Users/stu/dev/ssttuu/surrealdb.py/src/surrealdb/cbor2/decoder.py:7: UserWarning: The cbor.decoder module has been deprecated. Instead import everything directly from cbor2.
    warn(

src/surrealdb/cbor2/encoder.py:8
  /Users/stu/dev/ssttuu/surrealdb.py/src/surrealdb/cbor2/encoder.py:8: UserWarning: The cbor2.encoder module has been deprecated. Instead import everything directly from cbor2.
    warn(

src/surrealdb/cbor2/types.py:15
  /Users/stu/dev/ssttuu/surrealdb.py/src/surrealdb/cbor2/types.py:15: UserWarning: The cbor2.types module has been deprecated. Instead import everything directly from cbor2.
    warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================= 305 passed, 1 xfailed, 3 warnings in 73.57s (0:01:13) ==========================================
```

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
