### PR TITLE
Make node id not optional in Options.

### DIFF
--- a/crates/core/src/dbs/test.rs
+++ b/crates/core/src/dbs/test.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use uuid::Uuid;
+
 use crate::ctx::{Context, MutableContext};
 use crate::dbs::Options;
 use crate::iam::{Auth, Role};
@@ -8,7 +10,7 @@ use crate::kvs::LockType::*;
 use crate::kvs::TransactionType::*;
 
 pub async fn mock() -> (Context, Options) {
-	let opt = Options::default().with_auth(Arc::new(Auth::for_root(Role::Owner)));
+	let opt = Options::new(Uuid::new_v4()).with_auth(Arc::new(Auth::for_root(Role::Owner)));
 	let kvs = Datastore::new("memory").await.unwrap();
 	let txn = kvs.transaction(Write, Optimistic).await.unwrap().enclose();
 	let mut ctx = MutableContext::default();

--- a/crates/core/src/doc/lives.rs
+++ b/crates/core/src/doc/lives.rs
@@ -388,7 +388,7 @@ impl DefaultBroker {
 }
 impl MessageBroker for DefaultBroker {
 	fn can_be_sent(&self, opt: &Options, subscription: &SubscriptionDefinition) -> Result<bool> {
-		Ok(opt.id()? == subscription.node)
+		Ok(opt.id() == subscription.node)
 	}
 
 	fn send(

--- a/crates/core/src/expr/statements/kill.rs
+++ b/crates/core/src/expr/statements/kill.rs
@@ -45,7 +45,7 @@ impl KillStatement {
 			Ok(id) => id,
 		};
 		// Get the Node ID
-		let nid = opt.id()?;
+		let nid = opt.id();
 		// Get the LIVE ID
 		let lid = lid.0;
 		// Get the transaction

--- a/crates/core/src/expr/statements/live.rs
+++ b/crates/core/src/expr/statements/live.rs
@@ -43,7 +43,7 @@ impl LiveStatement {
 		// Valid options?
 		opt.valid_for_db()?;
 		// Get the Node ID
-		let nid = opt.id()?;
+		let nid = opt.id();
 
 		let mut vars = Variables::new();
 		let mut pass = ParameterCapturePass {

--- a/crates/core/src/idx/ft/analyzer/mod.rs
+++ b/crates/core/src/idx/ft/analyzer/mod.rs
@@ -201,7 +201,7 @@ mod tests {
 
 		let mut stack = reblessive::TreeStack::new();
 
-		let opts = Options::default();
+		let opts = Options::new(ds.id());
 		stack
 			.enter(|stk| async move {
 				let a = Analyzer::new(

--- a/crates/core/src/idx/index.rs
+++ b/crates/core/src/idx/index.rs
@@ -226,7 +226,7 @@ impl<'a> IndexOperation<'a> {
 			self.db,
 			&self.ix.table_name,
 			self.ix.index_id,
-			Some((self.opt.id()?, uuid::Uuid::now_v7())),
+			Some((self.opt.id(), uuid::Uuid::now_v7())),
 			relative_count > 0,
 			relative_count.unsigned_abs() as u64,
 		);
@@ -290,7 +290,7 @@ impl<'a> IndexOperation<'a> {
 	}
 
 	pub(crate) async fn trigger_compaction(&self) -> Result<()> {
-		FullTextIndex::trigger_compaction(&self.ikb, &self.ctx.tx(), self.opt.id()?).await
+		FullTextIndex::trigger_compaction(&self.ikb, &self.ctx.tx(), self.opt.id()).await
 	}
 
 	async fn index_hnsw(&mut self, p: &HnswParams) -> Result<()> {

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -871,7 +871,7 @@ impl Datastore {
 				pass,
 				INITIAL_USER_ROLE.to_owned(),
 			);
-			let opt = Options::new().with_auth(Arc::new(Auth::for_root(Role::Owner)));
+			let opt = Options::new(self.id).with_auth(Arc::new(Auth::for_root(Role::Owner)));
 			let mut ctx = MutableContext::default();
 			ctx.set_transaction(txn.clone());
 			let ctx = ctx.freeze();
@@ -2099,8 +2099,7 @@ impl Datastore {
 	}
 
 	pub fn setup_options(&self, sess: &Session) -> Options {
-		Options::default()
-			.with_id(self.id)
+		Options::new(self.id)
 			.with_ns(sess.ns())
 			.with_db(sess.db())
 			.with_live(sess.live())
@@ -2417,8 +2416,7 @@ mod test {
 
 		let dbs = Datastore::new("memory").await.unwrap().with_capabilities(Capabilities::all());
 
-		let opt = Options::default()
-			.with_id(dbs.id)
+		let opt = Options::new(dbs.id())
 			.with_ns(Some("test".into()))
 			.with_db(Some("test".into()))
 			.with_live(false)

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -711,7 +711,7 @@ impl Building {
 		if !*rc {
 			return Ok(());
 		}
-		FullTextIndex::trigger_compaction(&self.ikb, tx, self.opt.id()?).await?;
+		FullTextIndex::trigger_compaction(&self.ikb, tx, self.opt.id()).await?;
 		*rc = false;
 		Ok(())
 	}

--- a/crates/language-tests/Cargo.lock
+++ b/crates/language-tests/Cargo.lock
@@ -3889,7 +3889,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb-core"
-version = "3.0.0-alpha.16"
+version = "3.0.0-alpha.17"
 dependencies = [
  "addr",
  "affinitypool",
@@ -4064,7 +4064,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.0.0-alpha.16"
+version = "3.0.0-alpha.17"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.0.0-alpha.16"
+version = "3.0.0-alpha.17"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The node ID is expected to always be set and should not be optional.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Change `id: Option<Uuid>` to `id: Uuid`.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI is sufficient.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
