### PR TITLE
Fix bucket permission checks in streaming file executor

### DIFF
--- a/language-tests/tests/reproductions/7345_bucket_specific_permissions_record_user.surql
+++ b/language-tests/tests/reproductions/7345_bucket_specific_permissions_record_user.surql
@@ -1,0 +1,33 @@
+/**
+[env]
+imports = ["reproductions/7345_bucket_specific_permissions_record_user_import.surql"]
+auth = { namespace = "test", database = "test", access = "user", rid = "user:bob" }
+
+[env.capabilities]
+allow-experimental = ["files"]
+
+[test]
+reason = "Issue 7345: record users must not bypass DEFINE BUCKET PERMISSIONS WHERE in the streaming file executor."
+issue = 7345
+
+[[test.results]]
+error = "You don't have permission to get this file in the `deny_where` bucket"
+
+[[test.results]]
+value = '"ALLOWED"'
+
+[[test.results]]
+error = "You don't have permission to get this file in the `file_gate` bucket"
+
+[[test.results]]
+value = "NONE"
+
+[[test.results]]
+error = "You don't have permission to copy this file in the `target_gate` bucket"
+*/
+
+file::get(f"deny_where:/secret.txt").?.to_string();
+file::get(f"file_gate:/allowed.txt").?.to_string();
+file::get(f"file_gate:/denied.txt").?.to_string();
+file::copy(f"target_gate:/source.txt", "allowed-copy.txt");
+file::copy(f"target_gate:/source.txt", "denied-copy.txt");

--- a/language-tests/tests/reproductions/7345_bucket_specific_permissions_record_user_import.surql
+++ b/language-tests/tests/reproductions/7345_bucket_specific_permissions_record_user_import.surql
@@ -1,0 +1,25 @@
+/**
+[test]
+reason = "Setup for issue 7345: buckets with specific permissions used by a record user reproduction."
+run = false
+*/
+
+DEFINE ACCESS user ON DATABASE TYPE RECORD
+	SIGNIN ( $rid );
+
+CREATE user:bob;
+
+DEFINE BUCKET deny_where BACKEND "memory"
+	PERMISSIONS WHERE false;
+f"deny_where:/secret.txt".put("DENY-ME");
+
+DEFINE BUCKET file_gate BACKEND "memory"
+	PERMISSIONS WHERE $action = "get" AND $file = f"file_gate:/allowed.txt";
+f"file_gate:/allowed.txt".put("ALLOWED");
+f"file_gate:/denied.txt".put("DENIED");
+
+DEFINE BUCKET target_gate BACKEND "memory"
+	PERMISSIONS WHERE $action = "copy"
+		AND $file = f"target_gate:/source.txt"
+		AND $target = f"target_gate:/allowed-copy.txt";
+f"target_gate:/source.txt".put("SOURCE");

--- a/surrealdb/core/src/buc/controller.rs
+++ b/surrealdb/core/src/buc/controller.rs
@@ -244,7 +244,7 @@ impl<'a> BucketController<'a> {
 	/// The listing can be filtered by prefix and paginated using start key and limit.
 	/// Note: Guest and Record users are not allowed to list files in buckets.
 	pub(crate) async fn list(&mut self, opts: &ListOptions) -> Result<Vec<ObjectMeta>> {
-		self.check_permission(BucketOperation::Exists, None, None).await?;
+		self.check_permission(BucketOperation::List, None, None).await?;
 		self.store
 			.list(opts)
 			.await

--- a/surrealdb/core/src/exec/function/builtin/file.rs
+++ b/surrealdb/core/src/exec/function/builtin/file.rs
@@ -9,11 +9,13 @@ use anyhow::{Result, bail, ensure};
 
 use crate::buc::BucketOperation;
 use crate::buc::store::{ListOptions, ObjectKey, ObjectStore};
+use crate::catalog::BucketDefinition;
 use crate::catalog::providers::BucketProvider;
-use crate::catalog::{BucketDefinition, Permission};
 use crate::dbs::capabilities::ExperimentalTarget;
 use crate::err::Error;
+use crate::exec::ExecutionContext;
 use crate::exec::function::FunctionRegistry;
+use crate::exec::permission::{PhysicalPermission, convert_permission_to_physical_runtime};
 use crate::exec::physical_expr::EvalContext;
 use crate::fnc::args::FromArgs;
 use crate::val::{Bytes, File, Object, Value};
@@ -36,6 +38,7 @@ struct StreamingBucketOps<'a> {
 	bucket: Arc<BucketDefinition>,
 	store: Arc<dyn ObjectStore>,
 	frozen_ctx: &'a crate::ctx::FrozenContext,
+	exec_ctx: &'a ExecutionContext,
 	opt: &'a crate::dbs::Options,
 }
 
@@ -70,6 +73,7 @@ impl<'a> StreamingBucketOps<'a> {
 			bucket,
 			store,
 			frozen_ctx,
+			exec_ctx: ctx.exec_ctx,
 			opt,
 		})
 	}
@@ -81,11 +85,12 @@ impl<'a> StreamingBucketOps<'a> {
 	}
 
 	/// Check permissions for an operation.
-	///
-	/// For Permission::Specific, we currently don't support the full expression
-	/// evaluation in the streaming executor (requires Stk). In that case, we
-	/// fall back to checking based on role only.
-	fn check_permission(&self, op: BucketOperation) -> Result<()> {
+	async fn check_permission(
+		&self,
+		op: BucketOperation,
+		key: Option<&ObjectKey>,
+		target: Option<&ObjectKey>,
+	) -> Result<()> {
 		// Check if we should check permissions (uses Options::check_perms like fnc::file)
 		if self.frozen_ctx.check_perms(self.opt, op.into())? {
 			// Guest and Record users are not allowed to list files in buckets
@@ -97,22 +102,58 @@ impl<'a> StreamingBucketOps<'a> {
 				}
 			);
 
-			match &self.bucket.permissions {
-				Permission::None => {
+			match convert_permission_to_physical_runtime(
+				&self.bucket.permissions,
+				self.exec_ctx.ctx(),
+			)
+			.await?
+			{
+				PhysicalPermission::Deny => {
 					bail!(Error::BucketPermissions {
 						name: self.bucket.name.to_string(),
 						op,
 					})
 				}
-				Permission::Full => (),
-				Permission::Specific(_) => {
-					// For specific permissions, we would need to evaluate the expression
-					// using the legacy compute path. For now, we allow if auth is sufficient.
-					// This is a simplification - the full BucketController would evaluate
-					// the expression with $action, $file, $target variables.
-					//
-					// In practice, most buckets use Permission::Full or Permission::None,
-					// so this simplification should work for the common cases.
+				PhysicalPermission::Allow => (),
+				PhysicalPermission::Conditional(expr) => {
+					let mut exec_ctx =
+						self.exec_ctx.with_param("action", Value::from(op.to_string()));
+					if let Some(key) = key {
+						exec_ctx = exec_ctx.with_param(
+							"file",
+							Value::File(File {
+								bucket: self.bucket.name.to_string(),
+								key: key.to_string(),
+							}),
+						);
+					}
+					if let Some(target) = target {
+						exec_ctx = exec_ctx.with_param(
+							"target",
+							Value::File(File {
+								bucket: self.bucket.name.to_string(),
+								key: target.to_string(),
+							}),
+						);
+					}
+
+					// SECURITY: the bucket predicate runs with the caller's auth and only
+					// disables nested permission checks to avoid recursive permission
+					// evaluation, matching the bounded legacy `new_with_perms(false)` path.
+					let exec_ctx = exec_ctx.with_skip_fetch_perms(true);
+					let eval_ctx = EvalContext::from_exec_ctx(&exec_ctx);
+					let res = expr
+						.evaluate(eval_ctx)
+						.await
+						.map_err(|e| Error::Internal(e.to_string()))?;
+
+					ensure!(
+						res.is_truthy(),
+						Error::BucketPermissions {
+							name: self.bucket.name.to_string(),
+							op,
+						}
+					);
 				}
 			}
 		}
@@ -124,7 +165,7 @@ impl<'a> StreamingBucketOps<'a> {
 	async fn put(&self, key: &ObjectKey, value: Value) -> Result<()> {
 		let payload = accept_payload(value)?;
 		self.require_writeable()?;
-		self.check_permission(BucketOperation::Put)?;
+		self.check_permission(BucketOperation::Put, Some(key), None).await?;
 
 		self.store
 			.put(key, payload)
@@ -138,7 +179,7 @@ impl<'a> StreamingBucketOps<'a> {
 	async fn put_if_not_exists(&self, key: &ObjectKey, value: Value) -> Result<()> {
 		let payload = accept_payload(value)?;
 		self.require_writeable()?;
-		self.check_permission(BucketOperation::Put)?;
+		self.check_permission(BucketOperation::Put, Some(key), None).await?;
 
 		self.store
 			.put_if_not_exists(key, payload)
@@ -150,7 +191,7 @@ impl<'a> StreamingBucketOps<'a> {
 
 	/// Get a file from the bucket.
 	async fn get(&self, key: &ObjectKey) -> Result<Option<Bytes>> {
-		self.check_permission(BucketOperation::Get)?;
+		self.check_permission(BucketOperation::Get, Some(key), None).await?;
 
 		let bytes = match self
 			.store
@@ -167,7 +208,7 @@ impl<'a> StreamingBucketOps<'a> {
 
 	/// Get file metadata from the bucket.
 	async fn head(&self, key: &ObjectKey) -> Result<Option<Value>> {
-		self.check_permission(BucketOperation::Head)?;
+		self.check_permission(BucketOperation::Head, Some(key), None).await?;
 
 		let meta = self
 			.store
@@ -181,7 +222,7 @@ impl<'a> StreamingBucketOps<'a> {
 	/// Delete a file from the bucket.
 	async fn delete(&self, key: &ObjectKey) -> Result<()> {
 		self.require_writeable()?;
-		self.check_permission(BucketOperation::Delete)?;
+		self.check_permission(BucketOperation::Delete, Some(key), None).await?;
 
 		self.store
 			.delete(key)
@@ -194,7 +235,7 @@ impl<'a> StreamingBucketOps<'a> {
 	/// Copy a file within the bucket.
 	async fn copy(&self, src: &ObjectKey, dst: ObjectKey) -> Result<()> {
 		self.require_writeable()?;
-		self.check_permission(BucketOperation::Copy)?;
+		self.check_permission(BucketOperation::Copy, Some(src), Some(&dst)).await?;
 
 		self.store
 			.copy(src, &dst)
@@ -207,7 +248,7 @@ impl<'a> StreamingBucketOps<'a> {
 	/// Copy a file if destination doesn't exist.
 	async fn copy_if_not_exists(&self, src: &ObjectKey, dst: ObjectKey) -> Result<()> {
 		self.require_writeable()?;
-		self.check_permission(BucketOperation::Copy)?;
+		self.check_permission(BucketOperation::Copy, Some(src), Some(&dst)).await?;
 
 		self.store
 			.copy_if_not_exists(src, &dst)
@@ -220,7 +261,7 @@ impl<'a> StreamingBucketOps<'a> {
 	/// Rename a file within the bucket.
 	async fn rename(&self, src: &ObjectKey, dst: ObjectKey) -> Result<()> {
 		self.require_writeable()?;
-		self.check_permission(BucketOperation::Rename)?;
+		self.check_permission(BucketOperation::Rename, Some(src), Some(&dst)).await?;
 
 		self.store
 			.rename(src, &dst)
@@ -233,7 +274,7 @@ impl<'a> StreamingBucketOps<'a> {
 	/// Rename a file if destination doesn't exist.
 	async fn rename_if_not_exists(&self, src: &ObjectKey, dst: ObjectKey) -> Result<()> {
 		self.require_writeable()?;
-		self.check_permission(BucketOperation::Rename)?;
+		self.check_permission(BucketOperation::Rename, Some(src), Some(&dst)).await?;
 
 		self.store
 			.rename_if_not_exists(src, &dst)
@@ -245,7 +286,7 @@ impl<'a> StreamingBucketOps<'a> {
 
 	/// Check if a file exists.
 	async fn exists(&self, key: &ObjectKey) -> Result<bool> {
-		self.check_permission(BucketOperation::Exists)?;
+		self.check_permission(BucketOperation::Exists, Some(key), None).await?;
 
 		self.store
 			.exists(key)
@@ -256,7 +297,7 @@ impl<'a> StreamingBucketOps<'a> {
 
 	/// List files in the bucket.
 	async fn list(&self, opts: &ListOptions) -> Result<Vec<Value>> {
-		self.check_permission(BucketOperation::List)?;
+		self.check_permission(BucketOperation::List, None, None).await?;
 
 		let items = self
 			.store

--- a/surrealdb/core/src/exec/function/builtin/file.rs
+++ b/surrealdb/core/src/exec/function/builtin/file.rs
@@ -9,14 +9,14 @@ use anyhow::{Result, bail, ensure};
 
 use crate::buc::BucketOperation;
 use crate::buc::store::{ListOptions, ObjectKey, ObjectStore};
-use crate::catalog::BucketDefinition;
 use crate::catalog::providers::BucketProvider;
+use crate::catalog::{BucketDefinition, Permission};
 use crate::dbs::capabilities::ExperimentalTarget;
 use crate::err::Error;
 use crate::exec::ExecutionContext;
 use crate::exec::function::FunctionRegistry;
-use crate::exec::permission::{PhysicalPermission, convert_permission_to_physical_runtime};
 use crate::exec::physical_expr::EvalContext;
+use crate::exec::planner::Planner;
 use crate::fnc::args::FromArgs;
 use crate::val::{Bytes, File, Object, Value};
 use crate::{define_async_function, define_pure_function, register_functions};
@@ -102,20 +102,16 @@ impl<'a> StreamingBucketOps<'a> {
 				}
 			);
 
-			match convert_permission_to_physical_runtime(
-				&self.bucket.permissions,
-				self.exec_ctx.ctx(),
-			)
-			.await?
-			{
-				PhysicalPermission::Deny => {
+			match &self.bucket.permissions {
+				Permission::None => {
 					bail!(Error::BucketPermissions {
 						name: self.bucket.name.to_string(),
 						op,
 					})
 				}
-				PhysicalPermission::Allow => (),
-				PhysicalPermission::Conditional(expr) => {
+				Permission::Full => (),
+				Permission::Specific(e) => {
+					let expr = Planner::new(self.exec_ctx.ctx()).physical_expr(e.clone()).await?;
 					let mut exec_ctx =
 						self.exec_ctx.with_param("action", Value::from(op.to_string()));
 					if let Some(key) = key {

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -2737,6 +2737,511 @@ mod http_integration {
 		}
 	}
 
+	async fn start_bucket_permission_test_server(
+		planner_strategy: Option<&str>,
+	) -> Result<(String, common::Child, Client), Box<dyn std::error::Error>> {
+		const NS: &str = "bucket_permission_ns";
+		const DB: &str = "bucket_permission_db";
+
+		let mut args = "--allow-experimental files".to_string();
+		if let Some(planner_strategy) = planner_strategy {
+			args.push_str(&format!(" --planner-strategy {planner_strategy}"));
+		}
+		let (addr, server) = common::start_server(StartServerArguments {
+			args,
+			..Default::default()
+		})
+		.await?;
+
+		let mut headers = reqwest::header::HeaderMap::new();
+		headers.insert("surreal-ns", NS.parse()?);
+		headers.insert("surreal-db", DB.parse()?);
+		headers.insert(header::ACCEPT, "application/json".parse()?);
+		let client = reqwest::Client::builder()
+			.connect_timeout(Duration::from_millis(10))
+			.default_headers(headers)
+			.build()?;
+
+		Ok((addr, server, client))
+	}
+
+	async fn root_sql(
+		client: &Client,
+		addr: &str,
+		query: &str,
+	) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+		let res = client
+			.post(format!("http://{addr}/sql"))
+			.basic_auth(USER, Some(PASS))
+			.body(query.to_string())
+			.send()
+			.await?;
+		assert!(res.status().is_success(), "root SQL HTTP request failed: {}", res.status());
+		Ok(res.json().await?)
+	}
+
+	async fn record_sql(
+		client: &Client,
+		addr: &str,
+		token: &str,
+		query: &str,
+	) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+		let res = client
+			.post(format!("http://{addr}/sql"))
+			.header(header::AUTHORIZATION, format!("Bearer {token}"))
+			.body(query.to_string())
+			.send()
+			.await?;
+		assert!(res.status().is_success(), "record SQL HTTP request failed: {}", res.status());
+		Ok(res.json().await?)
+	}
+
+	async fn signin_bucket_record_user(
+		client: &Client,
+		addr: &str,
+	) -> Result<String, Box<dyn std::error::Error>> {
+		let res = client
+			.post(format!("http://{addr}/rpc"))
+			.header(header::CONTENT_TYPE, "application/json")
+			.body(
+				json!({
+					"id": "bucket-permission-signin",
+					"method": "signin",
+					"params": [{
+						"ns": "bucket_permission_ns",
+						"db": "bucket_permission_db",
+						"ac": "user",
+						"email": "bob@example.com",
+						"password": "pw"
+					}]
+				})
+				.to_string(),
+			)
+			.send()
+			.await?;
+		assert!(res.status().is_success(), "signin RPC HTTP request failed: {}", res.status());
+		let body: serde_json::Value = res.json().await?;
+		assert!(body.get("error").is_none(), "record signin must succeed: {body}");
+		let token = body
+			.get("result")
+			.and_then(|v| v.get("access").or(Some(v)))
+			.and_then(|v| v.as_str())
+			.unwrap_or_else(|| panic!("signin must return a token: {body}"));
+		Ok(token.to_owned())
+	}
+
+	async fn setup_bucket_permission_fixture(
+		client: &Client,
+		addr: &str,
+	) -> Result<String, Box<dyn std::error::Error>> {
+		let body = root_sql(
+			client,
+			addr,
+			r#"
+					DEFINE ACCESS user ON DATABASE TYPE RECORD
+						SIGNIN (
+							SELECT * FROM user
+							WHERE email = string::lowercase($email)
+								AND crypto::argon2::compare(password_hash, $password)
+						)
+						WITH JWT ALGORITHM HS512 KEY "test-key"
+						DURATION FOR TOKEN 1h, FOR SESSION 12h;
+					DEFINE TABLE user PERMISSIONS FOR select WHERE id = $auth.id;
+					CREATE user:bob SET
+						email = "bob@example.com",
+						password_hash = crypto::argon2::generate("pw"),
+						enabled = true;
+				"#,
+		)
+		.await?;
+		assert_all_sql_ok(&body, "record access setup");
+
+		let body = root_sql(
+			client,
+			addr,
+			r#"
+					DEFINE BUCKET deny_where BACKEND "memory" PERMISSIONS WHERE false;
+					f"deny_where:/secret.txt".put("DENY-ME");
+
+					DEFINE BUCKET file_gate BACKEND "memory"
+						PERMISSIONS WHERE $action = "get" AND $file = f"file_gate:/allowed.txt";
+					f"file_gate:/allowed.txt".put("ALLOWED");
+					f"file_gate:/denied.txt".put("DENIED");
+
+					DEFINE BUCKET head_gate BACKEND "memory"
+						PERMISSIONS WHERE $action = "head" AND $file = f"head_gate:/allowed.txt";
+					f"head_gate:/allowed.txt".put("HEAD");
+					f"head_gate:/denied.txt".put("HEAD-DENIED");
+
+					DEFINE BUCKET exists_gate BACKEND "memory"
+						PERMISSIONS WHERE $action = "exists" AND $file = f"exists_gate:/allowed.txt";
+					f"exists_gate:/allowed.txt".put("EXISTS");
+					f"exists_gate:/denied.txt".put("EXISTS-DENIED");
+
+					DEFINE BUCKET write_gate BACKEND "memory"
+						PERMISSIONS WHERE $action = "put" AND $file = f"write_gate:/allowed.txt";
+
+					DEFINE BUCKET delete_gate BACKEND "memory"
+						PERMISSIONS WHERE $action = "delete" AND $file = f"delete_gate:/allowed.txt";
+					f"delete_gate:/allowed.txt".put("DELETE");
+					f"delete_gate:/denied.txt".put("DELETE-DENIED");
+
+					DEFINE BUCKET target_gate BACKEND "memory"
+						PERMISSIONS WHERE $action = "copy"
+							AND $file = f"target_gate:/source.txt"
+							AND $target = f"target_gate:/allowed-copy.txt";
+					f"target_gate:/source.txt".put("SOURCE");
+
+					DEFINE BUCKET rename_gate BACKEND "memory"
+						PERMISSIONS WHERE $action = "rename"
+							AND $file = f"rename_gate:/source.txt"
+							AND $target = f"rename_gate:/allowed-rename.txt";
+					f"rename_gate:/source.txt".put("RENAME");
+					f"rename_gate:/denied-source.txt".put("RENAME-DENIED");
+
+					DEFINE BUCKET list_full BACKEND "memory" PERMISSIONS FULL;
+					f"list_full:/visible.txt".put("VISIBLE");
+				"#,
+		)
+		.await?;
+		assert_all_sql_ok(&body, "bucket permission fixture setup");
+
+		signin_bucket_record_user(client, addr).await
+	}
+
+	fn assert_all_sql_ok(body: &serde_json::Value, context: &str) {
+		let results =
+			body.as_array().unwrap_or_else(|| panic!("{context}: body must be an array: {body}"));
+		for result in results {
+			assert_eq!(
+				result.get("status").and_then(|v| v.as_str()),
+				Some("OK"),
+				"{context}: {body}"
+			);
+		}
+	}
+
+	fn assert_single_sql_ok<'a>(
+		body: &'a serde_json::Value,
+		context: &str,
+	) -> &'a serde_json::Value {
+		let results =
+			body.as_array().unwrap_or_else(|| panic!("{context}: body must be an array: {body}"));
+		assert_eq!(results.len(), 1, "{context}: expected one SQL result: {body}");
+		let result = &results[0];
+		assert_eq!(result.get("status").and_then(|v| v.as_str()), Some("OK"), "{context}: {body}");
+		result.get("result").unwrap_or_else(|| panic!("{context}: result missing: {body}"))
+	}
+
+	fn assert_single_sql_err_contains(body: &serde_json::Value, needle: &str, context: &str) {
+		let results =
+			body.as_array().unwrap_or_else(|| panic!("{context}: body must be an array: {body}"));
+		assert_eq!(results.len(), 1, "{context}: expected one SQL result: {body}");
+		let result = &results[0];
+		assert_eq!(result.get("status").and_then(|v| v.as_str()), Some("ERR"), "{context}: {body}");
+		let message = result.get("result").map(ToString::to_string).unwrap_or_default();
+		assert!(
+			message.contains(needle),
+			"{context}: expected error to contain {needle:?}, got: {body}"
+		);
+	}
+
+	#[test(tokio::test)]
+	async fn bucket_where_permissions_deny_record_users_in_streaming_planner()
+	-> Result<(), Box<dyn std::error::Error>> {
+		let (addr, _server, client) = start_bucket_permission_test_server(None).await?;
+		let token = setup_bucket_permission_fixture(&client, &addr).await?;
+
+		let body =
+			root_sql(&client, &addr, r#"RETURN <string>f"deny_where:/secret.txt".get();"#).await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "root users bypass bucket permissions"),
+			"DENY-ME",
+			"root/system users must retain the documented fine-grained permission bypass"
+		);
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"RETURN <string>f"deny_where:/secret.txt".get();"#,
+		)
+		.await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"record user must not read a bucket denied by PERMISSIONS WHERE false",
+		);
+
+		let body =
+			record_sql(&client, &addr, &token, r#"f"deny_where:/secret.txt".put("OVERWRITE");"#)
+				.await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"record user must not write a bucket denied by PERMISSIONS WHERE false",
+		);
+
+		Ok(())
+	}
+
+	#[test(tokio::test)]
+	async fn bucket_action_and_file_variables_gate_reads_in_streaming_planner()
+	-> Result<(), Box<dyn std::error::Error>> {
+		let (addr, _server, client) = start_bucket_permission_test_server(None).await?;
+		let token = setup_bucket_permission_fixture(&client, &addr).await?;
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"RETURN <string>f"file_gate:/allowed.txt".get();"#,
+		)
+		.await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "$action and $file allow matching reads"),
+			"ALLOWED"
+		);
+
+		let body =
+			record_sql(&client, &addr, &token, r#"RETURN <string>f"file_gate:/denied.txt".get();"#)
+				.await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"$file must deny non-matching file pointers",
+		);
+
+		let body =
+			record_sql(&client, &addr, &token, r#"RETURN file::head(f"head_gate:/allowed.txt");"#)
+				.await?;
+		assert_single_sql_ok(&body, "$action and $file allow matching metadata reads");
+
+		let body =
+			record_sql(&client, &addr, &token, r#"RETURN file::head(f"head_gate:/denied.txt");"#)
+				.await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"head must deny non-matching file pointers",
+		);
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"RETURN file::exists(f"exists_gate:/allowed.txt");"#,
+		)
+		.await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "$action and $file allow matching existence checks"),
+			true
+		);
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"RETURN file::exists(f"exists_gate:/denied.txt");"#,
+		)
+		.await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"exists must deny non-matching file pointers",
+		);
+
+		Ok(())
+	}
+
+	#[test(tokio::test)]
+	async fn bucket_action_and_file_variables_gate_writes_in_streaming_planner()
+	-> Result<(), Box<dyn std::error::Error>> {
+		let (addr, _server, client) = start_bucket_permission_test_server(None).await?;
+		let token = setup_bucket_permission_fixture(&client, &addr).await?;
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"file::put(f"write_gate:/allowed.txt", "WRITE-ALLOWED");"#,
+		)
+		.await?;
+		assert_single_sql_ok(&body, "$action and $file allow matching writes");
+
+		let body =
+			root_sql(&client, &addr, r#"RETURN <string>f"write_gate:/allowed.txt".get();"#).await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "allowed record write persists expected bytes"),
+			"WRITE-ALLOWED"
+		);
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"file::put(f"write_gate:/denied.txt", "WRITE-DENIED");"#,
+		)
+		.await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"put must deny non-matching file pointers",
+		);
+
+		let body =
+			root_sql(&client, &addr, r#"RETURN file::exists(f"write_gate:/denied.txt");"#).await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "denied record write must not create the target file"),
+			false
+		);
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"file::put_if_not_exists(f"write_gate:/allowed-if-missing.txt", "WRITE-IF-MISSING");"#,
+		)
+		.await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"put_if_not_exists must bind the same put action and file pointer",
+		);
+
+		let body =
+			record_sql(&client, &addr, &token, r#"file::delete(f"delete_gate:/allowed.txt");"#)
+				.await?;
+		assert_single_sql_ok(&body, "$action and $file allow matching deletes");
+
+		let body = root_sql(&client, &addr, r#"RETURN file::exists(f"delete_gate:/allowed.txt");"#)
+			.await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "allowed record delete removes the target file"),
+			false
+		);
+
+		let body =
+			record_sql(&client, &addr, &token, r#"file::delete(f"delete_gate:/denied.txt");"#)
+				.await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"delete must deny non-matching file pointers",
+		);
+
+		let body =
+			root_sql(&client, &addr, r#"RETURN file::exists(f"delete_gate:/denied.txt");"#).await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "denied record delete must leave the source file intact"),
+			true
+		);
+
+		Ok(())
+	}
+
+	#[test(tokio::test)]
+	async fn bucket_target_variable_gates_copy_and_rename_in_streaming_planner()
+	-> Result<(), Box<dyn std::error::Error>> {
+		let (addr, _server, client) = start_bucket_permission_test_server(None).await?;
+		let token = setup_bucket_permission_fixture(&client, &addr).await?;
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"file::copy(f"target_gate:/source.txt", "allowed-copy.txt");"#,
+		)
+		.await?;
+		assert_single_sql_ok(&body, "$target allows matching copy target");
+
+		let body =
+			root_sql(&client, &addr, r#"RETURN <string>f"target_gate:/allowed-copy.txt".get();"#)
+				.await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "allowed copy persists the expected bytes"),
+			"SOURCE"
+		);
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"file::copy(f"target_gate:/source.txt", "denied-copy.txt");"#,
+		)
+		.await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"$target must deny non-matching copy targets",
+		);
+
+		let body =
+			root_sql(&client, &addr, r#"RETURN file::exists(f"target_gate:/denied-copy.txt");"#)
+				.await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "denied copy must not create the target file"),
+			false
+		);
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"file::rename(f"rename_gate:/source.txt", "allowed-rename.txt");"#,
+		)
+		.await?;
+		assert_single_sql_ok(&body, "$target allows matching rename target");
+
+		let body =
+			root_sql(&client, &addr, r#"RETURN <string>f"rename_gate:/allowed-rename.txt".get();"#)
+				.await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "allowed rename moves the expected bytes"),
+			"RENAME"
+		);
+
+		let body = record_sql(
+			&client,
+			&addr,
+			&token,
+			r#"file::rename(f"rename_gate:/denied-source.txt", "denied-rename.txt");"#,
+		)
+		.await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"$target must deny non-matching rename targets",
+		);
+
+		let body =
+			root_sql(&client, &addr, r#"RETURN file::exists(f"rename_gate:/denied-rename.txt");"#)
+				.await?;
+		assert_eq!(
+			assert_single_sql_ok(&body, "denied rename must not create the target file"),
+			false
+		);
+
+		Ok(())
+	}
+
+	#[test(tokio::test)]
+	async fn bucket_list_is_denied_for_record_users_in_compute_only_planner()
+	-> Result<(), Box<dyn std::error::Error>> {
+		let (addr, _server, client) =
+			start_bucket_permission_test_server(Some("compute-only")).await?;
+		let token = setup_bucket_permission_fixture(&client, &addr).await?;
+
+		let body = record_sql(&client, &addr, &token, r#"file::list("list_full");"#).await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"record users must not list bucket contents even when bucket permissions are FULL",
+		);
+
+		Ok(())
+	}
+
 	#[test(tokio::test)]
 	async fn arbitrary_query_capabilities() {
 		// Allow system

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -3226,6 +3226,22 @@ mod http_integration {
 	}
 
 	#[test(tokio::test)]
+	async fn bucket_list_is_denied_for_record_users_in_streaming_planner()
+	-> Result<(), Box<dyn std::error::Error>> {
+		let (addr, _server, client) = start_bucket_permission_test_server(None).await?;
+		let token = setup_bucket_permission_fixture(&client, &addr).await?;
+
+		let body = record_sql(&client, &addr, &token, r#"file::list("list_full");"#).await?;
+		assert_single_sql_err_contains(
+			&body,
+			"permission",
+			"record users must not list bucket contents even when bucket permissions are FULL",
+		);
+
+		Ok(())
+	}
+
+	#[test(tokio::test)]
 	async fn bucket_list_is_denied_for_record_users_in_compute_only_planner()
 	-> Result<(), Box<dyn std::error::Error>> {
 		let (addr, _server, client) =


### PR DESCRIPTION
Fixes #7345.

## Summary

Bucket-specific `PERMISSIONS WHERE` predicates were not evaluated by the streaming file executor. Record users could pass the coarse auth gate and perform file operations that the compute/BucketController path correctly denied.

This change makes streaming file operations evaluate bucket permissions with the streaming physical expression runtime, while keeping the legacy compute path separate.

## What Changed

- Evaluate `Permission::None`, `Permission::Full`, and `Permission::Specific` in `StreamingBucketOps::check_permission`.
- Compile bucket `PERMISSIONS WHERE` predicates with the streaming planner instead of calling legacy `Expr::compute`.
- Bind bucket permission variables during streaming evaluation:
  - `$action`
  - `$file`
  - `$target` for copy and rename
- Disable nested permission checks while evaluating the permission predicate to avoid recursive permission evaluation.
- Pass source and target object keys into every streaming file permission check.
- Keep `BucketController` as the compute-path implementation rather than routing streaming execution through it.
- Add regression coverage for:
  - `PERMISSIONS WHERE false`
  - `$action` and `$file` on reads
  - `$action` and `$file` on writes
  - `$target` on copy and rename
  - record-user list denial in both streaming and compute-only planner paths

## Why

Bucket permissions are part of the database authorization model, not a legacy executor detail. The streaming executor had its own file operation path, but only enforced coarse permission checks and special-cased `list`.

That left a gap where `DEFINE BUCKET ... PERMISSIONS WHERE ...` was enforced by `BucketController`, but not by streaming file functions. Record users could therefore access files that bucket predicates were meant to deny.

Calling the old compute path from streaming was not chosen. The streaming executor should keep authorization checks in its own runtime model, using physical expressions and execution-context parameters.

## Performance

The common unconditional cases stay cheap:

- `PERMISSIONS NONE` denies directly
- `PERMISSIONS FULL` allows directly
- only `PERMISSIONS WHERE` predicates are compiled and evaluated

Conditional bucket permissions add streaming expression evaluation on each checked file operation. That work is required for correctness and matches the semantics already enforced by the compute path.

## Tests

This adds regression coverage at both the HTTP integration and SurrealQL language-test layers.

The new tests cover record-user bucket access through the streaming file executor, including `PERMISSIONS WHERE false`, `$action` and `$file` predicates for reads and writes, `$target` predicates for copy and rename, and list denial even when bucket permissions are `FULL`. Together these exercise both the streaming permission-evaluation path and the user-visible `file::*` behavior that previously bypassed bucket-specific predicates.

## Security Considerations

This change touches authorization and should receive security review.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

* [ ] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)
