### PR TITLE
Export UUID instead of plain string

### DIFF
--- a/crates/core/src/val/uuid.rs
+++ b/crates/core/src/val/uuid.rs
@@ -122,7 +122,7 @@ mod tests {
 		let uuid = Uuid::from_str(uuid_str).unwrap();
 
 		let mut output = String::new();
-		uuid.fmt_sql(&mut output, SqlFormat::Standard);
+		uuid.fmt_sql(&mut output, SqlFormat::SingleLine);
 
 		assert_eq!(output, format!("u'{}'", uuid_str));
 	}


### PR DESCRIPTION
 ## What is the motivation?

Exporting UUIDs results in a plain string instead of a UUID, causing parse errors and/or incorrect data on import.

## What does this change do?

It will export as `u'...'` (instead of `'...'`).

## What is your testing strategy?

Added the `test_uuid_to_sql_with_prefix`. 

## Is this related to any issues?

Closes https://github.com/surrealdb/surrealdb/issues/6696.

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
