### PR TITLE
Fix SELECT alias shadowing source field in projection fast path

### DIFF
--- a/language-tests/tests/reproductions/7161_alias_shadows_source_field.surql
+++ b/language-tests/tests/reproductions/7161_alias_shadows_source_field.surql
@@ -1,0 +1,41 @@
+/**
+[env]
+namespace = true
+database = true
+auth = { level = "owner" }
+
+[test]
+reason = "SELECT alias that matches a source field name should not shadow the original field for other projections"
+issue = 7161
+
+[[test.results]]
+value = "'OK'"
+
+[[test.results]]
+value = "[{ id: bug_relate:1, other_id: test:a }]"
+
+[[test.results]]
+value = "[{ id: bug_relate:1, other_id: test:a }]"
+
+[[test.results]]
+value = "[{ linked_id: bug_relate:1, other_id: test:a }]"
+*/
+
+-- Setup
+{
+	DEFINE TABLE bug_relate TYPE NORMAL;
+	DEFINE TABLE test TYPE NORMAL;
+	DEFINE FIELD bug_relate ON test TYPE record<bug_relate>;
+	CREATE bug_relate:1;
+	CREATE test:a SET bug_relate = bug_relate:1;
+	RETURN "OK";
+};
+
+-- Test 1: Computed alias first, simple field second (original bug report)
+SELECT bug_relate.id AS id, id AS other_id FROM test;
+
+-- Test 2: Simple field first, computed alias second (reversed order)
+SELECT id AS other_id, bug_relate.id AS id FROM test;
+
+-- Test 3: No shadowing (different alias name) — control case
+SELECT bug_relate.id AS linked_id, id AS other_id FROM test;

--- a/surrealdb/core/src/exec/planner/select.rs
+++ b/surrealdb/core/src/exec/planner/select.rs
@@ -13,6 +13,7 @@
 //! An `ExpressionRegistry` is shared between ORDER BY and projection planning
 //! to deduplicate expressions that appear in both clauses.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use surrealdb_types::ToSql;
@@ -495,6 +496,9 @@ impl<'ctx> Planner<'ctx> {
 				// operator (projection functions, nested output paths), fall back.
 				let mut projections = Vec::with_capacity(field_list.len());
 				let mut needs_fallback = false;
+				// Track source field names read by simple Include/Rename projections.
+				// Used post-loop to detect shadowing by Compute internal names.
+				let mut simple_source_fields: HashSet<String> = HashSet::new();
 
 				if has_wildcard {
 					projections.push(Projection::All);
@@ -530,6 +534,7 @@ impl<'ctx> Planner<'ctx> {
 
 								if let Some(field_name) = physical.try_simple_field() {
 									// Simple aliased field: rename
+									simple_source_fields.insert(field_name.to_string());
 									if field_name == output_name {
 										projections.push(Projection::Include(output_name));
 									} else {
@@ -552,6 +557,7 @@ impl<'ctx> Planner<'ctx> {
 								// No alias
 								if let Some(field_name) = physical.try_simple_field() {
 									// Simple field: include directly
+									simple_source_fields.insert(field_name.to_string());
 									projections.push(Projection::Include(field_name.to_string()));
 								} else if let Expr::Idiom(idiom) = &selector.expr {
 									let path = idiom_to_field_path(idiom);
@@ -584,6 +590,27 @@ impl<'ctx> Planner<'ctx> {
 								}
 							}
 						}
+					}
+				}
+
+				// A Compute expression whose internal name matches a simple
+				// projection's source field will overwrite that field in the
+				// per-row object, causing the simple projection to read the
+				// computed value instead of the original. Fall back to the
+				// full Project operator which evaluates every field against
+				// the original row values. Check both Sort and Project
+				// compute points since Sort Compute also feeds into
+				// SelectProject.
+				if !needs_fallback && !simple_source_fields.is_empty() {
+					let has_shadow =
+						[ComputePoint::Sort, ComputePoint::Project].iter().any(|point| {
+							registry
+								.get_expressions_for_point(*point)
+								.iter()
+								.any(|(name, _)| simple_source_fields.contains(name))
+						});
+					if has_shadow {
+						needs_fallback = true;
 					}
 				}
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉 

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

> [!WARNING]
No details provided.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

* When a computed expression alias (e.g. bug_relate.id AS id) matches a source field name used by another simple projection (id AS other_id), the Compute operator overwrites the original field, causing the simple projection to read the wrong value.
* Detect this naming conflict in plan_projections_fast and fall back to the full Project operator which evaluates all fields against the original row values.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Passing language tests.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

Fixes #7161.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
