### PR TITLE
Respond with a failure when an in-flight WebSocket request is cancelled

### DIFF
--- a/surrealdb/server/src/rpc/websocket.rs
+++ b/surrealdb/server/src/rpc/websocket.rs
@@ -40,6 +40,10 @@ const SERVER_OVERLOADED: &str = "The server is unable to handle the request";
 /// An error string sent when the server is gracefully shutting down
 const SERVER_SHUTTING_DOWN: &str = "The server is gracefully shutting down";
 
+/// An error string sent when an in-flight RPC is dropped because the
+/// connection-level `canceller` fires (e.g. the WebSocket has been torn down).
+const REQUEST_CANCELLED: &str = "The request was cancelled because the WebSocket is closing";
+
 pub struct Websocket {
 	/// The unique id of this WebSocket connection
 	pub(crate) id: Uuid,
@@ -349,12 +353,35 @@ impl Websocket {
 					let otel_cx = Arc::new(TelemetryContext::current_with_value(
 						req_cx.with_method(req.method.to_str()).with_size(len),
 					));
+					// Capture the request id, session id and a cloned channel handle up-front so we
+					// can still build a `DbResponse::failure` if the cancel branch wins the
+					// select below — by the time it fires, `req` and `chn` will have been moved
+					// into the inner `async move`.
+					let req_id = req.id.clone();
+					let req_session_id = req.session_id;
+					let cancel_chn = chn.clone();
+					let cancel_otel_cx = otel_cx.clone();
+					let cancel_format = rpc.format;
 					// Process the message
 					tokio::select! {
-						//
 						biased;
-						// Check if we should teardown
-						_ = canceller.cancelled() => (),
+						// The connection-level `canceller` has fired: the in-flight handler
+						// future is about to be dropped (along with any transaction it owns).
+						// Resource cleanup is handled by each `Transactable::Drop` impl
+						// (notably `DSTransaction::Drop`, which spawns a recovery abort), so
+						// the only thing left to do here is to make sure the client receives a
+						// terminating response — without it the SDK keeps awaiting a reply
+						// that will never come and the connection deadlocks.
+						_ = canceller.cancelled() => {
+							crate::rpc::response::send(
+								DbResponse::failure(req_id, req_session_id.map(Into::into), TypesError::internal(REQUEST_CANCELLED.to_string())),
+								cancel_otel_cx.clone(),
+								cancel_format,
+								cancel_chn
+							)
+								.with_context(cancel_otel_cx.as_ref().clone())
+								.await;
+						},
 						// Wait for the message to be processed
 						_ = async move {
 							// Don't start processing if we are gracefully shutting down


### PR DESCRIPTION
## What is the motivation?

When the connection-level `canceller` fires mid-request inside `Websocket::handle_message` (e.g. a write error tears the socket down, the keep-alive ping fails, or the server forces a close after `ALLOC.is_beyond_threshold()`), the in-flight handler future is simply dropped:

```rust
tokio::select! {
    biased;
    _ = canceller.cancelled() => (),  // silently drops the inner future
    _ = async move { ... } => (),
}
```

This has two consequences:

1. **(cosmetic)** The dropped future owns the request's `Arc<Transaction>`, so the transaction is torn down without ever invoking `commit` or `cancel`. Every storage backend's `Transactable::Drop` cleans up its own resources, so no actual leak, but `Transactor::Drop` rightly logs `"A transaction was dropped without being committed or cancelled"` at `error!` for every writable transaction caught mid-flight.
2. **(user-visible deadlock)** No `DbResponse` is ever sent on the cancel branch. A client that correlates responses by request id — every official SDK does — keeps awaiting a reply that will never arrive. Under heavy concurrency every client worker eventually parks on an in-flight `query()` future and the connection deadlocks.

The deadlock was reproduced under a high-concurrency CRUD workload (12 connections × 24 worker threads × 100k samples): both client and server process trees sat at ~0% CPU with the WebSocket still `ESTABLISHED`.

## What does this change do?

Make the cancel arm send a `DbResponse::failure` with a new `REQUEST_CANCELLED` reason before returning, instead of dropping the future silently. The request id, session id, channel handle, format and otel context are captured up-front so the cancel arm can build the response after `req` and `chn` have been moved into the wait arm's `async move`.

If the `write` task has already exited by the time the cancel arm runs, `chn.send` returns `Err` and the response is dropped — but in that case the WebSocket sink halves are gone too, so the client observes a clean TCP EOF and surfaces the failure to its in-flight requests rather than hanging on them.

The diff is +30 / −3 lines in `surrealdb/server/src/rpc/websocket.rs` and preserves the existing semantics (cancellation still cancels the in-flight future); it only adds the missing courtesy reply.

## What is your testing strategy?

- `cargo check -p surrealdb-server` and `cargo clippy -p surrealdb-server --no-deps` are clean.
- `cargo +nightly fmt -- --check surrealdb/server/src/rpc/websocket.rs` is clean.
- Manual repro / regression check for reviewers:
  1. Open a WebSocket connection and start a long-running query (or many concurrent queries).
  2. Force the server to close the connection while a request is in flight (e.g. trigger `ALLOC.is_beyond_threshold()` or simulate a socket teardown so `canceller.cancel()` fires).
  3. Before this change: the SDK's in-flight `query()` future hangs forever.
  4. After this change: the SDK's `query()` resolves with a failure carrying the `REQUEST_CANCELLED` message, and the client unwinds cleanly.

## Security Considerations

No security impact. The change only ensures an existing error path emits a terminating RPC response with a fixed, non-secret error string. There are no changes to authentication, authorization, session handling, namespace/database isolation, the query engine surface, or any user-controlled resource limits, and no new user input is processed.

## Is this related to any issues?

* [x] No related issues

## Have you read the Contributing Guidelines?

* [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)