### PR TITLE
Make HTTP Accept header optional per RFC 9110

### DIFF
--- a/surrealdb/core/src/api/mod.rs
+++ b/surrealdb/core/src/api/mod.rs
@@ -13,6 +13,8 @@ pub const X_SURREAL_REQUEST_ID: HeaderName = HeaderName::from_static("x-surreal-
 pub mod format {
 	//! MIME type string constants for use in HTTP headers
 
+	pub const ANY: &str = "*/*";
+
 	pub const JSON: &str = "application/json";
 	pub const CBOR: &str = "application/cbor";
 	pub const FLATBUFFERS: &str = "application/vnd.surrealdb.flatbuffers";

--- a/surrealdb/server/src/ntw/headers/accept.rs
+++ b/surrealdb/server/src/ntw/headers/accept.rs
@@ -46,6 +46,7 @@ impl Header for Accept {
 			value.to_str().map_err(|_| headers::Error::invalid())?.split(';').collect();
 
 		match parts[0] {
+			surrealdb_core::api::format::ANY => Ok(Accept::ApplicationJson),
 			surrealdb_core::api::format::PLAIN => Ok(Accept::TextPlain),
 			surrealdb_core::api::format::JSON => Ok(Accept::ApplicationJson),
 			surrealdb_core::api::format::CBOR => Ok(Accept::ApplicationCbor),

--- a/surrealdb/server/src/ntw/import.rs
+++ b/surrealdb/server/src/ntw/import.rs
@@ -51,7 +51,7 @@ async fn handler(
 		Ok(res) => {
 			match accept.as_deref() {
 				// Simple serialization
-				Some(Accept::ApplicationJson) => {
+				None | Some(Accept::ApplicationJson) => {
 					// TODO(3.0): This code here is using the wrong serialization method which might
 					// result in some values of the code being serialized wrong.
 					//
@@ -72,8 +72,8 @@ async fn handler(
 					let res = res.into_value();
 					Ok(Output::flatbuffers(&res))
 				}
-				// An incorrect content-type was requested
-				_ => Err(NetError::InvalidType.into()),
+				// An unsupported content-type was requested
+				Some(_) => Err(NetError::InvalidType.into()),
 			}
 		}
 		// There was an error when executing the query

--- a/surrealdb/server/src/ntw/key.rs
+++ b/surrealdb/server/src/ntw/key.rs
@@ -86,7 +86,7 @@ async fn execute_and_return(
 	match db.execute(sql, session, Some(vars)).await {
 		Ok(res) => match accept {
 			// Simple serialization
-			Some(Accept::ApplicationJson) => {
+			None | Some(Accept::ApplicationJson) => {
 				let v = Value::Array(Array::from(
 					res.into_iter().map(|x| x.into_value()).collect::<Vec<Value>>(),
 				));
@@ -105,8 +105,8 @@ async fn execute_and_return(
 				));
 				Ok(Output::flatbuffers(&v))
 			}
-			// An incorrect content-type was requested
-			_ => Err(NetError::InvalidType.into()),
+			// An unsupported content-type was requested
+			Some(_) => Err(NetError::InvalidType.into()),
 		},
 		// There was an error when executing the query
 		Err(err) => Err(err.into()),

--- a/surrealdb/server/src/ntw/sql.rs
+++ b/surrealdb/server/src/ntw/sql.rs
@@ -54,7 +54,7 @@ async fn post_handler(
 	match db.execute(sql, &session, Some(vars)).await {
 		Ok(res) => match output.as_deref() {
 			// Simple serialization
-			Some(Accept::ApplicationJson) => {
+			None | Some(Accept::ApplicationJson) => {
 				let v = Value::Array(Array::from(
 					res.into_iter().map(|x| x.into_value()).collect::<Vec<Value>>(),
 				));
@@ -71,8 +71,8 @@ async fn post_handler(
 				let v = res.into_value();
 				Ok(Output::flatbuffers(&v))
 			}
-			// An incorrect content-type was requested
-			_ => Err(NetError::InvalidType.into()),
+			// An unsupported content-type was requested
+			Some(_) => Err(NetError::InvalidType.into()),
 		},
 		// There was an error when executing the query
 		Err(err) => Err(ResponseError(err.into())),


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Per [RFC 9110 § 12.5.1](https://www.rfc-editor.org/rfc/rfc9110.html#name-accept), the HTTP `Accept` header is optional and its absence should be treated as equivalent to `Accept: */*`. However, requests to the `/sql`, `/key`, and `/import` endpoints without an `Accept` header (or with `Accept: */*`) currently return a 415 Unsupported Media Type error. This blocks use cases like using SurrealDB API endpoints as webhook listeners, since most webhook producers do not send an `Accept` header.

## What does this change do?

- Adds `*/*` as a recognised value in the `Accept` header parser, mapping it to `application/json` as the default format.
- Changes the `/sql`, `/key`, and `/import` endpoint handlers to default to JSON output when no `Accept` header is provided, instead of returning a 415 error.
- The `/signup` and `/signin` endpoints already handled this correctly and are unchanged.

## What is your testing strategy?

GitHub Actions testing.

## Is this related to any issues?

- [x] Closes #6138

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
