### PR TITLE
Fix SurrealValue derive macro emitting r#type instead of type for raw identifiers

### DIFF
--- a/surrealdb/types/derive/src/attr/enum.rs
+++ b/surrealdb/types/derive/src/attr/enum.rs
@@ -74,10 +74,11 @@ impl EnumAttributes {
 	}
 
 	pub fn variant_string(&self, variant: &Ident) -> String {
+		let s = crate::unraw(variant);
 		match self.casing {
-			Some(Casing::Uppercase) => variant.to_string().to_uppercase(),
-			Some(Casing::Lowercase) => variant.to_string().to_lowercase(),
-			None => variant.to_string(),
+			Some(Casing::Uppercase) => s.to_uppercase(),
+			Some(Casing::Lowercase) => s.to_lowercase(),
+			None => s,
 		}
 	}
 }

--- a/surrealdb/types/derive/src/lib.rs
+++ b/surrealdb/types/derive/src/lib.rs
@@ -22,6 +22,13 @@ mod kind;
 mod write_sql;
 use crate_path::CratePath;
 
+/// Returns the string representation of an identifier with any raw prefix (`r#`) stripped.
+/// Rust raw identifiers like `r#type` should serialize as `"type"`, not `"r#type"`.
+pub(crate) fn unraw(ident: &syn::Ident) -> String {
+	let s = ident.to_string();
+	s.strip_prefix("r#").unwrap_or(&s).to_string()
+}
+
 /// Derives the `SurrealValue` trait for a struct or enum.
 ///
 /// This macro automatically implements the `SurrealValue` trait, which provides conversion

--- a/surrealdb/types/derive/src/structs/fields/named.rs
+++ b/surrealdb/types/derive/src/structs/fields/named.rs
@@ -2,8 +2,8 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{Ident, Type};
 
-use crate::CratePath;
 use crate::attr::FieldDefault;
+use crate::{CratePath, unraw};
 
 #[derive(Debug)]
 pub struct NamedField {
@@ -39,7 +39,7 @@ impl NamedFields {
 				} else {
 					quote! {#field_name}
 				};
-				let field_name_str = field.ident.to_string();
+				let field_name_str = unraw(&field.ident);
 				let obj_key = field.rename.as_ref().unwrap_or(&field_name_str);
 
 				if field.flatten {
@@ -67,7 +67,7 @@ impl NamedFields {
 				.iter()
 				.map(|field| {
 					let field_name = &field.ident;
-					let field_name_str = field.ident.to_string();
+					let field_name_str = unraw(&field.ident);
 					let obj_key = field.rename.as_ref().unwrap_or(&field_name_str);
 					let ty = &field.ty;
 					let (potentially_wrapped_ty, val_access) = if field.wrap {
@@ -109,7 +109,7 @@ impl NamedFields {
 
 			for field in &self.fields {
 				let field_name = &field.ident;
-				let field_name_str = field.ident.to_string();
+				let field_name_str = unraw(&field.ident);
 				let obj_key = field.rename.as_ref().unwrap_or(&field_name_str);
 				let ty = &field.ty;
 				let (potentially_wrapped_ty, val_access) = if field.wrap {
@@ -185,7 +185,7 @@ impl NamedFields {
 			.iter()
 			.filter(|field| !field.flatten) // Flatten fields don't have a specific key to check
 			.map(|field| {
-				let struct_name = field.ident.to_string();
+				let struct_name = unraw(&field.ident);
 				let obj_key = field.rename.as_ref().unwrap_or(&struct_name);
 				let ty = &field.ty;
 				let potentially_wrapped_ty = if field.wrap {
@@ -230,7 +230,7 @@ impl NamedFields {
 			.filter(|field| !field.flatten) // Flatten fields don't have a specific key
 			.map(|field| {
 				let ty = &field.ty;
-				let struct_name = field.ident.to_string();
+				let struct_name = unraw(&field.ident);
 				let obj_key = field.rename.as_ref().unwrap_or(&struct_name);
 
 				if crate::type_contains_ident(ty, type_name) {
@@ -254,8 +254,6 @@ impl NamedFields {
 	}
 
 	pub fn contains_key(&self, key: &str) -> bool {
-		self.fields
-			.iter()
-			.any(|field| field.rename.as_ref().unwrap_or(&field.ident.to_string()) == key)
+		self.fields.iter().any(|field| field.rename.as_ref().unwrap_or(&unraw(&field.ident)) == key)
 	}
 }

--- a/surrealdb/types/tests/surreal_value/derive/mod.rs
+++ b/surrealdb/types/tests/surreal_value/derive/mod.rs
@@ -106,6 +106,91 @@ fn test_simple_struct_with_renamed_fields() {
 }
 
 ////////////////////////////////////////////////////
+/////// Struct with raw identifier fields //////////
+////////////////////////////////////////////////////
+
+#[derive(SurrealValue, Debug, PartialEq)]
+#[surreal(crate = "surrealdb_types")]
+struct RawIdentStruct {
+	r#type: String,
+	name: String,
+}
+
+#[test]
+fn test_raw_identifier_field_uses_unescaped_name() {
+	let val = RawIdentStruct {
+		r#type: "span".to_string(),
+		name: "test".to_string(),
+	};
+
+	let value = val.into_value();
+	if let Value::Object(obj) = &value {
+		assert_eq!(obj.get("type"), Some(&Value::String("span".to_string())));
+		assert!(obj.get("r#type").is_none(), "key must be 'type', not 'r#type'");
+		assert_eq!(obj.get("name"), Some(&Value::String("test".to_string())));
+	} else {
+		panic!("Expected Object value");
+	}
+
+	let converted = RawIdentStruct::from_value(value.clone()).unwrap();
+	assert_eq!(converted.r#type, "span");
+	assert_eq!(converted.name, "test");
+
+	let kind = RawIdentStruct::kind_of();
+	let debug = format!("{:?}", kind);
+	assert!(debug.contains(r#""type": String"#), "kind_of should use 'type' not 'r#type': {debug}");
+	assert!(!debug.contains("r#type"), "kind_of must not contain 'r#type': {debug}");
+
+	assert!(RawIdentStruct::is_value(&value));
+	assert!(value.is::<RawIdentStruct>());
+	assert!(!RawIdentStruct::is_value(&Value::None));
+	assert!(!RawIdentStruct::is_value(&Value::Object(Object::new())));
+}
+
+////////////////////////////////////////////////////
+///// Enum with raw identifier variant names ///////
+////////////////////////////////////////////////////
+
+#[derive(SurrealValue, Debug, PartialEq)]
+#[surreal(crate = "surrealdb_types")]
+#[surreal(tag = "kind")]
+#[allow(non_camel_case_types)]
+enum RawIdentEnum {
+	r#type {
+		name: String,
+	},
+	Normal {
+		name: String,
+	},
+}
+
+#[test]
+fn test_raw_identifier_enum_variant_uses_unescaped_name() {
+	let val = RawIdentEnum::r#type {
+		name: "test".to_string(),
+	};
+
+	let value = val.into_value();
+	if let Value::Object(obj) = &value {
+		assert_eq!(obj.get("kind"), Some(&Value::String("type".to_string())));
+		assert_eq!(obj.get("name"), Some(&Value::String("test".to_string())));
+	} else {
+		panic!("Expected Object value");
+	}
+
+	let converted = RawIdentEnum::from_value(value.clone()).unwrap();
+	assert_eq!(
+		converted,
+		RawIdentEnum::r#type {
+			name: "test".to_string()
+		}
+	);
+
+	assert!(RawIdentEnum::is_value(&value));
+	assert!(value.is::<RawIdentEnum>());
+}
+
+////////////////////////////////////////////////////
 /////////// Simple single field struct /////////////
 ////////////////////////////////////////////////////
 


### PR DESCRIPTION
## What is the motivation?

When a Rust struct field uses a raw identifier (e.g. `r#type`), the `SurrealValue` derive macro emits `"r#type"` as the serialized map key instead of `"type"`. This causes the field to appear as `NONE` when queried from SurrealDB, since the database stores it under `"r#type"` rather than the expected `"type"`.

The workaround is `#[surreal(rename = "type")]`, but raw identifiers should just work without explicit renaming.

## What does this change do?

Adds an `unraw()` helper function in the derive macro that strips the `r#` prefix from `Ident::to_string()` output. All 6 call sites in `named.rs` that convert field identifiers to serialized map keys now use this helper:

- `map_assignments` (serialization)
- `map_retrievals` (deserialization, both default and non-default paths)
- `field_checks` (value validation)
- `map_types` (kind/type generation)
- `contains_key` (tag key collision detection)

## What is your testing strategy?

Added `test_raw_identifier_field_uses_unescaped_name` in the derive test suite that verifies a struct with `r#type`:
- Serializes with key `"type"` (not `"r#type"`)
- Round-trips correctly via `from_value`
- Produces correct `kind_of()` output
- Passes `is_value()` checks

All 120 existing derive tests continue to pass.

## Security Considerations

No security implications — this is a compile-time macro fix affecting field name serialization only.

## Is this related to any issues?

Fixes #7164

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)