### PR TITLE
Backport: Fix HNSW layer pruning logic

### DIFF
--- a/crates/core/src/idx/trees/hnsw/mod.rs
+++ b/crates/core/src/idx/trees/hnsw/mod.rs
@@ -121,7 +121,7 @@ where
 			self.layers.push(l);
 		}
 		// Remove non-existing layers
-		for _ in self.layers.len()..st.layers.len() {
+		while self.layers.len() > st.layers.len() {
 			self.layers.pop();
 		}
 		// Set the enter_point


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

Backport HNSW layer pruning logic.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Fixes issue with layer pruning caused by start being greater than end in range for loop.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing CI.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [ ] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [ ] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
