### PR TITLE
Fix idiom continuity not being broken up by `()`

### DIFF
--- a/language-tests/tests/language/expression/operators/casting/geometry.surql
+++ b/language-tests/tests/language/expression/operators/casting/geometry.surql
@@ -1,3 +1,16 @@
+/**
+[test]
+
+[[test.results]]
+value = "(1f, 2f)"
+
+[[test.results]]
+value = "(1f, 2f)"
+
+[[test.results]]
+error = "Could not cast into `geometry` using input `[1f, 2f]`"
+
+*/
 <point> [1.0, 2.0];
 <geometry<point>> [1.0, 2.0];
 <geometry<multiline>> [1.0, 2.0];

--- a/language-tests/tests/language/idiom/continuity.surql
+++ b/language-tests/tests/language/idiom/continuity.surql
@@ -1,0 +1,16 @@
+/**
+[test]
+
+[[test.results]]
+value = "['a', 1]"
+
+[[test.results]]
+value = "['a', 'b']"
+
+*/
+
+// Idiom as part of a continues chain.
+[{ a: ["a","b"]},{ a: [1,2]}].a[0];
+
+// `()` should break up the chain.
+([{ a: ["a","b"]},{ a: [1,2]}].a)[0];

--- a/surrealdb/core/src/syn/parser/prime.rs
+++ b/surrealdb/core/src/syn/parser/prime.rs
@@ -537,7 +537,13 @@ impl Parser<'_> {
 			@peek.span => "This is a reserved keyword here and can't be an identifier");
 		}
 		self.expect_closing_delimiter(t!(")"), start)?;
-		Ok(res)
+
+		// Ensure that `((..).a).b` is broken up into seperate idioms.
+		if self.peek_continues_idiom() {
+			self.parse_remaining_value_idiom(stk, vec![Part::Start(res)]).await
+		} else {
+			Ok(res)
+		}
 	}
 
 	/// Parses a strand with legacy rules, parsing to a record id, datetime or


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

With 3.0 we changed idioms to behave like they operate on elements of the value.
```surql
[{ a: ["a","b"]}, {a: [1,2]}].a[0] 
// returns 
// [{ a: ["a","b"]}, {a: [1,2]}].a[0] =
// [({ a: ["a","b"]}.a)[0], ({a: [1,2]}.a)[0])] =
// [(["a","b"][0]), ([1,2][0])] = 
// ["a",1]
```
However wrapping a value in `()` should break up that continuity.
It currently does not.

## What does this change do?

Fix this behavior.

## What is your testing strategy?

Added a test for idiom continuity.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
