### PR TITLE
Only fetch edge keys because values are unused.

### DIFF
--- a/surrealdb/core/src/dbs/processor.rs
+++ b/surrealdb/core/src/dbs/processor.rs
@@ -1042,8 +1042,7 @@ pub(super) trait Collector {
 		// Loop over the chosen edge types
 		for (beg, end) in keys {
 			// Create a new iterable range
-			let mut stream =
-				txn.stream_keys_vals(beg..end, opt.version, None, ScanDirection::Forward);
+			let mut stream = txn.stream_keys(beg..end, opt.version, None, ScanDirection::Forward);
 			// Loop until no more entries
 			let mut count = 0;
 			while let Some(res) = stream.next().await {
@@ -1052,7 +1051,7 @@ pub(super) trait Collector {
 					break;
 				}
 				// Parse the key from the result
-				let key = res?.0;
+				let key = res?;
 				// Collector the key
 				self.collect(Collectable::Lookup(doc_ctx.clone(), kind.clone(), key)).await?;
 				count += 1;


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Edge keys have all of their data represented in the keys themselves and the values are completely empty. We are currently fetching keys and values (empty) and then not using the values. We should just fetch the keys.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Only fetch the keys on edge lookups.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Existing tests passing.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
