### PR TITLE
Add REVIEW.md for Claude Reviews

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,20 @@
+# Code Review Guidelines
+
+## Always check
+
+- **Performance**: flag allocations in hot paths, unnecessary clones, recursion without stack guards, and blocking work on async tasks. This is a database, performance and memory usage regressions matter.
+- **Security**: credentials and tokens must not appear in logs or error messages. New endpoints and operations must enforce authentication and authorization checks. User input must be validated before reaching the storage layer.
+- **Error handling**: errors must not be silently swallowed. No `.unwrap_or_default()` in non-test code, no `let _ =` on fallible calls without justification. Datastore errors should propagate through `crate::err::Error` before wrapping in `anyhow`.
+- **Concurrency**: background tasks must have cancellation paths tied to their owners. Lock ordering must be documented when multiple locks are held. No `.await` while holding synchronous locks.
+- **Revisioned structs**: changes to types that derive `Revision` must be backwards compatible.
+- **Test coverage**: bug fixes should include a language test (`language-tests/tests/`) or SDK test (`surrealdb/tests/`, `tests/`). New SurrealQL functionality needs corresponding `.surql` test files. Functionality that can be tested with language tests should be preferred over writing custom rust language tests.
+- **Dependency changes**: new external crates require justification. Prefer workspace-managed dependencies in the root `Cargo.toml`.
+
+## Skip
+
+- Formatting and style (enforced by `cargo make fmt` and nightly rustfmt in CI)
+- Clippy warnings (enforced by `cargo make ci-clippy` and `ci-clippy-release` in CI)
+- `std::time::Instant` / `std::time::SystemTime` imports (enforced by `cargo make ci-check-imports` in CI)
+- Unused dependencies (enforced by CI check)
+- Files under `target/`, `fuzz/`, and generated code
+- `revision.lock` file contents (validated by the `revision-lock` tool in CI)


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

We have enabled Claude PR Reviews for all PRs to do a first pass before a core contributor does a more thorough review.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

Adds `REVIEW.md` to guide what Claude comments on.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

N/A

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
