### PR TITLE
Fix trace filter warnings

### DIFF
--- a/crates/server/src/cli/validator/parser/tracing.rs
+++ b/crates/server/src/cli/validator/parser/tracing.rs
@@ -16,7 +16,7 @@ pub struct CustomFilter {
 impl Clone for CustomFilter {
 	fn clone(&self) -> Self {
 		Self {
-			env: EnvFilter::builder().parse(self.env.to_string()).unwrap_or(EnvFilter::default()),
+			env: EnvFilter::builder().parse(self.env.to_string()).unwrap_or_default(),
 			spans: self.spans.clone(),
 		}
 	}
@@ -24,7 +24,7 @@ impl Clone for CustomFilter {
 
 impl CustomFilter {
 	pub fn env(&self) -> EnvFilter {
-		EnvFilter::builder().parse(self.env.to_string()).unwrap_or(EnvFilter::default())
+		EnvFilter::builder().parse(self.env.to_string()).unwrap_or_default()
 	}
 
 	pub fn span_filter<S>(


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

The release binary currently displays a bunch of warnings like

```
warning: some trace filter directives would enable traces that are disabled statically
 | `none=trace` would enable the TRACE level for the `none` target
 = note: the static max level is `debug`
 = help: to enable TRACE logging, remove the `max_level_debug` feature from the `tracing` crate
```

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Replaces `EnvFilter::new("none")` with `EnvFilter::default()` in `CustomFilter` `Clone` and `env()` methods to avoid creating a `none=trace` directive that conflicts with the `max_level_debug` feature of the tracing crate.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Ran and inspected the binary manually.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
