### PR TITLE
Fix concurrent index conflicts and batch full-text indexing

### DIFF
--- a/surrealdb/core/src/idx/index.rs
+++ b/surrealdb/core/src/idx/index.rs
@@ -87,6 +87,19 @@ impl<'a> IndexOperation<'a> {
 		self
 	}
 
+	pub(crate) async fn create_fulltext_index(
+		ctx: &FrozenContext,
+		ns: NamespaceId,
+		db: DatabaseId,
+		ix: &IndexDefinition,
+	) -> Result<Option<FullTextIndex>> {
+		let Index::FullText(p) = &ix.index else {
+			return Ok(None);
+		};
+		let ikb = IndexKeyBase::new(ns, db, ix.table_name.clone(), ix.index_id);
+		Ok(Some(FullTextIndex::new(ctx.get_index_stores(), &ctx.tx(), ikb, p).await?))
+	}
+
 	pub(crate) async fn compute(
 		&mut self,
 		stk: &mut Stk,
@@ -307,11 +320,20 @@ impl<'a> IndexOperation<'a> {
 		p: &FullTextParams,
 		require_compaction: &mut bool,
 	) -> Result<()> {
-		let mut rc = false;
 		// Build a FullText instance
 		let fti =
 			FullTextIndex::new(self.ctx.get_index_stores(), &self.ctx.tx(), self.ikb.clone(), p)
 				.await?;
+		self.compute_fulltext_with_index(stk, &fti, require_compaction).await
+	}
+
+	pub(crate) async fn compute_fulltext_with_index(
+		&mut self,
+		stk: &mut Stk,
+		fti: &FullTextIndex,
+		require_compaction: &mut bool,
+	) -> Result<()> {
+		let mut rc = false;
 		// Delete the old index data
 		let doc_id = if let Some(o) = self.o.take() {
 			fti.remove_content(stk, self.ctx, self.opt, self.rid, o, &mut rc).await?

--- a/surrealdb/core/src/kvs/index.rs
+++ b/surrealdb/core/src/kvs/index.rs
@@ -847,70 +847,89 @@ impl Building {
 		let fulltext_index =
 			IndexOperation::create_fulltext_index(ctx, self.ix_key.ns, self.ix_key.db, &self.ix)
 				.await?;
-		// Index the records.
-		for (k, v) in values {
-			if self.is_aborted().await {
-				return Ok(count);
-			}
-			self.is_beyond_threshold(Some(initial_count + count))?;
-			let key = record::RecordKey::decode_key(&k)?;
-			// Parse the value.
-			let val = Record::kv_decode_value(v)?;
-			let rid: Arc<RecordId> = RecordId {
-				table: key.tb.into_owned(),
-				key: key.id,
-			}
-			.into();
+		let lookup_tx = self.new_read_tx().await?;
+		let result = async {
+			// Index the records.
+			for (k, v) in values {
+				if self.is_aborted().await {
+					return Ok(count);
+				}
+				self.is_beyond_threshold(Some(initial_count + count))?;
+				let key = record::RecordKey::decode_key(&k)?;
+				// Parse the value.
+				let val = Record::kv_decode_value(v)?;
+				let rid: Arc<RecordId> = RecordId {
+					table: key.tb.into_owned(),
+					key: key.id,
+				}
+				.into();
 
-			// Is there already a queued update for this record?
-			let opt_values = if let Some(a) =
-				self.check_existing_primary_appending(&rid.key, v1_appending_sentinel).await?
-			{
-				a.old_values
-			} else {
-				// Otherwise, proceed with normal indexing.
-				let doc = CursorDoc::new(Some(rid.clone()), None, val);
-				stack
-					.enter(|stk| Document::build_opt_values(stk, ctx, &self.opt, &self.ix, &doc))
-					.finish()
+				// Is there already a queued update for this record?
+				let opt_values = if let Some(a) = self
+					.check_existing_primary_appending(&lookup_tx, &rid.key, v1_appending_sentinel)
 					.await?
-			};
-			// Index the record.
-			let mut io = IndexOperation::new(
-				ctx,
-				&self.opt,
-				self.ix_key.ns,
-				self.ix_key.db,
-				self.tb,
-				&self.ix,
-				None,
-				opt_values.clone(),
-				&rid,
-			);
-			if let Some(fulltext_index) = &fulltext_index {
-				stack
-					.enter(|stk| io.compute_fulltext_with_index(stk, fulltext_index, &mut rc))
-					.finish()
-					.await?;
-			} else {
-				stack.enter(|stk| io.compute(stk, &mut rc)).finish().await?;
-			}
+				{
+					a.old_values
+				} else {
+					// Otherwise, proceed with normal indexing.
+					let doc = CursorDoc::new(Some(rid.clone()), None, val);
+					stack
+						.enter(|stk| {
+							Document::build_opt_values(stk, ctx, &self.opt, &self.ix, &doc)
+						})
+						.finish()
+						.await?
+				};
+				// Index the record.
+				let mut io = IndexOperation::new(
+					ctx,
+					&self.opt,
+					self.ix_key.ns,
+					self.ix_key.db,
+					self.tb,
+					&self.ix,
+					None,
+					opt_values.clone(),
+					&rid,
+				);
+				if let Some(fulltext_index) = &fulltext_index {
+					stack
+						.enter(|stk| io.compute_fulltext_with_index(stk, fulltext_index, &mut rc))
+						.finish()
+						.await?;
+				} else {
+					stack.enter(|stk| io.compute(stk, &mut rc)).finish().await?;
+				}
 
-			// Increment the count.
-			count += 1;
+				// Increment the count.
+				count += 1;
+			}
+			// Trigger compaction if needed.
+			self.check_index_compaction(tx, &mut rc).await?;
+			// We're done.
+			Ok(count)
 		}
-		// Trigger compaction if needed.
-		self.check_index_compaction(tx, &mut rc).await?;
-		// We're done.
-		Ok(count)
+		.await;
+		let cancel_result = lookup_tx.cancel().await;
+		match result {
+			Ok(count) => {
+				cancel_result?;
+				Ok(count)
+			}
+			Err(err) => {
+				let _ = cancel_result;
+				Err(err)
+			}
+		}
 	}
 
 	async fn check_existing_primary_appending(
 		&self,
+		lookup_tx: &Transaction,
 		id_key: &RecordIdKey,
 		v1_appending_sentinel: &mut bool,
 	) -> Result<Option<Appending>> {
-		match self.load_existing_primary_appending(id_key).await? {
+		match self.load_existing_primary_appending(lookup_tx, id_key).await? {
 			ExistingPrimaryAppending::None => Ok(None),
 			ExistingPrimaryAppending::Appending(appending) => Ok(Some(appending)),
 			ExistingPrimaryAppending::Legacy => {
@@ -929,25 +948,21 @@ impl Building {
 
 	async fn load_existing_primary_appending(
 		&self,
+		tx: &Transaction,
 		id_key: &RecordIdKey,
 	) -> Result<ExistingPrimaryAppending> {
-		let tx = self.new_read_tx().await?;
 		let ip = self.ikb.new_ip_key(id_key.clone());
-		let Some(pa) = catch!(tx, tx.get(&ip, None).await) else {
-			tx.cancel().await?;
+		let Some(pa) = tx.get(&ip, None).await? else {
 			return Ok(ExistingPrimaryAppending::None);
 		};
 		// Use the old values from the queued update as the initial indexing input.
 		if pa.1 == QueueSequences::LEGACY_BATCH_ID {
-			tx.cancel().await?;
 			return Ok(ExistingPrimaryAppending::Legacy);
 		}
 		let ig = self.ikb.new_ig_key(pa.0, pa.1);
-		let Some(appending) = catch!(tx, tx.get(&ig, None).await) else {
-			tx.cancel().await?;
+		let Some(appending) = tx.get(&ig, None).await? else {
 			return Err(Error::CorruptedIndex("Appending record is missing").into());
 		};
-		tx.cancel().await?;
 		Ok(ExistingPrimaryAppending::Appending(appending))
 	}
 

--- a/surrealdb/core/src/kvs/index.rs
+++ b/surrealdb/core/src/kvs/index.rs
@@ -335,6 +335,12 @@ impl PrimaryAppending {
 	}
 }
 
+enum ExistingPrimaryAppending {
+	None,
+	Legacy,
+	Appending(Appending),
+}
+
 /// Tracks sequence numbers and batches for the background indexing queue.
 struct QueueSequences {
 	/// Number of queued appends awaiting indexing.
@@ -662,18 +668,27 @@ impl Building {
 				let ctx = self.new_write_tx_ctx().await?;
 				let tx = ctx.tx();
 				// Index the batch.
-				catch!(
+				let indexed = catch!(
 					tx,
 					self.index_initial_batch(
 						&ctx,
 						&tx,
 						batch.result,
-						&mut initial_count,
+						initial_count,
 						&mut v1_appending_sentinel
 					)
 					.await
 				);
 				catch!(tx, tx.commit().await);
+				initial_count += indexed;
+				if !self.is_aborted().await {
+					self.set_status(BuildingStatus::Indexing {
+						initial: Some(initial_count),
+						pending: Some(self.queue.read().await.pending() as usize),
+						updated: None,
+					})
+					.await;
+				}
 			}
 		}
 		// Mark initial build as complete before entering the appending phase.
@@ -815,10 +830,11 @@ impl Building {
 		ctx: &FrozenContext,
 		tx: &Transaction,
 		values: Vec<(Key, Val)>,
-		count: &mut usize,
+		initial_count: usize,
 		v1_appending_sentinel: &mut bool,
-	) -> Result<()> {
+	) -> Result<usize> {
 		let mut rc = false;
+		let mut count = 0;
 		let mut stack = TreeStack::new();
 		let fulltext_index =
 			IndexOperation::create_fulltext_index(ctx, self.ix_key.ns, self.ix_key.db, &self.ix)
@@ -826,9 +842,9 @@ impl Building {
 		// Index the records.
 		for (k, v) in values {
 			if self.is_aborted().await {
-				return Ok(());
+				return Ok(count);
 			}
-			self.is_beyond_threshold(Some(*count))?;
+			self.is_beyond_threshold(Some(initial_count + count))?;
 			let key = record::RecordKey::decode_key(&k)?;
 			// Parse the value.
 			let val = Record::kv_decode_value(v)?;
@@ -840,7 +856,7 @@ impl Building {
 
 			// Is there already a queued update for this record?
 			let opt_values = if let Some(a) =
-				self.check_existing_primary_appending(tx, &rid.key, v1_appending_sentinel).await?
+				self.check_existing_primary_appending(&rid.key, v1_appending_sentinel).await?
 			{
 				a.old_values
 			} else {
@@ -873,51 +889,87 @@ impl Building {
 			}
 
 			// Increment the count.
-			*count += 1;
+			count += 1;
 		}
-		self.set_status(BuildingStatus::Indexing {
-			initial: Some(*count),
-			pending: Some(self.queue.read().await.pending() as usize),
-			updated: None,
-		})
-		.await;
 		// Trigger compaction if needed.
 		self.check_index_compaction(tx, &mut rc).await?;
 		// We're done.
-		Ok(())
+		Ok(count)
 	}
 
 	async fn check_existing_primary_appending(
 		&self,
-		tx: &Transaction,
 		id_key: &RecordIdKey,
 		v1_appending_sentinel: &mut bool,
 	) -> Result<Option<Appending>> {
+		match self.load_existing_primary_appending(id_key).await? {
+			ExistingPrimaryAppending::None => Ok(None),
+			ExistingPrimaryAppending::Appending(appending) => Ok(Some(appending)),
+			ExistingPrimaryAppending::Legacy => {
+				self.cleanup_legacy_primary_appending(id_key).await?;
+				if !*v1_appending_sentinel {
+					*v1_appending_sentinel = true;
+					warn!(
+						"Found legacy v1 primary appending entry from an older version; legacy queued updates will be ignored. Consider rebuilding index {} on table {}.",
+						self.ix.name, self.ix.table_name
+					);
+				}
+				Ok(None)
+			}
+		}
+	}
+
+	async fn load_existing_primary_appending(
+		&self,
+		id_key: &RecordIdKey,
+	) -> Result<ExistingPrimaryAppending> {
+		let tx = self.new_read_tx().await?;
 		let ip = self.ikb.new_ip_key(id_key.clone());
-		let Some(pa) = tx.get(&ip, None).await? else {
-			return Ok(None);
+		let Some(pa) = catch!(tx, tx.get(&ip, None).await) else {
+			tx.cancel().await?;
+			return Ok(ExistingPrimaryAppending::None);
 		};
 		// Use the old values from the queued update as the initial indexing input.
 		if pa.1 == QueueSequences::LEGACY_BATCH_ID {
-			// Legacy v1 primary appending entry (no batch id; queue stored under !ia).
-			// We can't resolve it to a v2 !ig record, so drop the marker and ignore the legacy
-			// queue.
-			tx.del(&ip).await?;
-			if !*v1_appending_sentinel {
-				*v1_appending_sentinel = true;
-				warn!(
-					"Found legacy v1 primary appending entry from an older version; legacy queued updates will be ignored. Consider rebuilding index {} on table {}.",
-					self.ix.name, self.ix.table_name
-				);
-			}
-			return Ok(None);
+			tx.cancel().await?;
+			return Ok(ExistingPrimaryAppending::Legacy);
 		}
-		let ib = self.ikb.new_ig_key(pa.0, pa.1);
-		let appending = tx
-			.get(&ib, None)
-			.await?
-			.ok_or_else(|| Error::CorruptedIndex("Appending record is missing"))?;
-		Ok(Some(appending))
+		let ig = self.ikb.new_ig_key(pa.0, pa.1);
+		let Some(appending) = catch!(tx, tx.get(&ig, None).await) else {
+			tx.cancel().await?;
+			return Err(Error::CorruptedIndex("Appending record is missing").into());
+		};
+		tx.cancel().await?;
+		Ok(ExistingPrimaryAppending::Appending(appending))
+	}
+
+	async fn cleanup_legacy_primary_appending(&self, id_key: &RecordIdKey) -> Result<()> {
+		// Legacy v1 primary appending entries have no batch id and cannot be resolved to a
+		// current !ig record. Clean them outside the initial-build write transaction so
+		// normal concurrent appends cannot make that transaction conflict.
+		let ctx = self.new_write_tx_ctx().await?;
+		let tx = ctx.tx();
+		let ip = self.ikb.new_ip_key(id_key.clone());
+		let pa = catch!(tx, tx.get(&ip, None).await);
+		if matches!(pa, Some(pa) if pa.1 == QueueSequences::LEGACY_BATCH_ID) {
+			catch!(tx, tx.del(&ip).await);
+		}
+		let res = tx.commit().await;
+		match res {
+			Ok(()) => Ok(()),
+			Err(err) if is_retryable_transaction_conflict(&err) => {
+				let _ = tx.cancel().await;
+				warn!(
+					"{}: transient conflict while cleaning legacy primary appending entry; continuing",
+					self.ix.name
+				);
+				Ok(())
+			}
+			Err(err) => {
+				let _ = tx.cancel().await;
+				Err(err)
+			}
+		}
 	}
 
 	async fn index_appending_range(

--- a/surrealdb/core/src/kvs/index.rs
+++ b/surrealdb/core/src/kvs/index.rs
@@ -770,9 +770,7 @@ impl Building {
 				let ctx = self.new_write_tx_ctx().await?;
 				let tx = ctx.tx();
 				let saved_updates_count = *updates_count;
-				let indexed = match self
-					.index_appending_range(&ctx, &tx, keys, initial_count, updates_count)
-					.await
+				let indexed = match self.index_appending_range(&ctx, &tx, keys, updates_count).await
 				{
 					Ok(indexed) => indexed,
 					Err(err) if is_retryable_transaction_conflict(&err) => {
@@ -791,7 +789,9 @@ impl Building {
 				match commit_result {
 					Ok(()) => {
 						// Clean up completed appendings and drop any stale rollback batch IDs.
-						if !indexed.is_empty() {
+						let pending = if indexed.is_empty() {
+							self.queue.read().await.pending() as usize
+						} else {
 							{
 								let mut clean_queue = self.clean_queue.lock().await;
 								for batch_id in indexed.keys() {
@@ -802,8 +802,16 @@ impl Building {
 									}
 								}
 							}
-							self.queue.write().await.clean(indexed);
-						}
+							let mut queue = self.queue.write().await;
+							queue.clean(indexed);
+							queue.pending() as usize
+						};
+						self.set_status(BuildingStatus::Indexing {
+							initial: Some(initial_count),
+							pending: Some(pending),
+							updated: Some(*updates_count),
+						})
+						.await;
 					}
 					Err(err) if is_retryable_transaction_conflict(&err) => {
 						let _ = tx.cancel().await;
@@ -977,7 +985,6 @@ impl Building {
 		ctx: &FrozenContext,
 		tx: &Transaction,
 		keys: Vec<Key>,
-		initial: usize,
 		count: &mut usize,
 	) -> Result<HashMap<BatchId, Vec<AppendingId>>> {
 		let mut rc = false;
@@ -1026,12 +1033,6 @@ impl Building {
 			*count += 1;
 			indexed.entry(ig.batch_id).or_insert(vec![]).push(ig.appending_id);
 		}
-		self.set_status(BuildingStatus::Indexing {
-			initial: Some(initial),
-			pending: Some(self.queue.read().await.pending() as usize),
-			updated: Some(*count),
-		})
-		.await;
 		// Trigger compaction if needed.
 		self.check_index_compaction(tx, &mut rc).await?;
 		// We're done.

--- a/surrealdb/core/src/kvs/index.rs
+++ b/surrealdb/core/src/kvs/index.rs
@@ -81,6 +81,16 @@ impl BuildingStatus {
 	}
 }
 
+fn is_retryable_transaction_conflict(err: &anyhow::Error) -> bool {
+	if let Some(kvs_err) = err.downcast_ref::<crate::kvs::Error>() {
+		return kvs_err.is_retryable();
+	}
+	matches!(
+		err.downcast_ref::<Error>(),
+		Some(Error::Kvs(kvs_err)) if kvs_err.is_retryable()
+	)
+}
+
 impl From<BuildingStatus> for Value {
 	fn from(st: BuildingStatus) -> Self {
 		let mut o = Object::default();
@@ -473,6 +483,13 @@ impl Building {
 		}
 	}
 
+	async fn mark_initial_build_complete(&self) {
+		// Hold the queue lock while flipping the phase flag so any subsequent
+		// consumer observes appending mode before it can enqueue more work.
+		let _queue = self.queue.write().await;
+		self.initial_build_complete.store(true, Ordering::Release);
+	}
+
 	async fn maybe_consume(
 		&self,
 		ctx: &FrozenContext,
@@ -514,8 +531,8 @@ impl Building {
 		// where `check_existing_primary_appending` uses it to find the latest appending
 		// for a record being initially indexed. Once the initial build is complete
 		// (appending phase), we skip setting ip to avoid write-write conflicts with the
-		// appending daemon which deletes ip keys.
-		if !self.initial_build_complete.load(Ordering::Relaxed) {
+		// appending phase which deletes ip keys.
+		if !self.initial_build_complete.load(Ordering::Acquire) {
 			let ip = self.ikb.new_ip_key(rid.key.clone());
 			let pa = tx.get(&ip, None).await?;
 			// We ignore legacy primary indexing.
@@ -660,7 +677,7 @@ impl Building {
 			}
 		}
 		// Mark initial build as complete before entering the appending phase.
-		self.initial_build_complete.store(true, Ordering::Relaxed);
+		self.mark_initial_build_complete().await;
 		// Second pass: index/remove records that changed during the initial pass.
 		self.set_status(BuildingStatus::Indexing {
 			initial: Some(initial_count),
@@ -669,6 +686,21 @@ impl Building {
 		})
 		.await;
 		let mut updates_count = 0;
+		self.index_appending_loop(
+			initial_count,
+			&mut updates_count,
+			&mut last_prepare_remove_check,
+		)
+		.await?;
+		Ok(())
+	}
+
+	async fn index_appending_loop(
+		&self,
+		initial_count: usize,
+		updates_count: &mut usize,
+		last_prepare_remove_check: &mut Instant,
+	) -> Result<()> {
 		let rng = self.ikb.new_ig_range()?;
 		loop {
 			if self.is_aborted().await {
@@ -676,7 +708,7 @@ impl Building {
 			}
 			self.is_beyond_threshold(None)?;
 			// Check the index still exists and has not been marked for removal
-			self.check_prepare_remove(&mut last_prepare_remove_check).await?;
+			self.check_prepare_remove(last_prepare_remove_check).await?;
 
 			let keys = {
 				let mut queue = self.queue.write().await;
@@ -702,7 +734,7 @@ impl Building {
 					self.set_status(BuildingStatus::Ready {
 						initial: Some(initial_count),
 						pending: Some(pending),
-						updated: Some(updates_count),
+						updated: Some(*updates_count),
 					})
 					.await;
 					break;
@@ -711,7 +743,7 @@ impl Building {
 				self.set_status(BuildingStatus::Indexing {
 					initial: Some(initial_count),
 					pending: Some(pending),
-					updated: Some(updates_count),
+					updated: Some(*updates_count),
 				})
 				.await;
 				drop(queue);
@@ -722,23 +754,53 @@ impl Building {
 				// Create a new context with a write transaction.
 				let ctx = self.new_write_tx_ctx().await?;
 				let tx = ctx.tx();
-				let indexed = catch!(
-					tx,
-					self.index_appending_range(&ctx, &tx, keys, initial_count, &mut updates_count)
-						.await
-				);
-				catch!(tx, tx.commit().await);
-				// Clean up completed appendings and drop any stale rollback batch IDs.
-				if !indexed.is_empty() {
-					{
-						let mut clean_queue = self.clean_queue.lock().await;
-						for batch_id in indexed.keys() {
-							if let Some(idx) = clean_queue.iter().position(|&id| id == *batch_id) {
-								clean_queue.remove(idx);
+				let saved_updates_count = *updates_count;
+				let indexed = match self
+					.index_appending_range(&ctx, &tx, keys, initial_count, updates_count)
+					.await
+				{
+					Ok(indexed) => indexed,
+					Err(err) if is_retryable_transaction_conflict(&err) => {
+						let _ = tx.cancel().await;
+						*updates_count = saved_updates_count;
+						warn!("{}: transient conflict in appending range, retrying", self.ix.name);
+						sleep(Duration::from_millis(100)).await;
+						continue;
+					}
+					Err(err) => {
+						let _ = tx.cancel().await;
+						return Err(err);
+					}
+				};
+				let commit_result = tx.commit().await;
+				match commit_result {
+					Ok(()) => {
+						// Clean up completed appendings and drop any stale rollback batch IDs.
+						if !indexed.is_empty() {
+							{
+								let mut clean_queue = self.clean_queue.lock().await;
+								for batch_id in indexed.keys() {
+									if let Some(idx) =
+										clean_queue.iter().position(|&id| id == *batch_id)
+									{
+										clean_queue.remove(idx);
+									}
+								}
 							}
+							self.queue.write().await.clean(indexed);
 						}
 					}
-					self.queue.write().await.clean(indexed);
+					Err(err) if is_retryable_transaction_conflict(&err) => {
+						let _ = tx.cancel().await;
+						*updates_count = saved_updates_count;
+						warn!("{}: transient conflict on commit, retrying", self.ix.name);
+						sleep(Duration::from_millis(100)).await;
+						continue;
+					}
+					Err(err) => {
+						let _ = tx.cancel().await;
+						return Err(err);
+					}
 				}
 			} else {
 				// No committed appends yet, but updates are in-flight; wait.
@@ -758,6 +820,9 @@ impl Building {
 	) -> Result<()> {
 		let mut rc = false;
 		let mut stack = TreeStack::new();
+		let fulltext_index =
+			IndexOperation::create_fulltext_index(ctx, self.ix_key.ns, self.ix_key.db, &self.ix)
+				.await?;
 		// Index the records.
 		for (k, v) in values {
 			if self.is_aborted().await {
@@ -798,17 +863,24 @@ impl Building {
 				opt_values.clone(),
 				&rid,
 			);
-			stack.enter(|stk| io.compute(stk, &mut rc)).finish().await?;
+			if let Some(fulltext_index) = &fulltext_index {
+				stack
+					.enter(|stk| io.compute_fulltext_with_index(stk, fulltext_index, &mut rc))
+					.finish()
+					.await?;
+			} else {
+				stack.enter(|stk| io.compute(stk, &mut rc)).finish().await?;
+			}
 
-			// Increment the count and update the status.
+			// Increment the count.
 			*count += 1;
-			self.set_status(BuildingStatus::Indexing {
-				initial: Some(*count),
-				pending: Some(self.queue.read().await.pending() as usize),
-				updated: None,
-			})
-			.await;
 		}
+		self.set_status(BuildingStatus::Indexing {
+			initial: Some(*count),
+			pending: Some(self.queue.read().await.pending() as usize),
+			updated: None,
+		})
+		.await;
 		// Trigger compaction if needed.
 		self.check_index_compaction(tx, &mut rc).await?;
 		// We're done.
@@ -859,6 +931,9 @@ impl Building {
 		let mut rc = false;
 		let mut stack = TreeStack::new();
 		let mut indexed = HashMap::new();
+		let fulltext_index =
+			IndexOperation::create_fulltext_index(ctx, self.ix_key.ns, self.ix_key.db, &self.ix)
+				.await?;
 		for k in keys {
 			if self.is_aborted().await {
 				return Ok(indexed);
@@ -881,7 +956,14 @@ impl Building {
 					appending.new_values,
 					&rid,
 				);
-				stack.enter(|stk| io.compute(stk, &mut rc)).finish().await?;
+				if let Some(fulltext_index) = &fulltext_index {
+					stack
+						.enter(|stk| io.compute_fulltext_with_index(stk, fulltext_index, &mut rc))
+						.finish()
+						.await?;
+				} else {
+					stack.enter(|stk| io.compute(stk, &mut rc)).finish().await?;
+				}
 				tx.del(&ig).await?;
 
 				// We can delete the ip record if any
@@ -890,14 +972,14 @@ impl Building {
 			}
 
 			*count += 1;
-			self.set_status(BuildingStatus::Indexing {
-				initial: Some(initial),
-				pending: Some(self.queue.read().await.pending() as usize),
-				updated: Some(*count),
-			})
-			.await;
 			indexed.entry(ig.batch_id).or_insert(vec![]).push(ig.appending_id);
 		}
+		self.set_status(BuildingStatus::Indexing {
+			initial: Some(initial),
+			pending: Some(self.queue.read().await.pending() as usize),
+			updated: Some(*count),
+		})
+		.await;
 		// Trigger compaction if needed.
 		self.check_index_compaction(tx, &mut rc).await?;
 		// We're done.


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉

Before proceeding, please add any of the following labels that apply:

* `breaking-change` if this PR includes a breaking change. This label is not needed for bug fixes, which change output in line with a user's original expectations.
* `needs-documentation` if documentation is needed to explain the change made in the PR.
* `Modifies env vars or commands` if any changes are made to environment variables or command flags.

## What is the motivation?

Concurrent index building can fail or degrade badly when records are modified while the builder is scanning the table or draining pending index updates.

The conflict risk comes from three behaviours:

1. The initial-build write transaction read `!ip` / `!ig` queue handoff records. Those records are written by concurrent user transactions while the initial build scans the table, so the initial-build write transaction could see optimistic read/write conflicts even though initial indexing should stay conflict-free and fail-fast.
2. `maybe_consume` could still write `!ip` keys after the initial build phase because `initial_build_complete` used relaxed ordering. The appending phase deletes those same `!ip` keys, so stale phase visibility can create write-write conflicts.
3. `index_appending_range` and the following `tx.commit()` used `catch!`, so retryable storage conflicts were treated as fatal build errors instead of being retried.

Full-text concurrent builds also recreated `FullTextIndex` for every document in a batch. That repeatedly reloads analyzer/index state and causes unnecessary overhead as batch size grows.

## What does this change do?

This change keeps the initial build out of active queue handoff contention, makes concurrent index appending resilient to transient transaction conflicts, and reduces full-text indexing overhead.

* Reads initial-build `!ip` / `!ig` handoff records through a separate read-only transaction instead of the initial-build write transaction.
* Reuses one read-only handoff lookup transaction for each initial indexing batch, avoiding a new read transaction per indexed record.
* Keeps initial-build progress publication after the batch commit succeeds, so `initial` status does not advance for an uncommitted batch.
* Keeps legacy primary-appending cleanup outside the initial-build write transaction, with guarded cleanup for the old batch-id-0 sentinel.
* Adds retry handling around appending batch processing and commit. Retryable `TransactionConflict` errors now cancel the current transaction, restore the appending `updated` counter to its pre-attempt value, sleep briefly, rescan the pending keys, and retry.
* Publishes appending progress only after the appending transaction commits and completed queue entries have been cleaned, so `updated` status reflects committed work.
* Changes `initial_build_complete` to an acquire/release phase boundary and flips it while holding the queue lock, so new consumers cannot keep enqueueing `!ip` keys after the builder enters the appending phase.
* Adds reusable full-text helpers to create one `FullTextIndex` per indexing transaction/batch, then reuses it across all records in that batch instead of recreating it per document.
* Moves `BuildingStatus::Indexing` updates out of the per-record loops, preserving the same final `initial`, `pending`, and `updated` values with fewer lock acquisitions.

No public API, SQL syntax, wire format, catalog schema, environment variable, or command flag changes are included.

## What is your testing strategy?

Ran the focused concurrent-index and formatting checks:

```bash
cargo fmt -p surrealdb-core
cargo test -p surrealdb-core index_appending -- --nocapture
cargo test -p surrealdb-core define_statement_index_concurrently_building_status -- --nocapture
cargo test -p surrealdb-core multi_index_concurrent_test_create_update_delete -- --nocapture
git diff --check
```

The concurrent building-status tests cover both standard and full-text concurrent index builds with updates/deletes during indexing. The multi-index stress test covers concurrent create/update/delete workloads across multiple full-text indexes with compaction running. In the latest local run, `index_appending` compiled `surrealdb-core` successfully but matched 0 runnable tests in this package.

## Security Considerations

No direct security implications. This change is limited to background index building, transaction retry handling, status accounting, and full-text index batching. It does not touch authentication, authorization, session handling, namespace/database isolation rules, user-controlled resource limits, or error responses exposed to users.

## Is this related to any issues?

Related to #7274.

## Have you read the Contributing Guidelines?

* [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
