### PR TITLE
Add value::expect method

### DIFF
--- a/fuzz/fuzz_targets/fuzz_executor.dict
+++ b/fuzz/fuzz_targets/fuzz_executor.dict
@@ -488,6 +488,8 @@
 "type::record("
 "type::uuid("
 "type::geometry("
+"value::chain("
+"value::expect("
 "vector::add("
 "vector::angle("
 "vector::cross("

--- a/fuzz/fuzz_targets/fuzz_sql_parser.dict
+++ b/fuzz/fuzz_targets/fuzz_sql_parser.dict
@@ -487,6 +487,8 @@
 "type::record("
 "type::uuid("
 "type::geometry("
+"value::chain("
+"value::expect("
 "vector::add("
 "vector::angle("
 "vector::cross("

--- a/language-tests/tests/language/functions/method_syntax.surql
+++ b/language-tests/tests/language/functions/method_syntax.surql
@@ -62,6 +62,8 @@ value = "NONE"
 	-- Universal methods
 	-- =====================================================================
 	123.chain(|$x| $x);
+	9.expect(|$n| $n = 9);
+	9.expect(|$n| $n = 9, "Should equal nine");
 	{ one: "object" }.diff({ another: "object" });
 	{ one: "object" }.patch([
 		{ op: "remove", path: "/one" },

--- a/language-tests/tests/language/functions/value/expect.surql
+++ b/language-tests/tests/language/functions/value/expect.surql
@@ -17,9 +17,6 @@ error = "An error occurred: value::expect assertion failed with message: 'Should
 error = "An error occurred: value::expect assertion failed"
 
 [[test.results]]
-error = "Incorrect arguments for method expect(). Expected 2 to 3 arguments"
-
-[[test.results]]
 value = "[{ num: 2 }, { num: 4 }, { num: 6 }]"
 
 [[test.results]]
@@ -32,7 +29,6 @@ error = "An error occurred: value::expect assertion failed with message: 'All nu
 10.expect(|$n| $n = 9);
 10.expect(|$n| $n = 9, "Should equal nine");
 10.expect(|$n| $n = 9, 1);
-9.expect(|$n| $n = 9, "a", "b");
 
 // .expect to assert inside of method chains
 [1,2,3]

--- a/language-tests/tests/language/functions/value/expect.surql
+++ b/language-tests/tests/language/functions/value/expect.surql
@@ -11,13 +11,13 @@ value = "9"
 error = "An error occurred: value::expect assertion failed"
 
 [[test.results]]
-error = "An error occurred: value::expect assertion failed with message: Should equal nine"
+error = "An error occurred: value::expect assertion failed with message: 'Should equal nine'"
 
 [[test.results]]
 error = "An error occurred: value::expect assertion failed"
 
 [[test.results]]
-error = "Incorrect arguments for function value::expect(). Expected 2 to 3 arguments"
+error = "Incorrect arguments for method expect(). Expected 2 to 3 arguments"
 
 [[test.results]]
 value = "[{ num: 2 }, { num: 4 }, { num: 6 }]"
@@ -32,7 +32,7 @@ error = "An error occurred: value::expect assertion failed with message: 'All nu
 10.expect(|$n| $n = 9);
 10.expect(|$n| $n = 9, "Should equal nine");
 10.expect(|$n| $n = 9, 1);
-value::expect(9, |$n| $n = 9, "a", "b");
+9.expect(|$n| $n = 9, "a", "b");
 
 // .expect to assert inside of method chains
 [1,2,3]

--- a/language-tests/tests/language/functions/value/expect_all_ro.surql
+++ b/language-tests/tests/language/functions/value/expect_all_ro.surql
@@ -1,0 +1,12 @@
+/**
+[test]
+reason = "'for method expect' / 'for function expect' output differs by planner strategy so have isolated each into its own file"
+
+[env]
+planner-strategy = ["all-ro"]
+
+[[test.results]]
+error = "Incorrect arguments for method expect(). Expected 2 to 3 arguments"
+*/
+
+9.expect(|$n| $n = 9, "a", "b");

--- a/language-tests/tests/language/functions/value/expect_best_effort_ro.surql
+++ b/language-tests/tests/language/functions/value/expect_best_effort_ro.surql
@@ -1,0 +1,12 @@
+/**
+[test]
+reason = "'for method expect' / 'for function expect' output differs by planner strategy so have isolated each into its own file"
+
+[env]
+planner-strategy = ["best-effort-ro"]
+
+[[test.results]]
+error = "Incorrect arguments for method expect(). Expected 2 to 3 arguments"
+*/
+
+9.expect(|$n| $n = 9, "a", "b");

--- a/language-tests/tests/language/functions/value/expect_compute_only.surql
+++ b/language-tests/tests/language/functions/value/expect_compute_only.surql
@@ -1,0 +1,12 @@
+/**
+[test]
+reason = "'for method expect' / 'for function expect' output differs by planner strategy so have isolated each into its own file"
+
+[env]
+planner-strategy = ["compute-only"]
+
+[[test.results]]
+error = "Incorrect arguments for function expect(). Expected 2 to 3 arguments"
+*/
+
+9.expect(|$n| $n = 9, "a", "b");

--- a/language-tests/tests/language/functions/value_expect.surql
+++ b/language-tests/tests/language/functions/value_expect.surql
@@ -1,0 +1,50 @@
+/**
+[test]
+
+[[test.results]]
+value = "9"
+
+[[test.results]]
+value = "9"
+
+[[test.results]]
+error = "An error occurred: value::expect assertion failed"
+
+[[test.results]]
+error = "An error occurred: value::expect assertion failed with message: Should equal nine"
+
+[[test.results]]
+error = "An error occurred: value::expect assertion failed"
+
+[[test.results]]
+error = "Incorrect arguments for function value::expect(). Expected 2 to 3 arguments"
+
+[[test.results]]
+value = "[[{ num: 2 }, { num: 4 }, { num: 6 }]]"
+
+[[test.results]]
+error = "An error occurred: value::expect assertion failed with message: 'All numbers should be positive'"
+*/
+
+// Simple assertions
+9.expect(|$n| $n = 9);
+9.expect(|$n| $n = 9, "Should equal nine");
+10.expect(|$n| $n = 9);
+10.expect(|$n| $n = 9, "Should equal nine");
+10.expect(|$n| $n = 9, 1);
+value::expect(9, |$n| $n = 9, "a", "b");
+
+// .expect to assert inside of method chains
+[1,2,3]
+    .map(|$num| $num * 2)
+    .expect(|$nums| $nums.all(|$num| $num > 0))
+    .map(|$num| {
+        num: $num
+    });
+
+[-1,2,3]
+    .map(|$num| $num * 2)
+    .expect(|$nums| $nums.all(|$num| $num > 0), "All numbers should be positive")
+    .map(|$num| {
+        num: $num
+    });

--- a/language-tests/tests/language/functions/value_expect.surql
+++ b/language-tests/tests/language/functions/value_expect.surql
@@ -20,7 +20,7 @@ error = "An error occurred: value::expect assertion failed"
 error = "Incorrect arguments for function value::expect(). Expected 2 to 3 arguments"
 
 [[test.results]]
-value = "[[{ num: 2 }, { num: 4 }, { num: 6 }]]"
+value = "[{ num: 2 }, { num: 4 }, { num: 6 }]"
 
 [[test.results]]
 error = "An error occurred: value::expect assertion failed with message: 'All numbers should be positive'"

--- a/surrealdb/core/src/err/mod.rs
+++ b/surrealdb/core/src/err/mod.rs
@@ -158,7 +158,7 @@ pub(crate) enum Error {
 	},
 
 	/// The wrong quantity or magnitude of arguments was given for the specified
-	/// function
+	/// method
 	#[error("Incorrect arguments for method {name}(). {message}")]
 	InvalidMethodArguments {
 		name: String,

--- a/surrealdb/core/src/exec/function/builtin/value.rs
+++ b/surrealdb/core/src/exec/function/builtin/value.rs
@@ -142,8 +142,64 @@ impl ScalarFunction for ValueChain {
 	}
 }
 
+// value::expect: Assert a value with a closure returning bool
+// Original value is passed on if closure returns true
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ValueExpect;
+
+impl ScalarFunction for ValueExpect {
+	fn name(&self) -> &'static str {
+		"value::expect"
+	}
+
+	fn signature(&self) -> Signature {
+		Signature::new()
+			.arg("value", Kind::Any)
+			.arg("closure", Kind::Any)
+			.optional("message", Kind::String)
+			.returns(Kind::Any)
+	}
+
+	fn is_pure(&self) -> bool {
+		false
+	}
+
+	fn is_async(&self) -> bool {
+		true
+	}
+
+	fn invoke(&self, _args: Vec<Value>) -> Result<Value> {
+		Err(anyhow::anyhow!("Function '{}' requires async execution", self.name()))
+	}
+
+	fn invoke_async<'a>(
+		&'a self,
+		ctx: &'a EvalContext<'_>,
+		args: Vec<Value>,
+	) -> crate::exec::BoxFut<'a, Result<Value>> {
+		Box::pin(async move {
+			use crate::doc::CursorDoc;
+			let args = FromArgs::from_args("value::expect", args)?;
+			let frozen = ctx.exec_ctx.ctx();
+			let opt = ctx.exec_ctx.options();
+			let doc = ctx
+				.document_root
+				.or(ctx.current_value)
+				.map(|v| CursorDoc::new(None, None, v.clone()));
+			let mut stack = TreeStack::new();
+			stack
+				.enter(|stk| async move {
+					crate::fnc::value::expect((stk, frozen, opt, doc.as_ref()), args).await
+				})
+				.finish()
+				.await
+		})
+	}
+}
+
 pub fn register(registry: &mut FunctionRegistry) {
 	registry.register(ValueDiff);
 	registry.register(ValuePatch);
 	registry.register(ValueChain);
+	registry.register(ValueExpect);
 }

--- a/surrealdb/core/src/exec/function/method.rs
+++ b/surrealdb/core/src/exec/function/method.rs
@@ -267,6 +267,7 @@ pub fn build_method_registry(funcs: &FunctionRegistry) -> MethodRegistry {
 	// Universal methods (available on all value types)
 	// =====================================================================
 	m.register_generic("chain", get(funcs, "value::chain"));
+	m.register_generic("expect", get(funcs, "value::expect"));
 	m.register_generic("diff", get(funcs, "value::diff"));
 	m.register_generic("patch", get(funcs, "value::patch"));
 	m.register_generic("repeat", get(funcs, "array::repeat"));

--- a/surrealdb/core/src/fnc/mod.rs
+++ b/surrealdb/core/src/fnc/mod.rs
@@ -88,6 +88,7 @@ pub async fn run(
 		|| name.eq("type::field")
 		|| name.eq("type::fields")
 		|| name.eq("value::diff")
+		|| name.eq("value::expect")
 		|| name.eq("value::patch")
 		|| name.eq("sequence::nextval")
 		|| name.starts_with("api")
@@ -646,6 +647,7 @@ pub async fn asynchronous(
 		"type::fields" => r#type::fields((stk, ctx, Some(opt), doc)).await,
 		//
 		"value::diff" => value::diff.await,
+		"value::expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 		"value::patch" => value::patch.await,
 		"schema::table::exists" => schema::table::exists((ctx, Some(opt))).await,
 	)
@@ -742,6 +744,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//
@@ -885,6 +888,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//
@@ -947,6 +951,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//
@@ -1017,6 +1022,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//
@@ -1086,6 +1092,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//
@@ -1152,6 +1159,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//
@@ -1221,6 +1229,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//
@@ -1301,6 +1310,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//
@@ -1416,6 +1426,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 			)
@@ -1501,6 +1512,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//
@@ -1575,6 +1587,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//
@@ -1636,6 +1649,7 @@ pub async fn idiom(
 				"to_uuid" => r#type::uuid,
 				//
 				"chain" => value::chain((stk, ctx, Some(opt), doc)).await,
+				"expect" => value::expect((stk, ctx, Some(opt), doc)).await,
 				"diff" => value::diff.await,
 				"patch" => value::patch.await,
 				//

--- a/surrealdb/core/src/fnc/script/modules/surrealdb/functions/value.rs
+++ b/surrealdb/core/src/fnc/script/modules/surrealdb/functions/value.rs
@@ -9,5 +9,6 @@ impl_module_def!(
 	Package,
 	"value",
 	"diff" => fut Async,
+	"expect" => fut Async,
 	"patch" => fut Async
 );

--- a/surrealdb/core/src/fnc/value.rs
+++ b/surrealdb/core/src/fnc/value.rs
@@ -1,10 +1,12 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use reblessive::tree::Stk;
 
 use crate::ctx::FrozenContext;
 use crate::dbs::Options;
 use crate::doc::CursorDoc;
+use crate::err::Error;
 use crate::expr::Operation;
+use crate::fnc::args::Optional;
 use crate::val::{Closure, Value};
 
 pub async fn chain(
@@ -13,6 +15,38 @@ pub async fn chain(
 ) -> Result<Value> {
 	if let Some(opt) = opt {
 		worker.invoke(stk, ctx, opt, doc, vec![value]).await
+	} else {
+		Ok(Value::None)
+	}
+}
+
+pub async fn expect(
+	(stk, ctx, opt, doc): (&mut Stk, &FrozenContext, Option<&Options>, Option<&CursorDoc>),
+	(value, worker, Optional(message)): (Value, Box<Closure>, Optional<Value>),
+) -> Result<Value> {
+	if let Some(opt) = opt {
+		let got = worker.invoke(stk, ctx, opt, doc, vec![value.clone()]).await?;
+		match got {
+			Value::Bool(true) => Ok(value),
+			Value::Bool(false) => {
+				if let Some(Value::String(user_message)) = message {
+					bail!(Error::Thrown(format!(
+						"value::expect assertion failed with message: {user_message}"
+					)))
+				} else {
+					bail!(Error::Thrown("value::expect assertion failed".to_owned()))
+				}
+			}
+			other => {
+				bail!(Error::InvalidFunctionArguments {
+					name: "value::expect".to_owned(),
+					message: format!(
+						"Assertion closure must return a bool, got {}",
+						other.kind_of()
+					),
+				})
+			}
+		}
 	} else {
 		Ok(Value::None)
 	}

--- a/surrealdb/core/src/fnc/value.rs
+++ b/surrealdb/core/src/fnc/value.rs
@@ -31,7 +31,7 @@ pub async fn expect(
 			Value::Bool(false) => {
 				if let Some(Value::String(user_message)) = message {
 					bail!(Error::Thrown(format!(
-						"value::expect assertion failed with message: {user_message}"
+						"value::expect assertion failed with message: '{user_message}'"
 					)))
 				} else {
 					bail!(Error::Thrown("value::expect assertion failed".to_owned()))

--- a/surrealdb/core/src/syn/parser/builtin.rs
+++ b/surrealdb/core/src/syn/parser/builtin.rs
@@ -458,6 +458,8 @@ pub(crate) static PATHS: phf::Map<
 		//
 		UniCase::ascii("value::diff") => (PathKind::Function, None),
 		UniCase::ascii("value::patch") => (PathKind::Function, None),
+		UniCase::ascii("value::chain") => (PathKind::Function, None),
+		UniCase::ascii("value::expect") => (PathKind::Function, None),
 		//
 		UniCase::ascii("vector::add") => (PathKind::Function, None),
 		UniCase::ascii("vector::angle") => (PathKind::Function, None),


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉

## What is the motivation?

It would be nice to be able to make assertions and pass on the value, especially when chaining methods.

## What does this change do?

Provides a method value::expect that does this.

## What is your testing strategy?

Adds to the language tests.

Edit: one particular error seems to differ slightly by planner strategy (compute-only says "function" when others say "method") so have isolated those assertions into their own separate language tests.

## Security Considerations

<!-- Briefly assess the security implications of this change. Consider:
- Does it touch authentication, authorization, or session handling?
- Does it affect data isolation between namespaces or databases?
- Does it process user input that reaches the query engine or storage layer?
- Could error messages or logs expose internal details?
- Are resource limits enforced for any new user-controlled operations?

If there are no security implications, briefly state why (e.g. "documentation-only change").
If there are security implications, or you're uncertain, please assign the `security-review` label to this PR
and request a security review by a member of the @surrealdb/security team. -->

No, does not touch authentication, namespaces, storage layer, internal details, etc. Very similar to the value::chain() method.

## Is this related to any issues?

No, though a comment on Discord gave me the idea.

## Have you read the Contributing Guidelines?

* [X] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
