### PR TITLE
Fix Docker volume permissions for nonroot container user

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -71,6 +71,29 @@ runs:
       shell: bash
       run: docker run --platform linux/amd64 --rm surrealdb-local:amd64 version
 
+    - name: Test Docker image volume permissions
+      shell: bash
+      run: |
+        # Verify /data and /logs are owned by the default user, not root.
+        # Uses docker export since prod images have no shell.
+        expected_uid=$(docker inspect --format '{{.Config.User}}' surrealdb-local:amd64)
+        cid=$(docker create --platform linux/amd64 surrealdb-local:amd64)
+        listing=$(docker export "$cid" | tar -tvf - data logs 2>/dev/null)
+        docker rm "$cid" > /dev/null
+        echo "$listing"
+        for dir in data logs; do
+          line=$(echo "$listing" | grep " ${dir}/$")
+          if echo "$line" | grep -qE "(^d\S+\s+0/0|^d\S+\s+0\s+0\s)"; then
+            echo "ERROR: /$dir is owned by root"
+            exit 1
+          fi
+          if ! echo "$line" | grep -q "$expected_uid"; then
+            echo "ERROR: /$dir is not owned by container user ($expected_uid)"
+            exit 1
+          fi
+          echo "OK: /$dir owned by $expected_uid"
+        done
+
     - name: Configure DockerHub
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       if: ${{ inputs.push == 'true' }}

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -109,9 +109,32 @@ environment variable:
 docker run -e TZ=Europe/London surrealdb/surrealdb:latest start
 ```
 
-SurrealDB can be executed as a non-root user for added security. This ensures that exploiting certain vulnerabilities in the SurrealDB process does not immediately result in privileged access to the container. When doing this, ensure that any files required by SurrealDB are mounted to the container in a volume and that are accessible to that non-root user through their ownership and permissions.
+To persist data using a Docker named volume, use the built-in `/data` directory:
 
-Here is an example of running the container with a persistent volume as a non-root user with Docker Compose:
+```yaml
+services:
+  surrealdb:
+    image: surrealdb/surrealdb:latest # Consider using a specific version
+    pull_policy: always
+    command: start rocksdb:/data/database.db
+    ports:
+      - 8000:8000
+    volumes:
+      - surrealdb-data:/data
+    environment:
+      - SURREAL_LOG=info # Use "info" in production
+      - SURREAL_USER=root
+      - SURREAL_PASS=root # Change this in production!
+
+volumes:
+  surrealdb-data:
+```
+
+The container runs as a non-root user by default and the `/data` directory is pre-configured with the correct ownership, so named volumes work without any additional setup.
+
+If you need to use a bind mount instead, ensure that the mounted directory is accessible to the container user through its ownership and permissions.
+
+Here is an example of running the container with a bind mount as a specific non-root user with Docker Compose:
 
 ```yaml
 services:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,9 +85,9 @@ COPY --from=tzdata /usr/share/zoneinfo /usr/share/zoneinfo
 
 COPY --from=tzdata /usr/share/zoneinfo/UTC /etc/localtime
 
-COPY --from=dev-ci /data /data
+COPY --chown=nonroot:nonroot --from=dev-ci /data /data
 
-COPY --from=dev-ci /logs /logs
+COPY --chown=nonroot:nonroot --from=dev-ci /logs /logs
 
 VOLUME /data /logs
 
@@ -136,9 +136,9 @@ COPY --from=tzdata /usr/share/zoneinfo /usr/share/zoneinfo
 
 COPY --from=tzdata /usr/share/zoneinfo/UTC /etc/localtime
 
-COPY --from=dev /data /data
+COPY --chown=nonroot:nonroot --from=dev /data /data
 
-COPY --from=dev /logs /logs
+COPY --chown=nonroot:nonroot --from=dev /logs /logs
 
 VOLUME /data /logs
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉

## What is the motivation?

The production Docker images (`prod`, `prod-ci`) have `/data` and `/logs` directories owned by `root:root`, even though the container runs as `nonroot` (uid 65532). This causes `PermissionDenied` errors when using persistent storage with Docker named volumes or Kubernetes PVCs.

**Root cause:** `COPY --from=dev /data /data` without `--chown` resets ownership to `root:root`, discarding the `chown nonroot:nonroot` done in the source stage. This is default Docker behavior — `COPY` always sets uid:gid to 0:0 unless `--chown` is specified.

## What does this change do?

- **`docker/Dockerfile`** — Add `--chown=nonroot:nonroot` to 4 COPY commands for `/data` and `/logs` in `prod-ci` and `prod` stages
- **`.github/actions/docker-build/action.yml`** — Add CI test that verifies `/data` and `/logs` ownership matches the container's default user (not hardcoded), preventing regression
- **`docker/DOCKER.md`** — Add recommended Docker Compose example using named volumes with the built-in `/data` directory

## What is your testing strategy?

Verified on the published `surrealdb/surrealdb:v3` image:

```
$ docker create surrealdb/surrealdb:v3 | xargs -I{} sh -c 'docker export {} | tar -tvf - data logs; docker rm {}'
drwxr-xr-x  0 0      0           0 Mar 13 19:32 data/    # root:root — BUG
drwxr-xr-x  0 0      0           0 Mar 13 19:32 logs/    # root:root — BUG
```

After the fix:

```
drwxr-xr-x  0 65532  65532       0 ... data/    # nonroot:nonroot
drwxr-xr-x  0 65532  65532       0 ... logs/    # nonroot:nonroot
```

Full build from source (Rocky Linux 9 builder → Chainguard prod image), tested on arm64:

| Test | v3 original | Fixed image |
|------|------------|-------------|
| `/data` ownership | `0:0` (root) | `65532:65532` (nonroot) |
| `/logs` ownership | `0:0` (root) | `65532:65532` (nonroot) |
| `rocksdb:/data/db` with named volume | `PermissionDenied` | Started successfully |
| Web server startup | N/A (crashed) | `Started web server on 0.0.0.0:8000` |

## Is this related to any issues?

Fixes #6317. Also related: #3468, #2704, #2601, #2574, #5161, #2477.

## Does this change need documentation?

- [x] Documentation changes are included in this PR (`docker/DOCKER.md`)

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)