### PR TITLE
Allow equality test with parameter when covered

### DIFF
--- a/language-tests/tests/parsing/deprecate/covered_param_equal.surql
+++ b/language-tests/tests/parsing/deprecate/covered_param_equal.surql
@@ -1,0 +1,13 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "true"
+
+*/
+let $p = 1;
+// This should be allowed and should be an equality test
+($p = 1)

--- a/surrealdb/core/src/syn/parser/stmt/mod.rs
+++ b/surrealdb/core/src/syn/parser/stmt/mod.rs
@@ -114,9 +114,12 @@ impl Parser<'_> {
 				self.parse_show_stmt().map(TopLevelExpr::Show)
 			}
 			_ => {
+				let covered = self.peek_kind() == t!("(");
 				let expr = self.parse_expr_start(stk).await?;
 				let span = token.span.covers(self.last_span);
-				Self::reject_letless_let(&expr, span)?;
+				if !covered {
+					Self::reject_letless_let(&expr, span)?;
+				}
 				Ok(TopLevelExpr::Expr(expr))
 			}
 		}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Let-less operator definition has been deprecated:
`$param = 1` would previously define a new parameter, this will throw an error in 3.0.
To still allow this type of syntax we should allow the equality test when covered:
`($param = 1)`. 

## What does this change do?

Allows `($param = 1)` to be valid syntax.

## What is your testing strategy?

Added lang tests

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
