### PR TITLE
Speed up dev builds on macOS by skipping dsymutil

### DIFF
--- a/.cursor/rules/pull-requests.mdc
+++ b/.cursor/rules/pull-requests.mdc
@@ -1,0 +1,40 @@
+---
+alwaysApply: true
+---
+
+# Pull request guidelines
+
+When creating a pull request, always follow the project's PR template format.
+
+## PR body format
+
+Every pull request body must include the following sections, filled in with relevant details:
+
+### What is the motivation?
+Explain why this change is needed - the problem being solved or the improvement being made.
+
+### What does this change do?
+Describe what the PR does and how it solves the problem. Be specific about the approach taken.
+
+### What is your testing strategy?
+If there is a specific testing strategy, and new tests are added, describe the changes. Otherwise insert 'GitHub Actions testing'.
+
+### Security Considerations
+Briefly assess security implications. If there are none, state why (e.g. "documentation-only change", "build profile change only"). If there are security implications, assign the `security-review` label and request review from `@surrealdb/security`.
+
+### Is this related to any issues?
+Link related issues using `Closes #123` or `Fixes #123` to auto-close them. If none, check "No related issues".
+
+### Have you read the Contributing Guidelines?
+Confirm with a checked box.
+
+## Labels
+
+Apply these labels when relevant:
+- `breaking-change` — if the PR includes a breaking change (not needed for bug fixes that correct behaviour)
+- `needs-documentation` — if documentation is needed to explain the change
+- `Modifies env vars or commands` — if environment variables or command flags are changed
+
+## Force-pushing
+
+After creating a PR, do not force-push to the branch unless the user explicitly asks for it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,6 +449,9 @@ unwrap_used = "warn"
 used_underscore_binding = "warn"
 
 # Profiles
+[profile.dev]
+split-debuginfo = "unpacked"
+
 [profile.release]
 codegen-units = 1
 lto = true


### PR DESCRIPTION
## What is the motivation?

Dev builds on macOS are slower than necessary because the default `split-debuginfo = "packed"` profile setting runs `dsymutil` after every link. On a project with 888 dependencies, this adds significant time to incremental rebuilds during local development.

## What does this change do?

Sets `split-debuginfo = "unpacked"` in the `[profile.dev]` section of the workspace `Cargo.toml`. This skips the expensive `dsymutil` bundling step after linking. Debug symbols remain available for debuggers (lldb, etc.) but stay in individual object files instead of being collected into a single `.dSYM` bundle.

No impact on release builds, benchmarks, or CI — those profiles have their own settings.

## What is your testing strategy?

- [x] `cargo check` passes
- [x] `cargo make fmt` clean
- [ ] CI passes

## Security Considerations

Build profile change only — no runtime, authentication, query engine, or storage impact.

## Is this related to any issues?

* [x] No related issues

## Have you read the Contributing Guidelines?

* [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)