### PR TITLE
Add error check after UPSERT tries to insert

### DIFF
--- a/surrealdb/core/src/dbs/iterator.rs
+++ b/surrealdb/core/src/dbs/iterator.rs
@@ -748,6 +748,11 @@ impl Iterator {
 					self.ingest(guaranteed);
 					// Process the pre-defined guaranteed document
 					self.iterate(stk, ctx, opt, stm, is_specific_permission, None).await?;
+
+					// // Return any document errors from guaranteed iteration
+					if let Some(e) = self.error.take() {
+						return Err(e);
+					}
 				}
 			}
 			// Process any SPLIT AT clause


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Described in https://github.com/surrealdb/surrealdb/issues/6816

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

When an upsert does not find a document matching its WHERE clause, it will try to insert a new document. This insertion happens in the iterator after errors are checked. This means that schema errors that might happen when inserting a new record are ignored and not shown to the user.
Upsert returns and empty array, even if it should be guaranteed to return a record.

I added an error check right after the insertion path. I am not sure if moving the already existing error check after the insertion path would cause any side effects, so I added a new one. 

DISCLAIMER: The cause of the error was found using an AI assistant.

## What is your testing strategy?

Manual testing

## Is this related to any issues?

https://github.com/surrealdb/surrealdb/issues/6816

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
