### PR TITLE
Add static expression optimiser & initial optimiser rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ tokio = { version = "1.44.2", default-features = false }
 tokio-stream = "0.1"
 tokio-tungstenite = "0.28.0"
 tokio-util = "0.7.11"
-tracing = { version = "0.1.43", features = ["release_max_level_debug"] }
+tracing = { version = "0.1.43", features = [] }
 ulid = "1.1.0"
 unicase = "2.7.0"
 url = "2.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ categories = ["database-implementations", "data-structures", "embedded"]
 [workspace.dependencies]
 # workspace internal dependencies
 surrealdb = { version = "=3.0.0-beta.1", path = "crates/sdk" }
-surrealdb-core = { version = "=3.0.0-beta.1", path = "crates/core", default-features = false }
+surrealdb-core = { version = "=3.0.0-beta.1", path = "crates/core", default-features = false, features = ["trace-doc-ops"] }
 surrealdb-macros = { version = "=3.0.0-beta.1", path = "crates/macros" }
 surrealdb-server = { version = "=3.0.0-beta.1", path = "crates/server", default-features = false }
 surrealdb-types = { version = "=3.0.0-beta.1", path = "crates/types" }

--- a/crates/core/src/cnf/mod.rs
+++ b/crates/core/src/cnf/mod.rs
@@ -41,6 +41,10 @@ pub static MAX_OBJECT_PARSING_DEPTH: LazyLock<u32> =
 pub static MAX_QUERY_PARSING_DEPTH: LazyLock<u32> =
 	lazy_env_parse!("SURREAL_MAX_QUERY_PARSING_DEPTH", u32, 20);
 
+/// The maximum number of optimiser passes to run on queries (default: 3)
+pub static OPTIMISER_MAX_PASSES: LazyLock<usize> =
+	lazy_env_parse!("SURREAL_OPTIMISER_MAX_PASSES", usize, 3);
+
 /// The maximum recursive idiom path depth allowed (default: 256)
 pub static IDIOM_RECURSION_LIMIT: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_IDIOM_RECURSION_LIMIT", usize, 256);

--- a/crates/core/src/doc/document.rs
+++ b/crates/core/src/doc/document.rs
@@ -40,14 +40,16 @@ pub(crate) struct Document {
 	pub(super) input_data: Option<ComputedData>,
 }
 
+/// Data required to access a database.
 #[derive(Clone, Debug)]
-pub(crate) struct NsDbCtx {
+pub(crate) struct DatabaseContext {
 	pub(crate) ns: Arc<NamespaceDefinition>,
 	pub(crate) db: Arc<DatabaseDefinition>,
 }
 
+/// Data required to access a table.
 #[derive(Clone, Debug)]
-pub(crate) struct NsDbTbCtx {
+pub(crate) struct TableContext {
 	pub(crate) ns: Arc<NamespaceDefinition>,
 	pub(crate) db: Arc<DatabaseDefinition>,
 	pub(crate) tb: Arc<TableDefinition>,
@@ -56,40 +58,40 @@ pub(crate) struct NsDbTbCtx {
 
 #[derive(Clone, Debug)]
 pub(crate) enum DocumentContext {
-	NsDbCtx(NsDbCtx),
-	NsDbTbCtx(NsDbTbCtx),
+	DbCtx(DatabaseContext),
+	TableCtx(TableContext),
 }
 
 impl DocumentContext {
 	pub(crate) fn ns(&self) -> &Arc<NamespaceDefinition> {
 		match self {
-			DocumentContext::NsDbCtx(ctx) => &ctx.ns,
-			DocumentContext::NsDbTbCtx(ctx) => &ctx.ns,
+			DocumentContext::DbCtx(ctx) => &ctx.ns,
+			DocumentContext::TableCtx(ctx) => &ctx.ns,
 		}
 	}
 
 	pub(crate) fn db(&self) -> &Arc<DatabaseDefinition> {
 		match self {
-			DocumentContext::NsDbCtx(ctx) => &ctx.db,
-			DocumentContext::NsDbTbCtx(ctx) => &ctx.db,
+			DocumentContext::DbCtx(ctx) => &ctx.db,
+			DocumentContext::TableCtx(ctx) => &ctx.db,
 		}
 	}
 
 	pub(crate) fn tb(&self) -> Result<&Arc<TableDefinition>> {
 		match self {
-			DocumentContext::NsDbCtx(_) => Err(anyhow::anyhow!(
+			DocumentContext::DbCtx(_) => Err(anyhow::anyhow!(
 				"Table not defined in DocumentContext, this is certainly a bug and should be reported."
 			)),
-			DocumentContext::NsDbTbCtx(ctx) => Ok(&ctx.tb),
+			DocumentContext::TableCtx(ctx) => Ok(&ctx.tb),
 		}
 	}
 
 	pub(crate) fn fd(&self) -> Result<&Arc<[FieldDefinition]>> {
 		match self {
-			DocumentContext::NsDbCtx(_) => Err(anyhow::anyhow!(
+			DocumentContext::DbCtx(_) => Err(anyhow::anyhow!(
 				"Fields not defined in DocumentContext, this is certainly a bug and should be reported."
 			)),
-			DocumentContext::NsDbTbCtx(ctx) => Ok(&ctx.fields),
+			DocumentContext::TableCtx(ctx) => Ok(&ctx.fields),
 		}
 	}
 }

--- a/crates/core/src/doc/field.rs
+++ b/crates/core/src/doc/field.rs
@@ -487,7 +487,7 @@ impl FieldEditContext<'_> {
 			catalog::DefineDefault::Set(v) | catalog::DefineDefault::Always(v) => Some(v),
 			_ => match &self.def.value {
 				// The VALUE clause doesn't
-				Some(v) if v.is_static() => Some(v),
+				Some(v) if v.is_pure() => Some(v),
 				_ => None,
 			},
 		};

--- a/crates/core/src/doc/table.rs
+++ b/crates/core/src/doc/table.rs
@@ -9,7 +9,7 @@ use crate::catalog::providers::TableProvider;
 use crate::catalog::{Data, Metadata, Record, RecordType, ViewDefinition};
 use crate::ctx::FrozenContext;
 use crate::dbs::{Options, Statement, Workable};
-use crate::doc::{Action, CursorDoc, Document, DocumentContext, NsDbTbCtx};
+use crate::doc::{Action, CursorDoc, Document, DocumentContext, TableContext};
 use crate::err::Error;
 use crate::expr::field::Selector;
 use crate::expr::statements::SelectStatement;
@@ -389,7 +389,7 @@ impl Document {
 			.tx()
 			.all_tb_fields(ns.namespace_id, db.database_id, view_table_name, opt.version)
 			.await?;
-		let doc_ctx = DocumentContext::NsDbTbCtx(NsDbTbCtx {
+		let doc_ctx = DocumentContext::TableCtx(TableContext {
 			ns: Arc::clone(ns),
 			db: Arc::clone(db),
 			tb,
@@ -456,7 +456,7 @@ impl Document {
 				.tx()
 				.all_tb_fields(ns.namespace_id, db.database_id, view_table_name, opt.version)
 				.await?;
-			let doc_ctx = DocumentContext::NsDbTbCtx(NsDbTbCtx {
+			let doc_ctx = DocumentContext::TableCtx(TableContext {
 				ns: Arc::clone(ns),
 				db: Arc::clone(db),
 				tb,
@@ -750,7 +750,7 @@ impl Document {
 			.tx()
 			.all_tb_fields(ns.namespace_id, db.database_id, view_table_name, opt.version)
 			.await?;
-		let doc_ctx = DocumentContext::NsDbTbCtx(NsDbTbCtx {
+		let doc_ctx = DocumentContext::TableCtx(TableContext {
 			ns: Arc::clone(ns),
 			db: Arc::clone(db),
 			tb,
@@ -1147,7 +1147,7 @@ impl Document {
 			.tx()
 			.all_tb_fields(ns.namespace_id, db.database_id, view_table_name, opt.version)
 			.await?;
-		let doc_ctx = DocumentContext::NsDbTbCtx(NsDbTbCtx {
+		let doc_ctx = DocumentContext::TableCtx(TableContext {
 			ns: Arc::clone(ns),
 			db: Arc::clone(db),
 			tb,

--- a/crates/core/src/expr/literal.rs
+++ b/crates/core/src/expr/literal.rs
@@ -31,11 +31,9 @@ pub(crate) enum Literal {
 	Bool(bool),
 	Float(f64),
 	Integer(i64),
-	//TODO: Possibly remove wrapper.
 	Decimal(Decimal),
 	String(String),
 	Bytes(Bytes),
-	//TODO: Possibly remove wrapper.
 	Regex(Regex),
 	RecordId(RecordIdLit),
 	Array(Vec<Expr>),
@@ -70,6 +68,30 @@ impl Literal {
 			Literal::Array(exprs) => exprs.iter().all(|x| x.is_static()),
 			Literal::Set(exprs) => exprs.iter().all(|x| x.is_static()),
 			Literal::Object(items) => items.iter().all(|x| x.value.is_static()),
+		}
+	}
+
+	pub(crate) fn is_pure(&self) -> bool {
+		match self {
+			Literal::None
+			| Literal::Null
+			| Literal::UnboundedRange
+			| Literal::Bool(_)
+			| Literal::Float(_)
+			| Literal::Integer(_)
+			| Literal::Decimal(_)
+			| Literal::String(_)
+			| Literal::Bytes(_)
+			| Literal::Regex(_)
+			| Literal::Duration(_)
+			| Literal::Datetime(_)
+			| Literal::Uuid(_)
+			| Literal::File(_)
+			| Literal::Geometry(_) => true,
+			Literal::RecordId(record_id_lit) => record_id_lit.is_pure(),
+			Literal::Array(exprs) => exprs.iter().all(|x| x.is_pure()),
+			Literal::Set(exprs) => exprs.iter().all(|x| x.is_pure()),
+			Literal::Object(items) => items.iter().all(|x| x.value.is_pure()),
 		}
 	}
 

--- a/crates/core/src/expr/mod.rs
+++ b/crates/core/src/expr/mod.rs
@@ -52,6 +52,7 @@ pub(crate) mod with;
 
 pub(crate) mod decimal;
 pub(crate) mod module;
+pub(crate) mod optimise;
 
 mod closure;
 pub(crate) mod statements;
@@ -85,6 +86,7 @@ pub(crate) use self::model::Model;
 pub(crate) use self::module::{ModuleExecutable, SiloExecutable, SurrealismExecutable};
 pub(crate) use self::operation::Operation;
 pub(crate) use self::operator::{AssignOperator, BinaryOperator, PostfixOperator, PrefixOperator};
+pub(crate) use self::optimise::Optimiser;
 pub(crate) use self::order::Order;
 pub(crate) use self::output::Output;
 pub(crate) use self::param::Param;

--- a/crates/core/src/expr/optimise/mod.rs
+++ b/crates/core/src/expr/optimise/mod.rs
@@ -1,0 +1,515 @@
+use anyhow::Result;
+
+use super::{Expr, LogicalPlan, TopLevelExpr};
+use crate::expr::statements::UseStatement;
+use crate::expr::{Cond, Fetch, Fetchs};
+
+mod rules;
+mod utils;
+
+pub(crate) use rules::{ConstantFolding, StaticLiteralFolding};
+
+/// Tracks whether a transformation occurred during optimisation.
+///
+/// Inspired by DataFusion's Transformed type, this wrapper indicates
+/// whether an expression or plan was modified during an optimisation pass.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Transformed<T> {
+	pub data: T,
+	pub transformed: bool,
+}
+
+impl<T> Transformed<T> {
+	/// Create a new Transformed indicating the data was changed
+	pub fn yes(data: T) -> Self {
+		Self {
+			data,
+			transformed: true,
+		}
+	}
+
+	/// Create a new Transformed indicating the data was not changed
+	pub fn no(data: T) -> Self {
+		Self {
+			data,
+			transformed: false,
+		}
+	}
+
+	/// Map the data using a function, preserving the transformed flag
+	pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Transformed<U> {
+		Transformed {
+			data: f(self.data),
+			transformed: self.transformed,
+		}
+	}
+
+	/// Transform the data with a function that returns a Transformed,
+	/// combining the transformed flags with OR
+	#[allow(dead_code)]
+	pub fn and_then<U, F: FnOnce(T) -> Result<Transformed<U>>>(
+		self,
+		f: F,
+	) -> Result<Transformed<U>> {
+		let result = f(self.data)?;
+		Ok(Transformed {
+			data: result.data,
+			transformed: self.transformed || result.transformed,
+		})
+	}
+}
+
+/// Trait for optimisation rules that can transform expressions and plans.
+///
+/// Following DataFusion's OptimiserRule pattern, each rule implements
+/// a specific optimisation strategy.
+pub(crate) trait OptimiserRule: Send + Sync {
+	/// Returns the name of this optimisation rule
+	#[allow(dead_code)]
+	fn name(&self) -> &str;
+
+	/// Optimise an expression, returning the potentially transformed expression
+	fn optimise_expr(&self, expr: Expr) -> Result<Transformed<Expr>>;
+
+	/// Optimise a top-level expression in the plan
+	fn optimise_top_level_expr(&self, expr: TopLevelExpr) -> Result<Transformed<TopLevelExpr>> {
+		match expr {
+			TopLevelExpr::Begin | TopLevelExpr::Cancel | TopLevelExpr::Commit => {
+				Ok(Transformed::no(expr))
+			}
+			TopLevelExpr::Access(_) => Ok(Transformed::no(expr)),
+			TopLevelExpr::Kill(mut kill) => {
+				let result = self.optimise_expr(kill.id)?;
+				kill.id = result.data;
+				Ok(Transformed {
+					data: TopLevelExpr::Kill(kill),
+					transformed: result.transformed,
+				})
+			}
+			TopLevelExpr::Live(mut live) => {
+				let mut transformed = false;
+
+				// Optimise the what expression
+				let what_result = self.optimise_expr(live.what)?;
+				transformed = transformed || what_result.transformed;
+				live.what = what_result.data;
+
+				// Optimise the cond expression if present
+				if let Some(cond) = live.cond {
+					let cond_result = self.optimise_expr(cond.0)?;
+					transformed = transformed || cond_result.transformed;
+					live.cond = Some(Cond(cond_result.data));
+				}
+
+				// Optimise the fetch expressions if present
+				if let Some(fetchs) = live.fetch {
+					let mut new_fetchs = Vec::with_capacity(fetchs.0.len());
+					for fetch in fetchs.0 {
+						let result = self.optimise_expr(fetch.0)?;
+						transformed = transformed || result.transformed;
+						new_fetchs.push(Fetch(result.data));
+					}
+					live.fetch = Some(Fetchs(new_fetchs));
+				}
+
+				Ok(Transformed {
+					data: TopLevelExpr::Live(live),
+					transformed,
+				})
+			}
+			TopLevelExpr::Option(option) => Ok(Transformed::no(TopLevelExpr::Option(option))),
+			TopLevelExpr::Use(use_stmt) => match use_stmt {
+				UseStatement::Ns(ns) => {
+					let result = self.optimise_expr(ns)?;
+					Ok(Transformed {
+						data: TopLevelExpr::Use(UseStatement::Ns(result.data)),
+						transformed: result.transformed,
+					})
+				}
+				UseStatement::Db(db) => {
+					let result = self.optimise_expr(db)?;
+					Ok(Transformed {
+						data: TopLevelExpr::Use(UseStatement::Db(result.data)),
+						transformed: result.transformed,
+					})
+				}
+				UseStatement::NsDb(ns, db) => {
+					let ns_result = self.optimise_expr(ns)?;
+					let db_result = self.optimise_expr(db)?;
+					Ok(Transformed {
+						data: TopLevelExpr::Use(UseStatement::NsDb(ns_result.data, db_result.data)),
+						transformed: ns_result.transformed || db_result.transformed,
+					})
+				}
+				UseStatement::Default => {
+					Ok(Transformed::no(TopLevelExpr::Use(UseStatement::Default)))
+				}
+			},
+			TopLevelExpr::Show(show) => Ok(Transformed::no(TopLevelExpr::Show(show))),
+			TopLevelExpr::Expr(e) => {
+				let result = self.optimise_expr(e)?;
+				Ok(result.map(TopLevelExpr::Expr))
+			}
+		}
+	}
+}
+
+/// The main optimiser that applies a sequence of optimisation rules.
+///
+/// The optimiser runs multiple passes over the logical plan, applying
+/// each rule in sequence until either no changes are made or the maximum
+/// number of passes is reached.
+pub(crate) struct Optimiser {
+	rules: Vec<Box<dyn OptimiserRule>>,
+	max_passes: usize,
+}
+
+impl Optimiser {
+	/// Create a new optimiser with no rules
+	///
+	/// By default, the optimiser will run a maximum of 3 passes.
+	/// Use `with_max_passes()` to configure a different value, or use
+	/// `Optimiser::all()` which automatically uses the configured value
+	/// from `SURREAL_OPTIMISER_MAX_PASSES` environment variable.
+	pub fn new() -> Self {
+		Self {
+			rules: Vec::new(),
+			// Default to 3, but Optimiser::all() uses the configured value
+			max_passes: 3,
+		}
+	}
+
+	/// Create an optimiser with all available optimisation rules
+	///
+	/// This optimiser includes:
+	/// - StaticLiteralFolding: Converts static literals to pre-computed values
+	/// - ConstantFolding: Evaluates constant expressions at compile time
+	///
+	/// The number of passes is configured via the SURREAL_OPTIMISER_MAX_PASSES
+	/// environment variable (default: 3).
+	pub fn all() -> Self {
+		Self::new()
+			.add_rule(Box::new(StaticLiteralFolding))
+			.add_rule(Box::new(ConstantFolding))
+			.with_max_passes(*crate::cnf::OPTIMISER_MAX_PASSES)
+	}
+
+	/// Add an optimisation rule to the optimiser
+	pub fn add_rule(mut self, rule: Box<dyn OptimiserRule>) -> Self {
+		self.rules.push(rule);
+		self
+	}
+
+	/// Set the maximum number of optimisation passes
+	pub fn with_max_passes(mut self, max_passes: usize) -> Self {
+		self.max_passes = max_passes;
+		self
+	}
+
+	/// Optimise a logical plan by applying all rules iteratively
+	pub fn optimise(&self, mut plan: LogicalPlan) -> Result<LogicalPlan> {
+		for pass in 0..self.max_passes {
+			let mut changed = false;
+
+			// Apply each rule in sequence
+			for rule in &self.rules {
+				let result = self.optimise_plan_with_rule(plan, rule.as_ref())?;
+				changed = changed || result.transformed;
+				plan = result.data;
+			}
+
+			// If nothing changed in this pass, we're done
+			if !changed {
+				tracing::debug!("Optimiser converged after {} passes", pass + 1);
+				break;
+			}
+		}
+
+		Ok(plan)
+	}
+
+	/// Apply a single rule to the entire plan
+	fn optimise_plan_with_rule(
+		&self,
+		plan: LogicalPlan,
+		rule: &dyn OptimiserRule,
+	) -> Result<Transformed<LogicalPlan>> {
+		let mut transformed = false;
+		let mut optimised_expressions = Vec::with_capacity(plan.expressions.len());
+
+		for expr in plan.expressions {
+			let result = rule.optimise_top_level_expr(expr)?;
+			transformed = transformed || result.transformed;
+			optimised_expressions.push(result.data);
+		}
+
+		Ok(Transformed {
+			data: LogicalPlan {
+				expressions: optimised_expressions,
+			},
+			transformed,
+		})
+	}
+}
+
+impl Default for Optimiser {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::expr::{BinaryOperator, Literal, ObjectEntry};
+	use crate::val::{Number, Value};
+
+	#[test]
+	fn test_transformed_yes() {
+		let t = Transformed::yes(42);
+		assert_eq!(t.data, 42);
+		assert!(t.transformed);
+	}
+
+	#[test]
+	fn test_transformed_no() {
+		let t = Transformed::no(42);
+		assert_eq!(t.data, 42);
+		assert!(!t.transformed);
+	}
+
+	#[test]
+	fn test_transformed_map() {
+		let t = Transformed::yes(42);
+		let mapped = t.map(|x| x * 2);
+		assert_eq!(mapped.data, 84);
+		assert!(mapped.transformed);
+	}
+
+	#[test]
+	fn test_transformed_and_then() {
+		let t = Transformed::yes(42);
+		let result = t.and_then(|x| Ok(Transformed::no(x * 2))).unwrap();
+		assert_eq!(result.data, 84);
+		assert!(result.transformed); // Original was transformed
+	}
+
+	#[test]
+	fn test_optimiser_empty() {
+		let optimiser = Optimiser::new();
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Literal(Literal::Integer(42)))],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		assert_eq!(result.expressions.len(), 1);
+	}
+
+	#[test]
+	fn test_static_literal_folding_simple() {
+		let optimiser = Optimiser::new().add_rule(Box::new(StaticLiteralFolding));
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Literal(Literal::Integer(42)))],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Value(Value::Number(Number::Int(42)))) => (),
+			other => panic!("Expected Value(42), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_static_literal_folding_array() {
+		let optimiser = Optimiser::new().add_rule(Box::new(StaticLiteralFolding));
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Literal(Literal::Array(vec![
+				Expr::Literal(Literal::Integer(1)),
+				Expr::Literal(Literal::Integer(2)),
+				Expr::Literal(Literal::Integer(3)),
+			])))],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Value(Value::Array(arr))) => {
+				assert_eq!(arr.len(), 3);
+			}
+			other => panic!("Expected Value(Array), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_static_literal_folding_object() {
+		let optimiser = Optimiser::new().add_rule(Box::new(StaticLiteralFolding));
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Literal(Literal::Object(vec![
+				ObjectEntry {
+					key: "a".to_string(),
+					value: Expr::Literal(Literal::Integer(5)),
+				},
+			])))],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Value(Value::Object(obj))) => {
+				assert_eq!(obj.get("a"), Some(&Value::Number(Number::Int(5))));
+			}
+			other => panic!("Expected Value(Object), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_constant_folding_add() {
+		let optimiser = Optimiser::new().add_rule(Box::new(ConstantFolding));
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Binary {
+				left: Box::new(Expr::Value(Value::Number(Number::Int(1)))),
+				op: BinaryOperator::Add,
+				right: Box::new(Expr::Value(Value::Number(Number::Int(2)))),
+			})],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Value(Value::Number(Number::Int(3)))) => (),
+			other => panic!("Expected Value(3), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_constant_folding_multiply() {
+		let optimiser = Optimiser::new().add_rule(Box::new(ConstantFolding));
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Binary {
+				left: Box::new(Expr::Value(Value::Number(Number::Int(10)))),
+				op: BinaryOperator::Multiply,
+				right: Box::new(Expr::Value(Value::Number(Number::Int(5)))),
+			})],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Value(Value::Number(Number::Int(50)))) => (),
+			other => panic!("Expected Value(50), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_constant_folding_nested() {
+		let optimiser = Optimiser::new().add_rule(Box::new(ConstantFolding));
+		// (1 + 2) * 3 = 9
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Binary {
+				left: Box::new(Expr::Binary {
+					left: Box::new(Expr::Value(Value::Number(Number::Int(1)))),
+					op: BinaryOperator::Add,
+					right: Box::new(Expr::Value(Value::Number(Number::Int(2)))),
+				}),
+				op: BinaryOperator::Multiply,
+				right: Box::new(Expr::Value(Value::Number(Number::Int(3)))),
+			})],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Value(Value::Number(Number::Int(9)))) => (),
+			other => panic!("Expected Value(9), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_constant_folding_comparison() {
+		let optimiser = Optimiser::new().add_rule(Box::new(ConstantFolding));
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Binary {
+				left: Box::new(Expr::Value(Value::Number(Number::Int(5)))),
+				op: BinaryOperator::MoreThan,
+				right: Box::new(Expr::Value(Value::Number(Number::Int(3)))),
+			})],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Value(Value::Bool(true))) => (),
+			other => panic!("Expected Value(true), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_both_rules_together() {
+		// Test that both rules work together: literals get folded to values,
+		// then constant expressions get evaluated
+		let optimiser = Optimiser::new()
+			.add_rule(Box::new(StaticLiteralFolding))
+			.add_rule(Box::new(ConstantFolding));
+
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Binary {
+				left: Box::new(Expr::Literal(Literal::Integer(1))),
+				op: BinaryOperator::Add,
+				right: Box::new(Expr::Literal(Literal::Integer(2))),
+			})],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Value(Value::Number(Number::Int(3)))) => (),
+			other => panic!("Expected Value(3), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_multiple_passes_converge() {
+		// Test that multiple passes work correctly
+		let optimiser = Optimiser::new()
+			.add_rule(Box::new(StaticLiteralFolding))
+			.add_rule(Box::new(ConstantFolding))
+			.with_max_passes(5);
+
+		// ((1 + 2) * 3) + 4 = 13
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Binary {
+				left: Box::new(Expr::Binary {
+					left: Box::new(Expr::Binary {
+						left: Box::new(Expr::Literal(Literal::Integer(1))),
+						op: BinaryOperator::Add,
+						right: Box::new(Expr::Literal(Literal::Integer(2))),
+					}),
+					op: BinaryOperator::Multiply,
+					right: Box::new(Expr::Literal(Literal::Integer(3))),
+				}),
+				op: BinaryOperator::Add,
+				right: Box::new(Expr::Literal(Literal::Integer(4))),
+			})],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Value(Value::Number(Number::Int(13)))) => (),
+			other => panic!("Expected Value(13), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_non_static_literal_unchanged() {
+		// Literals with parameters should not be folded
+		let optimiser = Optimiser::new().add_rule(Box::new(StaticLiteralFolding));
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Literal(Literal::Array(vec![
+				Expr::Param(crate::expr::Param::new("x".to_string())),
+			])))],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Literal(Literal::Array(_))) => (),
+			other => panic!("Expected Literal(Array) with param, got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_constant_expression() {
+		let optimiser = Optimiser::new().add_rule(Box::new(ConstantFolding));
+		let plan = LogicalPlan {
+			expressions: vec![TopLevelExpr::Expr(Expr::Constant(crate::expr::Constant::MathPi))],
+		};
+		let result = optimiser.optimise(plan).unwrap();
+		match &result.expressions[0] {
+			TopLevelExpr::Expr(Expr::Value(Value::Number(Number::Float(f)))) => {
+				assert!((f - std::f64::consts::PI).abs() < 1e-10);
+			}
+			other => panic!("Expected Value(pi), got {:?}", other),
+		}
+	}
+}

--- a/crates/core/src/expr/optimise/mod.rs
+++ b/crates/core/src/expr/optimise/mod.rs
@@ -10,9 +10,6 @@ mod utils;
 pub(crate) use rules::{ConstantFolding, StaticLiteralFolding};
 
 /// Tracks whether a transformation occurred during optimisation.
-///
-/// Inspired by DataFusion's Transformed type, this wrapper indicates
-/// whether an expression or plan was modified during an optimisation pass.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Transformed<T> {
 	pub data: T,
@@ -60,14 +57,7 @@ impl<T> Transformed<T> {
 }
 
 /// Trait for optimisation rules that can transform expressions and plans.
-///
-/// Following DataFusion's OptimiserRule pattern, each rule implements
-/// a specific optimisation strategy.
 pub(crate) trait OptimiserRule: Send + Sync {
-	/// Returns the name of this optimisation rule
-	#[allow(dead_code)]
-	fn name(&self) -> &str;
-
 	/// Optimise an expression, returning the potentially transformed expression
 	fn optimise_expr(&self, expr: Expr) -> Result<Transformed<Expr>>;
 

--- a/crates/core/src/expr/optimise/mod.rs
+++ b/crates/core/src/expr/optimise/mod.rs
@@ -185,13 +185,11 @@ impl Optimiser {
 	/// - StaticLiteralFolding: Converts static literals to pre-computed values
 	/// - ConstantFolding: Evaluates constant expressions at compile time
 	///
-	/// The number of passes is configured via the SURREAL_OPTIMISER_MAX_PASSES
-	/// environment variable (default: 3).
+	/// Note: The max_passes should be set by the caller using with_max_passes().
+	/// When used through the Datastore, it will be configured from EngineOptions.
 	pub fn all() -> Self {
-		Self::new()
-			.add_rule(Box::new(StaticLiteralFolding))
-			.add_rule(Box::new(ConstantFolding))
-			.with_max_passes(*crate::cnf::OPTIMISER_MAX_PASSES)
+		Self::new().add_rule(Box::new(StaticLiteralFolding)).add_rule(Box::new(ConstantFolding))
+		// Caller should set max_passes via with_max_passes()
 	}
 
 	/// Add an optimisation rule to the optimiser

--- a/crates/core/src/expr/optimise/rules/constant_folding.rs
+++ b/crates/core/src/expr/optimise/rules/constant_folding.rs
@@ -25,10 +25,6 @@ use crate::val::Value;
 pub(crate) struct ConstantFolding;
 
 impl OptimiserRule for ConstantFolding {
-	fn name(&self) -> &str {
-		"constant_folding"
-	}
-
 	fn optimise_expr(&self, expr: Expr) -> Result<Transformed<Expr>> {
 		optimise_expr_recursive(expr)
 	}

--- a/crates/core/src/expr/optimise/rules/constant_folding.rs
+++ b/crates/core/src/expr/optimise/rules/constant_folding.rs
@@ -1,0 +1,421 @@
+use anyhow::Result;
+
+use crate::expr::optimise::utils::{constant_to_value, expr_as_value};
+use crate::expr::optimise::{OptimiserRule, Transformed};
+use crate::expr::{BinaryOperator, Expr, PrefixOperator};
+use crate::fnc;
+use crate::val::Value;
+
+/// Optimization rule that evaluates constant expressions at compile time.
+///
+/// This rule identifies operations on constant values (Expr::Value or Expr::Constant)
+/// and computes their results, replacing the expression with the computed value.
+///
+/// Examples:
+/// - `1 + 2` → `3`
+/// - `10 * 5` → `50`
+/// - `true AND false` → `false`
+/// - `5 > 3` → `true`
+/// - `math::pi * 2` → computed value
+///
+/// Limitations:
+/// - Skips async operations (matches, knn)
+/// - Skips function calls (may add whitelist later)
+/// - Skips operations on ranges (can't be easily folded)
+pub(crate) struct ConstantFolding;
+
+impl OptimiserRule for ConstantFolding {
+	fn name(&self) -> &str {
+		"constant_folding"
+	}
+
+	fn optimise_expr(&self, expr: Expr) -> Result<Transformed<Expr>> {
+		optimise_expr_recursive(expr)
+	}
+}
+
+fn optimise_expr_recursive(expr: Expr) -> Result<Transformed<Expr>> {
+	match expr {
+		// Convert constants to values first
+		Expr::Constant(ref constant) => match constant_to_value(constant) {
+			Ok(value) => Ok(Transformed::yes(Expr::Value(value))),
+			Err(_) => Ok(Transformed::no(expr)),
+		},
+
+		// Optimise binary operations
+		Expr::Binary {
+			left,
+			op,
+			right,
+		} => {
+			// First, recursively optimise children
+			let left_result = optimise_expr_recursive(*left)?;
+			let right_result = optimise_expr_recursive(*right)?;
+			let transformed = left_result.transformed || right_result.transformed;
+
+			// Try to fold if both sides are values
+			let left_value = expr_as_value(&left_result.data);
+			let right_value = expr_as_value(&right_result.data);
+
+			if let (Some(left_val), Some(right_val)) = (left_value, right_value)
+				&& let Some(folded) = try_fold_binary(&op, left_val, right_val)
+			{
+				return Ok(Transformed::yes(Expr::Value(folded)));
+			}
+
+			Ok(Transformed {
+				data: Expr::Binary {
+					left: Box::new(left_result.data),
+					op,
+					right: Box::new(right_result.data),
+				},
+				transformed,
+			})
+		}
+
+		// Optimise prefix operations
+		Expr::Prefix {
+			op,
+			expr: inner,
+		} => {
+			let result = optimise_expr_recursive(*inner)?;
+
+			// Try to fold if the operand is a value
+			if let Some(value) = expr_as_value(&result.data)
+				&& let Some(folded) = try_fold_prefix(&op, value)
+			{
+				return Ok(Transformed::yes(Expr::Value(folded)));
+			}
+
+			Ok(result.map(|e| Expr::Prefix {
+				op,
+				expr: Box::new(e),
+			}))
+		}
+
+		// Optimise postfix operations (limited support)
+		Expr::Postfix {
+			expr: inner,
+			op,
+		} => {
+			let result = optimise_expr_recursive(*inner)?;
+			// Most postfix operations (ranges, method calls) can't be folded
+			Ok(result.map(|e| Expr::Postfix {
+				expr: Box::new(e),
+				op,
+			}))
+		}
+
+		// Recursively optimise composite expressions
+		Expr::Block(block) => {
+			let (new_exprs, transformed) = optimise_expr_vec(block.0.clone())?;
+			Ok(Transformed {
+				data: Expr::Block(Box::new(crate::expr::Block(new_exprs))),
+				transformed,
+			})
+		}
+
+		Expr::FunctionCall(mut call) => {
+			let (new_args, transformed) = optimise_expr_vec(call.arguments)?;
+			call.arguments = new_args;
+			// Don't fold function calls for now
+			Ok(Transformed {
+				data: Expr::FunctionCall(call),
+				transformed,
+			})
+		}
+
+		Expr::Throw(expr) => {
+			let result = optimise_expr_recursive(*expr)?;
+			Ok(result.map(|e| Expr::Throw(Box::new(e))))
+		}
+
+		Expr::Return(mut output) => {
+			let result = optimise_expr_recursive(output.what)?;
+			output.what = result.data;
+			Ok(Transformed {
+				data: Expr::Return(output),
+				transformed: result.transformed,
+			})
+		}
+
+		Expr::IfElse(mut ifelse) => {
+			let mut transformed = false;
+			let mut new_exprs = Vec::with_capacity(ifelse.exprs.len());
+			for (cond, then) in ifelse.exprs {
+				let cond_result = optimise_expr_recursive(cond)?;
+				transformed = transformed || cond_result.transformed;
+				let then_result = optimise_expr_recursive(then)?;
+				transformed = transformed || then_result.transformed;
+				new_exprs.push((cond_result.data, then_result.data));
+			}
+			ifelse.exprs = new_exprs;
+
+			if let Some(close) = ifelse.close {
+				let close_result = optimise_expr_recursive(close)?;
+				transformed = transformed || close_result.transformed;
+				ifelse.close = Some(close_result.data);
+			}
+
+			Ok(Transformed {
+				data: Expr::IfElse(ifelse),
+				transformed,
+			})
+		}
+
+		// Leaf nodes that don't need optimization
+		Expr::Value(_)
+		| Expr::Literal(_)
+		| Expr::Param(_)
+		| Expr::Idiom(_)
+		| Expr::Table(_)
+		| Expr::Mock(_)
+		| Expr::Closure(_)
+		| Expr::Break
+		| Expr::Continue
+		| Expr::Select(_)
+		| Expr::Create(_)
+		| Expr::Update(_)
+		| Expr::Upsert(_)
+		| Expr::Delete(_)
+		| Expr::Relate(_)
+		| Expr::Insert(_)
+		| Expr::Define(_)
+		| Expr::Remove(_)
+		| Expr::Rebuild(_)
+		| Expr::Alter(_)
+		| Expr::Info(_)
+		| Expr::Foreach(_)
+		| Expr::Let(_)
+		| Expr::Sleep(_) => Ok(Transformed::no(expr)),
+	}
+}
+
+fn optimise_expr_vec(exprs: Vec<Expr>) -> Result<(Vec<Expr>, bool)> {
+	let mut transformed = false;
+	let mut new_exprs = Vec::with_capacity(exprs.len());
+	for expr in exprs {
+		let result = optimise_expr_recursive(expr)?;
+		transformed = transformed || result.transformed;
+		new_exprs.push(result.data);
+	}
+	Ok((new_exprs, transformed))
+}
+
+/// Try to fold a binary operation on two constant values
+fn try_fold_binary(op: &BinaryOperator, left: &Value, right: &Value) -> Option<Value> {
+	let result = match op {
+		// Arithmetic operations
+		BinaryOperator::Add => fnc::operate::add(left.clone(), right.clone()),
+		BinaryOperator::Subtract => fnc::operate::sub(left.clone(), right.clone()),
+		BinaryOperator::Multiply => fnc::operate::mul(left.clone(), right.clone()),
+		BinaryOperator::Divide => fnc::operate::div(left.clone(), right.clone()),
+		BinaryOperator::Remainder => fnc::operate::rem(left.clone(), right.clone()),
+		BinaryOperator::Power => fnc::operate::pow(left.clone(), right.clone()),
+
+		// Comparison operations
+		BinaryOperator::Equal => fnc::operate::equal(left, right),
+		BinaryOperator::ExactEqual => fnc::operate::exact(left, right),
+		BinaryOperator::NotEqual => fnc::operate::not_equal(left, right),
+		BinaryOperator::AllEqual => fnc::operate::all_equal(left, right),
+		BinaryOperator::AnyEqual => fnc::operate::any_equal(left, right),
+		BinaryOperator::LessThan => fnc::operate::less_than(left, right),
+		BinaryOperator::LessThanEqual => fnc::operate::less_than_or_equal(left, right),
+		BinaryOperator::MoreThan => fnc::operate::more_than(left, right),
+		BinaryOperator::MoreThanEqual => fnc::operate::more_than_or_equal(left, right),
+
+		// Logical operations (short-circuiting handled differently)
+		BinaryOperator::And => {
+			if !left.is_truthy() {
+				return Some(left.clone());
+			}
+			return Some(right.clone());
+		}
+		BinaryOperator::Or | BinaryOperator::TenaryCondition => {
+			if left.is_truthy() {
+				return Some(left.clone());
+			}
+			return Some(right.clone());
+		}
+		BinaryOperator::NullCoalescing => {
+			if !left.is_nullish() {
+				return Some(left.clone());
+			}
+			return Some(right.clone());
+		}
+
+		// Set operations
+		BinaryOperator::Contain => fnc::operate::contain(left, right),
+		BinaryOperator::NotContain => fnc::operate::not_contain(left, right),
+		BinaryOperator::ContainAll => fnc::operate::contain_all(left, right),
+		BinaryOperator::ContainAny => fnc::operate::contain_any(left, right),
+		BinaryOperator::ContainNone => fnc::operate::contain_none(left, right),
+		BinaryOperator::Inside => fnc::operate::inside(left, right),
+		BinaryOperator::NotInside => fnc::operate::not_inside(left, right),
+		BinaryOperator::AllInside => fnc::operate::inside_all(left, right),
+		BinaryOperator::AnyInside => fnc::operate::inside_any(left, right),
+		BinaryOperator::NoneInside => fnc::operate::inside_none(left, right),
+		BinaryOperator::Outside => fnc::operate::outside(left, right),
+		BinaryOperator::Intersects => fnc::operate::intersects(left, right),
+
+		// Range operations - these create ranges, not values we can fold
+		BinaryOperator::Range
+		| BinaryOperator::RangeInclusive
+		| BinaryOperator::RangeSkip
+		| BinaryOperator::RangeSkipInclusive => return None,
+
+		// Skip async operations
+		BinaryOperator::Matches(_) | BinaryOperator::NearestNeighbor(_) => return None,
+	};
+
+	result.ok()
+}
+
+/// Try to fold a prefix operation on a constant value
+fn try_fold_prefix(op: &PrefixOperator, value: &Value) -> Option<Value> {
+	let result = match op {
+		PrefixOperator::Not => fnc::operate::not(value.clone()),
+		PrefixOperator::Negate => fnc::operate::neg(value.clone()),
+		PrefixOperator::Positive => Ok(value.clone()),
+		// Range operations create ranges, not values
+		PrefixOperator::Range | PrefixOperator::RangeInclusive => return None,
+		// Cast operations need kind information
+		PrefixOperator::Cast(_) => return None,
+	};
+
+	result.ok()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::val::Number;
+
+	fn int_value(n: i64) -> Expr {
+		Expr::Value(Value::Number(Number::Int(n)))
+	}
+
+	fn bool_value(b: bool) -> Expr {
+		Expr::Value(Value::Bool(b))
+	}
+
+	#[test]
+	fn test_add_integers() {
+		let expr = Expr::Binary {
+			left: Box::new(int_value(1)),
+			op: BinaryOperator::Add,
+			right: Box::new(int_value(2)),
+		};
+		let result = ConstantFolding.optimise_expr(expr).unwrap();
+		assert!(result.transformed);
+		match result.data {
+			Expr::Value(Value::Number(Number::Int(3))) => (),
+			other => panic!("Expected Value(3), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_multiply_integers() {
+		let expr = Expr::Binary {
+			left: Box::new(int_value(10)),
+			op: BinaryOperator::Multiply,
+			right: Box::new(int_value(5)),
+		};
+		let result = ConstantFolding.optimise_expr(expr).unwrap();
+		assert!(result.transformed);
+		match result.data {
+			Expr::Value(Value::Number(Number::Int(50))) => (),
+			other => panic!("Expected Value(50), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_nested_arithmetic() {
+		// (1 + 2) * 3
+		let inner = Expr::Binary {
+			left: Box::new(int_value(1)),
+			op: BinaryOperator::Add,
+			right: Box::new(int_value(2)),
+		};
+		let expr = Expr::Binary {
+			left: Box::new(inner),
+			op: BinaryOperator::Multiply,
+			right: Box::new(int_value(3)),
+		};
+		let result = ConstantFolding.optimise_expr(expr).unwrap();
+		assert!(result.transformed);
+		match result.data {
+			Expr::Value(Value::Number(Number::Int(9))) => (),
+			other => panic!("Expected Value(9), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_boolean_and() {
+		let expr = Expr::Binary {
+			left: Box::new(bool_value(true)),
+			op: BinaryOperator::And,
+			right: Box::new(bool_value(false)),
+		};
+		let result = ConstantFolding.optimise_expr(expr).unwrap();
+		assert!(result.transformed);
+		match result.data {
+			Expr::Value(Value::Bool(false)) => (),
+			other => panic!("Expected Value(false), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_comparison() {
+		let expr = Expr::Binary {
+			left: Box::new(int_value(5)),
+			op: BinaryOperator::MoreThan,
+			right: Box::new(int_value(3)),
+		};
+		let result = ConstantFolding.optimise_expr(expr).unwrap();
+		assert!(result.transformed);
+		match result.data {
+			Expr::Value(Value::Bool(true)) => (),
+			other => panic!("Expected Value(true), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_negation() {
+		let expr = Expr::Prefix {
+			op: PrefixOperator::Negate,
+			expr: Box::new(int_value(42)),
+		};
+		let result = ConstantFolding.optimise_expr(expr).unwrap();
+		assert!(result.transformed);
+		match result.data {
+			Expr::Value(Value::Number(Number::Int(-42))) => (),
+			other => panic!("Expected Value(-42), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_not_boolean() {
+		let expr = Expr::Prefix {
+			op: PrefixOperator::Not,
+			expr: Box::new(bool_value(true)),
+		};
+		let result = ConstantFolding.optimise_expr(expr).unwrap();
+		assert!(result.transformed);
+		match result.data {
+			Expr::Value(Value::Bool(false)) => (),
+			other => panic!("Expected Value(false), got {:?}", other),
+		}
+	}
+
+	#[test]
+	fn test_non_constant_unchanged() {
+		let expr = Expr::Binary {
+			left: Box::new(Expr::Param(crate::expr::Param::new("x".to_string()))),
+			op: BinaryOperator::Add,
+			right: Box::new(int_value(2)),
+		};
+		let result = ConstantFolding.optimise_expr(expr).unwrap();
+		assert!(!result.transformed);
+	}
+}

--- a/crates/core/src/expr/optimise/rules/mod.rs
+++ b/crates/core/src/expr/optimise/rules/mod.rs
@@ -1,0 +1,5 @@
+mod constant_folding;
+mod static_literal_folding;
+
+pub(crate) use constant_folding::ConstantFolding;
+pub(crate) use static_literal_folding::StaticLiteralFolding;

--- a/crates/core/src/expr/optimise/rules/static_literal_folding.rs
+++ b/crates/core/src/expr/optimise/rules/static_literal_folding.rs
@@ -1,0 +1,271 @@
+use anyhow::Result;
+
+use crate::expr::optimise::utils::literal_to_value;
+use crate::expr::optimise::{OptimiserRule, Transformed};
+use crate::expr::{Expr, Literal};
+
+/// Optimization rule that converts static literals to pre-computed values.
+///
+/// This rule identifies `Expr::Literal` nodes where `literal.is_static()` is true
+/// and converts them to `Expr::Value`, eliminating the need to compute them at runtime.
+///
+/// Examples:
+/// - `Literal::Integer(42)` → `Value(Number::Int(42))`
+/// - `Literal::Array([1, 2, 3])` → `Value(Array([1, 2, 3]))`
+/// - `Literal::Object({a: 5})` → `Value(Object(...))`
+///
+/// Non-static literals (containing parameters, idioms, etc.) are left unchanged.
+pub(crate) struct StaticLiteralFolding;
+
+impl OptimiserRule for StaticLiteralFolding {
+	fn name(&self) -> &str {
+		"static_literal_folding"
+	}
+
+	fn optimise_expr(&self, expr: Expr) -> Result<Transformed<Expr>> {
+		optimise_expr_recursive(expr)
+	}
+}
+
+fn optimise_expr_recursive(expr: Expr) -> Result<Transformed<Expr>> {
+	match expr {
+		// The main optimization: convert static literals to values
+		Expr::Literal(ref literal) if literal.is_static() => {
+			// First, recursively optimise children (for arrays/objects)
+			let optimised = match expr {
+				Expr::Literal(Literal::Array(exprs)) => {
+					let (new_exprs, child_transformed) = optimise_expr_vec(exprs)?;
+					let new_literal = Literal::Array(new_exprs);
+					(Expr::Literal(new_literal), child_transformed)
+				}
+				Expr::Literal(Literal::Set(exprs)) => {
+					let (new_exprs, child_transformed) = optimise_expr_vec(exprs)?;
+					let new_literal = Literal::Set(new_exprs);
+					(Expr::Literal(new_literal), child_transformed)
+				}
+				Expr::Literal(Literal::Object(items)) => {
+					let (new_items, child_transformed) = optimise_object_entries(items)?;
+					let new_literal = Literal::Object(new_items);
+					(Expr::Literal(new_literal), child_transformed)
+				}
+				other => (other, false),
+			};
+
+			// Now convert to value
+			if let Expr::Literal(ref lit) = optimised.0 {
+				match literal_to_value(lit) {
+					Ok(value) => Ok(Transformed::yes(Expr::Value(value))),
+					Err(_) => {
+						// If conversion fails, keep the original
+						Ok(Transformed {
+							data: optimised.0,
+							transformed: optimised.1,
+						})
+					}
+				}
+			} else {
+				Ok(Transformed {
+					data: optimised.0,
+					transformed: optimised.1,
+				})
+			}
+		}
+
+		// Recursively optimise composite expressions
+		Expr::Prefix {
+			op,
+			expr,
+		} => {
+			let result = optimise_expr_recursive(*expr)?;
+			Ok(result.map(|e| Expr::Prefix {
+				op,
+				expr: Box::new(e),
+			}))
+		}
+
+		Expr::Postfix {
+			expr,
+			op,
+		} => {
+			let result = optimise_expr_recursive(*expr)?;
+			Ok(result.map(|e| Expr::Postfix {
+				expr: Box::new(e),
+				op,
+			}))
+		}
+
+		Expr::Binary {
+			left,
+			op,
+			right,
+		} => {
+			let left_result = optimise_expr_recursive(*left)?;
+			let right_result = optimise_expr_recursive(*right)?;
+			let transformed = left_result.transformed || right_result.transformed;
+			Ok(Transformed {
+				data: Expr::Binary {
+					left: Box::new(left_result.data),
+					op,
+					right: Box::new(right_result.data),
+				},
+				transformed,
+			})
+		}
+
+		Expr::Block(block) => {
+			let (new_exprs, transformed) = optimise_expr_vec(block.0.clone())?;
+			Ok(Transformed {
+				data: Expr::Block(Box::new(crate::expr::Block(new_exprs))),
+				transformed,
+			})
+		}
+
+		Expr::FunctionCall(mut call) => {
+			let (new_args, transformed) = optimise_expr_vec(call.arguments)?;
+			call.arguments = new_args;
+			Ok(Transformed {
+				data: Expr::FunctionCall(call),
+				transformed,
+			})
+		}
+
+		Expr::Throw(expr) => {
+			let result = optimise_expr_recursive(*expr)?;
+			Ok(result.map(|e| Expr::Throw(Box::new(e))))
+		}
+
+		Expr::Return(mut output) => {
+			let result = optimise_expr_recursive(output.what)?;
+			output.what = result.data;
+			Ok(Transformed {
+				data: Expr::Return(output),
+				transformed: result.transformed,
+			})
+		}
+
+		// For statement expressions, optimise their internal expressions
+		Expr::IfElse(mut ifelse) => {
+			let mut transformed = false;
+			let mut new_exprs = Vec::with_capacity(ifelse.exprs.len());
+			for (cond, then) in ifelse.exprs {
+				let cond_result = optimise_expr_recursive(cond)?;
+				transformed = transformed || cond_result.transformed;
+				let then_result = optimise_expr_recursive(then)?;
+				transformed = transformed || then_result.transformed;
+				new_exprs.push((cond_result.data, then_result.data));
+			}
+			ifelse.exprs = new_exprs;
+
+			if let Some(close) = ifelse.close {
+				let close_result = optimise_expr_recursive(close)?;
+				transformed = transformed || close_result.transformed;
+				ifelse.close = Some(close_result.data);
+			}
+
+			Ok(Transformed {
+				data: Expr::IfElse(ifelse),
+				transformed,
+			})
+		}
+
+		// Leaf nodes and expressions we don't optimise
+		Expr::Value(_)
+		| Expr::Literal(_)
+		| Expr::Param(_)
+		| Expr::Idiom(_)
+		| Expr::Table(_)
+		| Expr::Mock(_)
+		| Expr::Constant(_)
+		| Expr::Closure(_)
+		| Expr::Break
+		| Expr::Continue
+		| Expr::Select(_)
+		| Expr::Create(_)
+		| Expr::Update(_)
+		| Expr::Upsert(_)
+		| Expr::Delete(_)
+		| Expr::Relate(_)
+		| Expr::Insert(_)
+		| Expr::Define(_)
+		| Expr::Remove(_)
+		| Expr::Rebuild(_)
+		| Expr::Alter(_)
+		| Expr::Info(_)
+		| Expr::Foreach(_)
+		| Expr::Let(_)
+		| Expr::Sleep(_) => Ok(Transformed::no(expr)),
+	}
+}
+
+fn optimise_expr_vec(exprs: Vec<Expr>) -> Result<(Vec<Expr>, bool)> {
+	let mut transformed = false;
+	let mut new_exprs = Vec::with_capacity(exprs.len());
+	for expr in exprs {
+		let result = optimise_expr_recursive(expr)?;
+		transformed = transformed || result.transformed;
+		new_exprs.push(result.data);
+	}
+	Ok((new_exprs, transformed))
+}
+
+fn optimise_object_entries(
+	items: Vec<crate::expr::ObjectEntry>,
+) -> Result<(Vec<crate::expr::ObjectEntry>, bool)> {
+	let mut transformed = false;
+	let mut new_items = Vec::with_capacity(items.len());
+	for item in items {
+		let result = optimise_expr_recursive(item.value)?;
+		transformed = transformed || result.transformed;
+		new_items.push(crate::expr::ObjectEntry {
+			key: item.key,
+			value: result.data,
+		});
+	}
+	Ok((new_items, transformed))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::val::Number;
+
+	#[test]
+	fn test_static_integer_literal() {
+		let expr = Expr::Literal(Literal::Integer(42));
+		let result = StaticLiteralFolding.optimise_expr(expr).unwrap();
+		assert!(result.transformed);
+		match result.data {
+			Expr::Value(v) => assert_eq!(v, crate::val::Value::Number(Number::Int(42))),
+			_ => panic!("Expected Value"),
+		}
+	}
+
+	#[test]
+	fn test_static_string_literal() {
+		let expr = Expr::Literal(Literal::String("hello".to_string()));
+		let result = StaticLiteralFolding.optimise_expr(expr).unwrap();
+		assert!(result.transformed);
+		match result.data {
+			Expr::Value(v) => assert_eq!(v, crate::val::Value::String("hello".to_string())),
+			_ => panic!("Expected Value"),
+		}
+	}
+
+	#[test]
+	fn test_static_bool_literal() {
+		let expr = Expr::Literal(Literal::Bool(true));
+		let result = StaticLiteralFolding.optimise_expr(expr).unwrap();
+		assert!(result.transformed);
+		match result.data {
+			Expr::Value(v) => assert_eq!(v, crate::val::Value::Bool(true)),
+			_ => panic!("Expected Value"),
+		}
+	}
+
+	#[test]
+	fn test_param_not_optimised() {
+		let expr = Expr::Param(crate::expr::Param::new("test".to_string()));
+		let result = StaticLiteralFolding.optimise_expr(expr).unwrap();
+		assert!(!result.transformed);
+	}
+}

--- a/crates/core/src/expr/optimise/rules/static_literal_folding.rs
+++ b/crates/core/src/expr/optimise/rules/static_literal_folding.rs
@@ -18,10 +18,6 @@ use crate::expr::{Expr, Literal};
 pub(crate) struct StaticLiteralFolding;
 
 impl OptimiserRule for StaticLiteralFolding {
-	fn name(&self) -> &str {
-		"static_literal_folding"
-	}
-
 	fn optimise_expr(&self, expr: Expr) -> Result<Transformed<Expr>> {
 		optimise_expr_recursive(expr)
 	}

--- a/crates/core/src/expr/optimise/rules/static_literal_folding.rs
+++ b/crates/core/src/expr/optimise/rules/static_literal_folding.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::expr::optimise::utils::literal_to_value;
+use crate::expr::optimise::utils::{LiteralConversion, literal_to_value};
 use crate::expr::optimise::{OptimiserRule, Transformed};
 use crate::expr::{Expr, Literal};
 
@@ -48,13 +48,13 @@ fn optimise_expr_recursive(expr: Expr) -> Result<Transformed<Expr>> {
 			};
 
 			// Now convert to value
-			if let Expr::Literal(ref lit) = optimised.0 {
+			if let Expr::Literal(lit) = optimised.0 {
 				match literal_to_value(lit) {
-					Ok(value) => Ok(Transformed::yes(Expr::Value(value))),
-					Err(_) => {
+					LiteralConversion::Value(value) => Ok(Transformed::yes(Expr::Value(value))),
+					LiteralConversion::Literal(lit) => {
 						// If conversion fails, keep the original
 						Ok(Transformed {
-							data: optimised.0,
+							data: Expr::Literal(lit),
 							transformed: optimised.1,
 						})
 					}

--- a/crates/core/src/expr/optimise/utils.rs
+++ b/crates/core/src/expr/optimise/utils.rs
@@ -1,0 +1,133 @@
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+
+use crate::expr::{Expr, Literal, RecordIdKeyLit, RecordIdLit};
+use crate::val::{Array, Number, Object, Range, RecordId, RecordIdKey, Value};
+
+/// Convert a static literal to a Value synchronously.
+///
+/// This function mirrors the logic of `Literal::compute()` but works
+/// synchronously for static literals that don't require async evaluation.
+///
+/// For arrays and objects, the children must already be converted to
+/// `Expr::Value` by the recursive traversal.
+pub(super) fn literal_to_value(literal: &Literal) -> Result<Value> {
+	let value = match literal {
+		Literal::None => Value::None,
+		Literal::Null => Value::Null,
+		Literal::UnboundedRange => Value::Range(Box::new(Range::unbounded())),
+		Literal::Bool(x) => Value::Bool(*x),
+		Literal::Float(x) => Value::Number(Number::Float(*x)),
+		Literal::Integer(i) => Value::Number(Number::Int(*i)),
+		Literal::Decimal(d) => Value::Number(Number::Decimal(*d)),
+		Literal::String(strand) => Value::String(strand.clone()),
+		Literal::Bytes(bytes) => Value::Bytes(bytes.clone()),
+		Literal::Regex(regex) => Value::Regex(regex.clone()),
+		Literal::RecordId(record_id_lit) => {
+			Value::RecordId(record_id_key_lit_to_record_id(record_id_lit)?)
+		}
+		Literal::Array(exprs) => {
+			let mut array = Vec::with_capacity(exprs.len());
+			for e in exprs.iter() {
+				match e {
+					Expr::Value(v) => array.push(v.clone()),
+					_ => {
+						anyhow::bail!("Array contains non-value expression in static literal")
+					}
+				}
+			}
+			Value::Array(Array(array))
+		}
+		Literal::Set(exprs) => {
+			let mut set = crate::val::Set::new();
+			for e in exprs.iter() {
+				match e {
+					Expr::Value(v) => {
+						set.insert(v.clone());
+					}
+					_ => anyhow::bail!("Set contains non-value expression in static literal"),
+				}
+			}
+			Value::Set(set)
+		}
+		Literal::Object(items) => {
+			let mut map = BTreeMap::new();
+			for i in items.iter() {
+				match &i.value {
+					Expr::Value(v) => {
+						map.insert(i.key.clone(), v.clone());
+					}
+					_ => {
+						anyhow::bail!("Object contains non-value expression in static literal")
+					}
+				}
+			}
+			Value::Object(Object(map))
+		}
+		Literal::Duration(duration) => Value::Duration(*duration),
+		Literal::Datetime(datetime) => Value::Datetime(datetime.clone()),
+		Literal::Uuid(uuid) => Value::Uuid(*uuid),
+		Literal::Geometry(geometry) => Value::Geometry(geometry.clone()),
+		Literal::File(file) => Value::File(file.clone()),
+	};
+	Ok(value)
+}
+
+/// Convert a RecordIdLit to a RecordId synchronously
+fn record_id_key_lit_to_record_id(record_id_lit: &RecordIdLit) -> Result<RecordId> {
+	let key = record_id_key_lit_to_key(&record_id_lit.key)?;
+	Ok(RecordId {
+		table: record_id_lit.table.clone(),
+		key,
+	})
+}
+
+/// Convert a RecordIdKeyLit to a RecordIdKey synchronously
+fn record_id_key_lit_to_key(key_lit: &RecordIdKeyLit) -> Result<RecordIdKey> {
+	let key = match key_lit {
+		RecordIdKeyLit::Number(v) => RecordIdKey::Number(*v),
+		RecordIdKeyLit::String(v) => RecordIdKey::String(v.clone()),
+		RecordIdKeyLit::Uuid(v) => RecordIdKey::Uuid(*v),
+		RecordIdKeyLit::Array(v) => {
+			let mut res = Vec::new();
+			for expr in v.iter() {
+				match expr {
+					Expr::Value(val) => res.push(val.clone()),
+					_ => anyhow::bail!("RecordId array key contains non-value expression"),
+				}
+			}
+			RecordIdKey::Array(Array(res))
+		}
+		RecordIdKeyLit::Object(v) => {
+			let mut res = Object::default();
+			for entry in v.iter() {
+				match &entry.value {
+					Expr::Value(val) => {
+						res.insert(entry.key.clone(), val.clone());
+					}
+					_ => anyhow::bail!("RecordId object key contains non-value expression"),
+				}
+			}
+			RecordIdKey::Object(res)
+		}
+		RecordIdKeyLit::Generate(v) => v.compute(),
+		RecordIdKeyLit::Range(_) => {
+			anyhow::bail!("RecordId range keys cannot be converted statically")
+		}
+	};
+	Ok(key)
+}
+
+/// Helper to extract a Value from an Expr if it's an Expr::Value
+pub(super) fn expr_as_value(expr: &Expr) -> Option<&Value> {
+	match expr {
+		Expr::Value(v) => Some(v),
+		_ => None,
+	}
+}
+
+/// Helper to convert Expr::Constant to Value
+pub(super) fn constant_to_value(constant: &crate::expr::Constant) -> Result<Value> {
+	constant.compute()
+}

--- a/crates/core/src/expr/record_id/key.rs
+++ b/crates/core/src/expr/record_id/key.rs
@@ -61,22 +61,7 @@ impl RecordIdKeyLit {
 			_ => false,
 		}
 	}
-}
 
-impl From<RecordIdKeyRangeLit> for RecordIdKeyLit {
-	fn from(v: RecordIdKeyRangeLit) -> Self {
-		Self::Range(Box::new(v))
-	}
-}
-
-impl ToSql for RecordIdKeyLit {
-	fn fmt_sql(&self, f: &mut String, fmt: SqlFormat) {
-		let sql_record_id_key_lit: crate::sql::RecordIdKeyLit = self.clone().into();
-		sql_record_id_key_lit.fmt_sql(f, fmt);
-	}
-}
-
-impl RecordIdKeyLit {
 	pub(crate) fn is_static(&self) -> bool {
 		match self {
 			RecordIdKeyLit::Number(_)
@@ -86,6 +71,18 @@ impl RecordIdKeyLit {
 			RecordIdKeyLit::Range(record_id_key_range_lit) => record_id_key_range_lit.is_static(),
 			RecordIdKeyLit::Array(exprs) => exprs.iter().all(|x| x.is_static()),
 			RecordIdKeyLit::Object(items) => items.iter().all(|x| x.value.is_static()),
+		}
+	}
+
+	pub(crate) fn is_pure(&self) -> bool {
+		match self {
+			RecordIdKeyLit::Number(_)
+			| RecordIdKeyLit::String(_)
+			| RecordIdKeyLit::Uuid(_)
+			| RecordIdKeyLit::Generate(_) => true,
+			RecordIdKeyLit::Range(record_id_key_range_lit) => record_id_key_range_lit.is_static(),
+			RecordIdKeyLit::Array(exprs) => exprs.iter().all(|x| x.is_pure()),
+			RecordIdKeyLit::Object(items) => items.iter().all(|x| x.value.is_pure()),
 		}
 	}
 
@@ -126,6 +123,19 @@ impl RecordIdKeyLit {
 				Ok(RecordIdKey::Range(Box::new(range)))
 			}
 		}
+	}
+}
+
+impl From<RecordIdKeyRangeLit> for RecordIdKeyLit {
+	fn from(v: RecordIdKeyRangeLit) -> Self {
+		Self::Range(Box::new(v))
+	}
+}
+
+impl ToSql for RecordIdKeyLit {
+	fn fmt_sql(&self, f: &mut String, fmt: SqlFormat) {
+		let sql_record_id_key_lit: crate::sql::RecordIdKeyLit = self.clone().into();
+		sql_record_id_key_lit.fmt_sql(f, fmt);
 	}
 }
 

--- a/crates/core/src/expr/record_id/mod.rs
+++ b/crates/core/src/expr/record_id/mod.rs
@@ -25,6 +25,10 @@ impl RecordIdLit {
 		self.key.is_static()
 	}
 
+	pub(crate) fn is_pure(&self) -> bool {
+		self.key.is_pure()
+	}
+
 	pub(crate) async fn compute(
 		&self,
 		stk: &mut Stk,

--- a/crates/core/src/expr/record_id/range.rs
+++ b/crates/core/src/expr/record_id/range.rs
@@ -19,8 +19,8 @@ pub(crate) struct RecordIdKeyRangeLit {
 impl RecordIdKeyRangeLit {
 	pub(crate) fn is_static(&self) -> bool {
 		let res = match &self.start {
-			Bound::Included(x) => x.is_static(),
-			Bound::Excluded(x) => x.is_static(),
+			Bound::Included(x) => x.is_pure(),
+			Bound::Excluded(x) => x.is_pure(),
 			Bound::Unbounded => true,
 		};
 
@@ -29,8 +29,8 @@ impl RecordIdKeyRangeLit {
 		}
 
 		match &self.end {
-			Bound::Included(x) => x.is_static(),
-			Bound::Excluded(x) => x.is_static(),
+			Bound::Included(x) => x.is_pure(),
+			Bound::Excluded(x) => x.is_pure(),
 			Bound::Unbounded => true,
 		}
 	}

--- a/crates/core/src/expr/statements/create.rs
+++ b/crates/core/src/expr/statements/create.rs
@@ -7,7 +7,7 @@ use surrealdb_types::{SqlFormat, ToSql};
 use crate::catalog::providers::{DatabaseProvider, NamespaceProvider};
 use crate::ctx::FrozenContext;
 use crate::dbs::{Iterator, Options, Statement};
-use crate::doc::{CursorDoc, NsDbCtx};
+use crate::doc::{CursorDoc, DatabaseContext};
 use crate::err::Error;
 use crate::expr::{Data, Expr, FlowResultExt as _, Literal, Output};
 use crate::idx::planner::{QueryPlanner, RecordStrategy, StatementContext};
@@ -82,7 +82,7 @@ impl CreateStatement {
 		let txn = ctx.tx();
 		let ns = txn.expect_ns_by_name(opt.ns()?).await?;
 		let db = txn.expect_db_by_name(opt.ns()?, opt.db()?).await?;
-		let doc_ctx = NsDbCtx {
+		let doc_ctx = DatabaseContext {
 			ns: Arc::clone(&ns),
 			db: Arc::clone(&db),
 		};

--- a/crates/core/src/expr/statements/define/table.rs
+++ b/crates/core/src/expr/statements/define/table.rs
@@ -16,7 +16,7 @@ use crate::catalog::{
 };
 use crate::ctx::FrozenContext;
 use crate::dbs::Options;
-use crate::doc::{self, CursorDoc, Document, DocumentContext, NsDbTbCtx};
+use crate::doc::{self, CursorDoc, Document, DocumentContext, TableContext};
 use crate::err::Error;
 use crate::expr::changefeed::ChangeFeed;
 use crate::expr::field::Selector;
@@ -152,7 +152,7 @@ impl DefineTableStatement {
 		// Clear the cache
 		txn.clear_cache();
 
-		let doc_ctx = DocumentContext::NsDbTbCtx(NsDbTbCtx {
+		let doc_ctx = DocumentContext::TableCtx(TableContext {
 			ns: Arc::clone(&ns),
 			db: Arc::clone(&db),
 			tb,
@@ -317,7 +317,7 @@ impl DefineTableStatement {
 				.tx()
 				.all_tb_fields(ns.namespace_id, db.database_id, view_table_name, opt.version)
 				.await?;
-			let doc_ctx = DocumentContext::NsDbTbCtx(NsDbTbCtx {
+			let doc_ctx = DocumentContext::TableCtx(TableContext {
 				ns: Arc::clone(ns),
 				db: Arc::clone(db),
 				tb,

--- a/crates/core/src/expr/statements/delete.rs
+++ b/crates/core/src/expr/statements/delete.rs
@@ -7,7 +7,7 @@ use surrealdb_types::{SqlFormat, ToSql};
 use crate::catalog::providers::{DatabaseProvider, NamespaceProvider};
 use crate::ctx::FrozenContext;
 use crate::dbs::{Iterator, Options, Statement};
-use crate::doc::{CursorDoc, NsDbCtx};
+use crate::doc::{CursorDoc, DatabaseContext};
 use crate::err::Error;
 use crate::expr::{Cond, Explain, Expr, Literal, Output, With};
 use crate::idx::planner::{QueryPlanner, RecordStrategy, StatementContext};
@@ -67,7 +67,7 @@ impl DeleteStatement {
 		let txn = ctx.tx();
 		let ns = txn.expect_ns_by_name(opt.ns()?).await?;
 		let db = txn.expect_db_by_name(opt.ns()?, opt.db()?).await?;
-		let doc_ctx = NsDbCtx {
+		let doc_ctx = DatabaseContext {
 			ns: Arc::clone(&ns),
 			db: Arc::clone(&db),
 		};

--- a/crates/core/src/expr/statements/insert.rs
+++ b/crates/core/src/expr/statements/insert.rs
@@ -7,7 +7,7 @@ use surrealdb_types::{SqlFormat, ToSql};
 use crate::catalog::providers::{DatabaseProvider, NamespaceProvider, TableProvider};
 use crate::ctx::{Context, FrozenContext};
 use crate::dbs::{Iterable, Iterator, Options, Statement};
-use crate::doc::{CursorDoc, NsDbTbCtx};
+use crate::doc::{CursorDoc, TableContext};
 use crate::err::Error;
 use crate::expr::paths::{IN, OUT};
 use crate::expr::statements::relate::RelateThrough;
@@ -106,7 +106,7 @@ impl InsertStatement {
 			let tb_def = ctx.tx().get_or_add_tb(Some(ctx), &ns.name, &db.name, tb).await?;
 			let fields =
 				ctx.tx().all_tb_fields(ns.namespace_id, db.database_id, tb, opt.version).await?;
-			doc_ctx = Some(NsDbTbCtx {
+			doc_ctx = Some(TableContext {
 				ns: Arc::clone(&ns),
 				db: Arc::clone(&db),
 				tb: tb_def,
@@ -138,7 +138,7 @@ impl InsertStatement {
 							let fields = txn
 								.all_tb_fields(ns.namespace_id, db.database_id, &tb, opt.version)
 								.await?;
-							Some(NsDbTbCtx {
+							Some(TableContext {
 								ns: Arc::clone(&ns),
 								db: Arc::clone(&db),
 								tb: tb_def,
@@ -180,7 +180,7 @@ impl InsertStatement {
 											opt.version,
 										)
 										.await?;
-									Some(NsDbTbCtx {
+									Some(TableContext {
 										ns: Arc::clone(&ns),
 										db: Arc::clone(&db),
 										tb: tb_def,
@@ -216,7 +216,7 @@ impl InsertStatement {
 										opt.version,
 									)
 									.await?;
-								Some(NsDbTbCtx {
+								Some(TableContext {
 									ns: Arc::clone(&ns),
 									db: Arc::clone(&db),
 									tb: tb_def,
@@ -269,7 +269,7 @@ impl ToSql for InsertStatement {
 }
 
 fn iterable(
-	doc_ctx: NsDbTbCtx,
+	doc_ctx: TableContext,
 	tb: TableName,
 	id: Option<RecordIdKey>,
 	v: Value,

--- a/crates/core/src/expr/statements/relate.rs
+++ b/crates/core/src/expr/statements/relate.rs
@@ -7,7 +7,7 @@ use surrealdb_types::ToSql;
 use crate::catalog::providers::{DatabaseProvider, NamespaceProvider, TableProvider};
 use crate::ctx::{Context, FrozenContext};
 use crate::dbs::{Iterable, Iterator, Options, Statement};
-use crate::doc::{CursorDoc, NsDbTbCtx};
+use crate::doc::{CursorDoc, TableContext};
 use crate::err::Error;
 use crate::expr::{Data, Expr, FlowResultExt as _, Output, Value};
 use crate::idx::planner::RecordStrategy;
@@ -165,7 +165,7 @@ impl RelateStatement {
 				let fields = txn
 					.all_tb_fields(ns.namespace_id, db.database_id, through_table, opt.version)
 					.await?;
-				let doc_ctx = NsDbTbCtx {
+				let doc_ctx = TableContext {
 					ns: Arc::clone(&ns),
 					db: Arc::clone(&db),
 					tb,

--- a/crates/core/src/expr/statements/select.rs
+++ b/crates/core/src/expr/statements/select.rs
@@ -6,7 +6,7 @@ use reblessive::tree::Stk;
 use crate::catalog::providers::{DatabaseProvider, NamespaceProvider};
 use crate::ctx::FrozenContext;
 use crate::dbs::{Iterator, Options, Statement};
-use crate::doc::{CursorDoc, NsDbCtx};
+use crate::doc::{CursorDoc, DatabaseContext};
 use crate::err::Error;
 use crate::expr::order::Ordering;
 use crate::expr::{
@@ -116,7 +116,7 @@ impl SelectStatement {
 		let txn = ctx.tx();
 		let ns = txn.expect_ns_by_name(opt.ns()?).await?;
 		let db = txn.expect_db_by_name(opt.ns()?, opt.db()?).await?;
-		let doc_ctx = NsDbCtx {
+		let doc_ctx = DatabaseContext {
 			ns: Arc::clone(&ns),
 			db: Arc::clone(&db),
 		};

--- a/crates/core/src/expr/statements/update.rs
+++ b/crates/core/src/expr/statements/update.rs
@@ -7,7 +7,7 @@ use surrealdb_types::{SqlFormat, ToSql};
 use crate::catalog::providers::{DatabaseProvider, NamespaceProvider};
 use crate::ctx::FrozenContext;
 use crate::dbs::{Iterator, Options, Statement};
-use crate::doc::{CursorDoc, NsDbCtx};
+use crate::doc::{CursorDoc, DatabaseContext};
 use crate::err::Error;
 use crate::expr::{Cond, Data, Explain, Expr, Literal, Output, With};
 use crate::idx::planner::{QueryPlanner, RecordStrategy, StatementContext};
@@ -70,7 +70,7 @@ impl UpdateStatement {
 		let txn = ctx.tx();
 		let ns = txn.expect_ns_by_name(opt.ns()?).await?;
 		let db = txn.expect_db_by_name(opt.ns()?, opt.db()?).await?;
-		let doc_ctx = NsDbCtx {
+		let doc_ctx = DatabaseContext {
 			ns: Arc::clone(&ns),
 			db: Arc::clone(&db),
 		};

--- a/crates/core/src/expr/statements/upsert.rs
+++ b/crates/core/src/expr/statements/upsert.rs
@@ -7,7 +7,7 @@ use surrealdb_types::{SqlFormat, ToSql};
 use crate::catalog::providers::{DatabaseProvider, NamespaceProvider};
 use crate::ctx::FrozenContext;
 use crate::dbs::{Iterator, Options, Statement};
-use crate::doc::{CursorDoc, NsDbCtx};
+use crate::doc::{CursorDoc, DatabaseContext};
 use crate::err::Error;
 use crate::expr::{Cond, Data, Explain, Expr, Literal, Output, With};
 use crate::idx::planner::{QueryPlanner, RecordStrategy, StatementContext};
@@ -70,7 +70,7 @@ impl UpsertStatement {
 		let txn = ctx.tx();
 		let ns = txn.expect_ns_by_name(opt.ns()?).await?;
 		let db = txn.expect_db_by_name(opt.ns()?, opt.db()?).await?;
-		let doc_ctx = NsDbCtx {
+		let doc_ctx = DatabaseContext {
 			ns: Arc::clone(&ns),
 			db: Arc::clone(&db),
 		};

--- a/crates/core/src/expr/visit.rs
+++ b/crates/core/src/expr/visit.rs
@@ -227,6 +227,7 @@ implement_visitor! {
 
 	fn visit_expr(this, s: &Expr){
 		match s {
+			Expr::Value(_) => {}
 			Expr::Literal(literal) => {
 				this.visit_literal(literal)?;
 			}
@@ -1638,6 +1639,7 @@ implement_visitor_mut! {
 
 	fn visit_mut_expr(this, s: &mut Expr){
 		match s {
+			Expr::Value(value) => {}
 			Expr::Literal(literal) => {
 				this.visit_mut_liter_mutal(literal)?;
 			}

--- a/crates/core/src/idx/planner/executor.rs
+++ b/crates/core/src/idx/planner/executor.rs
@@ -12,7 +12,7 @@ use crate::catalog::{
 };
 use crate::ctx::FrozenContext;
 use crate::dbs::Options;
-use crate::doc::{CursorDoc, NsDbTbCtx};
+use crate::doc::{CursorDoc, TableContext};
 use crate::err::Error;
 use crate::expr::operator::{BooleanOperator, MatchesOperator};
 use crate::expr::{Cond, Expr, FlowResultExt as _, Idiom};
@@ -125,7 +125,7 @@ impl InnerQueryExecutor {
 	#[expect(clippy::mutable_key_type)]
 	#[expect(clippy::too_many_arguments)]
 	pub(super) async fn new(
-		doc_ctx: &NsDbTbCtx,
+		doc_ctx: &TableContext,
 		stk: &mut Stk,
 		ctx: &FrozenContext,
 		opt: &Options,

--- a/crates/core/src/idx/planner/mod.rs
+++ b/crates/core/src/idx/planner/mod.rs
@@ -16,7 +16,7 @@ use reblessive::tree::Stk;
 use crate::catalog::providers::TableProvider;
 use crate::ctx::FrozenContext;
 use crate::dbs::{Iterable, Iterator, Options, Statement};
-use crate::doc::NsDbTbCtx;
+use crate::doc::TableContext;
 use crate::expr::order::Ordering;
 use crate::expr::with::With;
 use crate::expr::{Cond, Fields, Groups};
@@ -276,7 +276,7 @@ impl QueryPlanner {
 		&mut self,
 		stk: &mut Stk,
 		stm_ctx: &StatementContext<'_>,
-		doc_ctx: NsDbTbCtx,
+		doc_ctx: TableContext,
 		t: &TableName,
 		gp: GrantedPermission,
 		it: &mut Iterator,
@@ -361,7 +361,7 @@ impl QueryPlanner {
 
 	fn add(
 		&mut self,
-		doc_ctx: NsDbTbCtx,
+		doc_ctx: TableContext,
 		tb: TableName,
 		irf: Option<IteratorRef>,
 		exe: InnerQueryExecutor,

--- a/crates/core/src/kvs/tests/mod.rs
+++ b/crates/core/src/kvs/tests/mod.rs
@@ -80,6 +80,7 @@ mod mem {
 			path,
 			Some(clock),
 			CancellationToken::new(),
+			crate::options::EngineOptions::default(),
 		)
 		.await
 		.unwrap()
@@ -107,6 +108,7 @@ mod rocksdb {
 	use super::{ClockType, Kvs};
 	use crate::CommunityComposer;
 	use crate::kvs::Datastore;
+	use crate::options::EngineOptions;
 
 	async fn new_ds(id: Uuid, clock: ClockType) -> (Datastore, Kvs) {
 		// Setup the temporary data storage path
@@ -118,6 +120,7 @@ mod rocksdb {
 			&path,
 			Some(clock),
 			CancellationToken::new(),
+			EngineOptions::default(),
 		)
 		.await
 		.unwrap()
@@ -146,6 +149,7 @@ mod surrealkv {
 	use super::{ClockType, Kvs};
 	use crate::CommunityComposer;
 	use crate::kvs::Datastore;
+	use crate::options::EngineOptions;
 
 	async fn new_ds(id: Uuid, clock: ClockType) -> (Datastore, Kvs) {
 		// Setup the temporary data storage path
@@ -157,6 +161,7 @@ mod surrealkv {
 			&path,
 			Some(clock),
 			CancellationToken::new(),
+			EngineOptions::default(),
 		)
 		.await
 		.unwrap()
@@ -183,6 +188,7 @@ mod tikv {
 	use super::{ClockType, Kvs};
 	use crate::CommunityComposer;
 	use crate::kvs::{Datastore, LockType, TransactionType};
+	use crate::options::EngineOptions;
 
 	async fn new_ds(id: Uuid, clock: ClockType) -> (Datastore, Kvs) {
 		// Setup the cluster connection string
@@ -193,6 +199,7 @@ mod tikv {
 			path,
 			Some(clock),
 			CancellationToken::new(),
+			EngineOptions::default(),
 		)
 		.await
 		.unwrap()

--- a/crates/core/src/options.rs
+++ b/crates/core/src/options.rs
@@ -23,6 +23,14 @@ pub struct EngineOptions {
 	///
 	/// Default: 5 seconds
 	pub index_compaction_interval: Duration,
+	/// Maximum number of optimiser passes to run on queries
+	///
+	/// The optimiser runs multiple passes to simplify and optimize query
+	/// expressions. Each pass applies a set of optimization rules until
+	/// either no more changes occur or the maximum number of passes is reached.
+	///
+	/// Default: 3 passes
+	pub optimiser_max_passes: usize,
 }
 
 impl Default for EngineOptions {
@@ -33,6 +41,7 @@ impl Default for EngineOptions {
 			node_membership_cleanup_interval: Duration::from_secs(300),
 			changefeed_gc_interval: Duration::from_secs(30),
 			index_compaction_interval: Duration::from_secs(5),
+			optimiser_max_passes: 3,
 		}
 	}
 }
@@ -57,6 +66,11 @@ impl EngineOptions {
 
 	pub fn with_index_compaction_interval(mut self, interval: Duration) -> Self {
 		self.index_compaction_interval = interval;
+		self
+	}
+
+	pub fn with_optimiser_max_passes(mut self, passes: usize) -> Self {
+		self.optimiser_max_passes = passes;
 		self
 	}
 }

--- a/crates/core/src/sql/expression.rs
+++ b/crates/core/src/sql/expression.rs
@@ -541,6 +541,7 @@ impl From<Expr> for crate::expr::Expr {
 impl From<crate::expr::Expr> for Expr {
 	fn from(v: crate::expr::Expr) -> Self {
 		match v {
+			crate::expr::Expr::Value(v) => v.into_literal().into(),
 			crate::expr::Expr::Literal(l) => Expr::Literal(l.into()),
 			crate::expr::Expr::Param(p) => Expr::Param(p.into()),
 			crate::expr::Expr::Idiom(i) => Expr::Idiom(i.into()),

--- a/crates/server/src/cli/start.rs
+++ b/crates/server/src/cli/start.rs
@@ -69,6 +69,13 @@ pub struct StartCommandArguments {
 	#[arg(env = "SURREAL_INDEX_COMPACTION_INTERVAL", long = "index-compaction-interval", value_parser = super::validator::duration)]
 	#[arg(default_value = "5s")]
 	index_compaction_interval: Duration,
+	#[arg(
+		help = "The maximum number of optimiser passes to run on queries",
+		help_heading = "Database"
+	)]
+	#[arg(env = "SURREAL_OPTIMISER_MAX_PASSES", long = "optimiser-max-passes")]
+	#[arg(default_value = "3")]
+	optimiser_max_passes: usize,
 	//
 	// Authentication
 	#[arg(
@@ -178,6 +185,7 @@ pub async fn init<
 		node_membership_cleanup_interval,
 		changefeed_gc_interval,
 		index_compaction_interval,
+		optimiser_max_passes,
 		no_banner,
 		no_identification_headers,
 		..
@@ -208,7 +216,8 @@ pub async fn init<
 		.with_node_membership_check_interval(node_membership_check_interval)
 		.with_node_membership_cleanup_interval(node_membership_cleanup_interval)
 		.with_changefeed_gc_interval(changefeed_gc_interval)
-		.with_index_compaction_interval(index_compaction_interval);
+		.with_index_compaction_interval(index_compaction_interval)
+		.with_optimiser_max_passes(optimiser_max_passes);
 	// Configure the config
 	let Some(bind) = listen_addresses.first().copied() else {
 		return Err(anyhow::anyhow!("No listen address provided"));

--- a/crates/server/src/dbs/mod.rs
+++ b/crates/server/src/dbs/mod.rs
@@ -733,7 +733,7 @@ pub async fn init<C: TransactionBuilderFactory + BucketStoreProvider>(
 	// Log the specified server capabilities
 	debug!("Server capabilities: {capabilities}");
 	// Parse and setup the desired kv datastore
-	let dbs = Datastore::new_with_factory::<C>(composer, &opt.path, canceller)
+	let dbs = Datastore::new_with_clock::<C>(composer, &opt.path, None, canceller, opt.engine)
 		.await?
 		.with_notifications()
 		.with_query_timeout(query_timeout)

--- a/profiling/src/main.rs
+++ b/profiling/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<()> {
 
 	println!("Perfetto tracing enabled, writing to: {}", perfetto_path.display());
 
-	let mut results = db.query("SELECT * FROM person").await.context("Failed to query database")?;
+	let mut results = db.query("person:51").await.context("Failed to query database")?;
 
 	let _: Vec<Person> = results.take(0).context("Failed to take result")?;
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

There are straight forward expressions which do not need to be computed more than once. We can add an optimisation pass which simplifies expressions (and eventually does a lot more).


## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Introduces a pluggable optimiser framework for the LogicalPlan along with two initial optimisation rules that improve query performance by eliminating redundant runtime computations.

* `OptimiserRule` trait: Defines the interface for pluggable optimisation rules, allowing easy addition of new optimisations
* `Optimiser`: Orchestrates rule application with configurable multi-pass execution
  * Runs rules iteratively until convergence or max passes reached
  * Stops early when no changes occur
  * Configurable via `SURREAL_OPTIMISER_MAX_PASSES` environment variable (default: 3)
* Optimisation Rules
  1. `StaticLiteralFolding`
    * Converts static literals to pre-computed `Expr::Value` nodes
    * Eliminates runtime evaluation of constants like 42, "hello", [1, 2, 3], {a: 5}
    * Only transforms literals without parameters, idioms, or other dynamic expressions
    * Examples:
      * `Literal::Integer(42)` → `Value(Number::Int(42))`
      * `Literal::Array([1, 2, 3])` → `Value(Array([1, 2, 3]))`
2. `ConstantFolding`
    * Evaluates constant expressions at "compile" time
    * Performs synchronous computation using `fnc::operate::*` functions
    * Supports arithmetic, comparisons, logical operations, and mathematical constants
    * Examples:
      * `1 + 2` → `3`
      * `(1 + 2) * 3` → `9`
      * `5 > 3` → `true`
      * `math::pi * 2` → computed value

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI should be sufficient.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

Added `SURREAL_OPTIMISER_MAX_PASSES` environment variable which defaults to 3.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
