### PR TITLE
Disallow unwraps in production code.

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -6,3 +6,5 @@ disallowed-methods = [
   { path = "rust_decimal::Decimal::from_str", reason = "Must use a normalized method to ensure decimal values are represented consistently.", allow-invalid = true },
   { path = "rust_decimal::Decimal::parse", reason = "Must use a normalized method to ensure decimal values are represented consistently.", allow-invalid = true },
 ]
+
+allow-unwrap-in-tests = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -452,6 +452,10 @@ lossy_float_literal = "warn"
 # Warning or denying this lint can cause unexpected errors.
 unused_async = "allow"
 
+# Checks for `.unwrap()` or `.unwrap_err()` calls on Results and `.unwrap()` call on `Option`s.
+# https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_used
+unwrap_used = "warn"
+
 # Profiles
 [profile.release]
 codegen-units = 1

--- a/crates/core/src/catalog/schema/api.rs
+++ b/crates/core/src/catalog/schema/api.rs
@@ -242,7 +242,8 @@ impl MiddlewareDefinition {
 				.clone()
 				.into_iter()
 				.map(|v| {
-					let public_val: crate::types::PublicValue = v.try_into().unwrap();
+					let public_val: crate::types::PublicValue =
+						v.try_into().expect("value conversion should succeed");
 					crate::sql::Expr::from_public_value(public_val)
 				})
 				.collect(),

--- a/crates/core/src/catalog/schema/param.rs
+++ b/crates/core/src/catalog/schema/param.rs
@@ -24,7 +24,8 @@ impl ParamDefinition {
 			kind: DefineKind::Default,
 			name: self.name.clone(),
 			value: {
-				let public_val: crate::types::PublicValue = self.value.clone().try_into().unwrap();
+				let public_val: crate::types::PublicValue =
+					self.value.clone().try_into().expect("value conversion should succeed");
 				crate::sql::Expr::from_public_value(public_val)
 			},
 			comment: self

--- a/crates/core/src/cf/reader.rs
+++ b/crates/core/src/cf/reader.rs
@@ -87,7 +87,7 @@ pub async fn read(
 	// Collect all mutations together
 	if !buf.is_empty() {
 		let db_mut = DatabaseMutation(buf);
-		res.push(ChangeSet(vs.unwrap(), db_mut));
+		res.push(ChangeSet(vs.expect("versionstamp should be set when mutations exist"), db_mut));
 	}
 	// Return the results
 	Ok(res)

--- a/crates/core/src/dbs/file.rs
+++ b/crates/core/src/dbs/file.rs
@@ -272,9 +272,8 @@ impl FileReader {
 	fn read_usize<R: Read>(reader: &mut R) -> Result<usize, io::Error> {
 		let mut buf = vec![0u8; FileCollector::USIZE_SIZE];
 		reader.read_exact(&mut buf)?;
-		// Safe to call unwrap because we know the slice length matches the expected
-		// length
-		let u = usize::from_be_bytes(buf.try_into().unwrap());
+		// Safe because we know the slice length matches the expected length
+		let u = usize::from_be_bytes(buf.try_into().expect("buffer size matches usize"));
 		Ok(u)
 	}
 

--- a/crates/core/src/doc/table.rs
+++ b/crates/core/src/doc/table.rs
@@ -1000,7 +1000,9 @@ impl Document {
 					if !all_metadata_deltas.is_empty() || !all_set_ops.is_empty() {
 						// Use current_group_ids if available, otherwise use
 						// initial_group_ids
-						let group_ids = current_group_ids.or(initial_group_ids).unwrap();
+						let group_ids = current_group_ids
+							.or(initial_group_ids)
+							.expect("group_ids should be set for grouping");
 						let rid = RecordId {
 							table: ft.name.clone(),
 							key: RecordIdKey::Array(Array(group_ids)),

--- a/crates/core/src/expr/block.rs
+++ b/crates/core/src/expr/block.rs
@@ -70,7 +70,18 @@ impl Block {
 		for v in self.iter() {
 			match v {
 				Expr::Let(x) => res = x.compute(stk, &mut ctx, opt, doc).await?,
-				v => res = stk.run(|stk| v.compute(stk, ctx.as_ref().unwrap(), opt, doc)).await?,
+				v => {
+					res = stk
+						.run(|stk| {
+							v.compute(
+								stk,
+								ctx.as_ref().expect("context should be initialized"),
+								opt,
+								doc,
+							)
+						})
+						.await?
+				}
 			}
 		}
 		// Return nothing

--- a/crates/core/src/expr/bytesize.rs
+++ b/crates/core/src/expr/bytesize.rs
@@ -252,6 +252,7 @@ impl InfoStructure for Bytesize {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
 	use super::Bytesize;
 

--- a/crates/core/src/expr/data.rs
+++ b/crates/core/src/expr/data.rs
@@ -97,7 +97,9 @@ impl Display for Data {
 			Self::ValuesExpression(v) => write!(
 				f,
 				"({}) VALUES {}",
-				Fmt::comma_separated(v.first().unwrap().iter().map(|(v, _)| v)),
+				Fmt::comma_separated(
+					v.first().expect("values expression is non-empty").iter().map(|(v, _)| v)
+				),
 				Fmt::comma_separated(v.iter().map(|v| Fmt::new(v, |v, f| write!(
 					f,
 					"({})",

--- a/crates/core/src/expr/decimal.rs
+++ b/crates/core/src/expr/decimal.rs
@@ -386,7 +386,8 @@ impl DecimalLexEncoder {
 		// The function returns an error when the number has more significant bits then can fit
 		// into the amount of bits of a u128 which seems impossible for a function which takes a
 		// u128.
-		let abs = U128::from_u128(mantissa.unsigned_abs()).unwrap();
+		let abs =
+			U128::from_u128(mantissa.unsigned_abs()).expect("u128 conversion should not fail");
 		D128::from_parts(abs, -(scale as i32), sign, Context::default())
 	}
 

--- a/crates/core/src/expr/field.rs
+++ b/crates/core/src/expr/field.rs
@@ -195,7 +195,7 @@ impl Fields {
 							}
 							// Assign each fetched yield to the output
 							for (p, x) in res {
-								match p.last().unwrap().alias() {
+								match p.last().expect("idiom is non-empty").alias() {
 									// This is an alias expression part
 									Some(a) => {
 										if let Some(i) = alias {

--- a/crates/core/src/expr/idiom/mod.rs
+++ b/crates/core/src/expr/idiom/mod.rs
@@ -106,7 +106,9 @@ impl Idiom {
 
 		let mut iter = self.0.iter();
 		match iter.next() {
-			Some(Part::Field(v)) => write!(&mut s, "{}", EscapeKwFreeIdent(v)).unwrap(),
+			Some(Part::Field(v)) => {
+				write!(&mut s, "{}", EscapeKwFreeIdent(v)).expect("writing to string")
+			}
 			Some(x) => s.push_str(&x.to_raw_string()),
 			None => {}
 		};

--- a/crates/core/src/expr/model.rs
+++ b/crates/core/src/expr/model.rs
@@ -107,7 +107,7 @@ impl Model {
 		}
 
 		// Take the first and only specified argument
-		let argument = args.pop().unwrap();
+		let argument = args.pop().expect("single argument validated above");
 		match argument {
 			// Perform bufferered compute
 			Value::Object(v) => {
@@ -136,7 +136,7 @@ impl Model {
 					})
 				})
 				.await
-				.unwrap()
+				.map_err(|e| anyhow::anyhow!("ML task failed: {}", e))?
 				.map_err(ControlFlow::from)?;
 				// Convert the output to a value
 				Ok(outcome.into_iter().map(|x| Value::Number(Number::Float(x as f64))).collect())
@@ -168,7 +168,7 @@ impl Model {
 					})
 				})
 				.await
-				.unwrap()
+				.map_err(|e| anyhow::anyhow!("ML task failed: {}", e))?
 				.map_err(ControlFlow::from)?;
 				// Convert the output to a value
 				Ok(outcome.into_iter().map(|x| Value::Number(Number::Float(x as f64))).collect())
@@ -202,7 +202,7 @@ impl Model {
 					})
 				})
 				.await
-				.unwrap()
+				.map_err(|e| anyhow::anyhow!("ML task failed: {}", e))?
 				.map_err(ControlFlow::from)?;
 				// Convert the output to a value
 				Ok(outcome.into_iter().map(|x| Value::Number(Number::Float(x as f64))).collect())

--- a/crates/core/src/expr/statements/access.rs
+++ b/crates/core/src/expr/statements/access.rs
@@ -197,18 +197,17 @@ pub async fn create_grant(
 			let ns = ctx.expect_ns_id(opt).await?;
 			txn.get_ns_access(ns, &access).await?.ok_or_else(|| Error::AccessNsNotFound {
 				ac: access.to_string(),
-				// The namespace is expected above so this unwrap should not be able to trigger
-				ns: opt.ns.as_deref().unwrap().to_owned(),
+				// The namespace is expected above
+				ns: opt.ns.as_deref().expect("namespace validated by expect_ns_id").to_owned(),
 			})?
 		}
 		Base::Db => {
 			let (ns, db) = ctx.expect_ns_db_ids(opt).await?;
 			txn.get_db_access(ns, db, &access).await?.ok_or_else(|| Error::AccessDbNotFound {
 				ac: access.to_string(),
-				// The namespace and database is expected above so these unwraps should not be able
-				// to trigger
-				ns: opt.ns.as_deref().unwrap().to_owned(),
-				db: opt.db.as_deref().unwrap().to_owned(),
+				// The namespace and database is expected above
+				ns: opt.ns.as_deref().expect("namespace validated by expect_ns_db_ids").to_owned(),
+				db: opt.db.as_deref().expect("database validated by expect_ns_db_ids").to_owned(),
 			})?
 		}
 	};
@@ -315,9 +314,11 @@ pub async fn create_grant(
 							txn.get_ns_user(ns_id, user).await?.ok_or_else(|| {
 								Error::UserNsNotFound {
 									name: user.to_string(),
-									// We just retrieved the ns_id above so we should have a
-									// namespace.
-									ns: opt.ns().unwrap().to_owned(),
+									// We just retrieved the ns_id above
+									ns: opt
+										.ns()
+										.expect("namespace validated by get_ns_id")
+										.to_owned(),
 								}
 							})?
 						}
@@ -326,10 +327,15 @@ pub async fn create_grant(
 							txn.get_db_user(ns_id, db_id, user).await?.ok_or_else(|| {
 								Error::UserDbNotFound {
 									name: user.to_string(),
-									// We just retrieved the ns_id and db_id above so we should have
-									// a namespace and database.
-									ns: opt.ns().unwrap().to_owned(),
-									db: opt.db().unwrap().to_owned(),
+									// We just retrieved the ns_id and db_id above
+									ns: opt
+										.ns()
+										.expect("namespace validated by expect_ns_db_ids")
+										.to_owned(),
+									db: opt
+										.db()
+										.expect("database validated by expect_ns_db_ids")
+										.to_owned(),
 								}
 							})?
 						}
@@ -467,21 +473,28 @@ async fn compute_show(
 			if txn.get_ns_access(ns, &stmt.ac).await?.is_none() {
 				bail!(Error::AccessNsNotFound {
 					ac: stmt.ac.to_string(),
-					// We expected a namespace above so this unwrap shouldn't be able to trigger.
-					ns: opt.ns.as_deref().unwrap().to_owned(),
+					// We expected a namespace above
+					ns: opt.ns.as_deref().expect("namespace validated by expect_ns_id").to_owned(),
 				});
 			}
 		}
 		Base::Db => {
 			let (ns, db) = ctx.expect_ns_db_ids(opt).await?;
-			// We expected a namespace above so this unwrap shouldn't be able to trigger.
+			// We expected a namespace above
 			if txn.get_db_access(ns, db, &stmt.ac).await?.is_none() {
 				bail!(Error::AccessDbNotFound {
 					ac: stmt.ac.to_string(),
-					// We expected a namespace and database above so these unwrap shouldn't be able
-					// to trigger.
-					ns: opt.ns.as_deref().unwrap().to_owned(),
-					db: opt.db.as_deref().unwrap().to_owned(),
+					// We expected a namespace and database above
+					ns: opt
+						.ns
+						.as_deref()
+						.expect("namespace validated by expect_ns_db_ids")
+						.to_owned(),
+					db: opt
+						.db
+						.as_deref()
+						.expect("database validated by expect_ns_db_ids")
+						.to_owned(),
 				});
 			}
 		}

--- a/crates/core/src/expr/statements/define/user.rs
+++ b/crates/core/src/expr/statements/define/user.rs
@@ -69,7 +69,7 @@ impl DefineUserStatement {
 			name: Expr::Idiom(Idiom::field(user)),
 			hash: Argon2::default()
 				.hash_password(pass.as_ref(), &SaltString::generate(&mut OsRng))
-				.unwrap()
+				.expect("password hashing should not fail")
 				.to_string(),
 			code: rand::thread_rng()
 				.sample_iter(&Alphanumeric)

--- a/crates/core/src/expr/statements/foreach.rs
+++ b/crates/core/src/expr/statements/foreach.rs
@@ -82,7 +82,17 @@ impl ForeachStatement {
 				// Compute each block entry
 				let res = match v {
 					Expr::Let(x) => x.compute(stk, &mut ctx, opt, doc).await,
-					v => stk.run(|stk| v.compute(stk, ctx.as_ref().unwrap(), opt, doc)).await,
+					v => {
+						stk.run(|stk| {
+							v.compute(
+								stk,
+								ctx.as_ref().expect("context should be initialized"),
+								opt,
+								doc,
+							)
+						})
+						.await
+					}
 				};
 				// Catch any special errors
 				match res {

--- a/crates/core/src/expr/statements/ifelse.rs
+++ b/crates/core/src/expr/statements/ifelse.rs
@@ -135,6 +135,7 @@ impl Display for IfelseStatement {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
 	use crate::syn;
 

--- a/crates/core/src/expr/statements/live.rs
+++ b/crates/core/src/expr/statements/live.rs
@@ -134,6 +134,7 @@ impl fmt::Display for LiveStatement {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
 	use anyhow::Result;
 

--- a/crates/core/src/expr/statements/relate.rs
+++ b/crates/core/src/expr/statements/relate.rs
@@ -159,7 +159,7 @@ impl RelateStatement {
 			// This is a single record result
 			Value::Array(mut a) if self.only => match a.len() {
 				// There was exactly one result
-				1 => Ok(a.0.pop().unwrap()),
+				1 => Ok(a.0.pop().expect("array has exactly one element")),
 				// There were no results
 				_ => Err(anyhow::Error::new(Error::SingleOnlyOutput)),
 			},

--- a/crates/core/src/expr/statements/select.rs
+++ b/crates/core/src/expr/statements/select.rs
@@ -134,7 +134,7 @@ impl SelectStatement {
 						Ok(Value::None)
 					} else {
 						ensure!(array.len() == 1, Error::SingleOnlyOutput);
-						Ok(array.0.pop().unwrap())
+						Ok(array.0.pop().expect("array has exactly one element"))
 					}
 				}
 				x => Ok(x),

--- a/crates/core/src/expr/statements/set.rs
+++ b/crates/core/src/expr/statements/set.rs
@@ -50,7 +50,16 @@ impl SetStatement {
 			})));
 		}
 
-		let result = stk.run(|stk| self.what.compute(stk, ctx.as_ref().unwrap(), opt, doc)).await?;
+		let result = stk
+			.run(|stk| {
+				self.what.compute(
+					stk,
+					ctx.as_ref().expect("context should be initialized"),
+					opt,
+					doc,
+				)
+			})
+			.await?;
 		let result = match &self.kind {
 			Some(kind) => result
 				.coerce_to_kind(kind)
@@ -62,7 +71,7 @@ impl SetStatement {
 			None => result,
 		};
 
-		let mut c = MutableContext::unfreeze(ctx.take().unwrap())?;
+		let mut c = MutableContext::unfreeze(ctx.take().expect("context should be initialized"))?;
 		c.add_value(self.name.clone(), result.into());
 		*ctx = Some(c.freeze());
 		Ok(Value::None)

--- a/crates/core/src/expr/statements/sleep.rs
+++ b/crates/core/src/expr/statements/sleep.rs
@@ -46,6 +46,7 @@ impl fmt::Display for SleepStatement {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
 	use std::time::{self, SystemTime};
 

--- a/crates/core/src/fnc/array.rs
+++ b/crates/core/src/fnc/array.rs
@@ -223,8 +223,8 @@ pub fn fill(
 
 		TypedRange::from_range(start..end)
 	} else if range_start.is_range() {
-		// Condition checked above, unwrap cannot trigger.
-		let range = range_start.into_range().unwrap();
+		// Condition checked above, cannot fail
+		let range = range_start.into_range().expect("is_range() check passed");
 		range.coerce_to_typed::<i64>().map_err(|e| Error::InvalidArguments {
 			name: String::from("array::fill"),
 			message: format!("Argument 1 was the wrong type. {e}"),
@@ -627,8 +627,8 @@ pub fn range((start_range, Optional(end)): (Value, Optional<i64>)) -> Result<Val
 			end: Bound::Excluded(end),
 		}
 	} else if start_range.is_range() {
-		// Condition checked above, unwrap cannot trigger.
-		let range = start_range.into_range().unwrap();
+		// Condition checked above, cannot fail
+		let range = start_range.into_range().expect("is_range() check passed");
 		range.coerce_to_typed::<i64>().map_err(|e| Error::InvalidArguments {
 			name: String::from("array::range"),
 			message: format!("Argument 1 was the wrong type. {e}"),
@@ -756,8 +756,8 @@ pub fn slice(
 			end: Bound::Excluded(end),
 		}
 	} else if range_start.is_range() {
-		// Condition checked above, unwrap cannot trigger.
-		let range = range_start.into_range().unwrap();
+		// Condition checked above, cannot fail
+		let range = range_start.into_range().expect("is_range() check passed");
 		range.coerce_to_typed::<i64>().map_err(|e| Error::InvalidArguments {
 			name: String::from("array::range"),
 			message: format!("Argument 1 was the wrong type. {e}"),

--- a/crates/core/src/fnc/crypto.rs
+++ b/crates/core/src/fnc/crypto.rs
@@ -112,7 +112,10 @@ pub mod argon2 {
 	pub fn r#gen((pass,): (String,)) -> Result<Value> {
 		let algo = Argon2::default();
 		let salt = SaltString::generate(&mut OsRng);
-		let hash = algo.hash_password(pass.as_ref(), &salt).unwrap().to_string();
+		let hash = algo
+			.hash_password(pass.as_ref(), &salt)
+			.map_err(|e| anyhow::anyhow!("Failed to hash password: {}", e))?
+			.to_string();
 		Ok(hash.into())
 	}
 }
@@ -145,7 +148,8 @@ pub mod bcrypt {
 	}
 
 	pub fn r#gen((pass,): (String,)) -> Result<Value> {
-		let hash = bcrypt::hash(pass, bcrypt::DEFAULT_COST).unwrap();
+		let hash = bcrypt::hash(pass, bcrypt::DEFAULT_COST)
+			.map_err(|e| anyhow::anyhow!("Failed to hash password: {}", e))?;
 		Ok(hash.into())
 	}
 }
@@ -179,7 +183,10 @@ pub mod pbkdf2 {
 
 	pub fn r#gen((pass,): (String,)) -> Result<Value> {
 		let salt = SaltString::generate(&mut OsRng);
-		let hash = Pbkdf2.hash_password(pass.as_ref(), &salt).unwrap().to_string();
+		let hash = Pbkdf2
+			.hash_password(pass.as_ref(), &salt)
+			.map_err(|e| anyhow::anyhow!("Failed to hash password: {}", e))?
+			.to_string();
 		Ok(hash.into())
 	}
 }
@@ -213,7 +220,10 @@ pub mod scrypt {
 
 	pub fn r#gen((pass,): (String,)) -> Result<Value> {
 		let salt = SaltString::generate(&mut OsRng);
-		let hash = Scrypt.hash_password(pass.as_ref(), &salt).unwrap().to_string();
+		let hash = Scrypt
+			.hash_password(pass.as_ref(), &salt)
+			.map_err(|e| anyhow::anyhow!("Failed to hash password: {}", e))?
+			.to_string();
 		Ok(hash.into())
 	}
 }

--- a/crates/core/src/fnc/rand.rs
+++ b/crates/core/src/fnc/rand.rs
@@ -26,7 +26,7 @@ pub fn r#enum(Any(mut args): Any) -> Result<Value> {
 			Value::Array(v) => v.into_iter().choose(&mut rand::thread_rng()).unwrap_or(Value::None),
 			v => v,
 		},
-		_ => args.into_iter().choose(&mut rand::thread_rng()).unwrap(),
+		_ => args.into_iter().choose(&mut rand::thread_rng()).expect("non-empty args"),
 	})
 }
 

--- a/crates/core/src/fnc/script/fetch/body.rs
+++ b/crates/core/src/fnc/script/fetch/body.rs
@@ -134,10 +134,10 @@ impl<'js> FromJs<'js> for Body {
 	fn from_js(ctx: &Ctx<'js>, value: Value<'js>) -> Result<Self> {
 		let object = match value.type_of() {
 			Type::String => {
-				let string = value.into_string().unwrap().to_string()?;
+				let string = value.into_string().expect("type checked as string").to_string()?;
 				return Ok(Body::buffer(BodyKind::String, string));
 			}
-			Type::Object => value.as_object().unwrap(),
+			Type::Object => value.as_object().expect("type checked as object"),
 			x => {
 				return Err(Error::FromJs {
 					from: x.as_str(),

--- a/crates/core/src/fnc/script/fetch/classes/headers.rs
+++ b/crates/core/src/fnc/script/fetch/classes/headers.rs
@@ -58,13 +58,13 @@ impl Headers {
 		for (k, v) in self.inner.iter() {
 			let k = k.as_str();
 			if Some(k) == res.last().map(|x| x.0.0.as_str()) {
-				let ent = res.last_mut().unwrap();
+				let ent = res.last_mut().expect("last element exists");
 				ent.0.1.push_str(", ");
 				// Header value came from a string, so it should also be able to be cast back
 				// to a string
-				ent.0.1.push_str(v.to_str().unwrap());
+				ent.0.1.push_str(v.to_str().expect("valid header value"));
 			} else {
-				res.push(List((k.to_owned(), v.to_str().unwrap().to_owned())));
+				res.push(List((k.to_owned(), v.to_str().expect("valid header value").to_owned())));
 			}
 		}
 
@@ -86,7 +86,7 @@ impl Headers {
 			if idx != 0 {
 				res.push_str(", ");
 			}
-			res.push_str(v.to_str().unwrap());
+			res.push_str(v.to_str().expect("valid header value"));
 		}
 
 		if res.is_empty() {
@@ -99,8 +99,12 @@ impl Headers {
 	#[qjs(rename = "getSetCookie")]
 	pub fn get_set_cookie(&self) -> Vec<String> {
 		// This should always be a correct cookie;
-		let key = HeaderName::from_str("set-cookie").unwrap();
-		self.inner.get_all(key).iter().map(|x| x.to_str().unwrap().to_owned()).collect()
+		let key = HeaderName::from_str("set-cookie").expect("valid header name");
+		self.inner
+			.get_all(key)
+			.iter()
+			.map(|x| x.to_str().expect("valid header value").to_owned())
+			.collect()
 	}
 
 	// Checks to see if the header set contains a header
@@ -140,12 +144,12 @@ impl Headers {
 		let mut pref = None;
 		for (k, v) in self.inner.iter() {
 			if Some(k) == pref {
-				let ent = res.last_mut().unwrap();
+				let ent = res.last_mut().expect("last element exists");
 				ent.push_str(", ");
-				ent.push_str(v.to_str().unwrap())
+				ent.push_str(v.to_str().expect("valid header value"))
 			} else {
 				pref = Some(k);
-				res.push(v.to_str().unwrap().to_owned());
+				res.push(v.to_str().expect("valid header value").to_owned());
 			}
 		}
 

--- a/crates/core/src/fnc/script/from.rs
+++ b/crates/core/src/fnc/script/from.rs
@@ -8,7 +8,7 @@ use crate::val::{Array, Bytes, Datetime, Geometry, Object, RecordIdKey, Value};
 
 fn check_nul(s: &str) -> Result<(), Error> {
 	if s.contains('\0') {
-		Err(Error::InvalidString(std::ffi::CString::new(s).unwrap_err()))
+		Err(Error::InvalidString(std::ffi::CString::new(s).expect_err("string contains nul")))
 	} else {
 		Ok(())
 	}
@@ -19,12 +19,14 @@ impl<'js> FromJs<'js> for Value {
 		match val.type_of() {
 			js::Type::Undefined => Ok(Value::None),
 			js::Type::Null => Ok(Value::Null),
-			js::Type::Bool => Ok(Value::from(val.as_bool().unwrap())),
-			js::Type::Int => Ok(Value::from(val.as_int().unwrap() as f64)),
-			js::Type::Float => Ok(Value::from(val.as_float().unwrap())),
-			js::Type::String => Ok(Value::from(val.into_string().unwrap().to_string()?)),
+			js::Type::Bool => Ok(Value::from(val.as_bool().expect("type checked as bool"))),
+			js::Type::Int => Ok(Value::from(val.as_int().expect("type checked as int") as f64)),
+			js::Type::Float => Ok(Value::from(val.as_float().expect("type checked as float"))),
+			js::Type::String => {
+				Ok(Value::from(val.into_string().expect("type checked as string").to_string()?))
+			}
 			js::Type::Array => {
-				let v = val.as_array().unwrap();
+				let v = val.as_array().expect("type checked as array");
 				let mut x = Array::with_capacity(v.len());
 				for i in v.iter() {
 					let v = i?;
@@ -45,7 +47,7 @@ impl<'js> FromJs<'js> for Value {
 			}
 			js::Type::Object | js::Type::Exception => {
 				// Extract the value as an object
-				let v = val.into_object().unwrap();
+				let v = val.into_object().expect("type checked as object");
 				// Check to see if this object is an error
 				if v.is_error() {
 					let e: String = v.get(js::atom::PredefinedAtom::Message)?;
@@ -105,7 +107,10 @@ impl<'js> FromJs<'js> for Value {
 				if (v).is_instance_of(&date) {
 					let f: js::Function = v.get("getTime")?;
 					let m: i64 = f.call((This(v),))?;
-					let d = Utc.timestamp_millis_opt(m).unwrap();
+					let d = Utc
+						.timestamp_millis_opt(m)
+						.single()
+						.ok_or_else(|| Error::new_from_js("Date", "invalid timestamp"))?;
 					return Ok(Datetime::from(d).into());
 				}
 

--- a/crates/core/src/fnc/string.rs
+++ b/crates/core/src/fnc/string.rs
@@ -165,8 +165,8 @@ pub fn slice(
 			end: Bound::Excluded(end),
 		}
 	} else if range_start.is_range() {
-		// Condition checked above, unwrap cannot trigger.
-		let range = range_start.into_range().unwrap();
+		// Condition checked above, cannot fail
+		let range = range_start.into_range().expect("is_range() check passed");
 		range.coerce_to_typed::<i64>().map_err(|e| Error::InvalidArguments {
 			name: String::from("array::slice"),
 			message: format!("Argument 1 was the wrong type. {e}"),
@@ -348,8 +348,8 @@ pub mod is {
 	use crate::syn;
 	use crate::val::{Datetime, Value};
 
-	#[rustfmt::skip] static LATITUDE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$").unwrap());
-	#[rustfmt::skip] static LONGITUDE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$").unwrap());
+	#[rustfmt::skip] static LATITUDE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$").expect("valid regex pattern"));
+	#[rustfmt::skip] static LONGITUDE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new("^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$").expect("valid regex pattern"));
 
 	pub fn alphanum((arg,): (String,)) -> Result<Value> {
 		if arg.is_empty() {

--- a/crates/core/src/fnc/time.rs
+++ b/crates/core/src/fnc/time.rs
@@ -80,24 +80,30 @@ pub fn format((val, format): (Datetime, String)) -> Result<Value> {
 
 pub fn group((val, group): (Datetime, String)) -> Result<Value> {
 	match group.as_str() {
-		"year" => Ok(Utc.with_ymd_and_hms(val.year(), 1, 1, 0, 0, 0).earliest().unwrap().into()),
-		"month" => {
-			Ok(Utc.with_ymd_and_hms(val.year(), val.month(), 1, 0, 0, 0).earliest().unwrap().into())
-		}
+		"year" => Ok(Utc
+			.with_ymd_and_hms(val.year(), 1, 1, 0, 0, 0)
+			.earliest()
+			.expect("valid datetime")
+			.into()),
+		"month" => Ok(Utc
+			.with_ymd_and_hms(val.year(), val.month(), 1, 0, 0, 0)
+			.earliest()
+			.expect("valid datetime")
+			.into()),
 		"day" => Ok(Utc
 			.with_ymd_and_hms(val.year(), val.month(), val.day(), 0, 0, 0)
 			.earliest()
-			.unwrap()
+			.expect("valid datetime")
 			.into()),
 		"hour" => Ok(Utc
 			.with_ymd_and_hms(val.year(), val.month(), val.day(), val.hour(), 0, 0)
 			.earliest()
-			.unwrap()
+			.expect("valid datetime")
 			.into()),
 		"minute" => Ok(Utc
 			.with_ymd_and_hms(val.year(), val.month(), val.day(), val.hour(), val.minute(), 0)
 			.earliest()
-			.unwrap()
+			.expect("valid datetime")
 			.into()),
 		"second" => Ok(Utc
 			.with_ymd_and_hms(
@@ -109,7 +115,7 @@ pub fn group((val, group): (Datetime, String)) -> Result<Value> {
 				val.second(),
 			)
 			.earliest()
-			.unwrap()
+			.expect("valid datetime")
 			.into()),
 		_ => Err(anyhow::Error::new(Error::InvalidArguments {
 			name: String::from("time::group"),

--- a/crates/core/src/fnc/util/string/slug.rs
+++ b/crates/core/src/fnc/util/string/slug.rs
@@ -3,8 +3,9 @@ use std::sync::LazyLock;
 use deunicode::deunicode;
 use regex::Regex;
 
-static ALLOWED: LazyLock<Regex> = LazyLock::new(|| Regex::new("[^a-z0-9-_]").unwrap());
-static HYPHENS: LazyLock<Regex> = LazyLock::new(|| Regex::new("-+").unwrap());
+static ALLOWED: LazyLock<Regex> =
+	LazyLock::new(|| Regex::new("[^a-z0-9-_]").expect("valid regex pattern"));
+static HYPHENS: LazyLock<Regex> = LazyLock::new(|| Regex::new("-+").expect("valid regex pattern"));
 
 pub fn slug<S: AsRef<str>>(s: S) -> String {
 	// Get a reference

--- a/crates/core/src/gql/tables.rs
+++ b/crates/core/src/gql/tables.rs
@@ -550,7 +550,7 @@ fn val_from_filter(
 		return Err(resolver_error("Table Filter must have one item"));
 	}
 
-	let (k, v) = filter.iter().next().unwrap();
+	let (k, v) = filter.iter().next().expect("filter has exactly one item");
 
 	match k.as_str().to_lowercase().as_str() {
 		"or" => aggregate(v, AggregateOp::Or, fds),
@@ -634,7 +634,7 @@ fn binop(field_name: &str, val: &GqlValue, fds: &[FieldDefinition]) -> Result<Ex
 
 	let lhs = Expr::Idiom(Idiom::field(field_name.to_string()));
 
-	let (k, v) = obj.iter().next().unwrap();
+	let (k, v) = obj.iter().next().expect("field filter has exactly one item");
 	let op = parse_op(k)?;
 
 	let rhs = gql_to_sql_kind(v, fd.field_kind.clone().unwrap_or_default())?;

--- a/crates/core/src/iam/jwks.rs
+++ b/crates/core/src/iam/jwks.rs
@@ -308,7 +308,7 @@ async fn fetch_jwks_from_url(cache: &Arc<RwLock<JwksCache>>, url: &str) -> Resul
 	#[cfg(not(target_family = "wasm"))]
 	let req = req.header(reqwest::header::USER_AGENT, &*crate::cnf::SURREALDB_USER_AGENT);
 	#[cfg(not(target_family = "wasm"))]
-	let res = req.timeout((*REMOTE_TIMEOUT).to_std().unwrap()).send().await?;
+	let res = req.timeout((*REMOTE_TIMEOUT).to_std().expect("valid duration")).send().await?;
 	#[cfg(target_family = "wasm")]
 	let res = req.send().await?;
 	if !res.status().is_success() {

--- a/crates/core/src/iam/signin.rs
+++ b/crates/core/src/iam/signin.rs
@@ -220,13 +220,13 @@ pub async fn db_access(
 													crate::val::convert_value_to_public_value(
 														Value::RecordId(rid.clone().into()),
 													)
-													.unwrap(),
+													.expect("record id conversion should succeed"),
 												);
 												sess.tk = Some(
 													crate::val::convert_value_to_public_value(
 														claims.clone().into_claims_object().into(),
 													)
-													.unwrap(),
+													.expect("claims conversion should succeed"),
 												);
 												sess.ip.clone_from(&session.ip);
 												sess.or.clone_from(&session.or);
@@ -276,7 +276,7 @@ pub async fn db_access(
 												crate::val::convert_value_to_public_value(
 													claims.into_claims_object().into(),
 												)
-												.unwrap(),
+												.expect("claims conversion should succeed"),
 											);
 											session.ns = Some(ns.clone());
 											session.db = Some(db.clone());
@@ -285,7 +285,7 @@ pub async fn db_access(
 												crate::val::convert_value_to_public_value(
 													Value::RecordId(rid.clone().into()),
 												)
-												.unwrap(),
+												.expect("record id conversion should succeed"),
 											);
 											session.exp =
 												iam::issue::expiration(av.session_duration)?;
@@ -401,7 +401,8 @@ pub async fn db_user(
 
 			// Set the authentication on the session
 			session.tk = Some(
-				crate::val::convert_value_to_public_value(val.into_claims_object().into()).unwrap(),
+				crate::val::convert_value_to_public_value(val.into_claims_object().into())
+					.expect("claims conversion should succeed"),
 			);
 			session.ns = Some(ns.clone());
 			session.db = Some(db.clone());
@@ -495,7 +496,8 @@ pub async fn ns_user(
 
 			// Set the authentication on the session
 			session.tk = Some(
-				crate::val::convert_value_to_public_value(val.into_claims_object().into()).unwrap(),
+				crate::val::convert_value_to_public_value(val.into_claims_object().into())
+					.expect("claims conversion should succeed"),
 			);
 			session.ns = Some(ns.clone());
 			session.exp = expiration(u.session_duration)?;
@@ -549,7 +551,8 @@ pub async fn root_user(
 
 			// Set the authentication on the session
 			session.tk = Some(
-				crate::val::convert_value_to_public_value(val.into_claims_object().into()).unwrap(),
+				crate::val::convert_value_to_public_value(val.into_claims_object().into())
+					.expect("claims conversion should succeed"),
 			);
 			session.exp = expiration(u.session_duration)?;
 			session.au = Arc::new(au);
@@ -728,7 +731,7 @@ pub async fn signin_bearer(
 		};
 		sess.tk = Some(
 			crate::val::convert_value_to_public_value(claims.clone().into_claims_object().into())
-				.unwrap(),
+				.expect("claims conversion should succeed"),
 		);
 		sess.ip.clone_from(&session.ip);
 		sess.or.clone_from(&session.or);
@@ -782,7 +785,8 @@ pub async fn signin_bearer(
 	let enc = encode(&Header::new(algorithm_to_jwt_algorithm(iss.alg)), &claims, &key);
 	// Set the authentication on the session.
 	session.tk = Some(
-		crate::val::convert_value_to_public_value(claims.into_claims_object().into()).unwrap(),
+		crate::val::convert_value_to_public_value(claims.into_claims_object().into())
+			.expect("claims conversion should succeed"),
 	);
 	session.ns.clone_from(&ns.map(|ns| ns.name.clone()));
 	session.db.clone_from(&db.map(|db| db.name.clone()));
@@ -818,8 +822,10 @@ pub async fn signin_bearer(
 					bail!(Error::InvalidAuth);
 				},
 			)));
-			session.rd =
-				Some(crate::val::convert_value_to_public_value(Value::from(rid.clone())).unwrap());
+			session.rd = Some(
+				crate::val::convert_value_to_public_value(Value::from(rid.clone()))
+					.expect("value conversion should succeed"),
+			);
 		}
 	};
 	// Return the authentication token.

--- a/crates/core/src/iam/signup.rs
+++ b/crates/core/src/iam/signup.rs
@@ -146,13 +146,13 @@ pub async fn db_access(
 				let mut sess = Session::editor().with_ns(&ns).with_db(&db);
 				sess.rd = Some(
 					crate::val::convert_value_to_public_value(Value::RecordId(rid.clone().into()))
-						.unwrap(),
+						.expect("record id conversion should succeed"),
 				);
 				sess.tk = Some(
 					crate::val::convert_value_to_public_value(
 						claims.clone().into_claims_object().into(),
 					)
-					.unwrap(),
+					.expect("claims conversion should succeed"),
 				);
 				sess.ip.clone_from(&session.ip);
 				sess.or.clone_from(&session.or);
@@ -190,14 +190,14 @@ pub async fn db_access(
 			// Set the authentication on the session
 			session.tk = Some(
 				crate::val::convert_value_to_public_value(claims.into_claims_object().into())
-					.unwrap(),
+					.expect("claims conversion should succeed"),
 			);
 			session.ns = Some(ns.clone());
 			session.db = Some(db.clone());
 			session.ac = Some(ac.clone());
 			session.rd = Some(
 				crate::val::convert_value_to_public_value(Value::RecordId(rid.clone().into()))
-					.unwrap(),
+					.expect("record id conversion should succeed"),
 			);
 			session.exp = expiration(av.session_duration)?;
 			session.au = Arc::new(Auth::new(Actor::new(
@@ -237,6 +237,7 @@ pub async fn db_access(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
 	use chrono::Duration;
 

--- a/crates/core/src/iam/verify.rs
+++ b/crates/core/src/iam/verify.rs
@@ -242,13 +242,13 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 					crate::val::convert_value_to_public_value(crate::val::Value::RecordId(
 						rid.clone().into(),
 					))
-					.unwrap(),
+					.expect("record id conversion should succeed"),
 				);
 				sess.tk = Some(
 					crate::val::convert_value_to_public_value(
 						token_data.claims.clone().into_claims_object().into(),
 					)
-					.unwrap(),
+					.expect("claims conversion should succeed"),
 				);
 				sess.ip.clone_from(&session.ip);
 				sess.or.clone_from(&session.or);
@@ -257,7 +257,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the success
 			debug!("Authenticated with record access method `{}`", ac);
 			// Set the session
-			session.tk = Some(crate::val::convert_value_to_public_value(value).unwrap());
+			session.tk = Some(
+				crate::val::convert_value_to_public_value(value)
+					.expect("value conversion should succeed"),
+			);
 			session.ns = Some(ns.to_owned());
 			session.db = Some(db.to_owned());
 			session.ac = Some(ac.to_owned());
@@ -265,7 +268,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 				crate::val::convert_value_to_public_value(crate::val::Value::RecordId(
 					rid.clone().into(),
 				))
-				.unwrap(),
+				.expect("record id conversion should succeed"),
 			);
 			session.exp = expiration(de.session_duration)?;
 			session.au = Arc::new(Auth::new(Actor::new(
@@ -347,7 +350,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 							crate::val::convert_value_to_public_value(
 								token_data.claims.clone().into_claims_object().into(),
 							)
-							.unwrap(),
+							.expect("claims conversion should succeed"),
 						);
 						sess.ip.clone_from(&session.ip);
 						sess.or.clone_from(&session.or);
@@ -370,7 +373,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 					// Log the success
 					debug!("Authenticated to database `{}` with access method `{}`", db, ac);
 					// Set the session
-					session.tk = Some(crate::val::convert_value_to_public_value(value).unwrap());
+					session.tk = Some(
+						crate::val::convert_value_to_public_value(value)
+							.expect("value conversion should succeed"),
+					);
 					session.ns = Some(ns.to_owned());
 					session.db = Some(db.to_owned());
 					session.ac = Some(ac.to_owned());
@@ -416,7 +422,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 							crate::val::convert_value_to_public_value(
 								token_data.claims.clone().into_claims_object().into(),
 							)
-							.unwrap(),
+							.expect("claims conversion should succeed"),
 						);
 						sess.ip.clone_from(&session.ip);
 						sess.or.clone_from(&session.or);
@@ -424,8 +430,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 						// Log the success
 						debug!("Authenticated with record access method `{}`", ac);
 						// Set the session
-						session.tk =
-							Some(crate::val::convert_value_to_public_value(value).unwrap());
+						session.tk = Some(
+							crate::val::convert_value_to_public_value(value)
+								.expect("value conversion should succeed"),
+						);
 						session.ns = Some(ns.to_owned());
 						session.db = Some(db.to_owned());
 						session.ac = Some(ac.to_owned());
@@ -433,7 +441,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 							crate::val::convert_value_to_public_value(crate::val::Value::RecordId(
 								rid.clone().into(),
 							))
-							.unwrap(),
+							.expect("record id conversion should succeed"),
 						);
 						session.exp = expiration(de.session_duration)?;
 						session.au = Arc::new(Auth::new(Actor::new(
@@ -488,7 +496,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the success
 			debug!("Authenticated to database `{}` with user `{}` using token", db, id);
 			// Set the session
-			session.tk = Some(crate::val::convert_value_to_public_value(value).unwrap());
+			session.tk = Some(
+				crate::val::convert_value_to_public_value(value)
+					.expect("value conversion should succeed"),
+			);
 			session.ns = Some(ns.to_owned());
 			session.db = Some(db.to_owned());
 			session.exp = expiration(de.session_duration)?;
@@ -569,7 +580,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 					crate::val::convert_value_to_public_value(
 						token_data.claims.clone().into_claims_object().into(),
 					)
-					.unwrap(),
+					.expect("claims conversion should succeed"),
 				);
 				sess.ip.clone_from(&session.ip);
 				sess.or.clone_from(&session.or);
@@ -592,7 +603,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the success
 			debug!("Authenticated to namespace `{}` with access method `{}`", ns, ac);
 			// Set the session
-			session.tk = Some(crate::val::convert_value_to_public_value(value).unwrap());
+			session.tk = Some(
+				crate::val::convert_value_to_public_value(value)
+					.expect("value conversion should succeed"),
+			);
 			session.ns = Some(ns.to_owned());
 			session.ac = Some(ac.to_owned());
 			session.exp = expiration(de.session_duration)?;
@@ -640,7 +654,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the success
 			debug!("Authenticated to namespace `{}` with user `{}` using token", ns, id);
 			// Set the session
-			session.tk = Some(crate::val::convert_value_to_public_value(value).unwrap());
+			session.tk = Some(
+				crate::val::convert_value_to_public_value(value)
+					.expect("value conversion should succeed"),
+			);
 			session.ns = Some(ns.to_owned());
 			session.exp = expiration(de.session_duration)?;
 			session.au = Arc::new(Auth::new(Actor::new(
@@ -709,7 +726,7 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 					crate::val::convert_value_to_public_value(
 						token_data.claims.clone().into_claims_object().into(),
 					)
-					.unwrap(),
+					.expect("claims conversion should succeed"),
 				);
 				sess.ip.clone_from(&session.ip);
 				sess.or.clone_from(&session.or);
@@ -732,7 +749,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the success
 			debug!("Authenticated to root with access method `{}`", ac);
 			// Set the session
-			session.tk = Some(crate::val::convert_value_to_public_value(value).unwrap());
+			session.tk = Some(
+				crate::val::convert_value_to_public_value(value)
+					.expect("value conversion should succeed"),
+			);
 			session.ac = Some(ac.to_owned());
 			session.exp = expiration(de.session_duration)?;
 			session.au = Arc::new(Auth::new(Actor::new(de.name.to_string(), roles, Level::Root)));
@@ -761,7 +781,10 @@ pub async fn token(kvs: &Datastore, session: &mut Session, token: &str) -> Resul
 			// Log the success
 			debug!("Authenticated to root level with user `{}` using token", id);
 			// Set the session
-			session.tk = Some(crate::val::convert_value_to_public_value(value).unwrap());
+			session.tk = Some(
+				crate::val::convert_value_to_public_value(value)
+					.expect("value conversion should succeed"),
+			);
 			session.exp = expiration(de.session_duration)?;
 			session.au = Arc::new(Auth::new(Actor::new(
 				id.to_string(),
@@ -880,7 +903,8 @@ pub async fn verify_db_creds(
 
 fn verify_pass(pass: &str, hash: &str) -> Result<()> {
 	// Compute the hash and verify the password
-	let hash = PasswordHash::new(hash).unwrap();
+	let hash =
+		PasswordHash::new(hash).map_err(|e| anyhow::anyhow!("Invalid password hash: {}", e))?;
 	// Attempt to verify the password using Argon2
 	match Argon2::default().verify_password(pass.as_ref(), &hash) {
 		Ok(_) => Ok(()),
@@ -907,6 +931,7 @@ fn verify_token(token: &str, key: &DecodingKey, validation: &Validation) -> Resu
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
 	use argon2::password_hash::{PasswordHasher, SaltString};
 	use chrono::Duration;

--- a/crates/core/src/idx/index.rs
+++ b/crates/core/src/idx/index.rs
@@ -139,7 +139,8 @@ impl<'a> IndexOperation<'a> {
 					let key = self.get_unique_index_key(&n)?;
 					if txn.putc(&key, self.rid, None).await.is_err() {
 						let key = self.get_unique_index_key(&n)?;
-						let rid: RecordId = txn.get(&key, None).await?.unwrap();
+						let rid: RecordId =
+							txn.get(&key, None).await?.expect("record should exist");
 						return self.err_index_exists(rid, n);
 					}
 				}

--- a/crates/core/src/idx/trees/hnsw/layer.rs
+++ b/crates/core/src/idx/trees/hnsw/layer.rs
@@ -230,7 +230,7 @@ where
 							)
 							.await?
 							{
-								f_dist = w.peek_last_dist().unwrap(); // w can't be empty
+								f_dist = w.peek_last_dist().expect("w is non-empty"); // w can't be empty
 							}
 						}
 					}

--- a/crates/core/src/idx/trees/knn.rs
+++ b/crates/core/src/idx/trees/knn.rs
@@ -86,7 +86,7 @@ impl DoublePriorityQueue {
 	pub(super) fn peek_first(&self) -> Option<(f64, ElementId)> {
 		self.0.first_key_value().map(|(k, q)| {
 			let k = k.0;
-			let v = *q.iter().next().unwrap(); // By design the contains always contains one element
+			let v = *q.iter().next().expect("contains always has one element"); // By design the contains always contains one element
 			(k, v)
 		})
 	}

--- a/crates/core/src/idx/trees/vector.rs
+++ b/crates/core/src/idx/trees/vector.rs
@@ -290,8 +290,8 @@ impl Vector {
 	where
 		T: ToFloat + Clone + FromPrimitive + Add<Output = T> + Div<Output = T> + Zero,
 	{
-		let mean_x = x.mean().unwrap().to_float();
-		let mean_y = y.mean().unwrap().to_float();
+		let mean_x = x.mean().expect("mean should be computable").to_float();
+		let mean_y = y.mean().expect("mean should be computable").to_float();
 
 		let mut sum_xy = 0.0;
 		let mut sum_x2 = 0.0;

--- a/crates/core/src/key/index/mod.rs
+++ b/crates/core/src/key/index/mod.rs
@@ -258,7 +258,7 @@ impl<'a> Index<'a> {
 		fd: &Array,
 	) -> Result<Vec<u8>> {
 		let mut beg = Self::prefix_ids(ns, db, tb, ix, fd)?;
-		*beg.last_mut().unwrap() = 0x00; // set trailing sentinel to 0x00 -> inclusive lower bound within composite tuple
+		*beg.last_mut().expect("prefix buffer is non-empty") = 0x00; // set trailing sentinel to 0x00 -> inclusive lower bound within composite tuple
 		Ok(beg)
 	}
 
@@ -274,7 +274,7 @@ impl<'a> Index<'a> {
 		fd: &Array,
 	) -> Result<Vec<u8>> {
 		let mut beg = Self::prefix_ids(ns, db, tb, ix, fd)?;
-		*beg.last_mut().unwrap() = 0xff; // set trailing sentinel to 0xFF -> exclusive upper bound within composite tuple
+		*beg.last_mut().expect("prefix buffer is non-empty") = 0xff; // set trailing sentinel to 0xFF -> exclusive upper bound within composite tuple
 		Ok(beg)
 	}
 }

--- a/crates/core/src/kvs/export.rs
+++ b/crates/core/src/kvs/export.rs
@@ -411,7 +411,8 @@ impl Transaction {
 					} else {
 						// If the record is not a tombstone and a version exists, format it as an
 						// INSERT VERSION command.
-						let ts = Utc.timestamp_nanos(version.unwrap() as i64);
+						let ts =
+							Utc.timestamp_nanos(version.expect("version should be set") as i64);
 						format!("INSERT {} VERSION d'{:?}';", record.data.as_ref(), ts)
 					}
 				} else {

--- a/crates/core/src/kvs/fdb/mod.rs
+++ b/crates/core/src/kvs/fdb/mod.rs
@@ -219,7 +219,13 @@ impl super::api::Transaction for Transaction {
 		// Check to see if transaction is closed
 		ensure!(!self.done, Error::TxFinished);
 		// Check the key
-		let res = self.inner.as_ref().unwrap().get(&key, self.snapshot()).await?.is_some();
+		let res = self
+			.inner
+			.as_ref()
+			.expect("transaction should have inner")
+			.get(&key, self.snapshot())
+			.await?
+			.is_some();
 		// Return result
 		Ok(res)
 	}
@@ -232,8 +238,13 @@ impl super::api::Transaction for Transaction {
 		// Check to see if transaction is closed
 		ensure!(!self.done, Error::TxFinished);
 		// Get the key
-		let res =
-			self.inner.as_ref().unwrap().get(&key, self.snapshot()).await?.map(|v| v.to_vec());
+		let res = self
+			.inner
+			.as_ref()
+			.expect("transaction should have inner")
+			.get(&key, self.snapshot())
+			.await?
+			.map(|v| v.to_vec());
 		// Return result
 		Ok(res)
 	}
@@ -254,7 +265,7 @@ impl super::api::Transaction for Transaction {
 			None
 		};
 		// Set the key
-		self.inner.as_ref().unwrap().set(&key, &val);
+		self.inner.as_ref().expect("transaction should have inner").set(&key, &val);
 		// Confirm the save point
 		if let Some(prep) = prep {
 			self.save_points.save(prep);
@@ -280,7 +291,7 @@ impl super::api::Transaction for Transaction {
 			None
 		};
 		// Get the transaction
-		let inner = self.inner.as_ref().unwrap();
+		let inner = self.inner.as_ref().expect("transaction should have inner");
 		// Get the existing value (if any)
 		let key_exists = if let Some(SavePrepare::NewKey(_, sv)) = &prep {
 			sv.get_val().is_some()
@@ -313,7 +324,7 @@ impl super::api::Transaction for Transaction {
 			None
 		};
 		// Get the transaction
-		let inner = self.inner.as_ref().unwrap();
+		let inner = self.inner.as_ref().expect("transaction should have inner");
 		// Get the existing value (if any)
 		let current_val = if let Some(SavePrepare::NewKey(_, sv)) = &prep {
 			sv.get_val().cloned()
@@ -348,7 +359,7 @@ impl super::api::Transaction for Transaction {
 			None
 		};
 		// Remove the key
-		self.inner.as_ref().unwrap().clear(&key);
+		self.inner.as_ref().expect("transaction should have inner").clear(&key);
 		// Confirm the save point
 		if let Some(prep) = prep {
 			self.save_points.save(prep);
@@ -371,7 +382,7 @@ impl super::api::Transaction for Transaction {
 			None
 		};
 		// Get the transaction
-		let inner = self.inner.as_ref().unwrap();
+		let inner = self.inner.as_ref().expect("transaction should have inner");
 		// Get the existing value (if any)
 		let current_val = if let Some(SavePrepare::NewKey(_, sv)) = &prep {
 			sv.get_val().cloned()
@@ -402,7 +413,10 @@ impl super::api::Transaction for Transaction {
 		// TODO: Check if we need savepoint with ranges
 
 		// Delete the key range
-		self.inner.as_ref().unwrap().clear_range(&rng.start, &rng.end);
+		self.inner
+			.as_ref()
+			.expect("transaction should have inner")
+			.clear_range(&rng.start, &rng.end);
 		// Return result
 		Ok(())
 	}
@@ -420,7 +434,7 @@ impl super::api::Transaction for Transaction {
 		// Check to see if transaction is closed
 		ensure!(!self.done, Error::TxFinished);
 		// Get the transaction
-		let inner = self.inner.as_ref().unwrap();
+		let inner = self.inner.as_ref().expect("transaction should have inner");
 
 		// Create result set
 		let mut res = vec![];
@@ -454,7 +468,7 @@ impl super::api::Transaction for Transaction {
 		// Check to see if transaction is closed
 		ensure!(!self.done, Error::TxFinished);
 		// Get the transaction
-		let inner = self.inner.as_ref().unwrap();
+		let inner = self.inner.as_ref().expect("transaction should have inner");
 		// Create result set
 		let mut res = vec![];
 		// Set the key range
@@ -480,7 +494,8 @@ impl super::api::Transaction for Transaction {
 		// Check to see if transaction is closed
 		ensure!(!self.done, Error::TxFinished);
 		// Get the current read version
-		let res = self.inner.as_ref().unwrap().get_read_version().await?;
+		let res =
+			self.inner.as_ref().expect("transaction should have inner").get_read_version().await?;
 		// Convert to a version stamp
 		let res = VersionStamp::from_u64(res as u64);
 		// Return result
@@ -511,7 +526,11 @@ impl super::api::Transaction for Transaction {
 		// Append the 4 byte placeholder position in little endian
 		key.append(&mut pos.to_le_bytes().to_vec());
 		// Set the versionstamp key
-		self.inner.as_ref().unwrap().atomic_op(&key, &val, MutationType::SetVersionstampedKey);
+		self.inner.as_ref().expect("transaction should have inner").atomic_op(
+			&key,
+			&val,
+			MutationType::SetVersionstampedKey,
+		);
 		// Return result
 		Ok(())
 	}

--- a/crates/core/src/kvs/scanner.rs
+++ b/crates/core/src/kvs/scanner.rs
@@ -87,7 +87,7 @@ impl<'a, I> Scanner<'a, I> {
 			self.future = Some(scan(range, batch));
 		}
 		// Try to resolve the future
-		match self.future.as_mut().unwrap().poll_unpin(cx) {
+		match self.future.as_mut().expect("future should be set").poll_unpin(cx) {
 			// The future has now completed fully
 			Poll::Ready(result) => {
 				// Drop the completed asynchronous future
@@ -132,7 +132,8 @@ impl<'a, I> Scanner<'a, I> {
 							// Store the fetched range results
 							self.results.extend(v);
 							// Remove the first result to return
-							let item = self.results.pop_front().unwrap();
+							let item =
+								self.results.pop_front().expect("results should be non-empty");
 							// Return the first result
 							Poll::Ready(Some(Ok(item)))
 						}

--- a/crates/core/src/rpc/format/cbor/mod.rs
+++ b/crates/core/src/rpc/format/cbor/mod.rs
@@ -7,7 +7,7 @@ pub fn encode(v: Value) -> anyhow::Result<Vec<u8>> {
 	let encoding = convert::from_value(v).map_err(|e| anyhow::anyhow!(e))?;
 	let mut res = Vec::new();
 	//TODO: Check if this can ever panic.
-	ciborium::into_writer(&encoding, &mut res).unwrap();
+	ciborium::into_writer(&encoding, &mut res).expect("writing to vec should not fail");
 	Ok(res)
 }
 

--- a/crates/core/src/rpc/format/json.rs
+++ b/crates/core/src/rpc/format/json.rs
@@ -11,7 +11,7 @@ pub fn encode_str(value: PublicValue) -> anyhow::Result<String> {
 	let v = value.into_json_value();
 	// Because we convert to serde_json::Value first we can guarantee that
 	// serialization wont fail.
-	Ok(serde_json::to_string(&v).unwrap())
+	Ok(serde_json::to_string(&v).expect("serialization to json string should not fail"))
 }
 
 pub fn decode(value: &[u8]) -> anyhow::Result<PublicValue> {

--- a/crates/core/src/rpc/protocol.rs
+++ b/crates/core/src/rpc/protocol.rs
@@ -199,7 +199,7 @@ pub trait RpcProtocol {
 			PublicValue::None => (),
 			PublicValue::Null => session.db = None,
 			PublicValue::String(db) => {
-				let ns = session.ns.clone().unwrap();
+				let ns = session.ns.clone().expect("namespace should be set");
 				let tx =
 					self.kvs().transaction(TransactionType::Write, LockType::Optimistic).await?;
 				tx.ensure_ns_db(None, &ns, &db, self.kvs().is_strict_mode()).await?;
@@ -393,7 +393,7 @@ pub trait RpcProtocol {
 		};
 
 		let mutex = self.lock();
-		let guard = mutex.acquire().await.unwrap();
+		let guard = mutex.acquire().await.expect("mutex should not be poisoned");
 		let mut session = self.get_session(session_id.as_ref()).as_ref().clone();
 
 		if session.expired() {
@@ -510,7 +510,7 @@ pub trait RpcProtocol {
 		let res = run_query(self, session_id, QueryForm::Parsed(ast), vars).await?;
 
 		// Extract the first query result
-		Ok(DbResult::Other(res.into_iter().next().unwrap().result?))
+		Ok(DbResult::Other(res.into_iter().next().expect("single result expected").result?))
 	}
 
 	// ------------------------------

--- a/crates/core/src/sql/data.rs
+++ b/crates/core/src/sql/data.rs
@@ -78,7 +78,9 @@ impl Display for Data {
 			Self::ValuesExpression(v) => write!(
 				f,
 				"({}) VALUES {}",
-				Fmt::comma_separated(v.first().unwrap().iter().map(|(v, _)| v)),
+				Fmt::comma_separated(
+					v.first().expect("values expression is non-empty").iter().map(|(v, _)| v)
+				),
 				Fmt::comma_separated(v.iter().map(|v| Fmt::new(v, |v, f| write!(
 					f,
 					"({})",

--- a/crates/core/src/sql/statements/define/user.rs
+++ b/crates/core/src/sql/statements/define/user.rs
@@ -108,7 +108,7 @@ impl From<DefineUserStatement> for crate::expr::statements::DefineUserStatement 
 			// TODO: Move out of AST.
 			PassType::Password(p) => Argon2::default()
 				.hash_password(p.as_bytes(), &SaltString::generate(&mut OsRng))
-				.unwrap()
+				.expect("password hashing should not fail")
 				.to_string(),
 		};
 

--- a/crates/core/src/syn/error/render.rs
+++ b/crates/core/src/syn/error/render.rs
@@ -95,7 +95,7 @@ impl Snippet {
 		explain: Option<&'static str>,
 		kind: MessageKind,
 	) -> Self {
-		let line = source.split('\n').nth(location.line - 1).unwrap();
+		let line = source.split('\n').nth(location.line - 1).expect("line exists in source");
 		let (line, truncation, offset) = Self::truncate_line(line, location.column - 1);
 
 		Snippet {
@@ -115,7 +115,7 @@ impl Snippet {
 		explain: Option<&str>,
 		kind: MessageKind,
 	) -> Self {
-		let line = source.split('\n').nth(location.start.line - 1).unwrap();
+		let line = source.split('\n').nth(location.start.line - 1).expect("line exists in source");
 		let (line, truncation, offset) = Self::truncate_line(line, location.start.column - 1);
 		let length = if location.start.line == location.end.line {
 			(location.end.column - location.start.column).max(1)
@@ -178,7 +178,7 @@ impl Snippet {
 			}
 
 			// Unwrap because we just checked if the line length is longer then this.
-			let truncate_index = line.char_indices().nth(size).unwrap().0;
+			let truncate_index = line.char_indices().nth(size).expect("character index exists").0;
 			line = &line[..truncate_index];
 		}
 

--- a/crates/core/src/syn/lexer/compound/number.rs
+++ b/crates/core/src/syn/lexer/compound/number.rs
@@ -162,7 +162,7 @@ pub fn number_kind(lexer: &mut Lexer, start: Token) -> Result<NumberKind, Syntax
 	}
 
 	if has_ident_after(lexer) {
-		let char = lexer.reader.next().unwrap();
+		let char = lexer.reader.next().expect("lexer validated input");
 		let char = lexer.reader.convert_to_char(char)?;
 		bail!("Invalid token, found unexpected character `{char}` after number token", @lexer.current_span())
 	}
@@ -231,7 +231,7 @@ where
 	};
 
 	if has_ident_after(lexer) {
-		let char = lexer.reader.next().unwrap();
+		let char = lexer.reader.next().expect("lexer validated input");
 		let char = lexer.reader.convert_to_char(char)?;
 		bail!("Invalid token, found unexpected character `{char} after integer token", @lexer.current_span())
 	}
@@ -250,7 +250,7 @@ where
 	}
 
 	if peek == Some(b'e') || peek == Some(b'E') {
-		bail!("Unexpected character `{}` only integers are allowed here",peek.unwrap() as char, @lexer.current_span())
+		bail!("Unexpected character `{}` only integers are allowed here",peek.expect("validated input") as char, @lexer.current_span())
 	}
 
 	let span = lexer.current_span();
@@ -292,7 +292,7 @@ where
 	lexer.eat(b'f');
 
 	if has_ident_after(lexer) {
-		let char = lexer.reader.next().unwrap();
+		let char = lexer.reader.next().expect("lexer validated input");
 		let char = lexer.reader.convert_to_char(char)?;
 		bail!("Invalid token, found invalid character `{char}` after number token", @lexer.current_span())
 	}
@@ -414,7 +414,7 @@ fn lex_duration_suffix(lexer: &mut Lexer) -> Result<DurationSuffix, SyntaxError>
 	};
 
 	if has_ident_after(lexer) {
-		let char = lexer.reader.next().unwrap();
+		let char = lexer.reader.next().expect("lexer validated input");
 		let char = lexer.reader.convert_to_char(char)?;
 		bail!("Invalid token, found invalid character `{char}` after duration suffix", @lexer.current_span())
 	}

--- a/crates/core/src/syn/lexer/ident.rs
+++ b/crates/core/src/syn/lexer/ident.rs
@@ -40,7 +40,7 @@ impl Lexer<'_> {
 		loop {
 			// lexer ensures that backtick tokens end with `.
 			let before = reader.offset();
-			let x = reader.next().unwrap();
+			let x = reader.next().expect("lexer validated input");
 			match x {
 				b'\\' => {
 					// Lexer already ensures there is a valid character after the \
@@ -61,18 +61,18 @@ impl Lexer<'_> {
 		span: Span,
 		buffer: &'a mut Vec<u8>,
 	) -> Result<&'a str, SyntaxError> {
-		assert_eq!(reader.complete_char(BRACKET_START_CHARACTER).unwrap(), '⟨');
+		assert_eq!(reader.complete_char(BRACKET_START_CHARACTER).expect("valid character"), '⟨');
 		loop {
 			// lexer ensures that backtick tokens end with `
 			let before = reader.offset();
-			let x = reader.next().unwrap();
+			let x = reader.next().expect("lexer validated input");
 			match x {
 				b'\\' => {
 					// Lexer already ensures there is a valid character after the \
 					Self::lex_common_escape_sequence(&mut reader, span, before, buffer)?;
 				}
 				x if !x.is_ascii() => {
-					let c = reader.complete_char(x).unwrap();
+					let c = reader.complete_char(x).expect("valid character");
 					if c == '⟩' {
 						break;
 					} else {

--- a/crates/core/src/syn/lexer/strings/datetime.rs
+++ b/crates/core/src/syn/lexer/strings/datetime.rs
@@ -90,7 +90,7 @@ impl Lexer<'_> {
 					.fix()
 					.from_local_datetime(&date_time)
 					.earliest()
-					.unwrap()
+					.expect("valid datetime")
 					.with_timezone(&Utc);
 
 				return Ok(PublicDatetime::from(datetime));
@@ -167,9 +167,11 @@ impl Lexer<'_> {
 				// The range checks on the digits ensure that the offset can't exceed 23:59 so
 				// below unwraps won't panic.
 				if x == b'-' {
-					FixedOffset::west_opt((hour * 3600 + minutes * 60) as i32).unwrap()
+					FixedOffset::west_opt((hour * 3600 + minutes * 60) as i32)
+						.expect("valid timezone offset")
 				} else {
-					FixedOffset::east_opt((hour * 3600 + minutes * 60) as i32).unwrap()
+					FixedOffset::east_opt((hour * 3600 + minutes * 60) as i32)
+						.expect("valid timezone offset")
 				}
 			}
 			Some(b'Z' | b'z') => Utc.fix(),
@@ -189,8 +191,8 @@ impl Lexer<'_> {
 		let datetime = timezone
 			.from_local_datetime(&date_time)
 			.earliest()
-			// this should never panic with a fixed offset.
-			.unwrap()
+			// this should never panic with a fixed offset
+			.expect("valid datetime with fixed offset")
 			.with_timezone(&Utc);
 
 		Ok(PublicDatetime::from(datetime))

--- a/crates/core/src/syn/lexer/strings/mod.rs
+++ b/crates/core/src/syn/lexer/strings/mod.rs
@@ -219,13 +219,13 @@ impl Lexer<'_> {
 				break;
 			};
 			match b {
-				b'\\' => match reader.next().unwrap() {
+				b'\\' => match reader.next().expect("lexer validated input") {
 					b'u' => {
 						if reader.eat(b'{') {
 							let mut accum = 0;
 							let mut at_end = false;
 							for _ in 0..6 {
-								match reader.next().unwrap() {
+								match reader.next().expect("lexer validated input") {
 									c @ b'a'..=b'f' => {
 										accum <<= 4;
 										accum += (c - b'a') as u32 + 10;
@@ -250,12 +250,14 @@ impl Lexer<'_> {
 								reader.next();
 							}
 
-							offset_idx +=
-								char::from_u32(accum).unwrap().encode_utf8(&mut bytes).len() as u32;
+							offset_idx += char::from_u32(accum)
+								.expect("valid unicode codepoint")
+								.encode_utf8(&mut bytes)
+								.len() as u32;
 						} else {
 							let mut accum = 0;
 							for _ in 0..4 {
-								match reader.next().unwrap() {
+								match reader.next().expect("lexer validated input") {
 									c @ b'a'..=b'f' => {
 										accum <<= 4;
 										accum += (c - b'a') as u32 + 10;
@@ -272,8 +274,10 @@ impl Lexer<'_> {
 								}
 							}
 
-							offset_idx +=
-								char::from_u32(accum).unwrap().encode_utf8(&mut bytes).len() as u32;
+							offset_idx += char::from_u32(accum)
+								.expect("valid unicode codepoint")
+								.encode_utf8(&mut bytes)
+								.len() as u32;
 						}
 					}
 					_ => {
@@ -333,9 +337,9 @@ impl Lexer<'_> {
 			};
 			let Some(res) = ascii_to_hex(peek) else {
 				let offset = reader.offset();
-				let char = reader.next().unwrap();
+				let char = reader.next().expect("lexer validated input");
 				// Source is a string, so there can't be invalid characters.
-				let char = reader.convert_to_char(char).unwrap();
+				let char = reader.convert_to_char(char).expect("lexer validated input");
 				let span = reader.span_since(offset);
 				bail!("Unexpected character `{char}` expected hexidecimal digit",@span);
 			};
@@ -350,7 +354,7 @@ impl Lexer<'_> {
 				Some(x) => {
 					// This function operates on a valid string so this function can never error.
 					let span = reader.span_since(before);
-					let c = reader.convert_to_char(x).unwrap();
+					let c = reader.convert_to_char(x).expect("lexer validated input");
 					bail!("Unexpected character `{c}`, expected byte seperator `-`", @span);
 				}
 				None => {
@@ -393,7 +397,7 @@ impl Lexer<'_> {
 				x => {
 					let before = reader.offset() - 1;
 					// Source is a string, so there can't be invalid characters.
-					let c = reader.convert_to_char(x).unwrap();
+					let c = reader.convert_to_char(x).expect("lexer validated input");
 					let span = reader.span_since(before);
 					bail!("Unexpected character `{c}`, expected a hexidecimal digit", @span);
 				}
@@ -409,7 +413,7 @@ impl Lexer<'_> {
 				x => {
 					let before = reader.offset() - 1;
 					// Source is a string, so there can't be invalid characters.
-					let c = reader.convert_to_char(x).unwrap();
+					let c = reader.convert_to_char(x).expect("lexer validated input");
 					let span = reader.span_since(before);
 					bail!("Unexpected character `{c}`, expected a hexidecimal digit", @span);
 				}
@@ -438,7 +442,7 @@ impl Lexer<'_> {
 				x => {
 					let span = reader.span_since(before);
 					// Reader operates on a valid string so unwrap shouldn't trigger.
-					let c = reader.convert_to_char(x).unwrap();
+					let c = reader.convert_to_char(x).expect("lexer validated input");
 					bail!("Unexpected character `{c}`, file strings buckets only allow alpha numeric characters and `_`, `-`, and `.`", @span);
 				}
 			}
@@ -450,7 +454,7 @@ impl Lexer<'_> {
 			Some(x) => {
 				let span = reader.span_since(before);
 				// Reader operates on a valid string so unwrap shouldn't trigger.
-				let c = reader.convert_to_char(x).unwrap();
+				let c = reader.convert_to_char(x).expect("lexer validated input");
 				bail!("Unexpected character `{c}`, expected `/`", @span);
 			}
 			None => {
@@ -471,7 +475,7 @@ impl Lexer<'_> {
 				x => {
 					let before = reader.offset() - 1;
 					let span = reader.span_since(before);
-					let c = reader.convert_to_char(x).unwrap();
+					let c = reader.convert_to_char(x).expect("lexer validated input");
 					bail!("Unexpected character `{c}`, file strings key's only allow alpha numeric characters and `_`, `-`, `.`, and `/`", @span);
 				}
 			}

--- a/crates/core/src/syn/parser/mod.rs
+++ b/crates/core/src/syn/parser/mod.rs
@@ -256,7 +256,7 @@ impl<'a> Parser<'a> {
 	///
 	/// Should only be called after peeking a value.
 	pub fn pop_peek(&mut self) -> Token {
-		let res = self.token_buffer.pop().unwrap();
+		let res = self.token_buffer.pop().expect("token buffer is non-empty");
 		self.last_span = res.span;
 		res
 	}
@@ -313,7 +313,7 @@ impl<'a> Parser<'a> {
 			};
 			self.token_buffer.push(r);
 		}
-		self.token_buffer.at(at).unwrap()
+		self.token_buffer.at(at).expect("token exists at index")
 	}
 
 	pub fn peek1(&mut self) -> Token {
@@ -331,7 +331,7 @@ impl<'a> Parser<'a> {
 			let r = self.lexer.next_token();
 			self.token_buffer.push(r);
 		}
-		self.token_buffer.at(at).unwrap()
+		self.token_buffer.at(at).expect("token exists at index")
 	}
 
 	pub fn peek_whitespace1(&mut self) -> Token {
@@ -465,8 +465,12 @@ impl StatementStream {
 		// The parser should have ensured that bytes is a valid utf-8 string.
 		// TODO: Maybe change this to unsafe cast once we have more convidence in the
 		// parsers correctness.
-		let (line_num, remaining) =
-			std::str::from_utf8(bytes).unwrap().lines().enumerate().last().unwrap_or((0, ""));
+		let (line_num, remaining) = std::str::from_utf8(bytes)
+			.expect("parser validated utf8")
+			.lines()
+			.enumerate()
+			.last()
+			.unwrap_or((0, ""));
 
 		self.line_offset += line_num;
 		if line_num > 0 {

--- a/crates/core/src/syn/parser/record_id.rs
+++ b/crates/core/src/syn/parser/record_id.rs
@@ -272,7 +272,7 @@ impl Parser<'_> {
 					unexpected!(self, token, "a identifier");
 				}
 				// Should be valid utf-8 as it was already parsed by the lexer
-				let text = String::from_utf8(slice.to_vec()).unwrap();
+				let text = String::from_utf8(slice.to_vec()).expect("parser validated utf8");
 				// Safety: Parser guarentees no null bytes present in string.
 				Ok(RecordIdKeyLit::String(text))
 			}

--- a/crates/core/src/syn/parser/value.rs
+++ b/crates/core/src/syn/parser/value.rs
@@ -479,7 +479,7 @@ impl Parser<'_> {
 					unexpected!(self, peek, "a identifier");
 				}
 				// Should be valid utf-8 as it was already parsed by the lexer
-				let text = String::from_utf8(slice.to_vec()).unwrap();
+				let text = String::from_utf8(slice.to_vec()).expect("parser validated utf8");
 				PublicRecordIdKey::String(text)
 			}
 			_ => {

--- a/crates/core/src/val/value/convert/cast.rs
+++ b/crates/core/src/val/value/convert/cast.rs
@@ -466,8 +466,8 @@ impl Cast for Bytes {
 				let mut res = Vec::new();
 
 				for v in x.0.into_iter() {
-					// Unwrap condition checked above.
-					let x = v.clone().cast_to::<i64>().unwrap();
+					// Condition checked above
+					let x = v.clone().cast_to::<i64>().expect("value checked to be castable above");
 					// TODO: Fix truncation.
 					res.push(x as u8);
 				}
@@ -501,8 +501,8 @@ impl Cast for Array {
 						into: "array".to_string(),
 					});
 				}
-				// unwrap checked above
-				let range = range.coerce_to_typed::<i64>().unwrap();
+				// checked above
+				let range = range.coerce_to_typed::<i64>().expect("range type checked above");
 				if range.len() > *GENERATION_ALLOCATION_LIMIT {
 					return Err(CastError::RangeSizeLimit {
 						value: Box::new(Range::from(range)),
@@ -569,10 +569,10 @@ impl Cast for Box<Range> {
 				}
 
 				let mut iter = x.into_iter();
-				// unwrap checked above.
-				let beg = iter.next().unwrap();
-				// unwrap checked above.
-				let end = iter.next().unwrap();
+				// checked above
+				let beg = iter.next().expect("array length checked above");
+				// checked above
+				let end = iter.next().expect("array length checked above");
 
 				Ok(Box::new(Range {
 					start: Bound::Included(beg),
@@ -615,10 +615,18 @@ impl Cast for Point<f64> {
 				}
 
 				let mut iter = x.into_iter();
-				// Both unwraps checked above.
-				let x = iter.next().unwrap().cast_to::<f64>().unwrap();
-				// Both unwraps checked above.
-				let y = iter.next().unwrap().cast_to::<f64>().unwrap();
+				// checked above
+				let x = iter
+					.next()
+					.expect("array length checked above")
+					.cast_to::<f64>()
+					.expect("value type checked above");
+				// checked above
+				let y = iter
+					.next()
+					.expect("array length checked above")
+					.cast_to::<f64>()
+					.expect("value type checked above");
 
 				Ok(Point::new(x, y))
 			}

--- a/crates/core/src/val/value/convert/coerce.rs
+++ b/crates/core/src/val/value/convert/coerce.rs
@@ -300,8 +300,8 @@ impl<T: Coerce + HasKind> Coerce for Vec<T> {
 				into: <Self as HasKind>::kind().to_string(),
 			});
 		}
-		// Unwrap checked above
-		let array = v.into_array().unwrap();
+		// checked above
+		let array = v.into_array().expect("value type checked above");
 
 		let mut res = Vec::with_capacity(array.0.len());
 		for x in array.0 {
@@ -327,8 +327,8 @@ impl<T: Coerce + HasKind> Coerce for BTreeMap<String, T> {
 				into: Object::kind().to_string(),
 			});
 		};
-		// Unwrap checked above
-		let obj = v.into_object().unwrap();
+		// checked above
+		let obj = v.into_object().expect("value type checked above");
 
 		let mut res = BTreeMap::new();
 		for (k, v) in obj.0 {
@@ -359,8 +359,8 @@ impl<T: Coerce + HasKind, S: BuildHasher + Default> Coerce for HashMap<String, T
 				into: Kind::of::<Object>().to_string(),
 			});
 		};
-		// Unwrap checked above
-		let obj = v.into_object().unwrap();
+		// checked above
+		let obj = v.into_object().expect("value type checked above");
 
 		let mut res = HashMap::default();
 		for (k, v) in obj.0 {

--- a/crates/core/tests/create.rs
+++ b/crates/core/tests/create.rs
@@ -1,6 +1,9 @@
+#![allow(clippy::unwrap_used)]
+
 use surrealdb_core::iam::Level;
 use surrealdb_core::syn;
 use surrealdb_types::{Array, RecordId, Value};
+
 mod helpers;
 use anyhow::Result;
 use helpers::new_ds;

--- a/crates/core/tests/define.rs
+++ b/crates/core/tests/define.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 mod helpers;
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};

--- a/crates/core/tests/delete.rs
+++ b/crates/core/tests/delete.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 mod helpers;
 use anyhow::Result;
 use helpers::new_ds;

--- a/crates/core/tests/insert.rs
+++ b/crates/core/tests/insert.rs
@@ -1,6 +1,9 @@
+#![allow(clippy::unwrap_used)]
+
 use surrealdb_core::iam::Level;
 use surrealdb_core::syn;
 use surrealdb_types::{Array, Value};
+
 mod helpers;
 use anyhow::Result;
 use helpers::new_ds;

--- a/crates/core/tests/planner.rs
+++ b/crates/core/tests/planner.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 mod helpers;
 use anyhow::Result;
 use helpers::{new_ds, skip_ok};

--- a/crates/core/tests/select.rs
+++ b/crates/core/tests/select.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 mod helpers;
 use anyhow::Result;
 use helpers::{Test, new_ds};

--- a/crates/core/tests/sequence.rs
+++ b/crates/core/tests/sequence.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 mod helpers;
 
 use std::collections::BTreeSet;

--- a/crates/core/tests/update.rs
+++ b/crates/core/tests/update.rs
@@ -1,6 +1,9 @@
+#![allow(clippy::unwrap_used)]
+
 use surrealdb_core::iam::Level;
 use surrealdb_core::syn;
 use surrealdb_types::{Array, ToSql, Value};
+
 mod helpers;
 use anyhow::Result;
 use helpers::new_ds;

--- a/crates/core/tests/upsert.rs
+++ b/crates/core/tests/upsert.rs
@@ -1,6 +1,9 @@
+#![allow(clippy::unwrap_used)]
+
 use surrealdb_core::iam::Level;
 use surrealdb_core::syn;
 use surrealdb_types::{Array, ToSql, Value};
+
 mod helpers;
 use anyhow::Result;
 use helpers::new_ds;

--- a/crates/sdk/benches/allocator.rs
+++ b/crates/sdk/benches/allocator.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::RefCell;
 use std::hint::black_box;

--- a/crates/sdk/benches/array_complement.rs
+++ b/crates/sdk/benches/array_complement.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::collections::BTreeSet;
 use std::hint::black_box;
 

--- a/crates/sdk/benches/array_difference.rs
+++ b/crates/sdk/benches/array_difference.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::collections::VecDeque;
 use std::hint::black_box;
 

--- a/crates/sdk/benches/array_intersect.rs
+++ b/crates/sdk/benches/array_intersect.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::collections::VecDeque;
 use std::hint::black_box;
 

--- a/crates/sdk/benches/array_uniq.rs
+++ b/crates/sdk/benches/array_uniq.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::collections::HashSet;
 use std::hint::black_box;
 

--- a/crates/sdk/benches/executor.rs
+++ b/crates/sdk/benches/executor.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use futures::Future;
 use pprof::criterion::{Output, PProfProfiler};

--- a/crates/sdk/benches/hash_trie_btree.rs
+++ b/crates/sdk/benches/hash_trie_btree.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
 use std::time::Duration;

--- a/crates/sdk/benches/hashset_vs_vector.rs
+++ b/crates/sdk/benches/hashset_vs_vector.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::collections::HashSet;
 use std::time::{Duration, SystemTime};
 

--- a/crates/sdk/benches/index_hnsw.rs
+++ b/crates/sdk/benches/index_hnsw.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::time::Duration;

--- a/crates/sdk/benches/move_vs_clone.rs
+++ b/crates/sdk/benches/move_vs_clone.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;

--- a/crates/sdk/benches/order.rs
+++ b/crates/sdk/benches/order.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::time::Duration;
 
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/crates/sdk/benches/parser.rs
+++ b/crates/sdk/benches/parser.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use pprof::criterion::{Output, PProfProfiler};
 use surrealdb_core::syn;

--- a/crates/sdk/benches/processor.rs
+++ b/crates/sdk/benches/processor.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::time::Duration;
 
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};

--- a/crates/sdk/benches/sdb.rs
+++ b/crates/sdk/benches/sdb.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 mod sdb_benches;
 
 use criterion::{Criterion, criterion_group, criterion_main};

--- a/crates/sdk/benches/sdb_benches/lib/mod.rs
+++ b/crates/sdk/benches/sdb_benches/lib/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 

--- a/crates/sdk/benches/sdb_benches/lib/routines/create.rs
+++ b/crates/sdk/benches/sdb_benches/lib/routines/create.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::sync::Arc;
 
 use surrealdb_core::dbs::Session;

--- a/crates/sdk/benches/sdb_benches/lib/routines/mod.rs
+++ b/crates/sdk/benches/sdb_benches/lib/routines/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::sync::Arc;
 
 use criterion::Bencher;

--- a/crates/sdk/benches/sdb_benches/lib/routines/read.rs
+++ b/crates/sdk/benches/sdb_benches/lib/routines/read.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::sync::Arc;
 
 use surrealdb_core::dbs::Session;

--- a/crates/sdk/benches/sdb_benches/mod.rs
+++ b/crates/sdk/benches/sdb_benches/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::sync::{LazyLock, OnceLock};
 
 use criterion::Criterion;

--- a/crates/sdk/benches/sdb_benches/sdk/mod.rs
+++ b/crates/sdk/benches/sdb_benches/sdk/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::sync::LazyLock;
 use std::time::Duration;
 

--- a/crates/sdk/benches/sdb_benches/sdk/routines/create.rs
+++ b/crates/sdk/benches/sdb_benches/sdk/routines/create.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
 use surrealdb_types::RecordIdKey;

--- a/crates/sdk/benches/sdb_benches/sdk/routines/mod.rs
+++ b/crates/sdk/benches/sdb_benches/sdk/routines/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use criterion::Bencher;
 use criterion::measurement::WallTime;
 use surrealdb::Surreal;

--- a/crates/sdk/benches/sdb_benches/sdk/routines/read.rs
+++ b/crates/sdk/benches/sdb_benches/sdk/routines/read.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use surrealdb::Surreal;
 use surrealdb::engine::any::Any;
 use surrealdb_types::RecordIdKey;

--- a/crates/sdk/benches/with_or_without_index.rs
+++ b/crates/sdk/benches/with_or_without_index.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::collections::BTreeMap;
 use std::time::Duration;
 

--- a/crates/sdk/src/conn/mod.rs
+++ b/crates/sdk/src/conn/mod.rs
@@ -118,7 +118,7 @@ impl Router {
 			// signup/signin
 			let result = match value {
 				Value::Array(array) if array.len() == 1 => {
-					R::from_value(array.into_iter().next().unwrap())
+					R::from_value(array.into_iter().next().expect("array has exactly one element"))
 				}
 				v => R::from_value(v),
 			};
@@ -140,7 +140,9 @@ impl Router {
 					0 => Ok(None),
 					// Single-element array: extract and return the element
 					// This happens when operating on a record ID
-					1 => Ok(Some(R::from_value(array.into_iter().next().unwrap())?)),
+					1 => Ok(Some(R::from_value(
+						array.into_iter().next().expect("array has exactly one element"),
+					)?)),
 					// Multiple elements should not happen for operations expecting Option<T>
 					_ => Ok(Some(R::from_value(Value::Array(array))?)),
 				},

--- a/crates/sdk/src/engine/any/mod.rs
+++ b/crates/sdk/src/engine/any/mod.rs
@@ -195,7 +195,9 @@ impl IntoEndpoint for &str {}
 impl into_endpoint::Sealed for &str {
 	fn into_endpoint(self) -> Result<Endpoint> {
 		let (url, path) = match self {
-			"memory" | "mem://" => (Url::parse("mem://").unwrap(), "memory".to_owned()),
+			"memory" | "mem://" => {
+				(Url::parse("mem://").expect("valid memory url"), "memory".to_owned())
+			}
 			url if url.starts_with("ws") | url.starts_with("http") | url.starts_with("tikv") => {
 				(Url::parse(url).map_err(|_| Error::InvalidUrl(self.to_owned()))?, String::new())
 			}
@@ -329,6 +331,7 @@ pub fn connect(address: impl IntoEndpoint) -> Connect<Any, Surreal<Any>> {
 }
 
 #[cfg(all(test, feature = "kv-mem"))]
+#[allow(clippy::unwrap_used)]
 mod tests {
 
 	use surrealdb_types::{self, Object};

--- a/crates/sdk/src/engine/remote/http/mod.rs
+++ b/crates/sdk/src/engine/remote/http/mod.rs
@@ -267,7 +267,7 @@ async fn send_request(
 	headers: &HeaderMap,
 	auth: &Option<Auth>,
 ) -> Result<Vec<QueryResult>> {
-	let url = base_url.join(RPC_PATH).unwrap();
+	let url = base_url.join(RPC_PATH).expect("valid RPC path");
 
 	let req_value = req.into_value();
 	let body = surrealdb_core::rpc::format::flatbuffers::encode(&req_value)
@@ -311,7 +311,7 @@ async fn router(
 				database: database.clone(),
 			}
 			.into_router_request(None)
-			.unwrap();
+			.expect("USE command should convert to router request");
 			// process request to check permissions
 			let out = send_request(req, base_url, client, headers, auth).await?;
 			if let Some(ns) = namespace {
@@ -530,12 +530,14 @@ async fn router(
 				query,
 				variables: merged_vars,
 			};
-			let req = cmd.into_router_request(None).unwrap();
+			let req =
+				cmd.into_router_request(None).expect("command should convert to router request");
 			let res = send_request(req, base_url, client, headers, auth).await?;
 			Ok(res)
 		}
 		cmd => {
-			let req = cmd.into_router_request(None).unwrap();
+			let req =
+				cmd.into_router_request(None).expect("command should convert to router request");
 			let res = send_request(req, base_url, client, headers, auth).await?;
 			Ok(res)
 		}

--- a/crates/sdk/src/method/query.rs
+++ b/crates/sdk/src/method/query.rs
@@ -53,7 +53,9 @@ impl<T: SurrealValue> IntoVariables for T {
 			Value::Array(arr) => {
 				let mut vars = Variables::new();
 				for v in arr.chunks(2) {
-					let key = v[0].clone().into_string().unwrap();
+					let key = v[0].clone().into_string().map_err(|_| {
+						Error::InvalidParams("Variable key must be a string".to_string())
+					})?;
 					let value = v[1].clone();
 					vars.insert(key, value);
 				}

--- a/crates/sdk/tests/api.rs
+++ b/crates/sdk/tests/api.rs
@@ -1,1 +1,3 @@
+#![allow(clippy::unwrap_used)]
+
 mod api_integration;

--- a/crates/sdk/tests/api_integration/backup.rs
+++ b/crates/sdk/tests/api_integration/backup.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![cfg(any(
 	feature = "kv-mem",
 	feature = "kv-rocksdb",

--- a/crates/sdk/tests/api_integration/backup_version.rs
+++ b/crates/sdk/tests/api_integration/backup_version.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![cfg(feature = "kv-surrealkv")]
 
 use surrealdb_core::cnf::EXPORT_BATCH_SIZE;

--- a/crates/sdk/tests/api_integration/basic.rs
+++ b/crates/sdk/tests/api_integration/basic.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 // Tests common to all protocols and storage engines
 
 use std::time::Duration;

--- a/crates/sdk/tests/api_integration/live.rs
+++ b/crates/sdk/tests/api_integration/live.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![cfg(any(
 	feature = "protocol-ws",
 	feature = "kv-mem",

--- a/crates/sdk/tests/api_integration/mod.rs
+++ b/crates/sdk/tests/api_integration/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::future::Future;
 
 use surrealdb::types::{RecordId, SurrealValue};

--- a/crates/sdk/tests/api_integration/serialisation.rs
+++ b/crates/sdk/tests/api_integration/serialisation.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use surrealdb::types::SurrealValue;
 use ulid::Ulid;
 

--- a/crates/sdk/tests/api_integration/version.rs
+++ b/crates/sdk/tests/api_integration/version.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![cfg(feature = "kv-surrealkv")]
 
 use surrealdb::types::Value;

--- a/crates/types/src/traits/surreal_value.rs
+++ b/crates/types/src/traits/surreal_value.rs
@@ -1537,6 +1537,6 @@ impl SurrealValue for http::StatusCode {
 		let Value::Number(Number::Int(n)) = value else {
 			return Err(conversion_error(Self::kind_of(), value));
 		};
-		Ok(http::StatusCode::from_u16(n as u16).unwrap())
+		http::StatusCode::from_u16(n as u16).context("Failed to convert status code")
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

We have many `unwrap` calls in our production code. In almost all cases its because the statements preceding it ensured that it was impossible to panic - but not in ALL cases.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Enalbed the Clippy lint that disallows `unwrap`s outside of tests. It is still okay to use `expect` although it should be discouraged.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI is sufficient.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
