### PR TITLE
Fix compound unique indexing

### DIFF
--- a/language-tests/tests/reproductions/3290_multi_column_unique_index_none.surql
+++ b/language-tests/tests/reproductions/3290_multi_column_unique_index_none.surql
@@ -1,0 +1,46 @@
+/**
+[test]
+reason = "Multi-column unique indexes should ignore NONE/NULL values, matching SQL-standard semantics where NULLs are never considered equal for uniqueness"
+issue = 3290
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ f1: '2', id: t1:vb8vajoueg055hffmaon }]"
+skip-record-id-key = true
+
+[[test.results]]
+value = "[{ f1: '2', id: t1:iiwjbfgw36d3qtmx3l12 }]"
+skip-record-id-key = true
+
+[[test.results]]
+value = "[{ f1: 'a', f2: 'b', id: t1:kpbyjsraxhbrh30yciwt }]"
+skip-record-id-key = true
+
+[[test.results]]
+match = "$error = /Database index `idx_t1_f1_f2` already contains \\['a', 'b'\\]/"
+error = true
+
+*/
+DEFINE TABLE t1 SCHEMAFULL;
+DEFINE FIELD f1 ON TABLE t1 TYPE string;
+DEFINE FIELD f2 ON TABLE t1 TYPE option<string>;
+DEFINE INDEX idx_t1_f1_f2 ON TABLE t1 COLUMNS f1, f2 UNIQUE;
+
+-- Both rows have f2 = NONE; should not conflict
+CREATE t1 SET f1 = '2';
+CREATE t1 SET f1 = '2';
+
+-- Rows with explicit non-null values in all columns should still conflict
+CREATE t1 SET f1 = 'a', f2 = 'b';
+CREATE t1 SET f1 = 'a', f2 = 'b';

--- a/surrealdb/core/src/idx/index.rs
+++ b/surrealdb/core/src/idx/index.rs
@@ -151,7 +151,7 @@ impl<'a> IndexOperation<'a> {
 		if let Some(n) = self.n.take() {
 			let i = Indexable::new(n, self.ix);
 			for n in i {
-				if !n.is_all_none_or_null() {
+				if !n.is_any_none_or_null() {
 					let key = self.get_unique_index_key(&n)?;
 					if txn.putc(&key, self.rid, None).await.is_err() {
 						let key = self.get_unique_index_key(&n)?;

--- a/surrealdb/core/src/val/array.rs
+++ b/surrealdb/core/src/val/array.rs
@@ -102,6 +102,10 @@ impl Array {
 		self.0.iter().all(|v| v.is_nullish())
 	}
 
+	pub(crate) fn is_any_none_or_null(&self) -> bool {
+		self.0.iter().any(|v| v.is_nullish())
+	}
+
 	/// Removes all values in the array which are equal to the given value.
 	pub fn remove_value(mut self, other: &Value) -> Self {
 		self.retain(|x| x != other);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Fixes a bug where multi-column unique indexes incorrectly reject duplicate `NONE`/`NULL` values. Per SQL-standard semantics (and Postgres behavior), NULLs are never considered equal for uniqueness purposes. Single-column unique indexes already handled this correctly, but multi-column unique indexes did not -- inserting two rows like `{f1: '2', f2: NONE}` would erroneously produce an `IndexExists` error on the second insert.

## What does this change do?

The unique index insertion guard in `index_unique()` used `is_all_none_or_null()`, which only skips the index entry when **every** column is NONE/NULL. For a multi-column index like `UNIQUE(f1, f2)`, the value array `['2', NONE]` fails that check and gets indexed, causing a collision on the next identical insert.

This PR:

1. Adds an `is_any_none_or_null()` helper on `Array` that returns `true` when **any** element is NONE or NULL.
2. Changes the guard in `index_unique()` from `is_all_none_or_null()` to `is_any_none_or_null()`, so index entries are skipped whenever any column is nullish.

## What is your testing strategy?

- Added a language-test reproduction: `language-tests/tests/reproductions/3290_multi_column_unique_index_none.surql`
  - Defines a multi-column unique index on `(f1, f2)` where `f2` is `option<string>`
  - Verifies two rows with `f2 = NONE` and the same `f1` value do **not** conflict
  - Verifies two rows with identical non-null values in both columns **do** conflict
- All 31 existing `define/index` language tests pass
- Existing single-column NONE unique index test (`create_on_none_values_with_unique_index.surql`) continues to pass

## Is this related to any issues?

- Fixes #3290

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
