### PR TITLE
Don’t fail on datastore shutdown

### DIFF
--- a/language-tests/src/cmd/run/provisioner.rs
+++ b/language-tests/src/cmd/run/provisioner.rs
@@ -253,12 +253,20 @@ impl Provisioner {
 
 	pub async fn shutdown(mut self) -> Result<()> {
 		mem::drop(self.send);
-		while let Some(x) = self.recv.recv().await {
-			x.shutdown().await.context("Datastore failed to shutdown properly")?;
+		while let Some(datastore) = self.recv.recv().await {
+			// Best-effort shutdown - ignore errors since datastores may have been
+			// cleared by other tests, especially with shared datastore instances
+			if let Err(e) = datastore.shutdown().await {
+				println!("Warning: Datastore shutdown error: {e}");
+			}
 		}
 
 		if let Some(dir) = self.create_info.dir.as_ref() {
-			tokio::fs::remove_dir_all(dir).await.context("Failed to clean up temporary dir")?;
+			// Best-effort cleanup - ignore errors since datastores may have been
+			// cleared by other tests, especially with shared datastore instances
+			if let Err(e) = tokio::fs::remove_dir_all(dir).await {
+				println!("Failed to clean up temporary dir: {e}");
+			}
 		}
 
 		Ok(())

--- a/surrealdb/core/src/kvs/ds.rs
+++ b/surrealdb/core/src/kvs/ds.rs
@@ -1006,7 +1006,7 @@ impl Datastore {
 		trace!(target: TARGET, "Running datastore shutdown operations");
 		// Delete this datastore from the cluster
 		self.delete_node().await?;
-		// Run any storag engine shutdown tasks
+		// Run any storage engine shutdown tasks
 		self.transaction_factory.builder.shutdown().await
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Language tests running on TiKV sometimes fail intermittently. This is due to the TiKV datastore being used by multiple tests concurrently. In this scenario one test runner will delete the data from the datastore, while another test runner expects that data to still exist. This causes a 'Node does not exist' error and causes the tests to fail and shutdown incorrectly.

## What does this change do?

Prevents these errors from causing the language tests to fail as a whole.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
