### PR TITLE
Fix literal-union enums lose their non-null wrapper

### DIFF
--- a/language-tests/tests/reproductions/7452_graphql_enum_array_read.graphql
+++ b/language-tests/tests/reproductions/7452_graphql_enum_array_read.graphql
@@ -1,0 +1,18 @@
+/**
+[env]
+imports = ["reproductions/7452_graphql_enum_array_schema.surql"]
+
+[test]
+reason = "Elements of an `array<'A' | 'B'>` are read back as enum values, like a scalar literal union is — including when the array sits inside an `option<…>`"
+issue = 7452
+
+[[test.results]]
+value = "{ persons: [{ roles: ['PERSON_ROLES_ADMIN', 'PERSON_ROLES_DEV'], status: 'PERSON_STATUS_NEW', tags: ['PERSON_TAGS_X'] }] }"
+*/
+query {
+	persons {
+		status
+		roles
+		tags
+	}
+}

--- a/language-tests/tests/reproductions/7452_graphql_enum_array_schema.surql
+++ b/language-tests/tests/reproductions/7452_graphql_enum_array_schema.surql
@@ -1,0 +1,23 @@
+/**
+[env]
+namespace = true
+database = true
+auth = { level = "owner" }
+
+[test]
+run = false
+reason = "Schema fixture for the literal-union enum array-value reproductions (the value-conversion sibling of the #7452 nullability defect)"
+*/
+
+DEFINE CONFIG GRAPHQL TABLES AUTO FUNCTIONS NONE;
+
+DEFINE TABLE person SCHEMAFULL;
+DEFINE FIELD name ON person TYPE string;
+-- Control: a scalar literal union converts in both directions today.
+DEFINE FIELD status ON person TYPE 'NEW' | 'OLD';
+-- Subject: the element type is the same enum, so it must convert the same way.
+DEFINE FIELD roles ON person TYPE array<'ADMIN' | 'DEV'>;
+-- Subject: the array layer may itself sit inside an `option<…>`.
+DEFINE FIELD tags ON person TYPE option<array<'X' | 'Y'>>;
+
+CREATE person:alice SET name = "Alice", status = 'NEW', roles = ['ADMIN', 'DEV'], tags = ['X'];

--- a/language-tests/tests/reproductions/7452_graphql_enum_array_write.graphql
+++ b/language-tests/tests/reproductions/7452_graphql_enum_array_write.graphql
@@ -1,0 +1,26 @@
+/**
+[env]
+imports = ["reproductions/7452_graphql_enum_array_schema.surql"]
+
+[test]
+reason = "Enum values can be written into an `array<'A' | 'B'>` field, and read back unchanged"
+issue = 7452
+
+[[test.results]]
+value = "{ createPerson: { roles: ['PERSON_ROLES_DEV', 'PERSON_ROLES_ADMIN'], status: 'PERSON_STATUS_OLD', tags: ['PERSON_TAGS_Y'] } }"
+*/
+mutation {
+	createPerson(
+		data: {
+			id: "bob"
+			name: "Bob"
+			status: PERSON_STATUS_OLD
+			roles: [PERSON_ROLES_DEV, PERSON_ROLES_ADMIN]
+			tags: [PERSON_TAGS_Y]
+		}
+	) {
+		status
+		roles
+		tags
+	}
+}

--- a/language-tests/tests/reproductions/7452_graphql_enum_nullability.graphql
+++ b/language-tests/tests/reproductions/7452_graphql_enum_nullability.graphql
@@ -1,0 +1,26 @@
+/**
+[env]
+imports = ["reproductions/7452_graphql_enum_nullability_schema.surql"]
+
+[test]
+reason = "A literal-union field derives its non-null wrapper like every other kind: `'A' | 'B'` is `<Enum>!` and `option<'A' | 'B'>` stays nullable"
+issue = 7452
+
+[[test.results]]
+value = "{ __type: { fields: [{ name: 'id', type: { kind: 'NON_NULL', name: NULL, ofType: { kind: 'SCALAR', name: 'ID' } } }, { name: 'mood', type: { kind: 'ENUM', name: 'PERSON_MOOD_ENUM_HAPPY_OR_SAD', ofType: NULL } }, { name: 'name', type: { kind: 'NON_NULL', name: NULL, ofType: { kind: 'SCALAR', name: 'String' } } }, { name: 'note', type: { kind: 'SCALAR', name: 'String', ofType: NULL } }, { name: 'status', type: { kind: 'NON_NULL', name: NULL, ofType: { kind: 'ENUM', name: 'PERSON_STATUS_ENUM_ACTIVE_OR_BANNED' } } }] } }"
+*/
+query {
+	__type(name: "person") {
+		fields {
+			name
+			type {
+				kind
+				name
+				ofType {
+					kind
+					name
+				}
+			}
+		}
+	}
+}

--- a/language-tests/tests/reproductions/7452_graphql_enum_nullability_schema.surql
+++ b/language-tests/tests/reproductions/7452_graphql_enum_nullability_schema.surql
@@ -1,0 +1,22 @@
+/**
+[env]
+namespace = true
+database = true
+auth = { level = "owner" }
+
+[test]
+run = false
+reason = "Schema fixture for the #7452 GraphQL literal-union nullability reproduction"
+*/
+
+DEFINE CONFIG GRAPHQL TABLES AUTO FUNCTIONS NONE;
+
+DEFINE TABLE person SCHEMAFULL;
+-- Control: a non-optional scalar is emitted as `String!`.
+DEFINE FIELD name ON person TYPE string;
+-- Control: an optional scalar is emitted as `String`.
+DEFINE FIELD note ON person TYPE option<string>;
+-- Subject: a non-optional literal union must be emitted as `<Enum>!`.
+DEFINE FIELD status ON person TYPE 'ACTIVE' | 'BANNED';
+-- Subject: an optional literal union must stay nullable.
+DEFINE FIELD mood ON person TYPE option<'HAPPY' | 'SAD'>;

--- a/surrealdb/core/src/graphql/schema.rs
+++ b/surrealdb/core/src/graphql/schema.rs
@@ -379,6 +379,23 @@ pub(crate) fn sql_value_to_graphql_value(v: SurValue) -> Result<GraphqlValue, Gr
 	Ok(out)
 }
 
+/// Strip an `option<…>` wrapper, which is represented as an `Either` carrying a
+/// `None` variant: `option<array<T>>` collapses to `array<T>`.
+///
+/// A union with more than one meaningful variant is returned untouched — that
+/// deliberately includes `option<'A' | 'B'>`, which must stay an `Either` so it
+/// is still recognised as a literal union.
+fn strip_optional(kind: &Kind) -> &Kind {
+	let Kind::Either(ks) = kind else {
+		return kind;
+	};
+	let mut variants = ks.iter().filter(|k| !matches!(k, Kind::None | Kind::Null));
+	match (variants.next(), variants.next()) {
+		(Some(only), None) => only,
+		_ => kind,
+	}
+}
+
 /// Convert a SurrealDB runtime value to GraphQL, using field kind metadata when available.
 ///
 /// For string-literal `Either` kinds, this emits a GraphQL enum token instead
@@ -388,18 +405,34 @@ pub(crate) fn sql_value_to_graphql_value_with_kind(
 	kind: Option<&Kind>,
 	enum_scope: Option<&str>,
 ) -> Result<GraphqlValue, GraphqlError> {
-	if let SurValue::String(s) = &v
-		&& let Some(Kind::Either(ks)) = kind
-	{
-		for k in ks {
-			if let Kind::Literal(KindLiteral::String(lit)) = k
-				&& lit.as_str() == s.as_str()
-			{
-				return Ok(GraphqlValue::Enum(Name::new(literal_enum_item_name(enum_scope, lit))));
+	// `strip_optional` is needed to avoid the `Either([None, Array(Either([…]))])` case hitting
+	// the literal-lookup arm (and consequentially falling through) due to the outer `Either`.
+	match (v, kind.map(strip_optional)) {
+		// Convert element-wise so the enum mapping survives the array layer.
+		// `kind_to_type_inner` registers one enum for the *element* kind and
+		// passes `enum_scope` through the array unchanged, so the elements are
+		// scoped identically to a bare field of that kind.
+		(SurValue::Array(items), Some(Kind::Array(inner, _))) => items
+			.into_iter()
+			.map(|item| sql_value_to_graphql_value_with_kind(item, Some(inner), enum_scope))
+			.collect::<Result<Vec<_>, GraphqlError>>()
+			.map(GraphqlValue::List),
+		(v, Some(Kind::Either(ks))) => {
+			if let SurValue::String(s) = &v {
+				for k in ks {
+					if let Kind::Literal(KindLiteral::String(lit)) = k
+						&& lit.as_str() == s.as_str()
+					{
+						return Ok(GraphqlValue::Enum(Name::new(literal_enum_item_name(
+							enum_scope, lit,
+						))));
+					}
+				}
 			}
+			sql_value_to_graphql_value(v)
 		}
+		(v, _) => sql_value_to_graphql_value(v),
 	}
-	sql_value_to_graphql_value(v)
 }
 
 /// Formats a `RecordId` as a raw string without SQL-specific escaping.
@@ -1250,7 +1283,17 @@ pub(crate) fn graphql_to_sql_kind_with_scope(
 					Err(type_error(Kind::Either(ks), val))
 				}
 				list @ GraphqlValue::List(_) => {
-					either_try_kind!(ks, list, Kind::Array);
+					// Same shape as `either_try_kind!(ks, list, Kind::Array)`,
+					// but threading `enum_scope` through — the macro cannot see
+					// it (a `macro_rules!` body resolves free identifiers at its
+					// definition site), and without it the elements of an
+					// `option<array<'A' | 'B'>>` lose their enum mapping.
+					for arr_kind in ks.iter().filter(|k| matches!(k, Kind::Array(_, _))).cloned() {
+						if let Ok(out) = graphql_to_sql_kind_with_scope(list, arr_kind, enum_scope)
+						{
+							return Ok(out);
+						}
+					}
 					Err(type_error(Kind::Either(ks), val))
 				}
 				obj @ GraphqlValue::Object(_) => {
@@ -1268,7 +1311,11 @@ pub(crate) fn graphql_to_sql_kind_with_scope(
 		Kind::Set(_k, _n) => Err(resolver_error("Sets are not yet supported")),
 		Kind::Array(ref k, n) => match val {
 			GraphqlValue::List(l) => {
-				let list_iter = l.iter().map(|v| graphql_to_sql_kind(v, *k.to_owned()));
+				// Carry `enum_scope` into the elements: the element kind is what
+				// registered the enum, so dropping the scope here leaves the
+				// reverse mapping unable to recognise its own tokens.
+				let list_iter =
+					l.iter().map(|v| graphql_to_sql_kind_with_scope(v, *k.to_owned(), enum_scope));
 				let list: Result<Vec<SurValue>, GraphqlError> = list_iter.collect();
 
 				match (list, n) {
@@ -1814,5 +1861,63 @@ mod tests {
 		.unwrap();
 
 		assert_eq!(ty.to_string(), only_registered_enum(&types));
+	}
+
+	/// `array<'ACTIVE' | 'BANNED'>`, wrapped in `option<…>` when `optional`.
+	fn status_union_array(optional: bool) -> Kind {
+		let array = Kind::Array(Box::new(status_union(false)), None);
+		if optional {
+			Kind::Either(vec![Kind::None, array])
+		} else {
+			array
+		}
+	}
+
+	#[test]
+	fn enum_values_survive_an_array_layer_in_both_directions() {
+		// `kind_to_type` registers one enum for the *element* kind and passes
+		// the scope through the array unchanged, so both converters have to do
+		// the same. They used to stop at the array: reading produced raw
+		// strings that async-graphql rejected as invalid enum items, and
+		// writing produced tokens the reverse mapping no longer recognised.
+		for optional in [false, true] {
+			let kind = status_union_array(optional);
+			let stored = SurValue::Array(SurArray(vec![SurValue::from("BANNED")]));
+
+			let out = sql_value_to_graphql_value_with_kind(
+				stored.clone(),
+				Some(&kind),
+				Some("person_status"),
+			)
+			.unwrap();
+			assert_eq!(
+				out,
+				GraphqlValue::List(vec![GraphqlValue::Enum(Name::new("PERSON_STATUS_BANNED"))]),
+				"reading array<'A' | 'B'> (optional: {optional})"
+			);
+
+			// And the token round-trips back to the stored string.
+			assert_eq!(
+				graphql_to_sql_kind_with_scope(&out, kind, Some("person_status")).unwrap(),
+				stored,
+				"writing array<'A' | 'B'> (optional: {optional})"
+			);
+		}
+	}
+
+	#[test]
+	fn scalar_literal_union_conversion_is_unchanged() {
+		// The array handling is layered on top of the scalar path, not in place
+		// of it: a bare `'A' | 'B'` must still map string to token and back.
+		let kind = status_union(false);
+
+		let out =
+			sql_value_to_graphql_value_with_kind(SurValue::from("ACTIVE"), Some(&kind), Some("s"))
+				.unwrap();
+		assert_eq!(out, GraphqlValue::Enum(Name::new("S_ACTIVE")));
+		assert_eq!(
+			graphql_to_sql_kind_with_scope(&out, kind, Some("s")).unwrap(),
+			SurValue::from("ACTIVE")
+		);
 	}
 }

--- a/surrealdb/core/src/graphql/schema.rs
+++ b/surrealdb/core/src/graphql/schema.rs
@@ -1749,4 +1749,70 @@ mod tests {
 		let literal = GraphqlValue::String("19.99dec".to_owned());
 		assert_eq!(graphql_to_sql_kind(&literal, Kind::Decimal).unwrap(), decimal);
 	}
+
+	/// `'ACTIVE' | 'BANNED'`, wrapped in `option<…>` when `optional`.
+	fn status_union(optional: bool) -> Kind {
+		let mut variants = Vec::new();
+		if optional {
+			variants.push(Kind::None);
+		}
+		variants.push(Kind::Literal(KindLiteral::String("ACTIVE".into())));
+		variants.push(Kind::Literal(KindLiteral::String("BANNED".into())));
+		Kind::Either(variants)
+	}
+
+	/// Name of the one enum type a `kind_to_type*` call registered, so the
+	/// assertions below tie the returned `TypeRef` to the actual registration
+	/// instead of restating the generated name.
+	fn only_registered_enum(types: &[Type]) -> String {
+		let names: Vec<&str> = types
+			.iter()
+			.filter_map(|t| match t {
+				Type::Enum(e) => Some(e.type_name()),
+				_ => None,
+			})
+			.collect();
+		assert_eq!(names.len(), 1, "expected exactly one registered enum, got {names:?}");
+		names[0].to_owned()
+	}
+
+	#[test]
+	fn literal_union_derives_non_null_like_every_other_kind() {
+		// The `NonNull` wrapper is applied in a single place, at the end of
+		// `kind_to_type_inner`. The literal-union arm used to return the enum's
+		// `TypeRef` early and skip it, so `TYPE 'A' | 'B'` came out nullable
+		// while `TYPE string` correctly came out `String!` (issue #7452).
+		let mut types = Vec::new();
+		let ty = kind_to_type_with_enum_prefix(
+			status_union(false),
+			&mut types,
+			false,
+			Some("person_status"),
+		)
+		.unwrap();
+
+		let rendered = ty.to_string();
+		let TypeRef::NonNull(inner) = ty else {
+			panic!("a non-optional literal union should be NonNull, got `{rendered}`");
+		};
+		assert_eq!(inner.to_string(), only_registered_enum(&types));
+	}
+
+	#[test]
+	fn optional_literal_union_stays_nullable() {
+		// The other half of the same contract: `optional` is derived from the
+		// kind, which keeps its `None` variant, so `option<'A' | 'B'>` must not
+		// pick up a `NonNull` wrapper. Guards against "fixing" the case above by
+		// wrapping unconditionally.
+		let mut types = Vec::new();
+		let ty = kind_to_type_with_enum_prefix(
+			status_union(true),
+			&mut types,
+			false,
+			Some("person_mood"),
+		)
+		.unwrap();
+
+		assert_eq!(ty.to_string(), only_registered_enum(&types));
+	}
 }

--- a/surrealdb/core/src/graphql/schema.rs
+++ b/surrealdb/core/src/graphql/schema.rs
@@ -671,32 +671,41 @@ fn kind_to_type_inner(
 				let enum_ty = tmp.type_name().to_string();
 
 				types.push(Type::Enum(tmp));
-				if others.is_empty() {
-					return Ok(TypeRef::named(enum_ty));
-				}
 				Some(enum_ty)
 			} else {
 				None
 			};
 
-			let pos_names: Result<Vec<TypeRef>, GraphqlError> = others
-				.into_iter()
-				.map(|k| kind_to_type_inner(k, types, is_input, enum_scope, array_depth))
-				.collect();
-			let pos_names: Vec<String> = pos_names?.into_iter().map(|tr| tr.to_string()).collect();
-			let ty_name = pos_names.join("_or_");
+			match (enum_ty, others.is_empty()) {
+				// Every member was a string literal, so the field *is* the enum
+				// and there is nothing to union it with. Yielded here rather
+				// than returned early so that it still picks up the `optional`
+				// wrapping at the end of this function: a non-optional literal
+				// union must be emitted as `<Enum>!`, exactly like every other
+				// non-optional kind (issue #7452).
+				(Some(enum_ty), true) => TypeRef::named(enum_ty),
+				(enum_ty, _) => {
+					let pos_names: Result<Vec<TypeRef>, GraphqlError> = others
+						.into_iter()
+						.map(|k| kind_to_type_inner(k, types, is_input, enum_scope, array_depth))
+						.collect();
+					let pos_names: Vec<String> =
+						pos_names?.into_iter().map(|tr| tr.to_string()).collect();
+					let ty_name = pos_names.join("_or_");
 
-			let mut tmp_union = Union::new(ty_name.clone());
-			for n in pos_names {
-				tmp_union = tmp_union.possible_type(n);
+					let mut tmp_union = Union::new(ty_name.clone());
+					for n in pos_names {
+						tmp_union = tmp_union.possible_type(n);
+					}
+
+					if let Some(ty) = enum_ty {
+						tmp_union = tmp_union.possible_type(ty);
+					}
+
+					types.push(Type::Union(tmp_union));
+					TypeRef::named(ty_name)
+				}
 			}
-
-			if let Some(ty) = enum_ty {
-				tmp_union = tmp_union.possible_type(ty);
-			}
-
-			types.push(Type::Union(tmp_union));
-			TypeRef::named(ty_name)
 		}
 		Kind::Set(_, _) => return Err(schema_error("Kind::Set is not yet supported")),
 		Kind::Array(k, _) => {


### PR DESCRIPTION
Fixes #7452.

## Summary

`DEFINE FIELD status ON person TYPE 'ACTIVE' | 'BANNED'` comes out nullable in the generated schema, while `TYPE string` correctly gives `String!` and `TYPE option<string>` correctly gives `String`. So the non-null wrapper is derived correctly for every kind *except* the literal-union → enum path.

`kind_to_type_inner` computes `optional` once at the top and applies the `NonNull` wrapper once at the bottom. The `Kind::Either` arm returned early when every union member was a string literal, so the enum's `TypeRef` never reached that wrapping. The fix yields the value from the match arm instead of returning it.

I deliberately didn't fix it by wrapping at the early return, because duplicating the nullability logic is what caused the bug in the first place. Falling through to the single existing wrapping point is the whole point.

## Also in here: `array<'A' | 'B'>` was unusable

Found while testing the above. It's a separate defect from #7452. But similar feature and small, so it's in the same PR (happy to split it out if you'd rather).

Reading failed with `internal: invalid item for enum "..."`, writing with `Error converting value: PERSON_ROLES_DEV to type: 'ADMIN' | 'DEV'`. The scalar form of the same field worked.

`kind_to_type_inner` registers one enum for the *element* kind and passes `enum_scope` through the array unchanged, so an element is scoped exactly like a bare field of that kind. Neither converter did the same: the read path only matched a top-level string against a top-level `Either`, and the write path recursed into elements through `graphql_to_sql_kind`, which drops the scope. Both now recurse element-wise with the scope preserved, which also makes nested arrays work at any depth.

One caveat: the write-side `Either` arm had the same drop hidden inside `either_try_kind!`. The macro can't see `enum_scope` (a `macro_rules!` body resolves free identifiers at its definition site), and making it a parameter would mean touching a dozen call sites that mostly handle kinds which can never carry an enum token. So that one branch is spelled out inline with a comment saying why. Not lovely, but the alternative is worse.

`option<T>` is stripped before dispatch, via a helper that leaves a union alone unless exactly one meaningful variant remains — otherwise `option<'A' | 'B'>` would collapse and stop being recognised as a literal union.

## Testing

- Added new Language tests.
- Unit tests on `kind_to_type_with_enum_prefix` and both converters.

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)