### PR TITLE
fix: enforce schema validation when UPSERT acts as INSERT

### DIFF
--- a/surrealdb/core/src/dbs/iterator.rs
+++ b/surrealdb/core/src/dbs/iterator.rs
@@ -774,6 +774,10 @@ impl Iterator {
 					self.ingest(guaranteed);
 					// Process the pre-defined guaranteed document
 					self.iterate(stk, ctx, opt, stm, is_specific_permission, None).await?;
+					// Return any document errors from guaranteed iteration (e.g. UPSERT-as-INSERT schema validation)
+					if let Some(e) = self.error.take() {
+						return Err(e);
+					}
 				}
 			}
 			// Process any SPLIT AT clause

--- a/surrealdb/core/src/dbs/iterator.rs
+++ b/surrealdb/core/src/dbs/iterator.rs
@@ -774,7 +774,8 @@ impl Iterator {
 					self.ingest(guaranteed);
 					// Process the pre-defined guaranteed document
 					self.iterate(stk, ctx, opt, stm, is_specific_permission, None).await?;
-					// Return any document errors from guaranteed iteration (e.g. UPSERT-as-INSERT schema validation)
+					// Return any document errors from guaranteed iteration (e.g. UPSERT-as-INSERT
+					// schema validation)
 					if let Some(e) = self.error.take() {
 						return Err(e);
 					}


### PR DESCRIPTION
## Summary

Fixes #6816

When UPSERT creates a new record (acts as INSERT), schema validation
errors are silently ignored. This PR ensures the same field validation
runs regardless of whether UPSERT is creating or updating a record.


Made with [Cursor](https://cursor.com)