### PR TITLE
Fix streaming file functions without database context

### DIFF
--- a/language-tests/tests/reproductions/7361_bucket_auth_predicate_record_user.surql
+++ b/language-tests/tests/reproductions/7361_bucket_auth_predicate_record_user.surql
@@ -1,0 +1,33 @@
+/**
+[env]
+imports = ["reproductions/7361_bucket_auth_predicate_record_user_import.surql"]
+auth = { namespace = "test", database = "test", access = "user", rid = "user:bob" }
+
+[env.capabilities]
+allow-experimental = ["files"]
+
+[test]
+reason = "Issue 7361: top-level file functions must evaluate bucket predicates that dereference $auth with database context and return clean permission denials."
+issue = 7361
+
+[[test.results]]
+error = "You don't have permission to get this file in the `auth_gate` bucket"
+
+[[test.results]]
+error = "You don't have permission to exists this file in the `auth_gate` bucket"
+
+[[test.results]]
+error = "You don't have permission to put this file in the `auth_gate` bucket"
+
+[[test.results]]
+error = "You don't have permission to get this file in the `auth_gate` bucket"
+
+[[test.results]]
+error = "You don't have permission to list this file in the `auth_gate` bucket"
+*/
+
+file::get(f"auth_gate:/secret.txt").?.to_string();
+file::exists(f"auth_gate:/secret.txt");
+file::put(f"auth_gate:/new.txt", "NEW");
+fn::read_auth_gate(f"auth_gate:/secret.txt");
+file::list("auth_gate");

--- a/language-tests/tests/reproductions/7361_bucket_auth_predicate_record_user_import.surql
+++ b/language-tests/tests/reproductions/7361_bucket_auth_predicate_record_user_import.surql
@@ -1,0 +1,19 @@
+/**
+[test]
+reason = "Setup for issue 7361: a record user and bucket permission predicate that dereferences $auth."
+run = false
+*/
+
+DEFINE ACCESS user ON DATABASE TYPE RECORD
+	SIGNIN ( $rid );
+
+CREATE user:bob SET is_admin = false;
+
+DEFINE BUCKET auth_gate BACKEND "memory"
+	PERMISSIONS WHERE $auth = NONE OR $auth.is_admin = true;
+
+f"auth_gate:/secret.txt".put("SECRET");
+
+DEFINE FUNCTION fn::read_auth_gate($file: file) -> string {
+	RETURN <string>file::get($file);
+} PERMISSIONS FULL;

--- a/surrealdb/core/src/exec/function/builtin/file.rs
+++ b/surrealdb/core/src/exec/function/builtin/file.rs
@@ -519,17 +519,83 @@ fn file_key_impl((file,): (File,)) -> Result<Value> {
 
 // Note: We use `Any` for file arguments in the macro signature because Kind::File takes
 // parameters (bucket types). The actual type checking happens via FromArgs::from_args.
-define_async_function!(FilePut, "file::put", (file: Any, value: Any) -> Any, file_put_impl);
-define_async_function!(FilePutIfNotExists, "file::put_if_not_exists", (file: Any, value: Any) -> Any, file_put_if_not_exists_impl);
-define_async_function!(FileGet, "file::get", (file: Any) -> Any, file_get_impl);
-define_async_function!(FileHead, "file::head", (file: Any) -> Any, file_head_impl);
-define_async_function!(FileDelete, "file::delete", (file: Any) -> Any, file_delete_impl);
-define_async_function!(FileCopy, "file::copy", (src: Any, dst: Any) -> Any, file_copy_impl);
-define_async_function!(FileCopyIfNotExists, "file::copy_if_not_exists", (src: Any, dst: Any) -> Any, file_copy_if_not_exists_impl);
-define_async_function!(FileRename, "file::rename", (file: Any, target: String) -> Any, file_rename_impl);
-define_async_function!(FileRenameIfNotExists, "file::rename_if_not_exists", (file: Any, target: String) -> Any, file_rename_if_not_exists_impl);
-define_async_function!(FileExists, "file::exists", (file: Any) -> Any, file_exists_impl);
-define_async_function!(FileList, "file::list", (bucket: String, ?opts: Object) -> Any, file_list_impl);
+define_async_function!(
+	FilePut,
+	"file::put",
+	(file: Any, value: Any) -> Any,
+	file_put_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
+define_async_function!(
+	FilePutIfNotExists,
+	"file::put_if_not_exists",
+	(file: Any, value: Any) -> Any,
+	file_put_if_not_exists_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
+define_async_function!(
+	FileGet,
+	"file::get",
+	(file: Any) -> Any,
+	file_get_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
+define_async_function!(
+	FileHead,
+	"file::head",
+	(file: Any) -> Any,
+	file_head_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
+define_async_function!(
+	FileDelete,
+	"file::delete",
+	(file: Any) -> Any,
+	file_delete_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
+define_async_function!(
+	FileCopy,
+	"file::copy",
+	(src: Any, dst: Any) -> Any,
+	file_copy_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
+define_async_function!(
+	FileCopyIfNotExists,
+	"file::copy_if_not_exists",
+	(src: Any, dst: Any) -> Any,
+	file_copy_if_not_exists_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
+define_async_function!(
+	FileRename,
+	"file::rename",
+	(file: Any, target: String) -> Any,
+	file_rename_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
+define_async_function!(
+	FileRenameIfNotExists,
+	"file::rename_if_not_exists",
+	(file: Any, target: String) -> Any,
+	file_rename_if_not_exists_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
+define_async_function!(
+	FileExists,
+	"file::exists",
+	(file: Any) -> Any,
+	file_exists_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
+define_async_function!(
+	FileList,
+	"file::list",
+	(bucket: String, ?opts: Object) -> Any,
+	file_list_impl,
+	required_context = crate::exec::ContextLevel::Database
+);
 
 define_pure_function!(FileBucket, "file::bucket", (file: Any) -> Any, file_bucket_impl);
 define_pure_function!(FileKey, "file::key", (file: Any) -> Any, file_key_impl);

--- a/surrealdb/core/src/exec/function/macros.rs
+++ b/surrealdb/core/src/exec/function/macros.rs
@@ -390,11 +390,16 @@ macro_rules! define_context_function {
 /// - I/O-bound operations (HTTP requests)
 /// - CPU-intensive operations (crypto hashing)
 /// - Timer-based operations (sleep)
+/// - File operations that require database context (file)
+///
+/// If `required_context = ...` is omitted, the generated function falls back to
+/// `ContextLevel::Root`. Use an explicit context for async functions that read database-scoped
+/// metadata or evaluate expressions that require namespace/database context.
 ///
 /// # Usage
 ///
 /// ```ignore
-/// // Async function with one argument
+/// // Root-context async function with one argument, e.g. sleep timers.
 /// define_async_function!(
 ///     Sleep,                          // Struct name
 ///     "sleep",                        // Function name
@@ -402,22 +407,48 @@ macro_rules! define_context_function {
 ///     sleep_impl                      // Async implementation function
 /// );
 ///
-/// // Async function with two arguments
+/// // Root-context async function with two arguments, e.g. crypto hashing/checking.
+/// define_async_function!(
+///     CryptoArgon2Compare,
+///     "crypto::argon2::compare",
+///     (hash: String, pass: String) -> Bool,
+///     argon2_compare_impl
+/// );
+///
+/// // Root-context async function with an optional argument, e.g. HTTP requests.
 /// define_async_function!(
 ///     HttpGet,
 ///     "http::get",
 ///     (url: String, ?opts: Object) -> Any,
 ///     http_get_impl
 /// );
+///
+/// // Database-context async function, e.g. file operations that read bucket metadata
+/// // and evaluate bucket permission predicates.
+/// define_async_function!(
+///     FileGet,
+///     "file::get",
+///     (file: Any) -> Any,
+///     file_get_impl,
+///     required_context = crate::exec::ContextLevel::Database
+/// );
 /// ```
 #[macro_export]
 macro_rules! define_async_function {
+	(@required_context) => {
+		$crate::exec::ContextLevel::Root
+	};
+	(@required_context $context:expr) => {
+		$context
+	};
+
 	// No arguments: () -> ReturnType
 	(
 		$struct_name:ident,
 		$func_name:literal,
 		() -> $ret:ident,
 		$impl_fn:expr
+		$(, required_context = $context:expr)?
 	) => {
 		#[derive(Debug, Clone, Copy, Default)]
 		pub struct $struct_name;
@@ -429,6 +460,10 @@ macro_rules! define_async_function {
 
 			fn signature(&self) -> $crate::exec::function::Signature {
 				$crate::exec::function::Signature::new().returns($crate::expr::Kind::$ret)
+			}
+
+			fn required_context(&self) -> $crate::exec::ContextLevel {
+				$crate::define_async_function!(@required_context $($context)?)
 			}
 
 			fn is_pure(&self) -> bool {
@@ -459,6 +494,7 @@ macro_rules! define_async_function {
 		$func_name:literal,
 		($arg_name:ident : $arg_type:ident) -> $ret:ident,
 		$impl_fn:expr
+		$(, required_context = $context:expr)?
 	) => {
 		#[derive(Debug, Clone, Copy, Default)]
 		pub struct $struct_name;
@@ -472,6 +508,10 @@ macro_rules! define_async_function {
 				$crate::exec::function::Signature::new()
 					.arg(stringify!($arg_name), $crate::expr::Kind::$arg_type)
 					.returns($crate::expr::Kind::$ret)
+			}
+
+			fn required_context(&self) -> $crate::exec::ContextLevel {
+				$crate::define_async_function!(@required_context $($context)?)
 			}
 
 			fn is_pure(&self) -> bool {
@@ -502,6 +542,7 @@ macro_rules! define_async_function {
 		$func_name:literal,
 		($arg1_name:ident : $arg1_type:ident, $arg2_name:ident : $arg2_type:ident) -> $ret:ident,
 		$impl_fn:expr
+		$(, required_context = $context:expr)?
 	) => {
 		#[derive(Debug, Clone, Copy, Default)]
 		pub struct $struct_name;
@@ -516,6 +557,10 @@ macro_rules! define_async_function {
 					.arg(stringify!($arg1_name), $crate::expr::Kind::$arg1_type)
 					.arg(stringify!($arg2_name), $crate::expr::Kind::$arg2_type)
 					.returns($crate::expr::Kind::$ret)
+			}
+
+			fn required_context(&self) -> $crate::exec::ContextLevel {
+				$crate::define_async_function!(@required_context $($context)?)
 			}
 
 			fn is_pure(&self) -> bool {
@@ -546,6 +591,7 @@ macro_rules! define_async_function {
 		$func_name:literal,
 		($arg1_name:ident : $arg1_type:ident, ? $arg2_name:ident : $arg2_type:ident) -> $ret:ident,
 		$impl_fn:expr
+		$(, required_context = $context:expr)?
 	) => {
 		#[derive(Debug, Clone, Copy, Default)]
 		pub struct $struct_name;
@@ -560,6 +606,10 @@ macro_rules! define_async_function {
 					.arg(stringify!($arg1_name), $crate::expr::Kind::$arg1_type)
 					.optional(stringify!($arg2_name), $crate::expr::Kind::$arg2_type)
 					.returns($crate::expr::Kind::$ret)
+			}
+
+			fn required_context(&self) -> $crate::exec::ContextLevel {
+				$crate::define_async_function!(@required_context $($context)?)
 			}
 
 			fn is_pure(&self) -> bool {
@@ -590,6 +640,7 @@ macro_rules! define_async_function {
 		$func_name:literal,
 		($arg1_name:ident : $arg1_type:ident, ? $arg2_name:ident : $arg2_type:ident, ? $arg3_name:ident : $arg3_type:ident) -> $ret:ident,
 		$impl_fn:expr
+		$(, required_context = $context:expr)?
 	) => {
 		#[derive(Debug, Clone, Copy, Default)]
 		pub struct $struct_name;
@@ -605,6 +656,10 @@ macro_rules! define_async_function {
 					.optional(stringify!($arg2_name), $crate::expr::Kind::$arg2_type)
 					.optional(stringify!($arg3_name), $crate::expr::Kind::$arg3_type)
 					.returns($crate::expr::Kind::$ret)
+			}
+
+			fn required_context(&self) -> $crate::exec::ContextLevel {
+				$crate::define_async_function!(@required_context $($context)?)
 			}
 
 			fn is_pure(&self) -> bool {


### PR DESCRIPTION
Fixes #7361.

## Summary

Top-level streaming file functions could run without declaring that they need
database context. When bucket permission predicates referenced database-scoped
values like `$auth`, evaluation could fail as an internal database error instead
of returning the expected permission denial.

## What Changed

- Add an optional `required_context` override to the async function macro.
- Mark streaming file builtins as requiring database context.
- Add regression coverage for:
  - top-level `file::get`, `file::exists`, `file::put`, and `file::list`
  - bucket predicates that dereference `$auth`
  - file access through a stored function

## Why

File operations read database-scoped bucket metadata and evaluate bucket
permission predicates. They should therefore be planned with database context
before execution starts, matching the context their implementation already
expects.

## Tests

- `cd language-tests && cargo run -- test reproductions/7361_bucket_auth_predicate_record_user.surql`