### PR TITLE
Fix invalid time formatting string cause a panic

### DIFF
--- a/language-tests/tests/language/functions/time/invalid_format_string.surql
+++ b/language-tests/tests/language/functions/time/invalid_format_string.surql
@@ -1,0 +1,8 @@
+/**
+[test]
+
+[[test.results]]
+error = "Incorrect arguments for method time::format(). `%Y-%m-%dT%H:%M:%S.%3NZ` is not a valid time formatting string"
+
+*/
+time::format(d"2012-01-01T08:00:00Z", "%Y-%m-%dT%H:%M:%S.%3NZ")

--- a/surrealdb/core/src/fnc/time.rs
+++ b/surrealdb/core/src/fnc/time.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use chrono::offset::TimeZone;
 use chrono::{DateTime, Datelike, DurationRound, Local, Timelike, Utc};
 
@@ -75,7 +75,15 @@ pub fn floor((val, duration): (Datetime, Duration)) -> Result<Value> {
 }
 
 pub fn format((val, format): (Datetime, String)) -> Result<Value> {
-	Ok(val.format(&format).to_string().into())
+	use std::fmt::Write;
+	let mut res = String::new();
+	let Ok(()) = write!(&mut res, "{}", val.format(&format)) else {
+		bail!(Error::InvalidMethodArguments {
+			name: "time::format".to_owned(),
+			message: format!("`{}` is not a valid time formatting string", format)
+		});
+	};
+	Ok(res.into())
 }
 
 pub fn group((val, group): (Datetime, String)) -> Result<Value> {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Using an invalid formatting string for `time::format` currently causes a panic.
Fix suggested by @Dhghomon.

## What does this change do?

Fixes the issue, causing a error instead

## What is your testing strategy?

added a tests to the language test.

## Is this related to any issues?

- [x] fixes #7019

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
