### PR TITLE
Add community PR labeling job.

### DIFF
--- a/.github/workflows/community-pr-label.yml
+++ b/.github/workflows/community-pr-label.yml
@@ -3,11 +3,17 @@
 # This workflow automatically labels PRs from community contributors (non-core team members).
 # It runs when PRs are opened, marked ready for review, reopened, or synchronized.
 # PRs in draft mode are skipped.
+#
+# SECURITY NOTE: This uses pull_request_target (not pull_request) to allow labeling
+# forked PRs. This is safe because:
+# - We don't check out any code from the PR
+# - We only read PR metadata (author) from the GitHub API context
+# - The core team list is defined in this workflow file (not user-controlled)
 
 name: Community PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened, synchronize]
 
 permissions: read-all


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

We have been heads down as a team working through significant changes in preparation for the 3.0 Release. As a result, we have neglected our community PRs because they're not a part of our daily workflow at the moment. We're working to address that by setting up some basic tooling to make tracking PRs opened by the community easier.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR will add the `community` label to any PR which is authored by anyone other than our core team of developers. The `community` label is used by a private project to track the status of these PRs and ensure we have someone from the team assigned to each one.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Will need to validate on main most likely.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
