### PR TITLE
Fix transaction timeout stack cleanup

### DIFF
--- a/surrealdb/core/src/dbs/executor.rs
+++ b/surrealdb/core/src/dbs/executor.rs
@@ -73,6 +73,11 @@ impl Executor {
 		}
 	}
 
+	fn reset_stack_after_dropped_runner(&mut self) {
+		// Dropping a reblessive FinishFuture before completion leaves its stack dirty.
+		self.stack = TreeStack::new();
+	}
+
 	fn execute_option_statement(&mut self, stmt: OptionStatement) -> Result<()> {
 		// Allowed to run?
 		self.opt.is_allowed(Action::Edit, ResourceKind::Option, &Base::Db)?;
@@ -620,6 +625,7 @@ impl Executor {
 				{
 					Ok(res) => res,
 					Err(_) => {
+						self.reset_stack_after_dropped_runner();
 						let _ = txn.cancel().await;
 						bail!(Error::TransactionTimedout(timeout.into()))
 					}
@@ -720,6 +726,7 @@ impl Executor {
 				{
 					Ok(result) => result,
 					Err(_) => {
+						self.reset_stack_after_dropped_runner();
 						let _ = txn.cancel().await;
 						for res in &mut self.results[start_results..] {
 							res.query_type = QueryType::Other;

--- a/surrealdb/core/tests/timeout.rs
+++ b/surrealdb/core/tests/timeout.rs
@@ -6,6 +6,7 @@ use helpers::Test;
 use surrealdb_core::dbs::{Capabilities, Session};
 #[allow(unused_imports)]
 use surrealdb_core::kvs::Datastore;
+use surrealdb_types::Value;
 
 #[tokio::test]
 async fn statement_timeouts() -> Result<()> {
@@ -88,6 +89,23 @@ async fn transaction_timeout() -> Result<()> {
 	let result = res.pop().unwrap().result;
 	let err = result.unwrap_err().to_string();
 	assert!(err.contains("exceeded the timeout"), "Expected transaction timeout error, got: {err}");
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn transaction_timeout_does_not_poison_next_query() -> Result<()> {
+	let ds = new_ds_with_timeout(None, Some(Duration::from_millis(500))).await;
+	let session = Session::owner().with_ns("test").with_db("test");
+
+	let mut res =
+		ds.execute("LET $value = sleep(10s); LET $next = 1;", &session, None).await.unwrap();
+	assert_eq!(res.len(), 2);
+
+	let err = res.remove(0).result.unwrap_err().to_string();
+	assert!(err.contains("exceeded the timeout"), "Expected transaction timeout error, got: {err}");
+	let value = res.remove(0).result?;
+	assert_eq!(value, Value::None);
 
 	Ok(())
 }


### PR DESCRIPTION
## What is the motivation?

`--transaction-timeout` can cancel an executor future while it is inside a reblessive `TreeStack` runner. The dropped `FinishFuture` leaves the reusable executor stack dirty, so a later statement in the same `/sql` batch can panic with `Stack still has unresolved futures, did a previous runner leak?`.

## What does this change do?

Resets the executor's reusable `TreeStack` after a transaction timeout drops an in-flight runner, before later statements can enter the stack again. Adds a regression where a timed-out `LET $value = sleep(10s)` is followed by another `LET` statement in the same execution batch.

## What is your testing strategy?

- RED before the production fix: `cargo test -p surrealdb-core --test timeout transaction_timeout_does_not_poison_next_query -- --nocapture` failed with the reblessive unresolved-futures assertion.
- `cargo test -p surrealdb-core --test timeout transaction_timeout_does_not_poison_next_query -- --nocapture`
- `cargo test -p surrealdb-core --test timeout -- --nocapture`
- `cargo test -p surrealdb-core --lib check_execute_timeout -- --nocapture`
- `cargo fmt --package surrealdb-core -- --check`
- `git diff --check`
- `cargo clippy -p surrealdb-core --test timeout -- -D warnings`

## Security Considerations

This only changes cleanup after server-side transaction timeout cancellation and does not touch authentication, authorization, session handling, or user input parsing. It reduces a panic/availability failure mode.

## Is this related to any issues?

Fixes #7302

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)