### PR TITLE
fix(server): treat expired HTTP Bearer token as no-auth instead of 401

### DIFF
--- a/surrealdb/server/src/ntw/auth.rs
+++ b/surrealdb/server/src/ntw/auth.rs
@@ -153,7 +153,18 @@ async fn check_auth(parts: &mut Parts) -> Result<Session> {
 
 	// If Token authentication data was supplied
 	if let Ok(au) = parts.extract::<TypedHeader<Authorization<Bearer>>>().await {
-		token(kvs, &mut session, au.token()).await?;
+		match token(kvs, &mut session, au.token()).await {
+			Ok(()) => {}
+			Err(err) if surrealdb_core::iam::is_expired_token_error(&err) => {
+				// Treat an expired token as equivalent to no token. This allows
+				// recovery operations (signin, invalidate) to proceed instead of
+				// being blocked at the middleware layer — avoiding a deadlock where
+				// the client cannot obtain a fresh JWT because the expired Bearer
+				// is rejected before the request reaches the endpoint handler.
+				warn!("Ignoring expired bearer token, proceeding with unauthenticated session");
+			}
+			Err(err) => return Err(err),
+		}
 	};
 
 	Ok(session)

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -2472,4 +2472,108 @@ mod http_integration {
 			assert!(res.contains("The HTTP route 'sql' is forbidden"), "body: {}", res);
 		}
 	}
+
+	// -----------------------------------------------------------------------
+	// Expired JWT must not block signin or sql endpoints (deadlock fix)
+	// -----------------------------------------------------------------------
+
+	#[test(tokio::test)]
+	async fn expired_jwt_does_not_block_signin() -> Result<(), Box<dyn std::error::Error>> {
+		let (addr, _server) = common::start_server_with_defaults().await.unwrap();
+
+		let client =
+			reqwest::Client::builder().connect_timeout(Duration::from_millis(10)).build()?;
+
+		// Build a fabricated expired JWT (exp in the past).
+		// Header: {"alg":"HS512","typ":"JWT"}
+		// Payload: {"iat":1600000000,"exp":1600000001,"iss":"SurrealDB"}
+		// The signature is invalid, but the middleware checks expiry before
+		// cryptographic verification, so this is sufficient to trigger the
+		// expired-token path.
+		let expired_token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.\
+			eyJpYXQiOjE2MDAwMDAwMDAsImV4cCI6MTYwMDAwMDAwMSwiaXNzIjoiU3VycmVhbERCIn0.\
+			AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+		// 1. Signin via /signin with an expired Bearer — must NOT get 401
+		{
+			let req_body = serde_json::to_string(&json!({
+				"user": USER,
+				"pass": PASS,
+			}))?;
+
+			let res = client
+				.post(format!("http://{addr}/signin"))
+				.header(header::ACCEPT, "application/json")
+				.header(header::AUTHORIZATION, format!("Bearer {expired_token}"))
+				.body(req_body)
+				.send()
+				.await?;
+
+			assert_eq!(
+				res.status(),
+				200,
+				"signin with expired Bearer must succeed, got: {}",
+				res.text().await?
+			);
+		}
+
+		// 2. SQL query with expired Bearer — should get anonymous session (not 401)
+		{
+			let res = client
+				.post(format!("http://{addr}/sql"))
+				.header(header::ACCEPT, "application/json")
+				.header("surreal-ns", "test")
+				.header("surreal-db", "test")
+				.header(header::AUTHORIZATION, format!("Bearer {expired_token}"))
+				.body("RETURN 1")
+				.send()
+				.await?;
+
+			// The request should reach the handler. It may succeed with an
+			// anonymous session or fail with a permissions error — but it must
+			// NOT be rejected at the middleware level with 401.
+			assert_ne!(res.status(), 401, "expired Bearer must not cause 401 at middleware level");
+		}
+
+		// 3. Full recovery flow: signin, use token, expire it, re-signin
+		{
+			// Get a real token first
+			let req_body = serde_json::to_string(&json!({
+				"user": USER,
+				"pass": PASS,
+			}))?;
+
+			let res = client
+				.post(format!("http://{addr}/signin"))
+				.header(header::ACCEPT, "application/json")
+				.body(req_body)
+				.send()
+				.await?;
+			assert_eq!(res.status(), 200);
+
+			// Now try to re-signin while carrying an expired token — the
+			// exact scenario that causes the deadlock in production.
+			let req_body = serde_json::to_string(&json!({
+				"user": USER,
+				"pass": PASS,
+			}))?;
+
+			let res = client
+				.post(format!("http://{addr}/signin"))
+				.header(header::ACCEPT, "application/json")
+				.header(header::AUTHORIZATION, format!("Bearer {expired_token}"))
+				.body(req_body)
+				.send()
+				.await?;
+
+			assert_eq!(
+				res.status(),
+				200,
+				"re-signin with expired Bearer must succeed (deadlock recovery), got: {}",
+				res.text().await?
+			);
+		}
+
+		Ok(())
+	}
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉

## What is the motivation?

When an HTTP client's JWT expires, it enters a deadlock: `signin()` and `invalidate()` — the operations needed to recover — are also rejected with 401 because the auth middleware (`SurrealAuth`) validates the Bearer token on **all** incoming requests before the endpoint handler runs.

The SDK automatically attaches the `Authorization: Bearer <token>` header on every request, including recovery calls. The client has no way to obtain a fresh JWT without creating a brand-new connection (bypassing the stale Bearer header).

**The deadlock flow:**
1. Client signs in via HTTP → receives JWT with expiry
2. JWT expires
3. Client calls `signin()` with valid credentials
4. SDK attaches the expired JWT as `Authorization: Bearer <expired>`
5. Middleware: expired token → 401 → `signin` handler never runs
6. Client is stuck

WebSocket is unaffected — WS auth is per-RPC-method, not middleware-based.

**Historical context:**
- #3543 reported the opposite bug: expired tokens were silently **accepted** as valid
- #3561 fixed that by adding expiry checks — but the fix is too strict, blocking recovery endpoints as well
- This PR finds the middle ground: expired ≠ valid, but expired ≠ block everything

## What does this change do?

In `check_auth()` (`surrealdb/server/src/ntw/auth.rs`), when Bearer token validation returns `ExpiredToken`, the middleware now treats it as equivalent to **no token** — the request proceeds with an unauthenticated (anonymous) session. The endpoint handler then decides what to do:

- `/signin`: receives anonymous session + credentials from body → verifies → issues new JWT ✓
- `/sql` and other protected endpoints: anonymous session → permissions error (not 401) ✓
- `/invalidate`: clears the (already empty) session → succeeds ✓

**This is not a security downgrade:**
- An expired token provides zero security value
- The anonymous session is identical to not sending any `Authorization` header at all
- All endpoints enforce permissions based on the session's auth level, not the presence of a Bearer header
- Invalid tokens (bad signature, wrong claims, etc.) still return 401 as before

Uses the existing `is_expired_token_error()` helper from `surrealdb_core::iam`.

## What is your testing strategy?

New integration test `expired_jwt_does_not_block_signin` in `tests/http_integration.rs` with three scenarios:

1. **Signin with expired Bearer** — `POST /signin` with expired JWT in Authorization header → must return 200 (not 401)
2. **SQL with expired Bearer** — `POST /sql` with expired JWT → must not return 401 at middleware level (handler decides permissions)
3. **Full recovery flow** — sign in normally, then re-signin carrying an expired token → must succeed (reproduces the exact production deadlock)

All existing tests pass. Fork CI results: [22f/surrealdb#2](https://github.com/22f/surrealdb/pull/2)
- ✅ HTTP / WebSocket / CLI integration tests
- ✅ clippy, format, docs, revision
- ✅ KVS engines (mem, rocksdb, surrealkv), Rust SDK (all engines)
- ✅ SurrealQL tests (rocksdb, surrealkv, tikv)
- ⚠️ SurrealQL tests (mem) — pre-existing flaky failure in `access/record/variables.surql` ([same on upstream main](https://github.com/surrealdb/surrealdb/actions/runs/23588569757))

## Is this related to any issues?

- Fixes #7195
- Related: #3543 (expired tokens accepted — the original bug)
- Related: #3561 (session expiration fix — introduced the deadlock)

## Does this change need documentation?

- [x] No documentation needed

## Does this change make any alterations to environment variables or CLI commands?

- [x] No changes made to env vars

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)