### PR TITLE
PoC: opt-in field ordering preservation (PRESERVE ORDER)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6599,6 +6599,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,14 @@ schemars = "1.2.1"
 scrypt = "0.11.0"
 semver = "1.0.28"
 serde = "1.0.228"
-serde_json = "1.0.149"
+# NOTE (field-ordering PoC): `preserve_order` makes `serde_json::Value`'s map an
+# insertion-ordered `IndexMap` instead of a sorted `BTreeMap`, so the JSON `/sql`
+# encoder can emit fields in `PRESERVE ORDER` order. This is a PoC shortcut taken
+# to keep the change small. A production implementation would NOT flip this global
+# feature — it would use a dedicated ordered JSON encoder that walks the value via
+# `Object::iter_display()` and never builds a sorted `serde_json::Value` map, so no
+# global behaviour change is required. See `surrealdb/types/src/value/into_json.rs`.
+serde_json = { version = "1.0.149", features = ["preserve_order"] }
 sha1 = "0.10.6"
 sha2 = "0.10.9"
 snap = "1.1.1"

--- a/field-ordering-demo.surql
+++ b/field-ordering-demo.surql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- PRESERVE ORDER — field/key ordering PoC demo
+-- Run against a server started with:
+--   SURREAL_PATH=memory surreal start --user root --pass root \
+--     --bind 127.0.0.1:18066 --allow-experimental field_ordering
+-- ============================================================
+
+USE NS test DB test;
+
+-- Seed a few records. Note SET lists fields in non-alphabetical order;
+-- internally they are still stored sorted (a,b,c / canonical).
+DELETE person;
+CREATE person:1 SET name = "Ada",   email = "ada@x.dev",   age = 36, active = true;
+CREATE person:2 SET name = "Grace", email = "grace@x.dev", age = 45, active = false;
+
+-- 1) Explicit projection, NO clause  -> alphabetical (today's default)
+SELECT name, email, age FROM person;
+
+-- 2) Same projection + PRESERVE ORDER -> fields come back in written order
+SELECT name, email, age FROM person PRESERVE ORDER;
+
+-- 3) Reordered projection + PRESERVE ORDER -> honors exactly what you asked for
+SELECT age, active, name, email FROM person PRESERVE ORDER;
+
+-- 4) Aliases are honored in written order too
+SELECT name AS full_name, age AS years FROM person PRESERVE ORDER;
+
+-- 5) PRESERVE ORDER coexists with the rest of the clause chain
+SELECT email, name FROM person WHERE age > 40 ORDER BY name LIMIT 5 PRESERVE ORDER;
+
+-- 6) Equality is order-blind by design (#4053 guardrail):
+--    the two objects below are EQUAL even though one is written reversed.
+RETURN { a: 1, b: 2, c: 3 } = { c: 3, b: 2, a: 1 };   -- expect: true

--- a/surrealdb/core/src/dbs/capabilities.rs
+++ b/surrealdb/core/src/dbs/capabilities.rs
@@ -123,6 +123,8 @@ impl std::str::FromStr for FuncTarget {
 pub enum ExperimentalTarget {
 	Files,
 	Surrealism,
+	/// Field/key ordering preservation in query output (PoC).
+	FieldOrdering,
 }
 
 impl fmt::Display for ExperimentalTarget {
@@ -130,6 +132,7 @@ impl fmt::Display for ExperimentalTarget {
 		match self {
 			Self::Files => write!(f, "files"),
 			Self::Surrealism => write!(f, "surrealism"),
+			Self::FieldOrdering => write!(f, "field_ordering"),
 		}
 	}
 }
@@ -145,6 +148,7 @@ impl Target<str> for ExperimentalTarget {
 		match self {
 			Self::Files => elem.eq_ignore_ascii_case("files"),
 			Self::Surrealism => elem.eq_ignore_ascii_case("surrealism"),
+			Self::FieldOrdering => elem.eq_ignore_ascii_case("field_ordering"),
 		}
 	}
 }
@@ -172,6 +176,7 @@ impl std::str::FromStr for ExperimentalTarget {
 		match s.trim().to_ascii_lowercase().as_str() {
 			"files" => Ok(ExperimentalTarget::Files),
 			"surrealism" => Ok(ExperimentalTarget::Surrealism),
+			"field_ordering" => Ok(ExperimentalTarget::FieldOrdering),
 			_ => Err(ParseExperimentalTargetError::InvalidName),
 		}
 	}

--- a/surrealdb/core/src/doc/table.rs
+++ b/surrealdb/core/src/doc/table.rs
@@ -673,6 +673,7 @@ impl Document {
 				timeout: Expr::Literal(Literal::None),
 				explain: None,
 				tempfiles: false,
+				preserve_order: false,
 			};
 
 			let value = stk.run(|stk| recalc_stmt.compute(stk, ctx, opt, None)).await?;
@@ -1083,6 +1084,7 @@ impl Document {
 				timeout: Expr::Literal(Literal::None),
 				explain: None,
 				tempfiles: false,
+				preserve_order: false,
 			};
 
 			let value = stk.run(|stk| recalc_stmt.compute(stk, ctx, opt, None)).await?;

--- a/surrealdb/core/src/exec/operators/aggregate.rs
+++ b/surrealdb/core/src/exec/operators/aggregate.rs
@@ -853,6 +853,6 @@ async fn compute_aggregate_field_value(
 		}
 	} else {
 		// No post-expression means direct single aggregate - return first value
-		Ok(agg_doc.0.into_values().next().unwrap_or(Value::Null))
+		Ok(agg_doc.0.0.into_values().next().unwrap_or(Value::Null))
 	}
 }

--- a/surrealdb/core/src/exec/operators/project.rs
+++ b/surrealdb/core/src/exec/operators/project.rs
@@ -621,6 +621,8 @@ pub struct SelectProject {
 	pub input: Arc<dyn ExecOperator>,
 	/// The projections to apply (shared across batches via Arc)
 	pub projections: Arc<[Projection]>,
+	/// PoC: preserve written projection order in output objects.
+	pub(crate) preserve_order: bool,
 	/// Per-operator metrics for EXPLAIN ANALYZE
 	pub(crate) metrics: Arc<OperatorMetrics>,
 }
@@ -631,10 +633,12 @@ impl SelectProject {
 		input: Arc<dyn ExecOperator>,
 		projections: Vec<Projection>,
 		metrics: Arc<OperatorMetrics>,
+		preserve_order: bool,
 	) -> Self {
 		Self {
 			input,
 			projections: projections.into(),
+			preserve_order,
 			metrics,
 		}
 	}
@@ -703,6 +707,7 @@ impl ExecOperator for SelectProject {
 			ctx.root().ctx.config.operator_buffer_size,
 		);
 		let projections = Arc::clone(&self.projections);
+		let preserve_order = self.preserve_order;
 		let ctx = ctx.clone();
 
 		// Create a stream that applies projections
@@ -716,9 +721,12 @@ impl ExecOperator for SelectProject {
 
 				for value in batch.values {
 					let is_record_id = matches!(&value, Value::RecordId(_));
-					let projected = apply_projections(value, &projections, &ctx).await?;
+					let mut projected = apply_projections(value, &projections, &ctx).await?;
 					if is_record_id && matches!(&projected, Value::None) {
 						continue;
+					}
+					if preserve_order {
+						apply_written_order(&mut projected, &projections);
 					}
 					projected_values.push(projected);
 				}
@@ -818,9 +826,64 @@ fn apply_projections_to_object(
 	}
 }
 
+/// PoC (`PRESERVE ORDER`): record the written projection order on an output
+/// object so it is emitted in the order the query listed the fields rather than
+/// alphabetically. Presentation-only — never touches comparison or storage.
+pub(crate) fn apply_written_order(value: &mut Value, projections: &[Projection]) {
+	if let Value::Object(obj) = value {
+		let order: Vec<&str> = projections
+			.iter()
+			.filter_map(|p| match p {
+				Projection::Include(n) => Some(n.as_str()),
+				Projection::Rename {
+					to,
+					..
+				} => Some(to.as_str()),
+				_ => None,
+			})
+			.collect();
+		obj.set_written_order(order);
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn preserve_order_sets_written_display_order() {
+		// SELECT c, a, b — the output object is sorted internally but must
+		// display in written order once PRESERVE ORDER is applied.
+		let mut value = Value::Object(Object::from(vec![
+			("a".to_string(), Value::from(1)),
+			("b".to_string(), Value::from(2)),
+			("c".to_string(), Value::from(3)),
+		]));
+		let projections = vec![
+			Projection::Include(Strand::new("c")),
+			Projection::Include(Strand::new("a")),
+			Projection::Include(Strand::new("b")),
+		];
+		apply_written_order(&mut value, &projections);
+
+		let Value::Object(obj) = &value else {
+			panic!("expected object");
+		};
+		let display: Vec<&str> =
+			obj.iter_display().into_iter().map(|(k, _)| k.as_str()).collect();
+		assert_eq!(display, vec!["c", "a", "b"], "display order follows the projection list");
+
+		// Logical iteration (and therefore equality/storage) stays sorted.
+		let sorted: Vec<&str> = obj.keys().map(|k| k.as_str()).collect();
+		assert_eq!(sorted, vec!["a", "b", "c"]);
+
+		// ToSql renders in written order.
+		let rendered = surrealdb_types::ToSql::to_sql(&value);
+		assert!(
+			rendered.find('c').unwrap() < rendered.find('a').unwrap(),
+			"ToSql emits written order, got: {rendered}"
+		);
+	}
 
 	#[test]
 	fn test_apply_projections_include() {

--- a/surrealdb/core/src/exec/planner/select/mod.rs
+++ b/surrealdb/core/src/exec/planner/select/mod.rs
@@ -675,7 +675,15 @@ impl<'ctx> Planner<'ctx> {
 			timeout,
 			explain: _,
 			tempfiles,
+			preserve_order,
 		} = select;
+
+		// PoC: PRESERVE ORDER only takes effect when the experimental capability is on.
+		let preserve_order = preserve_order
+			&& self
+				.ctx
+				.get_capabilities()
+				.allows_experimental(&crate::dbs::capabilities::ExperimentalTarget::FieldOrdering);
 
 		let version = extract_version(version, self).await?;
 
@@ -1139,6 +1147,7 @@ impl<'ctx> Planner<'ctx> {
 			},
 			omit,
 			tempfiles,
+			preserve_order,
 		};
 
 		let projected = pp.plan_pipeline(source, Some(fields), config).await?;

--- a/surrealdb/core/src/exec/planner/select/pipeline.rs
+++ b/surrealdb/core/src/exec/planner/select/pipeline.rs
@@ -74,6 +74,7 @@ pub(crate) struct SelectPipelineConfig {
 	pub start: Option<crate::expr::start::Start>,
 	pub omit: Vec<Expr>,
 	pub tempfiles: bool,
+	pub preserve_order: bool,
 }
 
 /// Describes how the WHERE predicate should be handled after source planning.
@@ -136,6 +137,7 @@ impl<'ctx> Planner<'ctx> {
 			start,
 			omit,
 			tempfiles,
+			preserve_order,
 		} = config;
 
 		let filtered = match where_clause {
@@ -241,7 +243,7 @@ impl<'ctx> Planner<'ctx> {
 				limited
 			}
 		} else {
-			self.plan_projections_fast(fields, all_omit, limited, &mut registry).await?
+			self.plan_projections_fast(fields, all_omit, limited, &mut registry, preserve_order).await?
 		};
 
 		Ok(projected)

--- a/surrealdb/core/src/exec/planner/select/projection.rs
+++ b/surrealdb/core/src/exec/planner/select/projection.rs
@@ -161,6 +161,7 @@ impl<'ctx> Planner<'ctx> {
 		omit: Vec<Expr>,
 		input: Arc<dyn ExecOperator>,
 		registry: &mut ExpressionRegistry,
+		preserve_order: bool,
 	) -> Result<Arc<dyn ExecOperator>, Error> {
 		match fields {
 			Fields::Value(selector) => {
@@ -212,6 +213,7 @@ impl<'ctx> Planner<'ctx> {
 						input,
 						projections,
 						Arc::new(OperatorMetrics::new()),
+						false,
 					)) as Arc<dyn ExecOperator>);
 				}
 
@@ -383,6 +385,7 @@ impl<'ctx> Planner<'ctx> {
 					computed,
 					projections,
 					Arc::new(OperatorMetrics::new()),
+					preserve_order,
 				)) as Arc<dyn ExecOperator>)
 			}
 		}

--- a/surrealdb/core/src/exec/planner/source.rs
+++ b/surrealdb/core/src/exec/planner/source.rs
@@ -352,6 +352,7 @@ impl<'ctx> Planner<'ctx> {
 				start,
 				omit: vec![],
 				tempfiles: false,
+				preserve_order: false,
 			};
 			self.plan_pipeline(base_scan, expr, config).await
 		} else {

--- a/surrealdb/core/src/expr/operation.rs
+++ b/surrealdb/core/src/expr/operation.rs
@@ -4,7 +4,7 @@ use revision::revisioned;
 use surrealdb_strand::Strand;
 use surrealdb_types::{SqlFormat, ToSql};
 
-use crate::val::{Array, Object, Value};
+use crate::val::{Array, Object, ObjectMap, Value};
 
 #[derive(Debug)]
 pub(crate) struct PatchError {
@@ -92,7 +92,7 @@ impl Operation {
 			res.into()
 		}
 		// Return the JSON patch operation
-		Object(match self {
+		Object(ObjectMap(match self {
 			Operation::Add {
 				path,
 				value,
@@ -161,7 +161,7 @@ impl Operation {
 					"value".into() => value,
 				}
 			}
-		})
+		}), None)
 	}
 
 	/// Returns the operaton encoded in the object, or an error if the object

--- a/surrealdb/core/src/expr/statements/define/table.rs
+++ b/surrealdb/core/src/expr/statements/define/table.rs
@@ -315,6 +315,7 @@ impl DefineTableStatement {
 			timeout: Expr::Literal(Literal::None),
 			explain: None,
 			tempfiles: false,
+			preserve_order: false,
 		};
 
 		let Value::Array(Array(v)) = select.compute(stk, ctx, opt, None).await? else {
@@ -562,6 +563,7 @@ impl DefineTableStatement {
 			timeout: Expr::Literal(Literal::None),
 			explain: None,
 			tempfiles: false,
+			preserve_order: false,
 		};
 		let res = stmt.compute(stk, ctx, opt, None).await?;
 		let Value::Array(res) = res else {

--- a/surrealdb/core/src/expr/statements/select.rs
+++ b/surrealdb/core/src/expr/statements/select.rs
@@ -51,6 +51,8 @@ pub(crate) struct SelectStatement {
 	pub timeout: Expr,
 	pub explain: Option<Explain>,
 	pub tempfiles: bool,
+	/// PoC: PRESERVE ORDER trailing clause — preserve written field order in output.
+	pub preserve_order: bool,
 }
 
 impl SelectStatement {

--- a/surrealdb/core/src/gql/tables.rs
+++ b/surrealdb/core/src/gql/tables.rs
@@ -365,6 +365,7 @@ fn select_all_from_record(rid: &RecordId, version: &Option<Datetime>) -> SelectS
 		fetch: None,
 		explain: None,
 		tempfiles: false,
+		preserve_order: false,
 	}
 }
 
@@ -398,6 +399,7 @@ fn select_field_from_record(
 		fetch: None,
 		explain: None,
 		tempfiles: false,
+		preserve_order: false,
 	}
 }
 
@@ -430,6 +432,7 @@ fn select_all_from_table(
 		fetch: None,
 		explain: None,
 		tempfiles: false,
+		preserve_order: false,
 	}
 }
 
@@ -3177,6 +3180,7 @@ fn make_table_aggregate_field(
 				fetch: None,
 				explain: None,
 				tempfiles: false,
+				preserve_order: false,
 			};
 			let res = execute_select(&kvs, sess, stmt).await?;
 
@@ -3376,6 +3380,7 @@ async fn run_connection_total_count(
 		fetch: None,
 		explain: None,
 		tempfiles: false,
+		preserve_order: false,
 	};
 	let res = execute_select(&q.kvs, sess, stmt).await?;
 	let arr = match res {

--- a/surrealdb/core/src/rpc/protocol.rs
+++ b/surrealdb/core/src/rpc/protocol.rs
@@ -1026,6 +1026,7 @@ pub trait RpcProtocol {
 			timeout: Expr::Literal(Literal::None),
 			explain: None,
 			tempfiles: false,
+			preserve_order: false,
 		};
 		let ast = Ast::single_expr(Expr::Select(Box::new(sql)));
 

--- a/surrealdb/core/src/sql/arbitrary/statements.rs
+++ b/surrealdb/core/src/sql/arbitrary/statements.rs
@@ -208,6 +208,7 @@ impl<'a> arbitrary::Arbitrary<'a> for SelectStatement {
 			timeout: u.arbitrary()?,
 			explain: u.arbitrary()?,
 			tempfiles: u.arbitrary()?,
+			preserve_order: u.arbitrary()?,
 		})
 	}
 }

--- a/surrealdb/core/src/sql/statements/select.rs
+++ b/surrealdb/core/src/sql/statements/select.rs
@@ -26,6 +26,7 @@ pub struct SelectStatement {
 	pub timeout: Expr,
 	pub explain: Option<Explain>,
 	pub tempfiles: bool,
+	pub preserve_order: bool,
 }
 
 impl ToSql for SelectStatement {
@@ -69,6 +70,9 @@ impl ToSql for SelectStatement {
 		if !matches!(self.timeout, Expr::Literal(Literal::None)) {
 			write_sql!(f, fmt, " TIMEOUT {}", CoverStmts(&self.timeout));
 		}
+		if self.preserve_order {
+			write_sql!(f, fmt, " PRESERVE ORDER");
+		}
 		if let Some(ref v) = self.explain {
 			write_sql!(f, fmt, " {v}");
 		}
@@ -94,6 +98,7 @@ impl From<SelectStatement> for crate::expr::statements::SelectStatement {
 			timeout: v.timeout.into(),
 			explain: v.explain.map(Into::into),
 			tempfiles: v.tempfiles,
+			preserve_order: v.preserve_order,
 		}
 	}
 }
@@ -117,6 +122,7 @@ impl From<crate::expr::statements::SelectStatement> for SelectStatement {
 			timeout: v.timeout.into(),
 			explain: v.explain.map(Into::into),
 			tempfiles: v.tempfiles,
+			preserve_order: v.preserve_order,
 		}
 	}
 }

--- a/surrealdb/core/src/sql/test_to_sql.rs
+++ b/surrealdb/core/src/sql/test_to_sql.rs
@@ -142,7 +142,7 @@ use crate::val::{Bytes, Duration, File, Geometry, Number, Object, RecordId, Set,
             Expr::Literal(Literal::Integer(3)),
         ]))))], close: None })), "IF true {\n\t1;\n\t2;\n} ELSE IF false { 3 }", "IF true {\n\n\t1;\n\t2;\n} ELSE IF false { 3 }")]
 // Expression: Select
-#[case::expr_select(Expr::Select(Box::new(SelectStatement { fields: Fields::all(), omit: vec![], only: false, what: vec![Expr::Table("user".into())], with: None, cond: None, split: None, group: None, order: None, limit: None, start: None, fetch: None, version: Expr::Literal(Literal::None), timeout: Expr::Literal(Literal::None), explain: None, tempfiles: false })), "SELECT * FROM user", "SELECT * FROM user")]
+#[case::expr_select(Expr::Select(Box::new(SelectStatement { fields: Fields::all(), omit: vec![], only: false, what: vec![Expr::Table("user".into())], with: None, cond: None, split: None, group: None, order: None, limit: None, start: None, fetch: None, version: Expr::Literal(Literal::None), timeout: Expr::Literal(Literal::None), explain: None, tempfiles: false, preserve_order: false })), "SELECT * FROM user", "SELECT * FROM user")]
 // Expression: Create
 #[case::expr_create(Expr::Create(Box::new(CreateStatement { only: false, what: vec![Expr::Table("user".into())], data: None, output: None, timeout: Expr::Literal(Literal::None) })), "CREATE user", "CREATE user")]
 // Expression: Update
@@ -248,7 +248,7 @@ use crate::val::{Bytes, Duration, File, Geometry, Number, Object, RecordId, Set,
             version: Expr::Literal(Literal::None),
             timeout: Expr::Literal(Literal::None),
             explain: None,
-            tempfiles: false
+            tempfiles: false, preserve_order: false
         })),
         block: Block(vec![
             Expr::IfElse(Box::new(IfelseStatement {

--- a/surrealdb/core/src/syn/lexer/keywords.rs
+++ b/surrealdb/core/src/syn/lexer/keywords.rs
@@ -224,6 +224,7 @@ pub(crate) static KEYWORDS: phf::Map<UniCase<&'static str>, TokenKind> = phf_map
 	UniCase::ascii("PASSWORD") => TokenKind::Keyword(Keyword::Password),
 	UniCase::ascii("PATCH") => TokenKind::Keyword(Keyword::Patch),
 	UniCase::ascii("PERMISSIONS") => TokenKind::Keyword(Keyword::Permissions),
+	UniCase::ascii("PRESERVE") => TokenKind::Keyword(Keyword::Preserve),
 	UniCase::ascii("POSTINGS_CACHE") => TokenKind::Keyword(Keyword::PostingsCache),
 	UniCase::ascii("POSTINGS_ORDER") => TokenKind::Keyword(Keyword::PostingsOrder),
 	UniCase::ascii("PREPARE") => TokenKind::Keyword(Keyword::Prepare),

--- a/surrealdb/core/src/syn/parser/stmt/select.rs
+++ b/surrealdb/core/src/syn/parser/stmt/select.rs
@@ -66,6 +66,12 @@ impl Parser<'_> {
 		};
 		let timeout = self.try_parse_timeout(stk).await?;
 		let tempfiles = self.eat(t!("TEMPFILES"));
+		let preserve_order = if self.eat(t!("PRESERVE")) {
+			self.eat(t!("ORDER"));
+			true
+		} else {
+			false
+		};
 		let explain = self.try_parse_explain()?;
 
 		Ok(SelectStatement {
@@ -84,6 +90,7 @@ impl Parser<'_> {
 			version,
 			timeout,
 			tempfiles,
+			preserve_order,
 			explain,
 		})
 	}

--- a/surrealdb/core/src/syn/parser/test/stmt.rs
+++ b/surrealdb/core/src/syn/parser/test/stmt.rs
@@ -2006,7 +2006,7 @@ pub fn parse_for() {
 					version: Expr::Literal(Literal::None),
 					timeout: Expr::Literal(Literal::None),
 					explain: None,
-					tempfiles: false
+					tempfiles: false, preserve_order: false
 				}))),
 				op: BinaryOperator::Multiply,
 				right: Box::new(Expr::Literal(Literal::Integer(2)))
@@ -2368,7 +2368,7 @@ fn parse_insert_select() {
 				version: Expr::Literal(Literal::None),
 				timeout: Expr::Literal(Literal::None),
 				explain: None,
-				tempfiles: false
+				tempfiles: false, preserve_order: false
 			}))),
 			ignore: true,
 			update: None,
@@ -3083,4 +3083,32 @@ fn parse_access_purge() {
 			})))
 		);
 	}
+}
+
+#[test]
+fn parse_select_preserve_order() {
+	use surrealdb_types::ToSql;
+	// The clause parses and sets the flag.
+	let res = syn::parse_with(
+		r"SELECT c, a, b FROM t PRESERVE ORDER".as_bytes(),
+		async |parser, stk| parser.parse_expr_inherit(stk).await,
+	)
+	.unwrap();
+	let Expr::Select(stmt) = &res else {
+		panic!("expected select, got {res:?}");
+	};
+	assert!(stmt.preserve_order, "PRESERVE ORDER clause sets preserve_order");
+	assert!(res.to_sql().contains("PRESERVE ORDER"), "round-trips: {}", res.to_sql());
+
+	// Without the clause the flag is false (and ORDER BY parses independently).
+	let plain = syn::parse_with(
+		r"SELECT c, a, b FROM t ORDER BY a".as_bytes(),
+		async |parser, stk| parser.parse_expr_inherit(stk).await,
+	)
+	.unwrap();
+	let Expr::Select(stmt2) = &plain else {
+		panic!("expected select");
+	};
+	assert!(!stmt2.preserve_order);
+	assert!(!plain.to_sql().contains("PRESERVE ORDER"));
 }

--- a/surrealdb/core/src/syn/parser/test/streaming.rs
+++ b/surrealdb/core/src/syn/parser/test/streaming.rs
@@ -438,6 +438,7 @@ fn statements() -> Vec<TopLevelExpr> {
 					timeout: Expr::Literal(Literal::None),
 					explain: None,
 					tempfiles: false,
+					preserve_order: false,
 				}))),
 				op: BinaryOperator::Multiply,
 				right: Box::new(Expr::Literal(Literal::Integer(2))),
@@ -511,6 +512,7 @@ fn statements() -> Vec<TopLevelExpr> {
 			version: Expr::Literal(Literal::Datetime(PublicDatetime::from(expected_datetime))),
 			timeout: Expr::Literal(Literal::None),
 			tempfiles: false,
+			preserve_order: false,
 			explain: Some(Explain(true)),
 		}))),
 		TopLevelExpr::Expr(Expr::Select(Box::new(SelectStatement {
@@ -541,6 +543,7 @@ fn statements() -> Vec<TopLevelExpr> {
 			version: Expr::Literal(Literal::None),
 			timeout: Expr::Literal(Literal::None),
 			tempfiles: false,
+			preserve_order: false,
 			explain: None,
 		}))),
 		TopLevelExpr::Expr(Expr::Let(Box::new(SetStatement {

--- a/surrealdb/core/src/syn/token/keyword.rs
+++ b/surrealdb/core/src/syn/token/keyword.rs
@@ -161,6 +161,7 @@ keyword! {
 	PostingsCache => "POSTINGS_CACHE",
 	PostingsOrder => "POSTINGS_ORDER",
 	Prepare => "PREPARE",
+	Preserve => "PRESERVE",
 	Punct => "PUNCT",
 	Purge => "PURGE",
 	Range => "RANGE",

--- a/surrealdb/core/src/val/mod.rs
+++ b/surrealdb/core/src/val/mod.rs
@@ -48,7 +48,7 @@ pub(crate) use self::duration::Duration;
 pub(crate) use self::file::File;
 pub(crate) use self::geometry::Geometry;
 pub(crate) use self::number::{DecimalExt, Number};
-pub(crate) use self::object::Object;
+pub(crate) use self::object::{Object, ObjectMap};
 pub(crate) use self::range::Range;
 pub(crate) use self::record_id::{RecordId, RecordIdKey, RecordIdKeyRange};
 pub(crate) use self::regex::Regex;
@@ -1116,7 +1116,7 @@ impl From<VecMap<String, Value>> for Value {
 
 impl From<VecMap<Strand, Value>> for Value {
 	fn from(v: VecMap<Strand, Value>) -> Self {
-		Value::Object(Object(v))
+		Value::Object(Object::from(v))
 	}
 }
 
@@ -1263,8 +1263,13 @@ fn convert_set_to_public(value: crate::val::Set) -> Result<surrealdb_types::Valu
 }
 
 fn convert_object_to_public(value: crate::val::Object) -> Result<surrealdb_types::Value> {
+	// Carry the presentation-order side-car across the boundary so output
+	// formats can render fields in written order.
+	let order = value.1.clone();
 	let converted = convert_object_to_public_map(value)?;
-	Ok(surrealdb_types::Value::Object(surrealdb_types::Object::from(converted)))
+	let mut obj = surrealdb_types::Object::from(converted);
+	obj.set_display_order(order);
+	Ok(surrealdb_types::Value::Object(obj))
 }
 
 pub(crate) fn convert_object_to_public_map(

--- a/surrealdb/core/src/val/object.rs
+++ b/surrealdb/core/src/val/object.rs
@@ -1,10 +1,14 @@
 use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 
 use anyhow::Result;
 use http::{HeaderMap, HeaderName, HeaderValue};
-use revision::revisioned;
-use storekey::{BorrowDecode, Encode};
+use revision::{
+	BorrowedReader, DeserializeRevisioned, Revisioned, SerializeRevisioned, SkipRevisioned,
+	WalkRevisioned, revisioned,
+};
+use storekey::{BorrowDecode, BorrowReader, DecodeError, Encode, EncodeError, Writer};
 use surrealdb_collections::{Entry as VecMapEntry, VecMap, VecMapIntoIter};
 use surrealdb_types::{SqlFormat, ToSql, write_sql};
 
@@ -13,26 +17,149 @@ use crate::expr::literal::ObjectEntry;
 use crate::fmt::EscapeObjectKey;
 use crate::val::{IndexFormat, RecordId, Strand, Value};
 
-/// Invariant: Keys never contain NUL bytes.
+/// Canonical, always-sorted object map.
+///
+/// This is the byte-identical successor to the original `Object` newtype: it
+/// keeps the exact on-disk, revision, and storekey encoding the engine has
+/// always used (sorted keys, `#[revision(indexed_map)]`). The presentation
+/// order side-car lives on [`Object`], **not** here, so storage, comparison,
+/// index keys, and complex Record IDs are entirely unaffected.
 ///
 /// - **Rev 1** — `u16 revision || VecMap<Strand, Value>` (length-prefixed sorted entries).
-///   Byte-identical to the legacy on-disk encoding.
-/// - **Rev 2** — optimised envelope (`u16 revision || u32_le payload_length`), inner `VecMap`
-///   written via the indexed-map prologue past `OFFSET_TABLE_MIN_LEN = 8`. Walker descent stays
-///   zero-allocation: `walk_field_0()` on a `Wire`-repr parent borrows the field bytes directly by
-///   bracketing `skip_indexed_map` with `BorrowedReader::remaining()` snapshots, no decode +
-///   re-encode required.
+/// - **Rev 2** — optimised envelope, inner `VecMap` written via the indexed-map prologue.
 #[revisioned(revision(1), revision(2, optimised))]
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Hash, Encode, BorrowDecode)]
 #[storekey(format = "()")]
 #[storekey(format = "IndexFormat")]
-pub(crate) struct Object(#[revision(indexed_map)] pub(crate) VecMap<Strand, Value>);
+pub(crate) struct ObjectMap(#[revision(indexed_map)] pub(crate) VecMap<Strand, Value>);
+
+impl Deref for ObjectMap {
+	type Target = VecMap<Strand, Value>;
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl DerefMut for ObjectMap {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.0
+	}
+}
+
+impl IntoIterator for ObjectMap {
+	type Item = (Strand, Value);
+	type IntoIter = VecMapIntoIter<Strand, Value>;
+	fn into_iter(self) -> Self::IntoIter {
+		self.0.into_iter()
+	}
+}
+
+/// An object value: a canonical sorted map plus an **optional** presentation
+/// order used only for output.
+///
+/// `order`, when present, is a permutation of indices into the sorted entries
+/// (`order[i]` is the sorted position of the `i`-th field in display order). It
+/// is deliberately excluded from `PartialEq`/`Eq`/`Ord`/`Hash` and from every
+/// encoding path, so two objects that differ only in display order remain
+/// equal, hash identically, and serialise to identical bytes. This guarantees
+/// the feature can never affect comparison, dedup, index keys, Record IDs, or
+/// storage (see issue #4053). `order: None` is byte-for-byte today's behaviour.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Object(pub(crate) ObjectMap, pub(crate) Option<Box<[u32]>>);
+
+// --- Comparison / hashing: delegate to the sorted map, ignore `order`. ---
+
+impl PartialEq for Object {
+	fn eq(&self, other: &Self) -> bool {
+		self.0 == other.0
+	}
+}
+impl Eq for Object {}
+impl PartialOrd for Object {
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+		Some(self.cmp(other))
+	}
+}
+impl Ord for Object {
+	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+		self.0.cmp(&other.0)
+	}
+}
+impl Hash for Object {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.0.hash(state);
+	}
+}
+
+// --- Encoding: delegate to the sorted map; `order` is never written. ---
+
+impl<F> Encode<F> for Object
+where
+	ObjectMap: Encode<F>,
+{
+	fn encode<W: std::io::Write>(&self, w: &mut Writer<W>) -> Result<(), EncodeError> {
+		self.0.encode(w)
+	}
+}
+
+impl<'de, F> BorrowDecode<'de, F> for Object
+where
+	ObjectMap: BorrowDecode<'de, F>,
+{
+	fn borrow_decode(r: &mut BorrowReader<'de>) -> Result<Self, DecodeError> {
+		Ok(Object(ObjectMap::borrow_decode(r)?, None))
+	}
+}
+
+impl SerializeRevisioned for Object {
+	fn serialize_revisioned<W: std::io::Write>(&self, w: &mut W) -> Result<(), revision::Error> {
+		self.0.serialize_revisioned(w)
+	}
+}
+
+impl DeserializeRevisioned for Object {
+	fn deserialize_revisioned<R: std::io::Read>(r: &mut R) -> Result<Self, revision::Error> {
+		Ok(Object(ObjectMap::deserialize_revisioned(r)?, None))
+	}
+}
+
+impl Revisioned for Object {
+	fn revision() -> u16 {
+		ObjectMap::revision()
+	}
+}
+
+// Skipping and zero-copy walking delegate to the inner map, which carries the
+// real wire shape. The presentation-order side-car is never on the wire.
+impl SkipRevisioned for Object {
+	fn skip_revisioned<R: std::io::Read>(r: &mut R) -> Result<(), revision::Error> {
+		ObjectMap::skip_revisioned(r)
+	}
+}
+
+impl WalkRevisioned for Object {
+	type Walker<'r, R: BorrowedReader + 'r> = <ObjectMap as WalkRevisioned>::Walker<'r, R>;
+
+	fn walk_revisioned<'r, R: BorrowedReader>(
+		reader: &'r mut R,
+	) -> Result<Self::Walker<'r, R>, revision::Error> {
+		ObjectMap::walk_revisioned(reader)
+	}
+}
+
+// --- Constructors: build a sorted map with no presentation order. ---
+
+impl From<ObjectMap> for Object {
+	fn from(v: ObjectMap) -> Self {
+		Self(v, None)
+	}
+}
 
 impl From<BTreeMap<&str, Value>> for Object {
 	fn from(v: BTreeMap<&str, Value>) -> Self {
 		let mut entries = Vec::with_capacity(v.len());
 		entries.extend(v.into_iter().map(|(k, val)| (Strand::from(k), val)));
-		Self(VecMap::from_sorted_vec_unchecked(entries))
+		Self(ObjectMap(VecMap::from_sorted_vec_unchecked(entries)), None)
 	}
 }
 
@@ -40,19 +167,19 @@ impl From<BTreeMap<String, Value>> for Object {
 	fn from(v: BTreeMap<String, Value>) -> Self {
 		let mut entries = Vec::with_capacity(v.len());
 		entries.extend(v.into_iter().map(|(k, val)| (Strand::from(k), val)));
-		Self(VecMap::from_sorted_vec_unchecked(entries))
+		Self(ObjectMap(VecMap::from_sorted_vec_unchecked(entries)), None)
 	}
 }
 
 impl From<BTreeMap<Strand, Value>> for Object {
 	fn from(v: BTreeMap<Strand, Value>) -> Self {
-		Self(VecMap::from(v))
+		Self(ObjectMap(VecMap::from(v)), None)
 	}
 }
 
 impl From<VecMap<Strand, Value>> for Object {
 	fn from(v: VecMap<Strand, Value>) -> Self {
-		Self(v)
+		Self(ObjectMap(v), None)
 	}
 }
 
@@ -60,7 +187,7 @@ impl From<VecMap<String, Value>> for Object {
 	fn from(v: VecMap<String, Value>) -> Self {
 		let mut entries = Vec::with_capacity(v.len());
 		entries.extend(v.into_iter().map(|(k, val)| (Strand::from(k), val)));
-		Self(VecMap::from_sorted_vec_unchecked(entries))
+		Self(ObjectMap(VecMap::from_sorted_vec_unchecked(entries)), None)
 	}
 }
 
@@ -68,25 +195,25 @@ impl From<VecMap<&str, Value>> for Object {
 	fn from(v: VecMap<&str, Value>) -> Self {
 		let mut entries = Vec::with_capacity(v.len());
 		entries.extend(v.into_iter().map(|(k, val)| (Strand::from(k), val)));
-		Self(VecMap::from_sorted_vec_unchecked(entries))
+		Self(ObjectMap(VecMap::from_sorted_vec_unchecked(entries)), None)
 	}
 }
 
 impl FromIterator<(String, Value)> for Object {
 	fn from_iter<T: IntoIterator<Item = (String, Value)>>(iter: T) -> Self {
-		Self(VecMap::from_iter(iter.into_iter().map(|(k, v)| (Strand::from(k), v))))
+		Self(ObjectMap(VecMap::from_iter(iter.into_iter().map(|(k, v)| (Strand::from(k), v)))), None)
 	}
 }
 
 impl FromIterator<(Strand, Value)> for Object {
 	fn from_iter<T: IntoIterator<Item = (Strand, Value)>>(iter: T) -> Self {
-		Self(VecMap::from_iter(iter))
+		Self(ObjectMap(VecMap::from_iter(iter)), None)
 	}
 }
 
 impl<'a> FromIterator<(&'a str, Value)> for Object {
 	fn from_iter<T: IntoIterator<Item = (&'a str, Value)>>(iter: T) -> Self {
-		Self(VecMap::from_iter(iter.into_iter().map(|(k, v)| (Strand::from(k), v))))
+		Self(ObjectMap(VecMap::from_iter(iter.into_iter().map(|(k, v)| (Strand::from(k), v)))), None)
 	}
 }
 
@@ -94,25 +221,25 @@ impl From<BTreeMap<String, String>> for Object {
 	fn from(v: BTreeMap<String, String>) -> Self {
 		let mut entries = Vec::with_capacity(v.len());
 		entries.extend(v.into_iter().map(|(k, v)| (Strand::from(k), Value::from(v))));
-		Self(VecMap::from_sorted_vec_unchecked(entries))
+		Self(ObjectMap(VecMap::from_sorted_vec_unchecked(entries)), None)
 	}
 }
 
 impl From<Vec<(String, Value)>> for Object {
 	fn from(v: Vec<(String, Value)>) -> Self {
-		Self(VecMap::from_iter(v.into_iter().map(|(k, val)| (Strand::from(k), val))))
+		Self(ObjectMap(VecMap::from_iter(v.into_iter().map(|(k, val)| (Strand::from(k), val)))), None)
 	}
 }
 
 impl From<HashMap<&str, Value>> for Object {
 	fn from(v: HashMap<&str, Value>) -> Self {
-		Self(VecMap::from_iter(v.into_iter().map(|(key, val)| (Strand::from(key), val))))
+		Self(ObjectMap(VecMap::from_iter(v.into_iter().map(|(key, val)| (Strand::from(key), val)))), None)
 	}
 }
 
 impl From<HashMap<String, Value>> for Object {
 	fn from(v: HashMap<String, Value>) -> Self {
-		Self(VecMap::from_iter(v.into_iter().map(|(k, val)| (Strand::from(k), val))))
+		Self(ObjectMap(VecMap::from_iter(v.into_iter().map(|(k, val)| (Strand::from(k), val)))), None)
 	}
 }
 
@@ -126,9 +253,17 @@ impl TryFrom<Object> for crate::types::PublicObject {
 	type Error = anyhow::Error;
 
 	fn try_from(s: Object) -> Result<Self, Self::Error> {
-		s.0.into_iter()
+		// Carry the presentation order across the boundary. Both sides sort the
+		// same string keys identically, so the index permutation is preserved.
+		let order = s.1.clone();
+		let mut obj = s
+			.0
+			.0
+			.into_iter()
 			.map(|(k, v)| crate::types::PublicValue::try_from(v).map(|v| (k.into_string(), v)))
-			.collect()
+			.collect::<Result<crate::types::PublicObject, Self::Error>>()?;
+		obj.set_display_order(order);
+		Ok(obj)
 	}
 }
 
@@ -136,20 +271,20 @@ impl From<crate::types::PublicObject> for Object {
 	fn from(s: crate::types::PublicObject) -> Self {
 		let mut entries = Vec::with_capacity(s.len());
 		entries.extend(s.into_iter().map(|(k, v)| (Strand::from(k), Value::from(v))));
-		Self(VecMap::from_sorted_vec_unchecked(entries))
+		Self(ObjectMap(VecMap::from_sorted_vec_unchecked(entries)), None)
 	}
 }
 
 impl Deref for Object {
 	type Target = VecMap<Strand, Value>;
 	fn deref(&self) -> &Self::Target {
-		&self.0
+		&self.0.0
 	}
 }
 
 impl DerefMut for Object {
 	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.0
+		&mut self.0.0
 	}
 }
 
@@ -157,7 +292,7 @@ impl IntoIterator for Object {
 	type Item = (Strand, Value);
 	type IntoIter = VecMapIntoIter<Strand, Value>;
 	fn into_iter(self) -> Self::IntoIter {
-		self.0.into_iter()
+		self.0.0.into_iter()
 	}
 }
 
@@ -238,6 +373,7 @@ impl Object {
 
 	pub fn into_literal(self) -> Vec<ObjectEntry> {
 		self.0
+			.0
 			.into_iter()
 			.map(|(k, v)| ObjectEntry {
 				key: k,
@@ -245,13 +381,46 @@ impl Object {
 			})
 			.collect()
 	}
+
+	/// Build the presentation order from a sequence of keys in the order they
+	/// were written by the query, recording where each landed in the sorted
+	/// map. Keys not present are skipped.
+	pub(crate) fn set_written_order<'a, I>(&mut self, written_keys: I)
+	where
+		I: IntoIterator<Item = &'a str>,
+	{
+		let sorted: Vec<&Strand> = self.0.0.keys().collect();
+		let mut order: Vec<u32> = Vec::new();
+		for key in written_keys {
+			if let Some(idx) = sorted.iter().position(|k| k.as_str() == key) {
+				order.push(idx as u32);
+			}
+		}
+		self.1 = if order.is_empty() {
+			None
+		} else {
+			Some(order.into_boxed_slice())
+		};
+	}
+
+	/// Iterate entries in presentation order when a side-car order is set,
+	/// otherwise in canonical sorted order.
+	pub(crate) fn iter_display(&self) -> Vec<(&Strand, &Value)> {
+		let entries: Vec<(&Strand, &Value)> = self.0.0.iter().collect();
+		match &self.1 {
+			Some(order) => {
+				order.iter().filter_map(|&i| entries.get(i as usize).copied()).collect()
+			}
+			None => entries,
+		}
+	}
 }
 
 impl std::ops::Add for Object {
 	type Output = Self;
 
 	fn add(self, rhs: Self) -> Self::Output {
-		Self(VecMap::merge_sorted_prefer_rhs(self.0, rhs.0))
+		Self(ObjectMap(VecMap::merge_sorted_prefer_rhs(self.0.0, rhs.0.0)), None)
 	}
 }
 
@@ -273,7 +442,7 @@ impl ToSql for Object {
 				f.push('\n');
 				inner_fmt.write_indent(f);
 			}
-			for (i, (key, value)) in self.0.iter().enumerate() {
+			for (i, (key, value)) in self.iter_display().into_iter().enumerate() {
 				if i > 0 {
 					inner_fmt.write_separator(f);
 				}
@@ -291,5 +460,68 @@ impl ToSql for Object {
 		} else {
 			f.push_str(" }");
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use storekey::{decode_borrow, encode_vec};
+
+	use super::*;
+
+	fn obj_written(pairs: &[(&str, i64)], written: &[&str]) -> Object {
+		let mut o = Object::default();
+		for (k, v) in pairs {
+			o.insert(*k, Value::from(*v));
+		}
+		o.set_written_order(written.iter().copied());
+		o
+	}
+
+	#[test]
+	fn order_excluded_from_eq_and_hash() {
+		// Same fields, different written order → must stay equal + hash-equal.
+		let a = obj_written(&[("a", 1), ("b", 2), ("c", 3)], &["c", "a", "b"]);
+		let b = obj_written(&[("a", 1), ("b", 2), ("c", 3)], &["a", "b", "c"]);
+		assert_eq!(a, b, "objects differing only in display order must be equal");
+
+		let mut ha = std::collections::hash_map::DefaultHasher::new();
+		let mut hb = std::collections::hash_map::DefaultHasher::new();
+		a.hash(&mut ha);
+		b.hash(&mut hb);
+		assert_eq!(ha.finish(), hb.finish(), "hashes must match regardless of order");
+		assert_eq!(a.cmp(&b), std::cmp::Ordering::Equal, "Ord must ignore order");
+	}
+
+	#[test]
+	fn display_order_is_preserved() {
+		let a = obj_written(&[("a", 1), ("b", 2), ("c", 3)], &["c", "a", "b"]);
+		let keys: Vec<&str> = a.iter_display().into_iter().map(|(k, _)| k.as_str()).collect();
+		assert_eq!(keys, vec!["c", "a", "b"], "iter_display must follow written order");
+
+		// Logical iteration stays sorted.
+		let sorted: Vec<&str> = a.keys().map(|k| k.as_str()).collect();
+		assert_eq!(sorted, vec!["a", "b", "c"], "logical iteration stays sorted");
+	}
+
+	#[test]
+	fn storekey_encoding_is_byte_identical() {
+		// An object with a display-order side-car must encode to exactly the
+		// same bytes as the same object without one.
+		let ordered = obj_written(&[("a", 1), ("b", 2), ("c", 3)], &["c", "a", "b"]);
+		let mut plain = Object::default();
+		for (k, v) in [("a", 1), ("b", 2), ("c", 3)] {
+			plain.insert(k, Value::from(v));
+		}
+		assert!(ordered.1.is_some() && plain.1.is_none());
+
+		let enc_ordered = encode_vec(&ordered).expect("encode ordered");
+		let enc_plain = encode_vec(&plain).expect("encode plain");
+		assert_eq!(enc_ordered, enc_plain, "side-car must not change encoded bytes");
+
+		// And it round-trips back to the canonical (sorted, order-less) value.
+		let decoded: Object = decode_borrow(&enc_ordered).expect("decode");
+		assert_eq!(decoded, ordered);
+		assert!(decoded.1.is_none(), "decoded value carries no display order");
 	}
 }

--- a/surrealdb/core/src/val/record_id.rs
+++ b/surrealdb/core/src/val/record_id.rs
@@ -458,6 +458,7 @@ impl RecordId {
 			timeout: Expr::Literal(Literal::None),
 			explain: None,
 			tempfiles: false,
+			preserve_order: false,
 		};
 
 		Ok(stk.run(|stk| stm.compute(stk, ctx, opt, doc)).await?.first().into_object())

--- a/surrealdb/core/src/val/value/convert/coerce.rs
+++ b/surrealdb/core/src/val/value/convert/coerce.rs
@@ -960,7 +960,7 @@ mod tests {
 			surrealdb_strand::Strand::new_static("bad_field"),
 			Value::String(Strand::new_static("not_an_int")),
 		);
-		let value = Value::Object(Object(map.into()));
+		let value = Value::Object(Object::from(map));
 
 		let err = value.coerce_to::<BTreeMap<String, i64>>().unwrap_err();
 		let msg = err.to_string();

--- a/surrealdb/core/src/val/value/fetch.rs
+++ b/surrealdb/core/src/val/value/fetch.rs
@@ -67,6 +67,7 @@ impl Value {
 							timeout: Expr::Literal(Literal::None),
 							explain: None,
 							tempfiles: false,
+							preserve_order: false,
 						};
 						*this = stm
 							.compute(stk, ctx, opt, None)
@@ -270,6 +271,7 @@ impl Value {
 					timeout: Expr::Literal(Literal::None),
 					explain: None,
 					tempfiles: false,
+					preserve_order: false,
 				};
 				*this = stm.compute(stk, ctx, opt, None).await?.first();
 				Ok(())

--- a/surrealdb/core/src/val/value/get.rs
+++ b/surrealdb/core/src/val/value/get.rs
@@ -482,6 +482,7 @@ impl Value {
 								timeout: Expr::Literal(Literal::None),
 								explain: None,
 								tempfiles: false,
+								preserve_order: false,
 							};
 
 							let res = stk.run(|stk| stm.compute(stk, ctx, opt, doc)).await?.all();

--- a/surrealdb/types/src/flatbuffers/collections.rs
+++ b/surrealdb/types/src/flatbuffers/collections.rs
@@ -102,14 +102,14 @@ impl FromFlatbuffers for Object {
 		let mut map = BTreeMap::new();
 		let items = input.items().ok_or_else(|| anyhow::anyhow!("Missing items in Object"))?;
 		if items.is_empty() {
-			return Ok(Object(map));
+			return Ok(Object(map, None));
 		}
 		for entry in items {
 			let key = entry.key().context("Missing key in Object entry")?.to_string();
 			let value = entry.value().context("Missing value in Object entry")?;
 			map.insert(key, Value::from_fb(value)?);
 		}
-		Ok(Object(map))
+		Ok(Object(map, None))
 	}
 }
 

--- a/surrealdb/types/src/traits/surreal_value.rs
+++ b/surrealdb/types/src/traits/surreal_value.rs
@@ -953,15 +953,15 @@ impl_surreal_value!(
 impl_surreal_value!(
 	<V> BTreeMap<String, V> as kind!(object),
 	(value) => {
-		if let Value::Object(Object(o)) = value {
+		if let Value::Object(Object(o, ..)) = value {
 			o.iter().all(|(_, v)| V::is_value(v))
 		} else {
 			false
 		}
 	},
-	from_btreemap<V>(self) => Value::Object(Object(self.into_iter().map(|(k, v)| (k, v.into_value())).collect())),
+	from_btreemap<V>(self) => Value::Object(Object(self.into_iter().map(|(k, v)| (k, v.into_value())).collect(), None)),
 	into_btreemap<V>(value) => {
-		let Value::Object(Object(o)) = value else {
+		let Value::Object(Object(o, ..)) = value else {
 			return Err(ConversionError::from_value(Self::kind_of(), &value).into());
 		};
 		o
@@ -975,15 +975,15 @@ impl_surreal_value!(
 impl_surreal_value!(
 	<V> HashMap<String, V> as kind!(object),
 	(value) => {
-		if let Value::Object(Object(o)) = value {
+		if let Value::Object(Object(o, ..)) = value {
 			o.iter().all(|(_, v)| V::is_value(v))
 		} else {
 			false
 		}
 	},
-	from_hashmap<V>(self) => Value::Object(Object(self.into_iter().map(|(k, v)| (k, v.into_value())).collect())),
+	from_hashmap<V>(self) => Value::Object(Object(self.into_iter().map(|(k, v)| (k, v.into_value())).collect(), None)),
 	into_hashmap<V>(value) => {
-		let Value::Object(Object(o)) = value else {
+		let Value::Object(Object(o, ..)) = value else {
 			return Err(ConversionError::from_value(Self::kind_of(), &value).into());
 		};
 		o
@@ -1505,7 +1505,7 @@ impl SurrealValue for http::HeaderMap {
 		// For each kv pair in the object:
 		//  - If the value is an array, insert each value into the header map.
 		//  - Otherwise, insert the value into the header map.
-		let Value::Object(Object(o)) = value else {
+		let Value::Object(Object(o, ..)) = value else {
 			return Err(ConversionError::from_value(Self::kind_of(), &value).into());
 		};
 		let mut res = http::HeaderMap::new();
@@ -1774,36 +1774,42 @@ impl<T: Serialize + DeserializeOwned + 'static> SurrealValue for SerdeWrapper<T>
 					.into_iter()
 					.map(|(key, uuid)| (key, Value::Uuid(Uuid::from(uuid))))
 					.collect(),
+				None,
 			)),
 			BTreeMap<String, chrono::DateTime<chrono::Utc>> as map => Value::Object(Object(
 				map
 					.into_iter()
 					.map(|(key, datetime)| (key, Value::Datetime(Datetime::from(datetime))))
 					.collect(),
+				None,
 			)),
 		BTreeMap<String, std::time::Duration> as map => Value::Object(Object(
 			map
 				.into_iter()
 				.map(|(key, duration)| (key, Value::Duration(Duration::from(duration))))
 				.collect(),
+			None,
 		)),
 		HashMap<String, uuid::Uuid> as map => Value::Object(Object(
 			map
 				.into_iter()
 				.map(|(key, uuid)| (key, Value::Uuid(Uuid::from(uuid))))
 				.collect(),
+			None,
 		)),
 		HashMap<String, chrono::DateTime<chrono::Utc>> as map => Value::Object(Object(
 			map
 				.into_iter()
 				.map(|(key, datetime)| (key, Value::Datetime(Datetime::from(datetime))))
 				.collect(),
+			None,
 		)),
 		HashMap<String, std::time::Duration> as map => Value::Object(Object(
 			map
 				.into_iter()
 				.map(|(key, duration)| (key, Value::Duration(Duration::from(duration))))
 				.collect(),
+			None,
 		)),
 		value => match value.serialize(Serializer) {
 			Ok(value) => value,

--- a/surrealdb/types/src/value/into_json.rs
+++ b/surrealdb/types/src/value/into_json.rs
@@ -56,8 +56,14 @@ impl Value {
 				set.0.into_iter().map(Value::into_json_value).collect::<Vec<JsonValue>>(),
 			),
 			Value::Object(object) => {
-				let mut map = Map::with_capacity(object.len());
-				for (k, v) in object.0 {
+				// field-ordering PoC: emit fields in presentation order. This relies on
+				// `serde_json`'s `preserve_order` feature (enabled in the workspace
+				// Cargo.toml as a PoC shortcut) so the `Map` keeps insertion order rather
+				// than re-sorting. A production version would use a dedicated ordered JSON
+				// encoder here and drop that global feature — see the Cargo.toml note.
+				let entries = object.into_iter_display();
+				let mut map = Map::with_capacity(entries.len());
+				for (k, v) in entries {
 					map.insert(k, v.into_json_value());
 				}
 				JsonValue::Object(map)

--- a/surrealdb/types/src/value/object.rs
+++ b/surrealdb/types/src/value/object.rs
@@ -1,24 +1,28 @@
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 
-use serde::{Deserialize, Serialize};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::sql::{SqlFormat, ToSql};
 use crate::{SurrealValue, Value};
 
 /// Represents an object with key-value pairs in SurrealDB
 ///
-/// An object is a collection of key-value pairs where keys are strings and values can be of any
-/// type. The underlying storage is a `BTreeMap<String, Value>` which maintains sorted keys.
-
-#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct Object(pub(crate) BTreeMap<String, Value>);
+/// Keys are stored canonically sorted in a `BTreeMap<String, Value>`. The
+/// optional second field is a **presentation order** side-car (a permutation of
+/// the sorted entries) used only for output — it is excluded from equality,
+/// hashing, and the serialized data, so two objects that differ only in display
+/// order remain equal and serialise to the same shape. `None` = sorted output.
+#[derive(Clone, Debug, Default)]
+pub struct Object(pub(crate) BTreeMap<String, Value>, pub(crate) Option<Box<[u32]>>);
 
 impl Object {
 	/// Create a new empty object
 	pub fn new() -> Self {
-		Object(BTreeMap::new())
+		Object(BTreeMap::new(), None)
 	}
 
 	/// Insert a key-value pair into the object
@@ -29,6 +33,90 @@ impl Object {
 	/// Convert into the inner BTreeMap<String, Value>
 	pub fn into_inner(self) -> BTreeMap<String, Value> {
 		self.0
+	}
+
+	/// Set the presentation order (a permutation of indices into the sorted
+	/// entries). Affects only output formatting, never comparison or hashing.
+	pub fn set_display_order(&mut self, order: Option<Box<[u32]>>) {
+		self.1 = order;
+	}
+
+	/// Consume the object, returning entries in presentation order when set,
+	/// otherwise sorted.
+	pub fn into_iter_display(self) -> Vec<(String, Value)> {
+		let entries: Vec<(String, Value)> = self.0.into_iter().collect();
+		match self.1 {
+			Some(order) => {
+				let mut slots: Vec<Option<(String, Value)>> =
+					entries.into_iter().map(Some).collect();
+				order
+					.iter()
+					.filter_map(|&i| slots.get_mut(i as usize).and_then(Option::take))
+					.collect()
+			}
+			None => entries,
+		}
+	}
+
+	/// Iterate entries in presentation order when set, otherwise sorted.
+	pub fn iter_display(&self) -> Vec<(&String, &Value)> {
+		let entries: Vec<(&String, &Value)> = self.0.iter().collect();
+		match &self.1 {
+			Some(order) => {
+				order.iter().filter_map(|&i| entries.get(i as usize).copied()).collect()
+			}
+			None => entries,
+		}
+	}
+}
+
+// Comparison / hashing / serialized data delegate to the sorted map, ignoring
+// the presentation-order side-car.
+impl PartialEq for Object {
+	fn eq(&self, other: &Self) -> bool {
+		self.0 == other.0
+	}
+}
+impl Eq for Object {}
+impl PartialOrd for Object {
+	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+		Some(self.cmp(other))
+	}
+}
+impl Ord for Object {
+	fn cmp(&self, other: &Self) -> Ordering {
+		self.0.cmp(&other.0)
+	}
+}
+impl Hash for Object {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.0.hash(state);
+	}
+}
+
+impl Serialize for Object {
+	/// Serialise as a map. When a display order is set, entries are emitted in
+	/// that order, so JSON/CBOR clients receive keys in written order.
+	fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+		let entries = self.iter_display();
+		let mut map = serializer.serialize_map(Some(entries.len()))?;
+		for (k, v) in entries {
+			map.serialize_entry(k, v)?;
+		}
+		map.end()
+	}
+}
+
+impl<'de> Deserialize<'de> for Object {
+	fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+		Ok(Object(BTreeMap::deserialize(deserializer)?, None))
+	}
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Object {
+	fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+		Ok(Object(BTreeMap::arbitrary(u)?, None))
 	}
 }
 
@@ -62,7 +150,7 @@ impl ToSql for Object {
 
 		if !self.is_empty() {
 			let inner_fmt = fmt.increment();
-			fmt_sql_key_value(self.iter(), f, inner_fmt);
+			fmt_sql_key_value(self.iter_display().into_iter(), f, inner_fmt);
 		}
 
 		if fmt.is_pretty() {
@@ -75,31 +163,31 @@ impl ToSql for Object {
 
 impl<T: SurrealValue> From<BTreeMap<&str, T>> for Object {
 	fn from(v: BTreeMap<&str, T>) -> Self {
-		Self(v.into_iter().map(|(key, val)| (key.to_string(), val.into_value())).collect())
+		Self(v.into_iter().map(|(key, val)| (key.to_string(), val.into_value())).collect(), None)
 	}
 }
 
 impl<T: SurrealValue> From<BTreeMap<String, T>> for Object {
 	fn from(v: BTreeMap<String, T>) -> Self {
-		Self(v.into_iter().map(|(key, val)| (key, val.into_value())).collect())
+		Self(v.into_iter().map(|(key, val)| (key, val.into_value())).collect(), None)
 	}
 }
 
 impl<T: SurrealValue> FromIterator<(String, T)> for Object {
 	fn from_iter<I: IntoIterator<Item = (String, T)>>(iter: I) -> Self {
-		Self(BTreeMap::from_iter(iter.into_iter().map(|(k, v)| (k, v.into_value()))))
+		Self(BTreeMap::from_iter(iter.into_iter().map(|(k, v)| (k, v.into_value()))), None)
 	}
 }
 
 impl<T: SurrealValue> From<HashMap<&str, T>> for Object {
 	fn from(v: HashMap<&str, T>) -> Self {
-		Self(v.into_iter().map(|(key, val)| (key.to_string(), val.into_value())).collect())
+		Self(v.into_iter().map(|(key, val)| (key.to_string(), val.into_value())).collect(), None)
 	}
 }
 
 impl<T: SurrealValue> From<HashMap<String, T>> for Object {
 	fn from(v: HashMap<String, T>) -> Self {
-		Self(v.into_iter().map(|(key, val)| (key, val.into_value())).collect())
+		Self(v.into_iter().map(|(key, val)| (key, val.into_value())).collect(), None)
 	}
 }
 

--- a/surrealdb/types/src/variables.rs
+++ b/surrealdb/types/src/variables.rs
@@ -95,7 +95,7 @@ impl From<Object> for Variables {
 
 impl From<Variables> for Object {
 	fn from(vars: Variables) -> Self {
-		Object(vars.0)
+		Object(vars.0, None)
 	}
 }
 


### PR DESCRIPTION
**Draft / proof-of-concept** — revisits #2715 (closed `wontfix`) by preserving query-output field order *without* changing storage or comparison semantics. Companion to a design discussion; not intended to merge as-is.

## What this proves
Field order can be preserved as **presentation-only** metadata while the canonical sorted form stays authoritative for storage and comparison — directly answering the 2024 "objects are sorted B-trees, so output must be sorted" objection.

## Design
- Optional **presentation-order side-car** on `Object`, excluded from `Ord`/`Eq`/`Hash` and from the wire encoding. The existing revisioned/storekey map is kept as an inner type and delegated to, so encoding is **byte-identical**.
- Order is honored only at output (`ToSql` + the JSON `/sql` encoder).
- Gated behind `ExperimentalTarget::FieldOrdering` (`--allow-experimental field_ordering`), default off.

## Surface (Phase A)
`SELECT a, b FROM t PRESERVE ORDER` — trailing clause placed after `FETCH`/`TIMEOUT`, so it never collides with `ORDER BY`. Planner threads the capability-gated flag into `SelectProject`, which records written projection order on each output object; the core→public conversion carries it through to JSON output.

## Tests
- `storekey_encoding_is_byte_identical` — side-car never changes encoded bytes.
- `order_excluded_from_eq_and_hash` — order-differing objects stay `==` / hash-equal (honors #4053).
- `display_order_is_preserved`, `preserve_order_sets_written_display_order`, `parse_select_preserve_order`.

## Live demo
```
SELECT c, a, b FROM t PRESERVE ORDER;   ->  {"c":3,"a":1,"b":2}   (written order)
SELECT c, a, b FROM t;                  ->  {"a":1,"b":2,"c":3}   (sorted, default)
```
See `field-ordering-demo.surql`.

## Out of scope (PoC)
`SELECT *` / literals / `RETURN` (Phases B/C); CBOR/flatbuffers wire formats; the `DEFINE CONFIG FIELDS ORDER` surface. The `serde_json` `preserve_order` feature flip is a documented shortcut (a production version would use a dedicated ordered JSON encoder).
