### PR TITLE
Fix deferred index performance and contention failures

### DIFF
--- a/crates/core/src/ctx/context.rs
+++ b/crates/core/src/ctx/context.rs
@@ -394,12 +394,10 @@ impl MutableContext {
 				return Err(Error::QueryBeyondMemoryThreshold);
 			}
 			match self.deadline {
-				None => {}
-				Some(deadline) => {
-					if deadline <= Instant::now() {
-						return Ok(Some(Reason::Timedout));
-					}
+				Some(deadline) if deadline <= Instant::now() => {
+					return Ok(Some(Reason::Timedout));
 				}
+				_ => {}
 			}
 		}
 		if let Some(ctx) = &self.parent {

--- a/crates/core/src/dbs/executor.rs
+++ b/crates/core/src/dbs/executor.rs
@@ -218,25 +218,26 @@ impl Executor {
 					| Err(Error::Return {
 						value,
 					}) => {
-						let mut lock = txn.lock().await;
-
 						// non-writable transactions might return an error on commit.
 						// So cancel them instead. This is fine since a non-writable transaction
 						// has nothing to commit anyway.
 						if !writeable {
-							let _ = lock.cancel().await;
+							let _ = txn.cancel().await;
 							return Ok(value);
 						}
 
-						if let Err(e) = lock.complete_changes(false).await {
-							let _ = lock.cancel().await;
-
+						let complete = {
+							let mut lock = txn.lock().await;
+							lock.complete_changes(false).await
+						};
+						if let Err(e) = complete {
+							let _ = txn.cancel().await;
 							return Err(Error::QueryNotExecutedDetail {
 								message: e.to_string(),
 							});
 						}
 
-						if let Err(e) = lock.commit().await {
+						if let Err(e) = txn.commit().await {
 							return Err(Error::QueryNotExecutedDetail {
 								message: e.to_string(),
 							});
@@ -416,14 +417,16 @@ impl Executor {
 					return Ok(());
 				}
 				Statement::Commit(_) => {
-					let mut lock = txn.lock().await;
-
 					// complete_changes and then commit.
 					// If either error undo results.
-					let e = if let Err(e) = lock.complete_changes(false).await {
-						let _ = lock.cancel().await;
+					let complete = {
+						let mut lock = txn.lock().await;
+						lock.complete_changes(false).await
+					};
+					let e = if let Err(e) = complete {
+						let _ = txn.cancel().await;
 						e
-					} else if let Err(e) = lock.commit().await {
+					} else if let Err(e) = txn.commit().await {
 						e
 					} else {
 						// Successfully commited. everything is fine.

--- a/crates/core/src/doc/check.rs
+++ b/crates/core/src/doc/check.rs
@@ -30,32 +30,19 @@ impl Document {
 		let tb = self.tb(ctx, opt).await?;
 		// Determine the type of statement
 		match stm {
-			Statement::Create(_) => {
-				if !tb.allows_normal() {
-					return Err(Error::TableCheck {
-						thing: self.id()?.to_string(),
-						relation: false,
-						target_type: tb.kind.to_string(),
-					});
-				}
+			Statement::Create(_) | Statement::Upsert(_) if !tb.allows_normal() => {
+				return Err(Error::TableCheck {
+					thing: self.id()?.to_string(),
+					relation: false,
+					target_type: tb.kind.to_string(),
+				});
 			}
-			Statement::Upsert(_) => {
-				if !tb.allows_normal() {
-					return Err(Error::TableCheck {
-						thing: self.id()?.to_string(),
-						relation: false,
-						target_type: tb.kind.to_string(),
-					});
-				}
-			}
-			Statement::Relate(_) => {
-				if !tb.allows_relation() {
-					return Err(Error::TableCheck {
-						thing: self.id()?.to_string(),
-						relation: true,
-						target_type: tb.kind.to_string(),
-					});
-				}
+			Statement::Relate(_) if !tb.allows_relation() => {
+				return Err(Error::TableCheck {
+					thing: self.id()?.to_string(),
+					relation: true,
+					target_type: tb.kind.to_string(),
+				});
 			}
 			Statement::Insert(_) => match self.extras {
 				Workable::Relate(_, _, _) => {

--- a/crates/core/src/err/mod.rs
+++ b/crates/core/src/err/mod.rs
@@ -108,6 +108,12 @@ pub enum Error {
 	#[error("Failed to commit transaction due to a read or write conflict. This transaction can be retried")]
 	TxRetryable,
 
+	/// There was a transaction error that can be retried because conflict checking history is unavailable
+	#[error(
+		"Failed to commit transaction because conflict checking history is unavailable. This transaction can be retried"
+	)]
+	TxRetryableConflictCheck,
+
 	/// The transaction writes too much data for the KV store
 	#[error("Transaction is too large")]
 	TxTooLarge,
@@ -1381,11 +1387,16 @@ impl From<surrealkv::Error> for Error {
 #[cfg(feature = "kv-rocksdb")]
 impl From<rocksdb::Error> for Error {
 	fn from(e: rocksdb::Error) -> Error {
-		match e.kind() {
-			rocksdb::ErrorKind::Busy => Error::TxRetryable,
-			rocksdb::ErrorKind::TryAgain => Error::TxRetryable,
-			_ => Error::Tx(e.to_string()),
-		}
+		rocksdb_error_kind_to_error(e.kind(), e.to_string())
+	}
+}
+
+#[cfg(feature = "kv-rocksdb")]
+fn rocksdb_error_kind_to_error(kind: rocksdb::ErrorKind, message: String) -> Error {
+	match kind {
+		rocksdb::ErrorKind::Busy => Error::TxRetryable,
+		rocksdb::ErrorKind::TryAgain => Error::TxRetryableConflictCheck,
+		_ => Error::Tx(message),
 	}
 }
 
@@ -1525,5 +1536,22 @@ impl Error {
 			},
 			e => e,
 		}
+	}
+}
+
+#[cfg(all(test, feature = "kv-rocksdb"))]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn rocksdb_conflict_error_kinds_are_classified_separately() {
+		assert!(matches!(
+			rocksdb_error_kind_to_error(rocksdb::ErrorKind::Busy, "busy".to_string()),
+			Error::TxRetryable
+		));
+		assert!(matches!(
+			rocksdb_error_kind_to_error(rocksdb::ErrorKind::TryAgain, "try again".to_string()),
+			Error::TxRetryableConflictCheck
+		));
 	}
 }

--- a/crates/core/src/iam/access.rs
+++ b/crates/core/src/iam/access.rs
@@ -29,7 +29,10 @@ pub async fn authenticate_record(
 				Error::Thrown(_) => Err(e),
 				// If the AUTHENTICATE clause failed due to an unexpected error, be more specific
 				// This allows clients to handle these errors, which may be retryable
-				Error::Tx(_) | Error::TxFailure | Error::TxRetryable => {
+				Error::Tx(_)
+				| Error::TxFailure
+				| Error::TxRetryable
+				| Error::TxRetryableConflictCheck => {
 					debug!("Unexpected error found while executing AUTHENTICATE clause: {e}");
 					Err(Error::UnexpectedAuth)
 				}
@@ -71,7 +74,10 @@ pub async fn authenticate_generic(
 				Error::Thrown(_) => Err(e),
 				// If the AUTHENTICATE clause failed due to an unexpected error, be more specific
 				// This allows clients to handle these errors, which may be retryable
-				Error::Tx(_) | Error::TxFailure | Error::TxRetryable => {
+				Error::Tx(_)
+				| Error::TxFailure
+				| Error::TxRetryable
+				| Error::TxRetryableConflictCheck => {
 					debug!("Unexpected error found while executing an AUTHENTICATE clause: {e}");
 					Err(Error::UnexpectedAuth)
 				}

--- a/crates/core/src/iam/signin.rs
+++ b/crates/core/src/iam/signin.rs
@@ -290,7 +290,10 @@ pub async fn db_access(
 									Error::Thrown(_) => Err(e),
 									// If the SIGNIN clause failed due to an unexpected error, be more specific
 									// This allows clients to handle these errors, which may be retryable
-									Error::Tx(_) | Error::TxFailure | Error::TxRetryable => {
+									Error::Tx(_)
+									| Error::TxFailure
+									| Error::TxRetryable
+									| Error::TxRetryableConflictCheck => {
 										debug!("Unexpected error found while executing a SIGNIN clause: {e}");
 										Err(Error::UnexpectedAuth)
 									}

--- a/crates/core/src/iam/signup.rs
+++ b/crates/core/src/iam/signup.rs
@@ -198,7 +198,10 @@ pub async fn db_access(
 									Error::Thrown(_) => Err(e),
 									// If the SIGNUP clause failed due to an unexpected error, be more specific
 									// This allows clients to handle these errors, which may be retryable
-									Error::Tx(_) | Error::TxFailure | Error::TxRetryable => {
+									Error::Tx(_)
+									| Error::TxFailure
+									| Error::TxRetryable
+									| Error::TxRetryableConflictCheck => {
 										debug!("Unexpected error found while executing a SIGNUP clause: {e}");
 										Err(Error::UnexpectedAuth)
 									}

--- a/crates/core/src/idx/index.rs
+++ b/crates/core/src/idx/index.rs
@@ -62,6 +62,38 @@ impl<'a> IndexOperation<'a> {
 		}
 	}
 
+	/// Create a reusable FtIndex for batch operations on search indexes.
+	/// Returns None for non-search indexes.
+	/// The caller must call `FtIndex::finish()` after all documents are processed.
+	pub(crate) async fn create_ft_index(
+		ctx: &Context,
+		opt: &Options,
+		ix: &DefineIndexStatement,
+	) -> Result<Option<FtIndex>, Error> {
+		if let Index::Search(p) = &ix.index {
+			let (ns, db) = opt.ns_db()?;
+			let ikb = IndexKeyBase::new(ns, db, ix)?;
+			Ok(Some(FtIndex::new(ctx, opt, &p.az, ikb, p, TransactionType::Write).await?))
+		} else {
+			Ok(None)
+		}
+	}
+
+	/// Index a document using a pre-existing FtIndex, avoiding the per-document
+	/// creation/teardown overhead of `FtIndex::new()` + `FtIndex::finish()`.
+	pub(crate) async fn compute_search_with_ft(
+		&mut self,
+		stk: &mut Stk,
+		ft: &mut FtIndex,
+	) -> Result<(), Error> {
+		if let Some(n) = self.n.take() {
+			ft.index_document(stk, self.ctx, self.opt, self.rid, n).await?;
+		} else {
+			ft.remove_document(self.ctx, self.rid).await?;
+		}
+		Ok(())
+	}
+
 	fn get_unique_index_key(&self, v: &'a Array) -> Result<key::index::Index<'_>, Error> {
 		let (ns, db) = self.opt.ns_db()?;
 		Ok(key::index::Index::new(ns, db, &self.ix.what, &self.ix.name, v, None))

--- a/crates/core/src/idx/planner/tree.rs
+++ b/crates/core/src/idx/planner/tree.rs
@@ -634,15 +634,15 @@ impl<'a> TreeBuilder<'a> {
 						return Some(iop);
 					}
 				}
-				(Operator::Contain, v, IdiomPosition::Left) => {
-					if col == 0 && ixr.cols[0].contains(&Part::All) {
-						return Some(IndexOperator::Equality(v));
-					}
+				(Operator::Contain, v, IdiomPosition::Left)
+					if col == 0 && ixr.cols[0].contains(&Part::All) =>
+				{
+					return Some(IndexOperator::Equality(v));
 				}
-				(Operator::Inside, v, IdiomPosition::Right) => {
-					if col == 0 && ixr.cols[0].contains(&Part::All) {
-						return Some(IndexOperator::Equality(v));
-					}
+				(Operator::Inside, v, IdiomPosition::Right)
+					if col == 0 && ixr.cols[0].contains(&Part::All) =>
+				{
+					return Some(IndexOperator::Equality(v));
 				}
 				(Operator::Inside, v, IdiomPosition::Left) => {
 					if let Value::Array(a) = v.as_ref() {
@@ -653,10 +653,10 @@ impl<'a> TreeBuilder<'a> {
 					}
 				}
 				(Operator::ContainAny | Operator::ContainAll, v, IdiomPosition::Left)
-				| (Operator::AnyInside | Operator::AllInside, v, IdiomPosition::Right) => {
-					if v.is_array() && col == 0 {
-						return Some(IndexOperator::Union(v));
-					}
+				| (Operator::AnyInside | Operator::AllInside, v, IdiomPosition::Right)
+					if v.is_array() && col == 0 =>
+				{
+					return Some(IndexOperator::Union(v));
 				}
 				(
 					Operator::LessThan

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -884,9 +884,16 @@ impl Building {
 	) -> Result<(), Error> {
 		let mut rc = false;
 		let mut stack = TreeStack::new();
+		// For search indexes, create the FtIndex once for the entire batch
+		// instead of per-document, avoiding repeated BTree load/save overhead.
+		let mut ft_index = IndexOperation::create_ft_index(ctx, &self.opt, &self.ix).await?;
 		// Index the records
 		for (k, v) in values.into_iter() {
 			if self.is_aborted().await {
+				// Finish FtIndex to persist progress made so far in this batch
+				if let Some(ref ft) = ft_index {
+					ft.finish(ctx).await?;
+				}
 				return Ok(());
 			}
 			let key = thing::Thing::decode(&k)?;
@@ -912,17 +919,25 @@ impl Building {
 			// Index the record
 			let mut io =
 				IndexOperation::new(ctx, &self.opt, &self.ix, None, opt_values.clone(), &rid);
-			stack.enter(|stk| io.compute(stk, &mut rc)).finish().await?;
+			if let Some(ft) = &mut ft_index {
+				stack.enter(|stk| io.compute_search_with_ft(stk, ft)).finish().await?;
+			} else {
+				stack.enter(|stk| io.compute(stk, &mut rc)).finish().await?;
+			}
 
-			// Increment the count and update the status
 			*count += 1;
-			self.set_status(BuildingStatus::Indexing {
-				initial: Some(*count),
-				pending: Some(self.queue.read().await.pending() as usize),
-				updated: None,
-			})
-			.await;
 		}
+		// Finish the FtIndex once for the entire batch
+		if let Some(ref ft) = ft_index {
+			ft.finish(ctx).await?;
+		}
+		// Update status once per batch instead of per record
+		self.set_status(BuildingStatus::Indexing {
+			initial: Some(*count),
+			pending: Some(self.queue.read().await.pending() as usize),
+			updated: None,
+		})
+		.await;
 		// Check if we trigger the compaction
 		self.check_index_compaction(tx, &mut rc).await?;
 		// We're done
@@ -973,9 +988,14 @@ impl Building {
 		let mut rc = false;
 		let mut stack = TreeStack::new();
 		let mut indexed = HashMap::new();
+		// For search indexes, create the FtIndex once for the entire batch
+		let mut ft_index = IndexOperation::create_ft_index(ctx, &self.opt, &self.ix).await?;
 		trace!("{}: index_appending_range STARTS- len: {}", self.ix.name, keys.len());
 		for k in keys {
 			if self.is_aborted().await {
+				if let Some(ref ft) = ft_index {
+					ft.finish(ctx).await?;
+				}
 				return Ok(indexed);
 			}
 			let ib = Ib::decode(&k)?;
@@ -984,7 +1004,11 @@ impl Building {
 				let rid = Thing::from((self.tb.clone(), a.id));
 				let mut io =
 					IndexOperation::new(ctx, &self.opt, &self.ix, a.old_values, a.new_values, &rid);
-				stack.enter(|stk| io.compute(stk, &mut rc)).finish().await?;
+				if let Some(ft) = &mut ft_index {
+					stack.enter(|stk| io.compute_search_with_ft(stk, ft)).finish().await?;
+				} else {
+					stack.enter(|stk| io.compute(stk, &mut rc)).finish().await?;
+				}
 
 				// Delete the ip (primary appending) key if any
 				let ip = self.new_ip_key(rid.id)?;
@@ -993,15 +1017,20 @@ impl Building {
 			if let Some(c) = count {
 				*c += 1;
 			}
-			self.set_status(BuildingStatus::Indexing {
-				initial,
-				pending: Some(self.queue.read().await.pending() as usize),
-				updated: *count,
-			})
-			.await;
 			indexed.entry(ib.batch_id).or_insert(vec![]).push(ib.appending_id);
 			tx.del(ib).await?;
 		}
+		// Finish the FtIndex once for the entire batch
+		if let Some(ref ft) = ft_index {
+			ft.finish(ctx).await?;
+		}
+		// Update status once per batch instead of per record
+		self.set_status(BuildingStatus::Indexing {
+			initial,
+			pending: Some(self.queue.read().await.pending() as usize),
+			updated: *count,
+		})
+		.await;
 		trace!("{}: index_appending_range EXIT: {:?}", self.ix.name, indexed);
 		// Check if we trigger the compaction
 		self.check_index_compaction(tx, &mut rc).await?;

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -241,8 +241,16 @@ impl IndexBuilder {
 				return;
 			}
 			if b.ix.defer {
-				// If it is a deferred indexing, start the daemon and return
+				// Set deferred_daemon_running BEFORE marking the initial build complete,
+				// so that is_finished() does not momentarily return true.
+				b.deferred_daemon_running.store(true, Ordering::Release);
+				// Mark the initial build as complete BEFORE spawning the daemon.
+				// This prevents write-write conflicts on !ip keys between the daemon
+				// (which deletes them) and maybe_consume (which writes them while
+				// initial_build_complete is false).
+				drop(initial_guard);
 				Self::spawn_deferred_daemon(b.clone());
+				return;
 			}
 			drop(initial_guard);
 		});
@@ -261,7 +269,8 @@ impl IndexBuilder {
 	) -> Result<IndexBuilding, Error> {
 		let building = Arc::new(Building::new(ctx, self.tf.clone(), opt, ix, ix_key)?);
 		building.recover_queue().await?;
-		building.initial_build_complete.store(true, Ordering::Relaxed);
+		building.deferred_daemon_running.store(true, Ordering::Release);
+		building.initial_build_complete.store(true, Ordering::Release);
 		Self::spawn_deferred_daemon(building.clone());
 		Ok(building)
 	}
@@ -273,13 +282,20 @@ impl IndexBuilder {
 		spawn(async move {
 			// Ensure that the daemon running flag is properly managed
 			let daemon_guard = DeferredDaemonGuard(building.clone());
-			building.deferred_daemon_running.store(true, Ordering::Relaxed);
+			building.deferred_daemon_running.store(true, Ordering::Release);
 			loop {
 				if building.is_aborted().await {
 					building.set_status(BuildingStatus::Aborted).await;
 					break;
 				}
 				if let Err(e) = building.index_appending_loop(None).await {
+					if matches!(e, Error::TxRetryable) {
+						// Transient conflicts are retried within index_appending_loop,
+						// but handle any that still propagate as a safety net.
+						warn!("{}: deferred daemon transient conflict, retrying", building.ix.name);
+						sleep(Duration::from_millis(100)).await;
+						continue;
+					}
 					error!("Index appending loop error: {}", e);
 					building.set_status(BuildingStatus::Error(e.to_string())).await;
 					break;
@@ -639,7 +655,8 @@ impl Building {
 		// for a record being initially indexed. Once the initial build is complete
 		// (appending phase), we skip setting ip to avoid write-write conflicts with the
 		// deferred daemon which deletes ip keys.
-		if !self.initial_build_complete.load(Ordering::Relaxed) {
+		// Acquire pairs with the Release in InitialBuildGuard::drop / start_deferred_index.
+		if !self.initial_build_complete.load(Ordering::Acquire) {
 			let ip = self.new_ip_key(rid.id.clone())?;
 			let v = tx.get(ip.clone(), None).await?;
 			let pa: Option<PrimaryAppending> = if let Some(v) = v {
@@ -835,34 +852,48 @@ impl Building {
 				keys
 			};
 			if !keys.is_empty() {
-				// Create a new context with a write transaction
+				let ctx = self.new_write_tx_ctx().await?;
+				let tx = ctx.tx();
+				match self
+					.index_appending_range(&ctx, &tx, keys, initial_count, &mut updates_count)
+					.await
 				{
-					let ctx = self.new_write_tx_ctx().await?;
-					let tx = ctx.tx();
-					let indexed = catch!(
-						tx,
-						self.index_appending_range(
-							&ctx,
-							&tx,
-							keys,
-							initial_count,
-							&mut updates_count
-						)
-						.await
-					);
-					catch!(tx, tx.commit().await);
-					if !indexed.is_empty() {
-						{
-							let mut clean_queue = self.clean_queue.lock().await;
-							for batch_id in indexed.keys() {
-								if let Some(idx) =
-									clean_queue.iter().position(|&id| id == *batch_id)
+					Ok(indexed) => match tx.commit().await {
+						Ok(()) => {
+							if !indexed.is_empty() {
 								{
-									clean_queue.remove(idx);
+									let mut clean_queue = self.clean_queue.lock().await;
+									for batch_id in indexed.keys() {
+										if let Some(idx) =
+											clean_queue.iter().position(|&id| id == *batch_id)
+										{
+											clean_queue.remove(idx);
+										}
+									}
 								}
+								self.queue.write().await.clean(indexed);
 							}
 						}
-						self.queue.write().await.clean(indexed);
+						Err(Error::TxRetryable) => {
+							warn!("{}: transient conflict on commit, retrying batch", self.ix.name);
+							sleep(Duration::from_millis(100)).await;
+						}
+						Err(e) => {
+							let _ = tx.cancel().await;
+							return Err(e);
+						}
+					},
+					Err(Error::TxRetryable) => {
+						let _ = tx.cancel().await;
+						warn!(
+							"{}: transient conflict in appending range, retrying batch",
+							self.ix.name
+						);
+						sleep(Duration::from_millis(100)).await;
+					}
+					Err(e) => {
+						let _ = tx.cancel().await;
+						return Err(e);
 					}
 				}
 			} else {

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -1024,11 +1024,12 @@ impl Building {
 		trace!("{}: index_appending_range STARTS- len: {}", self.ix.name, keys.len());
 		for k in keys {
 			if self.is_aborted().await {
-				// Best-effort: persist FtIndex progress made so far in this batch
+				// Persist FtIndex progress made so far in this batch.
+				// Propagate errors so the caller cancels the transaction and we
+				// avoid committing !ip/!ib deletions without the corresponding
+				// FtIndex state (symmetric with index_initial_batch).
 				if let Some(ref ft) = ft_index {
-					if let Err(e) = ft.finish(ctx).await {
-						warn!("{}: failed to finish FtIndex on abort: {}", self.ix.name, e);
-					}
+					ft.finish(ctx).await?;
 				}
 				return Ok(indexed);
 			}

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -836,6 +836,12 @@ impl Building {
 					drop(queue);
 					break;
 				}
+				self.set_status(BuildingStatus::Indexing {
+					initial: initial_count,
+					pending: Some(pending),
+					updated: updates_count,
+				})
+				.await;
 				keys
 			};
 			if !keys.is_empty() {
@@ -847,13 +853,12 @@ impl Building {
 				// and re-processed on the next iteration since their deletions were
 				// rolled back with the transaction.
 				let saved_updates_count = updates_count;
-				match self
-					.index_appending_range(&ctx, &tx, keys, initial_count, &mut updates_count)
-					.await
-				{
+				match self.index_appending_range(&ctx, &tx, keys, &mut updates_count).await {
 					Ok(indexed) => match tx.commit().await {
 						Ok(()) => {
-							if !indexed.is_empty() {
+							let pending = if indexed.is_empty() {
+								self.queue.read().await.pending() as usize
+							} else {
 								{
 									let mut clean_queue = self.clean_queue.lock().await;
 									for batch_id in indexed.keys() {
@@ -864,8 +869,16 @@ impl Building {
 										}
 									}
 								}
-								self.queue.write().await.clean(indexed);
-							}
+								let mut queue = self.queue.write().await;
+								queue.clean(indexed);
+								queue.pending() as usize
+							};
+							self.set_status(BuildingStatus::Indexing {
+								initial: initial_count,
+								pending: Some(pending),
+								updated: updates_count,
+							})
+							.await;
 						}
 						Err(Error::TxRetryable) => {
 							let _ = tx.cancel().await;
@@ -1043,7 +1056,6 @@ impl Building {
 		ctx: &Context,
 		tx: &Transaction,
 		keys: Vec<Key>,
-		initial: Option<usize>,
 		count: &mut Option<usize>,
 	) -> Result<HashMap<u32, Vec<u32>>, Error> {
 		let mut rc = false;
@@ -1089,13 +1101,6 @@ impl Building {
 		if let Some(ref ft) = ft_index {
 			ft.finish(ctx).await?;
 		}
-		// Update status once per batch instead of per record
-		self.set_status(BuildingStatus::Indexing {
-			initial,
-			pending: Some(self.queue.read().await.pending() as usize),
-			updated: *count,
-		})
-		.await;
 		trace!("{}: index_appending_range EXIT: {:?}", self.ix.name, indexed);
 		// Check if we trigger the compaction
 		self.check_index_compaction(tx, &mut rc).await?;

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -282,7 +282,6 @@ impl IndexBuilder {
 		spawn(async move {
 			// Ensure that the daemon running flag is properly managed
 			let daemon_guard = DeferredDaemonGuard(building.clone());
-			building.deferred_daemon_running.store(true, Ordering::Release);
 			loop {
 				if building.is_aborted().await {
 					building.set_status(BuildingStatus::Aborted).await;
@@ -875,6 +874,7 @@ impl Building {
 							}
 						}
 						Err(Error::TxRetryable) => {
+							let _ = tx.cancel().await;
 							warn!("{}: transient conflict on commit, retrying batch", self.ix.name);
 							sleep(Duration::from_millis(100)).await;
 						}
@@ -1024,8 +1024,11 @@ impl Building {
 		trace!("{}: index_appending_range STARTS- len: {}", self.ix.name, keys.len());
 		for k in keys {
 			if self.is_aborted().await {
+				// Best-effort: persist FtIndex progress made so far in this batch
 				if let Some(ref ft) = ft_index {
-					ft.finish(ctx).await?;
+					if let Err(e) = ft.finish(ctx).await {
+						warn!("{}: failed to finish FtIndex on abort: {}", self.ix.name, e);
+					}
 				}
 				return Ok(indexed);
 			}

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -756,24 +756,12 @@ impl Building {
 				// If not, we are done with the initial indexing
 				break;
 			}
-			// Create a new context with a write transaction
-			{
-				let ctx = self.new_write_tx_ctx().await?;
-				let tx = ctx.tx();
-				// Index the batch
-				catch!(
-					tx,
-					self.index_initial_batch(
-						&ctx,
-						&tx,
-						batch.result,
-						&mut initial_count,
-						&mut v1_appending_sentinel
-					)
-					.await
-				);
-				catch!(tx, tx.commit().await);
-			}
+			self.index_initial_batch_once(
+				batch.result,
+				&mut initial_count,
+				&mut v1_appending_sentinel,
+			)
+			.await?;
 		}
 		self.set_status(BuildingStatus::Indexing {
 			initial: Some(initial_count),
@@ -912,11 +900,47 @@ impl Building {
 		Ok(())
 	}
 
+	/// Index one initial-build batch.
+	///
+	/// Initial build is expected to be conflict-free. Queue handoff records are read through a
+	/// separate read-only transaction, so commit conflicts here should surface as index build errors
+	/// rather than being hidden by a retry loop.
+	async fn index_initial_batch_once(
+		&self,
+		values: Vec<(Key, Val)>,
+		count: &mut usize,
+		v1_appending_sentinel: &mut bool,
+	) -> Result<(), Error> {
+		let read_tx = self.new_read_tx().await?;
+		let ctx = self.new_write_tx_ctx().await?;
+		let tx = ctx.tx();
+		let indexed = self
+			.index_initial_batch(&ctx, &read_tx, &tx, values, count, v1_appending_sentinel)
+			.await;
+		let _ = read_tx.cancel().await;
+		if let Err(e) = indexed {
+			let _ = tx.cancel().await;
+			return Err(e);
+		}
+		if let Err(e) = tx.commit().await {
+			let _ = tx.cancel().await;
+			return Err(e);
+		}
+		self.set_status(BuildingStatus::Indexing {
+			initial: Some(*count),
+			pending: Some(self.queue.read().await.pending() as usize),
+			updated: None,
+		})
+		.await;
+		Ok(())
+	}
+
 	/// Index a batch of records from the table
 	async fn index_initial_batch(
 		&self,
 		ctx: &Context,
-		tx: &Transaction,
+		read_tx: &Transaction,
+		write_tx: &Transaction,
 		values: Vec<(Key, Val)>,
 		count: &mut usize,
 		v1_appending_sentinel: &mut bool,
@@ -941,8 +965,9 @@ impl Building {
 			let rid: Arc<Thing> = Thing::from((key.tb, key.id)).into();
 
 			// Do we already have an appended value?
-			let opt_values = if let Some(a) =
-				self.check_existing_primary_appending(tx, &rid.id, v1_appending_sentinel).await?
+			let opt_values = if let Some(a) = self
+				.check_existing_primary_appending(read_tx, write_tx, &rid.id, v1_appending_sentinel)
+				.await?
 			{
 				a.old_values
 			} else {
@@ -970,27 +995,24 @@ impl Building {
 		if let Some(ref ft) = ft_index {
 			ft.finish(ctx).await?;
 		}
-		// Update status once per batch instead of per record
-		self.set_status(BuildingStatus::Indexing {
-			initial: Some(*count),
-			pending: Some(self.queue.read().await.pending() as usize),
-			updated: None,
-		})
-		.await;
 		// Check if we trigger the compaction
-		self.check_index_compaction(tx, &mut rc).await?;
+		self.check_index_compaction(write_tx, &mut rc).await?;
 		// We're done
 		Ok(())
 	}
 
 	async fn check_existing_primary_appending(
 		&self,
-		tx: &Transaction,
+		read_tx: &Transaction,
+		write_tx: &Transaction,
 		id: &Id,
 		v1_appending_sentinel: &mut bool,
 	) -> Result<Option<Appending>, Error> {
+		// Read queue markers outside the index write transaction. They are a
+		// handoff signal from user transactions, and reading them in the write
+		// transaction can create avoidable optimistic conflicts during commit.
 		let ip = self.new_ip_key(id.clone())?;
-		let Some(v) = tx.get(&ip, None).await? else {
+		let Some(v) = read_tx.get(&ip, None).await? else {
 			return Ok(None);
 		};
 		// Then we take the old value of the appending value as the initial indexing value
@@ -998,7 +1020,7 @@ impl Building {
 		if pa.1 == QueueSequences::LEGACY_BATCH_ID {
 			// Legacy v1 primary appending entry (no batch id; queue stored under !ia).
 			// We can't resolve it to a v2 !ib record, so drop the marker and ignore the legacy queue.
-			tx.del(ip).await?;
+			write_tx.del(ip).await?;
 			if !*v1_appending_sentinel {
 				*v1_appending_sentinel = true;
 				warn!("Found legacy v1 primary appending entry from an older version; legacy queued updates will be ignored. Consider rebuilding index {} on table {}.", self.ix.name, self.ix.what);
@@ -1006,7 +1028,7 @@ impl Building {
 			return Ok(None);
 		}
 		let ib = self.new_ib_key(pa.0, pa.1)?;
-		let v = tx
+		let v = read_tx
 			.get(ib, None)
 			.await?
 			.ok_or_else(|| Error::CorruptedIndex("Appending record is missing"))?;

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -853,6 +853,12 @@ impl Building {
 			if !keys.is_empty() {
 				let ctx = self.new_write_tx_ctx().await?;
 				let tx = ctx.tx();
+				// Snapshot so we can roll back counter-side effects on retry:
+				// tx.cancel() does not undo increments already applied to updates_count
+				// inside index_appending_range, and the same !ib keys will be re-read
+				// and re-processed on the next iteration since their deletions were
+				// rolled back with the transaction.
+				let saved_updates_count = updates_count;
 				match self
 					.index_appending_range(&ctx, &tx, keys, initial_count, &mut updates_count)
 					.await
@@ -875,6 +881,7 @@ impl Building {
 						}
 						Err(Error::TxRetryable) => {
 							let _ = tx.cancel().await;
+							updates_count = saved_updates_count;
 							warn!("{}: transient conflict on commit, retrying batch", self.ix.name);
 							sleep(Duration::from_millis(100)).await;
 						}
@@ -885,6 +892,7 @@ impl Building {
 					},
 					Err(Error::TxRetryable) => {
 						let _ = tx.cancel().await;
+						updates_count = saved_updates_count;
 						warn!(
 							"{}: transient conflict in appending range, retrying batch",
 							self.ix.name

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -162,6 +162,14 @@ impl IndexKey {
 	}
 }
 
+fn is_retryable_transaction_error(err: &Error) -> bool {
+	matches!(err, Error::TxRetryable | Error::TxRetryableConflictCheck)
+}
+
+fn is_initial_build_batch_retryable(err: &Error) -> bool {
+	matches!(err, Error::TxRetryableConflictCheck)
+}
+
 /// The builder for background index creation
 #[derive(Clone)]
 pub(crate) struct IndexBuilder {
@@ -288,7 +296,7 @@ impl IndexBuilder {
 					break;
 				}
 				if let Err(e) = building.index_appending_loop(None).await {
-					if matches!(e, Error::TxRetryable) {
+					if is_retryable_transaction_error(&e) {
 						// Transient conflicts are retried within index_appending_loop,
 						// but handle any that still propagate as a safety net.
 						warn!("{}: deferred daemon transient conflict, retrying", building.ix.name);
@@ -757,7 +765,7 @@ impl Building {
 				break;
 			}
 			self.index_initial_batch_once(
-				batch.result,
+				&batch.result,
 				&mut initial_count,
 				&mut v1_appending_sentinel,
 			)
@@ -880,7 +888,7 @@ impl Building {
 							})
 							.await;
 						}
-						Err(Error::TxRetryable) => {
+						Err(e) if is_retryable_transaction_error(&e) => {
 							let _ = tx.cancel().await;
 							updates_count = saved_updates_count;
 							warn!("{}: transient conflict on commit, retrying batch", self.ix.name);
@@ -891,7 +899,7 @@ impl Building {
 							return Err(e);
 						}
 					},
-					Err(Error::TxRetryable) => {
+					Err(e) if is_retryable_transaction_error(&e) => {
 						let _ = tx.cancel().await;
 						updates_count = saved_updates_count;
 						warn!(
@@ -916,36 +924,76 @@ impl Building {
 	/// Index one initial-build batch.
 	///
 	/// Initial build is expected to be conflict-free. Queue handoff records are read through a
-	/// separate read-only transaction, so commit conflicts here should surface as index build errors
-	/// rather than being hidden by a retry loop.
+	/// separate read-only transaction, so real commit conflicts here should surface as index build
+	/// errors. RocksDB can also return TryAgain when conflict-checking history is unavailable; that
+	/// is not a proven conflict, so retry the same fetched batch with fresh transactions.
 	async fn index_initial_batch_once(
 		&self,
-		values: Vec<(Key, Val)>,
+		values: &[(Key, Val)],
 		count: &mut usize,
 		v1_appending_sentinel: &mut bool,
 	) -> Result<(), Error> {
-		let read_tx = self.new_read_tx().await?;
-		let ctx = self.new_write_tx_ctx().await?;
-		let tx = ctx.tx();
-		let indexed = self
-			.index_initial_batch(&ctx, &read_tx, &tx, values, count, v1_appending_sentinel)
+		loop {
+			let read_tx = self.new_read_tx().await?;
+			let ctx = self.new_write_tx_ctx().await?;
+			let tx = ctx.tx();
+			let mut batch_count = 0;
+			let indexed = self
+				.index_initial_batch(
+					&ctx,
+					&read_tx,
+					&tx,
+					values,
+					&mut batch_count,
+					v1_appending_sentinel,
+				)
+				.await;
+			let cancel_read = read_tx.cancel().await;
+			if let Err(e) = indexed {
+				let _ = tx.cancel().await;
+				if is_initial_build_batch_retryable(&e) {
+					warn!(
+						"{}: conflict checking history unavailable during initial batch at initial={}, retrying",
+						self.ix.name, *count
+					);
+					sleep(Duration::from_millis(100)).await;
+					continue;
+				}
+				return Err(e);
+			}
+			if let Err(e) = cancel_read {
+				let _ = tx.cancel().await;
+				if is_initial_build_batch_retryable(&e) {
+					warn!(
+						"{}: conflict checking history unavailable while cancelling initial batch read at initial={}, retrying",
+						self.ix.name, *count
+					);
+					sleep(Duration::from_millis(100)).await;
+					continue;
+				}
+				return Err(e);
+			}
+			if let Err(e) = tx.commit().await {
+				let _ = tx.cancel().await;
+				if is_initial_build_batch_retryable(&e) {
+					warn!(
+						"{}: conflict checking history unavailable while committing initial batch at initial={}, retrying",
+						self.ix.name, *count
+					);
+					sleep(Duration::from_millis(100)).await;
+					continue;
+				}
+				return Err(e);
+			}
+			*count += batch_count;
+			self.set_status(BuildingStatus::Indexing {
+				initial: Some(*count),
+				pending: Some(self.queue.read().await.pending() as usize),
+				updated: None,
+			})
 			.await;
-		let _ = read_tx.cancel().await;
-		if let Err(e) = indexed {
-			let _ = tx.cancel().await;
-			return Err(e);
+			return Ok(());
 		}
-		if let Err(e) = tx.commit().await {
-			let _ = tx.cancel().await;
-			return Err(e);
-		}
-		self.set_status(BuildingStatus::Indexing {
-			initial: Some(*count),
-			pending: Some(self.queue.read().await.pending() as usize),
-			updated: None,
-		})
-		.await;
-		Ok(())
 	}
 
 	/// Index a batch of records from the table
@@ -954,7 +1002,7 @@ impl Building {
 		ctx: &Context,
 		read_tx: &Transaction,
 		write_tx: &Transaction,
-		values: Vec<(Key, Val)>,
+		values: &[(Key, Val)],
 		count: &mut usize,
 		v1_appending_sentinel: &mut bool,
 	) -> Result<(), Error> {
@@ -964,7 +1012,7 @@ impl Building {
 		// instead of per-document, avoiding repeated BTree load/save overhead.
 		let mut ft_index = IndexOperation::create_ft_index(ctx, &self.opt, &self.ix).await?;
 		// Index the records
-		for (k, v) in values.into_iter() {
+		for (k, v) in values {
 			if self.is_aborted().await {
 				// Finish FtIndex to persist progress made so far in this batch
 				if let Some(ref ft) = ft_index {
@@ -972,9 +1020,9 @@ impl Building {
 				}
 				return Ok(());
 			}
-			let key = thing::Thing::decode(&k)?;
+			let key = thing::Thing::decode(k)?;
 			// Parse the value
-			let val: Value = revision::from_slice(&v)?;
+			let val: Value = revision::from_slice(v)?;
 			let rid: Arc<Thing> = Thing::from((key.tb, key.id)).into();
 
 			// Do we already have an appended value?
@@ -1197,5 +1245,16 @@ impl Drop for DeferredDaemonGuard {
 	fn drop(&mut self) {
 		self.0.deferred_daemon_running.store(false, Ordering::Release);
 		self.0.completion_notify.notify_waiters();
+	}
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn initial_build_batch_retry_predicate_only_matches_conflict_check_gaps() {
+		assert!(is_initial_build_batch_retryable(&Error::TxRetryableConflictCheck));
+		assert!(!is_initial_build_batch_retryable(&Error::TxRetryable));
 	}
 }

--- a/crates/core/src/sql/expression.rs
+++ b/crates/core/src/sql/expression.rs
@@ -123,25 +123,14 @@ impl Expression {
 			} => {
 				let l = l.compute(stk, ctx, opt, doc).await?;
 				match o {
-					Operator::Or => {
-						if l.is_truthy() {
-							return Ok(l);
-						}
+					Operator::Or | Operator::Tco if l.is_truthy() => {
+						return Ok(l);
 					}
-					Operator::And => {
-						if !l.is_truthy() {
-							return Ok(l);
-						}
+					Operator::And if !l.is_truthy() => {
+						return Ok(l);
 					}
-					Operator::Tco => {
-						if l.is_truthy() {
-							return Ok(l);
-						}
-					}
-					Operator::Nco => {
-						if l.is_some() {
-							return Ok(l);
-						}
+					Operator::Nco if l.is_some() => {
+						return Ok(l);
 					}
 					_ => {} // Continue
 				}

--- a/crates/core/src/syn/lexer/byte.rs
+++ b/crates/core/src/syn/lexer/byte.rs
@@ -10,10 +10,7 @@ use crate::syn::{
 impl Lexer<'_> {
 	/// Eats a single line comment.
 	pub(super) fn eat_single_line_comment(&mut self) {
-		loop {
-			let Some(byte) = self.reader.next() else {
-				break;
-			};
+		while let Some(byte) = self.reader.next() {
 			match byte {
 				byte::CR => {
 					self.eat(byte::LF);

--- a/crates/core/src/syn/lexer/compound/datetime.rs
+++ b/crates/core/src/syn/lexer/compound/datetime.rs
@@ -71,10 +71,7 @@ pub fn datetime_inner(lexer: &mut Lexer) -> Result<DateTime<Utc>, SyntaxError> {
 		let mut number = 0u32;
 		let mut count = 0;
 
-		loop {
-			let Some(d) = lexer.reader.peek() else {
-				break;
-			};
+		while let Some(d) = lexer.reader.peek() {
 			if !d.is_ascii_digit() {
 				break;
 			}

--- a/crates/core/src/syn/parser/object.rs
+++ b/crates/core/src/syn/parser/object.rs
@@ -277,46 +277,34 @@ impl Parser<'_> {
 		let ate_comma = self.eat(t!(","));
 		// match the type and then match the coordinates field to a value of that type.
 		match type_value.as_str() {
-			"Point" => {
-				if self.eat(t!("}")) {
-					if let Some(point) = Geometry::array_to_point(&value) {
-						return Ok(Value::Geometry(Geometry::Point(point)));
-					}
+			"Point" if self.eat(t!("}")) => {
+				if let Some(point) = Geometry::array_to_point(&value) {
+					return Ok(Value::Geometry(Geometry::Point(point)));
 				}
 			}
-			"LineString" => {
-				if self.eat(t!("}")) {
-					if let Some(point) = Geometry::array_to_line(&value) {
-						return Ok(Value::Geometry(Geometry::Line(point)));
-					}
+			"LineString" if self.eat(t!("}")) => {
+				if let Some(point) = Geometry::array_to_line(&value) {
+					return Ok(Value::Geometry(Geometry::Line(point)));
 				}
 			}
-			"Polygon" => {
-				if self.eat(t!("}")) {
-					if let Some(point) = Geometry::array_to_polygon(&value) {
-						return Ok(Value::Geometry(Geometry::Polygon(point)));
-					}
+			"Polygon" if self.eat(t!("}")) => {
+				if let Some(point) = Geometry::array_to_polygon(&value) {
+					return Ok(Value::Geometry(Geometry::Polygon(point)));
 				}
 			}
-			"MultiPoint" => {
-				if self.eat(t!("}")) {
-					if let Some(point) = Geometry::array_to_multipolygon(&value) {
-						return Ok(Value::Geometry(Geometry::MultiPolygon(point)));
-					}
+			"MultiPoint" if self.eat(t!("}")) => {
+				if let Some(point) = Geometry::array_to_multipolygon(&value) {
+					return Ok(Value::Geometry(Geometry::MultiPolygon(point)));
 				}
 			}
-			"MultiLineString" => {
-				if self.eat(t!("}")) {
-					if let Some(point) = Geometry::array_to_multiline(&value) {
-						return Ok(Value::Geometry(Geometry::MultiLine(point)));
-					}
+			"MultiLineString" if self.eat(t!("}")) => {
+				if let Some(point) = Geometry::array_to_multiline(&value) {
+					return Ok(Value::Geometry(Geometry::MultiLine(point)));
 				}
 			}
-			"MultiPolygon" => {
-				if self.eat(t!("}")) {
-					if let Some(point) = Geometry::array_to_multipolygon(&value) {
-						return Ok(Value::Geometry(Geometry::MultiPolygon(point)));
-					}
+			"MultiPolygon" if self.eat(t!("}")) => {
+				if let Some(point) = Geometry::array_to_multipolygon(&value) {
+					return Ok(Value::Geometry(Geometry::MultiPolygon(point)));
 				}
 			}
 			_ => {}


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB.

Before proceeding, please add any of the following labels that apply:

* `breaking-change` if this PR includes a breaking change. This label is not needed for bug fixes, which change output in line with a user's original expectations.
* `needs-documentation` if documentation is needed to explain the change made in the PR.
* `Modifies env vars or commands` if any changes are made to environment variables or command flags.

## What is the motivation?

A user reported two issues with deferred `SEARCH` index building:

1. **Indexing slows down badly at scale** - indexing speed per 1,000 records degrades as the table grows, making large deferred full-text builds impractical.
2. **Deferred builds can fail under parallel pressure** - with 1M records and 10 deferred full-text indexes on the same table, RocksDB can return a retryable transaction error during the initial build and the index status becomes `building.status = error`.

## Root causes identified

**Full-text batching overhead:** A new `FtIndex` was created and finished for every document during batch indexing, both in the initial build and appending phases. That repeatedly loaded and persisted the DocIds, DocLengths, Postings, and Terms structures, with cost growing as the index grew. `set_status()` was also called per record.

**Queue handoff contention:** The initial-build write transaction read `!ip` / `!ib` queue handoff records. Those records are written by concurrent user transactions while the initial build scans the table, so the index write transaction could see avoidable optimistic conflicts.

**Daemon/appending contention:** The deferred daemon could be spawned before `initial_build_complete` was visible to `maybe_consume`, allowing user transactions and the daemon to both touch `!ip` keys. Appending-phase retryable transaction failures were also propagated as fatal errors instead of being retried.

**Pending queue cleanup:** Some executor commit/cancel paths called the inner transaction directly. That bypassed the `Transaction` wrapper cleanup for deferred index batches, so failed or cancelled user transactions could leave batch ids pending and make the daemon wait forever.

**RocksDB conflict-check history gaps:** The remaining 1M/10-index repro was not a proven same-key conflict. RocksDB returned `ErrorKind::TryAgain`, which means optimistic conflict checking could not be completed because the needed history was unavailable. That was previously mapped to the same internal error as `ErrorKind::Busy`, so initial builds treated a conflict-check gap as a fatal real conflict.

## What does this change do?

### Batch `FtIndex` work across records

- Add reusable full-text helpers so an `FtIndex` can be reused across multiple documents within a batch.
- In `index_initial_batch` and `index_appending_range`, create the `FtIndex` once before the record loop and call `finish()` once after, instead of per document.
- Move status updates from per record to per batch.

### Keep initial-build queue handoff reads out of the write transaction

- Read queue handoff records (`!ip` / `!ib`) through a separate read-only transaction, outside the index write transaction.
- Update initial-build progress only after a batch commits successfully.

### Retry RocksDB conflict-check gaps without hiding real conflicts

- Add `Error::TxRetryableConflictCheck` for RocksDB conflict-check history gaps.
- Map RocksDB `Busy` to `TxRetryable` and RocksDB `TryAgain` to `TxRetryableConflictCheck`.
- Retry deferred initial-build batches only for `TxRetryableConflictCheck`.
- Keep `TxRetryable` fatal for initial builds, preserving the fail-fast behavior for real read/write conflicts.
- Recreate both the read and write transactions on each retry, cancel failed attempts, sleep briefly, and retry the same fetched batch.
- Use a local `batch_count` and update the visible initial count only after commit, avoiding progress drift across retries.

### Fix daemon/appending contention

- Set `deferred_daemon_running` and complete the initial-build guard before spawning the deferred daemon.
- Use acquire/release ordering for the `initial_build_complete` phase boundary.
- Retry transient appending failures by cancelling the transaction, sleeping briefly, re-reading keys, and retrying the batch.
- Snapshot and restore `updates_count` around appending retries so repeated attempts do not double-count queued records.

### Clean up deferred index batches on rollback/failure

- Route executor commit/cancel paths through the high-level `Transaction::commit()` / `Transaction::cancel()` wrappers.
- This preserves inner transaction behavior while ensuring deferred-index pending batch ids are cleaned up after rollback or failed commit.

### Propagate `FtIndex` finish errors on abort

- In the abort branch of `index_appending_range`, propagate `ft.finish()` errors with `?` so the caller cancels the transaction instead of dequeuing records whose search index state was not persisted.

## What is your testing strategy?

Focused checks:

```bash
cargo fmt -p surrealdb-core
cargo make ci-clippy
cargo test -p surrealdb-core initial_build_batch_retry_predicate_only_matches_conflict_check_gaps -- --nocapture
cargo test -p surrealdb-core --features kv-rocksdb rocksdb_conflict_error_kinds_are_classified_separately -- --nocapture
cargo test -p surrealdb-core --features kv-rocksdb kvs::index::tests::initial_build_batch_retry_predicate_only_matches_conflict_check_gaps -- --nocapture
cargo build --release --bin surreal
git diff --check
```

Customer repro validation:

- Ran the release binary against a 1M-record, 10-deferred-`SEARCH`-index repro with all initial builders running in parallel.
- RocksDB hit the new retry path many times with logs like `conflict checking history unavailable while committing initial batch..., retrying`.
- No index entered `building.status = error`.
- All 10 indexes reached `ready`.
- Final result: `ALL INDEXES READY` at 34.4 minutes.

Known unrelated suite status:

- `cargo test -p surrealdb-core --features kv-rocksdb` still fails with existing unrelated failures observed before this change:
  - `kvs::tests::mem::keysr`
  - `kvs::tests::mem::scanr`
  - `kvs::tests::rocksdb::read_and_deletion_only`

## Security Considerations

No security implications. This changes background deferred index building, transaction cleanup, and retry/error handling for index maintenance. It does not change authentication, authorization, namespace/database isolation, user input handling, or exposed error detail.

## Is this related to any issues?

Related to #7292.

## Have you read the Contributing Guidelines?

* [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
