### PR TITLE
Add cursor rule for git safety guidelines

### DIFF
--- a/.cursor/rules/git-safety.mdc
+++ b/.cursor/rules/git-safety.mdc
@@ -1,0 +1,22 @@
+---
+alwaysApply: true
+---
+
+# Git safety rules
+
+## Commits
+
+- Never amend a commit that has already been pushed to a remote, unless specifically requested. Always create a new commit instead.
+- Never amend a commit unless the user explicitly asks for it.
+- When formatting or linting produces changes after a commit, create a new follow-up commit (e.g. "Format code") rather than amending.
+
+## Pushing
+
+- Never force-push (`--force`, `--force-with-lease`, or any variant) unless the user explicitly asks for it.
+- Always use a regular `git push` after creating new commits.
+
+## General
+
+- Never run destructive or irreversible git commands (hard reset, branch deletion, etc.) unless explicitly requested.
+- Never modify git config.
+- When in doubt, ask before running any git command that could rewrite history.


### PR DESCRIPTION
## What is the motivation?

Prevent AI agents from amending pushed commits or force-pushing branches without explicit user consent. This codifies git safety practices as an always-applied Cursor rule.

## What does this change do?

Adds `.cursor/rules/git-safety.mdc` with `alwaysApply: true` that instructs AI agents to:

- Never amend a commit that has been pushed to a remote
- Never amend without explicit user request
- Never force-push without explicit user request
- Create new follow-up commits for formatting/linting changes
- Never run destructive git commands without explicit request

## What is your testing strategy?

Not applicable — Cursor rule file only.

## Security Considerations

No security implications — this is a Cursor configuration file that restricts agent behaviour.

## Is this related to any issues?

- [x] No related issues

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)