### PR TITLE
test(language-tests): regression coverage for #7280 (relation UNIQUE + trailing NONE)

### DIFF
--- a/language-tests/tests/reproductions/7280_compound_unique_trailing_none_is_not_null_mechanism.surql
+++ b/language-tests/tests/reproductions/7280_compound_unique_trailing_none_is_not_null_mechanism.surql
@@ -1,0 +1,88 @@
+/**
+[env]
+namespace = true
+database = true
+auth = { level = "owner" }
+
+[test]
+reason = "Compound UNIQUE index: explicit != NONE / > NONE on trailing option column excludes NONE keys (same range mechanism as analyze_compound_conditions NotEqual→MoreThan; relates to #7280)"
+issue = 7280
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ a: 1, b: 1, id: t7280_compound:one }]"
+
+[[test.results]]
+value = "[{ a: 1, b: 1, c: 'x', id: t7280_compound:two }]"
+
+[[test.results]]
+value = "[{ c: NONE, id: t7280_compound:one }, { c: 'x', id: t7280_compound:two }]"
+
+[[test.results]]
+value = "[{ c: 'x', id: t7280_compound:two }]"
+
+[[test.results]]
+value = "[{ c: 'x', id: t7280_compound:two }]"
+
+[[test.results]]
+value = "[{ c: 'x', id: t7280_compound:two }]"
+
+[[test.results]]
+value = "[{ c: 'x', id: t7280_compound:two }]"
+
+[[test.results]]
+value = "[{ c: 'x', id: t7280_compound:two }]"
+
+[[test.results]]
+value = "[{ c: 'x', id: t7280_compound:two }]"
+
+[[test.results]]
+value = "[{ c: NONE, id: t7280_compound:one }]"
+
+*/
+
+DEFINE TABLE OVERWRITE t7280_compound SCHEMAFULL;
+DEFINE FIELD OVERWRITE a ON t7280_compound TYPE int;
+DEFINE FIELD OVERWRITE b ON t7280_compound TYPE int;
+DEFINE FIELD OVERWRITE c ON t7280_compound TYPE option<string>;
+DEFINE INDEX OVERWRITE t7280_compound_abc ON t7280_compound FIELDS a, b, c UNIQUE;
+
+-- Two keys under the same (a,b) prefix: trailing c is NONE vs a string
+CREATE t7280_compound:one SET a = 1, b = 1;
+CREATE t7280_compound:two SET a = 1, b = 1, c = 'x';
+
+-- Prefix on (a,b) only: must see BOTH rows (including c = NONE)
+SELECT id, c FROM t7280_compound WHERE a = 1 AND b = 1 ORDER BY id;
+
+-- Trailing column strictly above NONE: scan excludes NONE-valued index entries
+SELECT id, c FROM t7280_compound WHERE a = 1 AND b = 1 AND c > NONE ORDER BY id;
+
+-- Same as above with WITH NOINDEX (sanity: table scan agrees with index)
+SELECT id, c FROM t7280_compound WITH NOINDEX WHERE a = 1 AND b = 1 AND c > NONE ORDER BY id;
+
+-- NotEqual to NONE is lowered to a strict range above NONE for compound indexes (see exec/index/analysis.rs)
+SELECT id, c FROM t7280_compound WHERE a = 1 AND b = 1 AND c != NONE ORDER BY id;
+
+SELECT id, c FROM t7280_compound WITH NOINDEX WHERE a = 1 AND b = 1 AND c != NONE ORDER BY id;
+
+-- IS NOT NONE: same exclusion of NONE keys as != NONE / > NONE (see exec/index/analysis.rs)
+SELECT id, c FROM t7280_compound WHERE a = 1 AND b = 1 AND c IS NOT NONE ORDER BY id;
+
+SELECT id, c FROM t7280_compound WITH NOINDEX WHERE a = 1 AND b = 1 AND c IS NOT NONE ORDER BY id;
+
+-- Exact match on NONE: must find the NONE row
+SELECT id, c FROM t7280_compound WHERE a = 1 AND b = 1 AND c = NONE ORDER BY id;

--- a/language-tests/tests/reproductions/7280_relation_unique_index_none_phase_scan.surql
+++ b/language-tests/tests/reproductions/7280_relation_unique_index_none_phase_scan.surql
@@ -1,0 +1,99 @@
+/**
+[env]
+namespace = true
+database = true
+auth = { level = "owner" }
+
+[test]
+reason = "RELATION with 3-field UNIQUE index including option field NONE: index scan must return rows matching in/out (issue #7280)"
+issue = 7280
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: project:test_project_1, name: 'Test Project' }]"
+
+[[test.results]]
+value = "[{ id: agent:test_agent_1, is_built_in: false, name: 'Test Agent' }]"
+
+[[test.results]]
+value = "[{ id: uses_agent:x, in: project:test_project_1, is_active: true, out: agent:test_agent_1 }]"
+skip-record-id-key = true
+
+[[test.results]]
+value = "[{ is_active: true }]"
+
+[[test.results]]
+value = "[{ is_active: true }]"
+
+[[test.results]]
+value = "[{ id: uses_agent:x, in: project:test_project_1, out: agent:test_agent_1 }]"
+skip-record-id-key = true
+
+[[test.results]]
+value = "[{ id: uses_agent:x, in: project:test_project_1, is_active: true, out: agent:test_agent_1, phase: 'execution' }]"
+skip-record-id-key = true
+
+[[test.results]]
+value = "[{ is_active: true }]"
+
+*/
+
+DEFINE TABLE OVERWRITE project SCHEMAFULL;
+DEFINE FIELD OVERWRITE name ON project TYPE string;
+DEFINE TABLE OVERWRITE agent SCHEMAFULL;
+DEFINE FIELD OVERWRITE name ON agent TYPE string;
+DEFINE FIELD OVERWRITE is_built_in ON agent TYPE bool;
+DEFINE TABLE OVERWRITE uses_agent SCHEMAFULL TYPE RELATION FROM project TO agent ENFORCED;
+DEFINE FIELD OVERWRITE is_active ON uses_agent TYPE bool DEFAULT false;
+DEFINE FIELD OVERWRITE phase ON uses_agent TYPE option<string> DEFAULT NONE;
+DEFINE INDEX OVERWRITE uses_agent_unique_idx ON uses_agent FIELDS in, out, phase UNIQUE;
+
+CREATE project:test_project_1 CONTENT { name: 'Test Project' };
+CREATE agent:test_agent_1 CONTENT { name: 'Test Agent', is_built_in: false };
+RELATE project:test_project_1 -> uses_agent -> agent:test_agent_1 SET is_active = true;
+
+-- Index plan: must find the NONE-phase edge (reported as [] in v3.0.4+ for some index paths — #7280)
+SELECT is_active FROM uses_agent
+WHERE in = type::record('project', 'test_project_1')
+AND out = type::record('agent', 'test_agent_1');
+
+-- Table scan: must find the row
+SELECT is_active FROM uses_agent WITH NOINDEX
+WHERE in = type::record('project', 'test_project_1')
+AND out = type::record('agent', 'test_agent_1');
+
+-- Graph traversal: must find the edge
+SELECT id, in, out FROM project:test_project_1->uses_agent WHERE is_active = true;
+
+-- Concrete phase value: create second edge with phase set, query by full key (sanity)
+RELATE project:test_project_1 -> uses_agent -> agent:test_agent_1 SET is_active = true, phase = 'execution';
+SELECT is_active FROM uses_agent
+WHERE in = type::record('project', 'test_project_1')
+AND out = type::record('agent', 'test_agent_1')
+AND phase = 'execution';


### PR DESCRIPTION
### What is the motivation?

GitHub issue #7280 reports that on **SurrealDB 3.0.5**, a `SELECT` against a `TYPE RELATION` table with a **3-field `UNIQUE` index** (`in`, `out`, `phase`) can return **no rows** when filtering by **`in` and `out`** with `type::record()`, while the same predicate with **`WITH NOINDEX`** (or graph traversal) returns the edge. **Current `main` does not reproduce that failure**; this PR adds **language tests** so the correct behaviour stays covered.

### What does this change do?

Adds two SurrealQL reproduction files under `language-tests/tests/reproductions/`:

1. **`7280_relation_unique_index_none_phase_scan.surql`** — schema and queries aligned with the issue (relation + `option` field defaulting to `NONE`, composite unique index, indexed `SELECT` vs `WITH NOINDEX`, graph traversal, and a second edge with a concrete `phase`).

2. **`7280_compound_unique_trailing_none_is_not_null_mechanism.surql`** — a minimal **normal table** with the same **3-column unique** pattern, showing that **`> NONE` / `!= NONE` / `IS NOT NONE`** intentionally exclude **NONE** keys under a composite prefix, while a **prefix-only** predicate still returns **NONE** rows. This documents the index-range mechanism discussed in the issue thread (see `exec/index/analysis.rs` around the compound `NotEqual` → `MoreThan` handling for `NULL`/`NONE`).

### What is your testing strategy?

- Ran: `cd language-tests && cargo run -- run 7280_` — all **6** runs (both files × three modes) **pass** on `main`.
- Manually reproduced the reported failure on **SurrealDB 3.0.5** (indexed query empty, `WITH NOINDEX` returns the row); **main** matches the expectations encoded in these tests.

### Security Considerations

Test-only change; no security impact.

### Is this related to any issues?

Closes #7280

### Have you read the Contributing Guidelines?

- [x] I have read the Contributing Guidelines


Made with [Cursor](https://cursor.com)