### PR TITLE
Set recursion limit to server crate

### DIFF
--- a/surrealdb/server/src/lib.rs
+++ b/surrealdb/server/src/lib.rs
@@ -10,6 +10,7 @@
 //! <a href="https://crates.io/crates/surrealdb">the Rust SDK</a>.
 //! </section>
 
+#![recursion_limit = "256"]
 // Temporarily allow deprecated items until version 3.0 for backward compatibility
 #![allow(deprecated)]
 #![deny(clippy::mem_forget)]


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

The `surrealdb-server` crate can hit the default Rust recursion limit (128) during macro expansion, particularly from deeply nested type resolution in the query parser and execution engine. This mirrors the `recursion_limit` already set in other crates within the workspace.

## What does this change do?

Adds `#![recursion_limit = "256"]` to `surrealdb/server/src/lib.rs`, raising the compile-time recursion limit from the default 128 to 256 to prevent `recursion limit reached` compilation errors in the server crate.


## What is your testing strategy?

ci build

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

- [x] No related issues

## Does this change need documentation?

<!-- If this pull request requires changes, updates, or improvements to the documentation, then add a corresponding issue on the https://github.com/surrealdb/docs.surrealdb.com repository, and link to it here. -->

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

<!-- Please add the label "Modifies env vars or commands" from the Labels dropdown to the right and detail the changes. -->

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
