### PR TITLE
Fix auth limit with ALTER statements.

### DIFF
--- a/language-tests/tests/reproductions/alter_auth_limit_escalation.surql
+++ b/language-tests/tests/reproductions/alter_auth_limit_escalation.surql
@@ -1,0 +1,33 @@
+/**
+[env]
+namespace = true
+database = true
+imports = ["reproductions/alter_auth_limit_escalation_import.surql"]
+
+signin = """{
+	ns: "test",
+	db: "test",
+	user: "db_owner",
+	pass: "db_owner",
+}"""
+
+[test]
+reason = "ALTER FUNCTION must recompute auth_limit from the altering principal. A root-defined function altered by a DB-owner must not allow namespace-level operations."
+
+[[test.results]]
+error = false
+
+[[test.results]]
+error = "IAM error: Not enough permissions to perform this action"
+
+*/
+
+-- DB-owner alters the root-defined function to attempt namespace-level escalation.
+-- The auth_limit is recomputed from the DB-owner's actual privileges on ALTER.
+ALTER FUNCTION fn::escalate() {
+	DEFINE USER escalated ON NAMESPACE PASSWORD 'pass' ROLES OWNER;
+};
+
+-- Calling the altered function must fail: the auth_limit is now DB-level,
+-- blocking the embedded DEFINE USER ON NAMESPACE.
+fn::escalate();

--- a/language-tests/tests/reproductions/alter_auth_limit_escalation_import.surql
+++ b/language-tests/tests/reproductions/alter_auth_limit_escalation_import.surql
@@ -1,0 +1,8 @@
+/**
+[test]
+run = false
+*/
+
+-- Setup: define a DB-level owner user and a root-defined function
+DEFINE USER db_owner ON DATABASE PASSWORD 'db_owner' ROLES OWNER;
+DEFINE FUNCTION fn::escalate() { RETURN 'safe'; };

--- a/surrealdb/core/src/expr/statements/alter/api.rs
+++ b/surrealdb/core/src/expr/statements/alter/api.rs
@@ -15,7 +15,7 @@ use crate::expr::parameterize::expr_to_ident;
 use crate::expr::statements::define::ApiAction;
 use crate::expr::statements::define::config::api::ApiConfig;
 use crate::expr::{Base, Expr, Literal};
-use crate::iam::{Action, ResourceKind};
+use crate::iam::{Action, AuthLimit, ResourceKind};
 use crate::val::Value;
 
 /// A single `FOR` clause within an `ALTER API` statement.
@@ -131,6 +131,9 @@ impl AlterApiStatement {
 			AlterKind::Drop => ap.comment = None,
 			AlterKind::None => {}
 		}
+
+		// Recompute auth_limit from the current principal to prevent privilege escalation
+		ap.auth_limit = AuthLimit::new_from_auth(opt.auth.as_ref()).into();
 
 		let key = crate::key::database::ap::new(ns, db, &path_name);
 		txn.set(&key, &ap, None).await?;

--- a/surrealdb/core/src/expr/statements/alter/event.rs
+++ b/surrealdb/core/src/expr/statements/alter/event.rs
@@ -10,7 +10,7 @@ use crate::catalog::{EventKind, TableDefinition};
 use crate::ctx::FrozenContext;
 use crate::dbs::Options;
 use crate::expr::{Base, Expr};
-use crate::iam::{Action, ResourceKind};
+use crate::iam::{Action, AuthLimit, ResourceKind};
 use crate::val::{TableName, Value};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
@@ -66,6 +66,9 @@ impl AlterEventStatement {
 			AlterKind::Drop => ev.kind = EventKind::Sync,
 			AlterKind::None => {}
 		}
+
+		// Recompute auth_limit from the current principal to prevent privilege escalation
+		ev.auth_limit = AuthLimit::new_from_auth(opt.auth.as_ref()).into();
 
 		let key = crate::key::table::ev::new(ns, db, &self.what, ev_name);
 		txn.set(&key, &ev, None).await?;

--- a/surrealdb/core/src/expr/statements/alter/field.rs
+++ b/surrealdb/core/src/expr/statements/alter/field.rs
@@ -12,7 +12,7 @@ use crate::dbs::Options;
 use crate::err::Error;
 use crate::expr::reference::Reference;
 use crate::expr::{Base, Expr, Idiom, Kind};
-use crate::iam::{Action, ResourceKind};
+use crate::iam::{Action, AuthLimit, ResourceKind};
 use crate::val::{TableName, Value};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
@@ -133,7 +133,9 @@ impl AlterFieldStatement {
 		// Disallow mismatched types
 		//df.disallow_mismatched_types(ctx, ns, db).await?;
 
-		// Set the table definition
+		// Recompute auth_limit from the current principal to prevent privilege escalation
+		df.auth_limit = AuthLimit::new_from_auth(opt.auth.as_ref()).into();
+
 		let key = crate::key::table::fd::new(ns, db, &self.what, &name);
 		txn.set(&key, &df, None).await?;
 		// Refresh the table cache

--- a/surrealdb/core/src/expr/statements/alter/function.rs
+++ b/surrealdb/core/src/expr/statements/alter/function.rs
@@ -9,7 +9,7 @@ use crate::catalog::providers::DatabaseProvider;
 use crate::ctx::FrozenContext;
 use crate::dbs::Options;
 use crate::expr::{Base, Block, Kind};
-use crate::iam::{Action, ResourceKind};
+use crate::iam::{Action, AuthLimit, ResourceKind};
 use crate::val::Value;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
@@ -68,6 +68,9 @@ impl AlterFunctionStatement {
 			AlterKind::Drop => fc.returns = None,
 			AlterKind::None => {}
 		}
+
+		// Recompute auth_limit from the current principal to prevent privilege escalation
+		fc.auth_limit = AuthLimit::new_from_auth(&opt.auth).into();
 
 		let key = crate::key::database::fc::new(ns, db, &self.name);
 		txn.set(&key, &fc, None).await?;

--- a/surrealdb/core/tests/auth_limit.rs
+++ b/surrealdb/core/tests/auth_limit.rs
@@ -161,11 +161,22 @@ async fn auth_limit_alter_api_recomputes() -> Result<()> {
 	let res = &mut dbs.execute(sql, &ses_db, None).await?;
 	skip_ok(res, 1)?;
 
-	// NS-owner invokes the API
+	// NS-owner invokes the API -- the handler body must be blocked by the
+	// recomputed auth_limit, producing a 500 response with the IAM error.
 	let sql = r#"RETURN api::invoke("/test/escalate");"#;
-	let _ = dbs.execute(sql, &ses_ns, None).await?;
+	let res = &mut dbs.execute(sql, &ses_ns, None).await?;
+	assert_eq!(res.len(), 1);
+	let response = res.remove(0).result?.to_sql();
+	assert!(
+		response.contains("500"),
+		"Expected status 500 from blocked API handler, got: {response}"
+	);
+	assert!(
+		response.contains("Not enough permissions"),
+		"Expected IAM error in API response, got: {response}"
+	);
 
-	// Verify the backdoor user was NOT created
+	// Belt-and-suspenders: verify the backdoor user was NOT created
 	let mut t = Test::new_ds_session(dbs, ses_ns, "INFO FOR NS").await?;
 	let info = t.next_value()?.to_sql();
 	assert!(

--- a/surrealdb/core/tests/auth_limit.rs
+++ b/surrealdb/core/tests/auth_limit.rs
@@ -1,8 +1,9 @@
 mod helpers;
 use anyhow::Result;
-use helpers::{new_ds, skip_ok};
+use helpers::{Test, new_ds, skip_ok};
 use surrealdb_core::dbs::Session;
 use surrealdb_core::iam::{Level, Role};
+use surrealdb_types::ToSql;
 
 #[tokio::test]
 async fn auth_limit_diff_role() -> Result<()> {
@@ -72,5 +73,105 @@ async fn auth_limit_diff_level() -> Result<()> {
 		"IAM error: Not enough permissions to perform this action"
 	);
 	//
+	Ok(())
+}
+
+/// ALTER FUNCTION must recompute auth_limit from the altering principal.
+/// A NS-owner defines a harmless function; a DB-owner alters it to inject a
+/// namespace-level DEFINE USER. The recomputed auth_limit (DB-owner) must
+/// prevent the escalation even when invoked by a NS-owner.
+#[tokio::test]
+async fn auth_limit_alter_function_recomputes() -> Result<()> {
+	let dbs = new_ds("test", "test").await?.with_auth_enabled(true).with_notifications();
+
+	let ses_ns = Session::for_level(Level::Namespace("test".to_string()), Role::Owner)
+		.with_ns("test")
+		.with_db("test");
+
+	let ses_db =
+		Session::for_level(Level::Database("test".to_string(), "test".to_string()), Role::Owner)
+			.with_ns("test")
+			.with_db("test");
+
+	// NS-owner defines a function with a safe body
+	let sql = "DEFINE FUNCTION fn::escalate() { RETURN 'safe'; };";
+	let res = &mut dbs.execute(sql, &ses_ns, None).await?;
+	skip_ok(res, 1)?;
+
+	// DB-owner alters the function body to attempt namespace-level escalation
+	let sql = "
+		ALTER FUNCTION fn::escalate() {
+			DEFINE USER x ON NAMESPACE ROLES OWNER PASSWORD 'pass';
+		};
+	";
+	let res = &mut dbs.execute(sql, &ses_db, None).await?;
+	skip_ok(res, 1)?;
+
+	// NS-owner invokes -- auth_limit was recomputed to DB-owner level on ALTER,
+	// so the embedded DEFINE USER ON NAMESPACE must fail
+	let sql = "fn::escalate();";
+	let res = &mut dbs.execute(sql, &ses_ns, None).await?;
+	assert_eq!(res.len(), 1);
+
+	let tmp = res.remove(0).result;
+	assert!(tmp.is_err());
+	assert_eq!(
+		tmp.unwrap_err().to_string(),
+		"IAM error: Not enough permissions to perform this action"
+	);
+
+	Ok(())
+}
+
+/// ALTER API must recompute auth_limit from the altering principal.
+/// A NS-owner defines an API; a DB-owner alters its handler to inject a
+/// namespace-level DEFINE USER. The recomputed auth_limit (DB-owner) must
+/// prevent the escalation: no new user should appear in INFO FOR NS.
+#[tokio::test]
+async fn auth_limit_alter_api_recomputes() -> Result<()> {
+	let dbs = new_ds("test", "test").await?.with_auth_enabled(true).with_notifications();
+
+	let ses_ns = Session::for_level(Level::Namespace("test".to_string()), Role::Owner)
+		.with_ns("test")
+		.with_db("test");
+
+	let ses_db =
+		Session::for_level(Level::Database("test".to_string(), "test".to_string()), Role::Owner)
+			.with_ns("test")
+			.with_db("test");
+
+	// NS-owner defines a safe API
+	let sql = r#"
+		DEFINE API "/test/escalate"
+			FOR get THEN {
+				{ status: 200, body: 'safe' };
+			};
+	"#;
+	let res = &mut dbs.execute(sql, &ses_ns, None).await?;
+	skip_ok(res, 1)?;
+
+	// DB-owner alters the handler to attempt namespace-level escalation
+	let sql = r#"
+		ALTER API "/test/escalate"
+			FOR get THEN {
+				DEFINE USER backdoor ON NAMESPACE PASSWORD 'pass' ROLES OWNER;
+				{ status: 200, body: 'escalated' };
+			};
+	"#;
+	let res = &mut dbs.execute(sql, &ses_db, None).await?;
+	skip_ok(res, 1)?;
+
+	// NS-owner invokes the API
+	let sql = r#"RETURN api::invoke("/test/escalate");"#;
+	let _ = dbs.execute(sql, &ses_ns, None).await?;
+
+	// Verify the backdoor user was NOT created
+	let mut t = Test::new_ds_session(dbs, ses_ns, "INFO FOR NS").await?;
+	let info = t.next_value()?.to_sql();
+	assert!(
+		!info.contains("backdoor"),
+		"Privilege escalation succeeded: namespace user 'backdoor' was created"
+	);
+
 	Ok(())
 }


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉

## What is the motivation?

The `ALTER` code paths for schema types that carry an `auth_limit` field (API, function, event, field) clone the existing definition and mutate fields but never recompute `auth_limit` from the current principal. In contrast, `DEFINE` statements for the same types correctly snapshot the caller's privileges via `AuthLimit::new_from_auth(opt.auth)`. This means an `ALTER` by a lower-privileged user preserves a stale elevated `auth_limit` from the original definer, which could allow privilege escalation.

Note: the `ALTER` statements for these schema types were added on main and have not been included in any release, so this does not represent a vulnerability in any shipped version.

## What does this change do?

Adds `auth_limit` recomputation from the current session auth in all four `ALTER` statement implementations that carry an `auth_limit` field:

- `ALTER API`
- `ALTER FUNCTION`
- `ALTER EVENT`
- `ALTER FIELD`

Each now calls `AuthLimit::new_from_auth(opt.auth.as_ref()).into()` before writing to storage, matching the behavior of their `DEFINE` counterparts. This ensures the stored `auth_limit` always reflects the privileges of the last principal to modify the definition.

## What is your testing strategy?

Added Rust integration tests and a SurrealQL language test reproduction that verify the fix.

## Security Considerations

The `auth_limit` field controls the maximum privilege ceiling for executable code embedded in schema definitions (API handlers, function bodies, event triggers, field expressions). Without recomputation on `ALTER`, a lower-privileged principal could inherit and exploit a stale elevated `auth_limit` from a higher-privileged definition. Since the affected `ALTER` statements have not been released, no deployed instances are impacted.

## Is this related to any issues?

* [ ] No related issues

## Have you read the Contributing Guidelines?

* [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
