### PR TITLE
Add cursor rule for pull request guidelines

### DIFF
--- a/.cursor/rules/pull-requests.mdc
+++ b/.cursor/rules/pull-requests.mdc
@@ -1,0 +1,40 @@
+---
+alwaysApply: true
+---
+
+# Pull request guidelines
+
+When creating a pull request, always follow the project's PR template format.
+
+## PR body format
+
+Every pull request body must include the following sections, filled in with relevant details:
+
+### What is the motivation?
+Explain why this change is needed - the problem being solved or the improvement being made.
+
+### What does this change do?
+Describe what the PR does and how it solves the problem. Be specific about the approach taken.
+
+### What is your testing strategy?
+If there is a specific testing strategy, and new tests are added, describe the changes. Otherwise insert 'GitHub Actions testing'.
+
+### Security Considerations
+Briefly assess security implications. If there are none, state why (e.g. "documentation-only change", "build profile change only"). If there are security implications, assign the `security-review` label and request review from `@surrealdb/security`.
+
+### Is this related to any issues?
+Link related issues using `Closes #123` or `Fixes #123` to auto-close them. If none, check "No related issues".
+
+### Have you read the Contributing Guidelines?
+Confirm with a checked box.
+
+## Labels
+
+Apply these labels when relevant:
+- `breaking-change` — if the PR includes a breaking change (not needed for bug fixes that correct behaviour)
+- `needs-documentation` — if documentation is needed to explain the change
+- `Modifies env vars or commands` — if environment variables or command flags are changed
+
+## Force-pushing
+
+After creating a PR, do not force-push to the branch unless the user explicitly asks for it.


### PR DESCRIPTION
## What is the motivation?

AI coding assistants (Cursor, Claude, etc.) working in this repo need guidance on how to format pull request descriptions. Without a rule, PRs created by agents may not follow the project's template format, requiring manual edits.

## What does this change do?

Adds an always-applied Cursor rule (`.cursor/rules/pull-requests.mdc`) that instructs AI agents to follow the project's PR template format when creating pull requests. The rule covers:

- Required PR body sections (motivation, description, testing strategy, security considerations, related issues, contributing guidelines)
- When to apply labels (`breaking-change`, `needs-documentation`, `Modifies env vars or commands`)
- Guidance against force-pushing after PR creation unless explicitly requested

## What is your testing strategy?

No code changes — this is a Cursor rule file only. Validated by using it in practice during agent-assisted PR creation.

## Security Considerations

No security implications — this is a documentation/tooling-only change that adds guidance for AI assistants.

## Is this related to any issues?

- [x] No related issues

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)