### PR TITLE
Don't store any weights as zero in in-memory caches

### DIFF
--- a/crates/core/src/kvs/cache/tx/weight.rs
+++ b/crates/core/src/kvs/cache/tx/weight.rs
@@ -14,12 +14,11 @@ impl Weighter<Key, Entry> for Weight {
 			// the precise weight of a Value (when
 			// deserialising), and using this size to
 			// determine the actual cache weight.
-			Entry::Val(_) => 1,
-			// We don't want to evict other entries
-			// so we set the weight to 0 which will
-			// prevent entries being evicted, unless
-			// specifically removed from the cache.
-			_ => 0,
+			Entry::Val(_) => 2,
+			// We prefer to not evict other entries
+			// so we set the weight to 1 which will
+			// evict other entries before these.
+			_ => 1,
 		}
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Anything stored as a weight of zero is never evicted which can lead to unbounded memory growth.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Changes weight zero in tx cache to 1 and bumps Val to 2.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI tests.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
