### PR TITLE
Add doc comments for docs.rs

### DIFF
--- a/surrealdb/src/method/authenticate.rs
+++ b/surrealdb/src/method/authenticate.rs
@@ -8,7 +8,7 @@ use crate::opt::auth::{RefreshToken, Token};
 use crate::types::SurrealValue;
 use crate::{Connection, Error, Result, Surreal};
 
-/// An authentication future
+/// Returned by [`Surreal::authenticate`](crate::Surreal::authenticate) to attach a JWT (or refresh-token variant) to this connection.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Authenticate<'r, C: Connection, T = ()> {

--- a/surrealdb/src/method/authenticate.rs
+++ b/surrealdb/src/method/authenticate.rs
@@ -8,7 +8,8 @@ use crate::opt::auth::{RefreshToken, Token};
 use crate::types::SurrealValue;
 use crate::{Connection, Error, Result, Surreal};
 
-/// Returned by [`Surreal::authenticate`](crate::Surreal::authenticate) to attach a JWT (or refresh-token variant) to this connection.
+/// Returned by [`Surreal::authenticate`](crate::Surreal::authenticate) to attach a JWT (or
+/// refresh-token variant) to this connection.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Authenticate<'r, C: Connection, T = ()> {

--- a/surrealdb/src/method/begin.rs
+++ b/surrealdb/src/method/begin.rs
@@ -4,7 +4,11 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, Transaction};
 use crate::{Connection, OnceLockExt, Result, Surreal};
 
-/// From [`Surreal::begin`](crate::Surreal::begin). Yields a [`Transaction`](crate::method::Transaction) that can then take [queries](crate::method::Transaction::query), then be [committed](crate::method::Transaction::commit) or [cancelled](crate::method::Transaction::cancel).
+/// From [`Surreal::begin`](crate::Surreal::begin). Yields a
+/// [`Transaction`](crate::method::Transaction) that can then take
+/// [queries](crate::method::Transaction::query), then be
+/// [committed](crate::method::Transaction::commit) or
+/// [cancelled](crate::method::Transaction::cancel).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Begin<C: Connection> {

--- a/surrealdb/src/method/begin.rs
+++ b/surrealdb/src/method/begin.rs
@@ -4,7 +4,7 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, Transaction};
 use crate::{Connection, OnceLockExt, Result, Surreal};
 
-/// A beginning of a transaction
+/// From [`Surreal::begin`](crate::Surreal::begin). Yields a [`Transaction`](crate::method::Transaction) that can then take [queries](crate::method::Transaction::query), then be [committed](crate::method::Transaction::commit) or [cancelled](crate::method::Transaction::cancel).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Begin<C: Connection> {

--- a/surrealdb/src/method/cancel.rs
+++ b/surrealdb/src/method/cancel.rs
@@ -4,7 +4,7 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, Transaction};
 use crate::{Connection, OnceLockExt, Result, Surreal};
 
-/// A transaction cancellation future
+/// From [`Transaction::cancel`](crate::method::Transaction::cancel); rolls back the open transaction and yields the [`Surreal`](crate::Surreal) client again.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Cancel<C: Connection> {

--- a/surrealdb/src/method/cancel.rs
+++ b/surrealdb/src/method/cancel.rs
@@ -4,7 +4,8 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, Transaction};
 use crate::{Connection, OnceLockExt, Result, Surreal};
 
-/// From [`Transaction::cancel`](crate::method::Transaction::cancel); rolls back the open transaction and yields the [`Surreal`](crate::Surreal) client again.
+/// From [`Transaction::cancel`](crate::method::Transaction::cancel); rolls back the open
+/// transaction and yields the [`Surreal`](crate::Surreal) client again.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Cancel<C: Connection> {

--- a/surrealdb/src/method/commit.rs
+++ b/surrealdb/src/method/commit.rs
@@ -4,7 +4,7 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, Transaction};
 use crate::{Connection, OnceLockExt, Result, Surreal};
 
-/// A transaction commit future
+/// From [`Transaction::commit`](crate::method::Transaction::commit); persists the open transaction and yields the [`Surreal`](crate::Surreal) client again.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Commit<C: Connection> {

--- a/surrealdb/src/method/commit.rs
+++ b/surrealdb/src/method/commit.rs
@@ -4,7 +4,8 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, Transaction};
 use crate::{Connection, OnceLockExt, Result, Surreal};
 
-/// From [`Transaction::commit`](crate::method::Transaction::commit); persists the open transaction and yields the [`Surreal`](crate::Surreal) client again.
+/// From [`Transaction::commit`](crate::method::Transaction::commit); persists the open transaction
+/// and yields the [`Surreal`](crate::Surreal) client again.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Commit<C: Connection> {

--- a/surrealdb/src/method/content.rs
+++ b/surrealdb/src/method/content.rs
@@ -9,7 +9,9 @@ use crate::method::{BoxFuture, OnceLockExt};
 use crate::types::{SurrealValue, Value};
 use crate::{Connection, Result, Surreal};
 
-/// Payload from [`Update::content`](crate::method::Update::content), [`Upsert::content`](crate::method::Upsert::content), or [`Create::content`](crate::method::Create::content) (replaces the record body).
+/// Payload from [`Update::content`](crate::method::Update::content),
+/// [`Upsert::content`](crate::method::Upsert::content), or
+/// [`Create::content`](crate::method::Create::content) (replaces the record body).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Content<'r, C: Connection, R> {

--- a/surrealdb/src/method/content.rs
+++ b/surrealdb/src/method/content.rs
@@ -9,9 +9,7 @@ use crate::method::{BoxFuture, OnceLockExt};
 use crate::types::{SurrealValue, Value};
 use crate::{Connection, Result, Surreal};
 
-/// A content future
-///
-/// Content inserts or replaces the contents of a record entirely
+/// Payload from [`Update::content`](crate::method::Update::content), [`Upsert::content`](crate::method::Upsert::content), or [`Create::content`](crate::method::Create::content) (replaces the record body).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Content<'r, C: Connection, R> {

--- a/surrealdb/src/method/create.rs
+++ b/surrealdb/src/method/create.rs
@@ -12,7 +12,7 @@ use crate::opt::Resource;
 use crate::types::{SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// A record create future
+/// Returned by [`Surreal::create`](crate::Surreal::create) for `CREATE`-style inserts.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Create<'r, C: Connection, R> {

--- a/surrealdb/src/method/delete.rs
+++ b/surrealdb/src/method/delete.rs
@@ -11,7 +11,7 @@ use crate::opt::Resource;
 use crate::types::{RecordIdKeyRange, SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// A record delete future
+/// Returned by [`Surreal::delete`](crate::Surreal::delete) for `DELETE` on a table, range, or record.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Delete<'r, C: Connection, R> {

--- a/surrealdb/src/method/delete.rs
+++ b/surrealdb/src/method/delete.rs
@@ -11,7 +11,8 @@ use crate::opt::Resource;
 use crate::types::{RecordIdKeyRange, SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// Returned by [`Surreal::delete`](crate::Surreal::delete) for `DELETE` on a table, range, or record.
+/// Returned by [`Surreal::delete`](crate::Surreal::delete) for `DELETE` on a table, range, or
+/// record.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Delete<'r, C: Connection, R> {

--- a/surrealdb/src/method/export.rs
+++ b/surrealdb/src/method/export.rs
@@ -14,7 +14,8 @@ use crate::conn::{Command, MlExportConfig};
 use crate::method::{BoxFuture, ExportConfig as Config, Model, OnceLockExt};
 use crate::{Connection, Error, ExtraFeatures, Result, Surreal};
 
-/// Returned by [`Surreal::export`](crate::Surreal::export). File targets complete in place, while `()` targets resolve to [`Backup`] for streaming chunks.
+/// Returned by [`Surreal::export`](crate::Surreal::export). File targets complete in place, while
+/// `()` targets resolve to [`Backup`] for streaming chunks.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Export<'r, C: Connection, R, T = ()> {
@@ -285,7 +286,8 @@ where
 	}
 }
 
-/// Byte chunks from [`Export`] when the destination is `()` (see [`Surreal::export`](crate::Surreal::export)).
+/// Byte chunks from [`Export`] when the destination is `()` (see
+/// [`Surreal::export`](crate::Surreal::export)).
 #[derive(Debug, Clone)]
 #[must_use = "streams do nothing unless you poll them"]
 pub struct Backup {

--- a/surrealdb/src/method/export.rs
+++ b/surrealdb/src/method/export.rs
@@ -14,7 +14,7 @@ use crate::conn::{Command, MlExportConfig};
 use crate::method::{BoxFuture, ExportConfig as Config, Model, OnceLockExt};
 use crate::{Connection, Error, ExtraFeatures, Result, Surreal};
 
-/// A database export future
+/// Returned by [`Surreal::export`](crate::Surreal::export). File targets complete in place, while `()` targets resolve to [`Backup`] for streaming chunks.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Export<'r, C: Connection, R, T = ()> {
@@ -285,7 +285,7 @@ where
 	}
 }
 
-/// A stream of exported data
+/// Byte chunks from [`Export`] when the destination is `()` (see [`Surreal::export`](crate::Surreal::export)).
 #[derive(Debug, Clone)]
 #[must_use = "streams do nothing unless you poll them"]
 pub struct Backup {

--- a/surrealdb/src/method/health.rs
+++ b/surrealdb/src/method/health.rs
@@ -5,7 +5,7 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, OnceLockExt};
 use crate::{Connection, Result, Surreal};
 
-/// A health check future
+/// Returned by [`Surreal::health`](crate::Surreal::health), completing successfully when the server reports healthy.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Health<'r, C: Connection> {

--- a/surrealdb/src/method/health.rs
+++ b/surrealdb/src/method/health.rs
@@ -5,7 +5,8 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, OnceLockExt};
 use crate::{Connection, Result, Surreal};
 
-/// Returned by [`Surreal::health`](crate::Surreal::health), completing successfully when the server reports healthy.
+/// Returned by [`Surreal::health`](crate::Surreal::health), completing successfully when the server
+/// reports healthy.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Health<'r, C: Connection> {

--- a/surrealdb/src/method/import.rs
+++ b/surrealdb/src/method/import.rs
@@ -7,7 +7,7 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, Model, OnceLockExt};
 use crate::{Connection, Error, ExtraFeatures, Result, Surreal};
 
-/// An database import future
+/// Returned by [`Surreal::import`](crate::Surreal::import) to restore from a `.surql` backup file.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Import<'r, C: Connection, T = ()> {

--- a/surrealdb/src/method/insert.rs
+++ b/surrealdb/src/method/insert.rs
@@ -13,7 +13,7 @@ use crate::opt::Resource;
 use crate::types::{SurrealValue, Value, Variables};
 use crate::{Connection, Error, Result, Surreal};
 
-/// An insert future
+/// Returned by [`Surreal::insert`](crate::Surreal::insert) for `INSERT` batches; use [`Insert::relation`](Insert::relation) for graph edges.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Insert<'r, C: Connection, R> {

--- a/surrealdb/src/method/insert.rs
+++ b/surrealdb/src/method/insert.rs
@@ -13,7 +13,8 @@ use crate::opt::Resource;
 use crate::types::{SurrealValue, Value, Variables};
 use crate::{Connection, Error, Result, Surreal};
 
-/// Returned by [`Surreal::insert`](crate::Surreal::insert) for `INSERT` batches; use [`Insert::relation`](Insert::relation) for graph edges.
+/// Returned by [`Surreal::insert`](crate::Surreal::insert) for `INSERT` batches; use
+/// [`Insert::relation`](Insert::relation) for graph edges.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Insert<'r, C: Connection, R> {

--- a/surrealdb/src/method/insert_relation.rs
+++ b/surrealdb/src/method/insert_relation.rs
@@ -8,7 +8,8 @@ use crate::method::OnceLockExt;
 use crate::types::{SurrealValue, Value};
 use crate::{Connection, Result, Surreal};
 
-/// Returned by [`Insert::relation`](crate::method::Insert::relation) after [`Surreal::insert`](crate::Surreal::insert) for `RELATE`-style inserts.
+/// Returned by [`Insert::relation`](crate::method::Insert::relation) after
+/// [`Surreal::insert`](crate::Surreal::insert) for `RELATE`-style inserts.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct InsertRelation<'r, C: Connection, R> {

--- a/surrealdb/src/method/insert_relation.rs
+++ b/surrealdb/src/method/insert_relation.rs
@@ -8,7 +8,7 @@ use crate::method::OnceLockExt;
 use crate::types::{SurrealValue, Value};
 use crate::{Connection, Result, Surreal};
 
-/// An Insert Relation future
+/// Returned by [`Insert::relation`](crate::method::Insert::relation) after [`Surreal::insert`](crate::Surreal::insert) for `RELATE`-style inserts.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct InsertRelation<'r, C: Connection, R> {

--- a/surrealdb/src/method/invalidate.rs
+++ b/surrealdb/src/method/invalidate.rs
@@ -8,7 +8,7 @@ use crate::opt::auth::Token;
 use crate::types::{SurrealValue, Value};
 use crate::{Connection, Result, Surreal};
 
-/// A session invalidate future
+/// Returned by [`Surreal::invalidate`](crate::Surreal::invalidate) to clear auth on a connection.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Invalidate<'r, C: Connection, T = ()> {

--- a/surrealdb/src/method/live.rs
+++ b/surrealdb/src/method/live.rs
@@ -224,7 +224,9 @@ where
 	}
 }
 
-/// Notifications from [`Select::live`](crate::method::Select::live) (built via [`Surreal::select`](crate::Surreal::select)) or from live handles inside [`Surreal::query`](crate::Surreal::query).
+/// Notifications from [`Select::live`](crate::method::Select::live) (built via
+/// [`Surreal::select`](crate::Surreal::select)) or from live handles inside
+/// [`Surreal::query`](crate::Surreal::query).
 #[derive(Debug)]
 #[must_use = "streams do nothing unless you poll them"]
 pub struct Stream<R> {

--- a/surrealdb/src/method/live.rs
+++ b/surrealdb/src/method/live.rs
@@ -224,7 +224,7 @@ where
 	}
 }
 
-/// A stream of live query notifications
+/// Notifications from [`Select::live`](crate::method::Select::live) (built via [`Surreal::select`](crate::Surreal::select)) or from live handles inside [`Surreal::query`](crate::Surreal::query).
 #[derive(Debug)]
 #[must_use = "streams do nothing unless you poll them"]
 pub struct Stream<R> {

--- a/surrealdb/src/method/merge.rs
+++ b/surrealdb/src/method/merge.rs
@@ -11,7 +11,8 @@ use crate::opt::Resource;
 use crate::types::{SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// Patch-style payload from [`Update::merge`](crate::method::Update::merge) or [`Upsert::merge`](crate::method::Upsert::merge).
+/// Patch-style payload from [`Update::merge`](crate::method::Update::merge) or
+/// [`Upsert::merge`](crate::method::Upsert::merge).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Merge<'r, C: Connection, D, R> {

--- a/surrealdb/src/method/merge.rs
+++ b/surrealdb/src/method/merge.rs
@@ -11,7 +11,7 @@ use crate::opt::Resource;
 use crate::types::{SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// A merge future
+/// Patch-style payload from [`Update::merge`](crate::method::Update::merge) or [`Upsert::merge`](crate::method::Upsert::merge).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Merge<'r, C: Connection, D, R> {

--- a/surrealdb/src/method/mod.rs
+++ b/surrealdb/src/method/mod.rs
@@ -1,4 +1,4 @@
-//! Methods to use when interacting with a SurrealDB instance
+//! Methods to use when interacting with a SurrealDB instance.
 use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -80,23 +80,23 @@ pub use version::Version;
 
 use super::opt::{CreateResource, IntoResource};
 
-/// A alias for an often used type of future returned by async methods in this
+/// An alias for an often used type of future returned by async methods in this
 /// library
 pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>;
 
-/// Machine learning model marker type for import and export types
+/// Type-state marker for [`Export::ml`](Export::ml) on an [`Export`](Export) from [`Surreal::export`](crate::Surreal::export).
 pub struct Model;
 
-/// Marker type for configured exports
+/// Type-state marker for [`Export::with_config`](Export::with_config) on an [`Export`](Export) from [`Surreal::export`](crate::Surreal::export).
 pub struct ExportConfig;
 
-/// Live query marker type
+/// Type-state marker for [`Select::live`](Select::live) on a [`Select`] from [`Surreal::select`](crate::Surreal::select).
 pub struct Live;
 
 /// Relation marker type
 pub struct Relation;
 
-/// Query execution statistics
+/// Time elapsed for a single statement, paired by [`WithStats::take`](WithStats::take) after [`Query::with_stats`](crate::method::Query::with_stats).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub struct Stats {
@@ -104,7 +104,7 @@ pub struct Stats {
 	pub execution_time: Option<Duration>,
 }
 
-/// Responses returned with statistics
+/// Wraps the [`Query`] output from [`Query::with_stats`](crate::method::Query::with_stats) so each [`WithStats::take`](WithStats::take) includes [`Stats`].
 #[derive(Debug)]
 pub struct WithStats<T>(pub T);
 
@@ -153,7 +153,7 @@ where
 	///     }).await?;
 	///
 	///     // Select a namespace/database
-	///     DB.use_ns("namespace").use_db("database").await?;
+	///     DB.use_ns("main").use_db("main").await?;
 	///
 	///     // Create or update a specific record
 	///     let tobie: Option<Person> = DB.update(("person", "tobie"))
@@ -194,7 +194,7 @@ where
 	///     }).await?;
 	///
 	///     // Select a namespace/database
-	///     DB.use_ns("namespace").use_db("database").await?;
+	///     DB.use_ns("main").use_db("main").await?;
 	///
 	///     // Create or update a specific record
 	///     let tobie: Option<Person> = DB.update(("person", "tobie"))
@@ -242,6 +242,35 @@ where
 		}
 	}
 
+	/// Starts a client transaction and returns a handle for running
+	/// [`Transaction::query`], [`Transaction::select`], and other operations
+	/// in the same transaction until you call [`Transaction::commit`] or
+	/// [`Transaction::cancel`].
+	///
+	/// This is differs from writing `BEGIN` / `COMMIT` inside a raw SurrealQL
+	/// string in that the client issues a dedicated transaction begin command, then
+	/// keeps a [`Transaction`] that tags each subsequent
+	/// statement with the same transaction id.
+	///
+	/// The return type, [`Begin`], resolves to a [`Transaction`]. You can
+	/// end the transaction with [`Transaction::commit`] to apply changes, or
+	/// [`Transaction::cancel`] to roll them back. Both of those yield the original [`Surreal`]
+	/// client again on success so you can keep using the connection.
+	///
+	/// # Examples
+	///
+	/// ```no_run
+	/// # #[tokio::main]
+	/// # async fn main() -> surrealdb::Result<()> {
+	/// # let db = surrealdb::engine::any::connect("mem://").await?;
+	/// # db.use_ns("main").use_db("main").await?;
+	/// let tx = db.begin().await?;
+	/// tx.query("CREATE person SET name = 'Ann'").await?;
+	/// let db = tx.commit().await?;
+	/// # let _ = db;
+	/// # Ok(())
+	/// # }
+	/// ```
 	pub fn begin(self) -> Begin<C> {
 		Begin {
 			client: self,
@@ -274,7 +303,7 @@ where
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
-	/// db.use_ns("namespace").await?;
+	/// db.use_ns("main").await?;
 	/// # Ok(())
 	/// # }
 	/// ```
@@ -293,7 +322,7 @@ where
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
-	/// db.use_db("database").await?;
+	/// db.use_db("main").await?;
 	/// # Ok(())
 	/// # }
 	/// ```
@@ -411,7 +440,7 @@ where
 	/// .await?;
 	///
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Define the user record access
 	/// let surql = r#"
@@ -423,8 +452,8 @@ where
 	///
 	/// // Sign a user up
 	/// db.signup(Record {
-	///     namespace: "namespace",
-	///     database: "database",
+	///     namespace: "main",
+	///     database: "main",
 	///     access: "user_access",
 	///     params: AuthParams {
 	///         email: "john.doe@example.com".into(),
@@ -464,7 +493,7 @@ where
 	/// .await?;
 	///
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Define the user
 	/// let surql = "DEFINE USER johndoe ON NAMESPACE PASSWORD 'password123'";
@@ -472,7 +501,7 @@ where
 	///
 	/// // Sign a user in
 	/// db.signin(Namespace {
-	///     namespace: "namespace",
+	///     namespace: "main",
 	///     username: "johndoe",
 	///     password: "password123",
 	/// }).await?;
@@ -499,7 +528,7 @@ where
 	/// .await?;
 	///
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Define the user
 	/// let surql = "DEFINE USER johndoe ON DATABASE PASSWORD 'password123'";
@@ -507,8 +536,8 @@ where
 	///
 	/// // Sign a user in
 	/// db.signin(Database {
-	///     namespace: "namespace",
-	///     database: "database",
+	///     namespace: "main",
+	///     database: "main",
 	///     username: "johndoe",
 	///     password: "password123",
 	/// }).await?;
@@ -535,12 +564,12 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Sign a user in
 	/// db.signin(Record {
-	///     namespace: "namespace",
-	///     database: "database",
+	///     namespace: "main",
+	///     database: "main",
 	///     access: "user_access",
 	///     params: AuthParams {
 	///         email: "john.doe@example.com".into(),
@@ -611,7 +640,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Run queries
 	/// let mut result = db
@@ -672,7 +701,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Select all records from a table
 	/// let people: Vec<Person> = db.select("person").await?;
@@ -733,7 +762,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Create a record with a random ID
 	/// let person: Option<Person> = db.create("person").await?;
@@ -789,7 +818,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Insert a record with a specific ID
 	/// let person: Option<Person> = db.insert(("person", "tobie"))
@@ -936,7 +965,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Update all records in a table
 	/// let people: Vec<Person> = db.upsert("person").await?;
@@ -986,7 +1015,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Update all records in a table
 	/// let people: Vec<Person> = db.upsert("person")
@@ -1040,7 +1069,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Update all records in a table
 	/// let people: Vec<Person> = db.upsert("person")
@@ -1095,7 +1124,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Update all records in a table
 	/// let people: Vec<Person> = db.update("person").await?;
@@ -1145,7 +1174,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Update all records in a table
 	/// let people: Vec<Person> = db.update("person")
@@ -1199,7 +1228,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Update all records in a table
 	/// let people: Vec<Person> = db.update("person")
@@ -1238,7 +1267,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Delete all records from a table
 	/// let people: Vec<Person> = db.delete("person").await?;
@@ -1353,7 +1382,7 @@ where
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Export to a file
 	/// db.export("backup.sql").await?;
@@ -1398,7 +1427,7 @@ where
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// db.import("backup.sql").await?;
 	/// # Ok(())

--- a/surrealdb/src/method/mod.rs
+++ b/surrealdb/src/method/mod.rs
@@ -84,19 +84,23 @@ use super::opt::{CreateResource, IntoResource};
 /// library
 pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>;
 
-/// Type-state marker for [`Export::ml`](Export::ml) on an [`Export`](Export) from [`Surreal::export`](crate::Surreal::export).
+/// Type-state marker for [`Export::ml`](Export::ml) on an [`Export`](Export) from
+/// [`Surreal::export`](crate::Surreal::export).
 pub struct Model;
 
-/// Type-state marker for [`Export::with_config`](Export::with_config) on an [`Export`](Export) from [`Surreal::export`](crate::Surreal::export).
+/// Type-state marker for [`Export::with_config`](Export::with_config) on an [`Export`](Export) from
+/// [`Surreal::export`](crate::Surreal::export).
 pub struct ExportConfig;
 
-/// Type-state marker for [`Select::live`](Select::live) on a [`Select`] from [`Surreal::select`](crate::Surreal::select).
+/// Type-state marker for [`Select::live`](Select::live) on a [`Select`] from
+/// [`Surreal::select`](crate::Surreal::select).
 pub struct Live;
 
 /// Relation marker type
 pub struct Relation;
 
-/// Time elapsed for a single statement, paired by [`WithStats::take`](WithStats::take) after [`Query::with_stats`](crate::method::Query::with_stats).
+/// Time elapsed for a single statement, paired by [`WithStats::take`](WithStats::take) after
+/// [`Query::with_stats`](crate::method::Query::with_stats).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub struct Stats {
@@ -104,7 +108,8 @@ pub struct Stats {
 	pub execution_time: Option<Duration>,
 }
 
-/// Wraps the [`Query`] output from [`Query::with_stats`](crate::method::Query::with_stats) so each [`WithStats::take`](WithStats::take) includes [`Stats`].
+/// Wraps the [`Query`] output from [`Query::with_stats`](crate::method::Query::with_stats) so each
+/// [`WithStats::take`](WithStats::take) includes [`Stats`].
 #[derive(Debug)]
 pub struct WithStats<T>(pub T);
 

--- a/surrealdb/src/method/patch.rs
+++ b/surrealdb/src/method/patch.rs
@@ -10,7 +10,7 @@ use crate::opt::{PatchOp, PatchOps, Resource};
 use crate::types::{SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// A patch future
+/// JSON-patch payload from [`Update::patch`](crate::method::Update::patch) or [`Upsert::patch`](crate::method::Upsert::patch).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Patch<'r, C: Connection, R> {

--- a/surrealdb/src/method/patch.rs
+++ b/surrealdb/src/method/patch.rs
@@ -10,7 +10,8 @@ use crate::opt::{PatchOp, PatchOps, Resource};
 use crate::types::{SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// JSON-patch payload from [`Update::patch`](crate::method::Update::patch) or [`Upsert::patch`](crate::method::Upsert::patch).
+/// JSON-patch payload from [`Update::patch`](crate::method::Update::patch) or
+/// [`Upsert::patch`](crate::method::Upsert::patch).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Patch<'r, C: Connection, R> {

--- a/surrealdb/src/method/query.rs
+++ b/surrealdb/src/method/query.rs
@@ -21,7 +21,8 @@ use crate::notification::Notification;
 use crate::types::{SurrealValue, Value, Variables};
 use crate::{Connection, Error, Result, Surreal, opt};
 
-/// Returned by [`Surreal::query`](crate::Surreal::query), resolving to [`IndexedResults`] (optionally via [`Query::with_stats`](Self::with_stats)).
+/// Returned by [`Surreal::query`](crate::Surreal::query), resolving to [`IndexedResults`]
+/// (optionally via [`Query::with_stats`](Self::with_stats)).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Query<'r, C: Connection> {
@@ -269,7 +270,8 @@ where
 	}
 }
 
-/// Map of per-statement results from [`Surreal::query`](crate::Surreal::query); read rows with [`IndexedResults::take`](IndexedResults::take).
+/// Map of per-statement results from [`Surreal::query`](crate::Surreal::query); read rows with
+/// [`IndexedResults::take`](IndexedResults::take).
 #[derive(Debug)]
 pub struct IndexedResults {
 	pub(crate) results: IndexMap<usize, (DbResultStats, std::result::Result<Value, TypesError>)>,
@@ -446,7 +448,7 @@ impl IndexedResults {
 	/// # Examples
 	///
 	/// ```no_run
-	///
+	/// 
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -477,7 +479,7 @@ impl IndexedResults {
 	/// # Examples
 	///
 	/// ```no_run
-	///
+	/// 
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -507,7 +509,7 @@ impl IndexedResults {
 	/// # Examples
 	///
 	/// ```no_run
-	///
+	/// 
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -603,7 +605,7 @@ impl WithStats<IndexedResults> {
 	/// # Examples
 	///
 	/// ```no_run
-	///
+	/// 
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -637,7 +639,7 @@ impl WithStats<IndexedResults> {
 	/// # Examples
 	///
 	/// ```no_run
-	///
+	/// 
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -656,7 +658,7 @@ impl WithStats<IndexedResults> {
 	/// # Examples
 	///
 	/// ```no_run
-	///
+	/// 
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;

--- a/surrealdb/src/method/query.rs
+++ b/surrealdb/src/method/query.rs
@@ -446,7 +446,7 @@ impl IndexedResults {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -477,7 +477,7 @@ impl IndexedResults {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -507,7 +507,7 @@ impl IndexedResults {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -603,7 +603,7 @@ impl WithStats<IndexedResults> {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -637,7 +637,7 @@ impl WithStats<IndexedResults> {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
@@ -656,7 +656,7 @@ impl WithStats<IndexedResults> {
 	/// # Examples
 	///
 	/// ```no_run
-	/// 
+	///
 	/// # #[tokio::main]
 	/// # async fn main() -> surrealdb::Result<()> {
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;

--- a/surrealdb/src/method/query.rs
+++ b/surrealdb/src/method/query.rs
@@ -21,7 +21,7 @@ use crate::notification::Notification;
 use crate::types::{SurrealValue, Value, Variables};
 use crate::{Connection, Error, Result, Surreal, opt};
 
-/// A query future
+/// Returned by [`Surreal::query`](crate::Surreal::query), resolving to [`IndexedResults`] (optionally via [`Query::with_stats`](Self::with_stats)).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Query<'r, C: Connection> {
@@ -269,7 +269,7 @@ where
 	}
 }
 
-/// The response type of a `Surreal::query` request
+/// Map of per-statement results from [`Surreal::query`](crate::Surreal::query); read rows with [`IndexedResults::take`](IndexedResults::take).
 #[derive(Debug)]
 pub struct IndexedResults {
 	pub(crate) results: IndexMap<usize, (DbResultStats, std::result::Result<Value, TypesError>)>,

--- a/surrealdb/src/method/run.rs
+++ b/surrealdb/src/method/run.rs
@@ -7,7 +7,7 @@ use crate::method::{BoxFuture, OnceLockExt};
 use crate::types::{Array, SurrealValue, Value};
 use crate::{Connection, Result, Surreal};
 
-/// A run future
+/// Returned by [`Surreal::run`](crate::Surreal::run) to invoke a defined function (`fn::…`).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Run<'r, C: Connection, R> {

--- a/surrealdb/src/method/select.rs
+++ b/surrealdb/src/method/select.rs
@@ -11,7 +11,7 @@ use crate::opt::Resource;
 use crate::types::{RecordIdKeyRange, SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// A select future
+/// Returned by [`Surreal::select`](crate::Surreal::select) for `SELECT` (including [`Select::live`](Self::live) when using [`Live`](crate::method::Live)).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Select<'r, C: Connection, R, T = ()> {
@@ -154,7 +154,7 @@ where
 	/// # let db = surrealdb::engine::any::connect("mem://").await?;
 	/// #
 	/// // Select the namespace/database to use
-	/// db.use_ns("namespace").use_db("database").await?;
+	/// db.use_ns("main").use_db("main").await?;
 	///
 	/// // Listen to all updates on a table
 	/// let mut stream = db.select("person").live().await?;

--- a/surrealdb/src/method/select.rs
+++ b/surrealdb/src/method/select.rs
@@ -11,7 +11,8 @@ use crate::opt::Resource;
 use crate::types::{RecordIdKeyRange, SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// Returned by [`Surreal::select`](crate::Surreal::select) for `SELECT` (including [`Select::live`](Self::live) when using [`Live`](crate::method::Live)).
+/// Returned by [`Surreal::select`](crate::Surreal::select) for `SELECT` (including
+/// [`Select::live`](Self::live) when using [`Live`](crate::method::Live)).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Select<'r, C: Connection, R, T = ()> {

--- a/surrealdb/src/method/set.rs
+++ b/surrealdb/src/method/set.rs
@@ -6,7 +6,7 @@ use crate::method::{BoxFuture, OnceLockExt};
 use crate::types::Value;
 use crate::{Connection, Result, Surreal};
 
-/// A set future
+/// Returned by [`Surreal::set`](crate::Surreal::set) to bind a session variable for subsequent [`Surreal::query`](crate::Surreal::query) calls.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Set<'r, C: Connection> {

--- a/surrealdb/src/method/set.rs
+++ b/surrealdb/src/method/set.rs
@@ -6,7 +6,8 @@ use crate::method::{BoxFuture, OnceLockExt};
 use crate::types::Value;
 use crate::{Connection, Result, Surreal};
 
-/// Returned by [`Surreal::set`](crate::Surreal::set) to bind a session variable for subsequent [`Surreal::query`](crate::Surreal::query) calls.
+/// Returned by [`Surreal::set`](crate::Surreal::set) to bind a session variable for subsequent
+/// [`Surreal::query`](crate::Surreal::query) calls.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Set<'r, C: Connection> {

--- a/surrealdb/src/method/signin.rs
+++ b/surrealdb/src/method/signin.rs
@@ -7,7 +7,8 @@ use crate::opt::auth::Token;
 use crate::types::Value;
 use crate::{Connection, Result, Surreal};
 
-/// Returned by [`Surreal::signin`](crate::Surreal::signin) for root, namespace, database, or record credentials.
+/// Returned by [`Surreal::signin`](crate::Surreal::signin) for root, namespace, database, or record
+/// credentials.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Signin<'r, C: Connection> {

--- a/surrealdb/src/method/signin.rs
+++ b/surrealdb/src/method/signin.rs
@@ -7,7 +7,7 @@ use crate::opt::auth::Token;
 use crate::types::Value;
 use crate::{Connection, Result, Surreal};
 
-/// A signin future
+/// Returned by [`Surreal::signin`](crate::Surreal::signin) for root, namespace, database, or record credentials.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Signin<'r, C: Connection> {

--- a/surrealdb/src/method/signup.rs
+++ b/surrealdb/src/method/signup.rs
@@ -7,7 +7,7 @@ use crate::opt::auth::Token;
 use crate::types::Value;
 use crate::{Connection, Result, Surreal};
 
-/// A signup future
+/// Returned by [`Surreal::signup`](crate::Surreal::signup) for `DEFINE ACCESS … SIGNUP` flows.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Signup<'r, C: Connection> {

--- a/surrealdb/src/method/transaction.rs
+++ b/surrealdb/src/method/transaction.rs
@@ -6,7 +6,9 @@ use crate::method::{Cancel, Commit, Create, Delete, Insert, Query, Select, Updat
 use crate::opt::{CreateResource, IntoResource};
 use crate::{Connection, Surreal};
 
-/// An ongoing transaction
+/// Transaction handle produced when [`Begin`](crate::method::Begin) completes after [`Surreal::begin`](crate::Surreal::begin).
+///
+/// Use [`Transaction::query`](Transaction::query) and related methods on this handle, then [`Transaction::commit`](Transaction::commit) or [`Transaction::cancel`](Transaction::cancel).
 #[derive(Debug)]
 #[must_use = "transactions must be committed or cancelled to complete them"]
 pub struct Transaction<C: Connection> {
@@ -18,12 +20,16 @@ impl<C> Transaction<C>
 where
 	C: Connection,
 {
-	/// Creates a commit future
+	/// Commits this transaction, persisting the changes, and returns a
+	/// [`Commit`] future that yields the original [`Surreal`] client on
+	/// success.
 	pub fn commit(self) -> Commit<C> {
 		Commit::from_transaction(self)
 	}
 
-	/// Creates a cancel future
+	/// Rolls this transaction back and returns a [`Cancel`] future that yields
+	/// the original [`Surreal`] client on success, without persisting the
+	/// changes from this transaction.
 	pub fn cancel(self) -> Cancel<C> {
 		Cancel::from_transaction(self)
 	}

--- a/surrealdb/src/method/transaction.rs
+++ b/surrealdb/src/method/transaction.rs
@@ -6,9 +6,11 @@ use crate::method::{Cancel, Commit, Create, Delete, Insert, Query, Select, Updat
 use crate::opt::{CreateResource, IntoResource};
 use crate::{Connection, Surreal};
 
-/// Transaction handle produced when [`Begin`](crate::method::Begin) completes after [`Surreal::begin`](crate::Surreal::begin).
+/// Transaction handle produced when [`Begin`](crate::method::Begin) completes after
+/// [`Surreal::begin`](crate::Surreal::begin).
 ///
-/// Use [`Transaction::query`](Transaction::query) and related methods on this handle, then [`Transaction::commit`](Transaction::commit) or [`Transaction::cancel`](Transaction::cancel).
+/// Use [`Transaction::query`](Transaction::query) and related methods on this handle, then
+/// [`Transaction::commit`](Transaction::commit) or [`Transaction::cancel`](Transaction::cancel).
 #[derive(Debug)]
 #[must_use = "transactions must be committed or cancelled to complete them"]
 pub struct Transaction<C: Connection> {

--- a/surrealdb/src/method/unset.rs
+++ b/surrealdb/src/method/unset.rs
@@ -5,7 +5,8 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, OnceLockExt};
 use crate::{Connection, Result, Surreal};
 
-/// Returned by [`Surreal::unset`](crate::Surreal::unset); removes a session variable set on the connection via [`Surreal::set`](crate::Surreal::set).
+/// Returned by [`Surreal::unset`](crate::Surreal::unset); removes a session variable set on the
+/// connection via [`Surreal::set`](crate::Surreal::set).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Unset<'r, C: Connection> {

--- a/surrealdb/src/method/unset.rs
+++ b/surrealdb/src/method/unset.rs
@@ -5,7 +5,7 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, OnceLockExt};
 use crate::{Connection, Result, Surreal};
 
-/// An unset future
+/// Returned by [`Surreal::unset`](crate::Surreal::unset); removes a session variable set on the connection via [`Surreal::set`](crate::Surreal::set).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Unset<'r, C: Connection> {

--- a/surrealdb/src/method/update.rs
+++ b/surrealdb/src/method/update.rs
@@ -13,7 +13,9 @@ use crate::opt::{PatchOps, Resource};
 use crate::types::{RecordId, RecordIdKeyRange, SurrealValue, Value, Variables};
 use crate::{Connection, Error, Result, Surreal};
 
-/// Returned by [`Surreal::update`](crate::Surreal::update), followed by [`Update::content`](Update::content), [`Update::merge`](Update::merge), or [`Update::patch`](Update::patch) before running.
+/// Returned by [`Surreal::update`](crate::Surreal::update), followed by
+/// [`Update::content`](Update::content), [`Update::merge`](Update::merge), or
+/// [`Update::patch`](Update::patch) before running.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Update<'r, C: Connection, R> {

--- a/surrealdb/src/method/update.rs
+++ b/surrealdb/src/method/update.rs
@@ -13,7 +13,7 @@ use crate::opt::{PatchOps, Resource};
 use crate::types::{RecordId, RecordIdKeyRange, SurrealValue, Value, Variables};
 use crate::{Connection, Error, Result, Surreal};
 
-/// An update future
+/// Returned by [`Surreal::update`](crate::Surreal::update), followed by [`Update::content`](Update::content), [`Update::merge`](Update::merge), or [`Update::patch`](Update::patch) before running.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Update<'r, C: Connection, R> {

--- a/surrealdb/src/method/upsert.rs
+++ b/surrealdb/src/method/upsert.rs
@@ -12,7 +12,7 @@ use crate::opt::{PatchOps, Resource};
 use crate::types::{RecordIdKeyRange, SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// An upsert future
+/// Returned by [`Surreal::upsert`](crate::Surreal::upsert). Uses same content/merge/patch chaining as [`Update`](crate::method::Update).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Upsert<'r, C: Connection, R> {

--- a/surrealdb/src/method/upsert.rs
+++ b/surrealdb/src/method/upsert.rs
@@ -12,7 +12,8 @@ use crate::opt::{PatchOps, Resource};
 use crate::types::{RecordIdKeyRange, SurrealValue, Value, Variables};
 use crate::{Connection, Result, Surreal};
 
-/// Returned by [`Surreal::upsert`](crate::Surreal::upsert). Uses same content/merge/patch chaining as [`Update`](crate::method::Update).
+/// Returned by [`Surreal::upsert`](crate::Surreal::upsert). Uses same content/merge/patch chaining
+/// as [`Update`](crate::method::Update).
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Upsert<'r, C: Connection, R> {

--- a/surrealdb/src/method/use_db.rs
+++ b/surrealdb/src/method/use_db.rs
@@ -8,6 +8,7 @@ use crate::method::{BoxFuture, OnceLockExt};
 use crate::opt::WaitFor;
 use crate::{Connection, Result, Surreal};
 
+/// Returned by [`UseNs::use_db`](crate::method::UseNs::use_db), used to set the current database.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct UseDb<'r, C: Connection> {

--- a/surrealdb/src/method/use_defaults.rs
+++ b/surrealdb/src/method/use_defaults.rs
@@ -7,7 +7,7 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, OnceLockExt};
 use crate::{Connection, Result, Surreal};
 
-/// Stores the namespace to use
+/// Returned by [`Surreal::use_defaults`](crate::Surreal::use_defaults), used to apply the server's default namespace/database.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct UseDefaults<'r, C: Connection> {

--- a/surrealdb/src/method/use_defaults.rs
+++ b/surrealdb/src/method/use_defaults.rs
@@ -7,7 +7,8 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, OnceLockExt};
 use crate::{Connection, Result, Surreal};
 
-/// Returned by [`Surreal::use_defaults`](crate::Surreal::use_defaults), used to apply the server's default namespace/database.
+/// Returned by [`Surreal::use_defaults`](crate::Surreal::use_defaults), used to apply the server's
+/// default namespace/database.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct UseDefaults<'r, C: Connection> {

--- a/surrealdb/src/method/use_ns.rs
+++ b/surrealdb/src/method/use_ns.rs
@@ -7,7 +7,7 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, OnceLockExt, UseDb};
 use crate::{Connection, Result, Surreal};
 
-/// Stores the namespace to use
+/// Returned by [`Surreal::use_ns`](crate::Surreal::use_ns), used to set the current namespace.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct UseNs<'r, C: Connection> {

--- a/surrealdb/src/method/version.rs
+++ b/surrealdb/src/method/version.rs
@@ -5,7 +5,7 @@ use crate::conn::Command;
 use crate::method::{BoxFuture, OnceLockExt};
 use crate::{Connection, Error, Result, Surreal};
 
-/// A version future
+/// Returned by [`Surreal::version`](crate::Surreal::version), yields the server version string.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Version<'r, C: Connection> {


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉

## What is the motivation?

docs.rs documentation could use some more doc comments.

## What does this change do?

Mostly links structs to the methods that create them, as well as any other related ones.

Also changes default namespace and database names to "main" as that is the default since 3.0 and will be more useful to a user to copy and paste.

Plus a bit of wording here and there.

## What is your testing strategy?

Ran cargo doc until it didn't give any more suggestions about links.

## Security Considerations

None: it's just documentation.

## Is this related to any issues?

* [X] No related issues

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

* [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
