### PR TITLE
Auto-detect TTY for ANSI log output and respect NO_COLOR

### DIFF
--- a/surrealdb/server/src/telemetry/logs/mod.rs
+++ b/surrealdb/server/src/telemetry/logs/mod.rs
@@ -1,5 +1,7 @@
 pub mod socket;
 
+use std::io::IsTerminal;
+
 use anyhow::Result;
 use tracing::{Level, Subscriber};
 use tracing_appender::non_blocking::NonBlocking;
@@ -9,6 +11,15 @@ use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 use crate::cli::LogFormat;
 use crate::cli::validator::parser::tracing::CustomFilter;
+
+/// Determine whether ANSI escape codes should be emitted to the console.
+/// Returns `true` only when both stdout and stderr are TTYs and the
+/// `NO_COLOR` environment variable (https://no-color.org) is not set.
+fn use_ansi() -> bool {
+	std::io::stdout().is_terminal()
+		&& std::io::stderr().is_terminal()
+		&& std::env::var_os("NO_COLOR").is_none()
+}
 
 pub fn file<S>(
 	filter: CustomFilter,
@@ -64,6 +75,8 @@ where
 {
 	// Log INFO, DEBUG, TRACE to stdout, WARN, ERROR to stderr
 	let writer = stderr.with_max_level(Level::WARN).or_else(stdout);
+	// Check if ANSI escape codes should be used
+	let ansi = use_ansi();
 	// Configure the log tracer for production
 	#[cfg(not(debug_assertions))]
 	{
@@ -72,7 +85,7 @@ where
 		match format {
 			LogFormat::Json => Ok(layer
 				.json()
-				.with_ansi(true)
+				.with_ansi(ansi)
 				.with_file(false)
 				.with_target(true)
 				.with_line_number(false)
@@ -85,7 +98,7 @@ where
 				.boxed()),
 			LogFormat::Text => Ok(layer
 				.compact()
-				.with_ansi(true)
+				.with_ansi(ansi)
 				.with_file(false)
 				.with_target(true)
 				.with_line_number(false)
@@ -106,7 +119,7 @@ where
 		match format {
 			LogFormat::Json => Ok(layer
 				.json()
-				.with_ansi(true)
+				.with_ansi(ansi)
 				.with_file(true)
 				.with_target(true)
 				.with_line_number(true)
@@ -119,7 +132,7 @@ where
 				.boxed()),
 			LogFormat::Text => Ok(layer
 				.compact()
-				.with_ansi(true)
+				.with_ansi(ansi)
 				.with_file(true)
 				.with_target(true)
 				.with_line_number(true)


### PR DESCRIPTION
## What is the motivation?

Console log output hardcodes ANSI escape codes (`with_ansi(true)`), causing garbled output in non-terminal environments such as Docker containers, Kubernetes pods, and log shippers like Kibana/ELK and GKE Log Explorer. Users currently have no way to disable ANSI formatting for the text log format without switching to JSON.

## What does this change do?

Adds automatic TTY detection for console log output using `std::io::IsTerminal` from the standard library. ANSI escape codes are now only emitted when both stdout and stderr are TTYs. Additionally, the `NO_COLOR` environment variable is respected per the [no-color.org](https://no-color.org) convention.

The `file()` log layer already correctly used `.with_ansi(false)` — this change brings the `output()` (console) layer in line by computing the value dynamically via a `use_ansi()` helper. No new dependencies are added.

## What is your testing strategy?

- Run server in a terminal — verify colored output still works as before
- Run server with stdout piped (e.g. `surreal start 2>&1 | cat`) — verify no ANSI escape codes in output
- Run server with `NO_COLOR=1` set — verify no ANSI codes even in a terminal
- Run server in a Docker container — verify clean log output without escape sequences

## Security Considerations

No security implications. This change only affects log formatting (ANSI escape code emission) and does not touch authentication, authorization, data isolation, user input processing, or the query/storage layer.

## Is this related to any issues?

Fixes #4231
Fixes #5492

## Have you read the Contributing Guidelines?

* [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)