### PR TITLE
Fix reference key reconciliation when field schemas change

### DIFF
--- a/language-tests/tests/language/reference/alter_backfill_drop.surql
+++ b/language-tests/tests/language/reference/alter_backfill_drop.surql
@@ -1,0 +1,32 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[{ id: child:c1 }]"
+
+[[test.results]]
+value = "[{ child_ref: child:c1, id: parent:p1 }]"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[parent:p1]"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+value = "[]"
+
+*/
+DEFINE FIELD child_ref ON parent TYPE record<child>;
+CREATE child:c1;
+CREATE parent:p1 SET child_ref = child:c1;
+ALTER FIELD child_ref ON parent REFERENCE ON DELETE IGNORE;
+RETURN child:c1<~(parent FIELD child_ref);
+ALTER FIELD child_ref ON parent DROP REFERENCE;
+RETURN child:c1<~(parent FIELD child_ref);

--- a/language-tests/tests/language/reference/alter_invalid.surql
+++ b/language-tests/tests/language/reference/alter_invalid.surql
@@ -1,0 +1,20 @@
+/**
+[test]
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+error = "Cannot use the `REFERENCE` keyword with `TYPE number`. Specify only a `record` type, or a type containing only records, instead."
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+error = "Cannot use the `REFERENCE` keyword on nested field `nested.ref`. Specify a referencing field at the root level instead."
+
+*/
+DEFINE FIELD ref ON parent TYPE number;
+ALTER FIELD ref ON parent REFERENCE;
+DEFINE FIELD nested.ref ON parent TYPE record;
+ALTER FIELD nested.ref ON parent REFERENCE;

--- a/surrealdb/core/src/doc/alter.rs
+++ b/surrealdb/core/src/doc/alter.rs
@@ -373,6 +373,10 @@ impl Document {
 			None => Ok(None),
 		}
 	}
+
+	pub(super) fn input_writes_path(&self, path: &[Part]) -> bool {
+		self.input_data.as_ref().is_some_and(|data| data.writes_path(path))
+	}
 }
 
 /// The result of evaluating a statement's data clause once, cached on the
@@ -434,6 +438,22 @@ impl ComputedData {
 		}
 	}
 
+	pub(super) fn writes_path(&self, path: &[Part]) -> bool {
+		// Detect explicit user intent from the data clause instead of comparing final values.
+		// A no-op rewrite should be able to repair missing reference keys, while unrelated
+		// writes must remain diff-only so ON DELETE IGNORE cleanup is not undone.
+		match self {
+			ComputedData::Patch(v) => patch_writes_path(v, path),
+			ComputedData::Merge(v) | ComputedData::Replace(v) | ComputedData::Content(v) => {
+				!v.pick(path).is_none()
+			}
+			ComputedData::Unset(paths) => paths.iter().any(|p| p.0.as_slice().starts_with(path)),
+			ComputedData::Set(assignments) => {
+				assignments.iter().any(|a| a.place.0.as_slice().starts_with(path))
+			}
+		}
+	}
+
 	/// Asynchronously materialize the synthetic input value used by `$input`
 	/// in DEFINE EVENT and DEFINE FIELD VALUE / ASSERT expressions. For SET
 	/// this applies the assignments to an empty object so compound operators
@@ -459,6 +479,59 @@ impl ComputedData {
 			}
 		}
 	}
+}
+
+fn patch_writes_path(value: &Value, path: &[Part]) -> bool {
+	let Some(Part::Field(field)) = path.first() else {
+		return false;
+	};
+	let Value::Array(ops) = value else {
+		return false;
+	};
+	// JSON Patch paths use RFC 6901 pointers rather than SurrealQL idioms. Reference fields are
+	// constrained to root-level fields, so checking the first pointer segment is enough and avoids
+	// duplicating the patch evaluator just to classify user intent.
+	ops.iter().any(|op| {
+		let Value::Object(op) = op else {
+			return false;
+		};
+		let Some(Value::String(pointer)) = op.get("path") else {
+			return false;
+		};
+		json_pointer_touches_field(pointer.as_str(), field.as_str())
+	})
+}
+
+fn json_pointer_touches_field(pointer: &str, field: &str) -> bool {
+	if pointer.is_empty() {
+		return true;
+	}
+	let Some(pointer) = pointer.strip_prefix('/') else {
+		return false;
+	};
+	let first = pointer.split('/').next().unwrap_or_default();
+	json_pointer_unescape(first) == field
+}
+
+fn json_pointer_unescape(segment: &str) -> String {
+	let mut out = String::with_capacity(segment.len());
+	let mut chars = segment.chars();
+	while let Some(ch) = chars.next() {
+		if ch == '~' {
+			match chars.next() {
+				Some('0') => out.push('~'),
+				Some('1') => out.push('/'),
+				Some(next) => {
+					out.push('~');
+					out.push(next);
+				}
+				None => out.push('~'),
+			}
+		} else {
+			out.push(ch);
+		}
+	}
+	out
 }
 
 /// A single pre-evaluated assignment from a `SET …` / `ON DUPLICATE KEY

--- a/surrealdb/core/src/doc/field.rs
+++ b/surrealdb/core/src/doc/field.rs
@@ -399,6 +399,10 @@ impl Document {
 			for (k, val) in self.current.doc.as_ref().walk(&fd.name) {
 				// Get the initial value for diff comparison
 				let old = Arc::new(self.initial.doc.as_ref().pick(&k));
+				// Explicit rewrites are allowed to repair missing durable
+				// reference keys. Unrelated writes stay diff-only so they
+				// don't recreate keys removed by ON DELETE IGNORE.
+				let rewrite = self.is_new() || self.input_writes_path(&k);
 
 				let mut field = FieldEditContext {
 					context: None,
@@ -412,7 +416,7 @@ impl Document {
 					user_input: Value::None.into(),
 				};
 
-				field.process_reference_clause(&val).await?;
+				field.process_reference_clause(&val, rewrite).await?;
 			}
 		}
 
@@ -466,7 +470,7 @@ impl Document {
 				};
 
 				// Pass an empty value to delete all the existing references
-				field.process_reference_clause(&Value::None).await?;
+				field.process_reference_clause(&Value::None, false).await?;
 			}
 		}
 
@@ -780,16 +784,9 @@ impl FieldEditContext<'_> {
 	}
 
 	/// Process any REFERENCE clause for the field definition
-	async fn process_reference_clause(&mut self, val: &Value) -> Result<()> {
+	async fn process_reference_clause(&mut self, val: &Value, rewrite: bool) -> Result<()> {
 		// Is there a `REFERENCE` clause?
 		if self.def.reference.is_some() {
-			// Check if the value has actually changed
-			let old = self.old.as_ref();
-			if old == val {
-				// Nothing changed
-				return Ok(());
-			}
-
 			// Create a vector to store the actions
 			let mut actions = vec![];
 
@@ -806,14 +803,22 @@ impl FieldEditContext<'_> {
 				}
 			}
 
-			let old = collect_rids(old);
+			let old = collect_rids(self.old.as_ref());
 			let new = collect_rids(val);
 
 			for rid in old.difference(&new) {
 				actions.push(RefAction::Delete(rid));
 			}
 
-			for rid in new.difference(&old) {
+			// Explicit rewrites set every current reference so a user can repair missing durable
+			// keys by writing the same value again. For unrelated writes, keep the old diff-only
+			// behavior to avoid recreating keys intentionally removed by ON DELETE IGNORE.
+			let set: Vec<_> = if rewrite {
+				new.iter().collect()
+			} else {
+				new.difference(&old).collect()
+			};
+			for rid in set {
 				actions.push(RefAction::Set(rid));
 			}
 

--- a/surrealdb/core/src/expr/statements/alter/field.rs
+++ b/surrealdb/core/src/expr/statements/alter/field.rs
@@ -15,6 +15,7 @@ use crate::doc::CursorDoc;
 use crate::err::Error;
 use crate::expr::parameterize::{expr_to_ident, expr_to_idiom};
 use crate::expr::reference::Reference;
+use crate::expr::statements::DefineFieldStatement;
 use crate::expr::{Base, Expr, Kind, Literal};
 use crate::iam::{Action, AuthLimit, ResourceKind};
 use crate::val::{TableName, Value};
@@ -97,6 +98,7 @@ impl AlterFieldStatement {
 				.into());
 			}
 		};
+		let previous = df.clone();
 
 		match self.kind {
 			AlterKind::Set(ref k) => df.field_kind = Some(k.clone()),
@@ -165,6 +167,8 @@ impl AlterFieldStatement {
 		// Recompute auth_limit from the current principal to prevent privilege escalation
 		df.auth_limit = AuthLimit::new_from_auth(opt.auth.as_ref()).into();
 
+		DefineFieldStatement::validate_reference_options(&df)?;
+
 		let key = crate::key::table::fd::new(ns, db, &what, &name);
 		txn.set(&key, &df).await?;
 		// Refresh the table cache
@@ -183,6 +187,12 @@ impl AlterFieldStatement {
 			},
 		)
 		.await?;
+		if matches!(self.reference, AlterKind::Set(_) | AlterKind::Drop)
+			|| matches!(self.kind, AlterKind::Set(_) | AlterKind::Drop)
+		{
+			DefineFieldStatement::reconcile_reference_keys(ctx, ns, db, Some(&previous), &df)
+				.await?;
+		}
 		// Clear the cache
 		txn.clear_cache();
 		// Ok all good

--- a/surrealdb/core/src/expr/statements/define/field.rs
+++ b/surrealdb/core/src/expr/statements/define/field.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::{Result, bail, ensure};
@@ -21,8 +22,9 @@ use crate::expr::{
 	Base, Expr, FlowResultExt, Idiom, Kind, KindLiteral, Literal, Part, RecordIdKeyLit,
 };
 use crate::iam::{Action, AuthLimit, ResourceKind};
-use crate::kvs::Transaction;
-use crate::val::{TableName, Value};
+use crate::idx::planner::ScanDirection;
+use crate::kvs::{KVValue, NORMAL_BATCH_SIZE, ScanLimit, Transaction};
+use crate::val::{RecordId, TableName, Value};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub(crate) enum DefineDefault {
@@ -176,7 +178,7 @@ impl DefineFieldStatement {
 		self.validate_computed_cycles(ns, db, ctx.tx(), &definition).await?;
 
 		// Validate reference options
-		self.validate_reference_options(&definition)?;
+		Self::validate_reference_options(&definition)?;
 
 		// Disallow mismatched types
 		self.disallow_mismatched_types(ctx, ns, db, &definition).await?;
@@ -198,7 +200,8 @@ impl DefineFieldStatement {
 		// path silently overwrites the first.
 		let fd = definition.name.to_raw_string();
 		// Check if the definition exists
-		if let Some(fd) = txn.get_tb_field(ns, db, &tb.name, &fd, None).await? {
+		let previous = txn.get_tb_field(ns, db, &tb.name, &fd, None).await?;
+		if let Some(fd) = previous.as_ref() {
 			match self.kind {
 				DefineKind::Default => {
 					if !opt.import {
@@ -282,10 +285,181 @@ impl DefineFieldStatement {
 		// Process possible recursive defitions
 		self.process_recursive_definitions(ns, db, Arc::clone(&txn), &definition).await?;
 
+		// Reconcile durable reference keys with the new schema contract.
+		Self::reconcile_reference_keys(ctx, ns, db, previous.as_deref(), &definition).await?;
+
 		// Clear the cache
 		txn.clear_cache();
 		// Ok all good
 		Ok(Value::None)
+	}
+
+	pub(crate) async fn backfill_reference_keys(
+		ctx: &FrozenContext,
+		ns: NamespaceId,
+		db: DatabaseId,
+		definition: &catalog::FieldDefinition,
+	) -> Result<()> {
+		if definition.reference.is_none() {
+			return Ok(());
+		}
+
+		fn collect_rids(value: &Value) -> HashSet<&RecordId> {
+			match value {
+				Value::Array(array) => array.iter().filter_map(Value::as_record).collect(),
+				Value::Set(set) => set.iter().filter_map(Value::as_record).collect(),
+				Value::RecordId(rid) => HashSet::from([rid]),
+				_ => HashSet::new(),
+			}
+		}
+
+		let txn = ctx.tx();
+		let beg = crate::key::record::prefix(ns, db, &definition.table)?;
+		let end = crate::key::record::suffix(ns, db, &definition.table)?;
+		let field = definition.name.to_sql();
+		// Existing schemaless records can contain record IDs outside the newly declared TYPE.
+		// Filter during backfill so the schema change does not create out-of-contract reverse
+		// references that later cleanup cannot reason about from the field definition.
+		let allowed_target_tables = Self::reference_target_tables(definition);
+		let mut next = Some(beg..end);
+
+		while let Some(range) = next {
+			let batch = txn.batch_keys_vals(range, NORMAL_BATCH_SIZE, None).await?;
+			next = batch.next;
+
+			for (key, value) in batch.result {
+				let record_key = crate::key::record::RecordKey::decode_key(&key)?;
+				let origin = RecordId {
+					table: record_key.tb.as_ref().clone(),
+					key: record_key.id.clone(),
+				};
+				let record = catalog::Record::kv_decode_value(&value, origin.clone())?;
+				let value = record.data.pick(&definition.name);
+
+				for target in collect_rids(&value) {
+					if allowed_target_tables
+						.as_ref()
+						.is_some_and(|tables| !tables.contains(&target.table))
+					{
+						continue;
+					}
+					let key = crate::key::r#ref::new(
+						ns,
+						db,
+						&target.table,
+						&target.key,
+						&origin.table,
+						&field,
+						&origin.key,
+					);
+					txn.set(&key, &()).await?;
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	pub(crate) async fn delete_reference_keys(
+		ctx: &FrozenContext,
+		ns: NamespaceId,
+		db: DatabaseId,
+		definition: &catalog::FieldDefinition,
+	) -> Result<()> {
+		if definition.reference.is_none() {
+			return Ok(());
+		}
+
+		let txn = ctx.tx();
+		let field = definition.name.to_sql();
+		let range = crate::key::r#ref::dbprefix(ns, db)?..crate::key::r#ref::dbsuffix(ns, db)?;
+		// Reference keys are ordered by target record before origin table and field. When the
+		// schema changes, old durable keys may live under target tables that are no longer allowed
+		// by the new field type, so cleanup must scan the database reference-key range and filter
+		// by the previous origin table/field. Use the same cursor/yield pattern as record delete
+		// reference purging so large schema migrations make progress in bounded batches.
+		let mut cursor = txn.open_keys_cursor(range, ScanDirection::Forward, 0, None).await?;
+
+		loop {
+			let batch = cursor.next_batch(ScanLimit::Count(NORMAL_BATCH_SIZE)).await?;
+			if batch.is_empty() {
+				break;
+			}
+			let keys: Vec<Vec<u8>> = batch.iter().map(|key| key.to_vec()).collect();
+
+			for key in keys {
+				yield_now!();
+				let Ok(reference) = crate::key::r#ref::Ref::decode_key(&key) else {
+					continue;
+				};
+				if reference.ft.as_ref() == definition.table && reference.ff.as_ref() == field {
+					txn.del(&key).await?;
+				}
+			}
+		}
+
+		Ok(())
+	}
+
+	fn reference_target_tables(
+		definition: &catalog::FieldDefinition,
+	) -> Option<HashSet<TableName>> {
+		// None means the declared kind is unconstrained for target table purposes, e.g. `record`.
+		// Some(empty) means the kind contains no valid target tables, which causes backfill to
+		// skip every record ID instead of guessing.
+		fn collect(kind: &Kind, tables: &mut HashSet<TableName>) -> bool {
+			match kind {
+				Kind::None => true,
+				Kind::Record(record_tables) => {
+					if record_tables.is_empty() {
+						return false;
+					}
+					tables.extend(record_tables.iter().cloned());
+					true
+				}
+				Kind::Either(kinds) => kinds.iter().all(|kind| collect(kind, tables)),
+				Kind::Array(kind, _) | Kind::Set(kind, _) => collect(kind, tables),
+				Kind::Literal(KindLiteral::Array(kinds)) => {
+					kinds.iter().all(|kind| collect(kind, tables))
+				}
+				_ => true,
+			}
+		}
+
+		let kind = definition.field_kind.as_ref()?;
+		let mut tables = HashSet::new();
+		collect(kind, &mut tables).then_some(tables)
+	}
+
+	pub(crate) async fn reconcile_reference_keys(
+		ctx: &FrozenContext,
+		ns: NamespaceId,
+		db: DatabaseId,
+		previous: Option<&catalog::FieldDefinition>,
+		definition: &catalog::FieldDefinition,
+	) -> Result<()> {
+		if let Some(previous) = previous {
+			// Rebuild only when the durable key shape can change. The ON DELETE strategy lives in
+			// the field definition and is consulted when a target record is deleted; it does not
+			// affect reference-key bytes, so rebuilding on strategy-only changes is wasted work.
+			let origin_changed =
+				previous.table != definition.table || previous.name != definition.name;
+			let target_type_changed = previous.field_kind != definition.field_kind;
+			let reference_presence_changed =
+				previous.reference.is_some() != definition.reference.is_some();
+			let key_shape_changed =
+				origin_changed || target_type_changed || reference_presence_changed;
+
+			if previous.reference.is_some()
+				&& (definition.reference.is_none() || origin_changed || target_type_changed)
+			{
+				Self::delete_reference_keys(ctx, ns, db, previous).await?;
+			}
+			if definition.reference.is_some() && !key_shape_changed {
+				return Ok(());
+			}
+		}
+		Self::backfill_reference_keys(ctx, ns, db, definition).await
 	}
 
 	pub(crate) async fn process_recursive_definitions(
@@ -519,12 +693,9 @@ impl DefineFieldStatement {
 		Ok(())
 	}
 
-	pub(crate) fn validate_reference_options(
-		&self,
-		definition: &catalog::FieldDefinition,
-	) -> Result<()> {
+	pub(crate) fn validate_reference_options(definition: &catalog::FieldDefinition) -> Result<()> {
 		// If a reference is defined, the field must be a record
-		if self.reference.is_some() {
+		if definition.reference.is_some() {
 			ensure!(
 				definition.name.len() == 1,
 				Error::ReferenceNestedField(definition.name.to_sql())
@@ -541,7 +712,7 @@ impl DefineFieldStatement {
 				}
 			}
 
-			let is_record_id = match self.field_kind.as_ref() {
+			let is_record_id = match definition.field_kind.as_ref() {
 				Some(Kind::Either(kinds)) => kinds.iter().all(|k| valid(k, true)),
 				Some(Kind::Array(kind, _)) | Some(Kind::Set(kind, _)) => match kind.as_ref() {
 					Kind::Either(kinds) => kinds.iter().all(|k| valid(k, true)),
@@ -558,7 +729,7 @@ impl DefineFieldStatement {
 			ensure!(
 				is_record_id,
 				Error::ReferenceTypeConflict(
-					self.field_kind.as_ref().unwrap_or(&Kind::Any).to_sql()
+					definition.field_kind.as_ref().unwrap_or(&Kind::Any).to_sql()
 				)
 			);
 		}

--- a/surrealdb/core/src/key/ref/mod.rs
+++ b/surrealdb/core/src/key/ref/mod.rs
@@ -170,6 +170,18 @@ pub fn new<'a>(
 	Ref::new_impl(ns, db, tb, id, ft, ff, fk)
 }
 
+pub fn dbprefix(ns: NamespaceId, db: DatabaseId) -> Result<Vec<u8>> {
+	let mut k = crate::key::database::all::new(ns, db).encode_key()?;
+	k.extend_from_slice(b"*\x00");
+	Ok(k)
+}
+
+pub fn dbsuffix(ns: NamespaceId, db: DatabaseId) -> Result<Vec<u8>> {
+	let mut k = crate::key::database::all::new(ns, db).encode_key()?;
+	k.extend_from_slice(b"*\xff");
+	Ok(k)
+}
+
 pub fn prefix(
 	ns: NamespaceId,
 	db: DatabaseId,

--- a/surrealdb/core/tests/reference.rs
+++ b/surrealdb/core/tests/reference.rs
@@ -1,0 +1,442 @@
+#![recursion_limit = "256"]
+#![allow(clippy::unwrap_used)]
+
+mod helpers;
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use helpers::{Test, new_ds, new_ns_db};
+use surrealdb_core::dbs::Session;
+use surrealdb_core::dbs::capabilities::Capabilities;
+use surrealdb_core::kvs::Datastore;
+use surrealdb_core::observe::{
+	ExecutionObserver, Outcome, TransactionEvent, TransactionMetricsSnapshot,
+};
+use surrealdb_core::syn;
+use surrealdb_types::Value;
+
+#[derive(Default)]
+struct CapturingTransactionObserver {
+	metrics: Mutex<Vec<TransactionMetricsSnapshot>>,
+}
+
+impl CapturingTransactionObserver {
+	fn clear(&self) {
+		self.metrics.lock().unwrap().clear();
+	}
+
+	fn snapshot(&self) -> Vec<TransactionMetricsSnapshot> {
+		self.metrics.lock().unwrap().clone()
+	}
+}
+
+impl ExecutionObserver for CapturingTransactionObserver {
+	fn on_transaction_complete(&self, event: &TransactionEvent) {
+		if event.safe.write && event.safe.outcome == Outcome::Success {
+			self.metrics.lock().unwrap().push(event.safe.metrics);
+		}
+	}
+}
+
+async fn new_observed_ds() -> Result<(Datastore, Arc<CapturingTransactionObserver>)> {
+	let observer = Arc::new(CapturingTransactionObserver::default());
+	let ds = Datastore::builder()
+		.with_capabilities(Capabilities::all())
+		.with_observer(observer.clone())
+		.build_with_path("memory")
+		.await?;
+	new_ns_db(&ds, "test", "test").await?;
+	observer.clear();
+	Ok((ds, observer))
+}
+
+async fn run_ok(ds: &Datastore, ses: &Session, sql: &str) -> Result<()> {
+	for response in ds.execute(sql, ses, None).await? {
+		response.output()?;
+	}
+	Ok(())
+}
+
+async fn query_value(ds: &Datastore, ses: &Session, sql: &str) -> Result<Value> {
+	let mut res = ds.execute(sql, ses, None).await?;
+	Ok(res.remove(0).output()?)
+}
+
+#[tokio::test]
+async fn define_reference_backfills_existing_records() -> Result<()> {
+	let (_, ds) = new_ds("test", "test", false).await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		DEFINE TABLE child SCHEMAFULL;
+		DEFINE FIELD name ON child TYPE string;
+		DEFINE TABLE parent SCHEMAFULL;
+		DEFINE FIELD name ON parent TYPE string;
+		DEFINE FIELD child_ref ON parent TYPE record<child>;
+		CREATE child:c1 SET name = 'child1';
+		CREATE parent:p1 SET name = 'parent1', child_ref = child:c1;
+		DEFINE FIELD OVERWRITE child_ref ON parent TYPE record<child> REFERENCE ON DELETE REJECT;
+		DEFINE FIELD refs ON child COMPUTED <~(parent FIELD child_ref);
+		",
+	)
+	.await?;
+
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[parent:p1]")?
+	);
+	assert_eq!(query_value(&ds, &ses, "RETURN child:c1.refs").await?, syn::value("[parent:p1]")?);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn alter_reference_rejects_invalid_reference_fields() -> Result<()> {
+	Test::new(
+		"
+		DEFINE FIELD ref ON parent TYPE number;
+		ALTER FIELD ref ON parent REFERENCE;
+		DEFINE FIELD nested.ref ON parent TYPE record;
+		ALTER FIELD nested.ref ON parent REFERENCE;
+		",
+	)
+	.await?
+	.expect_val("NONE")?
+	.expect_error("Cannot use the `REFERENCE` keyword with `TYPE number`. Specify only a `record` type, or a type containing only records, instead.")?
+	.expect_val("NONE")?
+	.expect_error("Cannot use the `REFERENCE` keyword on nested field `nested.ref`. Specify a referencing field at the root level instead.")?;
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn define_reference_does_not_backfill_records_outside_declared_type() -> Result<()> {
+	let (_, ds) = new_ds("test", "test", false).await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		CREATE other:o;
+		CREATE parent:p1 SET child_ref = other:o;
+		DEFINE FIELD OVERWRITE child_ref ON parent TYPE record<child> REFERENCE ON DELETE IGNORE;
+		",
+	)
+	.await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN other:o<~(parent FIELD child_ref)").await?,
+		syn::value("[]")?
+	);
+
+	run_ok(&ds, &ses, "ALTER FIELD child_ref ON parent DROP REFERENCE").await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN other:o<~(parent FIELD child_ref)").await?,
+		syn::value("[]")?
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn define_reference_type_narrowing_removes_old_outside_type_reference_keys() -> Result<()> {
+	let (_, ds) = new_ds("test", "test", false).await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		CREATE other:o;
+		DEFINE FIELD child_ref ON parent TYPE record REFERENCE ON DELETE IGNORE;
+		CREATE parent:p1 SET child_ref = other:o;
+		",
+	)
+	.await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN other:o<~(parent FIELD child_ref)").await?,
+		syn::value("[parent:p1]")?
+	);
+
+	run_ok(
+		&ds,
+		&ses,
+		"DEFINE FIELD OVERWRITE child_ref ON parent TYPE record<child> REFERENCE ON DELETE IGNORE",
+	)
+	.await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN other:o<~(parent FIELD child_ref)").await?,
+		syn::value("[]")?
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn alter_reference_type_narrowing_removes_old_outside_type_reference_keys() -> Result<()> {
+	let (_, ds) = new_ds("test", "test", false).await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		CREATE other:o;
+		DEFINE FIELD child_ref ON parent TYPE record REFERENCE ON DELETE IGNORE;
+		CREATE parent:p1 SET child_ref = other:o;
+		",
+	)
+	.await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN other:o<~(parent FIELD child_ref)").await?,
+		syn::value("[parent:p1]")?
+	);
+
+	run_ok(&ds, &ses, "ALTER FIELD child_ref ON parent TYPE record<child>").await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN other:o<~(parent FIELD child_ref)").await?,
+		syn::value("[]")?
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn alter_reference_backfills_existing_records() -> Result<()> {
+	let (_, ds) = new_ds("test", "test", false).await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		DEFINE TABLE child SCHEMAFULL;
+		DEFINE FIELD name ON child TYPE string;
+		DEFINE TABLE parent SCHEMAFULL;
+		DEFINE FIELD name ON parent TYPE string;
+		DEFINE FIELD child_ref ON parent TYPE record<child>;
+		CREATE child:c1 SET name = 'child1';
+		CREATE parent:p1 SET name = 'parent1', child_ref = child:c1;
+		ALTER FIELD child_ref ON parent REFERENCE ON DELETE REJECT;
+		",
+	)
+	.await?;
+
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[parent:p1]")?
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn changing_reference_delete_strategy_does_not_rebuild_reference_keys() -> Result<()> {
+	let (ds, observer) = new_observed_ds().await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		DEFINE FIELD child_ref ON parent TYPE record<child> REFERENCE ON DELETE IGNORE;
+		CREATE child:c1;
+		CREATE parent:p1 SET child_ref = child:c1;
+		",
+	)
+	.await?;
+	observer.clear();
+
+	run_ok(&ds, &ses, "ALTER FIELD child_ref ON parent REFERENCE ON DELETE REJECT").await?;
+
+	let deleted_keys: u32 = observer.snapshot().iter().map(|metrics| metrics.ops_del).sum();
+	assert_eq!(
+		deleted_keys, 0,
+		"changing only ON DELETE strategy must not rebuild durable reference keys"
+	);
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[parent:p1]")?
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn update_reference_field_recreates_missing_reference_key() -> Result<()> {
+	let (_, ds) = new_ds("test", "test", false).await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		DEFINE TABLE child SCHEMAFULL;
+		DEFINE FIELD name ON child TYPE string;
+		DEFINE TABLE parent SCHEMAFULL;
+		DEFINE FIELD name ON parent TYPE string;
+		DEFINE FIELD child_ref ON parent TYPE record<child> REFERENCE ON DELETE IGNORE;
+		CREATE child:c1 SET name = 'child1';
+		CREATE parent:p1 SET name = 'parent1', child_ref = child:c1;
+		DELETE child:c1;
+		CREATE child:c1 SET name = 'child1';
+		",
+	)
+	.await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[]")?
+	);
+
+	run_ok(&ds, &ses, "UPDATE parent:p1 SET child_ref = child:c1").await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[parent:p1]")?
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn patch_reference_field_recreates_missing_reference_key() -> Result<()> {
+	let (_, ds) = new_ds("test", "test", false).await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		DEFINE TABLE child SCHEMAFULL;
+		DEFINE FIELD name ON child TYPE string;
+		DEFINE TABLE parent SCHEMAFULL;
+		DEFINE FIELD name ON parent TYPE string;
+		DEFINE FIELD child_ref ON parent TYPE record<child> REFERENCE ON DELETE IGNORE;
+		CREATE child:c1 SET name = 'child1';
+		CREATE parent:p1 SET name = 'parent1', child_ref = child:c1;
+		DELETE child:c1;
+		CREATE child:c1 SET name = 'child1';
+		",
+	)
+	.await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[]")?
+	);
+
+	run_ok(
+		&ds,
+		&ses,
+		"UPDATE parent:p1 PATCH [{ op: 'replace', path: '/child_ref', value: child:c1 }]",
+	)
+	.await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[parent:p1]")?
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn unrelated_update_does_not_recreate_ignored_reference_key() -> Result<()> {
+	let (_, ds) = new_ds("test", "test", false).await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		DEFINE TABLE child SCHEMAFULL;
+		DEFINE FIELD name ON child TYPE string;
+		DEFINE TABLE parent SCHEMAFULL;
+		DEFINE FIELD name ON parent TYPE string;
+		DEFINE FIELD child_ref ON parent TYPE record<child> REFERENCE ON DELETE IGNORE;
+		CREATE child:c1 SET name = 'child1';
+		CREATE parent:p1 SET name = 'parent1', child_ref = child:c1;
+		DELETE child:c1;
+		",
+	)
+	.await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[]")?
+	);
+
+	run_ok(&ds, &ses, "UPDATE parent:p1 SET name = 'renamed'").await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[]")?
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn alter_drop_reference_removes_reference_keys() -> Result<()> {
+	let (_, ds) = new_ds("test", "test", false).await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		DEFINE TABLE child SCHEMAFULL;
+		DEFINE FIELD name ON child TYPE string;
+		DEFINE TABLE parent SCHEMAFULL;
+		DEFINE FIELD name ON parent TYPE string;
+		DEFINE FIELD child_ref ON parent TYPE record<child> REFERENCE ON DELETE IGNORE;
+		CREATE child:c1 SET name = 'child1';
+		CREATE parent:p1 SET name = 'parent1', child_ref = child:c1;
+		",
+	)
+	.await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[parent:p1]")?
+	);
+
+	run_ok(&ds, &ses, "ALTER FIELD child_ref ON parent DROP REFERENCE").await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[]")?
+	);
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn define_overwrite_without_reference_removes_reference_keys() -> Result<()> {
+	let (_, ds) = new_ds("test", "test", false).await?;
+	let ses = Session::owner().with_ns("test").with_db("test");
+
+	run_ok(
+		&ds,
+		&ses,
+		"
+		DEFINE TABLE child SCHEMAFULL;
+		DEFINE FIELD name ON child TYPE string;
+		DEFINE TABLE parent SCHEMAFULL;
+		DEFINE FIELD name ON parent TYPE string;
+		DEFINE FIELD child_ref ON parent TYPE record<child> REFERENCE ON DELETE IGNORE;
+		CREATE child:c1 SET name = 'child1';
+		CREATE parent:p1 SET name = 'parent1', child_ref = child:c1;
+		",
+	)
+	.await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[parent:p1]")?
+	);
+
+	run_ok(&ds, &ses, "DEFINE FIELD OVERWRITE child_ref ON parent TYPE record<child>").await?;
+	assert_eq!(
+		query_value(&ds, &ses, "RETURN child:c1<~(parent FIELD child_ref)").await?,
+		syn::value("[]")?
+	);
+
+	Ok(())
+}


### PR DESCRIPTION
Fixes #7144.

## Summary

Reference tracking keys were not reconciled when `REFERENCE` was added, changed, or removed from an existing field definition. This meant reverse references via `<~` could remain empty for existing data, and same-value `UPDATE`s could not repair missing reference keys.

This change teaches field schema changes to reconcile durable reference keys when the reference key shape changes, while preserving the cheap metadata-only path for changes that do not affect stored keys.

## What Changed

- Backfill reference keys when `DEFINE FIELD OVERWRITE` or `ALTER FIELD` adds a `REFERENCE` to an existing field.
- Delete stale reference keys when a field drops `REFERENCE` or changes to a different reference key shape.
- Repair missing keys on explicit same-value writes to a reference field.
- Keep unrelated writes diff-based so normal document updates do not rewrite all reference keys.
- Validate reference options consistently after `ALTER FIELD`.
- Add database-level reference key prefix/suffix helpers for cleanup scans.
- Add regression coverage for:
  - adding references after data already exists
  - dropping references
  - invalid altered reference definitions
  - same-value repair behavior
  - language-level reference ALTER flows

## Why

SurrealDB stores reverse reference lookup data separately from the record value. Before this change, schema updates could change the declared reference behavior without reconciling that durable tracking data.

That left the database in a split state: the record contained a valid forward reference, but `<~` could not find it because the reverse tracking key was never created.

A lazy repair-only approach was not chosen because existing reverse lookups would stay incorrect until every affected record happened to be rewritten. Instead, schema changes that alter the stored key shape now do the required migration work immediately.

A full rebuild on every reference option change was also avoided. Changes such as `ON DELETE IGNORE` to `ON DELETE REJECT` do not alter the key shape, so they remain metadata-only and avoid unnecessary scans.

## Performance

The common hot paths remain cheap:

- strategy-only reference changes stay O(1)
- unrelated document updates stay diff-based
- same-value explicit rewrites only repair the affected field refs

Schema migration paths are intentionally linear:

- adding `REFERENCE` scans existing origin records to backfill keys
- dropping/changing reference key shape scans/deletes existing reference keys

Measured before/after comparison showed the old implementation was faster only because it skipped required work and produced incorrect reverse-reference state. The new implementation performs linear work where correctness requires it, while preserving O(1) behavior for metadata-only changes.

## Tests

This adds regression coverage at both the core engine and SurrealQL language-test layers.

The new tests cover adding `REFERENCE` to fields with existing data, removing or changing reference definitions, repairing missing keys through explicit same-value updates, and rejecting invalid altered reference definitions. Together these exercise both the durable reference-key reconciliation path and the user-visible `<~` query behavior.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

* [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
