### PR TITLE
Fix provided vars not being attached to context in surrealism 'sql_with_vars' function

### DIFF
--- a/crates/core/src/surrealism/host.rs
+++ b/crates/core/src/surrealism/host.rs
@@ -39,9 +39,13 @@ impl InvocationContext for Host {
 		query: String,
 		vars: PublicObject,
 	) -> Result<PublicValue> {
-		let mut ctx = MutableContext::new(&self.ctx);
-		ctx.attach_public_variables(vars.into())?;
-		let ctx = ctx.freeze();
+		let ctx = if vars.is_empty() {
+			self.ctx.clone()
+		} else {
+			let mut ctx = MutableContext::new(&self.ctx);
+			ctx.attach_public_variables(vars.into())?;
+			ctx.freeze()
+		};
 
 		let expr: Expr = syn::expr(&query)?.into();
 		let res = self


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

As detailed in #6589, the variables passed to `sql_with_vars` function were not available in the surql context.

## What does this change do?

This happened because in the implementation of `InvocationContext` for `Host` the sql method ignored the vars passed to it.
This is my first code PR to the project, so I have little knowledge on the internal workings of the DB or why these vars were left unused, so while the solution in the PR works, it might not be the desired one. 

## What is your testing strategy?

I did not create a separate test for the PR, the previous tests run successfully.

## Is this related to any issues?

#6589

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
