### PR TITLE
Fix flexible not being set correctly

### DIFF
--- a/crates/core/src/kvs/version/v3/pass/mod.rs
+++ b/crates/core/src/kvs/version/v3/pass/mod.rs
@@ -1243,6 +1243,7 @@ impl Visitor for MigratorPass<'_> {
 				Kind::Either(kinds) => kinds.iter().any(kind_contains_object),
 				Kind::Array(inner, _) | Kind::Set(inner, _) => kind_contains_object(inner),
 				Kind::Literal(Literal::Object(_)) => true,
+				Kind::Literal(Literal::DiscriminatedObject(..)) => true,
 				Kind::Literal(Literal::Array(x)) => x.iter().any(kind_contains_object),
 				_ => false,
 			}

--- a/crates/core/src/kvs/version/v3/pass/mod.rs
+++ b/crates/core/src/kvs/version/v3/pass/mod.rs
@@ -1239,6 +1239,7 @@ impl Visitor for MigratorPass<'_> {
 		fn kind_contains_object(kind: &Kind) -> bool {
 			match kind {
 				Kind::Object => true,
+				Kind::Option(x) => kind_contains_object(x),
 				Kind::Either(kinds) => kinds.iter().any(kind_contains_object),
 				Kind::Array(inner, _) | Kind::Set(inner, _) => kind_contains_object(inner),
 				Kind::Literal(Literal::Object(_)) => true,


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉

## What is the motivation?

The `FLEXIBLE` keyword is not always properly set when exporting from v2 to v3.
Specifically when the object is wrapped in a option type.

## What does this change do?

Fixes the issue

## What is your testing strategy?



## Security Considerations

N/A

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

* [x] No related issues

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

* [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
