### PR TITLE
Use serde_json for parsing external JSON in HTTP functions

### DIFF
--- a/language-tests/tests/reproductions/7039_json_escaped_forward_slash.surql
+++ b/language-tests/tests/reproductions/7039_json_escaped_forward_slash.surql
@@ -1,0 +1,24 @@
+/**
+[test]
+reason = "Ensure JSON escaped forward slash (\\/) is parsed correctly per RFC 8259"
+issue = 7039
+
+[[test.results]]
+value = "{ url: 'https://example.com/path' }"
+
+[[test.results]]
+value = "'https://example.com/path'"
+
+[[test.results]]
+value = "{ schedule_link: 'https://example.com/path', rating_link: 'https://example.com/review' }"
+
+*/
+
+-- Test escaped forward slashes in JSON object values
+encoding::json::decode('{"url":"https:\\/\\/example.com\\/path"}');
+
+-- Test escaped forward slashes in a plain JSON string
+encoding::json::decode('"https:\\/\\/example.com\\/path"');
+
+-- Test multiple fields with escaped forward slashes (matches the original issue)
+encoding::json::decode('{"schedule_link":"https:\\/\\/example.com\\/path","rating_link":"https:\\/\\/example.com\\/review"}');

--- a/surrealdb/core/src/exec/function/builtin/http.rs
+++ b/surrealdb/core/src/exec/function/builtin/http.rs
@@ -209,7 +209,6 @@ async fn http_request(
 	use crate::cnf::SURREALDB_USER_AGENT;
 	use crate::err::Error;
 	use crate::sql::expression::convert_public_value_to_internal;
-	use crate::syn;
 	use crate::types::{PublicBytes, PublicValue};
 
 	let url = url::Url::parse(&uri).map_err(|_| Error::InvalidUrl(uri.clone()))?;
@@ -318,8 +317,9 @@ async fn http_request(
 				Some(mime) => match mime.to_str() {
 					Ok(v) if v.starts_with("application/json") => {
 						let txt = res.text().await.map_err(Error::from)?;
-						let val = syn::json(&txt)
+						let json: serde_json::Value = serde_json::from_str(&txt)
 							.map_err(|e| Error::Http(format!("Failed to parse JSON: {}", e)))?;
+						let val = crate::rpc::format::json::json_to_value(json);
 						Ok(convert_public_value_to_internal(val))
 					}
 					Ok(v) if v.starts_with("application/octet-stream") => {

--- a/surrealdb/core/src/fnc/encoding.rs
+++ b/surrealdb/core/src/fnc/encoding.rs
@@ -87,13 +87,15 @@ pub mod json {
 		Ok(Value::from(val))
 	}
 
-	/// Decodes a JSON string into a SurrealDB value.
+	/// Decodes a JSON string into a SurrealDB value using an RFC 8259
+	/// compliant parser, supporting all valid JSON escape sequences.
 	pub fn decode((arg,): (String,)) -> Result<Value> {
-		let public_val =
-			json::decode(arg.as_bytes()).map_err(|_| Error::InvalidFunctionArguments {
+		let json: serde_json::Value =
+			serde_json::from_str(&arg).map_err(|_| Error::InvalidFunctionArguments {
 				name: "encoding::json::decode".to_owned(),
 				message: "Invalid JSON".to_owned(),
 			})?;
+		let public_val = crate::rpc::format::json::json_to_value(json);
 		Ok(crate::sql::expression::convert_public_value_to_internal(public_val))
 	}
 }

--- a/surrealdb/core/src/fnc/util/http/mod.rs
+++ b/surrealdb/core/src/fnc/util/http/mod.rs
@@ -17,7 +17,6 @@ use crate::cnf::SURREALDB_USER_AGENT;
 use crate::ctx::FrozenContext;
 use crate::err::Error;
 use crate::sql::expression::convert_public_value_to_internal;
-use crate::syn;
 use crate::types::{PublicBytes, PublicValue};
 use crate::val::{Object, Value};
 
@@ -146,10 +145,10 @@ async fn decode_response(res: Response) -> Result<PublicValue> {
 			Some(mime) => match mime.to_str() {
 				Ok(v) if v.starts_with("application/json") => {
 					let txt = res.text().await.map_err(Error::from)?;
-					let val = syn::json(&txt)
+					let json: serde_json::Value = serde_json::from_str(&txt)
 						.context("Failed to parse JSON response")
 						.map_err(|e| Error::Http(e.to_string()))?;
-					Ok(val)
+					Ok(crate::rpc::format::json::json_to_value(json))
 				}
 				Ok(v) if v.starts_with("application/octet-stream") => {
 					let bytes = res.bytes().await.map_err(Error::from)?;

--- a/surrealdb/core/src/rpc/format/json.rs
+++ b/surrealdb/core/src/rpc/format/json.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeMap;
+
 use crate::cnf::{MAX_OBJECT_PARSING_DEPTH, MAX_QUERY_PARSING_DEPTH};
 use crate::syn;
 use crate::syn::parser::ParserSettings;
-use crate::types::PublicValue;
+use crate::types::{PublicArray, PublicNumber, PublicObject, PublicValue};
 
 pub fn encode(value: PublicValue) -> anyhow::Result<Vec<u8>> {
 	encode_str(value).map(|x| x.into_bytes())
@@ -24,4 +26,34 @@ pub fn decode(value: &[u8]) -> anyhow::Result<PublicValue> {
 
 	syn::parse_with_settings(value, settings, async |parser, stk| parser.parse_value(stk).await)
 		.map_err(|err| anyhow::anyhow!(err.to_string()))
+}
+
+/// Converts a `serde_json::Value` into a `PublicValue`. Uses an RFC 8259
+/// compliant parser rather than the SurrealQL parser, which does not handle
+/// all valid JSON escape sequences (e.g. `\/` or surrogate pairs).
+pub fn json_to_value(json: serde_json::Value) -> PublicValue {
+	match json {
+		serde_json::Value::Null => PublicValue::Null,
+		serde_json::Value::Bool(b) => PublicValue::Bool(b),
+		serde_json::Value::Number(n) => {
+			if let Some(i) = n.as_i64() {
+				PublicValue::Number(PublicNumber::Int(i))
+			} else if let Some(u) = n.as_u64() {
+				PublicValue::Number(PublicNumber::Decimal(u.into()))
+			} else if let Some(f) = n.as_f64() {
+				PublicValue::Number(PublicNumber::Float(f))
+			} else {
+				PublicValue::Null
+			}
+		}
+		serde_json::Value::String(s) => PublicValue::String(s),
+		serde_json::Value::Array(a) => PublicValue::Array(PublicArray::from(
+			a.into_iter().map(json_to_value).collect::<Vec<_>>(),
+		)),
+		serde_json::Value::Object(o) => {
+			let map: BTreeMap<String, PublicValue> =
+				o.into_iter().map(|(k, v)| (k, json_to_value(v))).collect();
+			PublicValue::Object(PublicObject::from(map))
+		}
+	}
 }


### PR DESCRIPTION
## What is the motivation?

`http::post` and other HTTP functions reject valid JSON responses from external APIs when those responses contain `\/` (escaped forward slash) — a valid escape sequence per RFC 8259 §7. This is because the response body is parsed using SurrealDB's own SurrealQL parser (`syn::json`), which does not handle all JSON escape sequences. This commonly affects responses from PHP backends using default `json_encode()` settings.

Fixes #7039

## What does this change do?

Replaces `syn::json()` with `serde_json::from_str()` for parsing JSON in three places:

- **`fnc/util/http/mod.rs`** — `decode_response` for HTTP function responses
- **`exec/function/builtin/http.rs`** — the streaming executor's parallel HTTP implementation
- **`fnc/encoding.rs`** — `encoding::json::decode` function

A shared `json_to_value()` conversion function is added to `rpc/format/json.rs` (the inverse of the existing `into_json_value()`) to convert `serde_json::Value` into `PublicValue`. This handles null, bool, number (int/float), string, array, and object types.

This also has the benefit of preventing external JSON strings from being silently reinterpreted as SurrealDB record IDs, datetimes, or UUIDs (which the old `syn::json()` parser could do via legacy strand reparsing).

## What is your testing strategy?

- New language test: `reproductions/7039_json_escaped_forward_slash.surql` verifies that `\/` in JSON strings is parsed correctly via `encoding::json::decode`
- All existing encoding language tests (12 runs) pass
- All existing encoding unit tests (9 tests) pass
- GitHub Actions testing

## Security Considerations

No security implications. This switches from one JSON parser to another (both already dependencies) for parsing external HTTP response bodies. The `serde_json` parser is battle-tested and widely used.

## Is this related to any issues?

Fixes #7039

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)