### PR TITLE
Fix BM25 search::score() returning 0 after index compaction

### DIFF
--- a/surrealdb/core/src/ctx/context.rs
+++ b/surrealdb/core/src/ctx/context.rs
@@ -996,6 +996,7 @@ mod tests {
 	#[cfg(feature = "http")]
 	use url::Url;
 
+	#[cfg(all(feature = "allocation-tracking", feature = "allocator"))]
 	use crate::cnf::MEMORY_THRESHOLD;
 	use crate::ctx::Context;
 	use crate::ctx::reason::Reason;

--- a/surrealdb/core/src/idx/ft/fulltext.rs
+++ b/surrealdb/core/src/idx/ft/fulltext.rs
@@ -672,37 +672,46 @@ impl FullTextIndex {
 
 	/// Computes document length and count statistics for the index
 	///
-	/// This method calculates the total document length and count by reading
-	/// the compacted (root) key and then aggregating any uncompacted deltas.
-	/// If compact_log is provided, it will also remove the delta logs and set
-	/// the flag to true if any logs were removed.
+	/// This method calculates the total document length and count by scanning
+	/// both the compacted root key and any uncompacted delta entries in a
+	/// single range query (via `new_dc_range_with_root`). If `compact_log` is
+	/// provided, it will also remove the delta logs (but not the root key)
+	/// and set the flag to true if any delta logs were removed.
 	async fn compute_doc_length_and_count(
 		&self,
 		tx: &Transaction,
 		compact_log: Option<&mut bool>,
 	) -> Result<DocLengthAndCount> {
 		let mut dlc = DocLengthAndCount::default();
-		// Read the compacted (root) key -- this holds the aggregated stats
-		// from previous compaction cycles. The key sits lexicographically
-		// before the delta range, so getr() on the range alone never sees it.
-		let compacted_key = self.ikb.new_dc_compacted()?;
-		if let Some(v) = tx.get(&compacted_key, None).await? {
-			dlc = revision::from_slice(&v)?;
-		}
-		// Aggregate any uncompacted deltas written since the last compaction.
-		let (beg, end) = self.ikb.new_dc_range()?;
+		let (beg, end) = self.ikb.new_dc_range_with_root()?;
 		let range = beg..end;
+		// Compute the total number of documents (DocCount) and the total number of
+		// terms (DocLength) This key list is supposed to be small, subject to
+		// compaction. The root key is the compacted values, and the others are deltas
+		// from transaction not yet compacted.
+		let root_key = if compact_log.is_some() {
+			Some(self.ikb.new_dc_compacted()?)
+		} else {
+			None
+		};
 		let mut has_log = false;
-		for (_, v) in tx.getr(range.clone(), None).await? {
+		for (k, v) in tx.getr(range.clone(), None).await? {
 			let st: DocLengthAndCount = revision::from_slice(&v)?;
 			dlc.doc_count += st.doc_count;
 			dlc.total_docs_length += st.total_docs_length;
-			has_log = true;
+
+			if !has_log
+				&& let Some(r) = &root_key
+				&& k.ne(r)
+			{
+				has_log = true;
+			}
 		}
 		if let Some(compact_log) = compact_log
 			&& has_log
 		{
-			tx.delr(range).await?;
+			let (beg, end) = self.ikb.new_dc_range()?;
+			tx.delr(beg..end).await?;
 			*compact_log = true;
 		}
 		Ok(dlc)
@@ -1201,15 +1210,19 @@ mod tests {
 		assert_eq!(tx.count(beg..end, None).await.unwrap(), 0);
 		let (beg, end) = test.ikb.new_dc_range().unwrap();
 		assert_eq!(tx.count(beg..end, None).await.unwrap(), 0);
+		let (beg, end) = test.ikb.new_dc_range_with_root().unwrap();
+		assert_eq!(tx.count(beg..end, None).await.unwrap(), 1);
 	}
 
 	/// Regression test: BM25 scores must remain non-zero after compaction.
 	///
-	/// Before the fix, `compute_doc_length_and_count()` only read from the
-	/// dc delta range. Compaction deletes those deltas and writes the
-	/// aggregated stats to a compacted (root) key that sits outside the range,
-	/// so the scorer would get doc_count=0 / total_docs_length=0, producing
-	/// NaN → 0.0 scores.
+	/// Before the fix, `compute_doc_length_and_count()` only scanned the dc
+	/// delta range (via `new_dc_range`), which excludes the root/compacted
+	/// key. Compaction deletes those deltas and writes the aggregated stats
+	/// to the root key. Since the root key was not included in the scan, the
+	/// scorer would get doc_count=0 / total_docs_length=0, producing
+	/// NaN → 0.0 scores. The fix uses `new_dc_range_with_root` to include
+	/// the root key in the scan.
 	#[test(tokio::test(flavor = "multi_thread"))]
 	async fn bm25_score_survives_compaction() {
 		let test = TestContext::new().await;

--- a/surrealdb/core/src/idx/mod.rs
+++ b/surrealdb/core/src/idx/mod.rs
@@ -210,6 +210,10 @@ impl IndexKeyBase {
 		Dc::range(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
 	}
 
+	fn new_dc_range_with_root(&self) -> Result<(Key, Key)> {
+		Dc::range_with_root(self.0.ns, self.0.db, &self.0.tb, self.0.ix)
+	}
+
 	fn new_dl(&self, doc_id: DocId) -> Dl<'_> {
 		Dl::new(self.0.ns, self.0.db, &self.0.tb, self.0.ix, doc_id)
 	}

--- a/surrealdb/core/src/key/index/dc.rs
+++ b/surrealdb/core/src/key/index/dc.rs
@@ -124,12 +124,16 @@ impl<'a> Dc<'a> {
 		DcPrefix::new(ns, db, tb, ix).encode_key()
 	}
 
-	/// Creates a key range for querying document count and length statistics
+	/// Creates a key range for querying only the delta (non-root) document
+	/// count and length entries.
 	///
-	/// This method generates a key range that can be used to query all document
-	/// count and length statistics for a specific index. It's used for
-	/// operations like compaction, scoring calculations, and index
-	/// maintenance.
+	/// The range starts at `prefix + [0; 40]`, which sits lexicographically
+	/// after the root/compacted key (the bare prefix). This means the root
+	/// key is **excluded**. Use [`range_with_root`] when you need to include
+	/// the compacted root key as well.
+	///
+	/// This range is used during compaction to delete consumed delta logs
+	/// without affecting the root key.
 	///
 	/// # Arguments
 	/// * `ns` - Namespace identifier
@@ -138,7 +142,7 @@ impl<'a> Dc<'a> {
 	/// * `ix` - Index identifier
 	///
 	/// # Returns
-	/// A tuple of (start, end) keys that define the range for database queries
+	/// A tuple of (start, end) keys that define the delta-only range
 	pub(crate) fn range(
 		ns: NamespaceId,
 		db: DatabaseId,
@@ -148,6 +152,35 @@ impl<'a> Dc<'a> {
 		let prefix = DcPrefix::new(ns, db, tb, ix);
 		let mut beg = prefix.encode_key()?;
 		beg.extend([0; 40]);
+		let mut end = prefix.encode_key()?;
+		end.extend([255; 40]);
+		Ok((beg, end))
+	}
+
+	/// Creates a key range that includes the root/compacted key **and** all
+	/// delta entries.
+	///
+	/// Unlike [`range`], the range starts at the bare prefix (no zero-byte
+	/// padding), so the compacted root key is included in the scan. This is
+	/// used by [`FullTextIndex::compute_doc_length_and_count`] to aggregate
+	/// both compacted and uncompacted statistics in a single pass.
+	///
+	/// # Arguments
+	/// * `ns` - Namespace identifier
+	/// * `db` - Database identifier
+	/// * `tb` - Table identifier
+	/// * `ix` - Index identifier
+	///
+	/// # Returns
+	/// A tuple of (start, end) keys covering the root key and all deltas
+	pub(crate) fn range_with_root(
+		ns: NamespaceId,
+		db: DatabaseId,
+		tb: &'a TableName,
+		ix: IndexId,
+	) -> Result<(Vec<u8>, Vec<u8>)> {
+		let prefix = DcPrefix::new(ns, db, tb, ix);
+		let beg = prefix.encode_key()?;
 		let mut end = prefix.encode_key()?;
 		end.extend([255; 40]);
 		Ok((beg, end))
@@ -225,6 +258,18 @@ mod tests {
 		let tb = TableName::from("testtb");
 		let (beg, end) = Dc::range(NamespaceId(1), DatabaseId(2), &tb, IndexId(3)).unwrap();
 		assert_eq!(beg, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!dc\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+		assert_eq!(
+			end,
+			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!dc\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+		);
+	}
+
+	#[test]
+	fn range_with_root() {
+		let tb = TableName::from("testtb");
+		let (beg, end) =
+			Dc::range_with_root(NamespaceId(1), DatabaseId(2), &tb, IndexId(3)).unwrap();
+		assert_eq!(beg, b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!dc");
 		assert_eq!(
 			end,
 			b"/*\x00\x00\x00\x01*\x00\x00\x00\x02*testtb\0+\0\0\0\x03!dc\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

`search::score()` returns `0.0` for all BM25 fulltext results after the first index compaction cycle (~5 seconds after index creation). This makes BM25-weighted hybrid search (vector + fulltext) effectively vector-only, since all fulltext scores collapse to zero.

## What does this change do?

Fixes `compute_doc_length_and_count()` in `FullTextIndex` to include the compacted (root) key in its scan range.

**Root cause:** The compaction cycle (`compact_doc_length_and_count`) aggregates all doc-length/count deltas from the `dc` key range, deletes that range, and writes the result to a compacted root key (`new_dc_compacted()`). However, this root key is the bare `DcPrefix` encoding, which sits *lexicographically before* the delta range (prefix + 40 zero bytes .. prefix + 40 0xFF bytes). When `compute_doc_length_and_count()` subsequently called `tx.getr(range)`, it never saw the compacted key, returning `DocLengthAndCount::default()` (doc_count=0, total_docs_length=0). This caused `Scorer::new()` to compute `average_doc_length = 0/0 = NaN`, making all BM25 scores NaN, which becomes `0.0` when cast to `f32`.

The fix introduces `Dc::range_with_root()` (and its wrapper `new_dc_range_with_root()`), which starts the scan range at the bare prefix instead of `prefix + [0; 40]`, thereby including the compacted root key. `compute_doc_length_and_count()` now uses this wider range to aggregate both the root key and any uncompacted deltas in a single pass. During compaction cleanup, only the delta range (`new_dc_range()`) is deleted, leaving the root key intact.

## What is your testing strategy?

Added `bm25_score_survives_compaction` regression test that:

1. Indexes two documents into a fulltext index with BM25 scoring
2. Asserts `doc_count > 0` and `total_docs_length > 0` before compaction
3. Runs `fti.compaction()` and verifies the delta range is emptied
4. Asserts `doc_count > 0` and `total_docs_length > 0` after compaction
5. Verifies values are identical before and after compaction
6. Confirms the scorer is still constructable post-compaction

Verified the test fails without the fix (`doc_count after compaction should be > 0, got 0`) and passes with it. The existing `concurrent_test` also continues to pass.

## Is this related to any issues?

Fixes  #6546 

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
