### PR TITLE
 Fix `GRAPHQL_ALIAS` only reaches some of the generated names

### DIFF
--- a/language-tests/tests/reproductions/7453_graphql_alias_collision.graphql
+++ b/language-tests/tests/reproductions/7453_graphql_alias_collision.graphql
@@ -1,0 +1,14 @@
+/**
+[env]
+imports = ["reproductions/7453_graphql_alias_collision_schema.surql"]
+
+[test]
+reason = "Because the alias now names the table's Object type, aliasing onto a built-in type is reported as a naming collision instead of silently shadowing it"
+issue = 7453
+
+[[test.results]]
+error = "Error generating schema: GraphQL naming collision on type `PageInfo` — built-in type `PageInfo` and table `widget` produce the same type. Set an explicit `GRAPHQL_ALIAS` on the table."
+*/
+query {
+	__typename
+}

--- a/language-tests/tests/reproductions/7453_graphql_alias_collision_schema.surql
+++ b/language-tests/tests/reproductions/7453_graphql_alias_collision_schema.surql
@@ -1,0 +1,15 @@
+/**
+[env]
+namespace = true
+database = true
+auth = { level = "owner" }
+
+[test]
+run = false
+reason = "Schema fixture for the #7453 alias collision reproduction: the alias names the table's Object type, so it can now collide with a built-in one"
+*/
+
+DEFINE CONFIG GRAPHQL TABLES AUTO FUNCTIONS NONE;
+
+DEFINE TABLE widget SCHEMAFULL GRAPHQL_ALIAS 'PageInfo';
+DEFINE FIELD label ON widget TYPE string;

--- a/language-tests/tests/reproductions/7453_graphql_alias_function_record_return.graphql
+++ b/language-tests/tests/reproductions/7453_graphql_alias_function_record_return.graphql
@@ -1,0 +1,38 @@
+/**
+[env]
+imports = ["reproductions/7453_graphql_alias_function_schema.surql"]
+
+[test]
+reason = "A function returning `record` or `record<a | b>` tags its result with the table's aliased Object type, so interface and union fragments still match"
+issue = 7453
+
+[[test.results]]
+value = "{ anyRecord: { __typename: 'Gadget', label: 'First' }, singleTarget: { label: 'First' }, unionGadget: { __typename: 'Gadget', label: 'First' }, unionWidget: { __typename: 'Widget', title: 'Second' } }"
+*/
+query {
+	# `record` — the interface. Without a concrete tag async-graphql reports
+	# `object "gadget" does not implement interface "record"`.
+	anyRecord: fn_any_record {
+		__typename
+		... on Gadget {
+			label
+		}
+	}
+	# `record<gadget | widget>` — the generated union, both ways round.
+	unionGadget: fn_pick_gadget {
+		__typename
+		... on Gadget {
+			label
+		}
+	}
+	unionWidget: fn_pick_widget {
+		__typename
+		... on Widget {
+			title
+		}
+	}
+	# `record<gadget>` — already the `Gadget` Object type, no tag involved.
+	singleTarget: fn_the_gadget {
+		label
+	}
+}

--- a/language-tests/tests/reproductions/7453_graphql_alias_function_schema.surql
+++ b/language-tests/tests/reproductions/7453_graphql_alias_function_schema.surql
@@ -1,0 +1,31 @@
+/**
+[env]
+namespace = true
+database = true
+auth = { level = "owner" }
+
+[test]
+run = false
+reason = "Schema fixture for the #7453 GRAPHQL_ALIAS function-return reproduction: functions are exposed here, unlike in the other #7453 fixture"
+*/
+
+DEFINE CONFIG GRAPHQL TABLES AUTO FUNCTIONS AUTO;
+
+DEFINE TABLE gadget SCHEMAFULL GRAPHQL_ALIAS 'Gadget';
+DEFINE FIELD label ON gadget TYPE string;
+
+DEFINE TABLE widget SCHEMAFULL GRAPHQL_ALIAS 'Widget';
+DEFINE FIELD title ON widget TYPE string;
+
+-- A bare `record` return is typed as the `record` interface, and a multi-target
+-- one as the `Gadget_or_Widget` union: both need the resolver to tag the value
+-- with the aliased Object type name before a fragment can match it.
+DEFINE FUNCTION fn::any_record() -> record { RETURN gadget:one; };
+DEFINE FUNCTION fn::pick_gadget() -> record<gadget | widget> { RETURN gadget:one; };
+DEFINE FUNCTION fn::pick_widget() -> record<gadget | widget> { RETURN widget:one; };
+-- Control: a single-target return already *is* the aliased Object type, so it
+-- must keep resolving without a tag.
+DEFINE FUNCTION fn::the_gadget() -> record<gadget> { RETURN gadget:one; };
+
+CREATE gadget:one SET label = "First";
+CREATE widget:one SET title = "Second";

--- a/language-tests/tests/reproductions/7453_graphql_alias_schema.surql
+++ b/language-tests/tests/reproductions/7453_graphql_alias_schema.surql
@@ -1,0 +1,38 @@
+/**
+[env]
+namespace = true
+database = true
+auth = { level = "owner" }
+
+[test]
+run = false
+reason = "Schema fixture for the #7453 GRAPHQL_ALIAS reproductions"
+*/
+
+DEFINE CONFIG GRAPHQL TABLES AUTO FUNCTIONS NONE;
+
+-- No table alias here: this table isolates the *field* alias behaviour, so that
+-- the nested-field reproduction stays independent of the table-alias one.
+DEFINE TABLE widget SCHEMAFULL;
+-- Control: a top-level field alias is honoured today.
+DEFINE FIELD created_at ON widget TYPE datetime GRAPHQL_ALIAS 'createdAt';
+DEFINE FIELD price ON widget TYPE object;
+-- Subject: an alias on a nested field must be honoured the same way.
+DEFINE FIELD price.in_euro ON widget TYPE float GRAPHQL_ALIAS 'inEuro';
+DEFINE FIELD price.currency ON widget TYPE string;
+
+-- A table alias, exercised on its own table so the two reproductions do not
+-- interfere.
+DEFINE TABLE gadget SCHEMAFULL GRAPHQL_ALIAS 'Gadget';
+DEFINE FIELD label ON gadget TYPE string;
+
+-- Record links and relation traversals point at the aliased table, so they must
+-- reference its aliased Object type rather than the raw table name.
+DEFINE TABLE holder SCHEMAFULL;
+DEFINE FIELD item ON holder TYPE record<gadget>;
+DEFINE TABLE uses TYPE RELATION FROM holder TO gadget SCHEMAFULL;
+
+CREATE widget:one SET created_at = d"2024-01-15T10:00:00Z", price = { in_euro: 9.5f, currency: "EUR" };
+CREATE gadget:one SET label = "First";
+CREATE holder:h SET item = gadget:one;
+RELATE holder:h->uses->gadget:one;

--- a/language-tests/tests/reproductions/7453_graphql_nested_field_alias.graphql
+++ b/language-tests/tests/reproductions/7453_graphql_nested_field_alias.graphql
@@ -1,0 +1,20 @@
+/**
+[env]
+imports = ["reproductions/7453_graphql_alias_schema.surql"]
+
+[test]
+reason = "GRAPHQL_ALIAS on a nested field renames it and still resolves its value, like a top-level field alias does"
+issue = 7453
+
+[[test.results]]
+value = "{ widgets: [{ createdAt: '2024-01-15T10:00:00+00:00', price: { currency: 'EUR', inEuro: 9.5f } }] }"
+*/
+query {
+	widgets {
+		createdAt
+		price {
+			inEuro
+			currency
+		}
+	}
+}

--- a/language-tests/tests/reproductions/7453_graphql_table_alias_resolves.graphql
+++ b/language-tests/tests/reproductions/7453_graphql_table_alias_resolves.graphql
@@ -1,0 +1,36 @@
+/**
+[env]
+imports = ["reproductions/7453_graphql_alias_schema.surql"]
+
+[test]
+reason = "An aliased table still resolves: __typename reports the alias, and record links, relation traversals and the generic _get interface all reach the renamed Object type"
+issue = 7453
+
+[[test.results]]
+value = "{ _get: { label: 'First' }, holders: [{ item: { __typename: 'Gadget', label: 'First' }, uses: [{ out: { __typename: 'Gadget', label: 'First' } }] }], single: { __typename: 'Gadget', label: 'First' } }"
+*/
+query {
+	single: Gadget(id: "one") {
+		__typename
+		label
+	}
+	holders {
+		item {
+			__typename
+			label
+		}
+		uses {
+			out {
+				__typename
+				label
+			}
+		}
+	}
+	# The generic `_get` tags its result with the concrete type at runtime, so
+	# this only resolves if the alias reached that tag too.
+	_get(id: "gadget:one") {
+		... on Gadget {
+			label
+		}
+	}
+}

--- a/language-tests/tests/reproductions/7453_graphql_table_alias_types.graphql
+++ b/language-tests/tests/reproductions/7453_graphql_table_alias_types.graphql
@@ -1,0 +1,44 @@
+/**
+[env]
+imports = ["reproductions/7453_graphql_alias_schema.surql"]
+
+[test]
+reason = "GRAPHQL_ALIAS on a table names every type generated for it, not just the connection and input types"
+issue = 7453
+
+[[test.results]]
+value = "{ aggregateRow: { kind: 'OBJECT' }, connection: { kind: 'OBJECT' }, edge: { kind: 'OBJECT' }, filterInput: { kind: 'INPUT_OBJECT' }, groupableEnum: { kind: 'ENUM' }, objectType: { fields: [{ name: 'id' }, { name: 'label' }, { name: 'uses_in' }], kind: 'OBJECT' }, orderInput: { kind: 'INPUT_OBJECT' }, orderableEnum: { kind: 'ENUM' }, rawTableName: NULL }"
+*/
+query {
+	objectType: __type(name: "Gadget") {
+		kind
+		fields {
+			name
+		}
+	}
+	filterInput: __type(name: "_filter_Gadget") {
+		kind
+	}
+	orderInput: __type(name: "_order_Gadget") {
+		kind
+	}
+	orderableEnum: __type(name: "_orderable_Gadget") {
+		kind
+	}
+	groupableEnum: __type(name: "_groupable_Gadget") {
+		kind
+	}
+	aggregateRow: __type(name: "Gadget_aggregate_row") {
+		kind
+	}
+	connection: __type(name: "GadgetConnection") {
+		kind
+	}
+	edge: __type(name: "GadgetEdge") {
+		kind
+	}
+	# The raw table name must not leak a second type into the schema.
+	rawTableName: __type(name: "gadget") {
+		kind
+	}
+}

--- a/surrealdb/core/src/graphql/functions.rs
+++ b/surrealdb/core/src/graphql/functions.rs
@@ -51,6 +51,9 @@ pub async fn process_fns(
 		// resolvers in this crate.
 		let kvs1 = Arc::clone(datastore);
 		let fnd1 = fnd.clone();
+		// Decided by the declared return type, which is fixed for the life of
+		// the schema — so it is resolved here rather than on every invocation.
+		let tag_record_type = returns_abstract_record(fnd.returns.as_ref());
 
 		// Honour an explicit `GRAPHQL <ident>` alias when valid; otherwise fall
 		// back to the auto-derived `fn_<name>` form. See GitHub issue #4537.
@@ -107,13 +110,14 @@ pub async fn process_fns(
 					let graphql_res = match res {
 						Value::RecordId(rid) => {
 							let field_val = FieldValue::owned_any(rid.clone());
-							// Untyped record returns need `.with_type()` for
-							// interface resolution; typed `record<T>` do not.
-							let field_val = match &fnd1.returns {
-								Some(Kind::Record(ts)) if ts.is_empty() => {
-									field_val.with_type(rid.table)
-								}
-								_ => field_val,
+							// The tag names the table's *generated Object type*,
+							// which follows its `GRAPHQL_ALIAS` rather than its
+							// SurrealQL name (#7453).
+							let field_val = if tag_record_type {
+								field_val
+									.with_type(super::tables::graphql_type_of(&ctx, &rid.table))
+							} else {
+								field_val
 							};
 							Some(field_val)
 						}
@@ -156,4 +160,61 @@ pub async fn process_fns(
 	}
 
 	Ok(query)
+}
+
+/// `true` when a function's record-valued return lands on an *abstract* GraphQL
+/// type and therefore needs a `FieldValue::with_type()` tag to resolve.
+///
+/// [`kind_to_type`](super::schema::kind_to_type) maps a bare `record` to the
+/// `record` interface and a multi-target `record<a | b>` to a generated union;
+/// async-graphql cannot pick the concrete member of either without the tag. A
+/// single-target `record<t>` already *is* that Object type, so tagging it is
+/// unnecessary. `option<T>` is stored as `Either([None, T])` and is unwrapped
+/// here exactly as `kind_to_type` unwraps it when building the type reference.
+fn returns_abstract_record(kind: Option<&Kind>) -> bool {
+	match kind {
+		Some(Kind::Record(ts)) => ts.is_empty() || ts.len() > 1,
+		Some(Kind::Either(ks)) => {
+			let mut concrete = ks.iter().filter(|k| !matches!(k, Kind::None | Kind::Null));
+			match (concrete.next(), concrete.next()) {
+				(Some(only), None) => returns_abstract_record(Some(only)),
+				_ => false,
+			}
+		}
+		_ => false,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn record(tables: &[&str]) -> Kind {
+		Kind::Record(tables.iter().map(|t| (*t).into()).collect())
+	}
+
+	#[test]
+	fn abstract_record_returns_need_a_concrete_type_tag() {
+		// `record` is the interface, `record<a | b>` a union: neither resolves
+		// without `.with_type()`.
+		assert!(returns_abstract_record(Some(&record(&[]))));
+		assert!(returns_abstract_record(Some(&record(&["gadget", "widget"]))));
+		// `option<record>` strips to the same interface reference.
+		assert!(returns_abstract_record(Some(&Kind::Either(vec![Kind::None, record(&[])]))));
+	}
+
+	#[test]
+	fn concrete_and_non_record_returns_do_not() {
+		// A single-target record already resolves to that Object type.
+		assert!(!returns_abstract_record(Some(&record(&["gadget"]))));
+		assert!(!returns_abstract_record(Some(&Kind::Either(vec![
+			Kind::None,
+			record(&["gadget"])
+		]))));
+		assert!(!returns_abstract_record(Some(&Kind::String)));
+		assert!(!returns_abstract_record(None));
+		// A genuine multi-kind Either is its own union of those types; the
+		// record member is not what the field resolves to.
+		assert!(!returns_abstract_record(Some(&Kind::Either(vec![Kind::String, record(&[])]))));
+	}
 }

--- a/surrealdb/core/src/graphql/functions.rs
+++ b/surrealdb/core/src/graphql/functions.rs
@@ -18,7 +18,7 @@ use super::utils::execute_plan;
 use crate::catalog::FunctionDefinition;
 use crate::dbs::Session;
 use crate::expr::{Expr, FunctionCall, Kind, LogicalPlan, TopLevelExpr};
-use crate::graphql::schema::kind_to_type_with_enum_prefix;
+use crate::graphql::schema::{TableTypeNames, kind_to_type_with_enum_prefix};
 use crate::kvs::Datastore;
 use crate::val::Value;
 
@@ -35,6 +35,7 @@ pub async fn process_fns(
 	mut query: Object,
 	types: &mut Vec<Type>,
 	datastore: &Arc<Datastore>,
+	table_types: &TableTypeNames,
 ) -> Result<Object, GraphqlError> {
 	for fnd in fns.iter() {
 		let Some(kind) = &fnd.returns else {
@@ -66,6 +67,7 @@ pub async fn process_fns(
 				types,
 				false,
 				Some(&format!("fn_{}_return", fnd.name)),
+				table_types,
 			)?,
 			move |ctx| {
 				let kvs1 = Arc::clone(&kvs1);
@@ -145,6 +147,7 @@ pub async fn process_fns(
 				types,
 				true,
 				Some(&format!("fn_{}_{}", fnd.name, arg_name)),
+				table_types,
 			)?;
 			field = field.argument(InputValue::new(arg_name, arg_ty))
 		}

--- a/surrealdb/core/src/graphql/functions.rs
+++ b/surrealdb/core/src/graphql/functions.rs
@@ -35,7 +35,7 @@ pub async fn process_fns(
 	mut query: Object,
 	types: &mut Vec<Type>,
 	datastore: &Arc<Datastore>,
-	table_types: &TableTypeNames,
+	table_types: &Arc<TableTypeNames>,
 ) -> Result<Object, GraphqlError> {
 	for fnd in fns.iter() {
 		let Some(kind) = &fnd.returns else {
@@ -51,6 +51,7 @@ pub async fn process_fns(
 		// resolvers in this crate.
 		let kvs1 = Arc::clone(datastore);
 		let fnd1 = fnd.clone();
+		let table_types1 = Arc::clone(table_types);
 		// Decided by the declared return type, which is fixed for the life of
 		// the schema — so it is resolved here rather than on every invocation.
 		let tag_record_type = returns_abstract_record(fnd.returns.as_ref());
@@ -75,6 +76,7 @@ pub async fn process_fns(
 			move |ctx| {
 				let kvs1 = Arc::clone(&kvs1);
 				let fnd1 = fnd1.clone();
+				let table_types1 = Arc::clone(&table_types1);
 				FieldFuture::new(async move {
 					let sess1 = ctx.data::<Arc<Session>>()?;
 					let graphql_args = ctx.args.as_index_map();
@@ -112,10 +114,11 @@ pub async fn process_fns(
 							let field_val = FieldValue::owned_any(rid.clone());
 							// The tag names the table's *generated Object type*,
 							// which follows its `GRAPHQL_ALIAS` rather than its
-							// SurrealQL name (#7453).
+							// SurrealQL name (#7453). The map is fixed for the life
+							// of the schema, so it is captured rather than looked
+							// up in the per-request context.
 							let field_val = if tag_record_type {
-								field_val
-									.with_type(super::tables::graphql_type_of(&ctx, &rid.table))
+								field_val.with_type(table_types1.get(rid.table.as_str()).to_owned())
 							} else {
 								field_val
 							};

--- a/surrealdb/core/src/graphql/mutations.rs
+++ b/surrealdb/core/src/graphql/mutations.rs
@@ -21,7 +21,8 @@ use surrealdb_strand::Strand;
 
 use super::error::{GraphqlError, resolver_error};
 use super::schema::{
-	SchemaContext, graphql_to_sql_kind_with_scope, kind_to_type_with_enum_prefix, unwrap_type,
+	SchemaContext, TableTypeNames, graphql_to_sql_kind_with_scope, kind_to_type_with_enum_prefix,
+	unwrap_type,
 };
 use super::tables::{CachedRecord, cond_from_filter, idiom_to_graphql_name};
 use super::utils::{GraphqlValueUtils, execute_plan};
@@ -72,7 +73,7 @@ fn graphql_input_to_sql_object(
 	input: &IndexMap<Name, GraphqlValue>,
 	fds: &[FieldDefinition],
 	skip_fields: &[&str],
-	tb_name: &str,
+	gql_name: &str,
 ) -> Result<SurObject, GraphqlError> {
 	// Collect into `BTreeMap<Strand, _>` rather than
 	// `BTreeMap<String, _>` so the final `SurObject::from(map)`
@@ -110,7 +111,9 @@ fn graphql_input_to_sql_object(
 			})
 			.unwrap_or_else(|| key_str.to_owned());
 		let kind = matched.and_then(|fd| fd.field_kind.clone()).unwrap_or(Kind::Any);
-		let enum_scope = format!("{tb_name}_{key_str}");
+		// Scope keyed on the table's GraphQL name so it resolves the very enum
+		// the input type was built against, alias included (#7453).
+		let enum_scope = format!("{gql_name}_{key_str}");
 		let sql_val = graphql_to_sql_kind_with_scope(val, kind, Some(&enum_scope))?;
 		map.insert(storage_key.into(), sql_val);
 	}
@@ -126,6 +129,7 @@ fn kind_to_input_type_ref(
 	kind: Kind,
 	types: &mut Vec<Type>,
 	enum_scope: Option<&str>,
+	table_types: &TableTypeNames,
 ) -> Result<TypeRef, GraphqlError> {
 	let optional = kind.can_be_none();
 
@@ -173,7 +177,7 @@ fn kind_to_input_type_ref(
 	}
 
 	// For all other kinds, delegate to the standard kind_to_type with is_input=true
-	kind_to_type_with_enum_prefix(kind, types, true, enum_scope)
+	kind_to_type_with_enum_prefix(kind, types, true, enum_scope, table_types)
 }
 
 /// Generate Create/Update/Upsert input types for a table and return their names.
@@ -182,6 +186,7 @@ fn generate_input_types(
 	fds: &[FieldDefinition],
 	is_relation: bool,
 	types: &mut Vec<Type>,
+	table_types: &TableTypeNames,
 ) -> Result<(String, String, String), GraphqlError> {
 	let cap_name = capitalize_first(tb_name);
 	let create_name = format!("Create{cap_name}Input");
@@ -254,7 +259,8 @@ fn generate_input_types(
 
 		// For create and upsert: use the field's input type (preserving non-null)
 		let enum_scope = format!("{}_{}", tb_name, fd_name);
-		let create_type = kind_to_input_type_ref(kind.clone(), types, Some(&enum_scope))?;
+		let create_type =
+			kind_to_input_type_ref(kind.clone(), types, Some(&enum_scope), table_types)?;
 		let mut create_iv = InputValue::new(&fd_name, create_type.clone());
 		let mut upsert_iv = InputValue::new(&fd_name, create_type);
 		if let Some(ref d) = fd_desc {
@@ -265,8 +271,12 @@ fn generate_input_types(
 		upsert_input = upsert_input.field(upsert_iv);
 
 		// For update: all fields are optional (strip NonNull)
-		let update_type =
-			unwrap_type(kind_to_input_type_ref(kind.clone(), types, Some(&enum_scope))?);
+		let update_type = unwrap_type(kind_to_input_type_ref(
+			kind.clone(),
+			types,
+			Some(&enum_scope),
+			table_types,
+		)?);
 		let mut update_iv = InputValue::new(&fd_name, update_type);
 		if let Some(ref d) = fd_desc {
 			update_iv = update_iv.description(d);
@@ -292,8 +302,14 @@ struct MutationTableContext {
 	/// Pluralised PascalCased base used in bulk mutation field names
 	/// (e.g., "Stores" → `createStores`).
 	cap_plural_name: String,
-	/// The table name as a string (e.g., "person").
+	/// The table name as a string (e.g., "person"). Used in descriptions, which
+	/// name the SurrealQL table rather than the generated GraphQL type.
 	tb_name_str: String,
+	/// The name of the GraphQL Object type generated for this table — the
+	/// table's `GRAPHQL_ALIAS` when it sets one (#7453). Every mutation on this
+	/// table returns it, and every generated type and enum scope is named after
+	/// it.
+	gql_name: Arc<str>,
 	/// The table name.
 	tb_name: TableName,
 	/// Whether the table is a relation table.
@@ -326,6 +342,7 @@ pub async fn process_mutations(
 	tbs: Arc<[TableDefinition]>,
 	types: &mut Vec<Type>,
 	schema_ctx: &SchemaContext<'_>,
+	table_types: &TableTypeNames,
 ) -> Result<Object, GraphqlError> {
 	let mut mutation = Object::new("Mutation");
 
@@ -372,6 +389,10 @@ pub async fn process_mutations(
 
 		let tb_name = tb.name.clone();
 		let tb_name_str = tb_name.as_str().to_string();
+		// Every generated type name derives from the table's GraphQL name, not
+		// its SurrealQL one, so a `GRAPHQL_ALIAS` reaches the input types and
+		// the filter input as well (#7453).
+		let gql_name = super::naming::table_base_name(tb).to_owned();
 		let is_relation = matches!(tb.table_type, TableType::Relation(_));
 
 		let fds = schema_ctx.tx.all_tb_fields(schema_ctx.ns, schema_ctx.db, &tb.name, None).await?;
@@ -379,12 +400,13 @@ pub async fn process_mutations(
 		// Generate input types — fields are camelCased / aliased via the
 		// shared `naming` helpers (see GitHub issues #4537 and #4552).
 		let (create_input_name, update_input_name, upsert_input_name) =
-			generate_input_types(&tb_name_str, &fds, is_relation, types)?;
+			generate_input_types(&gql_name, &fds, is_relation, types, table_types)?;
 		let ctx = MutationTableContext {
 			cap_name: super::naming::mutation_cap_name(tb),
 			cap_plural_name: super::naming::mutation_cap_plural_name(tb),
-			table_filter_name: format!("_filter_{tb_name_str}"),
+			table_filter_name: format!("_filter_{gql_name}"),
 			tb_name_str,
+			gql_name: Arc::from(gql_name.as_str()),
 			tb_name,
 			is_relation,
 			fds,
@@ -416,15 +438,17 @@ fn add_create_field(mutation: Object, tc: &MutationTableContext, input_name: &st
 	let fds = Arc::clone(&tc.fds);
 	let kvs = Arc::clone(&tc.kvs);
 	let tb_name = tc.tb_name.clone();
+	let gql_name = Arc::clone(&tc.gql_name);
 	let is_relation = tc.is_relation;
 	mutation.field(
 		Field::new(
 			format!("create{}", tc.cap_name),
-			TypeRef::named(tc.tb_name_str.as_str()),
+			TypeRef::named(tc.gql_name.as_ref()),
 			move |ctx| {
 				let fds = Arc::clone(&fds);
 				let kvs = Arc::clone(&kvs);
 				let tb_name = tb_name.clone();
+				let gql_name = Arc::clone(&gql_name);
 				FieldFuture::new(async move {
 					let sess = ctx.data::<Arc<Session>>()?;
 					let args = ctx.args.as_index_map();
@@ -432,9 +456,15 @@ fn add_create_field(mutation: Object, tc: &MutationTableContext, input_name: &st
 					let id_opt = data_obj.get("id").and_then(GraphqlValueUtils::as_string);
 
 					if is_relation {
-						execute_relate_create(&kvs, sess, &tb_name, data_obj, &fds, id_opt).await
+						execute_relate_create(
+							&kvs, sess, &tb_name, &gql_name, data_obj, &fds, id_opt,
+						)
+						.await
 					} else {
-						execute_normal_create(&kvs, sess, &tb_name, data_obj, &fds, id_opt).await
+						execute_normal_create(
+							&kvs, sess, &tb_name, &gql_name, data_obj, &fds, id_opt,
+						)
+						.await
 					}
 				})
 			},
@@ -448,14 +478,16 @@ fn add_update_field(mutation: Object, tc: &MutationTableContext, input_name: &st
 	let fds = Arc::clone(&tc.fds);
 	let kvs = Arc::clone(&tc.kvs);
 	let tb_name = tc.tb_name.clone();
+	let gql_name = Arc::clone(&tc.gql_name);
 	mutation.field(
 		Field::new(
 			format!("update{}", tc.cap_name),
-			TypeRef::named(tc.tb_name_str.as_str()),
+			TypeRef::named(tc.gql_name.as_ref()),
 			move |ctx| {
 				let fds = Arc::clone(&fds);
 				let kvs = Arc::clone(&kvs);
 				let tb_name = tb_name.clone();
+				let gql_name = Arc::clone(&gql_name);
 				FieldFuture::new(async move {
 					let sess = ctx.data::<Arc<Session>>()?;
 					let args = ctx.args.as_index_map();
@@ -463,8 +495,7 @@ fn add_update_field(mutation: Object, tc: &MutationTableContext, input_name: &st
 					let data_obj = get_data_object(args)?;
 
 					let rid = parse_record_id(&tb_name, &id_str)?;
-					let content =
-						graphql_input_to_sql_object(data_obj, &fds, &["id"], tb_name.as_str())?;
+					let content = graphql_input_to_sql_object(data_obj, &fds, &["id"], &gql_name)?;
 
 					let data = if content.0.is_empty() {
 						None
@@ -501,14 +532,16 @@ fn add_upsert_field(mutation: Object, tc: &MutationTableContext, input_name: &st
 	let fds = Arc::clone(&tc.fds);
 	let kvs = Arc::clone(&tc.kvs);
 	let tb_name = tc.tb_name.clone();
+	let gql_name = Arc::clone(&tc.gql_name);
 	mutation.field(
 		Field::new(
 			format!("upsert{}", tc.cap_name),
-			TypeRef::named(tc.tb_name_str.as_str()),
+			TypeRef::named(tc.gql_name.as_ref()),
 			move |ctx| {
 				let fds = Arc::clone(&fds);
 				let kvs = Arc::clone(&kvs);
 				let tb_name = tb_name.clone();
+				let gql_name = Arc::clone(&gql_name);
 				FieldFuture::new(async move {
 					let sess = ctx.data::<Arc<Session>>()?;
 					let args = ctx.args.as_index_map();
@@ -516,8 +549,7 @@ fn add_upsert_field(mutation: Object, tc: &MutationTableContext, input_name: &st
 					let data_obj = get_data_object(args)?;
 
 					let rid = parse_record_id(&tb_name, &id_str)?;
-					let content =
-						graphql_input_to_sql_object(data_obj, &fds, &["id"], tb_name.as_str())?;
+					let content = graphql_input_to_sql_object(data_obj, &fds, &["id"], &gql_name)?;
 
 					let data = if content.0.is_empty() {
 						None
@@ -600,15 +632,17 @@ fn add_create_many_field(mutation: Object, tc: &MutationTableContext, input_name
 	let fds = Arc::clone(&tc.fds);
 	let kvs = Arc::clone(&tc.kvs);
 	let tb_name = tc.tb_name.clone();
+	let gql_name = Arc::clone(&tc.gql_name);
 	let is_relation = tc.is_relation;
 	mutation.field(
 		Field::new(
 			format!("create{}", tc.cap_plural_name),
-			TypeRef::named_nn_list_nn(tc.tb_name_str.as_str()),
+			TypeRef::named_nn_list_nn(tc.gql_name.as_ref()),
 			move |ctx| {
 				let fds = Arc::clone(&fds);
 				let kvs = Arc::clone(&kvs);
 				let tb_name = tb_name.clone();
+				let gql_name = Arc::clone(&gql_name);
 				FieldFuture::new(async move {
 					let sess = ctx.data::<Arc<Session>>()?;
 					let args = ctx.args.as_index_map();
@@ -626,11 +660,15 @@ fn add_create_many_field(mutation: Object, tc: &MutationTableContext, input_name
 						let id_opt = data_obj.get("id").and_then(GraphqlValueUtils::as_string);
 
 						let res = if is_relation {
-							execute_relate_create(&kvs, sess, &tb_name, data_obj, &fds, id_opt)
-								.await
+							execute_relate_create(
+								&kvs, sess, &tb_name, &gql_name, data_obj, &fds, id_opt,
+							)
+							.await
 						} else {
-							execute_normal_create(&kvs, sess, &tb_name, data_obj, &fds, id_opt)
-								.await
+							execute_normal_create(
+								&kvs, sess, &tb_name, &gql_name, data_obj, &fds, id_opt,
+							)
+							.await
 						};
 
 						match res? {
@@ -657,28 +695,29 @@ fn add_update_many_field(mutation: Object, tc: &MutationTableContext, input_name
 	let fds = Arc::clone(&tc.fds);
 	let kvs = Arc::clone(&tc.kvs);
 	let tb_name = tc.tb_name.clone();
+	let gql_name = Arc::clone(&tc.gql_name);
 	mutation.field(
 		Field::new(
 			format!("update{}", tc.cap_plural_name),
-			TypeRef::named_nn_list_nn(tc.tb_name_str.as_str()),
+			TypeRef::named_nn_list_nn(tc.gql_name.as_ref()),
 			move |ctx| {
 				let fds = Arc::clone(&fds);
 				let kvs = Arc::clone(&kvs);
 				let tb_name = tb_name.clone();
+				let gql_name = Arc::clone(&gql_name);
 				FieldFuture::new(async move {
 					let sess = ctx.data::<Arc<Session>>()?;
 					let args = ctx.args.as_index_map();
 
 					let data_obj = get_data_object(args)?;
-					let content =
-						graphql_input_to_sql_object(data_obj, &fds, &["id"], tb_name.as_str())?;
+					let content = graphql_input_to_sql_object(data_obj, &fds, &["id"], &gql_name)?;
 					let data = if content.0.is_empty() {
 						None
 					} else {
 						Some(Data::MergeExpression(Value::Object(content).into_literal()))
 					};
 
-					let cond = parse_where_arg(args, &fds, tb_name.as_str())?;
+					let cond = parse_where_arg(args, &fds, &gql_name)?;
 
 					let stmt = UpdateStatement {
 						only: false,
@@ -711,28 +750,29 @@ fn add_upsert_many_field(mutation: Object, tc: &MutationTableContext, input_name
 	let fds = Arc::clone(&tc.fds);
 	let kvs = Arc::clone(&tc.kvs);
 	let tb_name = tc.tb_name.clone();
+	let gql_name = Arc::clone(&tc.gql_name);
 	mutation.field(
 		Field::new(
 			format!("upsert{}", tc.cap_plural_name),
-			TypeRef::named_nn_list_nn(tc.tb_name_str.as_str()),
+			TypeRef::named_nn_list_nn(tc.gql_name.as_ref()),
 			move |ctx| {
 				let fds = Arc::clone(&fds);
 				let kvs = Arc::clone(&kvs);
 				let tb_name = tb_name.clone();
+				let gql_name = Arc::clone(&gql_name);
 				FieldFuture::new(async move {
 					let sess = ctx.data::<Arc<Session>>()?;
 					let args = ctx.args.as_index_map();
 
 					let data_obj = get_data_object(args)?;
-					let content =
-						graphql_input_to_sql_object(data_obj, &fds, &["id"], tb_name.as_str())?;
+					let content = graphql_input_to_sql_object(data_obj, &fds, &["id"], &gql_name)?;
 					let data = if content.0.is_empty() {
 						None
 					} else {
 						Some(Data::ContentExpression(Value::Object(content).into_literal()))
 					};
 
-					let cond = parse_where_arg(args, &fds, tb_name.as_str())?;
+					let cond = parse_where_arg(args, &fds, &gql_name)?;
 
 					let stmt = UpsertStatement {
 						only: false,
@@ -765,6 +805,7 @@ fn add_delete_many_field(mutation: Object, tc: &MutationTableContext) -> Object 
 	let fds = Arc::clone(&tc.fds);
 	let kvs = Arc::clone(&tc.kvs);
 	let tb_name = tc.tb_name.clone();
+	let gql_name = Arc::clone(&tc.gql_name);
 	mutation.field(
 		Field::new(
 			format!("delete{}", tc.cap_plural_name),
@@ -773,11 +814,12 @@ fn add_delete_many_field(mutation: Object, tc: &MutationTableContext) -> Object 
 				let fds = Arc::clone(&fds);
 				let kvs = Arc::clone(&kvs);
 				let tb_name = tb_name.clone();
+				let gql_name = Arc::clone(&gql_name);
 				FieldFuture::new(async move {
 					let sess = ctx.data::<Arc<Session>>()?;
 					let args = ctx.args.as_index_map();
 
-					let cond = parse_where_arg(args, &fds, tb_name.as_str())?;
+					let cond = parse_where_arg(args, &fds, &gql_name)?;
 
 					// Use RETURN BEFORE to count deleted records
 					let stmt = DeleteStatement {
@@ -849,11 +891,12 @@ async fn execute_normal_create(
 	kvs: &Arc<Datastore>,
 	sess: &Arc<Session>,
 	tb_name: &TableName,
+	gql_name: &str,
 	data_obj: &IndexMap<Name, GraphqlValue>,
 	fds: &[FieldDefinition],
 	id_opt: Option<String>,
 ) -> Result<Option<FieldValue<'static>>, async_graphql::Error> {
-	let content = graphql_input_to_sql_object(data_obj, fds, &["id"], tb_name.as_str())?;
+	let content = graphql_input_to_sql_object(data_obj, fds, &["id"], gql_name)?;
 
 	let what = match id_opt {
 		Some(id_str) => {
@@ -890,6 +933,7 @@ async fn execute_relate_create(
 	kvs: &Arc<Datastore>,
 	sess: &Arc<Session>,
 	tb_name: &TableName,
+	gql_name: &str,
 	data_obj: &IndexMap<Name, GraphqlValue>,
 	fds: &[FieldDefinition],
 	id_opt: Option<String>,
@@ -906,8 +950,7 @@ async fn execute_relate_create(
 	let from_rid = parse_full_record_id(&in_str)?;
 	let to_rid = parse_full_record_id(&out_str)?;
 
-	let content =
-		graphql_input_to_sql_object(data_obj, fds, &["id", "in", "out"], tb_name.as_str())?;
+	let content = graphql_input_to_sql_object(data_obj, fds, &["id", "in", "out"], gql_name)?;
 
 	let through = match id_opt {
 		Some(id_str) => {

--- a/surrealdb/core/src/graphql/naming.rs
+++ b/surrealdb/core/src/graphql/naming.rs
@@ -289,4 +289,45 @@ mod tests {
 		assert_eq!(pluralize("orders"), "orders"); // already plural
 		assert_eq!(pluralize(""), "");
 	}
+
+	/// A `DEFINE FIELD price.in_euro …` entry with the given `GRAPHQL_ALIAS`.
+	fn nested_field(alias: Option<&str>) -> FieldDefinition {
+		FieldDefinition {
+			name: Idiom(vec![Part::Field("price".into()), Part::Field("in_euro".into())]),
+			graphql_alias: alias.map(str::to_owned),
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn nested_field_name_prefers_the_alias_then_the_segment() {
+		// A sub-field of a generated nested Object type is addressed by the last
+		// segment of its idiom, so the un-aliased name is `in_euro` — not the
+		// flattened `price_in_euro` that `field_base_name` produces for the same
+		// definition. That difference is the reason both functions exist; if
+		// this assertion ever collapses, one of them is redundant.
+		let plain = nested_field(None);
+		assert_eq!(nested_field_graphql_name(&plain, "in_euro"), "in_euro");
+		assert_eq!(field_base_name(&plain), "price_in_euro");
+
+		let aliased = nested_field(Some("inEuro"));
+		assert_eq!(nested_field_graphql_name(&aliased, "in_euro"), "inEuro");
+	}
+
+	#[test]
+	fn nested_field_name_ignores_an_invalid_alias() {
+		// `DEFINE FIELD … GRAPHQL_ALIAS` rejects anything outside the GraphQL
+		// Name grammar, so this can only come from a catalog entry written
+		// before that validation existed. Degrade to the SurrealQL name rather
+		// than emitting a field GraphQL cannot parse — no language test can
+		// reach this, because the DDL path refuses to store such an alias.
+		for invalid in ["in euro", "1st", "in-euro", ""] {
+			let fd = nested_field(Some(invalid));
+			assert_eq!(
+				nested_field_graphql_name(&fd, "in_euro"),
+				"in_euro",
+				"alias {invalid:?} should have been rejected"
+			);
+		}
+	}
 }

--- a/surrealdb/core/src/graphql/naming.rs
+++ b/surrealdb/core/src/graphql/naming.rs
@@ -127,6 +127,21 @@ pub(crate) fn field_graphql_name(fd: &FieldDefinition) -> String {
 	field_base_name(fd)
 }
 
+/// Field name exposed on a generated *nested* Object type for a sub-field
+/// declared as `parent.child` (or `parent.*.child`).
+///
+/// Such a field is addressed by the last segment of its idiom rather than by
+/// the whole idiom, so it cannot go through [`field_base_name`], whose fallback
+/// flattens the full path (`price.in_euro` → `price_in_euro`). An explicit
+/// `GRAPHQL_ALIAS` still wins, exactly as it does for a top-level field
+/// (#7453); `lookup_name` is the raw segment used otherwise.
+pub(crate) fn nested_field_graphql_name(fd: &FieldDefinition, lookup_name: &str) -> String {
+	match fd.graphql_alias.as_deref() {
+		Some(alias) if is_valid_graphql_identifier(alias) => alias.to_owned(),
+		_ => lookup_name.to_owned(),
+	}
+}
+
 /// Plural query field name — the table list query (e.g. `stores`).
 ///
 /// When `GRAPHQL <alias>` is set on the table the alias is treated as the

--- a/surrealdb/core/src/graphql/schema.rs
+++ b/surrealdb/core/src/graphql/schema.rs
@@ -81,6 +81,11 @@ pub(crate) struct SchemaContext<'a> {
 /// are not exposed through GraphQL are therefore left untouched, producing the
 /// same dangling type reference they did before (async-graphql reports those at
 /// schema-build time).
+///
+/// Built once per schema and shared by `Arc` with the resolvers that need it at
+/// runtime, rather than registered as schema data: it is derived from the same
+/// catalog snapshot the schema was built from and never varies per request, so
+/// a captured handle is both cheaper and impossible to look up wrongly.
 #[derive(Clone, Debug, Default)]
 pub struct TableTypeNames(HashMap<String, String>);
 
@@ -273,14 +278,7 @@ pub async fn generate_schema(
 		None
 	};
 
-	let mut schema = Schema::build("Query", mutation_name, subscription_name)
-		.register(query)
-		// Resolvers that tag a value with its concrete type (`FieldValue::with_type`)
-		// only have the record's raw table name to hand, so they resolve it to the
-		// generated Object type name through this. Schema-level rather than
-		// request-level data: it is derived from the same catalog snapshot the
-		// schema was built from, and is cached alongside it.
-		.data(Arc::clone(&table_types));
+	let mut schema = Schema::build("Query", mutation_name, subscription_name).register(query);
 
 	// Apply depth and complexity limits from the GraphQL config
 	if let Some(depth) = graphql_config.depth_limit {

--- a/surrealdb/core/src/graphql/schema.rs
+++ b/surrealdb/core/src/graphql/schema.rs
@@ -39,7 +39,7 @@ use super::ext::ValidatorExt;
 use crate::catalog::providers::{AuthorisationProvider, DatabaseProvider, TableProvider};
 use crate::catalog::{
 	DatabaseId, FieldDefinition, GraphQLConfig, GraphQLFunctionsConfig, GraphQLIntrospectionConfig,
-	GraphQLTablesConfig, NamespaceId,
+	GraphQLTablesConfig, NamespaceId, TableDefinition,
 };
 use crate::dbs::Session;
 use crate::expr::kind::{GeometryKind, KindLiteral};
@@ -66,6 +66,41 @@ pub(crate) struct SchemaContext<'a> {
 	pub ns: NamespaceId,
 	pub db: DatabaseId,
 	pub datastore: &'a Arc<Datastore>,
+}
+
+/// Maps a raw SurrealQL table name to the name of the GraphQL Object type
+/// generated for it.
+///
+/// The two are identical until `GRAPHQL_ALIAS` is set on the table (#7453), so
+/// every place that turns a *table name* into a *GraphQL type reference* —
+/// `record<foo>` field types, relation traversal targets,
+/// [`FieldValue::with_type`] on a resolved record link — has to resolve it here
+/// rather than using the table name directly.
+///
+/// Only aliased tables are stored; anything else maps to itself. Tables that
+/// are not exposed through GraphQL are therefore left untouched, producing the
+/// same dangling type reference they did before (async-graphql reports those at
+/// schema-build time).
+#[derive(Clone, Debug, Default)]
+pub struct TableTypeNames(HashMap<String, String>);
+
+impl TableTypeNames {
+	/// Build the map from the tables that are being exposed.
+	pub(crate) fn new(tbs: &[TableDefinition]) -> Self {
+		Self(
+			tbs.iter()
+				.filter_map(|tb| {
+					let ty = super::naming::table_base_name(tb);
+					(ty != tb.name.as_str()).then(|| (tb.name.as_str().to_owned(), ty.to_owned()))
+				})
+				.collect(),
+		)
+	}
+
+	/// The GraphQL Object type name generated for `table`.
+	pub fn get<'a>(&'a self, table: &'a str) -> &'a str {
+		self.0.get(table).map_or(table, String::as_str)
+	}
 }
 
 /// Generate a complete GraphQL schema from database metadata.
@@ -162,6 +197,14 @@ pub async fn generate_schema(
 		None => Vec::new(),
 	};
 
+	// Resolved before any type is built: every generated type reference to a
+	// table goes through this, so it has to know about all exposed tables up
+	// front — including ones processed later than the field referring to them.
+	let table_types = Arc::new(match &tbs {
+		Some(tbs) => TableTypeNames::new(tbs),
+		None => TableTypeNames::default(),
+	});
+
 	let schema_ctx = SchemaContext {
 		tx: &tx,
 		ns: db_def.namespace_id,
@@ -182,11 +225,14 @@ pub async fn generate_schema(
 				&schema_ctx,
 				&relations,
 				&mut table_fields,
+				&table_types,
 			)
 			.await?;
 
 			// Generate mutations for all tables
-			mutation_obj = Some(process_mutations(Arc::clone(tbs), &mut types, &schema_ctx).await?);
+			mutation_obj = Some(
+				process_mutations(Arc::clone(tbs), &mut types, &schema_ctx, &table_types).await?,
+			);
 			subscription_obj = process_subscriptions(&tbs[..], &table_fields);
 		}
 		_ => {}
@@ -203,7 +249,7 @@ pub async fn generate_schema(
 	}
 
 	if let Some(fns) = fns {
-		query = process_fns(fns, query, &mut types, datastore).await?;
+		query = process_fns(fns, query, &mut types, datastore, &table_types).await?;
 	}
 
 	// Register all geometry-related types (enum, object types, union, input types)
@@ -227,7 +273,14 @@ pub async fn generate_schema(
 		None
 	};
 
-	let mut schema = Schema::build("Query", mutation_name, subscription_name).register(query);
+	let mut schema = Schema::build("Query", mutation_name, subscription_name)
+		.register(query)
+		// Resolvers that tag a value with its concrete type (`FieldValue::with_type`)
+		// only have the record's raw table name to hand, so they resolve it to the
+		// generated Object type name through this. Schema-level rather than
+		// request-level data: it is derived from the same catalog snapshot the
+		// schema was built from, and is cached alongside it.
+		.data(Arc::clone(&table_types));
 
 	// Apply depth and complexity limits from the GraphQL config
 	if let Some(depth) = graphql_config.depth_limit {
@@ -515,8 +568,9 @@ pub fn kind_to_type(
 	kind: Kind,
 	types: &mut Vec<Type>,
 	is_input: bool,
+	table_types: &TableTypeNames,
 ) -> Result<TypeRef, GraphqlError> {
-	kind_to_type_with_enum_prefix(kind, types, is_input, None)
+	kind_to_type_with_enum_prefix(kind, types, is_input, None, table_types)
 }
 
 /// Maximum allowed depth of nested `array<...>` types in the generated GraphQL
@@ -538,8 +592,9 @@ pub fn kind_to_type_with_enum_prefix(
 	types: &mut Vec<Type>,
 	is_input: bool,
 	enum_scope: Option<&str>,
+	table_types: &TableTypeNames,
 ) -> Result<TypeRef, GraphqlError> {
-	kind_to_type_inner(kind, types, is_input, enum_scope, 0)
+	kind_to_type_inner(kind, types, is_input, enum_scope, table_types, 0)
 }
 
 fn kind_to_type_inner(
@@ -547,6 +602,7 @@ fn kind_to_type_inner(
 	types: &mut Vec<Type>,
 	is_input: bool,
 	enum_scope: Option<&str>,
+	table_types: &TableTypeNames,
 	array_depth: usize,
 ) -> Result<TypeRef, GraphqlError> {
 	let optional = kind.can_be_none();
@@ -567,16 +623,23 @@ fn kind_to_type_inner(
 		Kind::String => TypeRef::named(TypeRef::STRING),
 		Kind::Uuid => TypeRef::named("uuid"),
 		Kind::Table(ref _t) => TypeRef::named(kind.to_sql()),
-		Kind::Record(mut tables) => match tables.len() {
+		Kind::Record(tables) => match tables.len() {
 			0 => TypeRef::named("record"),
-			1 => TypeRef::named(tables.pop().expect("single table in record kind").into_string()),
+			1 => {
+				let table = tables.first().expect("single table in record kind");
+				TypeRef::named(table_types.get(table.as_str()).to_owned())
+			}
 			_ => {
-				let ty_name = tables.join("_or_");
+				// Both the union's own name and its members follow the tables'
+				// GraphQL Object type names, so a `GRAPHQL_ALIAS` shows up here
+				// too rather than resurrecting the raw table name (#7453).
+				let names: Vec<&str> = tables.iter().map(|t| table_types.get(t.as_str())).collect();
+				let ty_name = names.join("_or_");
 
 				let mut tmp_union = Union::new(ty_name.clone())
-					.description(format!("A record which is one of: {}", tables.join(", ")));
-				for n in tables {
-					tmp_union = tmp_union.possible_type(n.into_string());
+					.description(format!("A record which is one of: {}", names.join(", ")));
+				for n in &names {
+					tmp_union = tmp_union.possible_type(*n);
 				}
 
 				types.push(Type::Union(tmp_union));
@@ -636,7 +699,14 @@ fn kind_to_type_inner(
 			// to avoid creating a single-member union.
 			if ks.len() == 1 {
 				let inner = ks.into_iter().next().expect("checked len == 1");
-				let inner_ty = kind_to_type_inner(inner, types, is_input, enum_scope, array_depth)?;
+				let inner_ty = kind_to_type_inner(
+					inner,
+					types,
+					is_input,
+					enum_scope,
+					table_types,
+					array_depth,
+				)?;
 				// Unwrap any NonNull wrapper — the outer optional flag will re-apply
 				// nullability as needed.
 				return Ok(match optional {
@@ -681,7 +751,9 @@ fn kind_to_type_inner(
 
 			let pos_names: Result<Vec<TypeRef>, GraphqlError> = others
 				.into_iter()
-				.map(|k| kind_to_type_inner(k, types, is_input, enum_scope, array_depth))
+				.map(|k| {
+					kind_to_type_inner(k, types, is_input, enum_scope, table_types, array_depth)
+				})
 				.collect();
 			let pos_names: Vec<String> = pos_names?.into_iter().map(|tr| tr.to_string()).collect();
 			let ty_name = pos_names.join("_or_");
@@ -717,6 +789,7 @@ fn kind_to_type_inner(
 					types,
 					is_input,
 					enum_scope,
+					table_types,
 					array_depth + 1,
 				)?))
 			}
@@ -729,6 +802,7 @@ fn kind_to_type_inner(
 				types,
 				is_input,
 				enum_scope,
+				table_types,
 				array_depth,
 			);
 		}

--- a/surrealdb/core/src/graphql/schema.rs
+++ b/surrealdb/core/src/graphql/schema.rs
@@ -1814,4 +1814,48 @@ mod tests {
 		let literal = GraphqlValue::String("19.99dec".to_owned());
 		assert_eq!(graphql_to_sql_kind(&literal, Kind::Decimal).unwrap(), decimal);
 	}
+
+	/// A table definition carrying the given `GRAPHQL_ALIAS`.
+	fn table(name: &str, alias: Option<&str>) -> TableDefinition {
+		let mut tb = TableDefinition::new(
+			crate::catalog::NamespaceId(1),
+			crate::catalog::DatabaseId(1),
+			crate::catalog::TableId(1),
+			name.into(),
+		);
+		tb.graphql_alias = alias.map(str::to_owned);
+		tb
+	}
+
+	#[test]
+	fn table_type_names_resolves_aliases_and_falls_back_to_the_table_name() {
+		let map = TableTypeNames::new(&[table("gadget", Some("Gadget")), table("holder", None)]);
+
+		assert_eq!(map.get("gadget"), "Gadget");
+		// Un-aliased tables resolve to themselves.
+		assert_eq!(map.get("holder"), "holder");
+		// Excluded tables stay untouched.
+		assert_eq!(map.get("never_exposed"), "never_exposed");
+	}
+
+	#[test]
+	fn table_type_names_stores_nothing_without_a_meaningful_alias() {
+		// The map is empty unless an alias actually changes a name.
+		let unaliased = TableTypeNames::new(&[table("widget", None), table("holder", None)]);
+		assert!(unaliased.0.is_empty(), "un-aliased tables must not be stored: {:?}", unaliased.0);
+
+		// An alias equal to the table name changes nothing either.
+		let identity = TableTypeNames::new(&[table("widget", Some("widget"))]);
+		assert!(identity.0.is_empty(), "identity alias must not be stored: {:?}", identity.0);
+
+		// An alias outside the GraphQL Name grammar is ignored by
+		// `table_base_name`, so it must not be stored either. `DEFINE TABLE …
+		// GRAPHQL_ALIAS` rejects these, so only a catalog entry predating that
+		// validation can reach here — which no language test can produce.
+		for invalid in ["My Table", "1st", "kebab-case", ""] {
+			let map = TableTypeNames::new(&[table("widget", Some(invalid))]);
+			assert!(map.0.is_empty(), "alias {invalid:?} should have been rejected");
+			assert_eq!(map.get("widget"), "widget");
+		}
+	}
 }

--- a/surrealdb/core/src/graphql/subscriptions.rs
+++ b/surrealdb/core/src/graphql/subscriptions.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use async_graphql::dynamic::indexmap::IndexMap;
@@ -114,13 +114,13 @@ fn make_table_subscription_field(
 	// name, so a `GRAPHQL_ALIAS` reaches them too (#7453).
 	let gql_name: Arc<str> = Arc::from(super::naming::table_base_name(tb));
 	let table_filter_name = filter_name_from_table(&gql_name);
-	let selectable_fields = selectable_top_level_fields(&fds);
+	let selectable_fields = Arc::new(selectable_top_level_fields(&fds));
 
 	SubscriptionField::new(gql_name.to_string(), TypeRef::named(gql_name.as_ref()), move |ctx| {
 		let tb_name = tb_name.clone();
 		let gql_name = Arc::clone(&gql_name);
 		let fds = Arc::clone(&fds);
-		let selectable_fields = selectable_fields.clone();
+		let selectable_fields = Arc::clone(&selectable_fields);
 		SubscriptionFieldFuture::new(async move {
 			let ds = ctx.data::<Arc<Datastore>>()?;
 			let sess = ctx.data::<Arc<Session>>()?;
@@ -164,15 +164,26 @@ fn make_table_subscription_field(
 	.argument(InputValue::new("fetch", TypeRef::named_nn_list(TypeRef::STRING)))
 }
 
-fn selectable_top_level_fields(fds: &[FieldDefinition]) -> HashSet<String> {
-	let mut out = HashSet::new();
-	out.insert("id".to_string());
+/// The top-level fields a subscription can project, keyed by the name they are
+/// selected under in GraphQL and valued by the SurrealQL field the LIVE query
+/// has to read.
+///
+/// The two diverge as soon as a field carries a `GRAPHQL_ALIAS` (#7453), so the
+/// mapping has to be built here rather than reconstructed from the selection
+/// set. Only single-part idioms are projectable: a nested `parent.child` field
+/// is reached by projecting `parent` whole.
+fn selectable_top_level_fields(fds: &[FieldDefinition]) -> HashMap<String, String> {
+	// Vec<(String, String)> with a linear scan would likely be slightly faster
+	// for under ~50 fields. Opting for code clarity over an unknown performance
+	// benefit with this cold code.
+	let mut out = HashMap::new();
+	out.insert("id".to_string(), "id".to_string());
 	for fd in fds {
 		if fd.name.0.len() != 1 {
 			continue;
 		}
 		if let Some(Part::Field(name)) = fd.name.0.first() {
-			out.insert(name.as_str().to_owned());
+			out.insert(super::naming::field_graphql_name(fd), name.as_str().to_owned());
 		}
 	}
 	out
@@ -180,23 +191,10 @@ fn selectable_top_level_fields(fds: &[FieldDefinition]) -> HashSet<String> {
 
 fn projected_live_fields(
 	ctx: &async_graphql::dynamic::ResolverContext<'_>,
-	selectable_fields: &HashSet<String>,
+	selectable_fields: &HashMap<String, String>,
 ) -> LiveFields {
-	let mut selected = Vec::new();
-	for field in ctx.field().selection_set() {
-		let name = field.name();
-		if name.starts_with("__") {
-			continue;
-		}
-		if selectable_fields.contains(name) {
-			selected.push(name.to_string());
-		}
-	}
-	if !selected.iter().any(|x| x == "id") {
-		selected.push("id".to_string());
-	}
-	selected.sort_unstable();
-	selected.dedup();
+	let selected =
+		projected_storage_names(ctx.field().selection_set().map(|f| f.name()), selectable_fields);
 	let projected = selected
 		.into_iter()
 		.map(|name| {
@@ -207,6 +205,31 @@ fn projected_live_fields(
 		})
 		.collect();
 	LiveFields::Select(Fields::Select(projected))
+}
+
+/// Translate a subscription's selection set into the sorted list of SurrealQL
+/// field names its LIVE query should project.
+///
+/// Selections carry *GraphQL* names, so an aliased field has to be mapped back
+/// to its storage name before it reaches the projection — otherwise the value
+/// is never fetched and the cached notification resolves it as missing (#7453).
+/// Names that are not stored columns (introspection, relation fields, which
+/// resolve by their own queries) are dropped, and `id` is always projected
+/// because the notification payload is keyed by it.
+fn projected_storage_names<'a>(
+	selection: impl Iterator<Item = &'a str>,
+	selectable_fields: &HashMap<String, String>,
+) -> Vec<String> {
+	let mut selected: Vec<String> = selection
+		.filter(|name| !name.starts_with("__"))
+		.filter_map(|name| selectable_fields.get(name).cloned())
+		.collect();
+	if !selected.iter().any(|x| x == "id") {
+		selected.push("id".to_string());
+	}
+	selected.sort_unstable();
+	selected.dedup();
+	selected
 }
 
 fn parse_subscription_cond(
@@ -412,5 +435,64 @@ impl Drop for LiveQueryCleanup {
 				trace!(?err, ?live_id, "failed to cleanup GraphQL live query");
 			}
 		});
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// A `DEFINE FIELD <name> ON <tb> …` entry with the given `GRAPHQL_ALIAS`.
+	fn field(name: &str, alias: Option<&str>) -> FieldDefinition {
+		FieldDefinition {
+			name: Idiom(vec![Part::Field(name.into())]),
+			graphql_alias: alias.map(str::to_owned),
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn selectable_fields_are_keyed_by_the_graphql_name() {
+		let map = selectable_top_level_fields(&[
+			field("created_at", Some("createdAt")),
+			field("label", None),
+			// A nested sub-field is not projectable on its own; its parent is.
+			FieldDefinition {
+				name: Idiom(vec![Part::Field("price".into()), Part::Field("in_euro".into())]),
+				..Default::default()
+			},
+		]);
+		assert_eq!(map.get("createdAt").map(String::as_str), Some("created_at"));
+		assert_eq!(map.get("label").map(String::as_str), Some("label"));
+		assert_eq!(map.get("id").map(String::as_str), Some("id"));
+		// The raw name of an aliased field is not selectable — the generated
+		// Object type does not expose it under that name either.
+		assert!(!map.contains_key("created_at"));
+		assert!(!map.contains_key("in_euro"));
+	}
+
+	#[test]
+	fn an_aliased_selection_projects_its_storage_name() {
+		let map = selectable_top_level_fields(&[field("created_at", Some("createdAt"))]);
+		// Selecting `createdAt` has to reach `created_at` in the LIVE query, or
+		// the notification never carries the value the resolver looks up.
+		assert_eq!(
+			projected_storage_names(["createdAt"].into_iter(), &map),
+			vec!["created_at".to_string(), "id".to_string()]
+		);
+	}
+
+	#[test]
+	fn id_is_always_projected_and_unknown_names_are_dropped() {
+		let map = selectable_top_level_fields(&[field("label", None)]);
+		assert_eq!(
+			projected_storage_names(["__typename", "label", "uses_in", "label"].into_iter(), &map),
+			vec!["id".to_string(), "label".to_string()]
+		);
+		// An explicit `id` selection must not be projected twice.
+		assert_eq!(
+			projected_storage_names(["id", "label"].into_iter(), &map),
+			vec!["id".to_string(), "label".to_string()]
+		);
 	}
 }

--- a/surrealdb/core/src/graphql/subscriptions.rs
+++ b/surrealdb/core/src/graphql/subscriptions.rs
@@ -110,12 +110,15 @@ fn make_table_subscription_field(
 	fds: Arc<[FieldDefinition]>,
 ) -> SubscriptionField {
 	let tb_name = tb.name.clone();
-	let tb_name_str = tb_name.as_str().to_string();
-	let table_filter_name = filter_name_from_table(&tb_name);
+	// The subscription field and its payload type follow the table's GraphQL
+	// name, so a `GRAPHQL_ALIAS` reaches them too (#7453).
+	let gql_name: Arc<str> = Arc::from(super::naming::table_base_name(tb));
+	let table_filter_name = filter_name_from_table(&gql_name);
 	let selectable_fields = selectable_top_level_fields(&fds);
 
-	SubscriptionField::new(tb_name_str.clone(), TypeRef::named(&tb_name_str), move |ctx| {
+	SubscriptionField::new(gql_name.to_string(), TypeRef::named(gql_name.as_ref()), move |ctx| {
 		let tb_name = tb_name.clone();
+		let gql_name = Arc::clone(&gql_name);
 		let fds = Arc::clone(&fds);
 		let selectable_fields = selectable_fields.clone();
 		SubscriptionFieldFuture::new(async move {
@@ -130,7 +133,7 @@ fn make_table_subscription_field(
 
 			let live_sess = sess.as_ref().clone().with_rt(true);
 			let fields = projected_live_fields(&ctx, &selectable_fields);
-			let cond = parse_subscription_cond(args, &fds, &tb_name)?;
+			let cond = parse_subscription_cond(args, &fds, &tb_name, &gql_name)?;
 			let fetch = parse_fetch_arg(args)?;
 			let live_id =
 				start_table_live_query(ds, &live_sess, &tb_name, fields, cond, fetch).await?;
@@ -210,9 +213,12 @@ fn parse_subscription_cond(
 	args: &IndexMap<Name, GraphqlValue>,
 	fds: &[FieldDefinition],
 	tb_name: &TableName,
+	gql_name: &str,
 ) -> Result<Option<Cond>, async_graphql::Error> {
 	let id_cond = parse_id_cond(args, tb_name)?;
-	let where_cond = parse_filter_arg(args, fds, tb_name.as_str(), &[])
+	// The `where` argument is typed by `_filter_<gql_name>`, so its enum scope
+	// has to be the table's GraphQL name rather than the SurrealQL one (#7453).
+	let where_cond = parse_filter_arg(args, fds, gql_name, &[])
 		.map_err(|e| async_graphql::Error::new(e.to_string()))?;
 	Ok(combine_cond(id_cond, where_cond))
 }

--- a/surrealdb/core/src/graphql/tables.rs
+++ b/surrealdb/core/src/graphql/tables.rs
@@ -84,8 +84,8 @@ use crate::expr::{
 };
 use crate::graphql::error::internal_error;
 use crate::graphql::schema::{
-	filter_type_name, geometry_graphql_type_name, kind_to_type, kind_to_type_with_enum_prefix,
-	unwrap_type,
+	TableTypeNames, filter_type_name, geometry_graphql_type_name, kind_to_type,
+	kind_to_type_with_enum_prefix, unwrap_type,
 };
 use crate::graphql::utils::{GraphqlValueUtils, execute_plan};
 use crate::kvs::Datastore;
@@ -453,8 +453,13 @@ async fn execute_select(
 
 /// Information about a sub-field of a nested object type.
 struct NestedSubField {
-	/// The GraphQL field name (e.g., "createdAt").
+	/// The GraphQL field name — the `GRAPHQL_ALIAS` when one is set, otherwise
+	/// the same as [`lookup_name`](Self::lookup_name).
 	name: String,
+	/// The key this sub-field is stored under inside the parent `SurObject`,
+	/// i.e. the last segment of the SurrealQL idiom (e.g. `in_euro`). Differs
+	/// from [`name`](Self::name) whenever the field is aliased.
+	lookup_name: String,
 	/// The field's SurrealDB kind, if defined.
 	kind: Option<Kind>,
 	/// Optional comment from the field definition.
@@ -526,7 +531,8 @@ fn detect_nested_objects(
 		parent_has_wildcard.entry(parent_name.clone()).or_insert(has_wildcard);
 
 		children_by_parent.entry(parent_name.clone()).or_default().push(NestedSubField {
-			name: child_name,
+			name: super::naming::nested_field_graphql_name(fd, &child_name),
+			lookup_name: child_name,
 			kind: fd.field_kind.clone(),
 			comment: fd.comment.clone(),
 		});
@@ -609,10 +615,14 @@ fn detect_nested_objects(
 			None => continue,
 		};
 
+		// Literal-object shapes are declared inline on the parent field's type,
+		// so there is no per-sub-field `DEFINE FIELD` to carry a
+		// `GRAPHQL_ALIAS`; the GraphQL name is always the raw key.
 		let sub_fields: Vec<NestedSubField> = literal_map
 			.iter()
 			.map(|(k, v)| NestedSubField {
 				name: k.as_str().to_owned(),
+				lookup_name: k.as_str().to_owned(),
 				kind: Some(v.clone()),
 				comment: None,
 			})
@@ -677,6 +687,7 @@ fn make_nested_object_type(
 	type_name: &str,
 	sub_fields: &[NestedSubField],
 	types: &mut Vec<Type>,
+	table_types: &TableTypeNames,
 ) -> Result<Object, GraphqlError> {
 	let mut obj = Object::new(type_name);
 
@@ -685,8 +696,16 @@ fn make_nested_object_type(
 			continue;
 		};
 		let enum_scope = format!("{type_name}_{}", sf.name);
-		let fd_type = kind_to_type_with_enum_prefix(kind.clone(), types, false, Some(&enum_scope))?;
-		let resolver = make_sub_field_resolver(sf.name.clone(), sf.kind.clone(), Some(enum_scope));
+		let fd_type = kind_to_type_with_enum_prefix(
+			kind.clone(),
+			types,
+			false,
+			Some(&enum_scope),
+			table_types,
+		)?;
+		// The resolver keys off the storage name, which an alias does not change.
+		let resolver =
+			make_sub_field_resolver(sf.lookup_name.clone(), sf.kind.clone(), Some(enum_scope));
 		let mut field = Field::new(&sf.name, fd_type, resolver);
 		if let Some(ref comment) = sf.comment {
 			field = field.description(comment.clone());
@@ -724,7 +743,7 @@ fn make_sub_field_resolver(
 						});
 						let field_val = match field_kind {
 							Some(Kind::Record(ref ts)) if ts.is_empty() || ts.len() > 1 => {
-								field_val.with_type(rid.table.clone())
+								field_val.with_type(graphql_type_of(&ctx, &rid.table))
 							}
 							_ => field_val,
 						};
@@ -836,6 +855,18 @@ pub(crate) fn filter_name_from_table(tb_name: impl Display) -> String {
 	format!("_filter_{tb_name}")
 }
 
+/// Resolve a record's table to the GraphQL Object type generated for it.
+///
+/// Used by resolvers that tag a value with its concrete type for interface or
+/// union resolution: they only have the record ID to hand, and the type name
+/// follows the table's `GRAPHQL_ALIAS` when it sets one (#7453). Falls back to
+/// the raw table name if the map is missing, which is what the type name was
+/// before aliases reached it.
+fn graphql_type_of(ctx: &ResolverContext<'_>, table: &TableName) -> String {
+	ctx.data::<Arc<TableTypeNames>>()
+		.map_or_else(|_| table.as_str().to_owned(), |m| m.get(table.as_str()).to_owned())
+}
+
 // ---------------------------------------------------------------------------
 // Result conversion helpers
 // ---------------------------------------------------------------------------
@@ -895,16 +926,19 @@ fn make_table_list_field(
 	kvs: Arc<Datastore>,
 ) -> Field {
 	let tb_name = tb.name.clone();
-	let tb_name_str = tb_name.as_str().to_string();
-	let table_order_name = format!("_order_{tb_name}");
-	let table_filter_name = filter_name_from_table(&tb_name);
+	// GraphQL-facing base name for every type and scope generated from this
+	// table (#7453). Distinct from `tb_name`, which stays the SurrealQL table
+	// the query actually runs against.
+	let gql_name: Arc<str> = Arc::from(super::naming::table_base_name(tb));
+	let table_order_name = format!("_order_{gql_name}");
+	let table_filter_name = filter_name_from_table(&gql_name);
 	// Apply the naming convention (#4552) plus any explicit
-	// `GRAPHQL <ident>` alias (#4537). The underlying Object type stays as
-	// the source table name so cross-table `record<T>` references remain valid.
+	// `GRAPHQL <ident>` alias (#4537).
 	let field_name = super::naming::list_field_name(tb);
 
-	Field::new(field_name, TypeRef::named_nn_list_nn(&tb_name_str), move |ctx| {
+	Field::new(field_name, TypeRef::named_nn_list_nn(gql_name.as_ref()), move |ctx| {
 		let tb_name = tb_name.clone();
+		let gql_name = Arc::clone(&gql_name);
 		let fds = Arc::clone(&fds);
 		let rel_filters = Arc::clone(&rel_filters);
 		let kvs = Arc::clone(&kvs);
@@ -917,8 +951,7 @@ fn make_table_list_field(
 			let limit = parse_limit_arg(args);
 			let version = parse_version_arg(args)?;
 			let order = parse_order_arg(args, &fds)?;
-			let tb_name_str_ref = tb_name.as_str();
-			let cond = parse_filter_arg(args, &fds, tb_name_str_ref, &rel_filters)?;
+			let cond = parse_filter_arg(args, &fds, &gql_name, &rel_filters)?;
 
 			trace!("parsed order: {order:?}");
 			trace!("parsed filter: {cond:?}");
@@ -959,10 +992,10 @@ fn make_table_list_field(
 /// or `null` if the record does not exist.
 fn make_table_get_field(tb: &TableDefinition, kvs: Arc<Datastore>) -> Field {
 	let tb_name = tb.name.clone();
-	let tb_name_str = tb_name.as_str().to_string();
+	let gql_name = super::naming::table_base_name(tb).to_owned();
 
 	let field_name = super::naming::get_field_name(tb);
-	Field::new(field_name, TypeRef::named(&tb_name_str), move |ctx| {
+	Field::new(field_name, TypeRef::named(gql_name), move |ctx| {
 		let tb_name = tb_name.clone();
 		let kvs = Arc::clone(&kvs);
 		FieldFuture::new(async move {
@@ -1056,14 +1089,14 @@ fn make_generic_get_field(kvs: Arc<Datastore>) -> Field {
 						Some(Value::RecordId(rid)) => rid.clone(),
 						_ => return Ok(None),
 					};
-					let table_name = rid.table.clone();
+					let type_name = graphql_type_of(&ctx, &rid.table);
 					Ok(Some(
 						FieldValue::owned_any(CachedRecord {
 							rid,
 							version,
 							data: obj,
 						})
-						.with_type(table_name),
+						.with_type(type_name),
 					))
 				}
 				_ => Ok(None),
@@ -1110,15 +1143,21 @@ fn build_table_type(
 	exposed_table_names: &HashSet<TableName>,
 	relation_table_fds: &HashMap<TableName, Arc<[FieldDefinition]>>,
 	types: &mut Vec<Type>,
+	table_types: &TableTypeNames,
 ) -> Result<TableGraphQLTypes, GraphqlError> {
 	let tb_name = &tb.name;
 	let tb_name_str = tb_name.as_str().to_string();
+	// Base name for every GraphQL type and enum scope generated below — the
+	// `GRAPHQL_ALIAS` when the table sets one, else the table name (#7453).
+	// `tb_name` / `tb_name_str` stay the raw SurrealQL name and are only used
+	// to address the table itself.
+	let gql_name = super::naming::table_base_name(tb).to_owned();
 
 	// --- Create initial types ---
 
-	let table_orderable_name = format!("_orderable_{tb_name}");
-	let table_order_name = format!("_order_{tb_name}");
-	let table_filter_name = filter_name_from_table(tb_name);
+	let table_orderable_name = format!("_orderable_{gql_name}");
+	let table_order_name = format!("_order_{gql_name}");
+	let table_filter_name = filter_name_from_table(&gql_name);
 
 	let mut orderable = Enum::new(&table_orderable_name).item("id").description(format!(
 		"Generated from `{tb_name}` the fields which a query can be ordered by"
@@ -1139,7 +1178,7 @@ fn build_table_type(
 	// `_filter_id` is registered once globally in `register_filter_helper_types`,
 	// not per-table — it's the same shape for every table.
 
-	let mut ty_obj = Object::new(&tb_name_str)
+	let mut ty_obj = Object::new(&gql_name)
 		.field(Field::new(
 			"id",
 			TypeRef::named_nn(TypeRef::ID),
@@ -1152,7 +1191,7 @@ fn build_table_type(
 
 	// --- Process field definitions ---
 
-	let nested_objects = detect_nested_objects(&tb_name_str, fds);
+	let nested_objects = detect_nested_objects(&gql_name, fds);
 
 	for fd in fds.iter() {
 		let Some(ref kind) = fd.field_kind else {
@@ -1179,8 +1218,12 @@ fn build_table_type(
 		// alias, so two columns aliased the same way would conflict — that's
 		// caught at schema build time by async-graphql.
 		if let Some(nested) = nested_objects.get(lookup_name.as_str()) {
-			let nested_type =
-				make_nested_object_type(&nested.graphql_type_name, &nested.sub_fields, types)?;
+			let nested_type = make_nested_object_type(
+				&nested.graphql_type_name,
+				&nested.sub_fields,
+				types,
+				table_types,
+			)?;
 			types.push(Type::Object(nested_type));
 
 			let fd_type = if nested.is_array {
@@ -1212,8 +1255,14 @@ fn build_table_type(
 		}
 
 		// Handle regular fields
-		let enum_scope = format!("{}_{}", tb_name_str, fd_name);
-		let fd_type = kind_to_type_with_enum_prefix(kind.clone(), types, false, Some(&enum_scope))?;
+		let enum_scope = format!("{gql_name}_{fd_name}");
+		let fd_type = kind_to_type_with_enum_prefix(
+			kind.clone(),
+			types,
+			false,
+			Some(&enum_scope),
+			table_types,
+		)?;
 		orderable = orderable.item(fd_name.to_string());
 
 		let type_filter_name = format!("_filter_{}", filter_type_name(&fd_type));
@@ -1227,6 +1276,7 @@ fn build_table_type(
 				type_filter_name.clone(),
 				types,
 				Some(&enum_scope),
+				table_types,
 			)?);
 			trace!("\n{type_filter:?}\n");
 			types.push(type_filter);
@@ -1255,9 +1305,10 @@ fn build_table_type(
 		if !exposed_table_names.contains(&rel.table_name) {
 			continue;
 		}
-		// Only allocate the `String` form once we know we'll use
-		// it for the GraphQL field/type names below.
-		let rel_table_str = rel.table_name.as_str().to_owned();
+		// The relation table's own GraphQL name — its `GRAPHQL_ALIAS` when it
+		// sets one (#7453). Names both the traversal field added here and the
+		// Object type the field resolves to.
+		let rel_table_str = table_types.get(rel.table_name.as_str()).to_owned();
 
 		let rel_fds = relation_table_fds.get(&rel.table_name).cloned();
 
@@ -1274,7 +1325,7 @@ fn build_table_type(
 					rel_fds.clone(),
 				));
 				let rel_filter_name =
-					register_relation_filter(&tb_name_str, &field_name, "out", types);
+					register_relation_filter(&gql_name, &field_name, "out", types);
 				filter = filter
 					.field(InputValue::new(field_name.clone(), TypeRef::named(rel_filter_name)));
 				rel_filters.push(RelationFieldInfo {
@@ -1303,8 +1354,7 @@ fn build_table_type(
 					RelationDirection::Incoming,
 					rel_fds.clone(),
 				));
-				let rel_filter_name =
-					register_relation_filter(&tb_name_str, &field_name, "in", types);
+				let rel_filter_name = register_relation_filter(&gql_name, &field_name, "in", types);
 				filter = filter
 					.field(InputValue::new(field_name.clone(), TypeRef::named(rel_filter_name)));
 				rel_filters.push(RelationFieldInfo {
@@ -1368,6 +1418,7 @@ pub async fn process_tbs(
 	ctx: &SchemaContext<'_>,
 	relations: &[RelationInfo],
 	table_fields: &mut HashMap<TableName, Arc<[FieldDefinition]>>,
+	table_types: &TableTypeNames,
 ) -> Result<Object, GraphqlError> {
 	// Pre-fetch field definitions for relation tables (needed for filter support
 	// in relation field resolvers). These are captured by the resolver closures.
@@ -1432,7 +1483,9 @@ pub async fn process_tbs(
 			let list = super::naming::list_field_name(tb);
 			let get = super::naming::get_field_name(tb);
 			let conn_field = format!("{list}Connection");
-			let aggregate = format!("{}_aggregate", tb.name.as_str());
+			// Matches `make_table_aggregate_field`, which prefixes the aggregate
+			// field with the list-field name rather than the raw table name.
+			let aggregate = aggregate_field_name(&list);
 			for name in [list, get, conn_field, aggregate] {
 				if let Some(prior) = seen.get(&name) {
 					let prior_desc = if prior == BUILTIN {
@@ -1453,10 +1506,10 @@ pub async fn process_tbs(
 			// two tables both produces `FooConnection` / `FooEdge`. The
 			// table's own Object type also collides if aliased to a built-in
 			// like `PageInfo`.
-			// The table's own Object type uses the raw table name (see
-			// `Object::new(&tb_name_str)` in `build_table_type`), so the
-			// collision surface for the Object name is the raw `tb.name`.
-			let tb_ty = tb.name.as_str().to_owned();
+			// The Object type is named after the table's GraphQL name (see
+			// `Object::new(&gql_name)` in `build_table_type`), so that — not the
+			// raw `tb.name` — is the collision surface (#7453).
+			let tb_ty = super::naming::table_base_name(tb).to_owned();
 			let conn_ty = connection_type_name(tb);
 			let edge_ty = edge_type_name(tb);
 			for ty_name in [tb_ty, conn_ty, edge_ty] {
@@ -1492,6 +1545,7 @@ pub async fn process_tbs(
 			&exposed_table_names,
 			&relation_table_fds,
 			types,
+			table_types,
 		)?;
 		let rel_filters: Arc<[RelationFieldInfo]> = tt.rel_filters.into();
 		types.push(Type::Object(tt.ty_obj));
@@ -1511,7 +1565,8 @@ pub async fn process_tbs(
 		// Aggregation query field — `<table_plural>_aggregate` returns
 		// `[{Table}AggregateRow!]!` with count + per-numeric-field stats and
 		// optional groupBy.  See `register_filter_helper_types` / Stage E.
-		let (agg_obj, agg_enum) = build_aggregate_type(tb.name.as_str(), &fds, types);
+		let (agg_obj, agg_enum) =
+			build_aggregate_type(super::naming::table_base_name(tb), &fds, types, table_types);
 		types.push(Type::Object(agg_obj));
 		types.push(Type::Enum(agg_enum));
 		query = query.field(make_table_aggregate_field(
@@ -1645,7 +1700,7 @@ async fn resolve_field_value(
 					});
 					let field_val = match field_kind {
 						Some(Kind::Record(ts)) if ts.is_empty() || ts.len() > 1 => {
-							field_val.with_type(target_rid.table)
+							field_val.with_type(graphql_type_of(ctx, &target_rid.table))
 						}
 						_ => field_val,
 					};
@@ -1852,6 +1907,7 @@ fn filter_from_type(
 	filter_name: String,
 	types: &mut Vec<Type>,
 	enum_scope: Option<&str>,
+	table_types: &TableTypeNames,
 ) -> Result<InputObject, GraphqlError> {
 	// Normalise `option<record<T>>` (Kind::Either([None, Record([T])])) down to the
 	// inner record kind so filters are generated correctly with ID-based filtering.
@@ -1877,7 +1933,8 @@ fn filter_from_type(
 		Kind::Record(ts) => match ts.len() {
 			1 => (
 				TypeRef::named(filter_name_from_table(
-					ts.first().expect("ts should have exactly one element").as_str(),
+					table_types
+						.get(ts.first().expect("ts should have exactly one element").as_str()),
 				)),
 				true,
 			),
@@ -1887,9 +1944,16 @@ fn filter_from_type(
 		Kind::Array(inner, _) if matches!(**inner, Kind::Record(_)) => {
 			(TypeRef::named(TypeRef::ID), false)
 		}
-		k => {
-			(unwrap_type(kind_to_type_with_enum_prefix(k.clone(), types, true, enum_scope)?), true)
-		}
+		k => (
+			unwrap_type(kind_to_type_with_enum_prefix(
+				k.clone(),
+				types,
+				true,
+				enum_scope,
+				table_types,
+			)?),
+			true,
+		),
 	};
 
 	let mut filter = InputObject::new(filter_name);
@@ -2962,6 +3026,7 @@ fn build_aggregate_type(
 	tb_name: &str,
 	fds: &[FieldDefinition],
 	types: &mut Vec<Type>,
+	table_types: &TableTypeNames,
 ) -> (Object, Enum) {
 	let obj_name = aggregate_object_type_name(tb_name);
 	let mut obj = Object::new(&obj_name)
@@ -2989,7 +3054,7 @@ fn build_aggregate_type(
 		let kind = fd.field_kind.clone().unwrap_or(Kind::Any);
 		if is_numeric_kind(&kind) {
 			let inner = numeric_kind(&kind);
-			let ty_min_max = match kind_to_type(inner.clone(), types, false) {
+			let ty_min_max = match kind_to_type(inner.clone(), types, false, table_types) {
 				Ok(t) => unwrap_type(t),
 				Err(_) => TypeRef::named("number"),
 			};
@@ -3025,6 +3090,7 @@ fn build_aggregate_type(
 				types,
 				false,
 				Some(&format!("{tb_name}_{fname}")),
+				table_types,
 			) {
 				Ok(t) => unwrap_type(t),
 				Err(_) => TypeRef::named("any"),
@@ -3072,10 +3138,10 @@ fn make_table_aggregate_field(
 	kvs: Arc<Datastore>,
 ) -> Field {
 	let tb_name = tb.name.clone();
-	let tb_name_str = tb_name.as_str().to_string();
-	let table_filter_name = filter_name_from_table(&tb_name);
-	let aggregate_row_name = aggregate_object_type_name(&tb_name_str);
-	let groupable_enum_name = aggregate_groupable_enum_name(&tb_name_str);
+	let gql_name: Arc<str> = Arc::from(super::naming::table_base_name(tb));
+	let table_filter_name = filter_name_from_table(&gql_name);
+	let aggregate_row_name = aggregate_object_type_name(&gql_name);
+	let groupable_enum_name = aggregate_groupable_enum_name(&gql_name);
 	// The aggregate Query field uses the active list-field name as its prefix
 	// so it pluralises in Apollo mode and honours any explicit alias.
 	let field_name = aggregate_field_name(&super::naming::list_field_name(tb));
@@ -3088,6 +3154,7 @@ fn make_table_aggregate_field(
 
 	Field::new(field_name, TypeRef::named_nn_list_nn(&aggregate_row_name), move |ctx| {
 		let tb_name = tb_name.clone();
+		let gql_name = Arc::clone(&gql_name);
 		let fds = Arc::clone(&fds);
 		let rel_filters = Arc::clone(&rel_filters);
 		let kvs = Arc::clone(&kvs);
@@ -3096,8 +3163,7 @@ fn make_table_aggregate_field(
 			let sess = ctx.data::<Arc<Session>>()?;
 			let args = ctx.args.as_index_map();
 
-			let tb_name_str_ref = tb_name.as_str();
-			let cond = parse_filter_arg(args, &fds, tb_name_str_ref, &rel_filters)?;
+			let cond = parse_filter_arg(args, &fds, &gql_name, &rel_filters)?;
 
 			// Parse groupBy: list of enum tokens identifying groupable fields.
 			let mut group_keys: Vec<String> = Vec::new();
@@ -3204,7 +3270,8 @@ fn make_table_aggregate_field(
 		})
 	})
 	.description(format!(
-		"Aggregation query over `{tb_name_str}`. Returns `count` plus per-numeric-field `min/max/sum/avg`. Group rows by one or more non-numeric fields via the `groupBy` argument."
+		"Aggregation query over `{}`. Returns `count` plus per-numeric-field `min/max/sum/avg`. Group rows by one or more non-numeric fields via the `groupBy` argument.",
+		tb.name
 	))
 	.argument(InputValue::new("filter", TypeRef::named(&table_filter_name)))
 	.argument(InputValue::new("groupBy", TypeRef::named_list(&groupable_enum_name)))
@@ -3236,7 +3303,7 @@ fn build_connection_types(tb: &TableDefinition, types: &mut Vec<Type>) {
 	let tb_name_str = tb.name.as_str().to_string();
 	let connection_name = connection_type_name(tb);
 	let edge_name = edge_type_name(tb);
-	let node_type = tb_name_str.clone();
+	let node_type = super::naming::table_base_name(tb).to_owned();
 
 	// <Table>Edge { cursor: String!, node: <table>! }
 	let edge_obj = Object::new(&edge_name)
@@ -3409,12 +3476,14 @@ fn make_table_connection_field(
 ) -> Field {
 	let tb_name = tb.name.clone();
 	let tb_name_str = tb_name.as_str().to_string();
+	let gql_name: Arc<str> = Arc::from(super::naming::table_base_name(tb));
 	let connection_name = connection_type_name(tb);
-	let table_filter_name = filter_name_from_table(&tb_name);
+	let table_filter_name = filter_name_from_table(&gql_name);
 	let field_name = format!("{}Connection", super::naming::list_field_name(tb));
 
 	Field::new(field_name, TypeRef::named_nn(connection_name), move |ctx| {
 		let tb_name = tb_name.clone();
+		let gql_name = Arc::clone(&gql_name);
 		let fds = Arc::clone(&fds);
 		let rel_filters = Arc::clone(&rel_filters);
 		let kvs = Arc::clone(&kvs);
@@ -3422,7 +3491,7 @@ fn make_table_connection_field(
 			let sess = ctx.data::<Arc<Session>>()?;
 			let args = ctx.args.as_index_map();
 			let version = parse_version_arg(args)?;
-			let mut cond = parse_filter_arg(args, &fds, tb_name.as_str(), &rel_filters)?;
+			let mut cond = parse_filter_arg(args, &fds, &gql_name, &rel_filters)?;
 
 			let first = args.get("first").and_then(|v| v.as_i64());
 			let last = args.get("last").and_then(|v| v.as_i64());

--- a/surrealdb/core/src/graphql/tables.rs
+++ b/surrealdb/core/src/graphql/tables.rs
@@ -862,7 +862,7 @@ pub(crate) fn filter_name_from_table(tb_name: impl Display) -> String {
 /// follows the table's `GRAPHQL_ALIAS` when it sets one (#7453). Falls back to
 /// the raw table name if the map is missing, which is what the type name was
 /// before aliases reached it.
-fn graphql_type_of(ctx: &ResolverContext<'_>, table: &TableName) -> String {
+pub(super) fn graphql_type_of(ctx: &ResolverContext<'_>, table: &TableName) -> String {
 	ctx.data::<Arc<TableTypeNames>>()
 		.map_or_else(|_| table.as_str().to_owned(), |m| m.get(table.as_str()).to_owned())
 }

--- a/surrealdb/core/src/graphql/tables.rs
+++ b/surrealdb/core/src/graphql/tables.rs
@@ -687,7 +687,7 @@ fn make_nested_object_type(
 	type_name: &str,
 	sub_fields: &[NestedSubField],
 	types: &mut Vec<Type>,
-	table_types: &TableTypeNames,
+	table_types: &Arc<TableTypeNames>,
 ) -> Result<Object, GraphqlError> {
 	let mut obj = Object::new(type_name);
 
@@ -704,8 +704,12 @@ fn make_nested_object_type(
 			table_types,
 		)?;
 		// The resolver keys off the storage name, which an alias does not change.
-		let resolver =
-			make_sub_field_resolver(sf.lookup_name.clone(), sf.kind.clone(), Some(enum_scope));
+		let resolver = make_sub_field_resolver(
+			sf.lookup_name.clone(),
+			sf.kind.clone(),
+			Some(enum_scope),
+			Arc::clone(table_types),
+		);
 		let mut field = Field::new(&sf.name, fd_type, resolver);
 		if let Some(ref comment) = sf.comment {
 			field = field.description(comment.clone());
@@ -724,11 +728,13 @@ fn make_sub_field_resolver(
 	field_name: String,
 	kind: Option<Kind>,
 	enum_scope: Option<String>,
+	table_types: Arc<TableTypeNames>,
 ) -> impl for<'a> Fn(ResolverContext<'a>) -> FieldFuture<'a> + Send + Sync + 'static {
 	move |ctx: ResolverContext| {
 		let field_name = field_name.clone();
 		let field_kind = kind.clone();
 		let enum_scope = enum_scope.clone();
+		let table_types = Arc::clone(&table_types);
 		FieldFuture::new(async move {
 			let obj = ctx.parent_value.try_downcast_ref::<SurObject>()?;
 
@@ -743,7 +749,7 @@ fn make_sub_field_resolver(
 						});
 						let field_val = match field_kind {
 							Some(Kind::Record(ref ts)) if ts.is_empty() || ts.len() > 1 => {
-								field_val.with_type(graphql_type_of(&ctx, &rid.table))
+								field_val.with_type(table_types.get(rid.table.as_str()).to_owned())
 							}
 							_ => field_val,
 						};
@@ -853,18 +859,6 @@ fn resolve_nested_object_value(
 /// Derive the GraphQL filter input type name for a table (e.g. `_filter_person`).
 pub(crate) fn filter_name_from_table(tb_name: impl Display) -> String {
 	format!("_filter_{tb_name}")
-}
-
-/// Resolve a record's table to the GraphQL Object type generated for it.
-///
-/// Used by resolvers that tag a value with its concrete type for interface or
-/// union resolution: they only have the record ID to hand, and the type name
-/// follows the table's `GRAPHQL_ALIAS` when it sets one (#7453). Falls back to
-/// the raw table name if the map is missing, which is what the type name was
-/// before aliases reached it.
-pub(super) fn graphql_type_of(ctx: &ResolverContext<'_>, table: &TableName) -> String {
-	ctx.data::<Arc<TableTypeNames>>()
-		.map_or_else(|_| table.as_str().to_owned(), |m| m.get(table.as_str()).to_owned())
 }
 
 // ---------------------------------------------------------------------------
@@ -1057,9 +1051,10 @@ fn make_table_get_field(tb: &TableDefinition, kvs: Arc<Datastore>) -> Field {
 /// Unlike `_get_<table>`, this accepts a full record ID (e.g. `"person:alice"`)
 /// and returns the `record` interface type, requiring `.with_type()` to
 /// indicate the concrete table type.
-fn make_generic_get_field(kvs: Arc<Datastore>) -> Field {
+fn make_generic_get_field(kvs: Arc<Datastore>, table_types: Arc<TableTypeNames>) -> Field {
 	Field::new("_get", TypeRef::named("record"), move |ctx| {
 		let kvs = Arc::clone(&kvs);
+		let table_types = Arc::clone(&table_types);
 		FieldFuture::new(async move {
 			let sess = ctx.data::<Arc<Session>>()?;
 			let args = ctx.args.as_index_map();
@@ -1089,7 +1084,7 @@ fn make_generic_get_field(kvs: Arc<Datastore>) -> Field {
 						Some(Value::RecordId(rid)) => rid.clone(),
 						_ => return Ok(None),
 					};
-					let type_name = graphql_type_of(&ctx, &rid.table);
+					let type_name = table_types.get(rid.table.as_str()).to_owned();
 					Ok(Some(
 						FieldValue::owned_any(CachedRecord {
 							rid,
@@ -1143,7 +1138,7 @@ fn build_table_type(
 	exposed_table_names: &HashSet<TableName>,
 	relation_table_fds: &HashMap<TableName, Arc<[FieldDefinition]>>,
 	types: &mut Vec<Type>,
-	table_types: &TableTypeNames,
+	table_types: &Arc<TableTypeNames>,
 ) -> Result<TableGraphQLTypes, GraphqlError> {
 	let tb_name = &tb.name;
 	let tb_name_str = tb_name.as_str().to_string();
@@ -1182,7 +1177,12 @@ fn build_table_type(
 		.field(Field::new(
 			"id",
 			TypeRef::named_nn(TypeRef::ID),
-			make_table_field_resolver("id", Some(Kind::Record(vec![tb_name.clone()])), None),
+			make_table_field_resolver(
+				"id",
+				Some(Kind::Record(vec![tb_name.clone()])),
+				None,
+				Arc::clone(table_types),
+			),
 		))
 		.implement("record");
 
@@ -1286,7 +1286,12 @@ fn build_table_type(
 		let mut field = Field::new(
 			fd_name.as_str(),
 			fd_type,
-			make_table_field_resolver(&lookup_name, fd.field_kind.clone(), Some(enum_scope)),
+			make_table_field_resolver(
+				&lookup_name,
+				fd.field_kind.clone(),
+				Some(enum_scope),
+				Arc::clone(table_types),
+			),
 		);
 		if let Some(desc) = super::naming::description_with_deprecation(
 			fd.comment.as_deref(),
@@ -1418,7 +1423,7 @@ pub async fn process_tbs(
 	ctx: &SchemaContext<'_>,
 	relations: &[RelationInfo],
 	table_fields: &mut HashMap<TableName, Arc<[FieldDefinition]>>,
-	table_types: &TableTypeNames,
+	table_types: &Arc<TableTypeNames>,
 ) -> Result<Object, GraphqlError> {
 	// Pre-fetch field definitions for relation tables (needed for filter support
 	// in relation field resolvers). These are captured by the resolver closures.
@@ -1587,7 +1592,7 @@ pub async fn process_tbs(
 	}
 
 	// Add generic _get query field for fetching any record by full ID
-	query = query.field(make_generic_get_field(Arc::clone(ctx.datastore)));
+	query = query.field(make_generic_get_field(Arc::clone(ctx.datastore), Arc::clone(table_types)));
 
 	Ok(query)
 }
@@ -1610,12 +1615,14 @@ fn make_table_field_resolver(
 	fd_name: impl Into<String>,
 	kind: Option<Kind>,
 	enum_scope: Option<String>,
+	table_types: Arc<TableTypeNames>,
 ) -> impl for<'a> Fn(ResolverContext<'a>) -> FieldFuture<'a> + Send + Sync + 'static {
 	let fd_name = fd_name.into();
 	move |ctx: ResolverContext| {
 		let fd_name = fd_name.clone();
 		let field_kind = kind.clone();
 		let enum_scope = enum_scope.clone();
+		let table_types = Arc::clone(&table_types);
 		FieldFuture::new({
 			async move {
 				// ── Fast path: extract field from CachedRecord ──
@@ -1631,6 +1638,7 @@ fn make_table_field_resolver(
 						&fd_name,
 						&field_kind,
 						enum_scope.as_deref(),
+						&table_types,
 					)
 					.await;
 				}
@@ -1660,6 +1668,7 @@ fn make_table_field_resolver(
 					&field_kind,
 					&version,
 					enum_scope.as_deref(),
+					&table_types,
 				)
 				.await
 			}
@@ -1679,6 +1688,7 @@ async fn resolve_field_value(
 	field_kind: &Option<Kind>,
 	version: &Option<Datetime>,
 	enum_scope: Option<&str>,
+	table_types: &TableTypeNames,
 ) -> Result<Option<FieldValue<'static>>, async_graphql::Error> {
 	match val {
 		Value::RecordId(target_rid) if fd_name != "id" => {
@@ -1699,9 +1709,8 @@ async fn resolve_field_value(
 						data: obj,
 					});
 					let field_val = match field_kind {
-						Some(Kind::Record(ts)) if ts.is_empty() || ts.len() > 1 => {
-							field_val.with_type(graphql_type_of(ctx, &target_rid.table))
-						}
+						Some(Kind::Record(ts)) if ts.is_empty() || ts.len() > 1 => field_val
+							.with_type(table_types.get(target_rid.table.as_str()).to_owned()),
 						_ => field_val,
 					};
 					Ok(Some(field_val))
@@ -1741,9 +1750,11 @@ async fn resolve_field_from_cached_record(
 	fd_name: &str,
 	field_kind: &Option<Kind>,
 	enum_scope: Option<&str>,
+	table_types: &TableTypeNames,
 ) -> Result<Option<FieldValue<'static>>, async_graphql::Error> {
 	let val = cached.data.get(fd_name).cloned().unwrap_or(Value::None);
-	resolve_field_value(ctx, val, fd_name, field_kind, &cached.version, enum_scope).await
+	resolve_field_value(ctx, val, fd_name, field_kind, &cached.version, enum_scope, table_types)
+		.await
 }
 
 /// Build a GraphQL field for a relation on a table type.

--- a/tests/graphql_integration.rs
+++ b/tests/graphql_integration.rs
@@ -7185,6 +7185,113 @@ mod graphql_integration {
 		Ok(())
 	}
 
+	/// A `GRAPHQL_ALIAS` renames the field in the schema but not in storage, so
+	/// the LIVE query behind a subscription has to project the *storage* name of
+	/// whatever was selected. Projecting the GraphQL name instead leaves the
+	/// value out of the notification, and a non-null field then fails to
+	/// resolve (#7453).
+	#[test(tokio::test)]
+	async fn subscriptions_live_query_projects_aliased_fields()
+	-> Result<(), Box<dyn std::error::Error>> {
+		let (addr, _server) = common::start_server_without_auth().await.unwrap();
+		let gql_ws_url = &format!("ws://{addr}/graphql");
+		let sql_url = &format!("http://{addr}/sql");
+
+		let mut headers = reqwest::header::HeaderMap::new();
+		let ns = Ulid::new().to_string();
+		let db = Ulid::new().to_string();
+		headers.insert("surreal-ns", ns.parse()?);
+		headers.insert("surreal-db", db.parse()?);
+		headers.insert(header::ACCEPT, "application/json".parse()?);
+		let client = Client::builder()
+			.connect_timeout(Duration::from_secs(10))
+			.default_headers(headers)
+			.build()?;
+
+		{
+			let res = client
+				.post(sql_url)
+				.body(
+					r#"
+					DEFINE CONFIG GRAPHQL AUTO;
+					DEFINE TABLE thing SCHEMAFUL GRAPHQL_ALIAS 'Thing';
+					DEFINE FIELD user_count ON thing TYPE int GRAPHQL_ALIAS 'userCount';
+					DEFINE FIELD label ON thing TYPE string;
+				"#,
+				)
+				.send()
+				.await?;
+			assert_eq!(res.status(), 200);
+		}
+
+		let mut req = gql_ws_url.into_client_request()?;
+		req.headers_mut().insert("surreal-ns", ns.parse()?);
+		req.headers_mut().insert("surreal-db", db.parse()?);
+		req.headers_mut().insert("Sec-WebSocket-Protocol", "graphql-transport-ws".parse()?);
+		let (mut ws, _) = connect_async(req).await?;
+
+		ws.send(Message::Text(json!({"type":"connection_init"}).to_string().into())).await?;
+		let Some(Ok(Message::Text(ack_msg))) = ws.next().await else {
+			return Err(std::io::Error::other("expected websocket connection ack").into());
+		};
+		let ack_json: serde_json::Value = serde_json::from_str(&ack_msg)?;
+		assert_eq!(ack_json["type"], "connection_ack");
+
+		ws.send(Message::Text(
+			json!({
+				"id": "sub-alias",
+				"type": "subscribe",
+				"payload": {
+					"query": "subscription { Thing { id userCount label } }"
+				}
+			})
+			.to_string()
+			.into(),
+		))
+		.await?;
+
+		// Allow the server to fully register the live query before mutating data
+		tokio::time::sleep(Duration::from_secs(1)).await;
+
+		{
+			let res = client
+				.post(sql_url)
+				.body(r#"CREATE thing:1 SET user_count = 7, label = "seven";"#)
+				.send()
+				.await?;
+			assert_eq!(res.status(), 200);
+		}
+
+		let received = tokio::time::timeout(Duration::from_secs(10), async {
+			while let Some(frame) = ws.next().await {
+				let Ok(frame) = frame else {
+					continue;
+				};
+				let Message::Text(text) = frame else {
+					continue;
+				};
+				let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
+					continue;
+				};
+				if matches!(value["type"].as_str(), Some("next" | "error"))
+					&& value["id"] == "sub-alias"
+				{
+					return Some(value);
+				}
+			}
+			None
+		})
+		.await?
+		.ok_or_else(|| std::io::Error::other("subscription stream ended before event"))?;
+
+		assert_eq!(received["type"], "next", "subscription errored: {received:?}");
+		assert_eq!(received["payload"]["data"]["Thing"]["id"], "thing:1");
+		assert_eq!(received["payload"]["data"]["Thing"]["userCount"], 7);
+		// The un-aliased field alongside it must keep working.
+		assert_eq!(received["payload"]["data"]["Thing"]["label"], "seven");
+		Ok(())
+	}
+
 	/// Helper to spin up an authless server with a fresh namespace/database and
 	/// return a GraphQL/SQL client pair.
 	async fn fresh_client() -> Result<


### PR DESCRIPTION
Fixes #7453.

## Summary

With `DEFINE TABLE widget ... GRAPHQL_ALIAS 'Gizmo'`, the alias lands on the query and mutation fields and the connection/edge types, but not on the table's own Object type, its nested-object types, `_filter_*`, `_order_*`, `_orderable_*`, `_groupable_*`, `*_aggregate_row`, the subscription field, or the enum scope of its literal-union fields.

On fields, the alias worked at top level only. `DEFINE FIELD price.in_euro …
GRAPHQL_ALIAS 'inEuro'` was silently ignored, with no error or warning.

### Why `TableTypeNames`

Other code refers to a table *by name only*, with no `TableDefinition` in scope: `record<gadget>` on some other table, relation targets, `FieldValue::with_type` at runtime. So there's a small map from raw table name to generated type name, built once up front. This is needed because `holder.item: record<gadget>` may be processed before `gadget` is.

The resolvers get the map by `Arc`, not from schema data. An earlier revision registered it as async-graphql schema data and read it back on every tag, which cost a type-map walk per resolution (`data_opt` probes four maps and checks schema data last) and needed a fallback to the raw table name for when the lookup failed. That fallback *is* the original bug, silently restored if the registration ever went missing. Threading the handle through the nine constructors is more plumbing, but there is no failure mode left to fall back from.

## Breaking (existing schema) change

Renaming the Object type breaks existing consumers of an aliased table, e.g. their relay fragments say `on widget` and will need `on Gizmo`. Same for `__typename` checks, and for operations that declare a variable against a generated input type, e.g. `$where: _filter_widget` becomes `$where: _filter_Gizmo`.

Only schemas that already set `GRAPHQL_ALIAS` on a table are affected. Everything else maps to itself and generates the same schema as before.

## Testing

- Added language tests, including the function record returns.
- Added unit tests for the name derivations, the abstract-record decision, and the subscription field mapping.
- Added a WebSocket integration test for the subscription projection. 

## Have you read the Contributing Guidelines?

<!-- All pull requests require that the contributing guidelines have been read and agreed to. -->

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealdb/blob/main/CONTRIBUTING.md)