### PR TITLE
fix: handle root-level scalar values in value::diff() and value::patch()

### DIFF
--- a/language-tests/tests/language/functions/value/dmp.surql
+++ b/language-tests/tests/language/functions/value/dmp.surql
@@ -1,0 +1,164 @@
+/**
+[test]
+reason = "diff-match-patch (DMP) coverage: string `change` ops from value::diff and value::patch application, method syntax, and non-DMP `replace` when types differ"
+
+[[test.results]]
+value = '''[{ op: 'change', path: '/note', value: '@@ -1,5 +1,11 @@\n-shor\n+longer tex\n t\n' }]'''
+
+[[test.results]]
+value = "{ note: 'longer text' }"
+
+[[test.results]]
+value = '''[{ op: 'change', path: '/note', value: '@@ -1,5 +1,11 @@\n-shor\n+longer tex\n t\n' }]'''
+
+[[test.results]]
+value = "{ note: 'longer text' }"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = '''[{ op: 'change', path: '/a/b/c', value: '@@ -1,1 +1,2 @@\n-x\n+yz\n' }]'''
+
+[[test.results]]
+value = "{ a: { b: { c: 'yz' } } }"
+
+[[test.results]]
+value = '''[{ op: 'change', path: '/a', value: '@@ -1,3 +1,4 @@\n foo\n+t\n' }, { op: 'change', path: '/b', value: '@@ -1,3 +1,3 @@\n ba\n-r\n+z\n' }]'''
+
+[[test.results]]
+value = "{ a: 'foot', b: 'baz' }"
+
+[[test.results]]
+value = "[{ op: 'replace', path: '/id', value: 5 }]"
+
+[[test.results]]
+value = "{ id: 5 }"
+
+[[test.results]]
+value = '''[{ op: 'replace', path: '/n', value: 2 }, { op: 'change', path: '/s', value: '@@ -1,2 +1,2 @@\n h\n-i\n+o\n' }]'''
+
+[[test.results]]
+value = "{ n: 2, s: 'ho' }"
+
+[[test.results]]
+value = '''[{ op: 'change', path: '/t', value: '@@ -1,4 +1,5 @@\n caf%C3%A9\n+s\n' }]'''
+
+[[test.results]]
+value = "{ t: 'cafés' }"
+
+[[test.results]]
+value = '''[{ op: 'change', path: '/s', value: '@@ -4,8 +4,14 @@\n e1%0Aline2\n+%0Aline3\n' }]'''
+
+[[test.results]]
+value = '''{ s: 'line1\nline2\nline3' }'''
+
+[[test.results]]
+value = '''[{ op: 'change', path: '/m', value: '@@ -0,0 +1,1 @@\n+x\n' }]'''
+
+[[test.results]]
+value = "{ m: 'x' }"
+
+[[test.results]]
+value = '''[{ op: 'change', path: '/items/1', value: '@@ -1,4 +1,5 @@\n-bet\n+gamm\n a\n' }]'''
+
+[[test.results]]
+value = "{ note: 'bb' }"
+
+[[test.results]]
+value = "[{ op: 'replace', path: '/x', value: ['a', 'b'] }]"
+
+[[test.results]]
+value = "{ x: ['a', 'b'] }"
+
+[[test.results]]
+value = '''[{ op: 'change', path: '/e', value: '@@ -1,1 +1,2 @@\n %F0%9F%91%8B\n+!\n' }]'''
+
+[[test.results]]
+value = "{ e: '👋!' }"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+error = "The JSON Patch contains invalid operations. Failed to parse JSON patch structure: InvalidInput"
+*/
+
+-- Basic nested string: DMP emits op `change` with unified diff text
+RETURN value::diff({ note: 'short' }, { note: 'longer text' });
+
+RETURN value::patch({ note: 'short' }, value::diff({ note: 'short' }, { note: 'longer text' }));
+
+-- Method call form (same as value::diff / value::patch)
+RETURN { note: 'short' }.diff({ note: 'longer text' });
+
+RETURN { note: 'short' }.patch({ note: 'short' }.diff({ note: 'longer text' }));
+
+-- Identical nested strings → empty list
+RETURN value::diff({ msg: 'same' }, { msg: 'same' });
+
+-- Deep path
+RETURN value::diff({ a: { b: { c: 'x' } } }, { a: { b: { c: 'yz' } } });
+
+RETURN value::patch(
+	{ a: { b: { c: 'x' } } },
+	value::diff({ a: { b: { c: 'x' } } }, { a: { b: { c: 'yz' } } })
+);
+
+-- Two differing string fields → two `change` operations
+RETURN value::diff({ a: 'foo', b: 'bar' }, { a: 'foot', b: 'baz' });
+
+RETURN value::patch({ a: 'foo', b: 'bar' }, value::diff({ a: 'foo', b: 'bar' }, { a: 'foot', b: 'baz' }));
+
+-- Non-DMP path: string value replaced by number (`replace`, not `change`)
+RETURN value::diff({ id: '5' }, { id: 5 });
+
+RETURN value::patch({ id: '5' }, value::diff({ id: '5' }, { id: 5 }));
+
+-- Mix `replace` (number) and `change` (string) in one diff
+RETURN value::diff({ n: 1, s: 'hi' }, { n: 2, s: 'ho' });
+
+RETURN value::patch({ n: 1, s: 'hi' }, value::diff({ n: 1, s: 'hi' }, { n: 2, s: 'ho' }));
+
+-- Unicode text (still two Surreal strings → DMP)
+RETURN value::diff({ t: 'café' }, { t: 'cafés' });
+
+RETURN value::patch({ t: 'café' }, value::diff({ t: 'café' }, { t: 'cafés' }));
+
+-- Multi-line string field
+RETURN value::diff({ s: "line1\nline2" }, { s: "line1\nline2\nline3" });
+
+RETURN value::patch({ s: "line1\nline2" }, value::diff({ s: "line1\nline2" }, { s: "line1\nline2\nline3" }));
+
+-- Empty string growing content
+RETURN value::diff({ m: '' }, { m: 'x' });
+
+RETURN value::patch({ m: '' }, value::diff({ m: '' }, { m: 'x' }));
+
+-- Array of strings: diff uses `/items/<index>`; patch of `change` on array cells is not asserted here
+RETURN value::diff({ items: ['alpha', 'beta'] }, { items: ['alpha', 'gamma'] });
+
+-- Combined patch: remove a field then DMP `change` on a remaining string
+RETURN value::patch(
+	{ keep: true, note: 'aa' },
+	array::concat(
+		[{ op: 'remove', path: '/keep' }],
+		value::diff({ note: 'aa' }, { note: 'bb' })
+	)
+);
+
+-- Structural change at nested path: `replace` when value is no longer a string
+RETURN value::diff({ x: 'ab' }, { x: ['a', 'b'] });
+
+RETURN value::patch({ x: 'ab' }, value::diff({ x: 'ab' }, { x: ['a', 'b'] }));
+
+-- Supplementary-plane (emoji) strings still use DMP `change`
+RETURN value::diff({ e: '👋' }, { e: '👋!' });
+
+RETURN value::patch({ e: '👋' }, value::diff({ e: '👋' }, { e: '👋!' }));
+
+-- Identical multi-line field: no ops
+RETURN value::diff({ s: "a\nb" }, { s: "a\nb" });
+
+-- Invalid `change` payload (not unified-diff text) must error
+RETURN value::patch({ x: 'hello' }, [{ op: 'change', path: '/x', value: 'plain-wrong' }]);

--- a/language-tests/tests/reproductions/7239_value_diff_patch_scalar_root.surql
+++ b/language-tests/tests/reproductions/7239_value_diff_patch_scalar_root.surql
@@ -1,7 +1,7 @@
 /**
 [test]
 issue = 7239
-reason = "Root-level scalars: value::patch($start, value::diff($start, $after)) must yield $after (Change for strings, Replace for other scalars and type changes). Covers ambiguous JSON Pointer / vs empty-string object keys."
+reason = "Root-level scalars: value::patch($start, value::diff($start, $after)) must yield $after (Change for strings, Replace for other scalars and type changes). Covers RFC 6901 path '' vs '/', scalar root diff using path [], and objects with an empty-string key."
 
 [[test.results]]
 value = "NONE"

--- a/language-tests/tests/reproductions/7239_value_diff_patch_scalar_root.surql
+++ b/language-tests/tests/reproductions/7239_value_diff_patch_scalar_root.surql
@@ -1,7 +1,7 @@
 /**
 [test]
 issue = 7239
-reason = "Root-level string scalars: value::patch($start, value::diff($start, $after)) must yield $after (invalid empty JSON Pointer path and missing root handling previously left the value unchanged)."
+reason = "Root-level scalars: value::patch($start, value::diff($start, $after)) must yield $after (Change for strings, Replace for other scalars and type changes). Covers ambiguous JSON Pointer / vs empty-string object keys."
 
 [[test.results]]
 value = "NONE"
@@ -15,9 +15,37 @@ value = "NONE"
 [[test.results]]
 value = "'Hello there!'"
 
+[[test.results]]
+value = "99"
+
+[[test.results]]
+value = "false"
+
+[[test.results]]
+value = "42"
+
+[[test.results]]
+value = "'something'"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "{ '': 'world', x: 1 }"
+
 */
 
 LET $start = 'Hello';
 LET $after = 'Hello there!';
 LET $diff = value::diff($start, $after);
 RETURN value::patch($start, $diff);
+RETURN value::patch(42, value::diff(42, 99));
+RETURN value::patch(true, value::diff(true, false));
+RETURN value::patch('hello', value::diff('hello', 42));
+RETURN value::patch(NULL, value::diff(NULL, 'something'));
+LET $a = { '': 'hello', x: 1 };
+LET $b = { '': 'world', x: 1 };
+RETURN value::patch($a, value::diff($a, $b));

--- a/language-tests/tests/reproductions/7239_value_diff_patch_scalar_root.surql
+++ b/language-tests/tests/reproductions/7239_value_diff_patch_scalar_root.surql
@@ -1,0 +1,23 @@
+/**
+[test]
+issue = 7239
+reason = "Root-level string scalars: value::patch($start, value::diff($start, $after)) must yield $after (invalid empty JSON Pointer path and missing root handling previously left the value unchanged)."
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "'Hello there!'"
+
+*/
+
+LET $start = 'Hello';
+LET $after = 'Hello there!';
+LET $diff = value::diff($start, $after);
+RETURN value::patch($start, $diff);

--- a/surrealdb/core/src/expr/operation.rs
+++ b/surrealdb/core/src/expr/operation.rs
@@ -128,7 +128,7 @@ impl Operation {
 			} => {
 				map! {
 					// safety: does not contain null bytes.
-					"op".to_owned() => Value::String("map".to_owned()),
+					"op".to_owned() => Value::String("move".to_owned()),
 					"path".to_owned() => path_to_strand(&path),
 					"from".to_owned() => path_to_strand(&from),
 				}

--- a/surrealdb/core/src/expr/operation.rs
+++ b/surrealdb/core/src/expr/operation.rs
@@ -52,11 +52,17 @@ pub(crate) enum Operation {
 
 impl Operation {
 	fn value_to_jsonpath(val: &Value) -> Vec<String> {
-		val.to_raw_string()
-			.trim_start_matches('/')
-			.split(&['.', '/'])
-			.map(|x| x.to_owned())
-			.collect()
+		let s = val.to_raw_string();
+		// RFC 6901: `""` is the root pointer; `"/"` is a pointer with one segment (the empty
+		// string key). The previous implementation stripped leading `/` first, so both became
+		// indistinguishable after parsing.
+		if s.is_empty() {
+			return Vec::new();
+		}
+		if s == "/" {
+			return vec![String::new()];
+		}
+		s.trim_start_matches('/').split(&['.', '/']).map(|x| x.to_owned()).collect()
 	}
 
 	pub fn into_object(self) -> Object {

--- a/surrealdb/core/src/val/value/diff.rs
+++ b/surrealdb/core/src/val/value/diff.rs
@@ -6,6 +6,11 @@ impl Value {
 		let mut res = Vec::new();
 		let mut path = Vec::new();
 
+		match (self, val) {
+			(Value::Object(_), _) | (Value::Array(_), _) => {}
+			_ => path.push(String::new()),
+		}
+
 		self.diff_rec(val, &mut path, &mut res);
 
 		res

--- a/surrealdb/core/src/val/value/diff.rs
+++ b/surrealdb/core/src/val/value/diff.rs
@@ -4,15 +4,10 @@ use crate::val::Value;
 impl Value {
 	pub(crate) fn diff(&self, val: &Value) -> Vec<Operation> {
 		let mut res = Vec::new();
+		// Root-level scalar diffs use `path == []`, which serializes to `""` (JSON Pointer root).
+		// A path of `[""]` is reserved for the empty-string object key (`"/"`).
 		let mut path = Vec::new();
-
-		match (self, val) {
-			(Value::Object(_), _) | (Value::Array(_), _) => {}
-			_ => path.push(String::new()),
-		}
-
 		self.diff_rec(val, &mut path, &mut res);
-
 		res
 	}
 
@@ -92,7 +87,7 @@ impl Value {
 #[cfg(test)]
 mod tests {
 
-	use super::*;
+	use crate::expr::operation::Operation;
 	use crate::syn;
 
 	macro_rules! parse_val {
@@ -155,5 +150,21 @@ mod tests {
 		);
 		let res = Operation::value_to_operations(res).unwrap();
 		assert_eq!(res, old.diff(&now));
+	}
+
+	#[test]
+	fn diff_root_scalar_uses_empty_path() {
+		let old = parse_val!("42");
+		let now = parse_val!("99");
+		assert_eq!(
+			old.diff(&now),
+			vec![Operation::Replace {
+				path: Vec::new(),
+				value: now.clone(),
+			}]
+		);
+		let round =
+			Operation::value_to_operations(Operation::operations_to_value(old.diff(&now))).unwrap();
+		assert_eq!(round, old.diff(&now));
 	}
 }

--- a/surrealdb/core/src/val/value/patch.rs
+++ b/surrealdb/core/src/val/value/patch.rs
@@ -7,6 +7,19 @@ use crate::expr::operation::PatchError;
 use crate::expr::part::Part;
 use crate::val::Value;
 
+/// True when a patch path addresses the whole document. A lone empty segment (`[""]`, JSON
+/// Pointer `/`) is ambiguous: it can mean root or a field named `""`. When the current value is
+/// an object or array, `[""]` must navigate into the `""` key; only scalars treat it as root.
+fn patch_path_is_root(path: &[String], this: &Value) -> bool {
+	if path.is_empty() {
+		return true;
+	}
+	if path.len() == 1 && path[0].is_empty() {
+		return !matches!(this, Value::Object(_) | Value::Array(_));
+	}
+	false
+}
+
 impl Value {
 	pub(crate) fn patch(&mut self, ops: Value) -> Result<()> {
 		let mut this = self.clone();
@@ -90,7 +103,7 @@ impl Value {
 					path,
 					value,
 				} => {
-					let is_root = path.is_empty() || (path.len() == 1 && path[0].is_empty());
+					let is_root = patch_path_is_root(&path, &this);
 					if is_root {
 						this = value;
 					} else {
@@ -104,7 +117,7 @@ impl Value {
 					value,
 				} => {
 					// "/" parses to [""] — one empty string segment meaning root
-					let is_root = path.is_empty() || (path.len() == 1 && path[0].is_empty());
+					let is_root = patch_path_is_root(&path, &this);
 					// Only root skips segments; preserve empty-string keys elsewhere (do not
 					// filter).
 					let path: Vec<Part> = if is_root {
@@ -366,6 +379,26 @@ mod tests {
 	async fn patch_change_root_round_trip_diff() {
 		let old = parse_val!("'Hello'");
 		let now = parse_val!("'Hello there!'");
+		let mut val = old.clone();
+		let ops = Operation::operations_to_value(old.diff(&now));
+		val.patch(ops).unwrap();
+		assert_eq!(now, val);
+	}
+
+	#[tokio::test]
+	async fn patch_change_empty_string_key_round_trip_diff() {
+		let old = parse_val!("{ '': 'hello', x: 1 }");
+		let now = parse_val!("{ '': 'world', x: 1 }");
+		let mut val = old.clone();
+		let ops = Operation::operations_to_value(old.diff(&now));
+		val.patch(ops).unwrap();
+		assert_eq!(now, val);
+	}
+
+	#[tokio::test]
+	async fn patch_replace_empty_string_key_round_trip_diff() {
+		let old = parse_val!("{ '': 'hello', x: 1 }");
+		let now = parse_val!("{ '': 42, x: 1 }");
 		let mut val = old.clone();
 		let ops = Operation::operations_to_value(old.diff(&now));
 		val.patch(ops).unwrap();

--- a/surrealdb/core/src/val/value/patch.rs
+++ b/surrealdb/core/src/val/value/patch.rs
@@ -90,8 +90,13 @@ impl Value {
 					path,
 					value,
 				} => {
-					let path = path.into_iter().map(Part::Field).collect::<Vec<_>>();
-					this.put(&path, value)
+					let is_root = path.is_empty() || (path.len() == 1 && path[0].is_empty());
+					if is_root {
+						this = value;
+					} else {
+						let path = path.into_iter().map(Part::Field).collect::<Vec<_>>();
+						this.put(&path, value);
+					}
 				}
 				// Modify a string at the specified path
 				Operation::Change {
@@ -100,11 +105,12 @@ impl Value {
 				} => {
 					// "/" parses to [""] — one empty string segment meaning root
 					let is_root = path.is_empty() || (path.len() == 1 && path[0].is_empty());
-					let path = path
-						.into_iter()
-						.filter(|p| !p.is_empty()) // strip the empty root segment
-						.map(Part::Field)
-						.collect::<Vec<_>>();
+					// Only root skips segments; preserve empty-string keys elsewhere (do not filter).
+					let path: Vec<Part> = if is_root {
+						vec![]
+					} else {
+						path.into_iter().map(Part::Field).collect()
+					};
 
 					if let Value::String(p) = value {
 						let current = if is_root {
@@ -183,6 +189,7 @@ impl Value {
 
 #[cfg(test)]
 mod tests {
+	use crate::expr::Operation;
 	use crate::syn;
 
 	macro_rules! parse_val {
@@ -334,6 +341,34 @@ mod tests {
 		let res = parse_val!("{ test: { something: 123 }, temp: true }");
 		val.patch(ops).unwrap();
 		assert_eq!(res, val);
+	}
+
+	#[tokio::test]
+	async fn patch_replace_root_scalar() {
+		let mut val = parse_val!("42");
+		let ops = parse_val!("[{ op: 'replace', path: '/', value: 99 }]");
+		val.patch(ops).unwrap();
+		assert_eq!(parse_val!("99"), val);
+	}
+
+	#[tokio::test]
+	async fn patch_replace_root_round_trip_diff() {
+		let old = parse_val!("42");
+		let now = parse_val!("99");
+		let mut val = old.clone();
+		let ops = Operation::operations_to_value(old.diff(&now));
+		val.patch(ops).unwrap();
+		assert_eq!(now, val);
+	}
+
+	#[tokio::test]
+	async fn patch_change_root_round_trip_diff() {
+		let old = parse_val!("'Hello'");
+		let now = parse_val!("'Hello there!'");
+		let mut val = old.clone();
+		let ops = Operation::operations_to_value(old.diff(&now));
+		val.patch(ops).unwrap();
+		assert_eq!(now, val);
 	}
 
 	#[tokio::test]

--- a/surrealdb/core/src/val/value/patch.rs
+++ b/surrealdb/core/src/val/value/patch.rs
@@ -98,23 +98,41 @@ impl Value {
 					path,
 					value,
 				} => {
-					let path = path.into_iter().map(Part::Field).collect::<Vec<_>>();
-					if let Value::String(p) = value
-						&& let Value::String(v) = this.pick(&path)
-					{
-						let dmp = dmp::new();
-						let pch = dmp.patch_from_text(p).map_err(|e| {
-							Error::InvalidPatch(PatchError {
-								message: format!("{e:?}"),
-							})
-						})?;
-						let (txt, _) = dmp.patch_apply(&pch, v.as_str()).map_err(|e| {
-							Error::InvalidPatch(PatchError {
-								message: format!("{e:?}"),
-							})
-						})?;
-						let txt = txt.into_iter().collect::<String>();
-						this.put(&path, Value::from(txt));
+					// "/" parses to [""] — one empty string segment meaning root
+					let is_root = path.is_empty() || (path.len() == 1 && path[0].is_empty());
+					let path = path
+						.into_iter()
+						.filter(|p| !p.is_empty()) // strip the empty root segment
+						.map(Part::Field)
+						.collect::<Vec<_>>();
+
+					if let Value::String(p) = value {
+						let current = if is_root {
+							this.clone()
+						} else {
+							this.pick(&path)
+						};
+
+						if let Value::String(v) = current {
+							let dmp = dmp::new();
+							let pch = dmp.patch_from_text(p).map_err(|e| {
+								Error::InvalidPatch(PatchError {
+									message: format!("{e:?}"),
+								})
+							})?;
+							let (txt, _) = dmp.patch_apply(&pch, v.as_str()).map_err(|e| {
+								Error::InvalidPatch(PatchError {
+									message: format!("{e:?}"),
+								})
+							})?;
+							let txt = txt.into_iter().collect::<String>();
+
+							if is_root {
+								this = Value::from(txt);
+							} else {
+								this.put(&path, Value::from(txt));
+							}
+						}
 					}
 				}
 				// Copy a value from one field to another

--- a/surrealdb/core/src/val/value/patch.rs
+++ b/surrealdb/core/src/val/value/patch.rs
@@ -366,6 +366,14 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn patch_replace_root_scalar_path_empty_string() {
+		let mut val = parse_val!("42");
+		let ops = parse_val!("[{ op: 'replace', path: '', value: 99 }]");
+		val.patch(ops).unwrap();
+		assert_eq!(parse_val!("99"), val);
+	}
+
+	#[tokio::test]
 	async fn patch_replace_root_round_trip_diff() {
 		let old = parse_val!("42");
 		let now = parse_val!("99");

--- a/surrealdb/core/src/val/value/patch.rs
+++ b/surrealdb/core/src/val/value/patch.rs
@@ -105,7 +105,8 @@ impl Value {
 				} => {
 					// "/" parses to [""] — one empty string segment meaning root
 					let is_root = path.is_empty() || (path.len() == 1 && path[0].is_empty());
-					// Only root skips segments; preserve empty-string keys elsewhere (do not filter).
+					// Only root skips segments; preserve empty-string keys elsewhere (do not
+					// filter).
 					let path: Vec<Part> = if is_root {
 						vec![]
 					} else {


### PR DESCRIPTION
value::diff() was emitting an empty path () instead of / when diffing non-object, non-array values, producing invalid patch operations.

value::patch() was not handling the root path case (/) for scalar values.

Fix diff.rs to emit / as the path for root-level scalar diffs. Fix patch.rs to detect [] as a root path, strip the empty segment, and replace  directly instead of trying to navigate into a scalar.

Fixes #7239

Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉

Before proceeding, please add any of the following labels that apply:

* `breaking-change` if this PR includes a breaking change. This label is not needed for bug fixes, which change output in line with a user's original expectations.
* `needs-documentation` if documentation is needed to explain the change made in the PR.
* `Modifies env vars or commands` if any changes are made to environment variables or command flags.

## What is the motivation?

<!-- Please provide details on the motivation for why you have made this change.-->

value::diff() and value::patch() did not work correctly when used directly on scalar values (e.g. plain strings). Calling value::patch($start, value::diff($start, $after)) would return the original value unchanged, making the two functions useless outside of objects and arrays. Reported in #7239.

## What does this change do?

<!-- Please provide a description of what this pull request does, and how it solves the problem. -->

diff.rs — when diffing two root-level scalar values, the generated patch operation was emitting an empty path ("") instead of the correct JSON Pointer root path ("/"). Fixed by detecting the non-object, non-array case and pushing an empty string segment onto the path before recursing, which path_to_strand correctly converts to "/".
patch.rs — when applying a patch operation with path: "/", the path string parses to [""] (a vec containing one empty string), not []. The existing this.put(&path, value) call silently no-oped on a scalar because there was nothing to navigate into. Fixed by detecting [""] as a root path, stripping the empty segment, and replacing this directly instead of navigating into it.

## What is your testing strategy?

<!-- Write your test plan here. Please provide us with clear instructions on how you verified your changes work. -->

Verified manually via the SurrealDB REPL:

LET $start = "Hello";
LET $after = "Hello there!";
LET $diff = value::diff($start, $after);
RETURN value::patch($start, $diff);
-- Now correctly returns "Hello there!"

## Security Considerations

<!-- Briefly assess the security implications of this change. Consider:
- Does it touch authentication, authorization, or session handling?
- Does it affect data isolation between namespaces or databases?
- Does it process user input that reaches the query engine or storage layer?
- Could error messages or logs expose internal details?
- Are resource limits enforced for any new user-controlled operations?

If there are no security implications, briefly state why (e.g. "documentation-only change").
If there are security implications, or you're uncertain, please assign the `security-review` label to this PR
and request a security review by a member of the @surrealdb/security team. -->

No security implications. This change only affects the diff/patch utility functions and does not touch authentication, authorization, data isolation, user input parsing, or resource limits.

## Is this related to any issues?

<!-- If this pull request is related to other pull requests, or resolves any issues, then link all related or closed items here, using 'Closes #101' or 'Fixes #101' to automatically close any linked issues. -->

* Fixes #7239

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

* [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
