### PR TITLE
use jemalloc only on x86_64 and x86

### DIFF
--- a/crates/core/src/mem/mod.rs
+++ b/crates/core/src/mem/mod.rs
@@ -15,10 +15,7 @@ pub static ALLOC: fake::FakeAlloc = fake::FakeAlloc::new();
 		target_os = "netbsd",
 		target_os = "openbsd"
 	),
-	any(
-		target_arch = "x86_64",
-		target_arch = "x86"
-	)
+	any(target_arch = "x86_64", target_arch = "x86")
 )))]
 #[global_allocator]
 pub static ALLOC: track::TrackAlloc<std::alloc::System> =
@@ -35,10 +32,7 @@ pub static ALLOC: track::TrackAlloc<std::alloc::System> =
 		target_os = "netbsd",
 		target_os = "openbsd"
 	),
-	any(
-		target_arch = "x86_64",
-		target_arch = "x86"
-	)
+	any(target_arch = "x86_64", target_arch = "x86")
 ))]
 #[global_allocator]
 pub static ALLOC: track::TrackAlloc<jemallocator::Jemalloc> =


### PR DESCRIPTION
## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->
incorrect platform configuration for allocators cause:
```
<jemalloc>: Unsupported system page size
<jemalloc>: Unsupported system page size
memory allocation of 16 bytes failed
Aborted (core dumped)
```

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

ensures jemalloc is only chosen on x86_64 and x86 devices
as seen on https://github.com/tikv/jemallocator readme under platform support section
platforms like aarch64 and powerpc64le doesn't seem to work as intended

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

tested on both aarch64 and amd64 devices locally

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- Fixes #6591 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
