### PR TITLE
Push `START` offset down to storage engine for scan fast path

### DIFF
--- a/surrealdb/core/src/exec/operators/scan.rs
+++ b/surrealdb/core/src/exec/operators/scan.rs
@@ -337,12 +337,9 @@ impl ExecOperator for Scan {
 			// so rows are discarded before deserialization.
 			let pre_skip = if !needs_processing { start_val } else { 0 };
 
-			// Push start+limit to the storage layer for the pure fast path.
-			let effective_storage_limit = if !needs_processing {
-				limit_val.map(|l| start_val.saturating_add(l))
-			} else {
-				None
-			};
+			// Push limit to the storage layer for the pure fast path.
+			// The KV scanner's skip is applied before the limit, so no adjustment needed.
+			let effective_storage_limit = if !needs_processing { limit_val } else { None };
 
 			let direction = determine_scan_direction(&order);
 
@@ -533,9 +530,10 @@ fn determine_scan_direction(order: &Option<Ordering>) -> ScanDirection {
 
 /// Produce a `ValueBatchStream` from a raw KV range scan.
 ///
-/// When `pre_skip > 0`, that many KV pairs are discarded *before* decoding,
-/// avoiding deserialization work for rows that will be skipped anyway (the
-/// fast-path optimisation for `START` without a pushdown predicate).
+/// When `pre_skip > 0`, that many entries are skipped at the KV storage layer
+/// before any data is returned, avoiding I/O, allocation, and deserialization
+/// for rows that will be discarded anyway (the fast-path optimisation for
+/// `START` without a pushdown predicate).
 fn kv_scan_stream(
 	txn: Arc<Transaction>,
 	beg: crate::kvs::Key,
@@ -545,26 +543,15 @@ fn kv_scan_stream(
 	direction: ScanDirection,
 	pre_skip: usize,
 ) -> ValueBatchStream {
+	let skip = pre_skip.min(u32::MAX as usize) as u32;
 	let stream = async_stream::try_stream! {
-		let kv_stream = txn.stream_keys_vals(beg..end, version, storage_limit, 0, direction);
+		let kv_stream = txn.stream_keys_vals(beg..end, version, storage_limit, skip, direction);
 		futures::pin_mut!(kv_stream);
 
-		let mut skipped = 0usize;
 		while let Some(result) = kv_stream.next().await {
 			let entries = result.context("Failed to scan record")?;
-			// Fast path: skip entire batch when all entries fall within pre_skip
-			let remaining_to_skip = pre_skip - skipped;
-			if entries.len() <= remaining_to_skip {
-				skipped += entries.len();
-				continue;
-			}
-			// Allocate only for entries that will actually be decoded
-			let mut batch = Vec::with_capacity(entries.len() - remaining_to_skip);
+			let mut batch = Vec::with_capacity(entries.len());
 			for (key, val) in entries {
-				if skipped < pre_skip {
-					skipped += 1;
-					continue; // discard without decoding
-				}
 				batch.push(decode_record(&key, val)?);
 			}
 			if !batch.is_empty() {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When a `SELECT ... START n` query hits the scan fast path (no table permissions to check, no computed fields, no WHERE predicate), the `START` offset was being skipped at the application level inside `kv_scan_stream`. Although deserialization was avoided for skipped entries, the storage engine still fetched the key-value pairs, allocated memory for them, and transmitted them through the streamed executor pipeline - only to be discarded.

With the newly introduced `skip` parameter on `stream_keys_vals` (and the underlying `Scanner`), skipping key-value entries can now be pushed down to the storage engine, where it is significantly cheaper:
- The in-memory storage engine advances its iterator without cloning data
- SurrealKV advances its iterator without cloning data
- RocksDB advances its iterator without copying data
- TiKV performs a keys-only scan to adjust the range start

## What does this change do?

Passes the `pre_skip` value as the `skip` argument to `stream_keys_vals` in `kv_scan_stream`, pushing the `START` offset down to the storage engine. This eliminates the 15-line application-level skip loop (batch counting, per-entry guard, partial-batch capacity math) and replaces it with a single parameter.

As a follow-on simplification, `effective_storage_limit` is reduced from `start + limit` to just `limit`, since the KV `Scanner` applies `skip` before counting entries toward its limit - there is no longer a need to over-request entries to compensate for application-level discarding.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] No related issues

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
