### PR TITLE
Complete the repo-local Nix development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,55 @@
         rustChannel = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain.channel;
         rustManifestSha256 = "sha256-gh/xTkxKHL4eiRXzWv8KP7vfjSk61Iq48x47BEDFgfk=";
 
+        nightlyPin = pkgs.lib.strings.trim (builtins.readFile ./rust-toolchain.nightly);
+        nightlyDate =
+          assert pkgs.lib.assertMsg (pkgs.lib.hasPrefix "nightly-" nightlyPin)
+            "rust-toolchain.nightly must start with nightly-";
+          pkgs.lib.removePrefix "nightly-" nightlyPin;
+        nightlyManifestSha256 = "sha256-2ppS21jOURao7IT5IOE1xz6JqjnpcvLOM865W2MMB54=";
+        nightlyComponents = fenix.packages.${system}.toolchainOf {
+          channel = "nightly";
+          date = nightlyDate;
+          sha256 = nightlyManifestSha256;
+        };
+        nightlyToolchain = fenix.packages.${system}.combine (with nightlyComponents; [
+          cargo
+          rustc
+          rust-std
+          rustfmt
+        ]);
+
+        revisionLockSource = pkgs.fetchCrate {
+          pname = "revision-lock";
+          version = "0.2.0";
+          registryDl = "https://static.crates.io/crates";
+          hash = "sha256-Jx4doNYO5hhAFCoXmfqi/0XeoMszcA6CXRw4IBcz+0c=";
+        };
+
+        revisionLockCargoDeps =
+          pkgs.runCommand "revision-lock-0.2.0-cargo-deps"
+            {
+              cargoDeps = pkgs.rustPlatform.importCargoLock {
+                lockFile = "${revisionLockSource}/Cargo.lock";
+                extraRegistries = {
+                  "https://github.com/rust-lang/crates.io-index" = "https://static.crates.io/crates";
+                };
+              };
+            }
+            ''
+              cp -R "$cargoDeps" "$out"
+              chmod u+w "$out/.cargo" "$out/.cargo/config.toml"
+              sed -i '/^\[source\."https:\/\/github.com\/rust-lang\/crates.io-index"\]$/,+2d' "$out/.cargo/config.toml"
+              sed -i 's|directory = "cargo-vendor-dir"|directory = "@vendor@"|' "$out/.cargo/config.toml"
+            '';
+
+        revisionLock = pkgs.rustPlatform.buildRustPackage {
+          pname = "revision-lock";
+          version = "0.2.0";
+          src = revisionLockSource;
+          cargoDeps = revisionLockCargoDeps;
+        };
+
         mkRustToolchain = {target, extraComponents ? []}:
           with fenix.packages.${system};
           combine ([
@@ -120,14 +169,44 @@
               (targets.${target}.toolchainOf { channel = rustChannel; sha256 = rustManifestSha256; }).rustfmt
             ];
             rustToolchain = mkRustToolchain { inherit target extraComponents; };
+            cargoFmtToolchainShim = pkgs.writeShellScriptBin "cargo-fmt" ''
+              if [ -n "''${RUSTUP_TOOLCHAIN:-}" ]; then
+                exec ${pkgs.rustup}/bin/rustup run "$RUSTUP_TOOLCHAIN" cargo-fmt "$@"
+              fi
+              exec ${rustToolchain}/bin/cargo-fmt "$@"
+            '';
             buildSpec = spec.buildSpec;
           in pkgs.mkShell (buildSpec // {
             hardeningDisable = [ "fortify" ];
 
             depsBuildBuild = buildSpec.depsBuildBuild or [ ]
-              ++ [ rustToolchain ] ++ (with pkgs; [ nixfmt cargo-watch wasm-pack pre-commit cargo-make]);
+              ++ [ cargoFmtToolchainShim rustToolchain revisionLock ]
+              ++ (with pkgs; [
+                nixfmt
+                cargo-watch
+                wasm-pack
+                pre-commit
+                cargo-make
+                cargo-nextest
+                rustup
+              ]);
 
             inherit (util) SURREAL_BUILD_VERSION SURREAL_BUILD_METADATA;
+
+            shellHook = (buildSpec.shellHook or "") + ''
+              export RUSTUP_HOME="''${XDG_CACHE_HOME:-$HOME/.cache}/surrealdb/rustup"
+              mkdir -p "$RUSTUP_HOME"
+              nightly_link="$RUSTUP_HOME/toolchains/surrealdb-nightly-2026-05-11"
+              if [ "$(readlink "$nightly_link" 2>/dev/null)" != "${nightlyToolchain}" ]; then
+                if [ -e "$nightly_link" ] && [ ! -L "$nightly_link" ]; then
+                  echo "error: $nightly_link exists and is not a symbolic link" >&2
+                  return 1
+                fi
+                rm -f "$nightly_link"
+                rustup toolchain link surrealdb-nightly-2026-05-11 ${nightlyToolchain}
+              fi
+              export SURREAL_NIGHTLY_RUST_TOOLCHAIN=surrealdb-nightly-2026-05-11
+            '';
           })) util.platforms);
 
         # nix run

--- a/pkg/nix/README.md
+++ b/pkg/nix/README.md
@@ -111,7 +111,7 @@ If you just want to build the binary, without running it, you can use `nix build
  
 ## Setting up a development environment
 
-Nix can be used to set up C/C++ dependencies for this project in order for Cargo commands to work properly.
+The Nix development shell is the canonical development environment. It supplies the stable Rust compiler, the pinned nightly formatter, `cargo-make`, `cargo-nextest`, `revision-lock`, and the existing native build dependencies.
 
 If you haven't already done so, you will need to clone this repo and `cd` into it
 
@@ -119,6 +119,26 @@ If you haven't already done so, you will need to clone this repo and `cd` into i
 git clone https://github.com/surrealdb/surrealdb.git
 cd surrealdb
 ```
+
+Enter the shell with:
+
+```
+nix develop
+```
+
+For a resource-bounded first build of the default shell, run:
+
+```
+nix build --no-link --max-jobs 1 --cores 2 .#devShells.x86_64-linux.default
+```
+
+The repository neither requires nor modifies a global binary cache. Before the first build, you can inspect the build plan with:
+
+```
+nix build --dry-run --no-link .#devShells.x86_64-linux.default
+```
+
+Check only the derivations listed as locally built; fetched paths are acceptable. Stop before the actual build if that local build list contains `xgcc`, `gcc-*`, or `bootstrap-stage*`, because it indicates a heavy local GCC bootstrap.
 
 ### Setting dependencies up automatically
 


### PR DESCRIPTION
Thank you for submitting this pull request. We really appreciate you spending the time to work on SurrealDB. 🚀 🎉

## What is the motivation?

This is a development-environment follow-up to the #7437 fix in #7438. That fix changed revisioned ANN pending values and needed the repository formatter, focused and language tests, and `revision-lock` verification.

The first Improve run failed before compilation because its executor was not launched with a usable development environment:

```text
/run/current-system/sw/bin/bash: line 1: cargo: command not found
```

The old executor sandbox also rejected a temporary Git index with `Read-only file system`, and one run could not resolve the configured USTC Cargo mirror. Those were executor and host-environment problems, fixed separately. This PR does not change Improve, sandbox permissions, or repository mirror configuration.

After repairing the executor, we tested the repository's existing Nix devShell from an empty caller environment. It supplied stable Rust and `cargo-make`, but not three tools used by the repository's own workflows:

```text
cargo=/nix/store/.../bin/cargo
rustc=/nix/store/.../bin/rustc
cargo-make=/nix/store/.../bin/cargo-make
rustup=MISSING
cargo-nextest=MISSING
revision-lock=MISSING
```

`cargo make fmt` and `cargo make ci-fmt` select the toolchain in `rust-toolchain.nightly` through cargo-make's Rustup integration. The existing devShell included stable `rustfmt`, but no `rustup` command or registered `nightly-2026-05-11` toolchain. Invoking stable `rustfmt` directly could not apply nightly-only settings such as `wrap_comments` and `imports_granularity`.

The #7437 fix also changed two revisioned persisted types. CI installs `revision-lock` 0.2.0 before checking `revision.lock`, while the devShell did not provide it. The same mismatch applied to `cargo-nextest`: the repository config and CI use it, but a fresh devShell did not include it.

We built the completed devShell in a separate worktree and used it as the declared environment for the unchanged #7437 worktree. The formatter, revision lock, focused ANN tests, both language reproductions, workspace check, and clippy gates then completed, leading to #7438. This PR makes that toolchain reproducible from the repository instead of leaving it as machine-local setup.

## What does this change do?

- Builds the nightly date read from `rust-toolchain.nightly` with Fenix and registers it under the repository-specific Rustup name `surrealdb-nightly-2026-05-11`.
- Keeps stable Rust 1.95 as the default PATH toolchain and exposes the nightly name through `SURREAL_NIGHTLY_RUST_TOOLCHAIN` for tasks that explicitly select it.
- Adds `rustup`, `cargo-nextest`, and the CI-pinned `revision-lock` 0.2.0 to the existing devShells.
- Adds a `cargo-fmt` shim for cargo-make's toolchain selection. `rustup run <toolchain> cargo` launches the selected Cargo, but Cargo resolves the `cargo-fmt` subcommand from PATH; without the shim it found the stable formatter. The shim dispatches `cargo-fmt` through Rustup when `RUSTUP_TOOLCHAIN` is set and otherwise preserves the stable default.
- Documents `nix develop`, a resource-bounded first build, and a dry-run guard against an accidental local GCC bootstrap.

Packaging `revision-lock` with the locked nixpkgs initially used the crates.io API download endpoint, which returned HTTP 403 for `crossbeam-utils/0.8.21`. The official `static.crates.io` endpoint returned HTTP 200 with the Cargo.lock checksum on the same connection. The package therefore uses the locked `fetchCrate` and `importCargoLock` interfaces with the official static endpoint.

The change does not modify `flake.lock`, product code, CI, global Cargo or Nix configuration, binary-cache settings, services, or release outputs.

## What is your testing strategy?

A clean-caller comparison reproduced the original devShell gap and verified the fix. With only the system Nix executable available outside the shell, the base devShell resolved `cargo`, `rustc`, and `cargo-make`, while `rustup`, `cargo-nextest`, and `revision-lock` were missing. The candidate devShell resolved all six commands from `/nix/store`.

Passed on the final two-file diff:

- `nix eval --raw .#devShells.x86_64-linux.default.drvPath`
- `nix build --no-link --max-jobs 1 --cores 2 .#devShells.x86_64-linux.default`
- `nix develop --command cargo make ci-fmt`
- `nix develop --command revision-lock --check`
- `cargo nextest --version` from an empty caller environment
- Evaluation of the default, static, and Windows development shells
- `git diff --check`

The formatter probes confirm the intended split:

```text
stable_rustc=rustc 1.95.0 (59807616e 2026-04-14)
stable_cargo_fmt=rustfmt 1.9.0-stable (59807616e1 2026-04-14)
nightly_rustfmt=rustfmt 1.9.0-nightly (4b0c9d76ae 2026-05-10)
```

The resulting devShell was also used as the declared environment for #7438. That work passed pinned-nightly formatting, focused HNSW and DiskANN compatibility tests, both #7437 language fixtures, `revision-lock --check`, workspace `ci-check`, and warnings-denied `ci-clippy`.

Two existing Nix limitations were reproduced unchanged on the base commit: `nix flake check --no-build` cannot evaluate the Darwin outputs because `darwin.apple_sdk_11_0` is unavailable, and the WASM devShell cannot provide target `rustfmt`.

## Security Considerations

This changes development tooling only. It does not touch authentication, authorization, query execution, storage, or runtime data handling. All new fetched inputs are version-pinned and hash-verified. The shell hook writes only to its repository-specific Rustup home and refuses to replace a non-symlink at the managed toolchain path.

## Is this related to any issues?

This is a development-environment follow-up to #7438. The functional fix for #7437 remains entirely in that separate PR.

## Have you read the Contributing Guidelines?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)