### PR TITLE
[Backport] Fix OOM crash in COUNT index on large datasets by batching key retrieval (#6601)

### DIFF
--- a/crates/core/src/idx/planner/iterators.rs
+++ b/crates/core/src/idx/planner/iterators.rs
@@ -1,3 +1,4 @@
+use crate::cnf::COUNT_BATCH_SIZE;
 use crate::ctx::Context;
 use crate::dbs::Options;
 use crate::err::Error;
@@ -1805,14 +1806,22 @@ impl IndexCountThingIterator {
 	) -> Result<usize, Error> {
 		if let Some(range) = self.0.take() {
 			let mut count: i64 = 0;
-			for (i, key) in txn.keys(range, u32::MAX, None).await?.into_iter().enumerate() {
-				ctx.is_done(i % 1000 == 0)?;
-				let iu = IndexCountKey::decode_key(&key)?;
-				if iu.pos {
-					count += iu.count as i64;
-				} else {
-					count -= iu.count as i64;
+			let mut loops = 0;
+			let mut current_range = Some(range);
+			while let Some(range) = current_range {
+				let batch = txn.batch_keys(range, *COUNT_BATCH_SIZE, None).await?;
+				for key in batch.result.iter() {
+					loops += 1;
+					ctx.is_done(loops % 1000 == 0)?;
+					let iu = IndexCountKey::decode_key(key)?;
+					if iu.pos {
+						count += iu.count as i64;
+					} else {
+						count -= iu.count as i64;
+					}
 				}
+				current_range = batch.next;
+				ctx.is_done(true)?;
 			}
 			Ok(count as usize)
 		} else {
@@ -1829,16 +1838,23 @@ impl IndexCountThingIterator {
 			return Ok(());
 		};
 		let mut count: i64 = 0;
-		for (i, key) in txn.keys(range.clone(), u32::MAX, None).await?.into_iter().enumerate() {
-			if i % 1000 == 0 {
-				yield_now!()
+		let mut loops = 0;
+		let mut current_range = Some(range.clone());
+		while let Some(r) = current_range {
+			let batch = txn.batch_keys(r, *COUNT_BATCH_SIZE, None).await?;
+			for key in batch.result.iter() {
+				loops += 1;
+				if loops % 1000 == 0 {
+					yield_now!()
+				}
+				let iu = IndexCountKey::decode_key(key)?;
+				if iu.pos {
+					count += iu.count as i64;
+				} else {
+					count -= iu.count as i64;
+				}
 			}
-			let iu = IndexCountKey::decode_key(&key)?;
-			if iu.pos {
-				count += iu.count as i64;
-			} else {
-				count -= iu.count as i64;
-			}
+			current_range = batch.next;
 		}
 		txn.delr(range).await?;
 		let pos = count.is_positive();


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Backport #6601 

## What does this change do?

Backport #6601 

## What is your testing strategy?

Github action / language tests

## Is this related to any issues?

Backport #6601 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
