### PR TITLE
Reduce instrumentation overhead in query record collectors

### DIFF
--- a/crates/core/src/dbs/processor.rs
+++ b/crates/core/src/dbs/processor.rs
@@ -520,7 +520,7 @@ pub(super) struct ConcurrentCollector<'a> {
 	ite: &'a mut Iterator,
 }
 impl Collector for ConcurrentCollector<'_> {
-	#[instrument(skip_all)]
+	#[instrument(level = "trace", skip_all)]
 	async fn collect(&mut self, collectable: Collectable) -> Result<()> {
 		// if it is skippable don't need to process the document
 		if self.ite.skippable() > 0 {
@@ -545,7 +545,7 @@ pub(super) struct ConcurrentDistinctCollector<'a> {
 }
 
 impl Collector for ConcurrentDistinctCollector<'_> {
-	#[instrument(skip_all)]
+	#[instrument(level = "trace", skip_all)]
 	async fn collect(&mut self, collectable: Collectable) -> Result<()> {
 		let skippable = self.coll.ite.skippable() > 0;
 		// If it is skippable, we just need to collect the record id (if any)


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The `collect` method is a critical hot path executed for every record in a query result set. Using default instrumentation (`INFO` level) on this method introduces significant overhead when processing large datasets, leading to:
- **Performance hits**: Millions of records mean millions of span creations/destructions.
- **Observability noise**: Flooding logs and tracing backends with per-record entry/exit spans at standard logging levels.
- **Resource waste**: Increased CPU and storage usage for telemetry that is typically only needed for deep debugging.

## What does this change do?

- Updates `#[instrument(skip_all)]` to `#[instrument(level = "trace", skip_all)]` for the `collect` implementations in `ConcurrentCollector` and `ConcurrentDistinctCollector`.
- Aligns the instrumentation level of these collectors with other hot-path methods in the query processor.
- Ensures per-record tracing is only active when the `trace` level is explicitly enabled, keeping `INFO` and `DEBUG` paths lean.

## What is your testing strategy?

Github actions

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
