### PR TITLE
Fix ANSI escape codes in JSON log output and per-stream TTY detection

### DIFF
--- a/surrealdb/server/src/telemetry/logs/mod.rs
+++ b/surrealdb/server/src/telemetry/logs/mod.rs
@@ -12,15 +12,6 @@ use tracing_subscriber::fmt::writer::MakeWriterExt;
 use crate::cli::LogFormat;
 use crate::cli::validator::parser::tracing::CustomFilter;
 
-/// Determine whether ANSI escape codes should be emitted to the console.
-/// Returns `true` only when both stdout and stderr are TTYs and the
-/// `NO_COLOR` environment variable (https://no-color.org) is not set.
-fn use_ansi() -> bool {
-	std::io::stdout().is_terminal()
-		&& std::io::stderr().is_terminal()
-		&& std::env::var_os("NO_COLOR").is_none()
-}
-
 pub fn file<S>(
 	filter: CustomFilter,
 	file: NonBlocking,
@@ -64,85 +55,96 @@ where
 	}
 }
 
+/// Build separate stdout and stderr logging layers with per-stream ANSI
+/// detection. Each stream independently checks whether it is a TTY and
+/// respects the `NO_COLOR` environment variable (https://no-color.org).
+/// JSON output never emits ANSI escape codes regardless of TTY state.
 pub fn output<S>(
 	filter: CustomFilter,
 	stdout: NonBlocking,
 	stderr: NonBlocking,
 	format: LogFormat,
-) -> Result<Box<dyn Layer<S> + Send + Sync>>
+) -> Result<Vec<Box<dyn Layer<S> + Send + Sync>>>
 where
 	S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a> + Send + Sync,
 {
-	// Log INFO, DEBUG, TRACE to stdout, WARN, ERROR to stderr
-	let writer = stderr.with_max_level(Level::WARN).or_else(stdout);
-	// Check if ANSI escape codes should be used
-	let ansi = use_ansi();
-	// Configure the log tracer for production
+	let no_color = std::env::var_os("NO_COLOR").is_some();
+	let ansi_stdout =
+		!no_color && std::io::stdout().is_terminal() && matches!(format, LogFormat::Text);
+	let ansi_stderr =
+		!no_color && std::io::stderr().is_terminal() && matches!(format, LogFormat::Text);
+	// Route WARN/ERROR to stderr, INFO/DEBUG/TRACE to stdout
+	let stderr_writer = stderr.with_max_level(Level::WARN);
+	let stdout_writer = stdout.with_min_level(Level::INFO);
+	// Include source location in debug builds only
 	#[cfg(not(debug_assertions))]
-	{
-		let layer = tracing_subscriber::fmt::layer();
-		// Configure the log console writer
-		match format {
-			LogFormat::Json => Ok(layer
-				.json()
-				.with_ansi(ansi)
-				.with_file(false)
-				.with_target(true)
-				.with_line_number(false)
-				.with_thread_ids(false)
-				.with_thread_names(false)
-				.with_span_events(FmtSpan::NONE)
-				.with_writer(writer)
-				.with_filter(filter.env())
-				.with_filter(filter.span_filter::<S>())
-				.boxed()),
-			LogFormat::Text => Ok(layer
-				.compact()
-				.with_ansi(ansi)
-				.with_file(false)
-				.with_target(true)
-				.with_line_number(false)
-				.with_thread_ids(false)
-				.with_thread_names(false)
-				.with_span_events(FmtSpan::NONE)
-				.with_writer(writer)
-				.with_filter(filter.env())
-				.with_filter(filter.span_filter::<S>())
-				.boxed()),
-		}
-	}
-	// Configure the log tracer for development
+	let (show_file, show_line) = (false, false);
 	#[cfg(debug_assertions)]
-	{
+	let (show_file, show_line) = (true, true);
+	// Build the stderr layer (WARN and ERROR)
+	let stderr_filter = filter.clone();
+	let stderr_layer = {
 		let layer = tracing_subscriber::fmt::layer();
-		// Configure the log console writer
 		match format {
-			LogFormat::Json => Ok(layer
+			LogFormat::Json => layer
 				.json()
-				.with_ansi(ansi)
-				.with_file(true)
+				.with_ansi(ansi_stderr)
+				.with_file(show_file)
 				.with_target(true)
-				.with_line_number(true)
+				.with_line_number(show_line)
 				.with_thread_ids(false)
 				.with_thread_names(false)
 				.with_span_events(FmtSpan::NONE)
-				.with_writer(writer)
-				.with_filter(filter.env())
-				.with_filter(filter.span_filter::<S>())
-				.boxed()),
-			LogFormat::Text => Ok(layer
+				.with_writer(stderr_writer)
+				.with_filter(stderr_filter.env())
+				.with_filter(stderr_filter.span_filter::<S>())
+				.boxed(),
+			LogFormat::Text => layer
 				.compact()
-				.with_ansi(ansi)
-				.with_file(true)
+				.with_ansi(ansi_stderr)
+				.with_file(show_file)
 				.with_target(true)
-				.with_line_number(true)
+				.with_line_number(show_line)
 				.with_thread_ids(false)
 				.with_thread_names(false)
 				.with_span_events(FmtSpan::NONE)
-				.with_writer(writer)
+				.with_writer(stderr_writer)
+				.with_filter(stderr_filter.env())
+				.with_filter(stderr_filter.span_filter::<S>())
+				.boxed(),
+		}
+	};
+	// Build the stdout layer (INFO, DEBUG, and TRACE)
+	let stdout_layer = {
+		let layer = tracing_subscriber::fmt::layer();
+		match format {
+			LogFormat::Json => layer
+				.json()
+				.with_ansi(ansi_stdout)
+				.with_file(show_file)
+				.with_target(true)
+				.with_line_number(show_line)
+				.with_thread_ids(false)
+				.with_thread_names(false)
+				.with_span_events(FmtSpan::NONE)
+				.with_writer(stdout_writer)
 				.with_filter(filter.env())
 				.with_filter(filter.span_filter::<S>())
-				.boxed()),
+				.boxed(),
+			LogFormat::Text => layer
+				.compact()
+				.with_ansi(ansi_stdout)
+				.with_file(show_file)
+				.with_target(true)
+				.with_line_number(show_line)
+				.with_thread_ids(false)
+				.with_thread_names(false)
+				.with_span_events(FmtSpan::NONE)
+				.with_writer(stdout_writer)
+				.with_filter(filter.env())
+				.with_filter(filter.span_filter::<S>())
+				.boxed(),
 		}
-	}
+	};
+	Ok(vec![stderr_layer, stdout_layer])
 }

--- a/surrealdb/server/src/telemetry/logs/mod.rs
+++ b/surrealdb/server/src/telemetry/logs/mod.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use tracing::{Level, Subscriber};
 use tracing_appender::non_blocking::NonBlocking;
 use tracing_subscriber::Layer;
+use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 
@@ -98,6 +99,7 @@ where
 				.with_writer(stderr_writer)
 				.with_filter(stderr_filter.env())
 				.with_filter(stderr_filter.span_filter::<S>())
+				.with_filter(LevelFilter::WARN)
 				.boxed(),
 			LogFormat::Text => layer
 				.compact()
@@ -111,12 +113,15 @@ where
 				.with_writer(stderr_writer)
 				.with_filter(stderr_filter.env())
 				.with_filter(stderr_filter.span_filter::<S>())
+				.with_filter(LevelFilter::WARN)
 				.boxed(),
 		}
 	};
 	// Build the stdout layer (INFO, DEBUG, and TRACE)
 	let stdout_layer = {
 		let layer = tracing_subscriber::fmt::layer();
+		let level_filter =
+			tracing_subscriber::filter::filter_fn(|meta| *meta.level() > Level::WARN);
 		match format {
 			LogFormat::Json => layer
 				.json()
@@ -130,6 +135,7 @@ where
 				.with_writer(stdout_writer)
 				.with_filter(filter.env())
 				.with_filter(filter.span_filter::<S>())
+				.with_filter(level_filter)
 				.boxed(),
 			LogFormat::Text => layer
 				.compact()
@@ -143,6 +149,7 @@ where
 				.with_writer(stdout_writer)
 				.with_filter(filter.env())
 				.with_filter(filter.span_filter::<S>())
+				.with_filter(level_filter)
 				.boxed(),
 		}
 	};

--- a/surrealdb/server/src/telemetry/mod.rs
+++ b/surrealdb/server/src/telemetry/mod.rs
@@ -183,12 +183,12 @@ impl Builder {
 			.lossy(true)
 			.thread_name("surrealdb-logger-stderr")
 			.finish(std::io::stderr());
-		// Create the display destination layer
-		let stdio_layer = logs::output(self.filter.clone(), stdout, stderr, self.format)?;
+		// Create the display destination layers (separate stdout/stderr)
+		let stdio_layers = logs::output(self.filter.clone(), stdout, stderr, self.format)?;
 		// Setup a registry for composing layers
 		let registry = tracing_subscriber::registry();
-		// Setup stdio destination layer
-		let registry = registry.with(stdio_layer);
+		// Setup stdio destination layers
+		let registry = registry.with(stdio_layers);
 		// Setup guards
 		let mut guards = vec![stdout_guard, stderr_guard];
 		// Setup layers


### PR DESCRIPTION
## What is the motivation?

The console logging introduced in #7246 has two issues identified during review of #7247:

1. **JSON output emits ANSI escape codes in TTY mode** — When `LogFormat::Json` is used in an interactive terminal, `with_ansi(true)` embeds ANSI color codes inside JSON field values (e.g., `level` becomes `\x1b[32mINFO\x1b[0m` instead of `INFO`). This corrupts the output for any downstream JSON parser or log aggregator (Elasticsearch, Splunk, Loki, etc.).

2. **Overly conservative TTY detection** — The `use_ansi()` function ANDs both `stdout.is_terminal()` and `stderr.is_terminal()`, but since WARN/ERROR routes to stderr and INFO/DEBUG/TRACE routes to stdout, mixed-redirect scenarios (e.g., `surreal start > app.log`) incorrectly strip ANSI from the stream that is still an interactive terminal.

## What does this change do?

- **Splits `output()` into two separate logging layers** — one for stderr (WARN/ERROR) and one for stdout (INFO/DEBUG/TRACE), each with independent TTY detection via `is_terminal()` and `NO_COLOR` checks.
- **JSON output always uses `with_ansi(false)`** — matching the existing `file()` function behavior, since JSON is a machine-readable format regardless of destination.
- **Eliminates the `use_ansi()` helper** — replaced by per-stream ANSI booleans computed inline.
- **Consolidates debug/release `cfg` blocks** — uses `#[cfg]` on the `show_file`/`show_line` bindings instead of duplicating entire layer construction blocks.

## What is your testing strategy?

GitHub Actions testing.

## Security Considerations

Logging format change only — no runtime, authentication, query engine, or storage impact.

## Is this related to any issues?

Addresses review feedback from #7246

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)