### PR TITLE
core: fix 'occured' -> 'occurred' in error derive strings

### DIFF
--- a/surrealdb/core/src/api/err.rs
+++ b/surrealdb/core/src/api/err.rs
@@ -27,7 +27,7 @@ pub enum ApiError {
 	#[error("Missing Accept or Content-Type header")]
 	MissingFormat,
 
-	#[error("An unreachable error occured: {0}")]
+	#[error("An unreachable error occurred: {0}")]
 	Unreachable(String),
 
 	// Status code errors

--- a/surrealdb/core/src/err/mod.rs
+++ b/surrealdb/core/src/err/mod.rs
@@ -1120,7 +1120,7 @@ pub(crate) enum Error {
 	ReferenceNestedField(String),
 
 	/// Something went wrong while updating references
-	#[error("An error occured while updating references for `{0}`: {1}")]
+	#[error("An error occurred while updating references for `{0}`: {1}")]
 	RefsUpdateFailure(String, String),
 
 	#[error(


### PR DESCRIPTION
Two `#[error]` derive strings contained `occured`:
- `surrealdb/core/src/api/err.rs` line 30: `An unreachable error occured`
- `surrealdb/core/src/err/mod.rs` line 1123: `An error occured while updating references`

Fixed to `occurred`. Error-display-only change; no API or behavior change.