### PR TITLE
fix: include element position in coercion error messages

### DIFF
--- a/crates/sdk/src/method/query.rs
+++ b/crates/sdk/src/method/query.rs
@@ -393,7 +393,7 @@ impl IndexedResults {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -424,7 +424,7 @@ impl IndexedResults {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -454,7 +454,7 @@ impl IndexedResults {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -547,7 +547,7 @@ impl WithStats<IndexedResults> {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -578,7 +578,7 @@ impl WithStats<IndexedResults> {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -597,7 +597,7 @@ impl WithStats<IndexedResults> {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;


### PR DESCRIPTION
## Summary

- Add index information for array elements and key names for object values when coercion fails, making debugging easier

## Changes

### Added `ElementPosition` enum
New enum to represent position information in coercion errors:
- `Index(usize)` - for array element positions (0-based)
- `Key(String)` - for object key names

### Extended `CoerceError::ElementOf` variant
Added optional `position` field to track where coercion failed.

### Added helper methods to `CoerceErrorExt` trait
- `with_element_of_at_index()` - wraps error with array index
- `with_element_of_at_key()` - wraps error with object key name

### Updated coercion loops
Updated all relevant coercion implementations to use the new positioned error methods:
- `Vec<T>` coercion
- `BTreeMap<String, T>` coercion
- `HashMap<String, T, S>` coercion
- `coerce_to_array_type()` / `coerce_to_array_type_len()`
- `coerce_to_set_kind()` / `coerce_to_set_kind_len()`

## Example

**Before:**
```
Expected `int` but found `"hello"` when coercing an element of `array<int>`
```

**After:**
```
Expected `int` but found `"hello"` when coercing element at index 2 of `array<int>`
Expected `int` but found `"hello"` when coercing value for key 'name' of `object<int>`
```

## Testing

- Added 4 unit tests to verify the improved error messages
- All existing tests pass