### PR TITLE
Fix permission check condition for root users

### DIFF
--- a/language-tests/tests/reproductions/param_permissions_none_root.surql
+++ b/language-tests/tests/reproductions/param_permissions_none_root.surql
@@ -1,0 +1,27 @@
+/**
+[env]
+namespace = true
+database = true
+auth = { level = "owner" }
+
+[test]
+reason = "DEFINE PARAM with PERMISSIONS NONE should still be accessible by system-level users (root/ns/db) since PERMISSIONS only applies to record users"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "123"
+
+[[test.results]]
+value = "123"
+
+[[test.results]]
+value = "[123]"
+
+*/
+
+DEFINE PARAM $test VALUE 123 PERMISSIONS NONE;
+$test;
+RETURN $test;
+SELECT * FROM $test;

--- a/surrealdb/core/src/exec/context.rs
+++ b/surrealdb/core/src/exec/context.rs
@@ -472,9 +472,14 @@ impl ExecutionContext {
 				}
 			}
 		} else {
-			// Without database context, we can't do the full check
-			// Default to requiring permission checks
-			Ok(true)
+			// Without database context we cannot verify namespace/database-level
+			// users, but root users with the appropriate role should still bypass
+			// permission checks regardless of context level.
+			let has_role = match action {
+				Action::Edit => root.auth.has_editor_role(),
+				Action::View => root.auth.has_viewer_role(),
+			};
+			Ok(!has_role || !root.auth.is_root())
 		}
 	}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

As described in #6966 since v3.0.0 the logic whether a PERMISSIONS caluse should be evaluated is not correct, resulting in PERMISSIONS clause being evaluated for root users.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

This PR adds an "is root user and has the appropriate accesses" check to the path where the user has no database-level access.

DISCLAIMER: I used AI to find the issue in the codebase

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Added a `language-tests/reproductions` test

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

#6966 

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
