### PR TITLE
Fix wrong index in prepare_array lookup check

### DIFF
--- a/surrealdb/core/src/dbs/iterator.rs
+++ b/surrealdb/core/src/dbs/iterator.rs
@@ -620,7 +620,7 @@ impl Iterator {
 							.await;
 					};
 
-					let Part::Lookup(ref lookup) = x[0] else {
+					let Part::Lookup(ref lookup) = x[1] else {
 						return self
 							.prepare_computed(stk, ctx, opt, doc, planner, stm_ctx, doc_ctx, v)
 							.await;


### PR DESCRIPTION
Fixes #7124

## Summary

`prepare_array` checks `x[0]` for `Part::Lookup` at line 623 after already confirming `x[0]` is `Part::Start` at line 617. Since enum variants are mutually exclusive, the `Part::Lookup` match always fails, making the entire lookup optimization branch dead code for array iterations. Edge traversals in arrays fall through to `prepare_computed` instead of taking the optimized lookup path.

The parallel function `prepare` correctly checks `x[1]` at line 225.

## Comparison

```rust
// prepare (line 219-225) — correct
let Part::Start(Expr::Literal(Literal::RecordId(ref from))) = x[0] else { ... };
let Part::Lookup(ref lookup) = x[1] else { ... };

// prepare_array (line 617-623) — bug
let Part::Start(Expr::Literal(Literal::RecordId(ref from))) = x[0] else { ... };
let Part::Lookup(ref lookup) = x[0] else { ... };  // should be x[1]
```

## Fix

One character: `x[0]` → `x[1]` on line 623.