### PR TITLE
Generalise `Cow` and `&str` SurrealValue implementations

### DIFF
--- a/surrealdb/types/src/traits/surreal_value.rs
+++ b/surrealdb/types/src/traits/surreal_value.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use crate as surrealdb_types;
-use crate::error::{ConversionError, LengthMismatchError, OutOfRangeError};
+use crate::error::{ConversionError, LengthMismatchError, OutOfRangeError, SerializationError};
 use crate::traits::ser::Serializer;
 use crate::{
 	Array, Bytes, Datetime, Duration, Error, File, Geometry, Kind, Number, Object, Range, RecordId,
@@ -496,7 +496,7 @@ where
 	}
 }
 
-impl SurrealValue for &'static str {
+impl SurrealValue for &str {
 	fn kind_of() -> Kind {
 		kind!(string)
 	}
@@ -509,9 +509,10 @@ impl SurrealValue for &'static str {
 		Value::String(self.to_string())
 	}
 
-	fn from_value(_value: Value) -> Result<Self, Error> {
-		Err(Error::internal(
-			"Cannot deserialize &'static str from value: static string references cannot be created from runtime values".to_string(),
+	fn from_value(_: Value) -> Result<Self, Error> {
+		Err(Error::serialization(
+			"Cannot convert to &str because the value would be dropped and the reference would dangle. Use String or Cow<'_, str> instead".to_owned(),
+			SerializationError::Deserialization,
 		))
 	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

These implementations are needlessly specialised.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

It makes their implementations more general.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Github Actions.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Fixes #6985.

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
