### PR TITLE
fix(kvs/index): break Arc cycle that pinned Datastore after DEFINE INDEX

### DIFF
--- a/surrealdb/core/src/ctx/context.rs
+++ b/surrealdb/core/src/ctx/context.rs
@@ -44,7 +44,7 @@ use crate::idx::planner::{IterationStage, QueryPlanner};
 use crate::idx::trees::store::IndexStores;
 use crate::kvs::Transaction;
 use crate::kvs::cache::ds::DatastoreCache;
-use crate::kvs::index::IndexBuilder;
+use crate::kvs::index::{IndexBuilder, WeakIndexBuilder};
 use crate::kvs::sequences::Sequences;
 use crate::kvs::slowlog::SlowLog;
 use crate::mem::ALLOC;
@@ -83,8 +83,8 @@ pub struct Context {
 	cache: Option<Arc<DatastoreCache>>,
 	// The index store
 	index_stores: IndexStores,
-	// The index concurrent builders
-	index_builder: Option<IndexBuilder>,
+	// Weak handle to the datastore's index_builder
+	index_builder: Option<WeakIndexBuilder>,
 	// The sequences
 	sequences: Option<Sequences>,
 	// Capabilities
@@ -356,7 +356,7 @@ impl Context {
 			capabilities,
 			index_stores,
 			cache: Some(cache),
-			index_builder: Some(index_builder),
+			index_builder: Some(index_builder.downgrade()),
 			sequences: Some(sequences),
 			#[cfg(storage)]
 			temporary_directory,
@@ -627,9 +627,9 @@ impl Context {
 		&self.index_stores
 	}
 
-	/// Get the index_builder for this context/ds
-	pub(crate) fn get_index_builder(&self) -> Option<&IndexBuilder> {
-		self.index_builder.as_ref()
+	/// Get the index_builder for this context/ds.
+	pub(crate) fn get_index_builder(&self) -> Option<IndexBuilder> {
+		self.index_builder.as_ref().and_then(|w| w.upgrade())
 	}
 
 	/// Return the sequences manager

--- a/surrealdb/core/src/expr/statements/define/index.rs
+++ b/surrealdb/core/src/expr/statements/define/index.rs
@@ -83,7 +83,13 @@ impl DefineIndexStatement {
 			}
 			// Clear the index store cache
 			ctx.get_index_stores()
-				.index_removed(ctx.get_index_builder(), tb.namespace_id, tb.database_id, &tb, &ix)
+				.index_removed(
+					ctx.get_index_builder().as_ref(),
+					tb.namespace_id,
+					tb.database_id,
+					&tb,
+					&ix,
+				)
 				.await?;
 			ix.index_id
 		} else {

--- a/surrealdb/core/src/expr/statements/remove/database.rs
+++ b/surrealdb/core/src/expr/statements/remove/database.rs
@@ -61,7 +61,12 @@ impl RemoveDatabaseStatement {
 
 		// Remove the index stores
 		ctx.get_index_stores()
-			.database_removed(ctx.get_index_builder(), &txn, db.namespace_id, db.database_id)
+			.database_removed(
+				ctx.get_index_builder().as_ref(),
+				&txn,
+				db.namespace_id,
+				db.database_id,
+			)
 			.await?;
 		// Remove the sequences
 		if let Some(seq) = ctx.get_sequences() {

--- a/surrealdb/core/src/expr/statements/remove/index.rs
+++ b/surrealdb/core/src/expr/statements/remove/index.rs
@@ -65,7 +65,9 @@ impl RemoveIndexStatement {
 		// Get the table definition
 		let tb = txn.expect_tb(ns, db, &table_name).await?;
 		// Clear the index store cache
-		ctx.get_index_stores().index_removed(ctx.get_index_builder(), ns, db, &tb, &ix).await?;
+		ctx.get_index_stores()
+			.index_removed(ctx.get_index_builder().as_ref(), ns, db, &tb, &ix)
+			.await?;
 		// Delete the index data.
 		txn.del_tb_index(ns, db, &table_name, &name).await?;
 		// Refresh the table cache for indexes

--- a/surrealdb/core/src/expr/statements/remove/namespace.rs
+++ b/surrealdb/core/src/expr/statements/remove/namespace.rs
@@ -58,7 +58,7 @@ impl RemoveNamespaceStatement {
 
 		// Remove the index stores
 		ctx.get_index_stores()
-			.namespace_removed(ctx.get_index_builder(), &txn, ns.namespace_id)
+			.namespace_removed(ctx.get_index_builder().as_ref(), &txn, ns.namespace_id)
 			.await?;
 		// Remove the sequences
 		if let Some(seq) = ctx.get_sequences() {

--- a/surrealdb/core/src/expr/statements/remove/table.rs
+++ b/surrealdb/core/src/expr/statements/remove/table.rs
@@ -62,7 +62,9 @@ impl RemoveTableStatement {
 			.into());
 		};
 		// Remove the index stores
-		ctx.get_index_stores().table_removed(ctx.get_index_builder(), &txn, ns, db, &tb).await?;
+		ctx.get_index_stores()
+			.table_removed(ctx.get_index_builder().as_ref(), &txn, ns, db, &tb)
+			.await?;
 
 		// Get the foreign tables
 		let fts = txn.all_tb_views(ns, db, &name, None).await?;

--- a/surrealdb/core/src/kvs/ds.rs
+++ b/surrealdb/core/src/kvs/ds.rs
@@ -122,7 +122,7 @@ pub struct Datastore {
 	// The cross transaction cache
 	cache: Arc<DatastoreCache>,
 	// The index asynchronous builder
-	index_builder: IndexBuilder,
+	pub(crate) index_builder: IndexBuilder,
 	#[cfg(feature = "jwks")]
 	// The JWKS object cache
 	jwks_cache: Arc<RwLock<JwksCache>>,

--- a/surrealdb/core/src/kvs/index.rs
+++ b/surrealdb/core/src/kvs/index.rs
@@ -169,11 +169,34 @@ pub(crate) struct IndexBuilder {
 	indexes: Arc<RwLock<HashMap<SharedIndexKey, IndexBuilding>>>,
 }
 
+/// Weak counterpart to [`IndexBuilder`].
+#[derive(Clone)]
+pub(crate) struct WeakIndexBuilder {
+	tf: TransactionFactory,
+	indexes: std::sync::Weak<RwLock<HashMap<SharedIndexKey, IndexBuilding>>>,
+}
+
+impl WeakIndexBuilder {
+	pub(crate) fn upgrade(&self) -> Option<IndexBuilder> {
+		self.indexes.upgrade().map(|indexes| IndexBuilder {
+			tf: self.tf.clone(),
+			indexes,
+		})
+	}
+}
+
 impl IndexBuilder {
 	pub(super) fn new(tf: TransactionFactory) -> Self {
 		Self {
 			tf,
 			indexes: Default::default(),
+		}
+	}
+
+	pub(crate) fn downgrade(&self) -> WeakIndexBuilder {
+		WeakIndexBuilder {
+			tf: self.tf.clone(),
+			indexes: Arc::downgrade(&self.indexes),
 		}
 	}
 
@@ -1105,5 +1128,45 @@ struct BuildingFinishGuard(IndexBuilding);
 impl Drop for BuildingFinishGuard {
 	fn drop(&mut self) {
 		self.0.finished.store(true, Ordering::Relaxed);
+	}
+}
+
+#[cfg(test)]
+#[cfg(feature = "kv-mem")]
+mod tests {
+	use std::sync::Arc;
+
+	use crate::dbs::Session;
+	use crate::kvs::Datastore;
+
+	/// Asserts that DEFINE INDEX doesn't leak the Datastore via the
+	/// IndexBuilder back-reference cycle.
+	#[tokio::test]
+	async fn define_index_does_not_leak_datastore_via_arc_cycle() {
+		let ds = Arc::new(Datastore::new("memory").await.unwrap());
+		let weak_indexes = Arc::downgrade(&ds.index_builder.indexes);
+
+		let session = Session::owner().with_ns("ns").with_db("db");
+		ds.execute(
+			"DEFINE TABLE t SCHEMAFULL; \
+			 DEFINE FIELD x ON t TYPE string; \
+			 DEFINE INDEX i ON t FIELDS x;",
+			&session,
+			None,
+		)
+		.await
+		.unwrap();
+
+		drop(ds);
+		for _ in 0..50 {
+			if weak_indexes.strong_count() == 0 {
+				return;
+			}
+			tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+		}
+		panic!(
+			"IndexBuilder.indexes still has {} strong refs after dropping the Datastore",
+			weak_indexes.strong_count(),
+		);
 	}
 }


### PR DESCRIPTION
See repro filedescriptors after the fix:

```
With surrealdb 3.0.5 (stock):
  baseline fds:    9
  after 30 iters:  231
  delta:           222         ← ~7.4 fds leaked per iteration

With fix/index-builder-arc-cycle (this PR):
  baseline fds:    9
  after 30 iters:  21
  delta:           12      ← one-time global runtime init; flat per iter

```

## What is the motivation?
Opening many surrealdb instances would leak file descriptors causing hangs in CI for me.

## What does this change do?
It changes the Arc ref to a Weak ref

## What is your testing strategy?
The testing suite + additional test to verify the strong ref count has dropped.

## Security Considerations
not realted.

## Is this related to any issues?
- closes https://github.com/surrealdb/surrealdb/issues/7304
## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

* [ x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
