### PR TITLE
Fix LIVE SELECT doesn't returning UUID

### DIFF
--- a/crates/sdk/src/method/query.rs
+++ b/crates/sdk/src/method/query.rs
@@ -137,6 +137,9 @@ where
 							Stream::new(client.inner.clone().into(), live_query_id.into(), Some(rx))
 						});
 						indexed_results.live_queries.insert(index, live_stream);
+						indexed_results
+							.results
+							.insert(index, (stats, Ok(Value::Uuid(live_query_id))));
 					}
 					QueryType::Kill => {}
 				}


### PR DESCRIPTION
## What is the motivation?

When executing `LIVE SELECT` queries via the SDK's `query()` method, the returned UUID was not accessible through the standard `take()` method. The `num_statements()` returned 0 and `take(0)` returned `Value::None` instead of the live query UUID.

## What does this change do?

This fix adds the UUID to `indexed_results.results` alongside the live stream registration, so the UUID is accessible via `take()` 


## What is your testing strategy?

Added integration test `live_select_returns_uuid`

## Is this related to any issues?

- Fixes #6693

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)