### PR TITLE
Fix JSON parser rejecting escaped forward slash (\/)

### DIFF
--- a/language-tests/tests/parsing/strings/escaped_forward_slash.surql
+++ b/language-tests/tests/parsing/strings/escaped_forward_slash.surql
@@ -1,0 +1,9 @@
+/**
+[test]
+
+[[test.results]]
+value = "'String with escaped forward slash /'"
+
+*/
+
+RETURN "String with escaped forward slash \/";

--- a/surrealdb/core/src/syn/lexer/strings/mod.rs
+++ b/surrealdb/core/src/syn/lexer/strings/mod.rs
@@ -153,6 +153,9 @@ impl Lexer<'_> {
 			b'`' => {
 				buffer.push(b'`');
 			}
+			b'/' => {
+				buffer.push(b'/');
+			}
 			b'u' => {
 				let char = Self::lex_unicode_escape(reader, before, span)?;
 				let mut char_buffer = [0u8; 4];


### PR DESCRIPTION
## Summary
Adds support for the escaped forward slash (`\/`) in the JSON response parser.

`\/` is a valid JSON escape sequence per RFC 8259 §7, commonly produced by PHP's `json_encode()`. SurrealDB's parser was rejecting it with "Invalid escape sequence", causing `http::post` to fail even though the remote server returned valid JSON.

The fix adds a `b'/'` match arm to `lex_common_escape_sequence` in the string lexer, alongside the existing escape characters (`\n`, `\t`, `\\`, `\"`, etc.).

A language test is included to verify that `\/` is correctly unescaped to `/`.

Fixes #7039