### PR TITLE
Pre-resolve analyzer when starting an index build

### DIFF
--- a/crates/core/src/doc/index.rs
+++ b/crates/core/src/doc/index.rs
@@ -67,8 +67,10 @@ impl Document {
 			(o, n)
 		};
 
-		// Store all the variables and parameters required by the index operation
-		let mut ic = IndexOperation::new(ctx, opt, ix, o, n, rid);
+		// Store all the variables and parameters required by the index operation.
+		// Document indexing operates on committed schema, so the analyzer (if any)
+		// can be looked up lazily by FtIndex::new from the current transaction.
+		let mut ic = IndexOperation::new(ctx, opt, ix, None, o, n, rid);
 		// Keep track of compaction requests, we need to trigger them after the index operation
 		let mut require_compaction = false;
 		// Execute the index operation

--- a/crates/core/src/idx/ft/mod.rs
+++ b/crates/core/src/idx/ft/mod.rs
@@ -100,15 +100,23 @@ impl FtIndex {
 	pub(crate) async fn new(
 		ctx: &Context,
 		opt: &Options,
-		az: &str,
+		az_name: &str,
+		pre_az: Option<Arc<DefineAnalyzerStatement>>,
 		index_key_base: IndexKeyBase,
 		p: &SearchParams,
 		tt: TransactionType,
 	) -> Result<Self, Error> {
 		let tx = ctx.tx();
 		let ixs = ctx.get_index_stores();
-		let (ns, db) = opt.ns_db()?;
-		let az = tx.get_db_analyzer(ns, db, az).await?;
+		// Use the pre-resolved analyzer when provided (e.g. when starting an index
+		// build inside a user transaction that defines the analyzer in the same
+		// transaction). Otherwise look it up from the current transaction.
+		let az = if let Some(az) = pre_az {
+			az
+		} else {
+			let (ns, db) = opt.ns_db()?;
+			tx.get_db_analyzer(ns, db, az_name).await?
+		};
 		ixs.mappers().check(&az).await?;
 		Self::with_analyzer(ixs, &tx, az, index_key_base, p, tt).await
 	}

--- a/crates/core/src/idx/index.rs
+++ b/crates/core/src/idx/index.rs
@@ -10,16 +10,21 @@ use crate::key::index::iu::IndexCountKey;
 use crate::key::root::ic::IndexCompactionKey;
 use crate::kvs::{Transaction, TransactionType};
 use crate::sql::index::{HnswParams, MTreeParams, SearchParams};
-use crate::sql::statements::DefineIndexStatement;
+use crate::sql::statements::{DefineAnalyzerStatement, DefineIndexStatement};
 use crate::sql::{Array, Index, Part, Thing, Value};
 use reblessive::tree::Stk;
 use std::borrow::Cow;
+use std::sync::Arc;
 use uuid::Uuid;
 
 pub(crate) struct IndexOperation<'a> {
 	ctx: &'a Context,
 	opt: &'a Options,
 	ix: &'a DefineIndexStatement,
+	/// Pre-resolved analyzer (used by background search-index builds when the
+	/// analyzer was defined in the same transaction as the index, so it cannot
+	/// be looked up from a fresh independent transaction).
+	az: Option<Arc<DefineAnalyzerStatement>>,
 	/// The old values (if existing)
 	o: Option<Vec<Value>>,
 	/// The new values (if existing)
@@ -32,6 +37,7 @@ impl<'a> IndexOperation<'a> {
 		ctx: &'a Context,
 		opt: &'a Options,
 		ix: &'a DefineIndexStatement,
+		az: Option<Arc<DefineAnalyzerStatement>>,
 		o: Option<Vec<Value>>,
 		n: Option<Vec<Value>>,
 		rid: &'a Thing,
@@ -40,6 +46,7 @@ impl<'a> IndexOperation<'a> {
 			ctx,
 			opt,
 			ix,
+			az,
 			o,
 			n,
 			rid,
@@ -69,11 +76,12 @@ impl<'a> IndexOperation<'a> {
 		ctx: &Context,
 		opt: &Options,
 		ix: &DefineIndexStatement,
+		az: Option<Arc<DefineAnalyzerStatement>>,
 	) -> Result<Option<FtIndex>, Error> {
 		if let Index::Search(p) = &ix.index {
 			let (ns, db) = opt.ns_db()?;
 			let ikb = IndexKeyBase::new(ns, db, ix)?;
-			Ok(Some(FtIndex::new(ctx, opt, &p.az, ikb, p, TransactionType::Write).await?))
+			Ok(Some(FtIndex::new(ctx, opt, &p.az, az, ikb, p, TransactionType::Write).await?))
 		} else {
 			Ok(None)
 		}
@@ -215,8 +223,16 @@ impl<'a> IndexOperation<'a> {
 		let (ns, db) = self.opt.ns_db()?;
 		let ikb = IndexKeyBase::new(ns, db, self.ix)?;
 
-		let mut ft =
-			FtIndex::new(self.ctx, self.opt, &p.az, ikb, p, TransactionType::Write).await?;
+		let mut ft = FtIndex::new(
+			self.ctx,
+			self.opt,
+			&p.az,
+			self.az.clone(),
+			ikb,
+			p,
+			TransactionType::Write,
+		)
+		.await?;
 
 		if let Some(n) = self.n.take() {
 			ft.index_document(stk, self.ctx, self.opt, self.rid, n).await?;

--- a/crates/core/src/idx/planner/executor.rs
+++ b/crates/core/src/idx/planner/executor.rs
@@ -142,6 +142,7 @@ impl InnerQueryExecutor {
 								ctx,
 								opt,
 								p.az.as_str(),
+								None,
 								ikb,
 								p,
 								TransactionType::Read,

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -532,11 +532,10 @@ struct Building {
 	tf: TransactionFactory,
 	/// The statement that defines the index
 	ix: Arc<DefineIndexStatement>,
-	/// Pre-resolved analyzer for `Index::Search` indexes. Resolved from the
-	/// originating user transaction (which can see the analyzer even when it
-	/// was defined in the same uncommitted transaction as the index), and
-	/// passed through to `IndexOperation` so background-task transactions don't
-	/// have to look it up themselves.
+	/// Pre-resolved analyzer for the initial build of `Index::Search` indexes.
+	/// Resolved from the originating user transaction, which can see the analyzer
+	/// even when it was defined in the same uncommitted transaction as the index.
+	/// Long-running deferred appends intentionally re-resolve schema instead.
 	az: Option<Arc<DefineAnalyzerStatement>>,
 	/// The table name
 	tb: String,
@@ -1093,9 +1092,11 @@ impl Building {
 		let mut rc = false;
 		let mut stack = TreeStack::new();
 		let mut indexed = HashMap::new();
-		// For search indexes, create the FtIndex once for the entire batch
-		let mut ft_index =
-			IndexOperation::create_ft_index(ctx, &self.opt, &self.ix, self.az.clone()).await?;
+		// For search indexes, create the FtIndex once for the entire batch.
+		// Deferred appends must observe analyzer schema changes made after the
+		// initial build, so do not use the analyzer cached for the originating
+		// transaction here.
+		let mut ft_index = IndexOperation::create_ft_index(ctx, &self.opt, &self.ix, None).await?;
 		trace!("{}: index_appending_range STARTS- len: {}", self.ix.name, keys.len());
 		for k in keys {
 			if self.is_aborted().await {
@@ -1116,7 +1117,7 @@ impl Building {
 					ctx,
 					&self.opt,
 					&self.ix,
-					self.az.clone(),
+					None,
 					a.old_values,
 					a.new_values,
 					&rid,

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -13,8 +13,8 @@ use crate::key::thing;
 use crate::kvs::ds::TransactionFactory;
 use crate::kvs::LockType::Optimistic;
 use crate::kvs::{Key, Transaction, TransactionType, Val};
-use crate::sql::statements::DefineIndexStatement;
-use crate::sql::{Id, Object, Thing, Value};
+use crate::sql::statements::{DefineAnalyzerStatement, DefineIndexStatement};
+use crate::sql::{Id, Index, Object, Thing, Value};
 use ahash::{HashMap, HashMapExt};
 use futures::channel::oneshot::{channel, Receiver, Sender};
 use reblessive::TreeStack;
@@ -202,7 +202,9 @@ impl IndexBuilder {
 			let building = if initial_build_done {
 				self.start_deferred_index(ctx, opt.clone(), ix, key).await?
 			} else {
-				self.start_building(ctx, opt.clone(), ix, key, None, true).await?
+				// At server restart time the analyzer is already committed and
+				// visible; lazy lookup in FtIndex::new will succeed, so we pass None.
+				self.start_building(ctx, opt.clone(), ix, None, key, None, true).await?
 			};
 			e.insert(building);
 		}
@@ -210,16 +212,18 @@ impl IndexBuilder {
 	}
 
 	/// Start building an index in the background
+	#[allow(clippy::too_many_arguments)]
 	async fn start_building(
 		&self,
 		ctx: &Context,
 		opt: Options,
 		ix: Arc<DefineIndexStatement>,
+		az: Option<Arc<DefineAnalyzerStatement>>,
 		ix_key: SharedIndexKey,
 		sdr: Option<Sender<Result<(), Error>>>,
 		recover_queue: bool,
 	) -> Result<IndexBuilding, Error> {
-		let building = Arc::new(Building::new(ctx, self.tf.clone(), opt, ix, ix_key)?);
+		let building = Arc::new(Building::new(ctx, self.tf.clone(), opt, ix, az, ix_key)?);
 		if recover_queue {
 			building.recover_queue().await?;
 		};
@@ -267,7 +271,9 @@ impl IndexBuilder {
 		ix: Arc<DefineIndexStatement>,
 		ix_key: SharedIndexKey,
 	) -> Result<IndexBuilding, Error> {
-		let building = Arc::new(Building::new(ctx, self.tf.clone(), opt, ix, ix_key)?);
+		// At server restart time the analyzer is already committed and visible
+		// to any new transaction, so we don't need to pre-resolve it here.
+		let building = Arc::new(Building::new(ctx, self.tf.clone(), opt, ix, None, ix_key)?);
 		building.recover_queue().await?;
 		building.deferred_daemon_running.store(true, Ordering::Release);
 		building.initial_build_complete.store(true, Ordering::Release);
@@ -321,6 +327,16 @@ impl IndexBuilder {
 		} else {
 			(None, None)
 		};
+		// Pre-resolve the analyzer for SEARCH indexes from the user's transaction.
+		// The background build runs in independent transactions which cannot see
+		// the analyzer if it was defined in the same (still uncommitted)
+		// transaction as this index. Resolving here avoids the AzNotFound failure
+		// in the background task; for any other case it's just an early lookup.
+		let az = if let Index::Search(p) = &ix.index {
+			Some(ctx.tx().get_db_analyzer(ns, db, &p.az).await?)
+		} else {
+			None
+		};
 		match self.indexes.write().await.entry(key.clone()) {
 			Entry::Occupied(mut e) => {
 				// If the building is currently running, we need to wait for it to finish
@@ -330,12 +346,12 @@ impl IndexBuilder {
 				// Wait for the old builder to fully stop
 				old_builder.wait_for_completion().await;
 				// Start building the index
-				let ib = self.start_building(ctx, opt, ix, key, sdr, false).await?;
+				let ib = self.start_building(ctx, opt, ix, az, key, sdr, false).await?;
 				e.insert(ib);
 			}
 			Entry::Vacant(e) => {
 				// No index is currently building, we can start building it
-				let ib = self.start_building(ctx, opt, ix, key, sdr, false).await?;
+				let ib = self.start_building(ctx, opt, ix, az, key, sdr, false).await?;
 				e.insert(ib);
 			}
 		}
@@ -516,6 +532,12 @@ struct Building {
 	tf: TransactionFactory,
 	/// The statement that defines the index
 	ix: Arc<DefineIndexStatement>,
+	/// Pre-resolved analyzer for `Index::Search` indexes. Resolved from the
+	/// originating user transaction (which can see the analyzer even when it
+	/// was defined in the same uncommitted transaction as the index), and
+	/// passed through to `IndexOperation` so background-task transactions don't
+	/// have to look it up themselves.
+	az: Option<Arc<DefineAnalyzerStatement>>,
 	/// The table name
 	tb: String,
 	/// The index key
@@ -543,6 +565,7 @@ impl Building {
 		tf: TransactionFactory,
 		opt: Options,
 		ix: Arc<DefineIndexStatement>,
+		az: Option<Arc<DefineAnalyzerStatement>>,
 		ix_key: SharedIndexKey,
 	) -> Result<Self, Error> {
 		Ok(Self {
@@ -551,6 +574,7 @@ impl Building {
 			tf,
 			tb: ix.what.to_raw(),
 			ix,
+			az,
 			ix_key,
 			status: RwLock::new(BuildingStatus::Started),
 			queue: Default::default(),
@@ -962,7 +986,8 @@ impl Building {
 		let mut stack = TreeStack::new();
 		// For search indexes, create the FtIndex once for the entire batch
 		// instead of per-document, avoiding repeated BTree load/save overhead.
-		let mut ft_index = IndexOperation::create_ft_index(ctx, &self.opt, &self.ix).await?;
+		let mut ft_index =
+			IndexOperation::create_ft_index(ctx, &self.opt, &self.ix, self.az.clone()).await?;
 		// Index the records
 		for (k, v) in values.into_iter() {
 			if self.is_aborted().await {
@@ -994,8 +1019,15 @@ impl Building {
 			};
 
 			// Index the record
-			let mut io =
-				IndexOperation::new(ctx, &self.opt, &self.ix, None, opt_values.clone(), &rid);
+			let mut io = IndexOperation::new(
+				ctx,
+				&self.opt,
+				&self.ix,
+				self.az.clone(),
+				None,
+				opt_values.clone(),
+				&rid,
+			);
 			if let Some(ft) = &mut ft_index {
 				stack.enter(|stk| io.compute_search_with_ft(stk, ft)).finish().await?;
 			} else {
@@ -1062,7 +1094,8 @@ impl Building {
 		let mut stack = TreeStack::new();
 		let mut indexed = HashMap::new();
 		// For search indexes, create the FtIndex once for the entire batch
-		let mut ft_index = IndexOperation::create_ft_index(ctx, &self.opt, &self.ix).await?;
+		let mut ft_index =
+			IndexOperation::create_ft_index(ctx, &self.opt, &self.ix, self.az.clone()).await?;
 		trace!("{}: index_appending_range STARTS- len: {}", self.ix.name, keys.len());
 		for k in keys {
 			if self.is_aborted().await {
@@ -1079,8 +1112,15 @@ impl Building {
 			if let Some(v) = tx.get(ib.clone(), None).await? {
 				let a: Appending = revision::from_slice(&v)?;
 				let rid = Thing::from((self.tb.clone(), a.id));
-				let mut io =
-					IndexOperation::new(ctx, &self.opt, &self.ix, a.old_values, a.new_values, &rid);
+				let mut io = IndexOperation::new(
+					ctx,
+					&self.opt,
+					&self.ix,
+					self.az.clone(),
+					a.old_values,
+					a.new_values,
+					&rid,
+				);
 				if let Some(ft) = &mut ft_index {
 					stack.enter(|stk| io.compute_search_with_ft(stk, ft)).finish().await?;
 				} else {

--- a/crates/core/src/kvs/index.rs
+++ b/crates/core/src/kvs/index.rs
@@ -218,12 +218,13 @@ impl IndexBuilder {
 		ctx: &Context,
 		opt: Options,
 		ix: Arc<DefineIndexStatement>,
-		az: Option<Arc<DefineAnalyzerStatement>>,
+		bootstrap_az: Option<Arc<DefineAnalyzerStatement>>,
 		ix_key: SharedIndexKey,
 		sdr: Option<Sender<Result<(), Error>>>,
 		recover_queue: bool,
 	) -> Result<IndexBuilding, Error> {
-		let building = Arc::new(Building::new(ctx, self.tf.clone(), opt, ix, az, ix_key)?);
+		let building =
+			Arc::new(Building::new(ctx, self.tf.clone(), opt, ix, bootstrap_az, ix_key)?);
 		if recover_queue {
 			building.recover_queue().await?;
 		};
@@ -532,11 +533,10 @@ struct Building {
 	tf: TransactionFactory,
 	/// The statement that defines the index
 	ix: Arc<DefineIndexStatement>,
-	/// Pre-resolved analyzer for the initial build of `Index::Search` indexes.
-	/// Resolved from the originating user transaction, which can see the analyzer
-	/// even when it was defined in the same uncommitted transaction as the index.
-	/// Long-running deferred appends intentionally re-resolve schema instead.
-	az: Option<Arc<DefineAnalyzerStatement>>,
+	/// Bootstrap analyzer for the initial build of `Index::Search` indexes.
+	/// This is only used until the background transaction can see the same
+	/// analyzer definition as the originating user transaction.
+	bootstrap_az: RwLock<Option<Arc<DefineAnalyzerStatement>>>,
 	/// The table name
 	tb: String,
 	/// The index key
@@ -564,7 +564,7 @@ impl Building {
 		tf: TransactionFactory,
 		opt: Options,
 		ix: Arc<DefineIndexStatement>,
-		az: Option<Arc<DefineAnalyzerStatement>>,
+		bootstrap_az: Option<Arc<DefineAnalyzerStatement>>,
 		ix_key: SharedIndexKey,
 	) -> Result<Self, Error> {
 		Ok(Self {
@@ -573,7 +573,7 @@ impl Building {
 			tf,
 			tb: ix.what.to_raw(),
 			ix,
-			az,
+			bootstrap_az: RwLock::new(bootstrap_az),
 			ix_key,
 			status: RwLock::new(BuildingStatus::Started),
 			queue: Default::default(),
@@ -971,6 +971,38 @@ impl Building {
 		Ok(())
 	}
 
+	async fn initial_build_analyzer(
+		&self,
+		ctx: &Context,
+	) -> Result<Option<Arc<DefineAnalyzerStatement>>, Error> {
+		// Prefer normal schema resolution once the background transaction sees
+		// the same analyzer as the originating user transaction. Until then, the
+		// bootstrap analyzer is needed for same-transaction definitions.
+		let Index::Search(p) = &self.ix.index else {
+			return Ok(None);
+		};
+		let Some(bootstrap_az) = self.bootstrap_az.read().await.clone() else {
+			return Ok(None);
+		};
+		let (ns, db) = self.opt.ns_db()?;
+		match ctx.tx().get_db_analyzer(ns, db, &p.az).await {
+			Ok(current_az) if current_az.as_ref() == bootstrap_az.as_ref() => {
+				let mut stored_az = self.bootstrap_az.write().await;
+				if let Some(current_stored_az) = stored_az.as_ref() {
+					if current_stored_az.as_ref() == bootstrap_az.as_ref() {
+						*stored_az = None;
+					}
+				}
+				Ok(None)
+			}
+			Ok(_)
+			| Err(Error::AzNotFound {
+				..
+			}) => Ok(Some(bootstrap_az)),
+			Err(e) => Err(e),
+		}
+	}
+
 	/// Index a batch of records from the table
 	async fn index_initial_batch(
 		&self,
@@ -983,10 +1015,11 @@ impl Building {
 	) -> Result<(), Error> {
 		let mut rc = false;
 		let mut stack = TreeStack::new();
+		let az = self.initial_build_analyzer(ctx).await?;
 		// For search indexes, create the FtIndex once for the entire batch
 		// instead of per-document, avoiding repeated BTree load/save overhead.
 		let mut ft_index =
-			IndexOperation::create_ft_index(ctx, &self.opt, &self.ix, self.az.clone()).await?;
+			IndexOperation::create_ft_index(ctx, &self.opt, &self.ix, az.clone()).await?;
 		// Index the records
 		for (k, v) in values.into_iter() {
 			if self.is_aborted().await {
@@ -1022,7 +1055,7 @@ impl Building {
 				ctx,
 				&self.opt,
 				&self.ix,
-				self.az.clone(),
+				az.clone(),
 				None,
 				opt_values.clone(),
 				&rid,

--- a/crates/core/src/sql/statements/analyze.rs
+++ b/crates/core/src/sql/statements/analyze.rs
@@ -44,9 +44,16 @@ impl AnalyzeStatement {
 				// Index operation dispatching
 				let value: Value = match &ix.index {
 					Index::Search(p) => {
-						let ft =
-							FtIndex::new(ctx, opt, p.az.as_str(), ikb, p, TransactionType::Read)
-								.await?;
+						let ft = FtIndex::new(
+							ctx,
+							opt,
+							p.az.as_str(),
+							None,
+							ikb,
+							p,
+							TransactionType::Read,
+						)
+						.await?;
 						ft.statistics(ctx).await?.into()
 					}
 					Index::MTree(p) => {

--- a/crates/language-tests/Cargo.lock
+++ b/crates/language-tests/Cargo.lock
@@ -3371,7 +3371,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb-core"
-version = "2.6.2"
+version = "2.6.5"
 dependencies = [
  "addr",
  "affinitypool",

--- a/crates/language-tests/tests/language/statements/define/index/search_deferred_analyzer_overwrite.surql
+++ b/crates/language-tests/tests/language/statements/define/index/search_deferred_analyzer_overwrite.surql
@@ -1,0 +1,46 @@
+/**
+[env]
+# Extra timeout because this test sleeps to wait for the deferred daemon.
+timeout = 5000
+
+[test]
+issue = 7234
+reason = "Deferred SEARCH index appends must re-resolve the analyzer after the initial build, so DEFINE ANALYZER OVERWRITE changes are observed by both indexing and querying."
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: article:1 }]"
+
+[[test.results]]
+match = """
+$result.building.status == 'ready'
+"""
+*/
+
+DEFINE ANALYZER deferredSearch TOKENIZERS blank;
+DEFINE INDEX search_title ON article FIELDS title SEARCH ANALYZER deferredSearch BM25(1.2, 0.75) CONCURRENTLY DEFER;
+SLEEP 1s;
+
+DEFINE ANALYZER OVERWRITE deferredSearch TOKENIZERS blank FILTERS lowercase;
+CREATE article:1 CONTENT { title: 'HELLO' } RETURN NONE;
+SLEEP 1s;
+
+SELECT id FROM article WHERE title @@ 'hello';
+INFO FOR INDEX search_title ON article;

--- a/crates/language-tests/tests/language/statements/define/index/search_same_tx_analyzer_overwrite.surql
+++ b/crates/language-tests/tests/language/statements/define/index/search_same_tx_analyzer_overwrite.surql
@@ -1,0 +1,39 @@
+/**
+[env]
+timeout = 4000
+
+[test]
+issue = 7234
+reason = "A SEARCH index defined in the same transaction as DEFINE ANALYZER OVERWRITE must use the uncommitted overwritten analyzer, even when a background build transaction can still see the previous committed analyzer."
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: article:1 }]"
+
+[[test.results]]
+match = """
+$result.building.status == 'ready'
+"""
+*/
+
+DEFINE ANALYZER sameTxOverwriteSearch TOKENIZERS blank;
+CREATE article:1 CONTENT { title: 'HELLO' } RETURN NONE;
+
+BEGIN;
+DEFINE ANALYZER OVERWRITE sameTxOverwriteSearch TOKENIZERS blank FILTERS lowercase;
+DEFINE INDEX search_title ON article FIELDS title SEARCH ANALYZER sameTxOverwriteSearch BM25(1.2, 0.75);
+COMMIT;
+
+SELECT id FROM article WHERE title @@ 'hello';
+INFO FOR INDEX search_title ON article;

--- a/crates/language-tests/tests/language/statements/define/index/search_same_tx_blocking.surql
+++ b/crates/language-tests/tests/language/statements/define/index/search_same_tx_blocking.surql
@@ -1,0 +1,36 @@
+/**
+[env]
+# Extra timeout because this test sleeps to wait for the background build.
+timeout = 4000
+
+[test]
+issue = 7234
+reason = "DEFINE ANALYZER and a SEARCH index in the same BEGIN/COMMIT transaction must not leave the index in an `error` state because the background build cannot see the not-yet-committed analyzer. Variant: blocking (no CONCURRENTLY) — the DEFINE INDEX itself must not return an `analyzer not found` error."
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+match = """
+$result.building.status == 'ready'
+"""
+*/
+
+CREATE |accounts:5| CONTENT { firstName: rand::string(5), lastName: rand::string(5), emailAddress: rand::string(5) } RETURN NONE;
+
+BEGIN;
+DEFINE ANALYZER accounts_adminSearch TOKENIZERS blank FILTERS lowercase, ascii, edgengram(1, 50);
+DEFINE INDEX _adminSearch ON accounts FIELDS firstName, lastName, emailAddress SEARCH ANALYZER accounts_adminSearch BM25(1.2, 0.75);
+COMMIT;
+
+SLEEP 1s;
+INFO FOR INDEX _adminSearch ON accounts;

--- a/crates/language-tests/tests/language/statements/define/index/search_same_tx_concurrently.surql
+++ b/crates/language-tests/tests/language/statements/define/index/search_same_tx_concurrently.surql
@@ -1,0 +1,36 @@
+/**
+[env]
+# Extra timeout because this test sleeps to wait for the background build.
+timeout = 4000
+
+[test]
+issue = 7234
+reason = "DEFINE ANALYZER and a SEARCH index in the same BEGIN/COMMIT transaction must not leave the index in an `error` state because the background build cannot see the not-yet-committed analyzer. Variant: CONCURRENTLY (no DEFER)."
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+match = """
+$result.building.status == 'ready'
+"""
+*/
+
+CREATE |accounts:5| CONTENT { firstName: rand::string(5), lastName: rand::string(5), emailAddress: rand::string(5) } RETURN NONE;
+
+BEGIN;
+DEFINE ANALYZER accounts_adminSearch TOKENIZERS blank FILTERS lowercase, ascii, edgengram(1, 50);
+DEFINE INDEX _adminSearch ON accounts FIELDS firstName, lastName, emailAddress SEARCH ANALYZER accounts_adminSearch BM25(1.2, 0.75) CONCURRENTLY;
+COMMIT;
+
+SLEEP 1s;
+INFO FOR INDEX _adminSearch ON accounts;

--- a/crates/language-tests/tests/language/statements/define/index/search_same_tx_concurrently_defer.surql
+++ b/crates/language-tests/tests/language/statements/define/index/search_same_tx_concurrently_defer.surql
@@ -1,0 +1,36 @@
+/**
+[env]
+# Extra timeout because this test sleeps to wait for the background build.
+timeout = 4000
+
+[test]
+issue = 7234
+reason = "DEFINE ANALYZER and a SEARCH index in the same BEGIN/COMMIT transaction must not leave the index in an `error` state because the background build cannot see the not-yet-committed analyzer. Variant: CONCURRENTLY DEFER (original report)."
+
+[[test.results]]
+value = "[]"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+match = """
+$result.building.status == 'ready'
+"""
+*/
+
+CREATE |accounts:5| CONTENT { firstName: rand::string(5), lastName: rand::string(5), emailAddress: rand::string(5) } RETURN NONE;
+
+BEGIN;
+DEFINE ANALYZER accounts_adminSearch TOKENIZERS blank FILTERS lowercase, ascii, edgengram(1, 50);
+DEFINE INDEX _adminSearch ON accounts FIELDS firstName, lastName, emailAddress SEARCH ANALYZER accounts_adminSearch BM25(1.2, 0.75) CONCURRENTLY DEFER;
+COMMIT;
+
+SLEEP 1s;
+INFO FOR INDEX _adminSearch ON accounts;

--- a/crates/language-tests/tests/migration/search_index.surql
+++ b/crates/language-tests/tests/migration/search_index.surql
@@ -5,9 +5,13 @@
 value = "NONE"
 
 [[test.results]]
+value = "NONE"
+
+[[test.results]]
 value = '''[{ details: '', error: "The `SEARCH` index has been renamed to `FULLTEXT` and some of it's parameters have been removed", kind: 'search index', location: { column: 21, kind: 'error', length: 24, line: 1, source: 'DEFINE INDEX f ON t1 FULLTEXT ANALYZER az VS', truncation: 'none' }, origin: ['ns', 'test', 'db', 'test', 'table', 't1', 'index', 'f'], severity: 'unlikely_break' }]'''
 
 */
 
+DEFINE ANALYZER az TOKENIZERS blank;
 DEFINE INDEX f ON t1 SEARCH ANALYZER az VS DOC_IDS_ORDER 50;
 migration::diagnose()


### PR DESCRIPTION
## What is the motivation?

When `DEFINE ANALYZER` and `DEFINE INDEX ... SEARCH ANALYZER ... [CONCURRENTLY [DEFER]]` are issued in the same `BEGIN/COMMIT` transaction, the background index builder creates independent transactions that cannot see the still-uncommitted analyzer. The build fails with `"The analyzer '<name>' does not exist"` and the index is left in a permanent error state, which `INFO FOR INDEX` then surfaces.

After rebasing on #7274, the fix also needs to preserve the existing deferred-index behavior for long-running appends: analyzer schema changes made after the initial build, such as `DEFINE ANALYZER ... OVERWRITE`, must be observed by the deferred daemon instead of reusing a stale analyzer snapshot forever.

## What does this change do?

Pre-resolves the analyzer from the user's transaction (where it is visible) inside `IndexBuilder::build`, then uses that resolved `Arc<DefineAnalyzerStatement>` as bootstrap state for the initial build. Initial background batches use the bootstrap analyzer only until their background transaction can see the same committed analyzer definition; after that the bootstrap value is cleared and normal schema resolution is used again.

- `FtIndex::new` accepts an optional pre-resolved analyzer; the existing `tx.get_db_analyzer(...)` lookup remains the default for callers operating against committed schema.
- `IndexOperation` carries the optional analyzer and forwards it from `index_full_text`.
- `IndexOperation::create_ft_index` also accepts the optional analyzer so #7274's batched full-text indexing path can use the same bootstrap analyzer during the initial build.
- `Building` stores the pre-resolved analyzer as clearable bootstrap state, avoiding a stale analyzer snapshot for the whole initial build.
- Deferred appending passes `None`, so the deferred daemon re-resolves the current analyzer schema for later batches.
- All other call sites (`doc/index.rs`, `analyze.rs`, `planner/executor.rs`, `restart_deferred_index`, `start_deferred_index`) pass `None` and keep the existing lazy-lookup behaviour.

A side benefit: a missing analyzer name on a `SEARCH` index now fails synchronously during `DEFINE INDEX` execution instead of only being discovered later via `INFO FOR INDEX`.

## What is your testing strategy?

Language tests under `crates/language-tests/tests/language/statements/define/index/` cover the same-transaction analyzer/index cases and the deferred analyzer refresh case:

- `search_same_tx_concurrently_defer.surql` — direct reproduction of the reported case (`CONCURRENTLY DEFER`).
- `search_same_tx_concurrently.surql` — `CONCURRENTLY` (no `DEFER`).
- `search_same_tx_blocking.surql` — blocking `DEFINE INDEX` (no `CONCURRENTLY`).
- `search_same_tx_analyzer_overwrite.surql` — verifies that same-transaction `DEFINE ANALYZER OVERWRITE` plus `DEFINE INDEX` uses the uncommitted overwritten analyzer, even if a background transaction can still see the older committed analyzer.
- `search_deferred_analyzer_overwrite.surql` — verifies that deferred appends re-resolve an overwritten analyzer instead of reusing the initial analyzer snapshot.

The migration search-index test now defines its analyzer explicitly because missing analyzers fail synchronously.

Checks run:

- `cargo fmt -p surrealdb-core`
- `cargo run run search_deferred_analyzer_overwrite`
- `cargo run run search_same_tx_analyzer_overwrite`
- `cargo run run search_same_tx`
- `cargo run run migration/search_index`
- `cargo run run search_`
- `cargo make ci-clippy`

## Security Considerations

No security implications. The change does not alter authentication, authorization, namespace/database isolation, or how user input reaches the query engine; it only changes when an already-visible analyzer definition is read and ensures deferred appends continue to observe current analyzer schema.

## Is this related to any issues?

Fixes #7234

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)