### PR TITLE
Move incremental monotonic timestamp to public type

### DIFF
--- a/crates/core/src/kvs/api.rs
+++ b/crates/core/src/kvs/api.rs
@@ -496,8 +496,7 @@ pub trait Transactable: requirements::TransactionRequirements {
 	/// Get the current monotonic timestamp
 	#[cfg(test)]
 	async fn timestamp(&self) -> Result<Box<dyn Timestamp>> {
-		static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
-		Ok(Box::new(COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst)))
+		Ok(Box::new(super::timestamp::IncTimestamp::next()))
 	}
 
 	/// Get the current monotonic timestamp

--- a/crates/core/src/kvs/mod.rs
+++ b/crates/core/src/kvs/mod.rs
@@ -54,7 +54,7 @@ pub use err::{Error, Result};
 pub use into::IntoBytes;
 pub(crate) use key::{KVKey, KVValue, impl_kv_key_storekey, impl_kv_value_revisioned};
 pub use scanner::{Direction, Scanner};
-pub use timestamp::Timestamp;
+pub use timestamp::{HlcTimestamp, IncTimestamp, Timestamp};
 pub use tr::{LockType, TransactionType, Transactor};
 pub use tx::Transaction;
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The incremental monotonic timestamp generator can now be used by external storage engines.

## What does this change do?

Moves the internal code for incremental timestamp generation in to its own type and makes it publicly accessible.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
