### PR TITLE
Fix parallel INSERT panics for HNSW vector indexes

### DIFF
--- a/crates/core/src/idx/trees/hnsw/mod.rs
+++ b/crates/core/src/idx/trees/hnsw/mod.rs
@@ -132,7 +132,7 @@ where
 			self.layers.push(l);
 		}
 		// Remove non-existing layers
-		for _ in self.layers.len()..st.layers.len() {
+		while self.layers.len() > st.layers.len() {
 			self.layers.pop();
 		}
 		// Set the enter_point

--- a/crates/core/src/idx/trees/store/mod.rs
+++ b/crates/core/src/idx/trees/store/mod.rs
@@ -64,6 +64,7 @@ impl IndexStores {
 	///
 	/// This method handles transaction conflicts by retrying with exponential backoff,
 	/// similar to how sequences handle batch allocation conflicts.
+	#[allow(clippy::too_many_arguments)]
 	pub(crate) async fn index_hnsw_document_with_retry(
 		&self,
 		ns: NamespaceId,
@@ -157,6 +158,7 @@ impl IndexStores {
 	}
 
 	/// Remove a document from HNSW with retry logic for transaction conflicts.
+	#[allow(clippy::too_many_arguments)]
 	pub(crate) async fn remove_hnsw_document_with_retry(
 		&self,
 		ns: NamespaceId,

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -643,7 +643,7 @@ impl Datastore {
 			notification_channel: None,
 			capabilities: Arc::new(Capabilities::default()),
 			index_stores: IndexStores::new(tf.clone(), sequences.clone()),
-			index_builder: IndexBuilder::new(tf.clone()),
+			index_builder: IndexBuilder::new(tf),
 			#[cfg(feature = "jwks")]
 			jwks_cache: Arc::new(RwLock::new(JwksCache::new())),
 			#[cfg(storage)]

--- a/crates/core/src/kvs/ds.rs
+++ b/crates/core/src/kvs/ds.rs
@@ -131,8 +131,12 @@ pub struct Datastore {
 	surrealism_cache: Arc<SurrealismCache>,
 }
 
+/// Factory for creating transactions with proper clock and backend configuration.
+///
+/// This struct is used to create transactions for operations that need retry logic,
+/// such as HNSW index updates and sequence allocations.
 #[derive(Clone)]
-pub(super) struct TransactionFactory {
+pub(crate) struct TransactionFactory {
 	// Clock for tracking time. It is read-only and accessible to all transactions.
 	clock: Arc<SizedClock>,
 	// The inner datastore type
@@ -628,6 +632,7 @@ impl Datastore {
 	) -> Result<Self> {
 		let tf = TransactionFactory::new(clock, builder);
 		let id = Uuid::new_v4();
+		let sequences = Sequences::new(tf.clone(), id);
 		Ok(Self {
 			id,
 			transaction_factory: tf.clone(),
@@ -637,7 +642,7 @@ impl Datastore {
 			transaction_timeout: None,
 			notification_channel: None,
 			capabilities: Arc::new(Capabilities::default()),
-			index_stores: IndexStores::default(),
+			index_stores: IndexStores::new(tf.clone(), sequences.clone()),
 			index_builder: IndexBuilder::new(tf.clone()),
 			#[cfg(feature = "jwks")]
 			jwks_cache: Arc::new(RwLock::new(JwksCache::new())),
@@ -645,7 +650,7 @@ impl Datastore {
 			temporary_directory: None,
 			cache: Arc::new(DatastoreCache::new()),
 			buckets,
-			sequences: Sequences::new(tf, id),
+			sequences,
 			#[cfg(feature = "surrealism")]
 			surrealism_cache: Arc::new(SurrealismCache::new()),
 		})
@@ -655,6 +660,8 @@ impl Datastore {
 	/// flushed cache. Simulating a server restart
 	pub fn restart(self) -> Self {
 		self.buckets.clear();
+		// Create sequences first so it can be shared with IndexStores
+		let sequences = Sequences::new(self.transaction_factory.clone(), self.id);
 		Self {
 			id: self.id,
 			auth_enabled: self.auth_enabled,
@@ -663,7 +670,8 @@ impl Datastore {
 			transaction_timeout: self.transaction_timeout,
 			capabilities: self.capabilities,
 			notification_channel: self.notification_channel,
-			index_stores: Default::default(),
+			// Create IndexStores with transaction factory for HNSW retry logic
+			index_stores: IndexStores::new(self.transaction_factory.clone(), sequences.clone()),
 			index_builder: IndexBuilder::new(self.transaction_factory.clone()),
 			#[cfg(feature = "jwks")]
 			jwks_cache: Arc::new(Default::default()),
@@ -671,7 +679,7 @@ impl Datastore {
 			temporary_directory: self.temporary_directory,
 			cache: Arc::new(DatastoreCache::new()),
 			buckets: self.buckets,
-			sequences: Sequences::new(self.transaction_factory.clone(), self.id),
+			sequences,
 			transaction_factory: self.transaction_factory,
 			#[cfg(feature = "surrealism")]
 			surrealism_cache: Arc::new(SurrealismCache::new()),

--- a/crates/core/src/kvs/mod.rs
+++ b/crates/core/src/kvs/mod.rs
@@ -46,6 +46,8 @@ pub(crate) mod slowlog;
 pub(crate) mod tasklease;
 pub(crate) mod version;
 
+pub(crate) use ds::TransactionFactory;
+
 pub use api::Transactable;
 pub use clock::SizedClock;
 pub use ds::requirements::{TransactionBuilderFactoryRequirements, TransactionBuilderRequirements};

--- a/crates/core/tests/parallel_insert_ft.rs
+++ b/crates/core/tests/parallel_insert_ft.rs
@@ -1,0 +1,1491 @@
+//! Test for parallel INSERT operations
+
+#![cfg(feature = "kv-rocksdb")]
+#![allow(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::Result;
+use surrealdb_core::dbs::Session;
+use surrealdb_core::dbs::capabilities::Capabilities;
+use surrealdb_core::kvs::Datastore;
+use temp_dir::TempDir;
+use tokio::task::JoinSet;
+
+/// Creates a RocksDB datastore in a temporary directory
+async fn new_rocksdb_ds(ns: &str, db: &str) -> Result<(Datastore, TempDir)> {
+	// Create temp directory (kept alive by returning it)
+	let temp_dir = TempDir::new()?;
+	let path = format!("rocksdb:{}", temp_dir.path().to_string_lossy());
+
+	// Create the datastore using the public API
+	let ds =
+		Datastore::new(&path).await?.with_capabilities(Capabilities::all()).with_notifications();
+
+	// Setup namespace and database
+	let sess = Session::owner().with_ns(ns);
+	ds.execute(&format!("DEFINE NS `{ns}`"), &Session::owner(), None).await?;
+	ds.execute(&format!("DEFINE DB `{db}`"), &sess, None).await?;
+
+	Ok((ds, temp_dir))
+}
+
+/// Test: Parallel INSERT
+///
+/// This test spawns concurrent tasks, each inserting documents with unique IDs
+/// into a table that has a fulltext search index. Due to the batch allocation
+/// mechanism in sequences, this should trigger transaction conflicts.
+#[tokio::test(flavor = "multi_thread")]
+async fn parallel_insert_with_fulltext_index_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const DOCS_PER_WORKER: usize = 50;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	// Create analyzer and fulltext index
+	let setup_sql = r#"
+		DEFINE ANALYZER doc_analyzer TOKENIZERS blank,class,punct FILTERS lowercase,ascii;
+		DEFINE INDEX doc_ft_idx ON TABLE docs FIELDS content FULLTEXT ANALYZER doc_analyzer BM25;
+	"#;
+	let res = ds.execute(setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	// Counters for tracking results
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+
+	// Spawn parallel insert tasks
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for doc_idx in 0..DOCS_PER_WORKER {
+				let doc_id = worker_id * DOCS_PER_WORKER + doc_idx;
+				let sql = format!(
+					"INSERT INTO docs {{ id: doc:{doc_id}, content: 'Document number {doc_id} with searchable text content for fulltext indexing' }}"
+				);
+
+				match ds.execute(&sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+										|| err_str.contains("TryAgain")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+									} else {
+										other_error_count.fetch_add(1, Ordering::SeqCst);
+										eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+							|| err_str.contains("TryAgain")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+						} else {
+							other_error_count.fetch_add(1, Ordering::SeqCst);
+							eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+						}
+					}
+				}
+			}
+		});
+	}
+
+	// Wait for all tasks to complete
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * DOCS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel INSERT Test Results (RocksDB + Fulltext Index) ===");
+	println!("Total documents attempted: {total_docs}");
+	println!("Successful inserts: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+
+	// Verify actual documents in the database
+	let count_sql = "SELECT count() FROM docs GROUP ALL";
+	let res = ds.execute(count_sql, &ses, None).await?;
+	if let Some(result) = res.into_iter().next() {
+		if let Ok(val) = result.result {
+			println!("Actual documents in database: {val:?}");
+		}
+	}
+
+	// The test "passes" but reports conflicts - this demonstrates the issue
+	// In a fixed version, conflicts should be 0
+	if conflicts > 0 {
+		println!("\nISSUE CONFIRMED: {conflicts} transaction conflicts detected!");
+		println!("This demonstrates the parallel INSERT conflict problem with fulltext indexes.");
+	}
+
+	Ok(())
+}
+
+/// Test: Parallel INSERT with fulltext index using batch INSERT syntax
+///
+/// This variant uses batch INSERT syntax which might have different behavior
+/// with respect to transaction conflicts.
+#[tokio::test(flavor = "multi_thread")]
+async fn parallel_batch_insert_with_fulltext_index_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const BATCH_SIZE: usize = 50;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	// Create analyzer and fulltext index
+	let setup_sql = r#"
+		DEFINE ANALYZER doc_analyzer TOKENIZERS blank,class,punct FILTERS lowercase,ascii;
+		DEFINE INDEX doc_ft_idx ON TABLE docs FIELDS content FULLTEXT ANALYZER doc_analyzer BM25;
+	"#;
+	let res = ds.execute(setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	// Counters for tracking results
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+
+	// Spawn parallel batch insert tasks
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			// Build batch of documents
+			let start_id = worker_id * BATCH_SIZE;
+			let docs: Vec<String> = (0..BATCH_SIZE)
+				.map(|i| {
+					let doc_id = start_id + i;
+					format!(
+						"{{ id: doc:{doc_id}, content: 'Batch document {doc_id} with text for fulltext search indexing' }}"
+					)
+				})
+				.collect();
+
+			let sql = format!("INSERT INTO docs [{}]", docs.join(", "));
+
+			match ds.execute(&sql, &ses, None).await {
+				Ok(mut res) => {
+					if let Some(result) = res.pop() {
+						match result.result {
+							Ok(_) => {
+								success_count.fetch_add(BATCH_SIZE, Ordering::SeqCst);
+							}
+							Err(e) => {
+								let err_str = e.to_string();
+								if err_str.contains("Resource busy")
+									|| err_str.contains("Transaction conflict")
+									|| err_str.contains("TryAgain")
+								{
+									conflict_count.fetch_add(BATCH_SIZE, Ordering::SeqCst);
+								} else {
+									other_error_count.fetch_add(BATCH_SIZE, Ordering::SeqCst);
+									eprintln!("Worker {worker_id} batch error: {err_str}");
+								}
+							}
+						}
+					}
+				}
+				Err(e) => {
+					let err_str = e.to_string();
+					if err_str.contains("Resource busy")
+						|| err_str.contains("Transaction conflict")
+						|| err_str.contains("TryAgain")
+					{
+						conflict_count.fetch_add(BATCH_SIZE, Ordering::SeqCst);
+					} else {
+						other_error_count.fetch_add(BATCH_SIZE, Ordering::SeqCst);
+						eprintln!("Worker {worker_id} batch error: {err_str}");
+					}
+				}
+			}
+		});
+	}
+
+	// Wait for all tasks to complete
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * BATCH_SIZE;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel Batch INSERT Test Results (RocksDB + Fulltext Index) ===");
+	println!("Total documents attempted: {total_docs}");
+	println!("Successful inserts: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+
+	// Verify actual documents in the database
+	let count_sql = "SELECT count() FROM docs GROUP ALL";
+	let res = ds.execute(count_sql, &ses, None).await?;
+	if let Some(result) = res.into_iter().next() {
+		if let Ok(val) = result.result {
+			println!("Actual documents in database: {val:?}");
+		}
+	}
+
+	if conflicts > 0 {
+		println!("\nISSUE CONFIRMED: {conflicts} transaction conflicts detected in batch mode!");
+	}
+
+	Ok(())
+}
+
+/// Test: Comparison - parallel INSERT WITHOUT fulltext index
+///
+/// This test serves as a control group to verify that the issue is specifically
+/// related to fulltext indexing and sequence allocation, not general INSERT conflicts.
+#[tokio::test(flavor = "multi_thread")]
+async fn parallel_insert_without_fulltext_index_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const DOCS_PER_WORKER: usize = 50;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	// Pre-define the table to avoid schema creation conflicts
+	let setup_sql = "DEFINE TABLE docs SCHEMAFULL; DEFINE FIELD content ON docs TYPE string;";
+	let res = ds.execute(setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for doc_idx in 0..DOCS_PER_WORKER {
+				let doc_id = worker_id * DOCS_PER_WORKER + doc_idx;
+				let sql = format!(
+					"INSERT INTO docs {{ id: doc:{doc_id}, content: 'Document number {doc_id} with some text content' }}"
+				);
+
+				match ds.execute(&sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+										|| err_str.contains("TryAgain")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+									} else {
+										other_error_count.fetch_add(1, Ordering::SeqCst);
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+							|| err_str.contains("TryAgain")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+						} else {
+							other_error_count.fetch_add(1, Ordering::SeqCst);
+						}
+					}
+				}
+			}
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * DOCS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel INSERT Test Results (RocksDB, NO Fulltext Index) ===");
+	println!("Total documents attempted: {total_docs}");
+	println!("Successful inserts: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+
+	// Verify actual documents
+	let count_sql = "SELECT count() FROM docs GROUP ALL";
+	let res = ds.execute(count_sql, &ses, None).await?;
+	if let Some(result) = res.into_iter().next() {
+		if let Ok(val) = result.result {
+			println!("Actual documents in database: {val:?}");
+		}
+	}
+
+	if conflicts > 0 {
+		println!("\nConflicts even without fulltext index: {conflicts}");
+	} else {
+		println!("\nNo conflicts without fulltext index (expected behavior)");
+	}
+
+	Ok(())
+}
+
+/// Test: Parallel INSERT with auto-generated IDs (no explicit record ID)
+///
+/// This test uses INSERT without explicit IDs, which may trigger different
+/// ID generation mechanisms that could cause conflicts.
+#[tokio::test(flavor = "multi_thread")]
+async fn parallel_insert_auto_id_with_fulltext_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const DOCS_PER_WORKER: usize = 20;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	// Create analyzer and fulltext index
+	let setup_sql = r#"
+		DEFINE ANALYZER doc_analyzer TOKENIZERS blank,class,punct FILTERS lowercase,ascii;
+		DEFINE INDEX doc_ft_idx ON TABLE docs FIELDS content FULLTEXT ANALYZER doc_analyzer BM25;
+	"#;
+	let res = ds.execute(setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for doc_idx in 0..DOCS_PER_WORKER {
+				// No explicit ID - let SurrealDB generate it
+				let sql = format!(
+					"INSERT INTO docs {{ content: 'Worker {worker_id} document {doc_idx} with searchable content' }}"
+				);
+
+				match ds.execute(&sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+										|| err_str.contains("TryAgain")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+									} else {
+										other_error_count.fetch_add(1, Ordering::SeqCst);
+										eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+							|| err_str.contains("TryAgain")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+						} else {
+							other_error_count.fetch_add(1, Ordering::SeqCst);
+							eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+						}
+					}
+				}
+			}
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * DOCS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel INSERT (Auto-ID) Test Results (RocksDB + Fulltext) ===");
+	println!("Total documents attempted: {total_docs}");
+	println!("Successful inserts: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+
+	let count_sql = "SELECT count() FROM docs GROUP ALL";
+	let res = ds.execute(count_sql, &ses, None).await?;
+	if let Some(result) = res.into_iter().next() {
+		if let Ok(val) = result.result {
+			println!("Actual documents in database: {val:?}");
+		}
+	}
+
+	if conflicts > 0 {
+		println!("\nISSUE CONFIRMED: {conflicts} transaction conflicts with auto-generated IDs!");
+	}
+
+	Ok(())
+}
+
+/// Test: Parallel operations using explicit SEQUENCE
+///
+/// This test directly uses SEQUENCE to verify if the batch allocation
+/// mechanism causes conflicts.
+#[tokio::test(flavor = "multi_thread")]
+async fn parallel_sequence_usage_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const OPS_PER_WORKER: usize = 50;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	// Define a sequence
+	let setup_sql = "DEFINE SEQUENCE test_seq;";
+	let res = ds.execute(setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for _ in 0..OPS_PER_WORKER {
+				let sql = "RETURN sequence::nextval('test_seq');";
+
+				match ds.execute(sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+										|| err_str.contains("TryAgain")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+									} else {
+										other_error_count.fetch_add(1, Ordering::SeqCst);
+										eprintln!("Worker {worker_id}: {err_str}");
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+							|| err_str.contains("TryAgain")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+						} else {
+							other_error_count.fetch_add(1, Ordering::SeqCst);
+							eprintln!("Worker {worker_id}: {err_str}");
+						}
+					}
+				}
+			}
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_ops = NUM_WORKERS * OPS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel SEQUENCE Test Results (RocksDB) ===");
+	println!("Total operations attempted: {total_ops}");
+	println!("Successful operations: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_ops as f64) * 100.0);
+
+	if conflicts > 0 {
+		println!("\nISSUE CONFIRMED: {conflicts} conflicts in SEQUENCE operations!");
+		println!("This confirms the batch allocation conflict hypothesis.");
+	} else {
+		println!("\nNo conflicts in SEQUENCE operations (retry mechanism working)");
+	}
+
+	Ok(())
+}
+
+/// Test: High-contention INSERT with CREATE statement (not INSERT)
+///
+/// CREATE may have different transaction semantics than INSERT.
+#[tokio::test(flavor = "multi_thread")]
+async fn parallel_create_with_fulltext_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const DOCS_PER_WORKER: usize = 20;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	// Pre-define the table with analyzer and fulltext index
+	// Note: Using "doc" table here (CREATE doc:id syntax)
+	let setup_sql = r#"
+		DEFINE TABLE doc SCHEMAFULL;
+		DEFINE FIELD content ON doc TYPE string;
+		DEFINE ANALYZER doc_analyzer TOKENIZERS blank,class,punct FILTERS lowercase,ascii;
+		DEFINE INDEX doc_ft_idx ON TABLE doc FIELDS content FULLTEXT ANALYZER doc_analyzer BM25;
+	"#;
+	let res = ds.execute(setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for doc_idx in 0..DOCS_PER_WORKER {
+				let doc_id = worker_id * DOCS_PER_WORKER + doc_idx;
+				// Use CREATE instead of INSERT
+				let sql = format!(
+					"CREATE doc:{doc_id} SET content = 'Document {doc_id} with fulltext content'"
+				);
+
+				match ds.execute(&sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+										|| err_str.contains("TryAgain")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+									} else {
+										other_error_count.fetch_add(1, Ordering::SeqCst);
+										eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+							|| err_str.contains("TryAgain")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+						} else {
+							other_error_count.fetch_add(1, Ordering::SeqCst);
+							eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+						}
+					}
+				}
+			}
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * DOCS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel CREATE Test Results (RocksDB + Fulltext) ===");
+	println!("Total documents attempted: {total_docs}");
+	println!("Successful creates: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+
+	let count_sql = "SELECT count() FROM doc GROUP ALL";
+	let res = ds.execute(count_sql, &ses, None).await?;
+	if let Some(result) = res.into_iter().next() {
+		if let Ok(val) = result.result {
+			println!("Actual documents in database: {val:?}");
+		}
+	}
+
+	if conflicts > 0 {
+		println!("\nISSUE CONFIRMED: {conflicts} transaction conflicts with CREATE!");
+	}
+
+	Ok(())
+}
+
+/// Test: Parallel INSERT triggering implicit table creation
+///
+/// This test demonstrates the ACTUAL root cause of conflicts:
+/// When parallel INSERT operations target a table that doesn't exist,
+/// each transaction tries to implicitly create the table schema,
+/// causing transaction conflicts.
+#[tokio::test(flavor = "multi_thread")]
+async fn parallel_insert_implicit_table_creation_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const DOCS_PER_WORKER: usize = 10;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+
+	// NO table pre-definition - table will be implicitly created
+
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+	let error_messages = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+		let error_messages = error_messages.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for doc_idx in 0..DOCS_PER_WORKER {
+				let doc_id = worker_id * DOCS_PER_WORKER + doc_idx;
+				let sql = format!(
+					"INSERT INTO new_table {{ id: item:{doc_id}, data: 'test data {doc_id}' }}"
+				);
+
+				match ds.execute(&sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+										|| err_str.contains("TryAgain")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+										if error_messages.lock().unwrap().len() < 5 {
+											error_messages.lock().unwrap().push(err_str);
+										}
+									} else {
+										other_error_count.fetch_add(1, Ordering::SeqCst);
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+							|| err_str.contains("TryAgain")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+							if error_messages.lock().unwrap().len() < 5 {
+								error_messages.lock().unwrap().push(err_str);
+							}
+						} else {
+							other_error_count.fetch_add(1, Ordering::SeqCst);
+						}
+					}
+				}
+			}
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * DOCS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel INSERT (Implicit Table Creation) Results ===");
+	println!("Total documents attempted: {total_docs}");
+	println!("Successful inserts: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+
+	if conflicts > 0 {
+		println!("\nROOT CAUSE CONFIRMED: {conflicts} conflicts due to implicit table creation!");
+		println!("Sample error messages:");
+		for msg in error_messages.lock().unwrap().iter() {
+			println!("  - {msg}");
+		}
+		println!("\nThis is the actual source of conflicts - not fulltext indexing.");
+		println!("Solution: Pre-define tables before parallel INSERT operations.");
+	}
+
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let count_sql = "SELECT count() FROM new_table GROUP ALL";
+	let res = ds.execute(count_sql, &ses, None).await?;
+	if let Some(result) = res.into_iter().next() {
+		if let Ok(val) = result.result {
+			println!("Actual documents in database: {val:?}");
+		}
+	}
+
+	Ok(())
+}
+
+/// Test: Verify that pre-defined tables eliminate conflicts completely
+#[tokio::test(flavor = "multi_thread")]
+async fn parallel_insert_predefined_table_no_conflicts_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const DOCS_PER_WORKER: usize = 10;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	// Pre-define the table
+	let setup_sql = "DEFINE TABLE new_table; DEFINE FIELD data ON new_table TYPE string;";
+	let res = ds.execute(setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for doc_idx in 0..DOCS_PER_WORKER {
+				let doc_id = worker_id * DOCS_PER_WORKER + doc_idx;
+				let sql = format!(
+					"INSERT INTO new_table {{ id: item:{doc_id}, data: 'test data {doc_id}' }}"
+				);
+
+				match ds.execute(&sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+						}
+					}
+				}
+			}
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * DOCS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel INSERT (Pre-defined Table) Results ===");
+	println!("Total documents attempted: {total_docs}");
+	println!("Successful inserts: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+
+	// This should have zero conflicts
+	assert_eq!(conflicts, 0, "Expected no conflicts with pre-defined table");
+	assert_eq!(successes, total_docs, "All inserts should succeed");
+
+	println!("\nVERIFIED: Pre-defined tables eliminate transaction conflicts");
+
+	Ok(())
+}
+
+// ============================================================================
+// HYBRID INDEX TESTS: Fulltext + Vector HNSW
+// ============================================================================
+
+/// Helper function to generate a random-ish embedding vector based on doc_id
+fn generate_embedding(doc_id: usize, dim: usize) -> String {
+	let values: Vec<String> = (0..dim)
+		.map(|i| {
+			let val = ((doc_id * 17 + i * 31) % 1000) as f64 / 1000.0;
+			format!("{:.4}", val)
+		})
+		.collect();
+	format!("[{}]", values.join(", "))
+}
+
+/// Test: Parallel INSERT with Fulltext + Vector HNSW indexes (implicit table)
+///
+/// This test combines fulltext search and vector KNN indexes to test
+/// if the combination causes more conflicts due to multiple index updates.
+#[tokio::test(flavor = "multi_thread")]
+async fn parallel_insert_fulltext_plus_vector_implicit_table_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const DOCS_PER_WORKER: usize = 10;
+	const VECTOR_DIM: usize = 128;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+
+	// NO table pre-definition - implicit creation
+	// Only define the analyzer (required before index)
+	let ses = Session::owner().with_ns("test").with_db("test");
+	let setup_sql = r#"
+		DEFINE ANALYZER hybrid_analyzer TOKENIZERS blank,class,punct FILTERS lowercase,ascii;
+	"#;
+	let res = ds.execute(setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+	let error_messages = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+		let error_messages = error_messages.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for doc_idx in 0..DOCS_PER_WORKER {
+				let doc_id = worker_id * DOCS_PER_WORKER + doc_idx;
+				let embedding = generate_embedding(doc_id, VECTOR_DIM);
+				let sql = format!(
+					"INSERT INTO hybrid_docs {{ id: doc:{doc_id}, content: 'Document {doc_id} with searchable text for hybrid search', embedding: {embedding} }}"
+				);
+
+				match ds.execute(&sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+										|| err_str.contains("TryAgain")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+										if error_messages.lock().unwrap().len() < 5 {
+											error_messages.lock().unwrap().push(err_str);
+										}
+									} else {
+										other_error_count.fetch_add(1, Ordering::SeqCst);
+										eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+							|| err_str.contains("TryAgain")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+							if error_messages.lock().unwrap().len() < 5 {
+								error_messages.lock().unwrap().push(err_str);
+							}
+						} else {
+							other_error_count.fetch_add(1, Ordering::SeqCst);
+							eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+						}
+					}
+				}
+			}
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * DOCS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel INSERT (Fulltext + Vector, Implicit Table) Results ===");
+	println!("Total documents attempted: {total_docs}");
+	println!("Successful inserts: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+	println!("Failure rate: {:.1}%", (conflicts as f64 / total_docs as f64) * 100.0);
+
+	if conflicts > 0 {
+		println!("\nCONFLICTS with Fulltext + Vector (implicit table): {conflicts}");
+		println!("Sample error messages:");
+		for msg in error_messages.lock().unwrap().iter() {
+			println!("  - {msg}");
+		}
+	}
+
+	let count_sql = "SELECT count() FROM hybrid_docs GROUP ALL";
+	let res = ds.execute(count_sql, &ses, None).await?;
+	if let Some(result) = res.into_iter().next() {
+		if let Ok(val) = result.result {
+			println!("Actual documents in database: {val:?}");
+		}
+	}
+
+	Ok(())
+}
+
+/// Test: Parallel INSERT with Fulltext + Vector HNSW indexes (pre-defined table)
+///
+/// This test uses pre-defined table with both fulltext and vector indexes
+/// to check if conflicts still occur with hybrid indexing.
+///
+/// NOTE: This test may panic due to HNSW race condition bug at
+/// crates/core/src/idx/trees/hnsw/mod.rs:266
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "HNSW has race condition causing panic - see crates/core/src/idx/trees/hnsw/mod.rs:266"]
+async fn parallel_insert_fulltext_plus_vector_predefined_table_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const DOCS_PER_WORKER: usize = 10;
+	const VECTOR_DIM: usize = 128;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	// Pre-define table with both fulltext and vector indexes
+	let setup_sql = format!(
+		r#"
+		DEFINE TABLE hybrid_docs SCHEMAFULL;
+		DEFINE FIELD content ON hybrid_docs TYPE string;
+		DEFINE FIELD embedding ON hybrid_docs TYPE array<float>;
+		DEFINE ANALYZER hybrid_analyzer TOKENIZERS blank,class,punct FILTERS lowercase,ascii;
+		DEFINE INDEX ft_idx ON TABLE hybrid_docs FIELDS content FULLTEXT ANALYZER hybrid_analyzer BM25;
+		DEFINE INDEX vec_idx ON TABLE hybrid_docs FIELDS embedding HNSW DIMENSION {VECTOR_DIM} DIST COSINE;
+	"#
+	);
+	let res = ds.execute(&setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+	let error_messages = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+		let error_messages = error_messages.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for doc_idx in 0..DOCS_PER_WORKER {
+				let doc_id = worker_id * DOCS_PER_WORKER + doc_idx;
+				let embedding = generate_embedding(doc_id, VECTOR_DIM);
+				let sql = format!(
+					"INSERT INTO hybrid_docs {{ id: doc:{doc_id}, content: 'Document {doc_id} with searchable text for hybrid search', embedding: {embedding} }}"
+				);
+
+				match ds.execute(&sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+										|| err_str.contains("TryAgain")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+										if error_messages.lock().unwrap().len() < 5 {
+											error_messages.lock().unwrap().push(err_str);
+										}
+									} else {
+										other_error_count.fetch_add(1, Ordering::SeqCst);
+										eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+							|| err_str.contains("TryAgain")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+							if error_messages.lock().unwrap().len() < 5 {
+								error_messages.lock().unwrap().push(err_str);
+							}
+						} else {
+							other_error_count.fetch_add(1, Ordering::SeqCst);
+							eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+						}
+					}
+				}
+			}
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * DOCS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel INSERT (Fulltext + Vector, Pre-defined Table) Results ===");
+	println!("Total documents attempted: {total_docs}");
+	println!("Successful inserts: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+	println!("Failure rate: {:.1}%", (conflicts as f64 / total_docs as f64) * 100.0);
+
+	if conflicts > 0 {
+		println!("\nCONFLICTS with Fulltext + Vector (pre-defined): {conflicts}");
+		println!("This may indicate issues with hybrid index updates!");
+		println!("Sample error messages:");
+		for msg in error_messages.lock().unwrap().iter() {
+			println!("  - {msg}");
+		}
+	} else {
+		println!("\nNo conflicts with pre-defined hybrid index table");
+	}
+
+	let count_sql = "SELECT count() FROM hybrid_docs GROUP ALL";
+	let res = ds.execute(count_sql, &ses, None).await?;
+	if let Some(result) = res.into_iter().next() {
+		if let Ok(val) = result.result {
+			println!("Actual documents in database: {val:?}");
+		}
+	}
+
+	Ok(())
+}
+
+/// Test: Parallel INSERT with ONLY Vector HNSW index (no fulltext)
+///
+/// Control test to isolate vector index behavior from fulltext.
+///
+/// NOTE: This test causes HNSW panic and 98.9% conflict rate
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "HNSW has race condition causing panic and 98.9% conflicts"]
+async fn parallel_insert_vector_only_predefined_table_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 100;
+	const DOCS_PER_WORKER: usize = 10;
+	const VECTOR_DIM: usize = 128;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	// Pre-define table with only vector index
+	let setup_sql = format!(
+		r#"
+		DEFINE TABLE vector_docs SCHEMAFULL;
+		DEFINE FIELD embedding ON vector_docs TYPE array<float>;
+		DEFINE INDEX vec_idx ON TABLE vector_docs FIELDS embedding HNSW DIMENSION {VECTOR_DIM} DIST COSINE;
+	"#
+	);
+	let res = ds.execute(&setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for doc_idx in 0..DOCS_PER_WORKER {
+				let doc_id = worker_id * DOCS_PER_WORKER + doc_idx;
+				let embedding = generate_embedding(doc_id, VECTOR_DIM);
+				let sql = format!(
+					"INSERT INTO vector_docs {{ id: doc:{doc_id}, embedding: {embedding} }}"
+				);
+
+				match ds.execute(&sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+										|| err_str.contains("TryAgain")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+									} else {
+										other_error_count.fetch_add(1, Ordering::SeqCst);
+										eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+							|| err_str.contains("TryAgain")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+						} else {
+							other_error_count.fetch_add(1, Ordering::SeqCst);
+							eprintln!("Worker {worker_id}, doc {doc_idx}: {err_str}");
+						}
+					}
+				}
+			}
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * DOCS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== Parallel INSERT (Vector ONLY, Pre-defined Table) Results ===");
+	println!("Total documents attempted: {total_docs}");
+	println!("Successful inserts: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+
+	if conflicts > 0 {
+		println!("\nCONFLICTS with Vector-only index: {conflicts}");
+	} else {
+		println!("\nNo conflicts with vector-only index");
+	}
+
+	let count_sql = "SELECT count() FROM vector_docs GROUP ALL";
+	let res = ds.execute(count_sql, &ses, None).await?;
+	if let Some(result) = res.into_iter().next() {
+		if let Ok(val) = result.result {
+			println!("Actual documents in database: {val:?}");
+		}
+	}
+
+	Ok(())
+}
+
+/// Test: High-load parallel INSERT with Fulltext + Vector (stress test)
+///
+/// More aggressive test with higher parallelism to trigger potential conflicts.
+///
+/// NOTE: This test may panic due to HNSW race condition bug at
+/// crates/core/src/idx/trees/hnsw/mod.rs:266
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "HNSW has race condition causing panic - see crates/core/src/idx/trees/hnsw/mod.rs:266"]
+async fn parallel_insert_fulltext_plus_vector_stress_test_rocksdb() -> Result<()> {
+	const NUM_WORKERS: usize = 200;
+	const DOCS_PER_WORKER: usize = 25;
+	const VECTOR_DIM: usize = 64;
+
+	let (ds, _temp_dir) = new_rocksdb_ds("test", "test").await?;
+	let ds = Arc::new(ds);
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	// Pre-define table with both indexes
+	let setup_sql = format!(
+		r#"
+		DEFINE TABLE stress_docs SCHEMAFULL;
+		DEFINE FIELD content ON stress_docs TYPE string;
+		DEFINE FIELD embedding ON stress_docs TYPE array<float>;
+		DEFINE ANALYZER stress_analyzer TOKENIZERS blank,class FILTERS lowercase;
+		DEFINE INDEX ft_idx ON TABLE stress_docs FIELDS content FULLTEXT ANALYZER stress_analyzer BM25;
+		DEFINE INDEX vec_idx ON TABLE stress_docs FIELDS embedding HNSW DIMENSION {VECTOR_DIM} DIST COSINE;
+	"#
+	);
+	let res = ds.execute(&setup_sql, &ses, None).await?;
+	for r in res {
+		r.result?;
+	}
+
+	let success_count = Arc::new(AtomicUsize::new(0));
+	let conflict_count = Arc::new(AtomicUsize::new(0));
+	let other_error_count = Arc::new(AtomicUsize::new(0));
+	let error_messages = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+
+	let mut tasks = JoinSet::new();
+
+	for worker_id in 0..NUM_WORKERS {
+		let ds = ds.clone();
+		let success_count = success_count.clone();
+		let conflict_count = conflict_count.clone();
+		let other_error_count = other_error_count.clone();
+		let error_messages = error_messages.clone();
+
+		tasks.spawn(async move {
+			let ses = Session::owner().with_ns("test").with_db("test");
+
+			for doc_idx in 0..DOCS_PER_WORKER {
+				let doc_id = worker_id * DOCS_PER_WORKER + doc_idx;
+				let embedding = generate_embedding(doc_id, VECTOR_DIM);
+				let sql = format!(
+					"INSERT INTO stress_docs {{ id: doc:{doc_id}, content: 'Stress test document {doc_id} with hybrid indexing for performance testing', embedding: {embedding} }}"
+				);
+
+				match ds.execute(&sql, &ses, None).await {
+					Ok(mut res) => {
+						if let Some(result) = res.pop() {
+							match result.result {
+								Ok(_) => {
+									success_count.fetch_add(1, Ordering::SeqCst);
+								}
+								Err(e) => {
+									let err_str = e.to_string();
+									if err_str.contains("Resource busy")
+										|| err_str.contains("Transaction conflict")
+										|| err_str.contains("TryAgain")
+									{
+										conflict_count.fetch_add(1, Ordering::SeqCst);
+										if error_messages.lock().unwrap().len() < 10 {
+											error_messages.lock().unwrap().push(err_str);
+										}
+									} else {
+										other_error_count.fetch_add(1, Ordering::SeqCst);
+									}
+								}
+							}
+						}
+					}
+					Err(e) => {
+						let err_str = e.to_string();
+						if err_str.contains("Resource busy")
+							|| err_str.contains("Transaction conflict")
+							|| err_str.contains("TryAgain")
+						{
+							conflict_count.fetch_add(1, Ordering::SeqCst);
+							if error_messages.lock().unwrap().len() < 10 {
+								error_messages.lock().unwrap().push(err_str);
+							}
+						} else {
+							other_error_count.fetch_add(1, Ordering::SeqCst);
+						}
+					}
+				}
+			}
+		});
+	}
+
+	while let Some(result) = tasks.join_next().await {
+		result?;
+	}
+
+	let total_docs = NUM_WORKERS * DOCS_PER_WORKER;
+	let successes = success_count.load(Ordering::SeqCst);
+	let conflicts = conflict_count.load(Ordering::SeqCst);
+	let other_errors = other_error_count.load(Ordering::SeqCst);
+
+	println!("\n=== STRESS TEST: Parallel INSERT (Fulltext + Vector) Results ===");
+	println!("Configuration: {NUM_WORKERS} workers * {DOCS_PER_WORKER} docs = {total_docs} total");
+	println!("Vector dimension: {VECTOR_DIM}");
+	println!("---");
+	println!("Successful inserts: {successes}");
+	println!("Transaction conflicts: {conflicts}");
+	println!("Other errors: {other_errors}");
+	println!("Success rate: {:.1}%", (successes as f64 / total_docs as f64) * 100.0);
+	println!("Failure rate: {:.1}%", (conflicts as f64 / total_docs as f64) * 100.0);
+
+	if conflicts > 0 {
+		let failure_pct = (conflicts as f64 / total_docs as f64) * 100.0;
+		println!("\nSTRESS TEST CONFLICTS: {conflicts} ({failure_pct:.1}%)");
+
+		if failure_pct >= 50.0 {
+			println!("CRITICAL: ≥50% failure rate detected!");
+		} else if failure_pct >= 10.0 {
+			println!("WARNING: ≥10% failure rate detected!");
+		}
+
+		println!("\nSample error messages:");
+		for msg in error_messages.lock().unwrap().iter() {
+			println!("  - {msg}");
+		}
+	} else {
+		println!("\nStress test passed without conflicts");
+	}
+
+	let count_sql = "SELECT count() FROM stress_docs GROUP ALL";
+	let res = ds.execute(count_sql, &ses, None).await?;
+	if let Some(result) = res.into_iter().next() {
+		if let Ok(val) = result.result {
+			println!("Actual documents in database: {val:?}");
+		}
+	}
+
+	Ok(())
+}

--- a/crates/core/tests/parallel_insert_ft.rs
+++ b/crates/core/tests/parallel_insert_ft.rs
@@ -1079,13 +1079,9 @@ async fn parallel_insert_fulltext_plus_vector_implicit_table_rocksdb() -> Result
 
 /// Test: Parallel INSERT with Fulltext + Vector HNSW indexes (pre-defined table)
 ///
-/// This test uses pre-defined table with both fulltext and vector indexes
-/// to check if conflicts still occur with hybrid indexing.
-///
-/// NOTE: This test may panic due to HNSW race condition bug at
-/// crates/core/src/idx/trees/hnsw/mod.rs:266
+/// This test uses pre-defined table with both fulltext and vector indexes.
+/// With retry logic in place, this passes without conflicts.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "HNSW has race condition causing panic - see crates/core/src/idx/trees/hnsw/mod.rs:266"]
 async fn parallel_insert_fulltext_plus_vector_predefined_table_rocksdb() -> Result<()> {
 	const NUM_WORKERS: usize = 100;
 	const DOCS_PER_WORKER: usize = 10;
@@ -1222,10 +1218,8 @@ async fn parallel_insert_fulltext_plus_vector_predefined_table_rocksdb() -> Resu
 /// Test: Parallel INSERT with ONLY Vector HNSW index (no fulltext)
 ///
 /// Control test to isolate vector index behavior from fulltext.
-///
-/// NOTE: This test causes HNSW panic and 98.9% conflict rate
+/// With retry logic in place, this passes without conflicts.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "HNSW has race condition causing panic and 98.9% conflicts"]
 async fn parallel_insert_vector_only_predefined_table_rocksdb() -> Result<()> {
 	const NUM_WORKERS: usize = 100;
 	const DOCS_PER_WORKER: usize = 10;
@@ -1345,11 +1339,8 @@ async fn parallel_insert_vector_only_predefined_table_rocksdb() -> Result<()> {
 /// Test: High-load parallel INSERT with Fulltext + Vector (stress test)
 ///
 /// More aggressive test with higher parallelism to trigger potential conflicts.
-///
-/// NOTE: This test may panic due to HNSW race condition bug at
-/// crates/core/src/idx/trees/hnsw/mod.rs:266
+/// With retry logic in place, this passes without conflicts.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "HNSW has race condition causing panic - see crates/core/src/idx/trees/hnsw/mod.rs:266"]
 async fn parallel_insert_fulltext_plus_vector_stress_test_rocksdb() -> Result<()> {
 	const NUM_WORKERS: usize = 200;
 	const DOCS_PER_WORKER: usize = 25;

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -168,6 +168,9 @@ harness = false
 
 [[bench]]
 name = "index_hnsw"
+
+[[bench]]
+name = "index_fulltext"
 harness = false
 
 [[bench]]

--- a/crates/sdk/benches/hash_trie_btree.rs
+++ b/crates/sdk/benches/hash_trie_btree.rs
@@ -62,7 +62,7 @@ fn bench_hash_trie_btree_value(c: &mut Criterion) {
 	let mut samples = Vec::with_capacity(N);
 	for i in 0..N {
 		let key = syn::value(&format!(
-			"{{ test: {{ something: [1, 'two', null, test:{i}, {{ trueee: false, noneee: nulll }}] }} }}"
+			"{{ test: {{ something: [1, 'two', null, test:{i}, {{ trueee: false, noneee: null }}] }} }}"
 		))
 		.unwrap();
 		samples.push((key, i));

--- a/crates/sdk/benches/index_fulltext.rs
+++ b/crates/sdk/benches/index_fulltext.rs
@@ -1,0 +1,559 @@
+#![allow(clippy::unwrap_used)]
+
+//! Benchmarks for full-text search performance with BM25 scoring.
+//!
+//! This benchmark measures:
+//! - Full-text index creation performance
+//! - BM25 scoring computation performance
+//! - Query performance with different corpus sizes
+//! - Hybrid search fusion (RRF and Linear) performance
+//!
+//! Run with RocksDB (set BENCH_DB_PATH to a real disk path):
+//!   BENCH_DB_PATH=/path/to/disk cargo bench -p surrealdb --features kv-rocksdb -- bm25
+
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use surrealdb_core::dbs::Session;
+use surrealdb_core::kvs::Datastore;
+use tokio::runtime::Runtime;
+
+/// Get datastore path based on enabled features.
+/// Uses RocksDB if kv-rocksdb feature is enabled and BENCH_DB_PATH env var is set.
+fn get_datastore_path() -> String {
+	#[cfg(feature = "kv-rocksdb")]
+	{
+		if let Ok(base_path) = std::env::var("BENCH_DB_PATH") {
+			let ts =
+				std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis();
+			format!("rocksdb://{}/bench-ft-{}.db", base_path, ts)
+		} else {
+			"memory".to_string()
+		}
+	}
+	#[cfg(not(feature = "kv-rocksdb"))]
+	{
+		"memory".to_string()
+	}
+}
+
+// Sample documents for benchmarking - varied lengths and vocabulary
+const DOCUMENTS: &[&str] = &[
+	"Graph databases excel at relationship traversal and connected data queries.",
+	"Relational databases store data in structured tables with SQL query support.",
+	"Document stores provide flexible schema-less data storage for JSON documents.",
+	"Key-value stores offer simple fast access patterns for caching and sessions.",
+	"Time series databases optimize for temporal data and metrics collection.",
+	"Search engines provide full-text indexing with relevance scoring algorithms.",
+	"Column-family databases handle wide columns and sparse data efficiently.",
+	"Vector databases enable similarity search for embeddings and ML applications.",
+	"Multi-model databases combine multiple data models in a single platform.",
+	"NewSQL databases provide SQL semantics with horizontal scalability features.",
+	"Graph traversal algorithms find shortest paths and connected components quickly.",
+	"Full-text search uses inverted indexes for fast term lookup and scoring.",
+	"BM25 scoring algorithm balances term frequency and document length normalization.",
+	"Distributed databases replicate data across nodes for fault tolerance.",
+	"ACID transactions ensure data consistency in concurrent environments.",
+	"Eventually consistent systems trade consistency for availability and performance.",
+	"Sharding distributes data horizontally across multiple database nodes.",
+	"Indexing strategies optimize query performance for specific access patterns.",
+	"Query optimization analyzes execution plans to minimize resource usage.",
+	"Database caching reduces latency by storing frequently accessed data in memory.",
+];
+
+// Longer documents for testing document length normalization
+const LONG_DOCUMENTS: &[&str] = &[
+	"Graph databases are specifically designed to store and navigate relationships between data points. Unlike relational databases that use tables and foreign keys, graph databases use nodes and edges to represent and store data. This makes them particularly efficient for use cases like social networks, recommendation engines, fraud detection, and knowledge graphs where understanding connections is crucial. The query language used by graph databases, such as Cypher or SPARQL, allows for intuitive expression of graph patterns.",
+	"Full-text search engines implement sophisticated algorithms for relevance ranking. The BM25 algorithm, also known as Okapi BM25, is a probabilistic retrieval function that ranks documents based on query terms appearing in each document. It considers term frequency, inverse document frequency, and document length normalization. The algorithm has proven effective across various information retrieval tasks and remains the default in many search systems including Elasticsearch and Lucene.",
+	"Modern database systems must balance multiple competing concerns including consistency, availability, partition tolerance, latency, and throughput. The CAP theorem states that distributed systems cannot simultaneously provide all three of consistency, availability, and partition tolerance. Different database designs make different tradeoffs based on their intended use cases. Understanding these tradeoffs is essential for choosing the right database for a specific application.",
+];
+
+struct BenchInput {
+	dbs: Datastore,
+	ses: Session,
+	doc_count: usize,
+}
+
+async fn prepare_small_corpus() -> BenchInput {
+	let dbs = Datastore::new(&get_datastore_path()).await.unwrap();
+	let ses = Session::owner().with_ns("bench").with_db("bench");
+
+	// Define analyzer and full-text index
+	let sql = r"
+        DEFINE ANALYZER bench_analyzer TOKENIZERS blank, class, punct FILTERS lowercase, ascii;
+        DEFINE INDEX ft_idx ON TABLE doc FIELDS content FULLTEXT ANALYZER bench_analyzer BM25;
+    ";
+	let res = &mut dbs.execute(sql, &ses, None).await.unwrap();
+	for _ in 0..2 {
+		res.remove(0).result.unwrap();
+	}
+
+	// Insert documents
+	let doc_count = if cfg!(debug_assertions) {
+		100
+	} else {
+		1_000
+	};
+
+	for i in 0..doc_count {
+		let content = DOCUMENTS[i % DOCUMENTS.len()];
+		let sql = format!(r#"CREATE doc SET content = "{content}""#);
+		dbs.execute(&sql, &ses, None).await.unwrap().remove(0).result.unwrap();
+	}
+
+	BenchInput {
+		dbs,
+		ses,
+		doc_count,
+	}
+}
+
+async fn prepare_medium_corpus() -> BenchInput {
+	let dbs = Datastore::new(&get_datastore_path()).await.unwrap();
+	let ses = Session::owner().with_ns("bench").with_db("bench");
+
+	let sql = r"
+        DEFINE ANALYZER bench_analyzer TOKENIZERS blank, class, punct FILTERS lowercase, ascii;
+        DEFINE INDEX ft_idx ON TABLE doc FIELDS content FULLTEXT ANALYZER bench_analyzer BM25;
+    ";
+	let res = &mut dbs.execute(sql, &ses, None).await.unwrap();
+	for _ in 0..2 {
+		res.remove(0).result.unwrap();
+	}
+
+	let doc_count = if cfg!(debug_assertions) {
+		500
+	} else {
+		10_000
+	};
+
+	for i in 0..doc_count {
+		let content = if i % 10 == 0 {
+			LONG_DOCUMENTS[i % LONG_DOCUMENTS.len()]
+		} else {
+			DOCUMENTS[i % DOCUMENTS.len()]
+		};
+		let sql = format!(r#"CREATE doc SET content = "{content}""#);
+		dbs.execute(&sql, &ses, None).await.unwrap().remove(0).result.unwrap();
+	}
+
+	BenchInput {
+		dbs,
+		ses,
+		doc_count,
+	}
+}
+
+async fn prepare_hybrid_corpus() -> BenchInput {
+	let dbs = Datastore::new(&get_datastore_path()).await.unwrap();
+	let ses = Session::owner().with_ns("bench").with_db("bench");
+
+	// Define analyzer, full-text index, and vector index
+	let sql = r"
+        DEFINE ANALYZER bench_analyzer TOKENIZERS blank, class, punct FILTERS lowercase, ascii;
+        DEFINE INDEX ft_idx ON TABLE doc FIELDS content FULLTEXT ANALYZER bench_analyzer BM25;
+        DEFINE INDEX vec_idx ON TABLE doc FIELDS embedding HNSW DIMENSION 8 DIST COSINE;
+    ";
+	let res = &mut dbs.execute(sql, &ses, None).await.unwrap();
+	for _ in 0..3 {
+		res.remove(0).result.unwrap();
+	}
+
+	let doc_count = if cfg!(debug_assertions) {
+		100
+	} else {
+		1_000
+	};
+
+	for i in 0..doc_count {
+		let content = DOCUMENTS[i % DOCUMENTS.len()];
+		// Generate pseudo-random embedding based on document index
+		let e: Vec<f32> = (0..8).map(|j| ((i + j) as f32 * 0.1).sin()).collect();
+		let embedding = format!(
+			"[{:.4}, {:.4}, {:.4}, {:.4}, {:.4}, {:.4}, {:.4}, {:.4}]",
+			e[0], e[1], e[2], e[3], e[4], e[5], e[6], e[7]
+		);
+		let sql = format!(r#"CREATE doc SET content = "{content}", embedding = {embedding}"#);
+		dbs.execute(&sql, &ses, None).await.unwrap().remove(0).result.unwrap();
+	}
+
+	BenchInput {
+		dbs,
+		ses,
+		doc_count,
+	}
+}
+
+async fn run_query(input: &BenchInput, query: &str) {
+	let r = input.dbs.execute(black_box(query), &input.ses, None).await.unwrap();
+	black_box(r);
+}
+
+fn bench_fulltext_search(c: &mut Criterion) {
+	let rt = Runtime::new().unwrap();
+
+	// Benchmark with small corpus
+	let small = rt.block_on(prepare_small_corpus());
+
+	let mut group = c.benchmark_group("fulltext_search");
+	group.sample_size(50);
+	group.measurement_time(Duration::from_secs(10));
+
+	// Single term search
+	group.bench_function("small_corpus/single_term", |b| {
+		b.to_async(Runtime::new().unwrap())
+			.iter(|| run_query(&small, "SELECT * FROM doc WHERE content @@ 'database'"))
+	});
+
+	// Multi-term search (AND)
+	group.bench_function("small_corpus/multi_term_and", |b| {
+		b.to_async(Runtime::new().unwrap())
+			.iter(|| run_query(&small, "SELECT * FROM doc WHERE content @@ 'graph database'"))
+	});
+
+	// Search with scoring
+	group.bench_function("small_corpus/with_bm25_score", |b| {
+		b.to_async(Runtime::new().unwrap()).iter(|| {
+			run_query(
+				&small,
+				"SELECT *, search::score(1) AS score FROM doc WHERE content @1@ 'database' ORDER BY score DESC",
+			)
+		})
+	});
+
+	// Search with limit
+	group.bench_function("small_corpus/with_limit", |b| {
+        b.to_async(Runtime::new().unwrap()).iter(|| {
+            run_query(
+                &small,
+                "SELECT *, search::score(1) AS score FROM doc WHERE content @1@ 'database' ORDER BY score DESC LIMIT 10",
+            )
+        })
+    });
+
+	group.finish();
+	rt.block_on(async { drop(small) });
+}
+
+fn bench_fulltext_scaling(c: &mut Criterion) {
+	let rt = Runtime::new().unwrap();
+
+	let medium = rt.block_on(prepare_medium_corpus());
+
+	let mut group = c.benchmark_group("fulltext_scaling");
+	group.sample_size(30);
+	group.measurement_time(Duration::from_secs(15));
+	group.throughput(Throughput::Elements(medium.doc_count as u64));
+
+	// Common term (appears in many documents)
+	group.bench_function(
+        BenchmarkId::new("common_term", medium.doc_count),
+        |b| {
+            b.to_async(Runtime::new().unwrap()).iter(|| {
+                run_query(
+                    &medium,
+                    "SELECT *, search::score(1) AS score FROM doc WHERE content @1@ 'data' ORDER BY score DESC LIMIT 20",
+                )
+            })
+        },
+    );
+
+	// Rare term (appears in few documents)
+	group.bench_function(BenchmarkId::new("rare_term", medium.doc_count), |b| {
+        b.to_async(Runtime::new().unwrap()).iter(|| {
+            run_query(
+                &medium,
+                "SELECT *, search::score(1) AS score FROM doc WHERE content @1@ 'probabilistic' ORDER BY score DESC LIMIT 20",
+            )
+        })
+    });
+
+	// Phrase-like query
+	group.bench_function(
+        BenchmarkId::new("phrase_query", medium.doc_count),
+        |b| {
+            b.to_async(Runtime::new().unwrap()).iter(|| {
+                run_query(
+                    &medium,
+                    "SELECT *, search::score(1) AS score FROM doc WHERE content @1@ 'full text search' ORDER BY score DESC LIMIT 20",
+                )
+            })
+        },
+    );
+
+	group.finish();
+	rt.block_on(async { drop(medium) });
+}
+
+fn bench_hybrid_search(c: &mut Criterion) {
+	let rt = Runtime::new().unwrap();
+
+	let hybrid = rt.block_on(prepare_hybrid_corpus());
+
+	let mut group = c.benchmark_group("hybrid_search");
+	group.sample_size(30);
+	group.measurement_time(Duration::from_secs(15));
+
+	// Full-text only
+	group.bench_function("fulltext_only", |b| {
+        b.to_async(Runtime::new().unwrap()).iter(|| {
+            run_query(
+                &hybrid,
+                "SELECT id, search::score(1) AS ft_score FROM doc WHERE content @1@ 'database' ORDER BY ft_score DESC LIMIT 10",
+            )
+        })
+    });
+
+	// Vector only
+	group.bench_function("vector_only", |b| {
+        b.to_async(Runtime::new().unwrap()).iter(|| {
+            run_query(
+                &hybrid,
+                "SELECT id, vector::distance::knn() AS distance FROM doc WHERE embedding <|10,100|> [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]",
+            )
+        })
+    });
+
+	// RRF fusion
+	group.bench_function("rrf_fusion", |b| {
+        b.to_async(Runtime::new().unwrap()).iter(|| {
+            run_query(
+                &hybrid,
+                r#"
+                LET $ft = SELECT id, search::score(1) AS ft_score FROM doc WHERE content @1@ 'database' ORDER BY ft_score DESC LIMIT 20;
+                LET $vec = SELECT id, vector::distance::knn() AS distance FROM doc WHERE embedding <|20,100|> [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
+                RETURN search::rrf([$ft, $vec], 10, 60);
+                "#,
+            )
+        })
+    });
+
+	// Linear fusion with minmax normalization
+	group.bench_function("linear_fusion_minmax", |b| {
+        b.to_async(Runtime::new().unwrap()).iter(|| {
+            run_query(
+                &hybrid,
+                r#"
+                LET $ft = SELECT id, search::score(1) AS ft_score FROM doc WHERE content @1@ 'database' ORDER BY ft_score DESC LIMIT 20;
+                LET $vec = SELECT id, vector::distance::knn() AS distance FROM doc WHERE embedding <|20,100|> [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
+                RETURN search::linear([$ft, $vec], [1, 1], 10, 'minmax');
+                "#,
+            )
+        })
+    });
+
+	// Linear fusion with zscore normalization
+	group.bench_function("linear_fusion_zscore", |b| {
+        b.to_async(Runtime::new().unwrap()).iter(|| {
+            run_query(
+                &hybrid,
+                r#"
+                LET $ft = SELECT id, search::score(1) AS ft_score FROM doc WHERE content @1@ 'database' ORDER BY ft_score DESC LIMIT 20;
+                LET $vec = SELECT id, vector::distance::knn() AS distance FROM doc WHERE embedding <|20,100|> [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8];
+                RETURN search::linear([$ft, $vec], [1, 1], 10, 'zscore');
+                "#,
+            )
+        })
+    });
+
+	group.finish();
+	rt.block_on(async { drop(hybrid) });
+}
+
+fn bench_bm25_scoring_only(c: &mut Criterion) {
+	let rt = Runtime::new().unwrap();
+
+	let small = rt.block_on(prepare_small_corpus());
+
+	let mut group = c.benchmark_group("bm25_scoring");
+	group.sample_size(100);
+	group.measurement_time(Duration::from_secs(10));
+
+	// Measure scoring overhead by comparing with/without score computation
+	group.bench_function("without_score", |b| {
+		b.to_async(Runtime::new().unwrap())
+			.iter(|| run_query(&small, "SELECT id FROM doc WHERE content @@ 'database' LIMIT 50"))
+	});
+
+	group.bench_function("with_score", |b| {
+		b.to_async(Runtime::new().unwrap()).iter(|| {
+			run_query(
+				&small,
+				"SELECT id, search::score(1) AS score FROM doc WHERE content @1@ 'database' LIMIT 50",
+			)
+		})
+	});
+
+	group.bench_function("with_score_and_order", |b| {
+        b.to_async(Runtime::new().unwrap()).iter(|| {
+            run_query(
+                &small,
+                "SELECT id, search::score(1) AS score FROM doc WHERE content @1@ 'database' ORDER BY score DESC LIMIT 50",
+            )
+        })
+    });
+
+	group.finish();
+	rt.block_on(async { drop(small) });
+}
+
+/// Prepare a large corpus using batch insertion.
+/// Inserts documents FIRST, then creates index (bulk loading pattern).
+async fn prepare_million_scale_corpus(doc_count: usize) -> BenchInput {
+	let dbs = Datastore::new(&get_datastore_path()).await.unwrap();
+	let ses = Session::owner().with_ns("bench").with_db("bench");
+
+	// Simple analyzer for speed
+	let sql = r"DEFINE ANALYZER bench_analyzer TOKENIZERS blank FILTERS lowercase;";
+	dbs.execute(sql, &ses, None).await.unwrap().remove(0).result.unwrap();
+
+	// Sequential batch insert (avoids transaction conflicts)
+	const BATCH_SIZE: usize = 1000;
+	let all_docs: Vec<&str> = DOCUMENTS.iter().chain(LONG_DOCUMENTS.iter()).copied().collect();
+
+	eprintln!("  Inserting {} documents...", doc_count);
+	let start = std::time::Instant::now();
+
+	for batch_start in (0..doc_count).step_by(BATCH_SIZE) {
+		let batch_end = (batch_start + BATCH_SIZE).min(doc_count);
+
+		let mut values = Vec::with_capacity(batch_end - batch_start);
+		for i in batch_start..batch_end {
+			let content = all_docs[i % all_docs.len()];
+			values.push(format!(r#"{{ content: "{content}" }}"#));
+		}
+
+		let sql = format!("INSERT INTO doc [{}]", values.join(", "));
+		dbs.execute(&sql, &ses, None).await.unwrap().remove(0).result.unwrap();
+
+		if batch_start % 100_000 == 0 && batch_start > 0 {
+			eprintln!("    ... {} docs inserted", batch_start);
+		}
+	}
+
+	eprintln!("  Inserted {} docs in {:.1}s", doc_count, start.elapsed().as_secs_f64());
+
+	// NOW create index (uses parallel batch processing internally)
+	eprintln!("  Creating fulltext index with BM25...");
+	let idx_start = std::time::Instant::now();
+	let sql = "DEFINE INDEX ft_idx ON TABLE doc FIELDS content FULLTEXT ANALYZER bench_analyzer BM25;";
+	dbs.execute(sql, &ses, None).await.unwrap().remove(0).result.unwrap();
+	eprintln!("  Index created in {:.1}s", idx_start.elapsed().as_secs_f64());
+
+	BenchInput {
+		dbs,
+		ses,
+		doc_count,
+	}
+}
+
+/// Benchmark with 1M documents.
+/// Run with: BENCH_DB_PATH=/path/to/disk cargo bench -p surrealdb --features kv-rocksdb -- 1m
+fn bench_bm25_1m_corpus(c: &mut Criterion) {
+	let rt = Runtime::new().unwrap();
+
+	// Only run with RocksDB to avoid memory issues
+	#[cfg(not(feature = "kv-rocksdb"))]
+	{
+		eprintln!("Skipping 1M benchmark: requires kv-rocksdb feature");
+		return;
+	}
+
+	if std::env::var("BENCH_DB_PATH").is_err() {
+		eprintln!("Skipping 1M benchmark: set BENCH_DB_PATH for RocksDB");
+		return;
+	}
+
+	let doc_count = 1_000_000;
+	eprintln!("Preparing 1M documents corpus...");
+	let corpus = rt.block_on(prepare_million_scale_corpus(doc_count));
+
+	let mut group = c.benchmark_group("bm25_1m_corpus");
+	group.sample_size(10);
+	group.measurement_time(Duration::from_secs(30));
+	group.throughput(Throughput::Elements(doc_count as u64));
+
+	// Common term - many matches
+	group.bench_function("common_term", |b| {
+		b.to_async(Runtime::new().unwrap()).iter(|| {
+			run_query(
+				&corpus,
+				"SELECT *, search::score(1) AS score FROM doc WHERE content @1@ 'database' ORDER BY score DESC LIMIT 100",
+			)
+		})
+	});
+
+	// Rare term - few matches
+	group.bench_function("rare_term", |b| {
+		b.to_async(Runtime::new().unwrap()).iter(|| {
+			run_query(
+				&corpus,
+				"SELECT *, search::score(1) AS score FROM doc WHERE content @1@ 'probabilistic' ORDER BY score DESC LIMIT 100",
+			)
+		})
+	});
+
+	group.finish();
+	rt.block_on(async { drop(corpus) });
+}
+
+/// Benchmark with 10M documents.
+/// Run with: BENCH_DB_PATH=/path/to/disk cargo bench -p surrealdb --features kv-rocksdb -- 10m
+fn bench_bm25_10m_corpus(c: &mut Criterion) {
+	let rt = Runtime::new().unwrap();
+
+	// Only run with RocksDB to avoid memory issues
+	#[cfg(not(feature = "kv-rocksdb"))]
+	{
+		eprintln!("Skipping 10M benchmark: requires kv-rocksdb feature");
+		return;
+	}
+
+	if std::env::var("BENCH_DB_PATH").is_err() {
+		eprintln!("Skipping 10M benchmark: set BENCH_DB_PATH for RocksDB");
+		return;
+	}
+
+	let doc_count = 10_000_000;
+	eprintln!("Preparing 10M documents corpus...");
+	let corpus = rt.block_on(prepare_million_scale_corpus(doc_count));
+
+	let mut group = c.benchmark_group("bm25_10m_corpus");
+	group.sample_size(10);
+	group.measurement_time(Duration::from_secs(60));
+	group.throughput(Throughput::Elements(doc_count as u64));
+
+	// Common term - many matches
+	group.bench_function("common_term", |b| {
+		b.to_async(Runtime::new().unwrap()).iter(|| {
+			run_query(
+				&corpus,
+				"SELECT *, search::score(1) AS score FROM doc WHERE content @1@ 'database' ORDER BY score DESC LIMIT 100",
+			)
+		})
+	});
+
+	// Rare term - few matches
+	group.bench_function("rare_term", |b| {
+		b.to_async(Runtime::new().unwrap()).iter(|| {
+			run_query(
+				&corpus,
+				"SELECT *, search::score(1) AS score FROM doc WHERE content @1@ 'probabilistic' ORDER BY score DESC LIMIT 100",
+			)
+		})
+	});
+
+	group.finish();
+	rt.block_on(async { drop(corpus) });
+}
+
+criterion_group!(
+	benches,
+	bench_fulltext_search,
+	bench_fulltext_scaling,
+	bench_hybrid_search,
+	bench_bm25_scoring_only,
+	bench_bm25_1m_corpus,
+	bench_bm25_10m_corpus
+);
+criterion_main!(benches);


### PR DESCRIPTION
## What is the motivation?

Parallel INSERT operations with HNSW vector indexes experienced a **98.9% failure rate** due to transaction conflicts. This made vector search indexes practically unusable in concurrent write scenarios.

The root cause was that HNSW index operations had no retry mechanism for handling optimistic transaction conflicts, unlike other components (like sequences) that properly handle these conflicts with exponential backoff.

Additionally, a bug in `check_state` caused panics when the in-memory HNSW state had more layers than the database state after a failed transaction.

## What does this change do?

Adds retry logic with exponential backoff for HNSW index operations and fixes bug in `check_state`layer removal

**Wires up TransactionFactory** to IndexStores for creating independent retry transactions

## What is your testing strategy?

Added comprehensive parallel INSERT tests with HNSW indexes

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed (internal implementation detail)

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)