### PR TITLE
Prevent panic when system memory info is unavailable

### DIFF
--- a/surrealdb/core/src/kvs/rocksdb/cnf.rs
+++ b/surrealdb/core/src/kvs/rocksdb/cnf.rs
@@ -2,7 +2,7 @@ use std::cmp::max;
 use std::sync::LazyLock;
 use std::time::Duration;
 
-use sysinfo::System;
+use crate::kvs::util::TOTAL_SYSTEM_MEMORY;
 
 // --------------------------------------------------
 // Basic options
@@ -47,16 +47,7 @@ pub(super) static ROCKSDB_FILE_COMPACTION_TRIGGER: LazyLock<usize> =
 /// (default: dynamic from 4 MiB to 16 MiB)
 pub(super) static ROCKSDB_COMPACTION_READAHEAD_SIZE: LazyLock<usize> =
 	lazy_env_parse!(bytes, "SURREAL_ROCKSDB_COMPACTION_READAHEAD_SIZE", usize, || {
-		// Load the system attributes
-		let mut system = System::new_all();
-		// Refresh the system memory
-		system.refresh_memory();
-		// Get the available memory
-		let memory = match system.cgroup_limits() {
-			Some(limits) => limits.total_memory,
-			None => system.total_memory(),
-		};
-		// Dynamically set the compaction readahead size
+		let memory = *TOTAL_SYSTEM_MEMORY;
 		if memory < 4 * 1024 * 1024 * 1024 {
 			4 * 1024 * 1024 // For systems with < 4 GiB, use 4 MiB
 		} else if memory < 16 * 1024 * 1024 * 1024 {
@@ -144,15 +135,7 @@ pub(super) static ROCKSDB_BLOB_COMPACTION_READAHEAD_SIZE: LazyLock<u64> =
 /// (default: dynamic depending on system memory)
 pub(super) static ROCKSDB_BLOCK_CACHE_SIZE: LazyLock<usize> =
 	lazy_env_parse!(bytes, "SURREAL_ROCKSDB_BLOCK_CACHE_SIZE", usize, || {
-		// Load the system attributes
-		let mut system = System::new_all();
-		// Refresh the system memory
-		system.refresh_memory();
-		// Get the available memory
-		let memory = match system.cgroup_limits() {
-			Some(limits) => limits.total_memory,
-			None => system.total_memory(),
-		};
+		let memory = *TOTAL_SYSTEM_MEMORY;
 		// Divide the total memory by 2
 		let memory = memory.saturating_div(2);
 		// Subtract 1 GiB from the memory size
@@ -165,16 +148,7 @@ pub(super) static ROCKSDB_BLOCK_CACHE_SIZE: LazyLock<usize> =
 /// (default: dynamic from 32 MiB to 128 MiB)
 pub(super) static ROCKSDB_WRITE_BUFFER_SIZE: LazyLock<usize> =
 	lazy_env_parse!(bytes, "SURREAL_ROCKSDB_WRITE_BUFFER_SIZE", usize, || {
-		// Load the system attributes
-		let mut system = System::new_all();
-		// Refresh the system memory
-		system.refresh_memory();
-		// Get the available memory
-		let memory = match system.cgroup_limits() {
-			Some(limits) => limits.total_memory,
-			None => system.total_memory(),
-		};
-		// Dynamically set the number of write buffers
+		let memory = *TOTAL_SYSTEM_MEMORY;
 		if memory < 1024 * 1024 * 1024 {
 			32 * 1024 * 1024 // For systems with < 1 GiB, use 32 MiB
 		} else if memory < 16 * 1024 * 1024 * 1024 {
@@ -188,16 +162,7 @@ pub(super) static ROCKSDB_WRITE_BUFFER_SIZE: LazyLock<usize> =
 /// (default: dynamic from 2 to 32)
 pub(super) static ROCKSDB_MAX_WRITE_BUFFER_NUMBER: LazyLock<usize> =
 	lazy_env_parse!("SURREAL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER", usize, || {
-		// Load the system attributes
-		let mut system = System::new_all();
-		// Refresh the system memory
-		system.refresh_memory();
-		// Get the available memory
-		let memory = match system.cgroup_limits() {
-			Some(limits) => limits.total_memory,
-			None => system.total_memory(),
-		};
-		// Dynamically set the number of write buffers
+		let memory = *TOTAL_SYSTEM_MEMORY;
 		if memory < 4 * 1024 * 1024 * 1024 {
 			2 // For systems with < 4 GiB, use 2 buffers
 		} else if memory < 16 * 1024 * 1024 * 1024 {

--- a/surrealdb/core/src/kvs/surrealkv/cnf.rs
+++ b/surrealdb/core/src/kvs/surrealkv/cnf.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 use std::sync::LazyLock;
 
-use sysinfo::System;
+use crate::kvs::util::TOTAL_SYSTEM_MEMORY;
 
 /// Whether to enable value log separation (default: true)
 pub(super) static SURREALKV_ENABLE_VLOG: LazyLock<bool> =
@@ -18,16 +18,7 @@ pub(super) static SURREALKV_BLOCK_SIZE: LazyLock<usize> =
 /// The maximum value log file size in bytes (default: dynamic from 64 MiB to 512 MiB)
 pub(super) static SURREALKV_VLOG_MAX_FILE_SIZE: LazyLock<u64> =
 	lazy_env_parse!(bytes, "SURREAL_SURREALKV_VLOG_MAX_FILE_SIZE", u64, || {
-		// Load the system attributes
-		let mut system = System::new_all();
-		// Refresh the system memory
-		system.refresh_memory();
-		// Get the available memory
-		let memory = match system.cgroup_limits() {
-			Some(limits) => limits.total_memory,
-			None => system.total_memory(),
-		};
-		// Dynamically set the vlog max file size based on available memory
+		let memory = *TOTAL_SYSTEM_MEMORY;
 		if memory < 4 * 1024 * 1024 * 1024 {
 			64 * 1024 * 1024 // For systems with < 4 GiB, use 64 MiB
 		} else if memory < 16 * 1024 * 1024 * 1024 {
@@ -47,15 +38,7 @@ pub(super) static SURREALKV_VLOG_THRESHOLD: LazyLock<usize> =
 /// The block cache capacity in bytes (default: dynamic based on memory)
 pub(super) static SURREALKV_BLOCK_CACHE_CAPACITY: LazyLock<u64> =
 	lazy_env_parse!(bytes, "SURREAL_SURREALKV_BLOCK_CACHE_CAPACITY", u64, || {
-		// Load the system attributes
-		let mut system = System::new_all();
-		// Refresh the system memory
-		system.refresh_memory();
-		// Get the available memory
-		let memory = match system.cgroup_limits() {
-			Some(limits) => limits.total_memory,
-			None => system.total_memory(),
-		};
+		let memory = *TOTAL_SYSTEM_MEMORY;
 		// Divide the total memory by 2
 		let memory = memory.saturating_div(2);
 		// Subtract 1 GiB from the memory size
@@ -70,16 +53,7 @@ pub(super) static SURREALKV_BLOCK_CACHE_CAPACITY: LazyLock<u64> =
 /// If a single transaction needs to store larger than this size, this value should be increased.
 pub(super) static SURREALKV_MAX_MEMTABLE_SIZE: LazyLock<usize> =
 	lazy_env_parse!(bytes, "SURREAL_SURREALKV_MAX_MEMTABLE_SIZE", usize, || {
-		// Load the system attributes
-		let mut system = System::new_all();
-		// Refresh the system memory
-		system.refresh_memory();
-		// Get the available memory
-		let memory = match system.cgroup_limits() {
-			Some(limits) => limits.total_memory,
-			None => system.total_memory(),
-		};
-		// Dynamically set the max memtable size
+		let memory = *TOTAL_SYSTEM_MEMORY;
 		if memory < 1024 * 1024 * 1024 {
 			64 * 1024 * 1024 // For systems with < 1 GiB, use 64 MiB
 		} else if memory < 4 * 1024 * 1024 * 1024 {

--- a/surrealdb/core/src/kvs/util.rs
+++ b/surrealdb/core/src/kvs/util.rs
@@ -1,9 +1,35 @@
 use std::ops::Range;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use anyhow::Result;
+use sysinfo::System;
 
 use crate::kvs::{KVKey, KVValue};
+
+/// Detected total system memory in bytes, cached at first access.
+/// Falls back to cgroup limits when running inside a container, and
+/// uses a conservative 1 GiB default when `/proc` is inaccessible
+/// (e.g. systemd `ProcSubset=pid` hardening).
+pub(crate) static TOTAL_SYSTEM_MEMORY: LazyLock<u64> = LazyLock::new(|| {
+	// Load the system attributes
+	let mut system = System::new_all();
+	// Refresh the system memory
+	system.refresh_memory();
+	// Get the total system memory
+	let host_memory = system.total_memory();
+	// If the total system memory is 0, use a safe default
+	if host_memory == 0 {
+		// Memory info unavailable (restricted /proc); use a safe default
+		return 1024 * 1024 * 1024; // 1 GiB
+	}
+	// Prefer cgroup limits when available (container environments)
+	match system.cgroup_limits() {
+		// If the limit has been configured, use it
+		Some(l) if l.total_memory > 0 => l.total_memory,
+		// Otherwise use the host memory
+		_ => host_memory,
+	}
+});
 
 /// Advances a key to the next value,
 /// can be used to skip over a certain key.

--- a/surrealdb/core/src/kvs/util.rs
+++ b/surrealdb/core/src/kvs/util.rs
@@ -12,15 +12,14 @@ use crate::kvs::{KVKey, KVValue};
 /// (e.g. systemd `ProcSubset=pid` hardening).
 pub(crate) static TOTAL_SYSTEM_MEMORY: LazyLock<u64> = LazyLock::new(|| {
 	// Load the system attributes
-	let mut system = System::new_all();
+	let mut system = System::new();
 	// Refresh the system memory
 	system.refresh_memory();
 	// Get the total system memory
 	let host_memory = system.total_memory();
 	// If the total system memory is 0, use a safe default
 	if host_memory == 0 {
-		// Memory info unavailable (restricted /proc); use a safe default
-		return 1024 * 1024 * 1024; // 1 GiB
+		return 1024 * 1024 * 1024;
 	}
 	// Prefer cgroup limits when available (container environments)
 	match system.cgroup_limits() {


### PR DESCRIPTION
## What is the motivation?

On systems with restricted `/proc` access (e.g. NixOS with systemd `ProcSubset=pid` hardening), the `sysinfo` crate cannot read `/proc/meminfo`, so `System::total_memory()` returns 0. The subsequent call to `System::cgroup_limits()` has an internal assertion that `total_memory != 0`, which causes a panic on startup — putting the systemd service into an infinite restart loop.

This affects both the RocksDB and SurrealKV storage backends, which use system memory to dynamically configure buffer sizes, cache sizes, and compaction settings.

Reported in #6153.

## What does this change do?

- Extracts the repeated memory-detection pattern (7 identical `System::new_all()` + `refresh_memory()` + `cgroup_limits()` blocks across `rocksdb/cnf.rs` and `surrealkv/cnf.rs`) into a single cached `TOTAL_SYSTEM_MEMORY` helper in `kvs/util.rs`.
- Guards against the panic by checking `total_memory() == 0` before calling `cgroup_limits()`, falling back to a conservative 1 GiB default when `/proc` is inaccessible.
- When memory info is available, prefers cgroup limits (for container environments) over host memory, preserving existing behaviour.
- Reduces code by 41 lines (71 removed, 30 added) and eliminates 6 redundant `System` instantiations at startup.

## What is your testing strategy?

GitHub Actions testing. The fix was also verified by compiling with both `storage-rocksdb` and `storage-surrealkv` features independently.

## Security Considerations

No security implications — this is a resilience fix for a startup panic path. No new capabilities, no changes to authentication or authorisation logic.

## Is this related to any issues?

Fixes #6153

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)