### PR TITLE
core: fix 'occured' -> 'occurred' typos in API and references update errors

### DIFF
--- a/surrealdb/core/src/api/err.rs
+++ b/surrealdb/core/src/api/err.rs
@@ -27,7 +27,7 @@ pub enum ApiError {
 	#[error("Missing Accept or Content-Type header")]
 	MissingFormat,
 
-	#[error("An unreachable error occured: {0}")]
+	#[error("An unreachable error occurred: {0}")]
 	Unreachable(String),
 
 	// Status code errors

--- a/surrealdb/core/src/err/mod.rs
+++ b/surrealdb/core/src/err/mod.rs
@@ -1120,7 +1120,7 @@ pub(crate) enum Error {
 	ReferenceNestedField(String),
 
 	/// Something went wrong while updating references
-	#[error("An error occured while updating references for `{0}`: {1}")]
+	#[error("An error occurred while updating references for `{0}`: {1}")]
 	RefsUpdateFailure(String, String),
 
 	#[error(


### PR DESCRIPTION
Two thiserror `#[error(...)]` attributes used `occured`:

- `surrealdb/core/src/api/err.rs:30` — `Unreachable` variant: `An unreachable error occured: {0}`.
- `surrealdb/core/src/err/mod.rs:1123` — references-update error: `An error occured while updating references for \`{0}\`: {1}`.

Both messages are surfaced as user-visible `Display` output on the respective error variants. String-literal-only change.