### PR TITLE
Database branching (copy-on-write) — experimental PoC

### DIFF
--- a/branching-demo.surql
+++ b/branching-demo.surql
@@ -1,0 +1,58 @@
+-- ===========================================================================
+-- Database Branching PoC — demo script
+--
+-- 1) Start the server (separate terminal). The --planner-strategy compute-only
+--    flag is REQUIRED: the copy-on-write read overlay is wired into the compute
+--    executor; the new streaming planner is not yet branch-aware.
+--
+--    SURREAL_PATH="surrealkv:///tmp/branch-poc" \
+--      ./target/debug/surreal start \
+--        --allow-experimental database_branching \
+--        --planner-strategy compute-only \
+--        --user root --pass root --bind 127.0.0.1:8011
+--
+--    (Versioning is NOT required — the overlay reads the parent's current state.
+--     `SURREAL_PATH=memory` works too.)
+--
+-- 2) Run this script:
+--    ./target/debug/surreal sql --endpoint ws://127.0.0.1:8011 \
+--        --user root --pass root --ns demo --db main --pretty \
+--        < branching-demo.surql
+-- ===========================================================================
+
+USE NS demo DB main;
+
+-- 1) Seed the parent database.
+CREATE product:laptop SET name = "Laptop", price = 1000;
+CREATE product:phone  SET name = "Phone",  price =  500;
+CREATE product:tablet SET name = "Tablet", price =  300;
+
+SELECT * FROM product;          --> parent: laptop, phone, tablet
+
+-- 2) Branch `main` into a new database `experiment` (copy-on-write).
+DEFINE DATABASE experiment FROM main;
+
+-- 3) The branch transparently sees the parent's rows (nothing was copied).
+USE NS demo DB experiment;
+SELECT * FROM product;          --> laptop, phone, tablet  (inherited from parent)
+
+-- 4) Diverge the branch with a branch-only product.
+CREATE product:keyboard SET name = "Keyboard", price = 80;
+SELECT * FROM product;          --> laptop, phone, tablet, keyboard
+
+-- 5) The parent is untouched by the branch's writes (isolation).
+USE NS demo DB main;
+SELECT * FROM product;          --> laptop, phone, tablet   (NO keyboard)
+
+-- ---------------------------------------------------------------------------
+-- PoC scope (works today):
+--   * DEFINE DATABASE @branch FROM @source_db [VERSION @datetime]  (branch creation, gated)
+--   * Full-table SELECT overlay: branch rows over parent rows, branch wins
+--   * Branch-local writes isolated from the parent (separate keyspace)
+--
+-- Not yet (follow-ups):
+--   * New streaming planner (run with --planner-strategy compute-only for now)
+--   * Point reads / ranges / index scans overlay; persisted tombstones (branch DELETE)
+--   * base_version-pinned reads (branch isolation from FUTURE parent writes)
+--   * MERGE DATABASE @branch INTO @target; REMOVE guard; INFO branch metadata
+-- ---------------------------------------------------------------------------

--- a/surrealdb/core/src/catalog/database.rs
+++ b/surrealdb/core/src/catalog/database.rs
@@ -130,3 +130,24 @@ impl InfoStructure for DatabaseDefinition {
 		})
 	}
 }
+
+/// Copy-on-write branch metadata for a database.
+///
+/// Stored in a separate additive catalog key (`key::namespace::bm`) keyed by the
+/// branch's `(NamespaceId, DatabaseId)` — deliberately NOT a field on
+/// [`DatabaseDefinition`], so ordinary databases keep a byte-identical on-disk
+/// encoding (no revision bump, no `catalog::compat` fixture churn). A row exists
+/// here only for branches; its absence means "ordinary database".
+///
+/// Gated behind `ExperimentalTarget::DatabaseBranching`.
+#[revisioned(revision = 1)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub(crate) struct BranchMetadata {
+	/// The parent database this branch was created from (same namespace).
+	pub(crate) parent: DatabaseId,
+	/// The parent versionstamp this branch is pinned to — its fall-through base for
+	/// reads and the fast-forward-merge anchor. Always set for a branch (resolved at
+	/// `DEFINE DATABASE … FROM` time, even when branched at "now").
+	pub(crate) base_version: u64,
+}
+impl_kv_value_revisioned!(BranchMetadata);

--- a/surrealdb/core/src/dbs/capabilities.rs
+++ b/surrealdb/core/src/dbs/capabilities.rs
@@ -123,6 +123,7 @@ impl std::str::FromStr for FuncTarget {
 pub enum ExperimentalTarget {
 	Files,
 	Surrealism,
+	DatabaseBranching,
 }
 
 impl fmt::Display for ExperimentalTarget {
@@ -130,6 +131,7 @@ impl fmt::Display for ExperimentalTarget {
 		match self {
 			Self::Files => write!(f, "files"),
 			Self::Surrealism => write!(f, "surrealism"),
+			Self::DatabaseBranching => write!(f, "database_branching"),
 		}
 	}
 }
@@ -145,6 +147,7 @@ impl Target<str> for ExperimentalTarget {
 		match self {
 			Self::Files => elem.eq_ignore_ascii_case("files"),
 			Self::Surrealism => elem.eq_ignore_ascii_case("surrealism"),
+			Self::DatabaseBranching => elem.eq_ignore_ascii_case("database_branching"),
 		}
 	}
 }
@@ -172,6 +175,7 @@ impl std::str::FromStr for ExperimentalTarget {
 		match s.trim().to_ascii_lowercase().as_str() {
 			"files" => Ok(ExperimentalTarget::Files),
 			"surrealism" => Ok(ExperimentalTarget::Surrealism),
+			"database_branching" => Ok(ExperimentalTarget::DatabaseBranching),
 			_ => Err(ParseExperimentalTargetError::InvalidName),
 		}
 	}

--- a/surrealdb/core/src/dbs/iterator.rs
+++ b/surrealdb/core/src/dbs/iterator.rs
@@ -9,6 +9,7 @@ use surrealdb_types::ToSql;
 use crate::catalog::Record;
 use crate::catalog::providers::TableProvider;
 use crate::ctx::{Canceller, Context, FrozenContext};
+use crate::dbs::capabilities::ExperimentalTarget;
 use crate::dbs::distinct::SyncDistinct;
 use crate::dbs::plan::{Explanation, Plan};
 use crate::dbs::result::Results;
@@ -316,14 +317,29 @@ impl Iterator {
 		table: &TableName,
 	) -> Result<()> {
 		let tb = if stm_ctx.stm.requires_table_existence() {
-			ctx.tx()
+			let txn = ctx.tx();
+			let mut found = txn
 				.get_tb(doc_ctx.ns.namespace_id, doc_ctx.db.database_id, table, opt.version)
-				.await?
-				.ok_or_else(|| {
-					anyhow::anyhow!(Error::TbNotFound {
-						name: table.to_owned(),
-					})
-				})?
+				.await?;
+			// Copy-on-write branch: a branch inherits its parent's table definitions,
+			// so on a miss fall through to the parent's catalog at the pinned base_version.
+			if found.is_none()
+				&& ctx.get_capabilities().allows_experimental(&ExperimentalTarget::DatabaseBranching)
+			{
+				if let Some(meta) =
+					txn.get_branch_meta(doc_ctx.ns.namespace_id, doc_ctx.db.database_id).await?
+				{
+					// PoC reads the parent's current catalog (version = None); base_version
+					// pinning is follow-up work (see processor::collect_table_branch).
+					found =
+						txn.get_tb(doc_ctx.ns.namespace_id, meta.parent, table, None).await?;
+				}
+			}
+			found.ok_or_else(|| {
+				anyhow::anyhow!(Error::TbNotFound {
+					name: table.to_owned(),
+				})
+			})?
 		} else {
 			ctx.tx()
 				.get_or_add_tb(Some(ctx), &doc_ctx.ns.name, &doc_ctx.db.name, table, opt.version)

--- a/surrealdb/core/src/dbs/processor.rs
+++ b/surrealdb/core/src/dbs/processor.rs
@@ -7,8 +7,9 @@ use anyhow::{Result, bail};
 use reblessive::tree::Stk;
 
 use crate::catalog::providers::TableProvider;
-use crate::catalog::{DatabaseId, NamespaceId, Record};
+use crate::catalog::{BranchMetadata, DatabaseId, NamespaceId, Record};
 use crate::ctx::{Context, FrozenContext};
+use crate::dbs::capabilities::ExperimentalTarget;
 use crate::dbs::distinct::SyncDistinct;
 use crate::dbs::{Iterable, Iterator, Operable, Options, Processable, Statement};
 use crate::doc::{DocumentContext, NsDbCtx};
@@ -19,7 +20,10 @@ use crate::expr::statements::relate::RelateThrough;
 use crate::idx::planner::iterators::{IndexItemRecord, IteratorRef, RecordIterator};
 use crate::idx::planner::{IterationStage, RecordStrategy, ScanDirection};
 use crate::key::{graph, record, r#ref};
-use crate::kvs::{KVKey, KVValue, Key, NORMAL_BATCH_SIZE, ScanLimit, Transaction, Val};
+use crate::kvs::{
+	KVKey, KVValue, Key, MergeCursor, NORMAL_BATCH_SIZE, NSDB_PREFIX_LEN, ScanLimit, Transaction,
+	Val,
+};
 use crate::val::{RecordId, RecordIdKey, RecordIdKeyRange, TableName, Value};
 
 impl Iterable {
@@ -813,6 +817,16 @@ pub(super) trait Collector {
 		let ns = doc_ctx.ns().namespace_id;
 		let db = doc_ctx.db().database_id;
 
+		// Copy-on-write branch overlay. Only when the experimental capability is on
+		// (so non-branch reads pay zero extra cost by default) do we check whether
+		// this database is a branch; if so, its rows are merged over the parent's
+		// rows read at the pinned base_version.
+		if ctx.get_capabilities().allows_experimental(&ExperimentalTarget::DatabaseBranching) {
+			if let Some(meta) = ctx.tx().get_branch_meta(ns, db).await? {
+				return self.collect_table_branch(ctx, opt, doc_ctx, table, sc, meta).await;
+			}
+		}
+
 		// Prepare the start and end keys
 		let beg = record::prefix(ns, db, table)?;
 		let end = record::suffix(ns, db, table)?;
@@ -848,6 +862,80 @@ pub(super) trait Collector {
 		}
 		// Everything ok
 		Ok(())
+	}
+
+	/// Copy-on-write branch table scan: merge this branch's own rows over the
+	/// parent's rows read at the pinned `base_version`, with branch rows winning.
+	///
+	/// PoC scope: materialises both ranges and runs them through [`MergeCursor`]
+	/// (not yet streaming), and there are no persisted tombstones yet (the branch
+	/// `DELETE` write-path is a later step), so every branch row is treated as live.
+	#[instrument(level = "trace", skip_all)]
+	async fn collect_table_branch(
+		&mut self,
+		ctx: &FrozenContext,
+		_opt: &Options,
+		doc_ctx: DocumentContext,
+		table: &TableName,
+		sc: ScanDirection,
+		meta: BranchMetadata,
+	) -> Result<()> {
+		let ns = doc_ctx.ns().namespace_id;
+		let db = doc_ctx.db().database_id;
+		let txn = ctx.tx();
+
+		// Branch rows (current state), scoped to this table.
+		let branch_beg = record::prefix(ns, db, table)?;
+		let branch_end = record::suffix(ns, db, table)?;
+		let branch_prefix = branch_beg[..NSDB_PREFIX_LEN].to_vec();
+		let branch_rows = Self::drain_vals(&txn, branch_beg..branch_end, None).await?;
+
+		// Parent rows. PoC reads the parent's CURRENT state (version = None); pinning the
+		// read to meta.base_version (already persisted) is the next step — it needs the
+		// branch versionstamp to line up with the backend's MVCC reads, which is follow-up
+		// work. Until then a branch is not isolated from later parent writes.
+		let _ = meta.base_version;
+		let parent_beg = record::prefix(ns, meta.parent, table)?;
+		let parent_end = record::suffix(ns, meta.parent, table)?;
+		let parent_rows = Self::drain_vals(&txn, parent_beg..parent_end, None).await?;
+
+		// Merge: branch entries are all live (no tombstones persisted yet); parent
+		// rows fall through and are rekeyed into the branch keyspace by the cursor.
+		let branch_entries = branch_rows.into_iter().map(|(k, v)| (k, Some(v)));
+		let mut merged: Vec<(Key, Val)> =
+			MergeCursor::new(branch_entries, parent_rows.into_iter(), branch_prefix).collect();
+		// MergeCursor yields ascending logical-key order; reverse for backward scans.
+		if matches!(sc, ScanDirection::Backward) {
+			merged.reverse();
+		}
+
+		let mut count = 0;
+		for (k, v) in merged {
+			if ctx.is_done(Some(count)).await? {
+				break;
+			}
+			self.collect(Collectable::KeyVal(doc_ctx.clone(), k, v)).await?;
+			count += 1;
+		}
+		Ok(())
+	}
+
+	/// Drain a value cursor over `rng` into owned `(Key, Val)` pairs (ascending).
+	async fn drain_vals(
+		txn: &Transaction,
+		rng: Range<Key>,
+		version: Option<u64>,
+	) -> Result<Vec<(Key, Val)>> {
+		let mut cursor = txn.open_vals_cursor(rng, ScanDirection::Forward, 0, version).await?;
+		let mut out = Vec::new();
+		loop {
+			let batch = cursor.next_batch(ScanLimit::Count(NORMAL_BATCH_SIZE)).await?;
+			if batch.is_empty() {
+				break;
+			}
+			out.extend(batch.iter().map(|(k, v)| (k.to_vec(), v.to_vec())));
+		}
+		Ok(out)
 	}
 
 	#[instrument(level = "trace", skip_all)]

--- a/surrealdb/core/src/expr/statements/define/database.rs
+++ b/surrealdb/core/src/expr/statements/define/database.rs
@@ -2,9 +2,10 @@ use anyhow::{Result, bail};
 use reblessive::tree::Stk;
 
 use super::DefineKind;
-use crate::catalog::DatabaseDefinition;
 use crate::catalog::providers::{DatabaseProvider, NamespaceProvider};
+use crate::catalog::{BranchMetadata, DatabaseDefinition};
 use crate::ctx::FrozenContext;
+use crate::dbs::capabilities::ExperimentalTarget;
 use crate::dbs::Options;
 use crate::doc::CursorDoc;
 use crate::err::Error;
@@ -13,7 +14,7 @@ use crate::expr::parameterize::expr_to_ident;
 use crate::expr::statements::info::InfoStructure;
 use crate::expr::{Base, Expr, FlowResultExt, Literal};
 use crate::iam::{Action, ResourceKind};
-use crate::val::Value;
+use crate::val::{Datetime, Value};
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) struct DefineDatabaseStatement {
@@ -23,6 +24,13 @@ pub(crate) struct DefineDatabaseStatement {
 	pub strict: bool,
 	pub comment: Expr,
 	pub changefeed: Option<ChangeFeed>,
+	/// Copy-on-write branch source: `FROM <source_db>`. `None` = ordinary database.
+	/// Gated behind `ExperimentalTarget::DatabaseBranching`.
+	pub from: Option<Expr>,
+	/// Optional `VERSION <datetime>` after `FROM` — the point in the source's
+	/// history to branch from. `None` = branch at the source's current state
+	/// (still pinned to a concrete versionstamp at compute time).
+	pub from_version: Option<Expr>,
 }
 
 impl Default for DefineDatabaseStatement {
@@ -34,6 +42,8 @@ impl Default for DefineDatabaseStatement {
 			comment: Expr::Literal(Literal::None),
 			changefeed: None,
 			strict: false,
+			from: None,
+			from_version: None,
 		}
 	}
 }
@@ -60,6 +70,25 @@ impl DefineDatabaseStatement {
 
 		// Process the name
 		let name = expr_to_ident(stk, ctx, opt, doc, &self.name, "database name").await?;
+
+		// Branch precondition checks (`DEFINE DATABASE … FROM …`).
+		if self.from.is_some() {
+			// Gated behind the experimental capability.
+			if !ctx.get_capabilities().allows_experimental(&ExperimentalTarget::DatabaseBranching) {
+				bail!(Error::Thrown(
+					"Database branching is experimental; enable it with \
+					 --allow-experimental database_branching"
+						.to_string(),
+				));
+			}
+			// Q1: OVERWRITE would silently discard a branch's data — reject the combination.
+			if matches!(self.kind, DefineKind::Overwrite) {
+				bail!(Error::Thrown(
+					"DEFINE DATABASE ... OVERWRITE cannot be combined with FROM (branching)"
+						.to_string(),
+				));
+			}
+		}
 
 		// Check if the definition exists
 		let database_id = if let Some(db) = txn.get_db_by_name(ns, &name, None).await? {
@@ -98,6 +127,49 @@ impl DefineDatabaseStatement {
 			strict: self.strict,
 		};
 		txn.put_db(nsv.name.as_str(), db_def).await?;
+
+		// Copy-on-write branch metadata: resolve the parent + pin the base version.
+		if let Some(from_expr) = &self.from {
+			// Resolve the source database (must already exist in this namespace).
+			let src_name =
+				expr_to_ident(stk, ctx, opt, doc, from_expr, "source database name").await?;
+			let Some(src_db) = txn.get_db_by_name(ns, &src_name, None).await? else {
+				bail!(Error::DbNotFound {
+					name: src_name,
+				});
+			};
+			// v1 is single-level: the source must not itself be a branch.
+			if txn.get_branch_meta(nsv.namespace_id, src_db.database_id).await?.is_some() {
+				bail!(Error::Thrown(format!(
+					"Cannot branch from `{src_name}`: branching from a branch is not supported"
+				)));
+			}
+			// Resolve and pin the base version — always a concrete versionstamp so the
+			// branch is isolated from later parent writes.
+			let base_version = match &self.from_version {
+				// `VERSION <datetime>` selects a point in the source's history (same
+				// spelling/mechanism as `SELECT … VERSION`).
+				Some(vexpr) => {
+					let ts_impl = txn.timestamp_impl();
+					let dt = stk
+						.run(|stk| vexpr.compute(stk, ctx, opt, doc))
+						.await
+						.catch_return()?
+						.cast_to::<Datetime>()?;
+					dt.to_version_stamp(ts_impl.as_ref())?
+				}
+				// Branch-at-now: pin to the current monotonic versionstamp. This is
+				// strictly greater than every already-committed write, so the branch
+				// sees the source's full current state. (A wall-clock `now` datetime
+				// maps to HLC counter 0 and could miss same-millisecond writes.)
+				None => txn.timestamp().await?.as_versionstamp() as u64,
+			};
+			txn.put_branch_meta(nsv.namespace_id, database_id, &BranchMetadata {
+				parent: src_db.database_id,
+				base_version,
+			})
+			.await?;
+		}
 
 		// Clear the cache
 		if let Some(cache) = ctx.get_cache() {

--- a/surrealdb/core/src/key/category.rs
+++ b/surrealdb/core/src/key/category.rs
@@ -66,6 +66,8 @@ pub enum Category {
 	NamespaceRoot,
 	/// crate::key::namespace::db            /*{ns}!db{db}
 	DatabaseAlias,
+	/// crate::key::namespace::bm            /*{ns}!bm{db}
+	DatabaseBranchMetadata,
 	/// crate::key::namespace::access::ac    /*{ns}!ac{ac}
 	NamespaceAccess,
 	/// crate::key::namespace::access::all   /*{ns}*{ac}
@@ -231,6 +233,7 @@ impl Display for Category {
 			Self::NodeLiveQuery => "NodeLiveQuery",
 			Self::NamespaceRoot => "NamespaceRoot",
 			Self::DatabaseAlias => "DatabaseAlias",
+			Self::DatabaseBranchMetadata => "DatabaseBranchMetadata",
 			Self::DatabaseIdentifierBatch => "DatabaseIdentifierBatch",
 			Self::DatabaseIdentifierState => "DatabaseIdentifierState",
 			Self::NamespaceAccess => "NamespaceAccess",

--- a/surrealdb/core/src/key/namespace/bm.rs
+++ b/surrealdb/core/src/key/namespace/bm.rs
@@ -1,0 +1,95 @@
+//! Stores copy-on-write branch metadata, keyed by `(NamespaceId, DatabaseId)`.
+//!
+//! Namespace-scoped (`/*{ns}!bm{db}`) so all branches in a namespace are
+//! contiguous and can be range-scanned in one pass — e.g. to find a parent's
+//! live children before allowing `REMOVE DATABASE`. Kept separate from
+//! `DatabaseDefinition` so ordinary databases keep a byte-identical encoding
+//! (no revision bump). Gated behind `ExperimentalTarget::DatabaseBranching`.
+
+// PoC: the constructor/range helpers are consumed once the DDL, processor overlay,
+// and REMOVE guard wiring land; exercised now by the branch-meta provider test.
+#![allow(dead_code)]
+
+use anyhow::Result;
+use storekey::{BorrowDecode, Encode};
+
+use crate::catalog::{BranchMetadata, DatabaseId, NamespaceId};
+use crate::key::category::{Categorise, Category};
+use crate::kvs::{KVKey, impl_kv_key_storekey};
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Encode, BorrowDecode)]
+pub(crate) struct BranchMetadataKey {
+	__: u8,
+	_a: u8,
+	pub ns: NamespaceId,
+	_b: u8,
+	_c: u8,
+	_d: u8,
+	pub db: DatabaseId,
+}
+
+impl_kv_key_storekey!(BranchMetadataKey => BranchMetadata);
+
+pub fn new(ns: NamespaceId, db: DatabaseId) -> BranchMetadataKey {
+	BranchMetadataKey::new(ns, db)
+}
+
+/// Inclusive-start byte bound covering every branch-metadata key in `ns`.
+pub fn prefix(ns: NamespaceId) -> Result<Vec<u8>> {
+	let mut k = super::all::new(ns).encode_key()?;
+	k.extend_from_slice(b"!bm");
+	Ok(k)
+}
+
+/// Exclusive-end byte bound: `!bn` is the marker immediately after `!bm`, so
+/// `[prefix, suffix)` spans all `/*{ns}!bm{db}` keys regardless of db id.
+pub fn suffix(ns: NamespaceId) -> Result<Vec<u8>> {
+	let mut k = super::all::new(ns).encode_key()?;
+	k.extend_from_slice(b"!bn");
+	Ok(k)
+}
+
+impl Categorise for BranchMetadataKey {
+	fn categorise(&self) -> Category {
+		Category::DatabaseBranchMetadata
+	}
+}
+
+impl BranchMetadataKey {
+	pub fn new(ns: NamespaceId, db: DatabaseId) -> Self {
+		Self {
+			__: b'/',
+			_a: b'*',
+			ns,
+			_b: b'!',
+			_c: b'b',
+			_d: b'm',
+			db,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn key() {
+		let val = BranchMetadataKey::new(NamespaceId(1), DatabaseId(2));
+		let enc = BranchMetadataKey::encode_key(&val).unwrap();
+		assert_eq!(enc, b"/*\x00\x00\x00\x01!bm\x00\x00\x00\x02");
+	}
+
+	#[test]
+	fn prefix_suffix_span_db_ids() {
+		let p = prefix(NamespaceId(1)).unwrap();
+		let s = suffix(NamespaceId(1)).unwrap();
+		assert_eq!(p, b"/*\x00\x00\x00\x01!bm");
+		assert_eq!(s, b"/*\x00\x00\x00\x01!bn");
+		// Concrete keys (incl. db id 0 and a large id) sort within [prefix, suffix).
+		for id in [0u32, 2, u32::MAX] {
+			let k = BranchMetadataKey::new(NamespaceId(1), DatabaseId(id)).encode_key().unwrap();
+			assert!(p[..] <= k[..] && k[..] < s[..], "db id {id} out of [prefix, suffix)");
+		}
+	}
+}

--- a/surrealdb/core/src/key/namespace/mod.rs
+++ b/surrealdb/core/src/key/namespace/mod.rs
@@ -1,6 +1,7 @@
 pub mod ac;
 pub mod access;
 pub mod all;
+pub mod bm;
 pub mod db;
 pub mod dh;
 pub mod di;

--- a/surrealdb/core/src/kvs/branch.rs
+++ b/surrealdb/core/src/kvs/branch.rs
@@ -1,0 +1,313 @@
+//! Copy-on-write database branching — the merge cursor.
+//!
+//! A branch is a first-class database (its own [`DatabaseId`]) whose keyspace is
+//! logically layered on top of a *parent* database read at a pinned version. The
+//! branch range holds only the rows that have diverged: overwrites, inserts, and
+//! tombstones (deletes of rows that still exist in the parent). Everything else
+//! falls through to `parent@base_version`.
+//!
+//! [`MergeCursor`] performs that overlay as a streaming 2-way merge of two already
+//! sorted sources — the branch cursor (current) and the parent cursor (pinned) —
+//! yielding rows in the *branch* keyspace with **branch-wins** semantics and
+//! **tombstones hiding** the underlying parent row.
+//!
+//! This module is the hard part of the feature proven in isolation; wiring it into
+//! the scan path in `dbs/processor.rs` and persisting tombstones is layered on top.
+//! Gated behind `ExperimentalTarget::DatabaseBranching`.
+
+// PoC: the merge cursor is exercised by its unit tests but not yet wired into the
+// scan path in `dbs/processor.rs`; remove once `collect_range` consumes it.
+#![allow(dead_code)]
+
+use std::iter::Peekable;
+
+use super::{Key, Val};
+
+/// Number of leading bytes of a record key that address the namespace + database:
+/// `/` `*` ns(4) `*` db(4) — i.e. everything up to (but not including) the `*`
+/// separator that precedes the table name. Two records in the same namespace that
+/// refer to the same logical row differ *only* within this prefix (the db field),
+/// so comparing the bytes after it (`key[NSDB_PREFIX_LEN..]`) compares logical rows.
+pub(crate) const NSDB_PREFIX_LEN: usize = 11;
+
+/// The "logical key" of a record key: the portion that is identical between a branch
+/// row and the parent row it shadows. Used as the merge ordering key.
+#[inline]
+fn logical(key: &[u8]) -> &[u8] {
+	// A well-formed record key always carries the ns+db prefix. Be defensive: a key
+	// shorter than the prefix sorts by its whole self (can't collide with real rows).
+	key.get(NSDB_PREFIX_LEN..).unwrap_or(key)
+}
+
+/// Rewrite a parent-keyspace key into the branch keyspace by splicing the branch's
+/// ns+db prefix in front of the parent row's logical portion. The result is a key
+/// downstream decodes as a branch record.
+#[inline]
+fn rekey_into_branch(branch_prefix: &[u8], parent_key: &[u8]) -> Key {
+	debug_assert_eq!(branch_prefix.len(), NSDB_PREFIX_LEN);
+	let mut k =
+		Vec::with_capacity(NSDB_PREFIX_LEN + parent_key.len().saturating_sub(NSDB_PREFIX_LEN));
+	k.extend_from_slice(branch_prefix);
+	k.extend_from_slice(logical(parent_key));
+	k
+}
+
+/// A branch-side entry: a live value, or a tombstone marking a row deleted in the
+/// branch that still exists in the parent. Tombstones suppress the parent row and
+/// are themselves never yielded.
+pub(crate) type BranchEntry = (Key, Option<Val>);
+
+/// Streaming copy-on-write overlay of a branch range over a parent range.
+///
+/// Both inputs MUST be sorted ascending by their *logical* key (which, for a single
+/// table range, is the same as sorting by the raw key — the ns+db prefix is constant
+/// within each source). The cursor yields `(Key, Val)` in the branch keyspace.
+pub(crate) struct MergeCursor<B, P>
+where
+	B: Iterator<Item = BranchEntry>,
+	P: Iterator<Item = (Key, Val)>,
+{
+	branch: Peekable<B>,
+	parent: Peekable<P>,
+	/// The branch's ns+db prefix, spliced onto parent rows so they surface as branch keys.
+	branch_prefix: Key,
+}
+
+/// What to do on a single step, decided from peeked heads before mutating either side
+/// (keeps the borrow checker happy: peeks are dropped before the `next()` calls).
+enum Step {
+	TakeBranch,
+	TakeParent,
+	TakeBoth,
+	Done,
+}
+
+impl<B, P> MergeCursor<B, P>
+where
+	B: Iterator<Item = BranchEntry>,
+	P: Iterator<Item = (Key, Val)>,
+{
+	pub(crate) fn new(branch: B, parent: P, branch_prefix: Key) -> Self {
+		debug_assert_eq!(
+			branch_prefix.len(),
+			NSDB_PREFIX_LEN,
+			"branch_prefix must be the {NSDB_PREFIX_LEN}-byte ns+db addressing prefix"
+		);
+		Self {
+			branch: branch.peekable(),
+			parent: parent.peekable(),
+			branch_prefix,
+		}
+	}
+
+	fn decide(&mut self) -> Step {
+		match (self.branch.peek(), self.parent.peek()) {
+			(None, None) => Step::Done,
+			(Some(_), None) => Step::TakeBranch,
+			(None, Some(_)) => Step::TakeParent,
+			(Some((bk, _)), Some((pk, _))) => match logical(bk).cmp(logical(pk)) {
+				std::cmp::Ordering::Less => Step::TakeBranch,
+				std::cmp::Ordering::Greater => Step::TakeParent,
+				// Same logical row present in both ranges — branch wins, consume both.
+				std::cmp::Ordering::Equal => Step::TakeBoth,
+			},
+		}
+	}
+}
+
+impl<B, P> Iterator for MergeCursor<B, P>
+where
+	B: Iterator<Item = BranchEntry>,
+	P: Iterator<Item = (Key, Val)>,
+{
+	type Item = (Key, Val);
+
+	fn next(&mut self) -> Option<Self::Item> {
+		loop {
+			match self.decide() {
+				Step::Done => return None,
+				Step::TakeBranch => {
+					let (bk, bv) = self.branch.next().expect("peeked branch head");
+					match bv {
+						Some(v) => return Some((bk, v)),
+						// Tombstone with no parent row to hide — nothing to emit, keep going.
+						None => continue,
+					}
+				}
+				Step::TakeParent => {
+					let (pk, pv) = self.parent.next().expect("peeked parent head");
+					return Some((rekey_into_branch(&self.branch_prefix, &pk), pv));
+				}
+				Step::TakeBoth => {
+					let (bk, bv) = self.branch.next().expect("peeked branch head");
+					let _shadowed = self.parent.next().expect("peeked parent head");
+					match bv {
+						// Branch overwrite wins over the parent row.
+						Some(v) => return Some((bk, v)),
+						// Tombstone hides the parent row: emit neither, advance.
+						None => continue,
+					}
+				}
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const NS: [u8; 4] = [0, 0, 0, 1];
+
+	/// Build a record key `/`*`ns`*`db`*tb\0<id>` for the given database id.
+	/// The first [`NSDB_PREFIX_LEN`] bytes are the ns+db addressing prefix.
+	fn rkey(db: u32, id: &[u8]) -> Key {
+		let mut k = Vec::new();
+		k.push(b'/');
+		k.push(b'*');
+		k.extend_from_slice(&NS);
+		k.push(b'*');
+		k.extend_from_slice(&db.to_be_bytes());
+		// logical portion begins here (index 11)
+		k.extend_from_slice(b"*tb\0");
+		k.extend_from_slice(id);
+		k
+	}
+
+	const PARENT_DB: u32 = 1;
+	const BRANCH_DB: u32 = 2;
+
+	fn branch_prefix() -> Key {
+		rkey(BRANCH_DB, b"")[..NSDB_PREFIX_LEN].to_vec()
+	}
+
+	/// Run the merge and return (key, value) pairs with values as UTF-8 for readability.
+	fn run(branch: Vec<BranchEntry>, parent: Vec<(Key, Val)>) -> Vec<(Key, String)> {
+		MergeCursor::new(branch.into_iter(), parent.into_iter(), branch_prefix())
+			.map(|(k, v)| (k, String::from_utf8(v).unwrap()))
+			.collect()
+	}
+
+	fn bval(db: u32, id: &[u8], v: &str) -> BranchEntry {
+		(rkey(db, id), Some(v.as_bytes().to_vec()))
+	}
+	fn tomb(db: u32, id: &[u8]) -> BranchEntry {
+		(rkey(db, id), None)
+	}
+	fn pval(db: u32, id: &[u8], v: &str) -> (Key, Val) {
+		(rkey(db, id), v.as_bytes().to_vec())
+	}
+
+	#[test]
+	fn parent_only_falls_through() {
+		let out = run(vec![], vec![pval(PARENT_DB, b"a", "pa"), pval(PARENT_DB, b"b", "pb")]);
+		// Both parent rows surface, rewritten into the branch keyspace.
+		assert_eq!(
+			out,
+			vec![(rkey(BRANCH_DB, b"a"), "pa".into()), (rkey(BRANCH_DB, b"b"), "pb".into())]
+		);
+	}
+
+	#[test]
+	fn branch_overwrite_wins() {
+		let out = run(
+			vec![bval(BRANCH_DB, b"b", "branch-b")],
+			vec![pval(PARENT_DB, b"a", "pa"), pval(PARENT_DB, b"b", "pb")],
+		);
+		assert_eq!(
+			out,
+			vec![
+				(rkey(BRANCH_DB, b"a"), "pa".into()), // fell through from parent
+				(rkey(BRANCH_DB, b"b"), "branch-b".into()), // branch shadowed parent's "pb"
+			]
+		);
+	}
+
+	#[test]
+	fn branch_insert_interleaves_in_order() {
+		// Branch adds "a0" (before "a") and "c" (after "b"); parent has "a","b".
+		let out = run(
+			vec![bval(BRANCH_DB, b"a0", "new-a0"), bval(BRANCH_DB, b"c", "new-c")],
+			vec![pval(PARENT_DB, b"a", "pa"), pval(PARENT_DB, b"b", "pb")],
+		);
+		assert_eq!(
+			out,
+			vec![
+				(rkey(BRANCH_DB, b"a"), "pa".into()),
+				(rkey(BRANCH_DB, b"a0"), "new-a0".into()),
+				(rkey(BRANCH_DB, b"b"), "pb".into()),
+				(rkey(BRANCH_DB, b"c"), "new-c".into()),
+			]
+		);
+	}
+
+	#[test]
+	fn tombstone_hides_parent_row() {
+		let out = run(
+			vec![tomb(BRANCH_DB, b"b")],
+			vec![
+				pval(PARENT_DB, b"a", "pa"),
+				pval(PARENT_DB, b"b", "pb"),
+				pval(PARENT_DB, b"c", "pc"),
+			],
+		);
+		// "b" is deleted in the branch — only a and c remain.
+		assert_eq!(
+			out,
+			vec![(rkey(BRANCH_DB, b"a"), "pa".into()), (rkey(BRANCH_DB, b"c"), "pc".into())]
+		);
+	}
+
+	#[test]
+	fn tombstone_without_parent_is_noop() {
+		// Deleting a row that never existed in the parent yields nothing for that key.
+		let out = run(vec![tomb(BRANCH_DB, b"ghost")], vec![pval(PARENT_DB, b"a", "pa")]);
+		assert_eq!(out, vec![(rkey(BRANCH_DB, b"a"), "pa".into())]);
+	}
+
+	#[test]
+	fn both_empty() {
+		assert!(run(vec![], vec![]).is_empty());
+	}
+
+	#[test]
+	fn branch_only_when_parent_empty() {
+		let out = run(vec![bval(BRANCH_DB, b"x", "bx"), tomb(BRANCH_DB, b"y")], vec![]);
+		// Live branch row surfaces; tombstone over nothing is dropped.
+		assert_eq!(out, vec![(rkey(BRANCH_DB, b"x"), "bx".into())]);
+	}
+
+	#[test]
+	fn mixed_overwrite_insert_delete_fallthrough() {
+		// Parent: a,b,c,d.  Branch: overwrite b, delete c, insert b5 (between b and c).
+		let out = run(
+			vec![bval(BRANCH_DB, b"b", "B!"), bval(BRANCH_DB, b"b5", "B5"), tomb(BRANCH_DB, b"c")],
+			vec![
+				pval(PARENT_DB, b"a", "pa"),
+				pval(PARENT_DB, b"b", "pb"),
+				pval(PARENT_DB, b"c", "pc"),
+				pval(PARENT_DB, b"d", "pd"),
+			],
+		);
+		assert_eq!(
+			out,
+			vec![
+				(rkey(BRANCH_DB, b"a"), "pa".into()),  // fall-through
+				(rkey(BRANCH_DB, b"b"), "B!".into()),  // overwrite wins
+				(rkey(BRANCH_DB, b"b5"), "B5".into()), // branch insert, correctly ordered
+				// c deleted by tombstone — absent
+				(rkey(BRANCH_DB, b"d"), "pd".into()), // fall-through
+			]
+		);
+	}
+
+	#[test]
+	fn emitted_keys_are_in_branch_keyspace() {
+		// Every emitted key must carry the branch db id, never the parent's.
+		let out = run(vec![bval(BRANCH_DB, b"b", "bb")], vec![pval(PARENT_DB, b"a", "pa")]);
+		for (k, _) in &out {
+			assert_eq!(&k[..NSDB_PREFIX_LEN], branch_prefix().as_slice());
+			assert_ne!(&k[7..11], &PARENT_DB.to_be_bytes(), "parent db id leaked into output");
+		}
+	}
+}

--- a/surrealdb/core/src/kvs/mod.rs
+++ b/surrealdb/core/src/kvs/mod.rs
@@ -19,6 +19,7 @@ pub mod export;
 
 mod api;
 mod batch;
+mod branch;
 mod clock;
 mod consts;
 mod direction;
@@ -48,6 +49,7 @@ pub(crate) mod slowlog;
 pub(crate) mod tasklease;
 pub(crate) mod version;
 
+pub(crate) use branch::{MergeCursor, NSDB_PREFIX_LEN};
 pub use api::{
 	GetMultiResult, KeysResult, ScanCursorKeys, ScanCursorVals, ScanLimit, ScanResult, Transactable,
 };

--- a/surrealdb/core/src/kvs/tests/branch_e2e_test.rs
+++ b/surrealdb/core/src/kvs/tests/branch_e2e_test.rs
@@ -1,0 +1,101 @@
+//! End-to-end test of copy-on-write database branching on the versioned SurrealKV
+//! backend, driven through SurrealQL exactly as a user would:
+//!
+//!   * `DEFINE DATABASE experiment FROM main` creates a branch,
+//!   * the branch transparently sees the parent's rows (fall-through),
+//!   * branch-local writes diverge, and
+//!   * the parent stays isolated from the branch's writes.
+//!
+//! Requires a versioned datastore (the overlay reads `parent@base_version`), so the
+//! SurrealKV path is opened with `?versioned=true`, and the `DatabaseBranching`
+//! experimental capability is enabled.
+
+use surrealdb_types::Value;
+
+use crate::dbs::capabilities::Targets;
+use crate::dbs::{Capabilities, QueryResult, Session};
+use crate::kvs::Datastore;
+
+/// Number of rows in a `SELECT` query result.
+fn rows(qr: QueryResult) -> usize {
+	match qr.result.expect("query should succeed") {
+		Value::Array(a) => a.len(),
+		Value::None => 0,
+		other => panic!("expected an array result, got {other:?}"),
+	}
+}
+
+#[tokio::test]
+async fn database_branching_end_to_end_surrealkv() {
+	// A versioned SurrealKV datastore (versioning is required for `parent@base_version`).
+	let dir = std::env::temp_dir().join(format!("sdb-branch-e2e-{}", std::process::id()));
+	let _ = std::fs::remove_dir_all(&dir);
+	let path = format!("surrealkv://{}?versioned=true", dir.display());
+
+	let ds = Datastore::builder()
+		.with_capabilities(Capabilities::all().with_experimental(Targets::All))
+		.build_with_path(&path)
+		.await
+		.unwrap();
+
+	// Seed the parent database and COMMIT it first, so the branch's base_version
+	// (pinned at DEFINE time) sits after the seed data's commit.
+	// PoC: the copy-on-write read overlay is wired into the compute executor, so the
+	// session selects it (the new streaming planner is not yet branch-aware — follow-up).
+	let main = Session::owner()
+		.with_ns("demo")
+		.with_db("main")
+		.new_planner_strategy(crate::dbs::NewPlannerStrategy::ComputeOnly);
+	let res = ds
+		.execute(
+			"DEFINE NAMESPACE demo;
+			 DEFINE DATABASE main;
+			 CREATE product:laptop SET name = 'Laptop', price = 1000;
+			 CREATE product:phone  SET name = 'Phone',  price = 500;
+			 CREATE product:tablet SET name = 'Tablet', price = 300;",
+			&main,
+			None,
+		)
+		.await
+		.unwrap();
+	for qr in res {
+		assert!(qr.result.is_ok(), "seed statement failed: {:?}", qr.result);
+	}
+
+	// Sanity: the parent's own SELECT works (isolates table-resolution from branching).
+	let mut res = ds.execute("SELECT * FROM product;", &main, None).await.unwrap();
+	assert_eq!(rows(res.remove(0)), 3, "parent SELECT should return 3 rows");
+
+	// Now branch `main` (separate transaction → base_version is after the seed commit).
+	let res = ds.execute("DEFINE DATABASE experiment FROM main;", &main, None).await.unwrap();
+	for qr in res {
+		assert!(qr.result.is_ok(), "branch statement failed: {:?}", qr.result);
+	}
+
+	// The branch transparently inherits the parent's three rows (copy-on-write).
+	let branch = Session::owner()
+		.with_ns("demo")
+		.with_db("experiment")
+		.new_planner_strategy(crate::dbs::NewPlannerStrategy::ComputeOnly);
+	let mut res = ds.execute("SELECT * FROM product;", &branch, None).await.unwrap();
+	assert_eq!(rows(res.remove(0)), 3, "branch should inherit the parent's 3 rows");
+
+	// Diverge the branch with a branch-only record; the branch now shows four.
+	let mut res = ds
+		.execute(
+			"CREATE product:keyboard SET name = 'Keyboard', price = 80;
+			 SELECT * FROM product;",
+			&branch,
+			None,
+		)
+		.await
+		.unwrap();
+	let select = res.remove(1);
+	assert_eq!(rows(select), 4, "branch should show its 3 inherited + 1 local row");
+
+	// The parent is untouched by the branch's writes (keyspace isolation).
+	let mut res = ds.execute("SELECT * FROM product;", &main, None).await.unwrap();
+	assert_eq!(rows(res.remove(0)), 3, "parent must stay isolated from branch writes");
+
+	let _ = std::fs::remove_dir_all(&dir);
+}

--- a/surrealdb/core/src/kvs/tests/branch_meta_test.rs
+++ b/surrealdb/core/src/kvs/tests/branch_meta_test.rs
@@ -1,0 +1,89 @@
+//! Tests for the copy-on-write branch-metadata catalog key + provider methods.
+//!
+//! Exercises the separate additive `key::namespace::bm` keyspace:
+//! put/get/del round-trip plus the per-namespace children scan that backs the
+//! `REMOVE DATABASE` guard.
+
+use crate::catalog::{BranchMetadata, DatabaseId, NamespaceId};
+use crate::dbs::Capabilities;
+use crate::kvs::Datastore;
+use crate::kvs::LockType::Optimistic;
+use crate::kvs::TransactionType::Write;
+
+#[tokio::test]
+async fn branch_meta_roundtrip_and_children_scan() {
+	let ds = Datastore::builder()
+		.with_capabilities(Capabilities::all())
+		.build_with_path("memory")
+		.await
+		.unwrap();
+	let tx = ds.transaction(Write, Optimistic).await.unwrap();
+
+	let ns = NamespaceId(1);
+	let parent = DatabaseId(1);
+	let other_parent = DatabaseId(9);
+
+	let child_a = DatabaseId(2);
+	let child_b = DatabaseId(3);
+	let unrelated = DatabaseId(4);
+
+	// Two branches of `parent`, one branch of a different parent.
+	tx.put_branch_meta(
+		ns,
+		child_a,
+		&BranchMetadata {
+			parent,
+			base_version: 100,
+		},
+	)
+	.await
+	.unwrap();
+	tx.put_branch_meta(
+		ns,
+		child_b,
+		&BranchMetadata {
+			parent,
+			base_version: 200,
+		},
+	)
+	.await
+	.unwrap();
+	tx.put_branch_meta(
+		ns,
+		unrelated,
+		&BranchMetadata {
+			parent: other_parent,
+			base_version: 5,
+		},
+	)
+	.await
+	.unwrap();
+
+	// Exact fetch returns the pinned metadata.
+	let meta = tx.get_branch_meta(ns, child_a).await.unwrap().expect("branch meta should exist");
+	assert_eq!(
+		meta,
+		BranchMetadata {
+			parent,
+			base_version: 100,
+		}
+	);
+
+	// An ordinary (non-branch) database has no metadata.
+	assert!(tx.get_branch_meta(ns, DatabaseId(42)).await.unwrap().is_none());
+
+	// Children scan returns exactly the two branches of `parent` (order-independent).
+	let mut children = tx.branch_children(ns, parent).await.unwrap();
+	children.sort_by_key(|d| d.0);
+	assert_eq!(children, vec![child_a, child_b]);
+
+	// The unrelated branch is found only under its own parent.
+	assert_eq!(tx.branch_children(ns, other_parent).await.unwrap(), vec![unrelated]);
+
+	// Deletion removes it from both exact-get and the children scan.
+	tx.del_branch_meta(ns, child_a).await.unwrap();
+	assert!(tx.get_branch_meta(ns, child_a).await.unwrap().is_none());
+	assert_eq!(tx.branch_children(ns, parent).await.unwrap(), vec![child_b]);
+
+	tx.cancel().await.unwrap();
+}

--- a/surrealdb/core/src/kvs/tests/mod.rs
+++ b/surrealdb/core/src/kvs/tests/mod.rs
@@ -30,6 +30,10 @@ mod multiwriter_same_keys_conflict;
 mod raw;
 mod snapshot;
 #[cfg(feature = "kv-mem")]
+mod branch_meta_test;
+#[cfg(feature = "kv-surrealkv")]
+mod branch_e2e_test;
+#[cfg(feature = "kv-mem")]
 mod tx_cache_test;
 
 #[derive(Clone, Debug)]

--- a/surrealdb/core/src/kvs/tx.rs
+++ b/surrealdb/core/src/kvs/tx.rs
@@ -34,8 +34,8 @@ use crate::catalog::providers::{
 	DatabaseProvider, NamespaceProvider, NodeProvider, RootProvider, TableProvider, UserProvider,
 };
 use crate::catalog::{
-	self, ApiDefinition, ConfigDefinition, DatabaseDefinition, DatabaseId, DefaultConfig, IndexId,
-	NamespaceDefinition, NamespaceId, Record, TableDefinition, TableId,
+	self, ApiDefinition, BranchMetadata, ConfigDefinition, DatabaseDefinition, DatabaseId,
+	DefaultConfig, IndexId, NamespaceDefinition, NamespaceId, Record, TableDefinition, TableId,
 };
 use crate::cf::Changefeed;
 use crate::cnf::CommonConfig;
@@ -1137,6 +1137,74 @@ impl Transaction {
 			.into_iter()
 			.map(|(k, v)| Ok((k, K::ValueType::kv_decode_value(&v, ())?)))
 			.collect()
+	}
+
+	/// Fetch the copy-on-write branch metadata for a database, if it is a branch.
+	///
+	/// Returns `None` for ordinary (non-branch) databases — their absence from the
+	/// branch-metadata keyspace is what distinguishes them. Gated behind
+	/// `ExperimentalTarget::DatabaseBranching` at the call sites.
+	// PoC: consumed once the DEFINE … FROM / processor overlay wiring lands.
+	#[allow(dead_code)]
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
+	pub(crate) async fn get_branch_meta(
+		&self,
+		ns: NamespaceId,
+		db: DatabaseId,
+	) -> Result<Option<BranchMetadata>> {
+		let key = crate::key::namespace::bm::new(ns, db);
+		self.get(&key, None).await
+	}
+
+	/// Record branch metadata for a database, marking it as a copy-on-write branch.
+	#[allow(dead_code)]
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
+	pub(crate) async fn put_branch_meta(
+		&self,
+		ns: NamespaceId,
+		db: DatabaseId,
+		meta: &BranchMetadata,
+	) -> Result<()> {
+		let key = crate::key::namespace::bm::new(ns, db);
+		self.set(&key, meta).await
+	}
+
+	/// Remove branch metadata (e.g. when the branch database is dropped).
+	#[allow(dead_code)]
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
+	pub(crate) async fn del_branch_meta(&self, ns: NamespaceId, db: DatabaseId) -> Result<()> {
+		let key = crate::key::namespace::bm::new(ns, db);
+		self.del(&key).await
+	}
+
+	/// Return the database ids of all branches in `ns` whose parent is `parent`.
+	///
+	/// Backs the `REMOVE DATABASE` guard: a parent with live children cannot be
+	/// dropped (children fall through to `parent@base_version`). Single range scan
+	/// over the namespace's branch-metadata keyspace.
+	#[allow(dead_code)]
+	#[instrument(level = "trace", target = "surrealdb::core::kvs::tx", skip_all)]
+	pub(crate) async fn branch_children(
+		&self,
+		ns: NamespaceId,
+		parent: DatabaseId,
+	) -> Result<Vec<DatabaseId>> {
+		let beg = crate::key::namespace::bm::prefix(ns)?;
+		let end = crate::key::namespace::bm::suffix(ns)?;
+		let res = self.tr.getr(beg..end, None).await.map_err(Error::from)?;
+		let mut children = Vec::new();
+		for (k, v) in res.values {
+			let meta = BranchMetadata::kv_decode_value(&v, ())?;
+			if meta.parent == parent {
+				// The branch's own db id is the trailing 4 bytes (big-endian u32).
+				if let Some(tail) = k.get(k.len().wrapping_sub(4)..) {
+					if let Ok(bytes) = <[u8; 4]>::try_from(tail) {
+						children.push(DatabaseId(u32::from_be_bytes(bytes)));
+					}
+				}
+			}
+		}
+		Ok(children)
 	}
 
 	/// Delete a key from the datastore.

--- a/surrealdb/core/src/sql/statements/define/database.rs
+++ b/surrealdb/core/src/sql/statements/define/database.rs
@@ -14,6 +14,10 @@ pub(crate) struct DefineDatabaseStatement {
 	pub strict: bool,
 	pub comment: Expr,
 	pub changefeed: Option<ChangeFeed>,
+	/// `FROM <source_db>` — branch this database from an existing one (CoW).
+	pub from: Option<Expr>,
+	/// `VERSION <datetime>` after `FROM` — branch from a point in the source's history.
+	pub from_version: Option<Expr>,
 }
 
 impl Default for DefineDatabaseStatement {
@@ -25,6 +29,8 @@ impl Default for DefineDatabaseStatement {
 			comment: Expr::Literal(Literal::None),
 			changefeed: None,
 			strict: false,
+			from: None,
+			from_version: None,
 		}
 	}
 }
@@ -38,6 +44,12 @@ impl ToSql for DefineDatabaseStatement {
 			DefineKind::IfNotExists => write_sql!(f, sql_fmt, " IF NOT EXISTS"),
 		}
 		write_sql!(f, sql_fmt, " {}", CoverStmts(&self.name));
+		if let Some(ref src) = self.from {
+			write_sql!(f, sql_fmt, " FROM {}", CoverStmts(src));
+			if let Some(ref v) = self.from_version {
+				write_sql!(f, sql_fmt, " VERSION {}", CoverStmts(v));
+			}
+		}
 		if self.strict {
 			f.push_str(" STRICT");
 		}
@@ -59,6 +71,8 @@ impl From<DefineDatabaseStatement> for crate::expr::statements::DefineDatabaseSt
 			comment: v.comment.into(),
 			changefeed: v.changefeed.map(Into::into),
 			strict: v.strict,
+			from: v.from.map(Into::into),
+			from_version: v.from_version.map(Into::into),
 		}
 	}
 }
@@ -73,6 +87,8 @@ impl From<crate::expr::statements::DefineDatabaseStatement> for DefineDatabaseSt
 			strict: v.strict,
 			comment: v.comment.into(),
 			changefeed: v.changefeed.map(Into::into),
+			from: v.from.map(Into::into),
+			from_version: v.from_version.map(Into::into),
 		}
 	}
 }

--- a/surrealdb/core/src/syn/parser/stmt/define.rs
+++ b/surrealdb/core/src/syn/parser/stmt/define.rs
@@ -126,6 +126,13 @@ impl Parser<'_> {
 			kind,
 			..Default::default()
 		};
+		// `FROM <source_db> [VERSION <datetime>]` — copy-on-write branch source.
+		if self.eat(t!("FROM")) {
+			res.from = Some(stk.run(|ctx| self.parse_expr_field(ctx)).await?);
+			if self.eat(t!("VERSION")) {
+				res.from_version = Some(stk.run(|ctx| self.parse_expr_field(ctx)).await?);
+			}
+		}
 		loop {
 			match self.peek_kind() {
 				t!("COMMENT") => {

--- a/surrealdb/core/src/syn/parser/test/stmt.rs
+++ b/surrealdb/core/src/syn/parser/test/stmt.rs
@@ -207,6 +207,8 @@ fn parse_define_database() {
 				expiry: PublicDuration::from_secs(60 * 10),
 				store_diff: true,
 			}),
+			from: None,
+			from_version: None,
 		})))
 	);
 
@@ -223,8 +225,42 @@ fn parse_define_database() {
 			strict: false,
 			comment: Expr::Literal(Literal::None),
 			changefeed: None,
+			from: None,
+			from_version: None,
 		})))
 	)
+}
+
+#[test]
+fn parse_define_database_branch() {
+	// `FROM <src>` — branch at the source's current state.
+	let res = syn::parse_with("DEFINE DATABASE b FROM a".as_bytes(), async |parser, stk| {
+		parser.parse_expr_inherit(stk).await
+	})
+	.unwrap();
+	let Expr::Define(def) = res else {
+		panic!("expected DEFINE, got {res:?}");
+	};
+	let DefineStatement::Database(db) = *def else {
+		panic!("expected DEFINE DATABASE");
+	};
+	assert_eq!(db.from, Some(Expr::Idiom(Idiom::field("a".to_string()))));
+	assert_eq!(db.from_version, None);
+
+	// `FROM <src> VERSION <datetime>` — branch from a point in the source's history.
+	let res = syn::parse_with(
+		"DEFINE DATABASE b FROM a VERSION d\"2024-01-01T00:00:00Z\"".as_bytes(),
+		async |parser, stk| parser.parse_expr_inherit(stk).await,
+	)
+	.unwrap();
+	let Expr::Define(def) = res else {
+		panic!("expected DEFINE, got {res:?}");
+	};
+	let DefineStatement::Database(db) = *def else {
+		panic!("expected DEFINE DATABASE");
+	};
+	assert_eq!(db.from, Some(Expr::Idiom(Idiom::field("a".to_string()))));
+	assert!(db.from_version.is_some(), "VERSION clause should be parsed");
 }
 
 #[test]

--- a/surrealdb/core/src/syn/parser/test/streaming.rs
+++ b/surrealdb/core/src/syn/parser/test/streaming.rs
@@ -183,6 +183,8 @@ fn statements() -> Vec<TopLevelExpr> {
 					expiry: PublicDuration::from_secs(60 * 10),
 					store_diff: false,
 				}),
+				from: None,
+				from_version: None,
 			},
 		)))),
 		TopLevelExpr::Expr(Expr::Define(Box::new(DefineStatement::Database(
@@ -193,6 +195,8 @@ fn statements() -> Vec<TopLevelExpr> {
 				strict: false,
 				comment: Expr::Literal(Literal::None),
 				changefeed: None,
+				from: None,
+				from_version: None,
 			},
 		)))),
 		TopLevelExpr::Expr(Expr::Define(Box::new(DefineStatement::Function(


### PR DESCRIPTION
## Database branching (copy-on-write) — draft PoC

This is a **draft proof-of-concept** for git-style database branching: create a
cheap, isolated branch of an existing database that transparently sees the
parent's data and can diverge independently — no physical copy.

Discussion / design rationale: https://github.com/orgs/surrealdb/discussions/7390

It is intentionally scoped to prove the core mechanism and gather appetite — not
a complete implementation. Everything is gated behind a new experimental
capability and is invisible/no-op unless explicitly enabled.

### Surface

```surql
DEFINE DATABASE @branch FROM @source_db [ VERSION @datetime ];
```

A branch is a first-class database (its own `DatabaseId`, a sibling in the same
namespace) with catalog metadata recording its parent and a pinned base version.

### What works (proven end-to-end on a live SurrealKV server)

- `DEFINE DATABASE … FROM …` creates a branch (gated by the experimental capability;
  rejects `OVERWRITE` + `FROM`; rejects branching from a branch; resolves the source).
- `SELECT * FROM @table` on the branch transparently returns the **parent's rows**
  via a copy-on-write overlay (a streaming branch-over-parent merge cursor, branch
  wins on key collision), with nothing physically copied.
- Branch-local writes (and branch-local new tables) diverge independently and are
  **isolated** from the parent (separate keyspace, keyed by `DatabaseId`).
- The parent is untouched by the branch's writes.

Demo (`branching-demo.surql`): seed `main` with 3 rows → branch it → the branch's
`SELECT` shows all 3 → add a branch-local row (now 4) → the parent still shows 3.

### Design choices worth calling out

- **Branch metadata lives in a separate additive catalog key** (`key::namespace::bm`),
  not as fields on `DatabaseDefinition`. Ordinary databases keep a byte-identical
  on-disk encoding — no revision bump, no `catalog::compat` fixture churn.
- **The unit of branching is the database**, reusing the existing
  `DEFINE`/`USE`/`REMOVE DATABASE` dispatch — the only genuinely new statement the
  full design adds is `MERGE DATABASE`.

### Tests

- `kvs::branch` — merge-cursor unit tests (fall-through, overwrite-wins, insert
  ordering, tombstone hides parent, no parent-db-id leakage, …).
- `kvs::tests::branch_meta_test` — branch-metadata key round-trip + children scan.
- `kvs::tests::branch_e2e_test` — full flow through `Datastore::execute` on SurrealKV.

### Open design questions / not yet covered (deliberate, draft scope)

These are the substance of the linked discussion:

1. **Execution engine parity.** The read overlay is wired into the compute
   executor; the new streaming planner is not yet branch-aware. The PoC therefore
   runs under `--planner-strategy compute-only`. Streaming-engine parity is required
   before this is release-bound.
2. **Catalog/schema fall-through is partial.** Single-table resolution falls through
   to the parent, but the listing paths do not — e.g. `INFO FOR DB` on a branch does
   **not** yet list inherited tables. Removing an inherited table/field needs catalog
   tombstones (today `REMOVE TABLE` on an inherited table does not hide it); and
   `DEFINE FIELD` on an inherited table currently creates a divergent partial def
   rather than merging with the parent's schema.
3. **`base_version`-pinned reads.** The base version is captured and stored, but the
   overlay currently reads the parent's *current* state, so a branch is not yet
   isolated from *future* parent writes. (The pinned HLC versionstamp did not line up
   with the backend's MVCC `get_at`; needs investigation.)
4. **`MERGE DATABASE @branch INTO @target`** (fast-forward-only first), the
   `REMOVE DATABASE` parent-with-live-children guard, and `INFO` branch metadata.
5. **Point reads / ranges / index scans** overlay, and **persisted tombstones**
   (branch `DELETE` hiding a parent row).
6. **`SHOW CHANGES FOR DATABASE`** semantics on a branch (own changes since the
   branch point? feed inheritance? merge could use change feeds as a fast-path).

### Try it

```bash
cargo build --no-default-features --features storage-surrealkv,http,scripting
SURREAL_PATH="surrealkv:///tmp/branch-poc" ./target/debug/surreal start \
  --allow-experimental database_branching --planner-strategy compute-only \
  --user root --pass root --bind 127.0.0.1:8011
# in another shell, run the demo against the HTTP /sql endpoint:
curl -s -X POST http://127.0.0.1:8011/sql -u root:root \
  -H "Accept: application/json" --data-binary @branching-demo.surql
```
