### PR TITLE
Add retry logic for initial datastore transactions to prevent conflicts on concurrent startup

### DIFF
--- a/surrealdb/core/src/kvs/ds.rs
+++ b/surrealdb/core/src/kvs/ds.rs
@@ -1017,7 +1017,7 @@ impl Datastore {
 	pub async fn bootstrap(&self) -> Result<()> {
 		// Each bootstrap step is retried independently, because concurrent instances
 		// writing to the same cluster metadata keys may cause transaction conflicts.
-		let time_out = Duration::from_mins(1);
+		let time_out = Duration::from_secs(60);
 		// Insert this node in the cluster
 		Self::retry(time_out, || self.insert_node()).await?;
 		// Mark inactive nodes as archived


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

When multiple SurrealDB instances start simultaneously against the same remote storage backend (e.g., TiKV or FoundationDB), the initial bootstrap transactions, setting the storage version, creating the root user, and registering cluster nodes, can conflict with each other. These are write transactions that touch the same keys (version key, root user records, node registrations), and with optimistic concurrency control, only one writer can succeed. Today, if the transaction fails, the instance simply errors out and refuses to start, which is problematic in orchestrated deployments (Kubernetes, auto-scaling groups) where multiple nodes commonly boot at the same time.

## What does this change do?

- Introduces a generic `retry` helper on `Datastore` that re-attempts a fallible async operation with a randomized back-off (0–10 s jitter) until it succeeds or a 1-minute timeout is exceeded. On timeout, the last encountered error is surfaced.
- Wraps the three startup-critical code paths in the retry loop:
  - **`check_version`** → `get_version()` (reads or writes the storage version key)
  - **`initialise_credentials`** → `initialise_credentials_attempt()` (creates the root user if none exists)
  - **`bootstrap`** → `insert_node()`, `expire_nodes()`, `remove_nodes()` (cluster node bookkeeping)
- Keeps the happy-path unchanged — if the transaction succeeds on the first attempt, no delay is added.


## What is your testing strategy?

- **Unit / integration tests** – Existing tests continue to pass; the change is transparent when there is no contention.
- **Concurrent startup test** – Start 3+ SurrealDB instances simultaneously against a shared TiKV/FoundationDB cluster and verify all instances bootstrap successfully without manual intervention.


## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
