### PR TITLE
Cargo publish failures shouldn't block nightly

### DIFF
--- a/.github/actions/publish-crate/action.yml
+++ b/.github/actions/publish-crate/action.yml
@@ -37,7 +37,26 @@ runs:
         git_tag_enable = false
         EOF
 
+    - name: Publish the crate (dry-run)
+      if: ${{ inputs.publish == 'false' || inputs.nightly-release == 'true' }}
+      shell: bash
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ inputs.cargo-registry-token }}
+      run: |
+        set -x
+        
+        # Create a temporary branch in case the git ref is not a branch
+        git checkout -b crate
+        
+        echo "Running cargo publish --workspace --dry-run"
+        echo "Note: Failures here are informational and do not block nightly builds"
+        echo "Common cause: workspace crates with new APIs not yet published"
+        
+        # Let this fail naturally - workflow will handle continuation
+        cargo publish --workspace --dry-run
+
     - name: Publish the crate
+      if: ${{ inputs.publish == 'true' && inputs.nightly-release != 'true' }}
       shell: bash
       env:
         CARGO_REGISTRY_TOKEN: ${{ inputs.cargo-registry-token }}
@@ -47,39 +66,34 @@ runs:
         # Create a temporary branch in case the git ref is not a branch
         git checkout -b crate
 
-        if [[ "${{ inputs.publish }}" == "false" || "${{ inputs.nightly-release }}" == "true" ]]; then
-          # Dry run - use cargo publish directly as it works better for testing
-          cargo publish --workspace --dry-run
-        else
-          # Real publish - use release-plz for retry logic
-          # If all crates are already published, release-plz will fail
-          # We should treat this as success (idempotency)
-          if ! release-plz release --config /tmp/release-plz.toml; then
-            # Check if the failure was because everything is already published
-            echo "release-plz failed, checking if all crates are already published..."
+        # Real publish - use release-plz for retry logic
+        # If all crates are already published, release-plz will fail
+        # We should treat this as success (idempotency)
+        if ! release-plz release --config /tmp/release-plz.toml; then
+          # Check if the failure was because everything is already published
+          echo "release-plz failed, checking if all crates are already published..."
 
-            # Get all workspace crates (exclude crates with publish = false)
-            all_published=true
-            for crate in $(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.publish != []) | .name'); do
-              version=$(cargo metadata --format-version 1 --no-deps | jq -r ".packages[] | select(.name == \"$crate\") | .version")
-              echo "Checking if $crate@$version is published..."
+          # Get all workspace crates (exclude crates with publish = false)
+          all_published=true
+          for crate in $(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.publish != []) | .name'); do
+            version=$(cargo metadata --format-version 1 --no-deps | jq -r ".packages[] | select(.name == \"$crate\") | .version")
+            echo "Checking if $crate@$version is published..."
 
-              if ! cargo search "$crate" --limit 1 | grep -q "^$crate = \"$version\""; then
-                echo "  $crate@$version is NOT published"
-                all_published=false
-                break
-              else
-                echo "  $crate@$version is already published"
-              fi
-            done
-
-            if [[ "$all_published" == "true" ]]; then
-              echo "All crates are already published. Treating as success (idempotent)."
-              exit 0
+            if ! cargo search "$crate" --limit 1 | grep -q "^$crate = \"$version\""; then
+              echo "  $crate@$version is NOT published"
+              all_published=false
+              break
             else
-              echo "Some crates failed to publish. Failing."
-              exit 1
+              echo "  $crate@$version is already published"
             fi
+          done
+
+          if [[ "$all_published" == "true" ]]; then
+            echo "All crates are already published. Treating as success (idempotent)."
+            exit 0
+          else
+            echo "Some crates failed to publish. Failing."
+            exit 1
           fi
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,6 +412,7 @@ jobs:
     name: Publish crates
     needs: [ test, format, clippy, check, check-wasm, check-docs, build, prepare-vars ]
     runs-on: ubuntu-latest
+    continue-on-error: ${{ needs.prepare-vars.outputs.publish != 'true' || needs.prepare-vars.outputs.nightly-release == 'true' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Nightly is currently broken because the dry run publish failed due to new functions in the core crate that are now used in the server crate. The code compiles fine. This is a limitation of `cargo publish --workspace --dry-run`.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It makes the cargo publish check optional when building nightly.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
