### PR TITLE
Fix async event requeue after commit conflicts

### DIFF
--- a/surrealdb/core/src/doc/event.rs
+++ b/surrealdb/core/src/doc/event.rs
@@ -440,9 +440,21 @@ impl AsyncEventContext {
 			Ok(_) => {
 				// Event processed successfully, delete the event from the queue.
 				catch!(tx, tx.del(&eq).await);
-				if let Err(e) = tx.commit().await {
-					// If the commit fails, requeue the event and commit that update.
+				#[cfg(test)]
+				let commit_result = if let Err(e) = crate::kvs::testing::maybe_inject_retryable_conflict(
+					crate::kvs::testing::RetryableConflictSite::AsyncEventCompletionCommit,
+					ctx.node_id(),
+				) {
 					tx.cancel().await?;
+					Err(e)
+				} else {
+					tx.commit().await
+				};
+				#[cfg(not(test))]
+				let commit_result = tx.commit().await;
+				if let Err(e) = commit_result {
+					// A commit attempt closes the transaction even on failure, so requeue in a
+					// fresh transaction.
 					let tx = self.new_write_tx().await?;
 					return Self::retry_attempt(tx, e, &eq, &mut ev).await;
 				}
@@ -524,5 +536,74 @@ impl AsyncEventContext {
 		let opt = ev.build_event_options(&ctx.tx(), opt, eq).await?;
 		let doc = ev.build_event_cursor_doc();
 		Document::process_event_sync(stk, ctx, opt, lh, &ev.event_definition, &doc).await
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::catalog::providers::CatalogProvider;
+	use crate::kvs::testing::{
+		RetryableConflictSite, inject_retryable_conflict, retryable_conflict_count,
+	};
+	use crate::types::PublicValue;
+
+	#[tokio::test]
+	async fn async_event_completion_commit_conflict_requeues() -> Result<()> {
+		let ds = Datastore::new("memory").await?;
+		let tx = ds.transaction(TransactionType::Write, LockType::Optimistic).await?;
+		tx.ensure_ns_db(None, "test", "test").await?;
+		tx.commit().await?;
+		let session = Session::owner().with_ns("test").with_db("test");
+		let mut responses = ds
+			.execute(
+				"
+				UPSERT sink:counter SET counter = 0;
+				DEFINE EVENT increment ON source ASYNC RETRY 1 THEN (
+					UPDATE sink:counter SET counter += 1
+				);
+				CREATE source:one;
+				",
+				&session,
+				None,
+			)
+			.await?;
+		for response in responses.drain(..) {
+			response.result?;
+		}
+
+		let _conflict =
+			inject_retryable_conflict(RetryableConflictSite::AsyncEventCompletionCommit, ds.id());
+
+		assert_eq!(AsyncEventRecord::process_next_events_batch(&ds, None).await?, 1);
+
+		let tx = ds.transaction(TransactionType::Read, LockType::Optimistic).await?;
+		let (beg, end) = EventQueue::range();
+		let queued = tx.scan(beg..end, NORMAL_BATCH_SIZE, 0, None).await?;
+		tx.cancel().await?;
+		assert_eq!(queued.len(), 1);
+		let queued_event = AsyncEventRecord::kv_decode_value(&queued[0].1, ())?;
+		assert_eq!(queued_event.attempt, 1);
+
+		let mut responses = ds.execute("RETURN sink:counter.counter;", &session, None).await?;
+		assert_eq!(responses.remove(0).result?, PublicValue::Number(0.into()));
+		assert_eq!(
+			retryable_conflict_count(RetryableConflictSite::AsyncEventCompletionCommit, ds.id()),
+			0
+		);
+
+		assert_eq!(AsyncEventRecord::process_next_events_batch(&ds, None).await?, 1);
+		assert_eq!(AsyncEventRecord::process_next_events_batch(&ds, None).await?, 0);
+
+		let tx = ds.transaction(TransactionType::Read, LockType::Optimistic).await?;
+		let (beg, end) = EventQueue::range();
+		let queued = tx.scan(beg..end, NORMAL_BATCH_SIZE, 0, None).await?;
+		tx.cancel().await?;
+		assert!(queued.is_empty());
+
+		let mut responses = ds.execute("RETURN sink:counter.counter;", &session, None).await?;
+		assert_eq!(responses.remove(0).result?, PublicValue::Number(1.into()));
+
+		Ok(())
 	}
 }

--- a/surrealdb/core/src/kvs/mod.rs
+++ b/surrealdb/core/src/kvs/mod.rs
@@ -103,6 +103,7 @@ pub(crate) mod testing {
 
 	#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 	pub(crate) enum RetryableConflictSite {
+		AsyncEventCompletionCommit,
 		ConcurrentIndexInitialCleanup,
 		ConcurrentIndexInitialBatch,
 		ConcurrentIndexReservationRelease,


### PR DESCRIPTION
## Problem

#7411 reports `Couldn't update a finished transaction` while the async-event worker updates `/!eq` queue entries under write bursts.

The error is still reproducible on the official v3.2.4 image (`3.2.4+20260803.93ab219`). In one bounded run, 62 async-event triggers produced 150 finished-transaction errors, all on `/!eq` keys. The sink eventually reached the expected value of 62 and the container did not OOM, so that run demonstrated repeated queue-bookkeeping failure without observable event loss.

The completion path currently:

1. executes the event body in a write transaction;
2. deletes the queue entry in that transaction;
3. attempts to commit both changes;
4. calls `cancel()` on the same transaction if the commit fails;
5. opens a fresh transaction and calls `retry_attempt`.

`Transaction::commit()` and the storage backends mark a transaction finished before attempting the commit. The `cancel()` in step 4 therefore returns `TransactionFinished`, and `?` exits before the worker reaches the fresh transaction or `retry_attempt`. The original queue entry remains at attempt 0, so later queue drains repeat the same path.

## Change

The completion-commit error path now passes the original commit error directly to `retry_attempt` using a fresh write transaction. It no longer tries to cancel the already-finished transaction.

The separate cancellation after an event-body error is unchanged because that transaction has not attempted to commit and still needs to roll back partial event effects.

This does not change the public API, persisted async-event record, queue key, retry limit, or delivery policy.

## Regression coverage

A test-only conflict site injects a retryable conflict at the completion commit. The regression verifies that the failed commit rolls back the event effect and queue deletion, persists the queue record at attempt 1, consumes the injected conflict, applies the event effect exactly once on retry, and leaves the queue empty.

Against current `main` at `18971ffba`:

- restoring the faulty post-commit `cancel()` made the focused test fail at the intended assertion (`attempt`: actual 0, expected 1);
- this PR at `ebdfa29dc` passes the same test.

## Validation

- `cargo test -p surrealdb-core --lib async_event_completion_commit_conflict_requeues` — 1 passed
- `cargo test -p surrealdb-core --test asyncevent` — 3 passed
- `cargo check --locked -p surrealdb-core --all-targets`
- `cargo clippy -p surrealdb-core --all-targets -- -D warnings`
- `revision-lock --check` — passed with unchanged hash `7973a347c7837ee792363e461d5a36f1c9cb0e1936e637e68f695c1b8bc85178`
- `git diff --check`

Maintainer question: is requeueing through a fresh transaction after a completion-commit conflict the intended async-event behavior? If so, a review from the KV/transaction owner would unblock this small transaction-lifecycle fix.

Closes #7411
