### PR TITLE
Set max memtable size for large sized transactions in SurrealKV

### DIFF
--- a/surrealdb/core/src/kvs/surrealkv/cnf.rs
+++ b/surrealdb/core/src/kvs/surrealkv/cnf.rs
@@ -64,6 +64,35 @@ pub(super) static SURREALKV_BLOCK_CACHE_CAPACITY: LazyLock<u64> =
 		max(memory, 16 * 1024 * 1024)
 	});
 
+/// The maximum memtable size in bytes before flushing to disk
+/// This is the arena of memory that is used to store the memtable data.
+/// If a single transaction is larger than this size, it will throw an error.
+/// If a single transaction needs to store larger than this size, this value should be increased.
+pub(super) static SURREALKV_MAX_MEMTABLE_SIZE: LazyLock<usize> =
+	lazy_env_parse!(bytes, "SURREAL_SURREALKV_MAX_MEMTABLE_SIZE", usize, || {
+		// Load the system attributes
+		let mut system = System::new_all();
+		// Refresh the system memory
+		system.refresh_memory();
+		// Get the available memory
+		let memory = match system.cgroup_limits() {
+			Some(limits) => limits.total_memory,
+			None => system.total_memory(),
+		};
+		// Dynamically set the max memtable size
+		if memory < 1024 * 1024 * 1024 {
+			64 * 1024 * 1024 // For systems with < 1 GiB, use 64 MiB
+		} else if memory < 4 * 1024 * 1024 * 1024 {
+			128 * 1024 * 1024 // For systems with < 4 GiB, use 128 MiB
+		} else if memory < 16 * 1024 * 1024 * 1024 {
+			256 * 1024 * 1024 // For systems with < 16 GiB, use 256 MiB
+		} else if memory < 64 * 1024 * 1024 * 1024 {
+			1024 * 1024 * 1024 // For systems with < 64 GiB, use 1 GiB
+		} else {
+			4 * 1024 * 1024 * 1024 // For systems with >= 64 GiB, use 4 GiB
+		}
+	});
+
 /// The maximum wait time in nanoseconds before forcing a grouped commit (default: 5ms).
 /// This timeout ensures that transactions don't wait indefinitely under low concurrency and
 /// balances commit latency against write throughput.

--- a/surrealdb/core/src/kvs/surrealkv/mod.rs
+++ b/surrealdb/core/src/kvs/surrealkv/mod.rs
@@ -76,6 +76,9 @@ impl Datastore {
 		info!(target: TARGET, "Versioning with versioned_index: {}", versioned_index);
 		let builder = builder.with_versioned_index(versioned_index);
 
+		// Configure the maximum memtable size
+		info!(target: TARGET, "Setting max memtable size: {}", *cnf::SURREALKV_MAX_MEMTABLE_SIZE);
+		let builder = builder.with_max_memtable_size(*cnf::SURREALKV_MAX_MEMTABLE_SIZE);
 		// Enable the block cache capacity
 		info!(target: TARGET, "Setting block cache capacity: {}", *cnf::SURREALKV_BLOCK_CACHE_CAPACITY);
 		let builder = builder.with_block_cache_capacity(*cnf::SURREALKV_BLOCK_CACHE_CAPACITY);


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

Allow users to insert large sized transactions in surrealkv.

## What does this change do?

Add SURREAL_SURREALKV_MAX_MEMTABLE_SIZE environment variable to configure the maximum memtable size before flushing to disk.

## What is your testing strategy?

The memtable in surrealkv is backed by an arena allocator where writes accumulate before being flushed to disk. If a single transaction exceeds this size, SurrealKV will throw an error. Users with large transactions (bulk imports, large document updates) need to increase this value.

## Is this related to any issues?

https://github.com/surrealdb/surrealkv/issues/377

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [ ] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
