### PR TITLE
Fix ci-feature-check: exclude --no-default-features for SDK and server

### DIFF
--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -142,6 +142,7 @@ args = [
     "--each-feature",
     "--exclude-features",
     "kv-indxdb",
+    "--exclude-no-default-features",
 ]
 
 [tasks.ci-feature-check-core]
@@ -176,6 +177,7 @@ args = [
     "storage-indxdb",
     "--include-features",
     "storage-mem",
+    "--exclude-no-default-features",
 ]
 
 [tasks.ci-unused-deps]

--- a/crates/sdk/src/engine/mod.rs
+++ b/crates/sdk/src/engine/mod.rs
@@ -49,6 +49,7 @@ impl Stream for IntervalStream {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 enum SessionError {
 	NotFound(Uuid),
 	Remote(String),

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -203,6 +203,7 @@ pub(crate) enum ExtraFeatures {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 enum SessionId {
 	Initial(Uuid),
 	Clone {
@@ -215,6 +216,7 @@ enum SessionId {
 #[derive(Debug, Clone)]
 struct SessionClone {
 	sender: Sender<SessionId>,
+	#[allow(dead_code)]
 	receiver: Receiver<SessionId>,
 }
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

`cargo make ci-feature-check` is currently broken on main.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

- Add `#[allow(dead_code)]` to `SessionId`, `SessionClone`, and `SessionError` types that are used conditionally based on enabled features
- Exclude `--no-default-features` base check for SDK and server binaries using `--exclude-no-default-features` flag in cargo-hack
- Keep `--no-default-features` check for core library crate

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
